### PR TITLE
model/x: Fix typo in legacy offset_options envelope template

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -118,7 +118,7 @@ operator<<(std::ostream& os, const transform_offset_options& opts) {
  */
 struct legacy_transform_offset_options
   : serde::envelope<
-      transform_offset_options,
+      legacy_transform_offset_options,
       serde::version<0>,
       serde::compat_version<0>> {
     serde::variant<transform_offset_options::latest_offset, model::timestamp>


### PR DESCRIPTION
s/transform_offset_options/legacy_transform_offset_options/

Also adds unit tests to try prove out the theory of selectively writing out older versions of the serde::variant. Works as expected.

Also worth noting that this works regardless of the serde::envelope CRTP param fixed by this diff...perhaps that's due to the narrow scope of the legacy struct - only ever being written out explicitly in transform_metadata::serde_write.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->