### PR TITLE
[CORE-4443] Pandaproxy: Avoid large allocations whilst serializing JSON

### DIFF
--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -526,7 +526,7 @@ inline void rjson_serialize(
           ss.rdstate()));
     }
     w.Key("address");
-    rjson_serialize<std::string_view>(w, ss.str());
+    rjson_serialize(w, std::string_view{ss.str()});
     w.EndObject();
 }
 

--- a/src/v/container/include/container/json.h
+++ b/src/v/container/include/container/json.h
@@ -15,10 +15,9 @@
 
 namespace json {
 
-template<typename T, size_t max_fragment_size>
+template<typename Buffer, typename T, size_t max_fragment_size>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const fragmented_vector<T, max_fragment_size>& v) {
+  json::Writer<Buffer>& w, const fragmented_vector<T, max_fragment_size>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/json/chunked_buffer.h
+++ b/src/v/json/chunked_buffer.h
@@ -1,0 +1,59 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/encodings.h"
+
+namespace json {
+
+namespace impl {
+
+/**
+ * \brief An in-memory output stream with non-contiguous memory allocation.
+ */
+template<typename Encoding>
+struct generic_chunked_buffer {
+    using Ch = Encoding::Ch;
+
+    /**
+     * \defgroup Implement rapidjson::Stream
+     */
+    /**@{*/
+
+    void Put(Ch c) { _impl.append(&c, sizeof(Ch)); }
+    void Flush() {}
+
+    //! Get the size of string in bytes in the string buffer.
+    size_t GetSize() const { return _impl.size_bytes(); }
+
+    //! Get the length of string in Ch in the string buffer.
+    size_t GetLength() const { return _impl.size_bytes() / sizeof(Ch); }
+
+    void Reserve(size_t s) { _impl.reserve(s); }
+
+    void Clear() { _impl.clear(); }
+
+    /**@}*/
+
+    iobuf as_iobuf() && { return std::move(_impl); }
+
+private:
+    iobuf _impl;
+};
+
+} // namespace impl
+
+template<typename Encoding>
+using generic_chunked_buffer = impl::generic_chunked_buffer<Encoding>;
+
+using chunked_buffer = generic_chunked_buffer<UTF8<>>;
+
+} // namespace json

--- a/src/v/json/chunked_input_stream.h
+++ b/src/v/json/chunked_input_stream.h
@@ -1,0 +1,64 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/streambuf.h"
+#include "json/encodings.h"
+#include "json/istreamwrapper.h"
+
+namespace json {
+
+namespace impl {
+
+/**
+ * \brief An in-memory input stream with non-contiguous memory allocation.
+ */
+template<typename Encoding = ::json::UTF8<>>
+class chunked_input_stream {
+public:
+    using Ch = Encoding::Ch;
+
+    explicit chunked_input_stream(iobuf&& buf)
+      : _buf(std::move(buf))
+      , _is(_buf)
+      , _sis{&_is}
+      , _isw(_sis) {}
+
+    /**
+     * \defgroup Implement rapidjson::Stream
+     */
+    /**@{*/
+
+    Ch Peek() const { return _isw.Peek(); }
+    Ch Peek4() const { return _isw.Peek4(); }
+    Ch Take() { return _isw.Take(); }
+    size_t Tell() const { return _isw.Tell(); }
+    void Put(Ch ch) { return _isw.Put(ch); }
+    Ch* PutBegin() { return _isw.PutBegin(); }
+    size_t PutEnd(Ch* ch) { return _isw.PutEnd(ch); }
+    void Flush() { return _isw.Flush(); }
+
+    /**@}*/
+
+private:
+    iobuf _buf;
+    iobuf_istreambuf _is;
+    std::istream _sis;
+    ::json::IStreamWrapper _isw;
+};
+
+} // namespace impl
+
+template<typename Encoding>
+using generic_chunked_input_stream = impl::chunked_input_stream<Encoding>;
+
+using chunked_input_stream = generic_chunked_input_stream<UTF8<>>;
+
+} // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -9,6 +9,7 @@
 
 #include "json/json.h"
 
+#include "json/chunked_buffer.h"
 #include "json/stringbuffer.h"
 
 namespace json {
@@ -174,5 +175,44 @@ template void rjson_serialize<json::StringBuffer>(
 
 template void rjson_serialize<json::StringBuffer>(
   json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, short v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, bool v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, long long v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, int v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, unsigned int v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, long v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, unsigned long v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, double v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, std::string_view s);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const net::unresolved_address& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::chrono::milliseconds& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::chrono::seconds& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::filesystem::path& path);
 
 } // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -9,40 +9,57 @@
 
 #include "json/json.h"
 
+#include "json/stringbuffer.h"
+
 namespace json {
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, short v) { w.Int(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, short v) {
+    w.Int(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v) { w.Bool(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, bool v) {
+    w.Bool(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, int v) { w.Int(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, int v) {
+    w.Int(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned int v) {
     w.Uint(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned long v) {
     w.Uint64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, double v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, double v) {
     w.Double(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, std::string_view v) {
     w.String(v.data(), v.size());
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::socket_address& v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const ss::socket_address& v) {
     w.StartObject();
 
     std::ostringstream a;
@@ -68,8 +85,9 @@ void rjson_serialize(
     w.EndObject();
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v) {
+  json::Writer<Buffer>& w, const net::unresolved_address& v) {
     w.StartObject();
 
     w.Key("address");
@@ -81,20 +99,22 @@ void rjson_serialize(
     w.EndObject();
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v) {
+  json::Writer<Buffer>& w, const std::chrono::milliseconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const std::chrono::seconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path) {
+  json::Writer<Buffer>& w, const std::filesystem::path& path) {
     rjson_serialize(w, std::string_view{path.native()});
 }
 
@@ -115,5 +135,44 @@ ss::sstring prettify(std::string_view json) {
     r.Parse(in, w);
     return ss::sstring(out.GetString(), out.GetSize());
 }
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, short v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, bool v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, long long v);
+
+template void
+rjson_serialize<json::StringBuffer>(json::Writer<json::StringBuffer>& w, int v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, unsigned int v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, long v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, unsigned long v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, double v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, std::string_view s);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
 
 } // namespace json

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -29,50 +29,62 @@
 
 namespace json {
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, short v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, short v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, bool v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, int v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, int v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned int v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, double v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, double v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view s);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, std::string_view s);
 
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const net::unresolved_address& v);
+
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);
+  json::Writer<Buffer>& w, const std::chrono::milliseconds& v);
 
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const std::chrono::seconds& v);
+
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v);
+  json::Writer<Buffer>& w, const std::filesystem::path& path);
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v);
-
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
-
-template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
-void rjson_serialize(json::Writer<json::StringBuffer>& w, T v) {
+template<
+  typename Buffer,
+  typename T,
+  typename = std::enable_if_t<std::is_enum_v<T>>>
+void rjson_serialize(json::Writer<Buffer>& w, T v) {
     rjson_serialize(w, static_cast<std::underlying_type_t<T>>(v));
 }
 
-template<typename T, typename Tag>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const named_type<T, Tag>& v) {
+template<typename Buffer, typename T, typename Tag>
+void rjson_serialize(json::Writer<Buffer>& w, const named_type<T, Tag>& v) {
     rjson_serialize(w, v());
 }
 
-template<typename T>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::optional<T>& v) {
+template<typename Buffer, typename T>
+void rjson_serialize(json::Writer<Buffer>& w, const std::optional<T>& v) {
     if (v) {
         rjson_serialize(w, *v);
         return;
@@ -80,9 +92,8 @@ void rjson_serialize(
     w.Null();
 }
 
-template<typename T, typename A>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::vector<T, A>& v) {
+template<typename Buffer, typename T, typename A>
+void rjson_serialize(json::Writer<Buffer>& w, const std::vector<T, A>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);
@@ -90,10 +101,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, size_t chunk_size>
+template<typename Buffer, typename T, size_t chunk_size>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const ss::chunked_fifo<T, chunk_size>& v) {
+  json::Writer<Buffer>& w, const ss::chunked_fifo<T, chunk_size>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);
@@ -101,9 +111,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T>
+template<typename Buffer, typename T>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
+  json::Writer<Buffer>& w,
   const std::unordered_map<typename T::key_type, T>& v) {
     w.StartArray();
     for (const auto& e : v) {
@@ -112,9 +122,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, typename A>
+template<typename Buffer, typename T, typename A>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::circular_buffer<T, A>& v) {
+  json::Writer<Buffer>& w, const ss::circular_buffer<T, A>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -41,8 +41,8 @@ struct personne_t {
 
 } // namespace
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const personne_t::nested& obj) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const personne_t::nested& obj) {
     w.StartObject();
 
     w.Key("x");
@@ -57,11 +57,12 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, const personne_t& p) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const personne_t& p) {
     w.StartObject();
 
     w.Key("full_name");
-    json::rjson_serialize<std::string_view>(w, p.full_name);
+    json::rjson_serialize(w, std::string_view{p.full_name});
 
     w.Key("nic");
     json::rjson_serialize(w, p.nic);

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -15,9 +15,8 @@
 #include "bytes/iobuf_parser.h"
 #include "json/reader.h"
 #include "json/stream.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
-#include "pandaproxy/json/types.h"
+#include "pandaproxy/json/rjson_util.h"
 #include "utils/base64.h"
 
 #include <seastar/core/loop.hh>

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -65,7 +65,8 @@ public:
     explicit rjson_serialize_impl(serialization_format fmt)
       : _fmt(fmt) {}
 
-    bool operator()(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, iobuf buf) {
         switch (_fmt) {
         case serialization_format::none:
             [[fallthrough]];
@@ -80,7 +81,8 @@ public:
         }
     }
 
-    bool encode_base64(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool encode_base64(::json::Writer<Buffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }
@@ -88,7 +90,8 @@ public:
         return w.String(iobuf_to_base64(buf));
     };
 
-    bool encode_json(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool encode_json(::json::Writer<Buffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -21,8 +21,9 @@ struct get_brokers_res {
     std::vector<model::node_id> ids;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const get_brokers_res& brokers) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_brokers_res& brokers) {
     w.StartObject();
     w.Key("brokers");
     ::json::rjson_serialize(w, brokers.ids);

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include "json/stringbuffer.h"
+#include "json/json.h"
 #include "json/writer.h"
-#include "model/metadata.h"
+#include "model/fundamental.h"
 
 namespace pandaproxy::json {
 

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -12,14 +12,9 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "bytes/iobuf.h"
-#include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
-#include "kafka/protocol/errors.h"
-#include "kafka/protocol/produce.h"
-#include "kafka/types.h"
-#include "pandaproxy/json/iobuf.h"
+#include "kafka/protocol/join_group.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "strings/string_switch.h"
 

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -107,9 +107,9 @@ struct create_consumer_response {
     ss::sstring base_uri;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const create_consumer_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const create_consumer_response& res) {
     w.StartObject();
     w.Key("instance_id");
     w.String(res.instance_id());

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -26,8 +26,8 @@ struct error_body {
     ss::sstring message;
 };
 
-inline void
-rjson_serialize(::json::Writer<::json::StringBuffer>& w, const error_body& v) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const error_body& v) {
     w.StartObject();
     w.Key("error_code");
     ::json::rjson_serialize(w, v.ec.value());

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -13,7 +13,6 @@
 
 #include "base/seastarx.h"
 #include "json/json.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
 
 #include <seastar/core/sstring.hh>

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -43,8 +43,8 @@ public:
       , _tpv(tpv)
       , _base_offset(base_offset) {}
 
-    bool
-    operator()(::json::Writer<::json::StringBuffer>& w, model::record record) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, model::record record) {
         auto offset = _base_offset() + record.offset_delta();
 
         w.StartObject();
@@ -97,8 +97,8 @@ public:
     explicit rjson_serialize_impl(serialization_format fmt)
       : _fmt(fmt) {}
 
-    bool operator()(
-      ::json::Writer<::json::StringBuffer>& w, kafka::fetch_response&& res) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, kafka::fetch_response&& res) {
         // Eager check for errors
         for (auto& v : res) {
             if (v.partition_response->error_code != kafka::error_code::none) {

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -12,18 +12,13 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "bytes/iobuf.h"
-#include "bytes/iobuf_parser.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "model/fundamental.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 #include "storage/parser_utils.h"

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -40,9 +40,9 @@ partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
     return res;
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::offset_fetch_response_topic& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::offset_fetch_response_topic& v) {
     for (const auto& p : v.partitions) {
         w.StartObject();
         w.Key("topic");
@@ -57,9 +57,9 @@ inline void rjson_serialize(
     }
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::offset_fetch_response& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::offset_fetch_response& v) {
     w.StartObject();
     w.Key("offsets");
     w.StartArray();

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -12,9 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
-#include "kafka/protocol/errors.h"
 #include "kafka/protocol/offset_fetch.h"
 
 #include <seastar/core/sstring.hh>
@@ -39,6 +37,9 @@ partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
     }
     return res;
 }
+} // namespace pandaproxy::json
+
+namespace kafka {
 
 template<typename Buffer>
 void rjson_serialize(
@@ -70,4 +71,4 @@ void rjson_serialize(
     w.EndObject();
 }
 
-} // namespace pandaproxy::json
+} // namespace kafka

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -265,9 +265,9 @@ private:
     std::optional<json_writer> _json_writer;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::produce_response::partition& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::produce_response::partition& v) {
     w.StartObject();
     w.Key("partition");
     w.Int(v.partition_index);
@@ -280,9 +280,9 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::produce_response::topic& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::produce_response::topic& v) {
     w.StartObject();
     w.Key("offsets");
     w.StartArray();

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -13,7 +13,6 @@
 
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
-#include "json/json.h"
 #include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
@@ -21,7 +20,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/types.h"
+#include "pandaproxy/json/rjson_util.h"
 #include "utils/tristate.h"
 
 #include <seastar/core/sstring.hh>
@@ -265,6 +264,9 @@ private:
     std::optional<json_writer> _json_writer;
 };
 
+} // namespace pandaproxy::json
+
+namespace kafka {
 template<typename Buffer>
 void rjson_serialize(
   ::json::Writer<Buffer>& w, const kafka::produce_response::partition& v) {
@@ -273,7 +275,7 @@ void rjson_serialize(
     w.Int(v.partition_index);
     if (v.error_code != kafka::error_code::none) {
         w.Key("error_code");
-        ::json::rjson_serialize(w, v.error_code);
+        rjson_serialize(w, v.error_code);
     }
     w.Key("offset");
     w.Int64(v.base_offset);
@@ -293,4 +295,4 @@ void rjson_serialize(
     w.EndObject();
 }
 
-} // namespace pandaproxy::json
+} // namespace kafka

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -13,14 +13,14 @@
 
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
-#include "json/stringbuffer.h"
+#include "json/chunked_buffer.h"
 #include "json/types.h"
 #include "json/writer.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/json/types.h"
 #include "utils/tristate.h"
 
 #include <seastar/core/sstring.hh>
@@ -42,7 +42,7 @@ private:
     serialization_format _fmt = serialization_format::none;
     state state = state::empty;
 
-    using json_writer = ::json::Writer<::json::StringBuffer>;
+    using json_writer = ::json::Writer<::json::chunked_buffer>;
 
     // If we're parsing json_v2, and the field is key or value (implied by
     // _json_writer being set), then forward calls to json_writer.
@@ -55,8 +55,7 @@ private:
         auto res = std::invoke(
           mem_func, *_json_writer, std::forward<Args>(args)...);
         if (_json_writer->IsComplete()) {
-            iobuf buf;
-            buf.append(_buf.GetString(), _buf.GetSize());
+            iobuf buf = std::move(_buf).as_iobuf();
             switch (state) {
             case state::key:
                 result.back().key.emplace(std::move(buf));
@@ -260,7 +259,7 @@ public:
     }
 
 private:
-    ::json::StringBuffer _buf;
+    ::json::chunked_buffer _buf;
     std::optional<json_writer> _json_writer;
 };
 

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -15,12 +15,9 @@
 #include "json/writer.h"
 #include "kafka/client/test/utils.h"
 #include "kafka/protocol/errors.h"
-#include "kafka/protocol/fetch.h"
 #include "kafka/protocol/wire.h"
 #include "model/fundamental.h"
-#include "model/record.h"
 #include "model/timestamp.h"
-#include "pandaproxy/json/requests/fetch.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 
@@ -28,8 +25,6 @@
 
 #include <boost/test/tools/interface.hpp>
 #include <boost/test/tools/old/interface.hpp>
-
-#include <type_traits>
 
 namespace ppj = pandaproxy::json;
 

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -278,7 +278,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_response) {
       .log_append_time_ms = model::timestamp{},
       .log_start_offset = model::offset{}});
 
-    auto output = ppj::rjson_serialize(topic);
+    auto output = ppj::rjson_serialize_str(topic);
 
     BOOST_TEST(output == expected);
 }

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -46,7 +46,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_binary_request) {
         ]
       })";
 
-    auto records = ppj::rjson_parse(input, make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_binary_v2_handler());
     BOOST_TEST(records.size() == 2);
     BOOST_TEST(!!records[0].value);
 
@@ -77,7 +77,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_json_request) {
         ]
       })";
 
-    auto records = ppj::rjson_parse(input, make_json_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_json_v2_handler());
     BOOST_REQUIRE_EQUAL(records.size(), 2);
     BOOST_REQUIRE_EQUAL(records[0].partition_id, model::partition_id(0));
     BOOST_REQUIRE(!records[0].key);
@@ -111,7 +111,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_invalid_json_request) {
       })";
 
     BOOST_CHECK_THROW(
-      ppj::rjson_parse(input, make_json_v2_handler()),
+      ppj::impl::rjson_parse(input, make_json_v2_handler()),
       pandaproxy::json::parse_error);
 }
 
@@ -121,7 +121,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_empty) {
         "records": []
       })";
 
-    auto records = ppj::rjson_parse(input, make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_binary_v2_handler());
     BOOST_TEST(records.size() == 0);
 }
 
@@ -137,7 +137,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_records_name) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 25");
@@ -156,7 +156,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_name) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 99");
@@ -175,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_type) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 112");
@@ -195,7 +195,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_before_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 28");
@@ -215,7 +215,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_after_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 152");
@@ -235,7 +235,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_between_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 144");
@@ -250,7 +250,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_no_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 24");

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iostream.h"
 #include "json/chunked_buffer.h"
+#include "json/chunked_input_stream.h"
 #include "json/json.h"
 #include "json/reader.h"
 #include "json/stream.h"
@@ -21,7 +22,12 @@
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/http/request.hh>
+
+#include <concepts>
 
 namespace pandaproxy::json {
 
@@ -94,18 +100,68 @@ inline rjson_serialize_fmt_impl rjson_serialize_fmt(serialization_format fmt) {
     return rjson_serialize_fmt_impl{fmt};
 }
 
+namespace impl {
+
 template<typename Handler>
-requires std::is_same_v<
-  decltype(std::declval<Handler>().result),
-  typename Handler::rjson_parse_result>
+concept RjsonParseHandler = requires {
+    std::same_as<
+      decltype(std::declval<Handler>().result),
+      typename Handler::rjson_parse_result>;
+};
+
+template<typename IStream, typename Arg, impl::RjsonParseHandler Handler>
 typename Handler::rjson_parse_result
-rjson_parse(const char* const s, Handler&& handler) {
+rjson_parse_buf(Arg&& arg, Handler&& handler) {
     ::json::Reader reader;
-    ::json::StringStream ss(s);
+    IStream ss(std::forward<Arg>(arg));
     if (!reader.Parse(ss, handler)) {
         throw parse_error(reader.GetErrorOffset());
     }
-    return std::move(handler.result);
+    return std::forward<Handler>(handler).result;
+}
+
+} // namespace impl
+
+/// \brief Parse a payload using the handler.
+///
+/// \warning rjson_parse is preferred, since it can be chunked.
+template<impl::RjsonParseHandler Handler>
+typename Handler::rjson_parse_result
+rjson_parse(const char* const s, Handler&& handler) {
+    return impl::rjson_parse_buf<::json::StringStream>(
+      s, std::forward<Handler>(handler));
+}
+
+///\brief Parse a payload using the handler.
+template<impl::RjsonParseHandler Handler>
+typename Handler::rjson_parse_result rjson_parse(iobuf buf, Handler&& handler) {
+    return impl::rjson_parse_buf<::json::chunked_input_stream>(
+      std::move(buf), std::forward<Handler>(handler));
+}
+
+///\brief Parse a request body using the handler.
+template<impl::RjsonParseHandler Handler>
+typename ss::future<typename Handler::rjson_parse_result>
+rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
+    if (!req->content.empty()) {
+        co_return rjson_parse(req->content.data(), std::move(handler));
+    }
+
+    iobuf buf;
+    auto is = req->content_stream;
+    co_await ss::repeat([&buf, &is]() {
+        return is->read().then([&buf](ss::temporary_buffer<char> tmp_buf) {
+            if (tmp_buf.empty()) {
+                return ss::make_ready_future<ss::stop_iteration>(
+                  ss::stop_iteration::yes);
+            }
+            buf.append(std::move(tmp_buf));
+            return ss::make_ready_future<ss::stop_iteration>(
+              ss::stop_iteration::no);
+        });
+    });
+
+    co_return rjson_parse(std::move(buf), std::move(handler));
 }
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -120,8 +120,6 @@ rjson_parse_buf(Arg&& arg, Handler&& handler) {
     return std::forward<Handler>(handler).result;
 }
 
-} // namespace impl
-
 /// \brief Parse a payload using the handler.
 ///
 /// \warning rjson_parse is preferred, since it can be chunked.
@@ -131,6 +129,8 @@ rjson_parse(const char* const s, Handler&& handler) {
     return impl::rjson_parse_buf<::json::StringStream>(
       s, std::forward<Handler>(handler));
 }
+
+} // namespace impl
 
 ///\brief Parse a payload using the handler.
 template<impl::RjsonParseHandler Handler>
@@ -144,7 +144,7 @@ template<impl::RjsonParseHandler Handler>
 typename ss::future<typename Handler::rjson_parse_result>
 rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
     if (!req->content.empty()) {
-        co_return rjson_parse(req->content.data(), std::move(handler));
+        co_return impl::rjson_parse(req->content.data(), std::move(handler));
     }
 
     iobuf buf;

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -48,8 +48,8 @@ struct rjson_serialize_fmt_impl {
         return rjson_serialize_impl<std::remove_reference_t<T>>{fmt}(
           std::forward<T>(t));
     }
-    template<typename T>
-    bool operator()(::json::Writer<::json::StringBuffer>& w, T&& t) {
+    template<typename Buffer, typename T>
+    bool operator()(::json::Writer<Buffer>& w, T&& t) {
         return rjson_serialize_impl<std::remove_reference_t<T>>{fmt}(
           w, std::forward<T>(t));
     }

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "json/json.h"
-#include "json/prettywriter.h"
 #include "json/reader.h"
 #include "json/stream.h"
 #include "json/stringbuffer.h"
@@ -22,9 +21,13 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <stdexcept>
-
 namespace pandaproxy::json {
+
+template<typename T>
+class rjson_parse_impl;
+
+template<typename T>
+class rjson_serialize_impl;
 
 template<typename T>
 ss::sstring rjson_serialize(const T& v) {

--- a/src/v/pandaproxy/json/test/parse.cc
+++ b/src/v/pandaproxy/json/test/parse.cc
@@ -43,7 +43,8 @@ inline void parse_test(size_t data_size) {
     auto input = gen(data_size);
 
     perf_tests::start_measuring_time();
-    auto records = ppj::rjson_parse(input.c_str(), make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(
+      input.c_str(), make_binary_v2_handler());
     perf_tests::stop_measuring_time();
 }
 

--- a/src/v/pandaproxy/json/types.h
+++ b/src/v/pandaproxy/json/types.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 
 namespace pandaproxy::json {
 
@@ -51,11 +51,5 @@ inline std::string_view name(serialization_format fmt) {
     }
     return "(unknown format)";
 }
-
-template<typename T>
-class rjson_parse_impl;
-
-template<typename T>
-class rjson_serialize_impl;
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -76,8 +76,7 @@ errored_body(std::error_condition ec, ss::sstring msg) {
     pandaproxy::json::error_body body{.ec = ec, .message = std::move(msg)};
     auto rep = std::make_unique<ss::http::reply>();
     rep->set_status(error_code_to_status(ec));
-    auto b = json::rjson_serialize(body);
-    rep->write_body("json", b);
+    rep->write_body("json", json::rjson_serialize(body));
     return rep;
 }
 

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -144,16 +144,16 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
           return client
             .fetch_partition(std::move(tp), offset, max_bytes, timeout)
             .then([res_fmt](kafka::fetch_response res) {
-                ::json::StringBuffer str_buf;
-                ::json::Writer<::json::StringBuffer> w(str_buf);
+                ::json::chunked_buffer buf;
+                ::json::Writer<::json::chunked_buffer> w(buf);
 
                 ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
-                // TODO Ben: Prevent this linearization
-                return ss::make_ready_future<ss::sstring>(str_buf.GetString());
+                return buf;
             });
       })
-      .then([res_fmt, rp = std::move(rp)](ss::sstring json_rslt) mutable {
-          rp.rep->write_body("json", json_rslt);
+      .then([res_fmt, rp = std::move(rp)](auto buf) mutable {
+          rp.rep->write_body(
+            "json", json::as_body_writer(std::move(buf).as_iobuf()));
           rp.mime_type = res_fmt;
           return std::move(rp);
       });
@@ -393,14 +393,13 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
 
           return client.consumer_fetch(group_id, name, timeout, max_bytes)
             .then([res_fmt, rp{std::move(rp)}](auto res) mutable {
-                ::json::StringBuffer str_buf;
-                ::json::Writer<::json::StringBuffer> w(str_buf);
+                ::json::chunked_buffer buf;
+                ::json::Writer<::json::chunked_buffer> w(buf);
 
                 ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
 
-                // TODO Ben: Prevent this linearization
-                ss::sstring json_rslt = str_buf.GetString();
-                rp.rep->write_body("json", json_rslt);
+                rp.rep->write_body(
+                  "json", json::as_body_writer(std::move(buf).as_iobuf()));
                 rp.mime_type = res_fmt;
                 return std::move(rp);
             });

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -456,7 +456,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
 
     // If the request is empty, commit all offsets
-    auto req_data = rq.req->content.length() == 0
+    auto req_data = rq.req->content_length == 0
                       ? std::vector<kafka::offset_commit_request_topic>()
                       : ppj::partition_offsets_request_to_offset_commit_request(
                         co_await ppj::rjson_parse(

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -78,8 +78,7 @@ get_brokers(server::request_t rq, server::reply_t rp) {
                 return b.node_id;
             });
 
-          auto json_rslt = ppj::rjson_serialize(brokers);
-          rp.rep->write_body("json", json_rslt);
+          rp.rep->write_body("json", ppj::rjson_serialize(brokers));
 
           rp.mime_type = res_fmt;
           return std::move(rp);
@@ -109,8 +108,7 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
               }
           }
 
-          auto json_rslt = ppj::rjson_serialize(names);
-          rp.rep->write_body("json", json_rslt);
+          rp.rep->write_body("json", ppj::rjson_serialize(names));
           rp.mime_type = res_fmt;
           return std::move(rp);
       });
@@ -186,8 +184,8 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
           return client.produce_records(topic, std::move(records))
             .then([rp{std::move(rp)},
                    res_fmt](kafka::produce_response res) mutable {
-                auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
-                rp.rep->write_body("json", json_rslt);
+                rp.rep->write_body(
+                  "json", ppj::rjson_serialize(res.data.responses[0]));
                 rp.mime_type = res_fmt;
                 return std::move(rp);
             });
@@ -278,8 +276,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
                             kafka::member_id name) mutable {
                         json::create_consumer_response res{
                           .instance_id = name, .base_uri = base_uri + name};
-                        auto json_rslt = ppj::rjson_serialize(res);
-                        rp.rep->write_body("json", json_rslt);
+                        rp.rep->write_body("json", ppj::rjson_serialize(res));
                         rp.mime_type = res_fmt;
                         return std::move(rp);
                     });
@@ -444,11 +441,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
           return client
             .consumer_offset_fetch(group_id, member_id, std::move(req_data))
             .then([rp{std::move(rp)}, res_fmt](auto res) mutable {
-                ::json::StringBuffer str_buf;
-                ::json::Writer<::json::StringBuffer> w(str_buf);
-                ppj::rjson_serialize(w, res);
-                ss::sstring json_rslt = str_buf.GetString();
-                rp.rep->write_body("json", json_rslt);
+                rp.rep->write_body("json", ppj::rjson_serialize(res));
                 rp.mime_type = res_fmt;
                 return std::move(rp);
             });

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -173,14 +173,11 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
 
     vlog(plog.debug, "get_topics_name: topic: {}", topic);
 
+    auto records = co_await ppj::rjson_parse(
+      std::move(rq.req), ppj::produce_request_handler(req_fmt));
     co_return co_await rq.dispatch(
-      [data{rq.req->content.data()},
-       topic,
-       req_fmt,
-       res_fmt,
-       rp{std::move(rp)}](kafka::client::client& client) mutable {
-          auto records = ppj::rjson_parse(
-            data, ppj::produce_request_handler(req_fmt));
+      [records{std::move(records)}, topic, res_fmt, rp{std::move(rp)}](
+        kafka::client::client& client) mutable {
           return client.produce_records(topic, std::move(records))
             .then([rp{std::move(rp)},
                    res_fmt](kafka::produce_response res) mutable {
@@ -213,8 +210,10 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     auto group_id = parse::request_param<kafka::group_id>(
       *rq.req, "group_name");
 
-    auto req_data = ppj::rjson_parse(
-      rq.req->content.data(), ppj::create_consumer_request_handler());
+    auto base_uri = make_consumer_uri_base(rq, group_id);
+
+    auto req_data = co_await ppj::rjson_parse(
+      std::move(rq.req), ppj::create_consumer_request_handler());
 
     validate_no_control(
       req_data.name(), parse::pp_parsing_error{req_data.name()});
@@ -232,8 +231,6 @@ create_consumer(server::request_t rq, server::reply_t rp) {
         throw parse::error(
           parse::error_code::invalid_param, "auto.commit must be false");
     }
-
-    auto base_uri = make_consumer_uri_base(rq, group_id);
 
     co_return co_await rq.dispatch(
       group_id,
@@ -326,8 +323,8 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     auto member_id = parse::request_param<kafka::member_id>(
       *rq.req, "instance");
 
-    auto req_data = ppj::rjson_parse(
-      rq.req->content.data(), ppj::subscribe_consumer_request_handler());
+    auto req_data = co_await ppj::rjson_parse(
+      std::move(rq.req), ppj::subscribe_consumer_request_handler());
     std::for_each(
       req_data.topics.begin(),
       req_data.topics.end(),
@@ -416,8 +413,9 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto group_id{parse::request_param<kafka::group_id>(*rq.req, "group_name")};
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
 
-    auto req_data = ppj::partitions_request_to_offset_request(ppj::rjson_parse(
-      rq.req->content.data(), ppj::partitions_request_handler()));
+    auto req_data = ppj::partitions_request_to_offset_request(
+      co_await ppj::rjson_parse(
+        std::move(rq.req), ppj::partitions_request_handler()));
 
     std::for_each(req_data.begin(), req_data.end(), [](const auto& r) {
         validate_no_control(r.name(), parse::pp_parsing_error{r.name()});
@@ -461,8 +459,8 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto req_data = rq.req->content.length() == 0
                       ? std::vector<kafka::offset_commit_request_topic>()
                       : ppj::partition_offsets_request_to_offset_commit_request(
-                        ppj::rjson_parse(
-                          rq.req->content.data(),
+                        co_await ppj::rjson_parse(
+                          std::move(rq.req),
                           ppj::partition_offsets_request_handler()));
 
     std::for_each(req_data.begin(), req_data.end(), [](const auto& r) {

--- a/src/v/pandaproxy/rest/test/consumer_group.cc
+++ b/src/v/pandaproxy/rest/test/consumer_group.cc
@@ -84,7 +84,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
-        auto res_data = ppj::rjson_parse(
+        auto res_data = ppj::impl::rjson_parse(
           res.body.data(), ppj::create_consumer_response_handler());
         BOOST_REQUIRE_EQUAL(res_data.instance_id, "test_consumer");
         member_id = res_data.instance_id;
@@ -315,7 +315,7 @@ FIXTURE_TEST(
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
-        auto res_data = ppj::rjson_parse(
+        auto res_data = ppj::impl::rjson_parse(
           res.body.data(), ppj::create_consumer_response_handler());
         BOOST_REQUIRE_EQUAL(res_data.instance_id, "test_consumer");
         member_id = res_data.instance_id;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -85,8 +85,8 @@ get_config(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_compatibility();
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
     co_return rp;
 }
 
@@ -100,8 +100,7 @@ put_config(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_config(std::nullopt, config.compat);
 
-    auto json_rslt = ppj::rjson_serialize(config);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(config));
     co_return rp;
 }
 
@@ -120,8 +119,8 @@ get_config_subject(server::request_t rq, server::reply_t rp) {
     auto res = co_await rq.service().schema_store().get_compatibility(
       sub, fallback);
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
     co_return rp;
 }
 
@@ -169,8 +168,7 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_config(sub, config.compat);
 
-    auto json_rslt = ppj::rjson_serialize(config);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(config));
     co_return rp;
 }
 
@@ -199,8 +197,8 @@ delete_config_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_config(sub);
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = lvl});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = lvl}));
     co_return rp;
 }
 
@@ -213,8 +211,7 @@ ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_mode();
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
     co_return rp;
 }
 
@@ -228,8 +225,7 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
-    auto json_rslt = ppj::rjson_serialize(res);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(res));
     co_return rp;
 }
 
@@ -247,8 +243,7 @@ get_mode_subject(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_mode(sub, fallback);
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
     co_return rp;
 }
 
@@ -266,8 +261,7 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_mode(sub, res.mode, frc);
 
-    auto json_rslt = ppj::rjson_serialize(res);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(res));
     co_return rp;
 }
 
@@ -295,8 +289,7 @@ delete_mode_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_mode(sub);
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = m});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = m}));
     co_return rp;
 }
 
@@ -307,8 +300,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 
     static const std::vector<std::string_view> schemas_types{
       "JSON", "PROTOBUF", "AVRO"};
-    auto json_rslt = ppj::rjson_serialize(schemas_types);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(schemas_types));
     return ss::make_ready_future<server::reply_t>(std::move(rp));
 }
 
@@ -322,9 +314,10 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
         return rq.service().schema_store().get_schema_definition(id);
     });
 
-    auto json_rslt = ppj::rjson_serialize(
-      get_schemas_ids_id_response{.definition{std::move(def)}});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(
+        get_schemas_ids_id_response{.definition{std::move(def)}}));
     co_return rp;
 }
 
@@ -454,8 +447,7 @@ get_subject_versions(server::request_t rq, server::reply_t rp) {
     auto versions = co_await rq.service().schema_store().get_versions(
       sub, inc_del);
 
-    auto json_rslt{json::rjson_serialize(versions)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(versions));
     co_return rp;
 }
 
@@ -494,11 +486,12 @@ post_subject(server::request_t rq, server::reply_t rp) {
     auto sub_schema = co_await rq.service().schema_store().has_schema(
       schema, inc_del);
 
-    auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
-      .schema{std::move(sub_schema.schema)},
-      .id{sub_schema.id},
-      .version{sub_schema.version}})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_version_response{
+        .schema{std::move(sub_schema.schema)},
+        .id{sub_schema.id},
+        .version{sub_schema.version}}));
     co_return rp;
 }
 
@@ -534,9 +527,9 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
           std::move(schema));
     }
 
-    auto json_rslt{
-      json::rjson_serialize(post_subject_versions_response{.id{schema_id}})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_response{.id{schema_id}}));
     co_return rp;
 }
 
@@ -559,11 +552,12 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
           sub, version, inc_del);
     });
 
-    auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
-      .schema = std::move(get_res.schema),
-      .id = get_res.id,
-      .version = get_res.version})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_version_response{
+        .schema = std::move(get_res.schema),
+        .id = get_res.id,
+        .version = get_res.version}));
     co_return rp;
 }
 
@@ -603,8 +597,7 @@ get_subject_versions_version_referenced_by(
     auto references = co_await rq.service().schema_store().referenced_by(
       sub, version);
 
-    auto json_rslt{json::rjson_serialize(references)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(references));
     co_return rp;
 }
 
@@ -627,8 +620,7 @@ delete_subject(server::request_t rq, server::reply_t rp) {
             sub, std::nullopt)
           : co_await rq.service().writer().delete_subject_impermanent(sub);
 
-    auto json_rslt{json::rjson_serialize(versions)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(versions));
     co_return rp;
 }
 
@@ -675,8 +667,7 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
         co_await rq.service().writer().delete_subject_version(sub, version);
     }
 
-    auto json_rslt{json::rjson_serialize(version)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(version));
     co_return rp;
 }
 
@@ -716,9 +707,9 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
         return rq.service().schema_store().is_compatible(version, schema);
     });
 
-    auto json_rslt{
-      json::rjson_serialize(post_compatibility_res{.is_compat = get_res})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_compatibility_res{.is_compat = get_res}));
     co_return rp;
 }
 

--- a/src/v/pandaproxy/schema_registry/requests/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/requests/compatibility.h
@@ -20,8 +20,9 @@ struct post_compatibility_res {
     bool is_compat{false};
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w,
   const schema_registry::post_compatibility_res& res) {
     w.StartObject();
     w.Key("is_compatible");

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -82,18 +82,18 @@ public:
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::get_config_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::get_config_req_rep& res) {
     w.StartObject();
     w.Key(get_config_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.compat));
     w.EndObject();
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::put_config_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::put_config_req_rep& res) {
     w.StartObject();
     w.Key(put_config_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.compat));

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -20,9 +20,9 @@ struct get_schemas_ids_id_response {
     canonical_schema_definition definition;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const get_schemas_ids_id_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_schemas_ids_id_response& res) {
     w.StartObject();
     if (res.definition.type() != schema_type::avro) {
         w.Key("schemaType");

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
@@ -21,9 +21,9 @@ struct get_schemas_ids_id_versions_response {
     chunked_vector<subject_version> subject_versions;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const get_schemas_ids_id_versions_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_schemas_ids_id_versions_response& res) {
     w.StartArray();
     for (const auto& sv : res.subject_versions) {
         w.StartObject();

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -22,8 +22,9 @@ struct post_subject_versions_version_response {
     schema_version version;
 };
 
+template<typename Buffer>
 inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+  ::json::Writer<Buffer>& w,
   const post_subject_versions_version_response& res) {
     w.StartObject();
     w.Key("subject");

--- a/src/v/pandaproxy/schema_registry/requests/mode.h
+++ b/src/v/pandaproxy/schema_registry/requests/mode.h
@@ -77,9 +77,9 @@ public:
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_req_rep& res) {
     w.StartObject();
     w.Key(mode_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.mode));

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -241,8 +241,9 @@ struct post_subject_versions_response {
     schema_id id;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w,
   const schema_registry::post_subject_versions_response& res) {
     w.StartObject();
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -48,7 +48,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
   "schema": ")"
       + escaped_schema_def + R"("})"};
 
-    auto result{ppj::rjson_serialize(response)};
+    auto result = ppj::rjson_serialize_str(response);
 
     BOOST_REQUIRE_EQUAL(::json::minify(expected), result);
 }

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -52,7 +52,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
     const parse_result expected{
       {sub, expected_schema_def}, std::nullopt, std::nullopt};
 
-    auto result{ppj::rjson_parse(
+    auto result{ppj::impl::rjson_parse(
       payload.data(), pps::post_subject_versions_request_handler{sub})};
 
     // canonicalisation now requires a sharded_store, for now, minify.

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -161,9 +161,9 @@ struct schema_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::schema_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::schema_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -324,9 +324,8 @@ struct schema_value {
 using unparsed_schema_value = schema_value<unparsed_schema_defnition_tag>;
 using canonical_schema_value = schema_value<canonical_schema_definition_tag>;
 
-template<typename Tag>
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const schema_value<Tag>& val) {
+template<typename Buffer, typename Tag>
+void rjson_serialize(::json::Writer<Buffer>& w, const schema_value<Tag>& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.schema.sub());
@@ -645,9 +644,9 @@ struct config_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::config_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::config_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -783,9 +782,9 @@ struct config_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::config_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::config_value& val) {
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
@@ -881,9 +880,9 @@ struct mode_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -1019,9 +1018,9 @@ struct mode_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_value& val) {
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
@@ -1118,8 +1117,8 @@ struct delete_subject_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const delete_subject_key& key) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const delete_subject_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -1259,8 +1258,9 @@ struct delete_subject_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const delete_subject_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const delete_subject_value& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.sub);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -14,7 +14,6 @@
 #include "base/vlog.h"
 #include "bytes/iobuf_parser.h"
 #include "json/json.h"
-#include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
 #include "model/metadata.h"
@@ -1354,11 +1353,8 @@ auto from_json_iobuf(iobuf&& iobuf, Args&&... args) {
 }
 
 template<typename T>
-auto to_json_iobuf(T t) {
-    auto val_js = json::rjson_serialize(t);
-    iobuf buf;
-    buf.append(val_js.data(), val_js.size());
-    return buf;
+auto to_json_iobuf(T&& t) {
+    return json::rjson_serialize_iobuf(std::forward<T>(t));
 }
 
 template<typename Key, typename Value>

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1347,9 +1347,8 @@ public:
 
 template<typename Handler, typename... Args>
 auto from_json_iobuf(iobuf&& iobuf, Args&&... args) {
-    auto p = iobuf_parser(std::move(iobuf));
-    auto str = p.read_string(p.bytes_left());
-    return json::rjson_parse(str.data(), Handler{std::forward<Args>(args)...});
+    return json::rjson_parse(
+      std::move(iobuf), Handler{std::forward<Args>(args)...});
 }
 
 template<typename T>

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -566,7 +566,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post company schema (expect schema_id=1)");
     auto res = post_schema(
-      client, company_req.schema.sub(), ppj::rjson_serialize(company_req));
+      client, company_req.schema.sub(), ppj::rjson_serialize_str(company_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),
@@ -574,7 +574,9 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post employee schema (expect schema_id=2)");
     res = post_schema(
-      client, employee_req.schema.sub(), ppj::rjson_serialize(employee_req));
+      client,
+      employee_req.schema.sub(),
+      ppj::rjson_serialize_str(employee_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -8,15 +8,12 @@
 // by the Apache License, Version 2.0
 
 #include "pandaproxy/error.h"
-#include "pandaproxy/json/error.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/test/avro_payloads.h"
 #include "pandaproxy/schema_registry/test/client_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
-
-#include <array>
 
 namespace pp = pandaproxy;
 namespace ppj = pp::json;

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -26,8 +26,8 @@ struct request {
     pps::canonical_schema schema;
 };
 
-void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const request& r) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const request& r) {
     w.StartObject();
     w.Key("schema");
     ::json::rjson_serialize(w, r.schema.def().raw());

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           avro_schema_key_sv.data(), pps::schema_key_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_key, key);
 
-        auto str = ppj::rjson_serialize(avro_schema_key);
+        auto str = ppj::rjson_serialize_str(avro_schema_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_key_sv));
     }
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
-        auto str = ppj::rjson_serialize(avro_schema_value);
+        auto str = ppj::rjson_serialize_str(avro_schema_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_value_sv));
     }
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_key_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key, val);
 
-        auto str = ppj::rjson_serialize(config_key);
+        auto str = ppj::rjson_serialize_str(config_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sv));
     }
 
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_key_sub_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key_sub, val);
 
-        auto str = ppj::rjson_serialize(config_key_sub);
+        auto str = ppj::rjson_serialize_str(config_key_sub);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sub_sv));
     }
 
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_value_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value, val);
 
-        auto str = ppj::rjson_serialize(config_value);
+        auto str = ppj::rjson_serialize_str(config_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sv));
     }
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_value_sub_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value_sub, val);
 
-        auto str = ppj::rjson_serialize(config_value_sub);
+        auto str = ppj::rjson_serialize_str(config_value_sub);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sub_sv));
     }
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           delete_subject_key_sv.data(), pps::delete_subject_key_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_key, val);
 
-        auto str = ppj::rjson_serialize(delete_subject_key);
+        auto str = ppj::rjson_serialize_str(delete_subject_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_key_sv));
     }
 
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           pps::delete_subject_value_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_value, val);
 
-        auto str = ppj::rjson_serialize(delete_subject_value);
+        auto str = ppj::rjson_serialize_str(delete_subject_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_value_sv));
     }
 }

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -127,7 +127,7 @@ const pps::delete_subject_value delete_subject_value{
 
 BOOST_AUTO_TEST_CASE(test_storage_serde) {
     {
-        auto key = ppj::rjson_parse(
+        auto key = ppj::impl::rjson_parse(
           avro_schema_key_sv.data(), pps::schema_key_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_key, key);
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_key_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key, val);
 
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_key_sub_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key_sub, val);
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_value_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value, val);
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_value_sub_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value_sub, val);
 
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           delete_subject_key_sv.data(), pps::delete_subject_key_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_key, val);
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           delete_subject_value_sv.data(),
           pps::delete_subject_value_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_value, val);

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -154,6 +154,7 @@ server::server(
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
+    _server.set_content_streaming(true);
 }
 
 /*


### PR DESCRIPTION
Replace use of `::json::StringStream` with a custom stream based on `iobuf` to avoid large contiguous allocations.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* HTTP Proxy: Avoid large allocations during JSON serde of requests and responses
* Schema Registry: Avoid large allocations during JSON serde of requests and responses
