### PR TITLE
tests: made atomic consume-transform-produce test more robust

### DIFF
--- a/tests/rptest/transactions/tx_atomic_produce_consume_test.py
+++ b/tests/rptest/transactions/tx_atomic_produce_consume_test.py
@@ -35,6 +35,7 @@ class ExactlyOnceVerifier():
     def __init__(self,
                  redpanda,
                  src_topic: str,
+                 partition_count: int,
                  dst_topic: str,
                  transform_func,
                  logger,
@@ -44,6 +45,7 @@ class ExactlyOnceVerifier():
                  commit_every: int = 50,
                  timeout_sec: int = 60):
         self._src_topic = src_topic
+        self._partition_count = partition_count
         self._dst_topic = dst_topic
         self._transform_func = transform_func
         self._logger = logger
@@ -185,7 +187,7 @@ class ExactlyOnceVerifier():
                 with self._lock:
                     self._finished_partitions |= end_for
                     consumers = self._consumer_cnt
-                    if len(self._finished_partitions) == len(high_watermarks):
+                    if len(self._finished_partitions) == self._partition_count:
                         return True
 
                 return len(end_for) == len(assignments) and consumers > 1
@@ -359,6 +361,7 @@ class TxAtomicProduceConsumeTest(RedpandaTest):
 
         transformer = ExactlyOnceVerifier(self.redpanda,
                                           topic.name,
+                                          topic.partition_count,
                                           dst_topic.name,
                                           simple_transform,
                                           self.logger,


### PR DESCRIPTION
The exactly once delivery semantic tests was using a stop condition where a size of the finished processing partition set was compared with the size of high watermark list. Sometimes the high watermark list may not contain all the partitions as they are not reported when there is no leader. This lead to test stopping to early and desitination topic missing some messages.  Changed the test to use the topic partition count in the stop condition instead.

Fixes: #20315

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none