### PR TITLE
cloud_storage: use `topic_namespace_override` in `remote_path_provider`

### DIFF
--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -644,7 +644,8 @@ archival_metadata_stm::archival_metadata_stm(
   cloud_storage::remote& remote,
   features::feature_table& ft,
   ss::logger& logger,
-  std::optional<cloud_storage::remote_label> remote_label)
+  std::optional<cloud_storage::remote_label> remote_label,
+  std::optional<model::topic_namespace> topic_namespace_override)
   : raft::persisted_stm<>(archival_stm_snapshot, logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
   , _mem_tracker(ss::make_shared<util::mem_tracker>(raft->ntp().path()))
@@ -652,7 +653,7 @@ archival_metadata_stm::archival_metadata_stm(
       raft->ntp(), raft->log_config().get_initial_revision(), _mem_tracker))
   , _cloud_storage_api(remote)
   , _feature_table(ft)
-  , _remote_path_provider(remote_label, std::nullopt) {}
+  , _remote_path_provider(remote_label, topic_namespace_override) {}
 
 ss::future<std::error_code> archival_metadata_stm::truncate(
   model::offset start_rp_offset,
@@ -1716,12 +1717,18 @@ void archival_metadata_stm_factory::create(
       = topic_md.has_value()
           ? topic_md->get().get_configuration().properties.remote_label
           : std::nullopt;
+    auto topic_namespace_override = topic_md.has_value()
+                                      ? topic_md->get()
+                                          .get_configuration()
+                                          .properties.topic_namespace_override
+                                      : std::nullopt;
     auto stm = builder.create_stm<cluster::archival_metadata_stm>(
       raft,
       _cloud_storage_api.local(),
       _feature_table.local(),
       clusterlog,
-      remote_label);
+      remote_label,
+      topic_namespace_override);
     raft->log()->stm_manager()->add_stm(stm);
 }
 

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -652,7 +652,7 @@ archival_metadata_stm::archival_metadata_stm(
       raft->ntp(), raft->log_config().get_initial_revision(), _mem_tracker))
   , _cloud_storage_api(remote)
   , _feature_table(ft)
-  , _remote_path_provider({remote_label}) {}
+  , _remote_path_provider(remote_label, std::nullopt) {}
 
 ss::future<std::error_code> archival_metadata_stm::truncate(
   model::offset start_rp_offset,

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -136,7 +136,8 @@ public:
       cloud_storage::remote& remote,
       features::feature_table&,
       ss::logger& logger,
-      std::optional<cloud_storage::remote_label>);
+      std::optional<cloud_storage::remote_label>,
+      std::optional<model::topic_namespace>);
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.

--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -400,7 +400,7 @@ ss::future<housekeeping_job::run_result> purger::run(run_quota_t quota) {
 
         cloud_storage::remote_path_provider path_provider(
           marker.config.properties.remote_label,
-          marker.config.properties.topic_namespace_override);
+          marker.config.properties.remote_topic_namespace_override);
         if (my_global_position.self == hash % my_global_position.total) {
             vlog(
               archival_log.info,

--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -399,7 +399,7 @@ ss::future<housekeeping_job::run_result> purger::run(run_quota_t quota) {
         uint32_t hash = static_cast<uint32_t>(inc_hash.digest() & 0xffffffff);
 
         cloud_storage::remote_path_provider path_provider(
-          marker.config.properties.remote_label);
+          marker.config.properties.remote_label, std::nullopt);
         if (my_global_position.self == hash % my_global_position.total) {
             vlog(
               archival_log.info,

--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -399,7 +399,8 @@ ss::future<housekeeping_job::run_result> purger::run(run_quota_t quota) {
         uint32_t hash = static_cast<uint32_t>(inc_hash.digest() & 0xffffffff);
 
         cloud_storage::remote_path_provider path_provider(
-          marker.config.properties.remote_label, std::nullopt);
+          marker.config.properties.remote_label,
+          marker.config.properties.topic_namespace_override);
         if (my_global_position.self == hash % my_global_position.total) {
             vlog(
               archival_log.info,

--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -103,6 +103,7 @@ public:
               stm_node.remote.local(),
               node->get_feature_table().local(),
               fixture_logger,
+              std::nullopt,
               std::nullopt);
 
             stm_node.archival_stm = std::move(stm);

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -144,6 +144,7 @@ struct archival_metadata_stm_fixture : archival_metadata_stm_base_fixture {
           cloud_api.local(),
           feature_table.local(),
           logger,
+          std::nullopt,
           std::nullopt);
 
         _raft->start(std::move(builder)).get();
@@ -359,6 +360,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
       cloud_api.local(),
       feature_table.local(),
       logger,
+      std::nullopt,
       std::nullopt);
     _raft->start(std::move(builder)).get();
     _started = true;
@@ -458,6 +460,7 @@ FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
       cloud_api.local(),
       feature_table.local(),
       logger,
+      std::nullopt,
       std::nullopt);
 
     _raft->start(std::move(builder)).get();
@@ -671,7 +674,9 @@ FIXTURE_TEST(
       cloud_api.local(),
       feature_table.local(),
       logger,
+      std::nullopt,
       std::nullopt);
+
     _raft->start(std::move(builder)).get();
     _started = true;
     wait_for_confirmed_leader();

--- a/src/v/archival/tests/archiver_operations_impl_gtest.cc
+++ b/src/v/archival/tests/archiver_operations_impl_gtest.cc
@@ -57,7 +57,8 @@
 inline ss::logger test_log("arch_op_impl_test");
 
 namespace {
-cloud_storage::remote_path_provider null_path_provider(std::nullopt);
+cloud_storage::remote_path_provider
+  null_path_provider(std::nullopt, std::nullopt);
 const model::ktp
   expected_ntp(model::topic("panda-topic"), model::partition_id(137));
 const model::initial_revision_id expected_revision_id(42);

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -26,7 +26,7 @@ using namespace archival;
 inline ss::logger test_log("test");
 
 namespace {
-cloud_storage::remote_path_provider path_provider(std::nullopt);
+cloud_storage::remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // anonymous namespace
 
 static const auto manifest_namespace = model::ns("kafka");

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -52,7 +52,7 @@ using namespace archival;
 inline ss::logger test_log("test"); // NOLINT
 
 namespace {
-cloud_storage::remote_path_provider path_provider(std::nullopt);
+cloud_storage::remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // anonymous namespace
 
 static ss::abort_source never_abort;

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -28,7 +28,8 @@
 using namespace archival;
 
 namespace {
-static const cloud_storage::remote_path_provider path_provider(std::nullopt);
+static const cloud_storage::remote_path_provider
+  path_provider(std::nullopt, std::nullopt);
 } // anonymous namespace
 
 inline ss::logger test_log("test");

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -49,7 +49,7 @@
 namespace archival {
 
 namespace {
-cloud_storage::remote_path_provider path_provider(std::nullopt);
+cloud_storage::remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // namespace
 
 using namespace std::chrono_literals;

--- a/src/v/cloud_storage/remote_path_provider.cc
+++ b/src/v/cloud_storage/remote_path_provider.cc
@@ -19,11 +19,14 @@
 
 namespace cloud_storage {
 
-remote_path_provider::remote_path_provider(std::optional<remote_label> label)
-  : label_(label) {}
+remote_path_provider::remote_path_provider(
+  std::optional<remote_label> label,
+  std::optional<model::topic_namespace> topic_namespace_override)
+  : label_(label)
+  , _topic_namespace_override(topic_namespace_override) {}
 
 remote_path_provider remote_path_provider::copy() const {
-    remote_path_provider ret(label_);
+    remote_path_provider ret(label_, _topic_namespace_override);
     return ret;
 }
 

--- a/src/v/cloud_storage/remote_path_provider.h
+++ b/src/v/cloud_storage/remote_path_provider.h
@@ -29,7 +29,9 @@ public:
     remote_path_provider& operator=(remote_path_provider&&) = delete;
     ~remote_path_provider() = default;
 
-    explicit remote_path_provider(std::optional<remote_label> label);
+    explicit remote_path_provider(
+      std::optional<remote_label> label,
+      std::optional<model::topic_namespace> topic_namespace_override);
 
     // An explicit copy method. Callers should think twice about using this and
     // instead consider if there is an existing path provider that makes sense
@@ -95,6 +97,7 @@ public:
 
 private:
     std::optional<remote_label> label_;
+    std::optional<model::topic_namespace> _topic_namespace_override;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -53,7 +53,6 @@ rp_test(
     remote_segment_test.cc
     remote_partition_test.cc
     topic_recovery_service_test.cc
-    cloud_storage_e2e_test.cc
     delete_records_e2e_test.cc
     async_manifest_view_test.cc
     read_replica_test.cc
@@ -79,6 +78,7 @@ rp_test(
   TIMEOUT 1000
   BINARY_NAME gtest_cloud_storage
   SOURCES
+    cloud_storage_e2e_test.cc
     partition_manifest_downloader_test.cc
     remote_path_provider_test.cc
     remote_test.cc

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ rp_test(
     remote_test.cc
     s3_imposter.cc
     topic_manifest_downloader_test.cc
+    topic_namespace_override_recovery_test.cc
     util.cc
   LIBRARIES
     v::gtest_main

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -44,7 +44,7 @@ bool operator==(const anomalies& lhs, const anomalies& rhs) {
 
 namespace {
 
-cloud_storage::remote_path_provider path_provider(std::nullopt);
+cloud_storage::remote_path_provider path_provider(std::nullopt, std::nullopt);
 
 ss::logger test_logger{"anomaly_detection_test"};
 

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -43,7 +43,7 @@ using eof = async_manifest_view_cursor::eof;
 
 static ss::logger test_log("async_manifest_view_log");
 static const model::initial_revision_id manifest_rev(111);
-static const remote_path_provider path_provider(std::nullopt);
+static const remote_path_provider path_provider(std::nullopt, std::nullopt);
 
 class set_config_mixin {
 public:

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -69,7 +69,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     props.shadow_indexing = model::shadow_indexing_mode::full;
     if (GetParam()) {
         // Override topic_namespace.
-        props.topic_namespace_override = model::topic_namespace(
+        props.remote_topic_namespace_override = model::topic_namespace(
           model::kafka_namespace, model::topic("cassava"));
     }
     props.retention_local_target_bytes = tristate<size_t>(1);
@@ -140,7 +140,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
     props.shadow_indexing = model::shadow_indexing_mode::full;
     if (GetParam()) {
         // Override topic_namespace.
-        props.topic_namespace_override = model::topic_namespace(
+        props.remote_topic_namespace_override = model::topic_namespace(
           model::kafka_namespace, model::topic("cassava"));
     }
     props.retention_local_target_bytes = tristate<size_t>(1);
@@ -395,7 +395,7 @@ public:
         props.shadow_indexing = model::shadow_indexing_mode::full;
         if (GetParam()) {
             // Override topic_namespace.
-            props.topic_namespace_override = model::topic_namespace(
+            props.remote_topic_namespace_override = model::topic_namespace(
               model::kafka_namespace, model::topic("cassava"));
         }
         props.retention_local_target_bytes = tristate<size_t>(1);
@@ -772,7 +772,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     props.shadow_indexing = model::shadow_indexing_mode::full;
     if (GetParam()) {
         // Override topic_namespace.
-        props.topic_namespace_override = model::topic_namespace(
+        props.remote_topic_namespace_override = model::topic_namespace(
           model::kafka_namespace, model::topic("cassava"));
     }
 
@@ -867,7 +867,7 @@ TEST_P(EndToEndFixture, TestMixedTimequery) {
     props.shadow_indexing = model::shadow_indexing_mode::full;
     if (GetParam()) {
         // Override topic_namespace.
-        props.topic_namespace_override = model::topic_namespace(
+        props.remote_topic_namespace_override = model::topic_namespace(
           model::kafka_namespace, model::topic("cassava"));
     }
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -21,6 +21,8 @@
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/ntp_config.h"
@@ -29,7 +31,7 @@
 
 #include <seastar/core/io_priority_class.hh>
 
-#include <boost/algorithm/string/predicate.hpp>
+#include <gtest/gtest.h>
 
 #include <iterator>
 
@@ -39,13 +41,14 @@ using tests::kv_t;
 
 static ss::logger e2e_test_log("e2e_test");
 
-class e2e_fixture
+class EndToEndFixture
   : public s3_imposter_fixture
   , public manual_metadata_upload_mixin
   , public redpanda_thread_fixture
-  , public enable_cloud_storage_fixture {
+  , public enable_cloud_storage_fixture
+  , public ::testing::TestWithParam<bool> {
 public:
-    e2e_fixture()
+    EndToEndFixture()
       : redpanda_thread_fixture(
         redpanda_thread_fixture::init_cloud_storage_tag{},
         httpd_port_number()) {
@@ -57,13 +60,18 @@ public:
     scoped_config test_local_cfg;
 };
 
-FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
+TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
       .set_value(true);
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    if (GetParam()) {
+        // Override topic_namespace.
+        props.topic_namespace_override = model::topic_namespace(
+          model::kafka_namespace, model::topic("cassava"));
+    }
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -73,12 +81,12 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
-    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    ASSERT_TRUE(archiver.sync_for_tests().get());
 
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
-    BOOST_REQUIRE_EQUAL(3, gen.records_per_batch(3).produce().get());
-    BOOST_REQUIRE_EQUAL(2, log->segments().size());
-    BOOST_REQUIRE_EQUAL(1, archiver.manifest().size());
+    ASSERT_EQ(3, gen.records_per_batch(3).produce().get());
+    ASSERT_EQ(2, log->segments().size());
+    ASSERT_EQ(1, archiver.manifest().size());
 
     // Compact the local log to GC to the collectible offset.
     ss::abort_source as;
@@ -113,7 +121,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud, e2e_fixture) {
     }
 }
 
-FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
+TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
 #ifndef _NDEBUG
     test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
       .set_value(true);
@@ -128,8 +136,13 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, 0);
     cluster::topic_properties props;
-    BOOST_REQUIRE(props.is_compacted() == false);
+    ASSERT_TRUE(props.is_compacted() == false);
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    if (GetParam()) {
+        // Override topic_namespace.
+        props.topic_namespace_override = model::topic_namespace(
+          model::kafka_namespace, model::topic("cassava"));
+    }
     props.retention_local_target_bytes = tristate<size_t>(1);
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
     wait_for_leader(ntp).get();
@@ -139,7 +152,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto archiver_ref = partition->archiver();
-    BOOST_REQUIRE(archiver_ref.has_value());
+    ASSERT_TRUE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
 
     kafka_produce_transport producer(make_kafka_client().get());
@@ -167,10 +180,10 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
         log->flush().get();
         log->force_roll(ss::default_priority_class()).get();
 
-        BOOST_REQUIRE(archiver.sync_for_tests().get());
+        ASSERT_TRUE(archiver.sync_for_tests().get());
         archiver.upload_next_candidates().get();
     }
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       cloud_storage::upload_result::success,
       archiver.upload_manifest("test").get());
     archiver.flush_manifest_clean_offset().get();
@@ -189,7 +202,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
 
     // This should upload several spillover manifests and apply changes to the
     // archival metadata STM.
-    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    ASSERT_TRUE(archiver.sync_for_tests().get());
     archiver.apply_spillover().get();
 
     const auto& local_manifest = partition->archival_meta_stm()->manifest();
@@ -227,7 +240,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
             // Skip topic manifests manifest
             continue;
         }
-        BOOST_REQUIRE_EQUAL(req.method, "PUT");
+        ASSERT_EQ(req.method, "PUT");
         cloud_storage::partition_manifest spm(
           partition->get_ntp_config().ntp(),
           partition->get_ntp_config().get_initial_revision());
@@ -250,20 +263,20 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
         spillover_manifests.insert(std::make_pair(spm_so, std::move(spm)));
     }
 
-    BOOST_REQUIRE(spillover_manifests.size() != 0);
+    ASSERT_TRUE(spillover_manifests.size() != 0);
     const auto& last = spillover_manifests.rbegin()->second;
     const auto& first = spillover_manifests.begin()->second;
 
-    BOOST_REQUIRE(model::next_offset(last.get_last_offset()) == so);
-    BOOST_REQUIRE(first.get_start_offset().has_value());
-    BOOST_REQUIRE(first.get_start_offset().value() == archive_so);
-    BOOST_REQUIRE(first.get_start_kafka_offset().has_value());
-    BOOST_REQUIRE(first.get_start_kafka_offset().value() == archive_ko);
+    ASSERT_TRUE(model::next_offset(last.get_last_offset()) == so);
+    ASSERT_TRUE(first.get_start_offset().has_value());
+    ASSERT_TRUE(first.get_start_offset().value() == archive_so);
+    ASSERT_TRUE(first.get_start_kafka_offset().has_value());
+    ASSERT_TRUE(first.get_start_kafka_offset().value() == archive_ko);
 
     model::offset expected_so = archive_so;
     for (const auto& [key, m] : spillover_manifests) {
         std::ignore = key;
-        BOOST_REQUIRE(m.get_start_offset().value() == expected_so);
+        ASSERT_TRUE(m.get_start_offset().value() == expected_so);
         expected_so = model::next_offset(m.get_last_offset());
     }
 
@@ -285,13 +298,13 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
         next_offset += model::offset((int64_t)tmp.size());
     }
 
-    BOOST_REQUIRE_EQUAL(total_records, consumed_records.size());
+    ASSERT_EQ(total_records, consumed_records.size());
     int i = 0;
     for (const auto& rec : consumed_records) {
         auto expected_key = ssx::sformat("key{}", i);
         auto expected_val = ssx::sformat("val{}", i);
-        BOOST_REQUIRE_EQUAL(rec.key, expected_key);
-        BOOST_REQUIRE_EQUAL(rec.val, expected_val);
+        ASSERT_EQ(rec.key, expected_key);
+        ASSERT_EQ(rec.val, expected_val);
         i++;
     }
 
@@ -331,25 +344,26 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
           last_offset);
     }
 
-    BOOST_REQUIRE_EQUAL(total_records - new_so, consumed_records.size());
+    ASSERT_EQ(total_records - new_so, consumed_records.size());
     i = new_so;
     for (const auto& rec : consumed_records) {
         auto expected_key = ssx::sformat("key{}", i);
         auto expected_val = ssx::sformat("val{}", i);
-        BOOST_REQUIRE_EQUAL(rec.key, expected_key);
-        BOOST_REQUIRE_EQUAL(rec.val, expected_val);
+        ASSERT_EQ(rec.key, expected_key);
+        ASSERT_EQ(rec.val, expected_val);
         i++;
     }
 #endif
 }
 
-class cloud_storage_manual_e2e_test
+class CloudStorageEndToEndManualTest
   : public s3_imposter_fixture
   , public redpanda_thread_fixture
-  , public enable_cloud_storage_fixture {
+  , public enable_cloud_storage_fixture
+  , public ::testing::TestWithParam<bool> {
 public:
     static constexpr auto segs_per_spill = 10;
-    cloud_storage_manual_e2e_test()
+    CloudStorageEndToEndManualTest()
       : redpanda_thread_fixture(
         redpanda_thread_fixture::init_cloud_storage_tag{},
         httpd_port_number()) {
@@ -379,6 +393,11 @@ public:
         // Create a tiered storage topic with very little local retention.
         cluster::topic_properties props;
         props.shadow_indexing = model::shadow_indexing_mode::full;
+        if (GetParam()) {
+            // Override topic_namespace.
+            props.topic_namespace_override = model::topic_namespace(
+              model::kafka_namespace, model::topic("cassava"));
+        }
         props.retention_local_target_bytes = tristate<size_t>(1);
         props.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::deletion;
@@ -429,7 +448,7 @@ ss::future<bool> check_consume_from_beginning(
 
 } // namespace
 
-FIXTURE_TEST(test_consume_during_spillover, cloud_storage_manual_e2e_test) {
+TEST_P(CloudStorageEndToEndManualTest, TestConsumeDuringSpillover) {
     test_local_cfg.get("fetch_max_bytes").set_value(size_t{10});
     const auto records_per_seg = 5;
     const auto num_segs = 40;
@@ -438,7 +457,7 @@ FIXTURE_TEST(test_consume_during_spillover, cloud_storage_manual_e2e_test) {
                            .batches_per_segment(records_per_seg)
                            .produce()
                            .get();
-    BOOST_REQUIRE_GE(total_records, 200);
+    ASSERT_GE(total_records, 200);
 
     ss::gate g;
 
@@ -463,10 +482,9 @@ FIXTURE_TEST(test_consume_during_spillover, cloud_storage_manual_e2e_test) {
     });
 
     auto start_before_spill = archiver->manifest().get_start_offset();
-    BOOST_REQUIRE(archiver->sync_for_tests().get());
+    ASSERT_TRUE(archiver->sync_for_tests().get());
     archiver->apply_spillover().get();
-    BOOST_REQUIRE_NE(
-      start_before_spill, archiver->manifest().get_start_offset());
+    ASSERT_NE(start_before_spill, archiver->manifest().get_start_offset());
 
     g.close().get();
     for (auto& check : checks) {
@@ -478,7 +496,7 @@ FIXTURE_TEST(test_consume_during_spillover, cloud_storage_manual_e2e_test) {
 // Regression test for #15042, where a timequery could land below the archive
 // start offset and throw due to a NotFound error, ultimately resulting in a
 // consumer hang.
-FIXTURE_TEST(test_timequery_after_archival_gc, cloud_storage_manual_e2e_test) {
+TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
     const auto records_per_seg = 5;
     const auto num_segs = 40;
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
@@ -487,7 +505,7 @@ FIXTURE_TEST(test_timequery_after_archival_gc, cloud_storage_manual_e2e_test) {
                            .batch_time_delta_ms(10)
                            .produce()
                            .get();
-    BOOST_REQUIRE_GE(total_records, 200);
+    ASSERT_GE(total_records, 200);
 
     // Run local housekeeping with aggressive GC and wait for eviction to
     // ensure subsequent queries hit tiered storage.
@@ -501,7 +519,7 @@ FIXTURE_TEST(test_timequery_after_archival_gc, cloud_storage_manual_e2e_test) {
     partition->log()->housekeeping(housekeeping_conf).get();
     RPTEST_REQUIRE_EVENTUALLY(
       10s, [log = partition->log()] { return log->segments().size() == 1; });
-    BOOST_REQUIRE_GT(partition->raft_start_offset(), model::offset{0});
+    ASSERT_GT(partition->raft_start_offset(), model::offset{0});
 
     // Remove exactly one segment, so a portion of a manifest can be removed
     // when we housekeeping on the spillover region.
@@ -510,30 +528,28 @@ FIXTURE_TEST(test_timequery_after_archival_gc, cloud_storage_manual_e2e_test) {
       = *archiver->manifest().first_addressable_segment();
     auto size_without_first_seg = archiver->manifest().cloud_log_size()
                                   - first_seg.size_bytes;
-    BOOST_REQUIRE_GT(size_without_first_seg, 0);
+    ASSERT_GT(size_without_first_seg, 0);
 
     // Spillover.
-    BOOST_REQUIRE(archiver->sync_for_tests().get());
+    ASSERT_TRUE(archiver->sync_for_tests().get());
     archiver->apply_spillover().get();
-    BOOST_REQUIRE_NE(
-      start_before_spill, archiver->manifest().get_start_offset());
+    ASSERT_NE(start_before_spill, archiver->manifest().get_start_offset());
 
     // Set up retention such that exactly one segment is removed, from the
     // beginning of the archival region.
     test_local_cfg.get("retention_bytes")
       .set_value(std::make_optional<size_t>(size_without_first_seg));
     archiver->housekeeping().get();
-    BOOST_REQUIRE_EQUAL(
-      archiver->manifest().cloud_log_size(), size_without_first_seg);
+    ASSERT_EQ(archiver->manifest().cloud_log_size(), size_without_first_seg);
     auto new_start_offset = model::next_offset(first_seg.committed_offset);
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       archiver->manifest().get_archive_clean_offset(), new_start_offset);
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       archiver->manifest().get_archive_start_offset(), new_start_offset);
 
     // Sanity check: we should still have the removed segment in our spillover
     // manifest, even if it's been removed.
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       archiver->manifest().get_spillover_map().begin()->base_offset,
       first_seg.base_offset);
 
@@ -553,14 +569,16 @@ FIXTURE_TEST(test_timequery_after_archival_gc, cloud_storage_manual_e2e_test) {
                     .list_offset_for_partition(
                       topic_name, model::partition_id(0), first_seg_base_ts)
                     .get();
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       model::offset_cast(offset),
       kafka::next_offset(first_seg.last_kafka_offset()));
 }
 
-FIXTURE_TEST(
-  reclaimable_reported_in_health_report,
-  cloud_storage_manual_multinode_test_base) {
+class CloudStorageManualMultiNodeTestBase
+  : public cloud_storage_manual_multinode_test_base
+  , public ::testing::Test {};
+
+TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
     test_local_cfg.get("retention_local_trim_interval")
       .set_value(std::chrono::milliseconds(2000));
 
@@ -661,7 +679,7 @@ FIXTURE_TEST(
 
         auto sizes = get_reclaimable();
         if (sizes.has_value()) {
-            BOOST_REQUIRE(!sizes->empty());
+            ASSERT_TRUE(!sizes->empty());
             if (std::all_of(sizes->begin(), sizes->end(), [](size_t s) {
                     return s > 0;
                 })) {
@@ -671,17 +689,16 @@ FIXTURE_TEST(
     }
 
     // health report never reported non-zero reclaimable sizes. bummer!
-    BOOST_REQUIRE(false);
+    ASSERT_TRUE(false);
 }
 
-FIXTURE_TEST(test_local_timequery, e2e_fixture) {
+TEST_F(EndToEndFixture, TestLocalTimequery) {
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
 
     // Force local timequeries only through archival mode.
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::archival;
-
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
 
     wait_for_leader(ntp).get();
@@ -689,7 +706,7 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
-    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    ASSERT_TRUE(archiver.sync_for_tests().get());
 
     const auto batches_per_segment = 1;
     const auto num_segs = 5;
@@ -702,7 +719,7 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
                            .batch_time_delta_ms(batch_time_delta_ms)
                            .produce()
                            .get();
-    BOOST_REQUIRE_EQUAL(total_records, 5);
+    ASSERT_EQ(total_records, 5);
 
     auto make_and_verify_timequery =
       [partition](
@@ -716,10 +733,10 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
           auto result = partition->timequery(timequery_conf).get();
 
           if (expect_value) {
-              BOOST_REQUIRE(result.has_value());
-              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+              ASSERT_TRUE(result.has_value());
+              ASSERT_EQ(result.value().offset, expected_o.value());
           } else {
-              BOOST_REQUIRE(!result.has_value());
+              ASSERT_TRUE(!result.has_value());
           }
       };
 
@@ -746,13 +763,19 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
       false);
 }
 
-FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
+TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
 
     // Allow cloud storage timequeries with full shadow indexing mode.
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
+    if (GetParam()) {
+        // Override topic_namespace.
+        props.topic_namespace_override = model::topic_namespace(
+          model::kafka_namespace, model::topic("cassava"));
+    }
+
     props.retention_local_target_bytes = tristate<size_t>(0);
 
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
@@ -762,7 +785,7 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
-    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    ASSERT_TRUE(archiver.sync_for_tests().get());
 
     const auto batches_per_segment = 1;
     const auto num_segs = 5;
@@ -775,7 +798,7 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
                            .batch_time_delta_ms(batch_time_delta_ms)
                            .produce()
                            .get();
-    BOOST_REQUIRE_EQUAL(total_records, 5);
+    ASSERT_EQ(total_records, 5);
 
     // Force garbage collection of all local records, so that timequeries must
     // go through cloud storage.
@@ -803,10 +826,10 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
           auto result = partition->timequery(timequery_conf).get();
 
           if (expect_value) {
-              BOOST_REQUIRE(result.has_value());
-              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+              ASSERT_TRUE(result.has_value());
+              ASSERT_EQ(result.value().offset, expected_o.value());
           } else {
-              BOOST_REQUIRE(!result.has_value());
+              ASSERT_TRUE(!result.has_value());
           }
       };
 
@@ -835,14 +858,18 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
       false);
 }
 
-FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
+TEST_P(EndToEndFixture, TestMixedTimequery) {
     const model::topic topic_name("tapioca");
     model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
 
     // Enable full shadow indexing for now.
     cluster::topic_properties props;
     props.shadow_indexing = model::shadow_indexing_mode::full;
-
+    if (GetParam()) {
+        // Override topic_namespace.
+        props.topic_namespace_override = model::topic_namespace(
+          model::kafka_namespace, model::topic("cassava"));
+    }
     add_topic({model::kafka_namespace, topic_name}, 1, props).get();
 
     wait_for_leader(ntp).get();
@@ -850,7 +877,7 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
-    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    ASSERT_TRUE(archiver.sync_for_tests().get());
 
     // Generate batches [0, 10, 20, ..., 100]
     const auto num_segs = 11;
@@ -863,10 +890,10 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
                            .batch_time_delta_ms(batch_time_delta_ms)
                            .produce()
                            .get();
-    BOOST_REQUIRE_EQUAL(total_records, 11);
+    ASSERT_EQ(total_records, 11);
 
     const auto base_timestamp = log->start_timestamp();
-    BOOST_REQUIRE_EQUAL(base_timestamp, model::timestamp{0});
+    ASSERT_EQ(base_timestamp, model::timestamp{0});
 
     const auto num_segments_to_keep = 2;
     const auto upper_timestamp = base_timestamp()
@@ -909,10 +936,10 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
           auto result = partition->timequery(timequery_conf).get();
 
           if (expect_value) {
-              BOOST_REQUIRE(result.has_value());
-              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+              ASSERT_TRUE(result.has_value());
+              ASSERT_EQ(result.value().offset, expected_o.value());
           } else {
-              BOOST_REQUIRE(!result.has_value());
+              ASSERT_TRUE(!result.has_value());
           }
       };
 
@@ -953,3 +980,8 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
           model::offset{i});
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(WithOverride, EndToEndFixture, ::testing::Bool());
+
+INSTANTIATE_TEST_SUITE_P(
+  ManualWithOverride, CloudStorageEndToEndManualTest, ::testing::Bool());

--- a/src/v/cloud_storage/tests/partition_manifest_downloader_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_downloader_test.cc
@@ -34,6 +34,7 @@ constexpr model::cloud_credentials_source config_file{
 const ss::sstring test_uuid_str = "deadbeef-0000-0000-0000-000000000000";
 const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
 const remote_label test_label{test_uuid};
+const std::optional<model::topic_namespace> test_tp_ns_override = std::nullopt;
 const model::ntp test_ntp{
   model::ns{"test-ns"}, model::topic{"test-topic"}, model::partition_id{42}};
 const model::initial_revision_id test_rev{0};
@@ -133,7 +134,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadLabeledManifest) {
     ASSERT_NO_FATAL_FAILURE(upload_labeled_bin_manifest(pm));
     retry_chain_node retry(never_abort, 1s, 10ms);
     {
-        remote_path_provider path_provider(test_label);
+        remote_path_provider path_provider(test_label, test_tp_ns_override);
         partition_manifest_downloader dl(
           bucket_name, path_provider, test_ntp, test_rev, remote_.local());
         partition_manifest dl_pm;
@@ -145,7 +146,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadLabeledManifest) {
     {
         // The downloader can only look for what has been allowed by the path
         // provider, i.e. only those without any label.
-        remote_path_provider path_provider(std::nullopt);
+        remote_path_provider path_provider(std::nullopt, std::nullopt);
         partition_manifest_downloader dl(
           bucket_name, path_provider, test_ntp, test_rev, remote_.local());
         partition_manifest dl_pm;
@@ -162,7 +163,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadPrefixedManifest) {
     ASSERT_NO_FATAL_FAILURE(upload_prefixed_bin_manifest(pm));
     retry_chain_node retry(never_abort, 1s, 10ms);
     {
-        remote_path_provider path_provider(std::nullopt);
+        remote_path_provider path_provider(std::nullopt, std::nullopt);
         partition_manifest_downloader dl(
           bucket_name, path_provider, test_ntp, test_rev, remote_.local());
         partition_manifest dl_pm;
@@ -174,7 +175,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadPrefixedManifest) {
     {
         // The downloader can only look for what has been allowed by the path
         // provider, i.e. only those with the supplied remote label.
-        remote_path_provider path_provider(test_label);
+        remote_path_provider path_provider(test_label, test_tp_ns_override);
         partition_manifest_downloader dl(
           bucket_name, path_provider, test_ntp, test_rev, remote_.local());
         partition_manifest dl_pm;
@@ -191,7 +192,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadJsonManifest) {
     ASSERT_NO_FATAL_FAILURE(upload_prefixed_json_manifest(pm));
     retry_chain_node retry(never_abort, 1s, 10ms);
 
-    remote_path_provider path_provider(std::nullopt);
+    remote_path_provider path_provider(std::nullopt, std::nullopt);
     partition_manifest_downloader dl(
       bucket_name, path_provider, test_ntp, test_rev, remote_.local());
     partition_manifest dl_pm;
@@ -230,7 +231,7 @@ TEST_F(PartitionManifestDownloaderTest, TestDownloadJsonManifest) {
 }
 
 TEST_F(PartitionManifestDownloaderTest, TestLabeledManifestExists) {
-    remote_path_provider path_provider(test_label);
+    remote_path_provider path_provider(test_label, test_tp_ns_override);
     partition_manifest_downloader dl(
       bucket_name, path_provider, test_ntp, test_rev, remote_.local());
 
@@ -256,7 +257,7 @@ TEST_F(PartitionManifestDownloaderTest, TestLabeledManifestExists) {
 }
 
 TEST_F(PartitionManifestDownloaderTest, TestPrefixedJSONManifestExists) {
-    remote_path_provider path_provider(std::nullopt);
+    remote_path_provider path_provider(std::nullopt, std::nullopt);
     partition_manifest_downloader dl(
       bucket_name, path_provider, test_ntp, test_rev, remote_.local());
     auto pm = dummy_partition_manifest();
@@ -278,7 +279,7 @@ TEST_F(PartitionManifestDownloaderTest, TestPrefixedJSONManifestExists) {
 }
 
 TEST_F(PartitionManifestDownloaderTest, TestPrefixedBinaryManifestExists) {
-    remote_path_provider path_provider(std::nullopt);
+    remote_path_provider path_provider(std::nullopt, std::nullopt);
     partition_manifest_downloader dl(
       bucket_name, path_provider, test_ntp, test_rev, remote_.local());
     auto pm = dummy_partition_manifest();

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -35,7 +35,7 @@
 using namespace cloud_storage;
 
 namespace {
-const remote_path_provider path_provider(std::nullopt);
+const remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // anonymous namespace
 
 static constexpr std::string_view empty_manifest_json = R"json({

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -24,7 +24,7 @@
 
 using namespace cloud_storage;
 
-static const remote_path_provider path_provider(std::nullopt);
+static const remote_path_provider path_provider(std::nullopt, std::nullopt);
 
 inline ss::logger test_log("test"); // NOLINT
 

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -74,7 +74,7 @@ static void print_segments(const std::vector<in_memory_segment>& segments) {
     }
 }
 
-static const remote_path_provider path_provider(std::nullopt);
+static const remote_path_provider path_provider(std::nullopt, std::nullopt);
 
 /// Return vector<bool> which have a value for every recrod_batch_header in
 /// 'segments' If i'th value is true then the value are present in both

--- a/src/v/cloud_storage/tests/remote_path_provider_test.cc
+++ b/src/v/cloud_storage/tests/remote_path_provider_test.cc
@@ -14,6 +14,8 @@
 #include "cloud_storage/types.h"
 #include "gtest/gtest.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/tests/randoms.h"
 #include "utils/uuid.h"
 
 #include <gtest/gtest.h>
@@ -24,7 +26,8 @@ namespace {
 const ss::sstring test_uuid_str = "deadbeef-0000-0000-0000-000000000000";
 const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
 const remote_label test_label{test_uuid};
-const std::optional<model::topic_namespace> test_tp_ns_override = std::nullopt;
+const model::topic_namespace test_tp_ns_override{
+  model::ns{"kafka"}, model::topic{"override"}};
 const model::topic_namespace test_tp_ns{model::ns{"kafka"}, model::topic{"tp"}};
 const model::initial_revision_id test_rev{21};
 const model::partition_id test_pid{5};
@@ -52,31 +55,72 @@ const segment_meta test_smeta{
 };
 } // namespace
 
-TEST(TopicFromPathTest, TestTopicFromLabeledTopicManifestPath) {
-    remote_path_provider path_provider(test_label, test_tp_ns_override);
-    auto bin_path = path_provider.topic_manifest_path(test_tp_ns, test_rev);
+// Parameterized topic namespace override with a label.
+// For use with Labeled tests
+class OverrideParamRemotePathProviderWithLabelTest
+  : public ::testing::TestWithParam<bool> {
+public:
+    OverrideParamRemotePathProviderWithLabelTest()
+      : has_override(GetParam())
+      , path_provider(
+          test_label,
+          has_override
+            ? std::make_optional<model::topic_namespace>(test_tp_ns_override)
+            : std::nullopt) {}
 
+protected:
+    const bool has_override;
+    const remote_path_provider path_provider;
+};
+
+// Parameterized topic namespace override without a label.
+// For use with Labeled tests
+class OverrideParamRemotePathProviderTest
+  : public ::testing::TestWithParam<bool> {
+public:
+    OverrideParamRemotePathProviderTest()
+      : has_override(GetParam())
+      , path_provider(
+          std::nullopt,
+          has_override
+            ? std::make_optional<model::topic_namespace>(test_tp_ns_override)
+            : std::nullopt) {}
+
+protected:
+    const bool has_override;
+    const remote_path_provider path_provider;
+};
+
+TEST_P(
+  OverrideParamRemotePathProviderWithLabelTest,
+  TestTopicFromLabeledTopicManifestPath) {
+    auto bin_path = path_provider.topic_manifest_path(test_tp_ns, test_rev);
     auto parsed_labeled_tp_ns = tp_ns_from_labeled_path(bin_path);
     ASSERT_TRUE(parsed_labeled_tp_ns.has_value());
-    ASSERT_EQ(*parsed_labeled_tp_ns, test_tp_ns);
+    const auto& expected_tp_ns = has_override ? test_tp_ns_override
+                                              : test_tp_ns;
+    ASSERT_EQ(*parsed_labeled_tp_ns, expected_tp_ns);
 
     // Using the wrong method should result in nullopt.
     auto parsed_prefixed_tp_ns = tp_ns_from_prefixed_path(bin_path);
     ASSERT_FALSE(parsed_prefixed_tp_ns.has_value());
 }
 
-TEST(TopicFromPathTest, TestTopicFromPrefixedTopicManifestPath) {
-    remote_path_provider path_provider(std::nullopt, std::nullopt);
+TEST_P(
+  OverrideParamRemotePathProviderTest, TestTopicFromPrefixedTopicManifestPath) {
     auto bin_path = path_provider.topic_manifest_path(test_tp_ns, test_rev);
     auto json_path = *path_provider.topic_manifest_path_json(test_tp_ns);
 
     auto parsed_bin_tp_ns = tp_ns_from_prefixed_path(bin_path);
     ASSERT_TRUE(parsed_bin_tp_ns.has_value());
-    ASSERT_EQ(*parsed_bin_tp_ns, test_tp_ns);
+    const auto& expected_tp_ns = has_override ? test_tp_ns_override
+                                              : test_tp_ns;
+
+    ASSERT_EQ(*parsed_bin_tp_ns, expected_tp_ns);
 
     auto parsed_json_tp_ns = tp_ns_from_prefixed_path(json_path);
     ASSERT_TRUE(parsed_json_tp_ns.has_value());
-    ASSERT_EQ(*parsed_json_tp_ns, test_tp_ns);
+    ASSERT_EQ(*parsed_json_tp_ns, expected_tp_ns);
 
     // Using the wrong method should result in nullopt.
     auto parsed_labeled_tp_ns = tp_ns_from_labeled_path(bin_path);
@@ -85,29 +129,37 @@ TEST(TopicFromPathTest, TestTopicFromPrefixedTopicManifestPath) {
     ASSERT_FALSE(parsed_labeled_tp_ns.has_value());
 }
 
-TEST(RemotePathProviderTest, TestPrefixedTopicManifestPaths) {
-    remote_path_provider path_provider(std::nullopt, std::nullopt);
+TEST_P(OverrideParamRemotePathProviderTest, TestPrefixedTopicManifestPaths) {
+    const ss::sstring expected_path = has_override
+                                        ? "10000000/meta/kafka/override"
+                                        : "e0000000/meta/kafka/tp";
     EXPECT_STREQ(
       path_provider.topic_manifest_path(test_tp_ns, test_rev).c_str(),
-      "e0000000/meta/kafka/tp/topic_manifest.bin");
+      fmt::format("{}/topic_manifest.bin", expected_path).c_str());
     EXPECT_STREQ(
       path_provider.topic_manifest_prefix(test_tp_ns).c_str(),
-      "e0000000/meta/kafka/tp");
+      expected_path.c_str());
     const auto json_str = path_provider.topic_manifest_path_json(test_tp_ns);
     ASSERT_TRUE(json_str.has_value());
     EXPECT_STREQ(
-      json_str->c_str(), "e0000000/meta/kafka/tp/topic_manifest.json");
+      json_str->c_str(),
+      fmt::format("{}/topic_manifest.json", expected_path).c_str());
 }
 
-TEST(RemotePathProviderTest, TestLabeledTopicManifestPaths) {
-    remote_path_provider path_provider(test_label, test_tp_ns_override);
+TEST_P(
+  OverrideParamRemotePathProviderWithLabelTest, TestLabeledTopicManifestPaths) {
+    const ss::sstring expected_path = has_override ? "meta/kafka/override"
+                                                   : "meta/kafka/tp";
     EXPECT_STREQ(
       path_provider.topic_manifest_path(test_tp_ns, test_rev).c_str(),
-      "meta/kafka/tp/deadbeef-0000-0000-0000-000000000000/21/"
-      "topic_manifest.bin");
+      fmt::format(
+        "{}/deadbeef-0000-0000-0000-000000000000/21/topic_manifest.bin",
+        expected_path)
+        .c_str());
     EXPECT_STREQ(
       path_provider.topic_manifest_prefix(test_tp_ns).c_str(),
-      "meta/kafka/tp/deadbeef-0000-0000-0000-000000000000");
+      fmt::format("{}/deadbeef-0000-0000-0000-000000000000", expected_path)
+        .c_str());
 
     // We don't expect to read or write JSON topic manifests with the cluster
     // uuid labels.
@@ -115,54 +167,69 @@ TEST(RemotePathProviderTest, TestLabeledTopicManifestPaths) {
     ASSERT_FALSE(json_str.has_value());
 }
 
-TEST(RemotePathProviderTest, TestPrefixedPartitionManifestPaths) {
-    remote_path_provider path_provider(std::nullopt, std::nullopt);
+TEST_P(
+  OverrideParamRemotePathProviderTest, TestPrefixedPartitionManifestPaths) {
+    const ss::sstring expected_path = has_override
+                                        ? "50000000/meta/kafka/override"
+                                        : "e0000000/meta/kafka/tp";
     EXPECT_STREQ(
       path_provider.partition_manifest_path(test_ntp, test_rev).c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format("{}/5_21/manifest.bin", expected_path).c_str());
     EXPECT_STREQ(
       path_provider.partition_manifest_prefix(test_ntp, test_rev).c_str(),
-      "e0000000/meta/kafka/tp/5_21");
+      fmt::format("{}/5_21", expected_path).c_str());
 
     auto json_path = path_provider.partition_manifest_path_json(
       test_ntp, test_rev);
     ASSERT_TRUE(json_path.has_value());
     EXPECT_STREQ(
-      json_path.value().c_str(), "e0000000/meta/kafka/tp/5_21/manifest.json");
+      json_path.value().c_str(),
+      fmt::format("{}/5_21/manifest.json", expected_path).c_str());
 
     partition_manifest pm(test_ntp, test_rev);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(pm).c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format("{}/5_21/manifest.bin", expected_path).c_str());
     EXPECT_STREQ(
       path_provider.spillover_manifest_path(pm, test_spill_comps).c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+      fmt::format("{}/5_21/manifest.bin.10.11.0.1.999.1000", expected_path)
+        .c_str());
     EXPECT_STREQ(
       pm.get_manifest_path(path_provider)().native().c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format("{}/5_21/manifest.bin", expected_path).c_str());
 
     spillover_manifest spill_m(test_ntp, test_rev);
     spill_m.add(test_smeta);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(spill_m).c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+      fmt::format("{}/5_21/manifest.bin.10.11.0.1.999.1000", expected_path)
+        .c_str());
     EXPECT_STREQ(
       spill_m.get_manifest_path(path_provider)().native().c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+      fmt::format("{}/5_21/manifest.bin.10.11.0.1.999.1000", expected_path)
+        .c_str());
     partition_manifest* disguised_manifest = &spill_m;
     EXPECT_STREQ(
       disguised_manifest->get_manifest_path(path_provider)().native().c_str(),
-      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+      fmt::format("{}/5_21/manifest.bin.10.11.0.1.999.1000", expected_path)
+        .c_str());
 }
 
-TEST(RemotePathProviderTest, TestLabeledPartitionManifestPaths) {
-    remote_path_provider path_provider(test_label, test_tp_ns_override);
+TEST_P(
+  OverrideParamRemotePathProviderWithLabelTest,
+  TestLabeledPartitionManifestPaths) {
+    const ss::sstring expected_path = has_override ? "meta/kafka/override"
+                                                   : "meta/kafka/tp";
     EXPECT_STREQ(
       path_provider.partition_manifest_path(test_ntp, test_rev).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/manifest.bin",
+        expected_path)
+        .c_str());
     EXPECT_STREQ(
       path_provider.partition_manifest_prefix(test_ntp, test_rev).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21");
+      fmt::format("deadbeef-0000-0000-0000-000000000000/{}/5_21", expected_path)
+        .c_str());
 
     auto json_path = path_provider.partition_manifest_path_json(
       test_ntp, test_rev);
@@ -171,74 +238,103 @@ TEST(RemotePathProviderTest, TestLabeledPartitionManifestPaths) {
     partition_manifest pm(test_ntp, test_rev);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(pm).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/manifest.bin",
+        expected_path)
+        .c_str());
     EXPECT_STREQ(
       pm.get_manifest_path(path_provider)().native().c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/manifest.bin");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/manifest.bin",
+        expected_path)
+        .c_str());
     EXPECT_STREQ(
       path_provider.spillover_manifest_path(pm, test_spill_comps).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
-      "manifest.bin.10.11.0.1.999.1000");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "manifest.bin.10.11.0.1.999.1000",
+        expected_path)
+        .c_str());
 
     spillover_manifest spill_m(test_ntp, test_rev);
     spill_m.add(test_smeta);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(spill_m).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
-      "manifest.bin.10.11.0.1.999.1000");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "manifest.bin.10.11.0.1.999.1000",
+        expected_path)
+        .c_str());
     EXPECT_STREQ(
       spill_m.get_manifest_path(path_provider)().native().c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
-      "manifest.bin.10.11.0.1.999.1000");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "manifest.bin.10.11.0.1.999.1000",
+        expected_path)
+        .c_str());
     partition_manifest* disguised_manifest = &spill_m;
     EXPECT_STREQ(
       disguised_manifest->get_manifest_path(path_provider)().native().c_str(),
-      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
-      "manifest.bin.10.11.0.1.999.1000");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "manifest.bin.10.11.0.1.999.1000",
+        expected_path)
+        .c_str());
 }
 
-TEST(RemotePathProviderTest, TestPrefixedSegmentPaths) {
-    remote_path_provider path_provider(std::nullopt, std::nullopt);
+TEST_P(OverrideParamRemotePathProviderTest, TestPrefixedSegmentPaths) {
+    const ss::sstring expected_path = has_override ? "426917a1/kafka/override"
+                                                   : "d13f1c8e/kafka/tp";
     partition_manifest pm(test_ntp, test_rev);
     EXPECT_STREQ(
       path_provider.segment_path(pm, test_smeta).c_str(),
-      "d13f1c8e/kafka/tp/5_21/10-11-1048576-12-v1.log.13");
+      fmt::format("{}/5_21/10-11-1048576-12-v1.log.13", expected_path).c_str());
     EXPECT_STREQ(
       path_provider.segment_path(test_ntp, test_rev, test_smeta).c_str(),
-      "d13f1c8e/kafka/tp/5_21/10-11-1048576-12-v1.log.13");
+      fmt::format("{}/5_21/10-11-1048576-12-v1.log.13", expected_path).c_str());
 
     // Resetting the term should result in the term being missing.
     auto smeta_no_term = test_smeta;
     smeta_no_term.archiver_term = model::term_id{};
     EXPECT_STREQ(
       path_provider.segment_path(pm, smeta_no_term).c_str(),
-      "d13f1c8e/kafka/tp/5_21/10-11-1048576-12-v1.log");
+      fmt::format("{}/5_21/10-11-1048576-12-v1.log", expected_path).c_str());
 }
 
-TEST(RemotePathProviderTest, TestLabeledSegmentPaths) {
-    remote_path_provider path_provider(test_label, test_tp_ns_override);
+TEST_P(OverrideParamRemotePathProviderWithLabelTest, TestLabeledSegmentPaths) {
+    const ss::sstring expected_tp_ns = has_override ? "kafka/override"
+                                                    : "kafka/tp";
     partition_manifest pm(test_ntp, test_rev);
     EXPECT_STREQ(
       path_provider.segment_path(pm, test_smeta).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/kafka/tp/5_21/"
-      "10-11-1048576-12-v1.log.13");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "10-11-1048576-12-v1.log.13",
+        expected_tp_ns)
+        .c_str());
     EXPECT_STREQ(
       path_provider.segment_path(test_ntp, test_rev, test_smeta).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/kafka/tp/5_21/"
-      "10-11-1048576-12-v1.log.13");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "10-11-1048576-12-v1.log.13",
+        expected_tp_ns)
+        .c_str());
 
     // Resetting the term should result in the term being missing.
     auto smeta_no_term = test_smeta;
     smeta_no_term.archiver_term = model::term_id{};
     EXPECT_STREQ(
       path_provider.segment_path(pm, smeta_no_term).c_str(),
-      "deadbeef-0000-0000-0000-000000000000/kafka/tp/5_21/"
-      "10-11-1048576-12-v1.log");
+      fmt::format(
+        "deadbeef-0000-0000-0000-000000000000/{}/5_21/"
+        "10-11-1048576-12-v1.log",
+        expected_tp_ns)
+        .c_str());
 }
 
-class ParamsRemotePathProviderTest : public ::testing::TestWithParam<bool> {
+class LabelParamRemotePathProviderTest : public ::testing::TestWithParam<bool> {
 public:
-    ParamsRemotePathProviderTest()
+    LabelParamRemotePathProviderTest()
       : path_provider(
         GetParam() ? std::make_optional<remote_label>(
           model::cluster_uuid{uuid_t::create()})
@@ -249,7 +345,7 @@ protected:
     const remote_path_provider path_provider;
 };
 
-TEST_P(ParamsRemotePathProviderTest, TestTopicPrefixPrefixesPath) {
+TEST_P(LabelParamRemotePathProviderTest, TestTopicPrefixPrefixesPath) {
     // The topic manifest prefix, if used as a list prefix, should catch the
     // topic manifest.
     const auto topic_path = path_provider.topic_manifest_path(
@@ -258,7 +354,7 @@ TEST_P(ParamsRemotePathProviderTest, TestTopicPrefixPrefixesPath) {
     ASSERT_TRUE(topic_path.starts_with(topic_prefix));
 }
 
-TEST_P(ParamsRemotePathProviderTest, TestPartitionPrefixPrefixesPath) {
+TEST_P(LabelParamRemotePathProviderTest, TestPartitionPrefixPrefixesPath) {
     // The partition manifest prefix, if used as a list prefix, should catch
     // both STM manifests and spillover manifests.
     const auto partition_path = path_provider.partition_manifest_path(
@@ -273,7 +369,8 @@ TEST_P(ParamsRemotePathProviderTest, TestPartitionPrefixPrefixesPath) {
     ASSERT_TRUE(spillover_path.starts_with(partition_prefix));
 }
 
-TEST_P(ParamsRemotePathProviderTest, TestPartitionPrefixDoesntPrefixSegments) {
+TEST_P(
+  LabelParamRemotePathProviderTest, TestPartitionPrefixDoesntPrefixSegments) {
     // The partition manifest prefix, if used as a list prefix, shouldn't catch
     // any segments.
     const auto partition_prefix = path_provider.partition_manifest_prefix(
@@ -283,4 +380,12 @@ TEST_P(ParamsRemotePathProviderTest, TestPartitionPrefixDoesntPrefixSegments) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  WithLabel, ParamsRemotePathProviderTest, ::testing::Bool());
+  LabeledWithOverride,
+  OverrideParamRemotePathProviderWithLabelTest,
+  ::testing::Bool());
+
+INSTANTIATE_TEST_SUITE_P(
+  WithOverride, OverrideParamRemotePathProviderTest, ::testing::Bool());
+
+INSTANTIATE_TEST_SUITE_P(
+  WithLabel, LabelParamRemotePathProviderTest, ::testing::Bool());

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -48,7 +48,7 @@ inline ss::logger test_log("test"); // NOLINT
 static ss::abort_source never_abort;
 
 namespace {
-remote_path_provider path_provider(std::nullopt);
+remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // namespace
 
 static cloud_storage::lazy_abort_source always_continue([]() {

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -1319,7 +1319,7 @@ TEST_P(all_types_remote_fixture, test_notification_retry_meta) {
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto filter = remote::event_filter{};
 
-    remote_path_provider path_provider(std::nullopt);
+    remote_path_provider path_provider(std::nullopt, std::nullopt);
     partition_manifest_downloader dl(
       bucket_name,
       path_provider,

--- a/src/v/cloud_storage/tests/segment_chunk_hydration_test.cc
+++ b/src/v/cloud_storage/tests/segment_chunk_hydration_test.cc
@@ -22,7 +22,7 @@
 
 inline ss::logger test_log("test"); // NOLINT
 namespace cloud_storage {
-remote_path_provider path_provider(std::nullopt);
+remote_path_provider path_provider(std::nullopt, std::nullopt);
 class remote_segment_test_helper {
 public:
     explicit remote_segment_test_helper(remote_segment& r)

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -459,6 +459,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       true,
       "rrr",
       std::nullopt,
+      std::nullopt,
       313,
       tristate<size_t>{disable_tristate},
       tristate<std::chrono::milliseconds>{std::chrono::milliseconds{20}},

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -41,7 +41,7 @@
 using namespace cloud_storage;
 
 namespace {
-const remote_path_provider path_provider(std::nullopt);
+const remote_path_provider path_provider(std::nullopt, std::nullopt);
 } // anonymous namespace
 
 // update manifest, serialize, compare jsons

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "archival/archival_metadata_stm.h"
+#include "archival/ntp_archiver_service.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/tests/produce_utils.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
+#include "cluster/cloud_metadata/uploader.h"
+#include "cluster/config_frontend.h"
+#include "cluster/controller_snapshot.h"
+#include "cluster/feature_manager.h"
+#include "cluster/id_allocator_frontend.h"
+#include "cluster/partition.h"
+#include "cluster/tests/topic_properties_generator.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "redpanda/application.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/scoped_config.h"
+#include "test_utils/test.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/util/defer.hh>
+
+class TopicRecoveryFixture
+  : public seastar_test
+  , public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    TopicRecoveryFixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{}, httpd_port_number())
+      , bucket(cloud_storage_clients::bucket_name("test-bucket")) {
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+    }
+
+    ss::future<> SetUpAsync() override {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+            return app.storage.local().get_cluster_uuid().has_value();
+        });
+        cluster_uuid = app.storage.local().get_cluster_uuid().value();
+    }
+
+protected:
+    const cloud_storage_clients::bucket_name bucket;
+    model::cluster_uuid cluster_uuid = {};
+    scoped_config test_local_cfg;
+};
+
+using tests::kafka_consume_transport;
+using tests::kv_t;
+
+TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
+    test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+      .set_value(true);
+
+    model::partition_id pid{0};
+
+    // The "source" topic namespace.
+    model::topic_namespace src_tp_ns{
+      model::kafka_namespace, model::topic{"cassava"}};
+    model::ntp src_ntp(src_tp_ns.ns, src_tp_ns.tp, pid);
+
+    cluster::topic_properties src_props;
+    src_props.shadow_indexing = model::shadow_indexing_mode::full;
+    src_props.retention_local_target_bytes = tristate<size_t>(1);
+
+    add_topic(src_tp_ns, 1, src_props).get();
+    wait_for_leader(src_ntp).get();
+
+    static constexpr size_t num_records_to_produce = 10;
+    const auto records = kv_t::sequence(0, num_records_to_produce);
+
+    // Nested scope here, because the ptr to partition is going to be invalid
+    // post cluster restart. Attempting to free it at the end of test fixture
+    // scope will result in use-after-free.
+    {
+        auto partition = app.partition_manager.local().get(src_ntp);
+        auto log = partition->log();
+        auto archiver_ref = partition->archiver();
+        ASSERT_TRUE(archiver_ref.has_value());
+        auto& archiver = archiver_ref.value().get();
+
+        // Produce some records to the partition.
+        tests::remote_segment_generator gen(
+          make_kafka_client().get(), *partition);
+
+        ASSERT_EQ(
+          num_records_to_produce,
+          gen.records_per_batch(num_records_to_produce).produce().get());
+
+        // Assert consuming from original topic works fine.
+        kafka_consume_transport consumer(make_kafka_client().get());
+        consumer.start().get();
+        auto consumed_records
+          = consumer.consume_from_partition(src_tp_ns.tp, pid, model::offset(0))
+              .get();
+
+        ASSERT_EQ(records.size(), consumed_records.size());
+        for (int i = 0; i < records.size(); ++i) {
+            ASSERT_EQ(records[i].key, consumed_records[i].key);
+            ASSERT_EQ(records[i].val, consumed_records[i].val);
+        }
+
+        // Sync archiver, upload candidates (if needed) and upload manifest.
+        archiver.sync_for_tests().get();
+        std::ignore = archiver.upload_next_candidates().get();
+        archiver.upload_topic_manifest().get();
+    }
+
+    // Restart the cluster, wiping all local data in the process.
+    restart(should_wipe::yes);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [this] {
+        return app.storage.local().get_cluster_uuid().has_value();
+    });
+
+    // Now, create a new topic namespace that differs from the original,
+    // but uses the original src_tp_ns as an override in topic_properties.
+    // By setting recovery to true, it will attempt to use the src topic for
+    // recovery upon creation.
+    model::topic_namespace dest_tp_ns{
+      model::kafka_namespace, model::topic{"tapioca"}};
+    model::ntp dest_ntp(dest_tp_ns.ns, dest_tp_ns.tp, pid);
+
+    // Expect that no requests will be made to the s3_imposter using the
+    // destination topic.
+    http_test_utils::response fail_response{
+      .body = "Should not have recieved a request with tapioca in it",
+      .status = http_test_utils::response::status_type::bad_request};
+    req_pred_t fail_dest_topic_request =
+      [](const http_test_utils::request_info& info) {
+          return info.url.contains("tapioca");
+      };
+    fail_request_if(fail_dest_topic_request, fail_response);
+
+    cluster::topic_properties dest_props;
+    dest_props.shadow_indexing = model::shadow_indexing_mode::full;
+    dest_props.retention_local_target_bytes = tristate<size_t>(1);
+    dest_props.remote_topic_namespace_override = src_tp_ns;
+    dest_props.recovery = true;
+
+    add_topic(dest_tp_ns, 1, dest_props).get();
+    wait_for_leader(dest_ntp).get();
+
+    // Assert consuming from recovered destination topic works fine.
+    kafka_consume_transport consumer(make_kafka_client().get());
+    consumer.start().get();
+    auto consumed_records
+      = consumer.consume_from_partition(dest_tp_ns.tp, pid, model::offset(0))
+          .get();
+
+    ASSERT_EQ(records.size(), consumed_records.size());
+    for (int i = 0; i < records.size(); ++i) {
+        ASSERT_EQ(records[i].key, consumed_records[i].key);
+        ASSERT_EQ(records[i].val, consumed_records[i].val);
+    }
+
+    // Produce more to the destination topic, s3_imposter will fail if any
+    // "tapioca" related requests are made.
+    auto partition = app.partition_manager.local().get(dest_ntp);
+    auto archiver_ref = partition->archiver();
+    ASSERT_TRUE(archiver_ref.has_value());
+    auto& archiver = archiver_ref.value().get();
+
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+
+    ASSERT_EQ(
+      num_records_to_produce,
+      gen.num_segments(2)
+        .records_per_batch(num_records_to_produce)
+        .produce()
+        .get());
+
+    archiver.sync_for_tests().get();
+    std::ignore = archiver.upload_next_candidates().get();
+
+    // Check requests with the same predicate at end of scope, just to be
+    // explicit about bad requests.
+    const auto bad_requests = get_requests(fail_dest_topic_request);
+    ASSERT_TRUE(bad_requests.empty());
+}

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -26,7 +26,7 @@
 
 namespace cloud_storage {
 
-static const remote_path_provider path_provider(std::nullopt);
+static const remote_path_provider path_provider(std::nullopt, std::nullopt);
 
 segment_layout
 generate_segment_layout(int num_segments, int seed, bool exclude_tx_fence) {
@@ -626,7 +626,7 @@ partition_manifest hydrate_manifest(
   remote& api, const cloud_storage_clients::bucket_name& bucket) {
     static ss::abort_source never_abort;
 
-    remote_path_provider path_provider(std::nullopt);
+    remote_path_provider path_provider(std::nullopt, std::nullopt);
     partition_manifest_downloader dl(
       bucket, path_provider, manifest_ntp, manifest_revision, api);
     partition_manifest m(manifest_ntp, manifest_revision);

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1408,7 +1408,7 @@ ss::future<std::error_code> controller_backend::create_partition(
               raft::with_learner_recovery_throttle::yes,
               raft::keep_snapshotted_log::no,
               cfg->properties.remote_label,
-              cfg->properties.topic_namespace_override);
+              cfg->properties.remote_topic_namespace_override);
 
             co_await add_to_shard_table(
               ntp, group_id, ss::this_shard_id(), log_revision);

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1407,7 +1407,8 @@ ss::future<std::error_code> controller_backend::create_partition(
               read_replica_bucket,
               raft::with_learner_recovery_throttle::yes,
               raft::keep_snapshotted_log::no,
-              cfg->properties.remote_label);
+              cfg->properties.remote_label,
+              cfg->properties.topic_namespace_override);
 
             co_await add_to_shard_table(
               ntp, group_id, ss::this_shard_id(), log_revision);

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -127,7 +127,8 @@ ss::future<consensus_ptr> partition_manager::manage(
     // be used at runtime by the partition. The latter is owned by the archival
     // metadata STM and its lifecycle is therefore tied to the partition, which
     // hasn't been constructed yet.
-    cloud_storage::remote_path_provider path_provider(remote_label);
+    cloud_storage::remote_path_provider path_provider(
+      remote_label, std::nullopt);
     auto dl_result = co_await maybe_download_log(ntp_cfg, rtp, path_provider);
     auto& [logs_recovered, clean_download, min_offset, max_offset, manifest, ot_state]
       = dl_result;

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -96,7 +96,8 @@ public:
       raft::with_learner_recovery_throttle
       = raft::with_learner_recovery_throttle::yes,
       raft::keep_snapshotted_log = raft::keep_snapshotted_log::no,
-      std::optional<cloud_storage::remote_label> = std::nullopt);
+      std::optional<cloud_storage::remote_label> = std::nullopt,
+      std::optional<model::topic_namespace> = std::nullopt);
 
     ss::future<> shutdown(const model::ntp& ntp);
 

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -40,7 +40,7 @@ static ss::future<errc> download_topic_manifest(
     cloud_storage::topic_manifest_downloader dl(
       bucket,
       /*remote_label=*/std::nullopt,
-      cfg.cfg.archival_tp_ns(),
+      cfg.cfg.remote_tp_ns(),
       remote);
     auto deadline = model::timeout_clock::now() + timeout;
     auto download_res = co_await dl.download_manifest(

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -40,7 +40,7 @@ static ss::future<errc> download_topic_manifest(
     cloud_storage::topic_manifest_downloader dl(
       bucket,
       /*remote_label=*/std::nullopt,
-      cfg.cfg.tp_ns,
+      cfg.cfg.archival_tp_ns(),
       remote);
     auto deadline = model::timeout_clock::now() + timeout;
     auto download_res = co_await dl.download_manifest(

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -48,6 +48,16 @@ struct topic_configuration
     bool is_recovery_enabled() const {
         return properties.recovery && properties.recovery.value();
     }
+    bool has_topic_namespace_override() const {
+        return properties.topic_namespace_override.has_value();
+    }
+
+    const model::topic_namespace& archival_tp_ns() const {
+        if (has_topic_namespace_override()) {
+            return properties.topic_namespace_override.value();
+        }
+        return tp_ns;
+    }
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -48,13 +48,13 @@ struct topic_configuration
     bool is_recovery_enabled() const {
         return properties.recovery && properties.recovery.value();
     }
-    bool has_topic_namespace_override() const {
-        return properties.topic_namespace_override.has_value();
+    bool has_remote_topic_namespace_override() const {
+        return properties.remote_topic_namespace_override.has_value();
     }
 
-    const model::topic_namespace& archival_tp_ns() const {
-        if (has_topic_namespace_override()) {
-            return properties.topic_namespace_override.value();
+    const model::topic_namespace& remote_tp_ns() const {
+        if (has_remote_topic_namespace_override()) {
+            return properties.remote_topic_namespace_override.value();
         }
         return tp_ns;
     }

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -20,7 +20,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "{{compression: {}, cleanup_policy_bitflags: {}, compaction_strategy: "
       "{}, retention_bytes: {}, retention_duration_ms: {}, segment_size: {}, "
       "timestamp_type: {}, recovery_enabled: {}, shadow_indexing: {}, "
-      "read_replica: {}, read_replica_bucket: {} remote_topic_properties: {}, "
+      "read_replica: {}, read_replica_bucket: {}, topic_namespace_override: "
+      "{}, "
+      "remote_topic_properties: {}, "
       "batch_max_bytes: {}, retention_local_target_bytes: {}, "
       "retention_local_target_ms: {}, remote_delete: {}, segment_ms: {}, "
       "record_key_schema_id_validation: {}, "
@@ -49,6 +51,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.shadow_indexing,
       properties.read_replica,
       properties.read_replica_bucket,
+      properties.topic_namespace_override,
       properties.remote_topic_properties,
       properties.batch_max_bytes,
       properties.retention_local_target_bytes,
@@ -87,7 +90,8 @@ bool topic_properties::has_overrides() const {
     return cleanup_policy_bitflags || compaction_strategy || segment_size
            || retention_bytes.is_engaged() || retention_duration.is_engaged()
            || recovery.has_value() || shadow_indexing.has_value()
-           || read_replica.has_value() || batch_max_bytes.has_value()
+           || read_replica.has_value() || topic_namespace_override.has_value()
+           || batch_max_bytes.has_value()
            || retention_local_target_bytes.is_engaged()
            || retention_local_target_ms.is_engaged()
            || remote_delete != storage::ntp_config::default_remote_delete
@@ -201,6 +205,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       shadow_indexing,
       read_replica,
       read_replica_bucket,
+      std::nullopt,
       remote_topic_properties,
       std::nullopt,
       tristate<size_t>{std::nullopt},

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -20,7 +20,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "{{compression: {}, cleanup_policy_bitflags: {}, compaction_strategy: "
       "{}, retention_bytes: {}, retention_duration_ms: {}, segment_size: {}, "
       "timestamp_type: {}, recovery_enabled: {}, shadow_indexing: {}, "
-      "read_replica: {}, read_replica_bucket: {}, topic_namespace_override: "
+      "read_replica: {}, read_replica_bucket: {}, "
+      "remote_topic_namespace_override: "
       "{}, "
       "remote_topic_properties: {}, "
       "batch_max_bytes: {}, retention_local_target_bytes: {}, "
@@ -51,7 +52,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.shadow_indexing,
       properties.read_replica,
       properties.read_replica_bucket,
-      properties.topic_namespace_override,
+      properties.remote_topic_namespace_override,
       properties.remote_topic_properties,
       properties.batch_max_bytes,
       properties.retention_local_target_bytes,
@@ -90,7 +91,8 @@ bool topic_properties::has_overrides() const {
     return cleanup_policy_bitflags || compaction_strategy || segment_size
            || retention_bytes.is_engaged() || retention_duration.is_engaged()
            || recovery.has_value() || shadow_indexing.has_value()
-           || read_replica.has_value() || topic_namespace_override.has_value()
+           || read_replica.has_value()
+           || remote_topic_namespace_override.has_value()
            || batch_max_bytes.has_value()
            || retention_local_target_bytes.is_engaged()
            || retention_local_target_ms.is_engaged()

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -43,6 +43,7 @@ struct topic_properties
       std::optional<model::shadow_indexing_mode> shadow_indexing,
       std::optional<bool> read_replica,
       std::optional<ss::sstring> read_replica_bucket,
+      std::optional<model::topic_namespace> topic_namespace_override,
       std::optional<remote_topic_properties> remote_topic_properties,
       std::optional<uint32_t> batch_max_bytes,
       tristate<size_t> retention_local_target_bytes,
@@ -78,6 +79,7 @@ struct topic_properties
       , shadow_indexing(shadow_indexing)
       , read_replica(read_replica)
       , read_replica_bucket(std::move(read_replica_bucket))
+      , topic_namespace_override(topic_namespace_override)
       , remote_topic_properties(remote_topic_properties)
       , batch_max_bytes(batch_max_bytes)
       , retention_local_target_bytes(retention_local_target_bytes)
@@ -115,6 +117,10 @@ struct topic_properties
     std::optional<model::shadow_indexing_mode> shadow_indexing;
     std::optional<bool> read_replica;
     std::optional<ss::sstring> read_replica_bucket;
+    // The ntp override used for tiered storage. In case of a
+    // cross-cluster migration, the ntp used for archival subsystems may differ
+    // from the ntp used for local storage.
+    std::optional<model::topic_namespace> topic_namespace_override;
 
     // Topic properties for a topic that already has remote data (e.g.
     // recovery topics).
@@ -206,7 +212,8 @@ struct topic_properties
           write_caching,
           flush_ms,
           flush_bytes,
-          remote_label);
+          remote_label,
+          topic_namespace_override);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -43,7 +43,7 @@ struct topic_properties
       std::optional<model::shadow_indexing_mode> shadow_indexing,
       std::optional<bool> read_replica,
       std::optional<ss::sstring> read_replica_bucket,
-      std::optional<model::topic_namespace> topic_namespace_override,
+      std::optional<model::topic_namespace> remote_topic_namespace_override,
       std::optional<remote_topic_properties> remote_topic_properties,
       std::optional<uint32_t> batch_max_bytes,
       tristate<size_t> retention_local_target_bytes,
@@ -79,7 +79,7 @@ struct topic_properties
       , shadow_indexing(shadow_indexing)
       , read_replica(read_replica)
       , read_replica_bucket(std::move(read_replica_bucket))
-      , topic_namespace_override(topic_namespace_override)
+      , remote_topic_namespace_override(remote_topic_namespace_override)
       , remote_topic_properties(remote_topic_properties)
       , batch_max_bytes(batch_max_bytes)
       , retention_local_target_bytes(retention_local_target_bytes)
@@ -120,7 +120,7 @@ struct topic_properties
     // The ntp override used for tiered storage. In case of a
     // cross-cluster migration, the ntp used for archival subsystems may differ
     // from the ntp used for local storage.
-    std::optional<model::topic_namespace> topic_namespace_override;
+    std::optional<model::topic_namespace> remote_topic_namespace_override;
 
     // Topic properties for a topic that already has remote data (e.g.
     // recovery topics).
@@ -213,7 +213,7 @@ struct topic_properties
           flush_ms,
           flush_bytes,
           remote_label,
-          topic_namespace_override);
+          remote_topic_namespace_override);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -301,7 +301,8 @@ maybe_validate_recovery_topic(
     // start validation for each partition, collect the results and return
     // them
     const cloud_storage::remote_path_provider path_provider(
-      assignable_config.cfg.properties.remote_label, std::nullopt);
+      assignable_config.cfg.properties.remote_label,
+      assignable_config.cfg.properties.topic_namespace_override);
 
     co_await ss::max_concurrent_for_each(
       enumerate_partitions, concurrency, [&](model::partition_id p) {

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -302,7 +302,7 @@ maybe_validate_recovery_topic(
     // them
     const cloud_storage::remote_path_provider path_provider(
       assignable_config.cfg.properties.remote_label,
-      assignable_config.cfg.properties.topic_namespace_override);
+      assignable_config.cfg.properties.remote_topic_namespace_override);
 
     co_await ss::max_concurrent_for_each(
       enumerate_partitions, concurrency, [&](model::partition_id p) {

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -301,7 +301,7 @@ maybe_validate_recovery_topic(
     // start validation for each partition, collect the results and return
     // them
     const cloud_storage::remote_path_provider path_provider(
-      assignable_config.cfg.properties.remote_label);
+      assignable_config.cfg.properties.remote_label, std::nullopt);
 
     co_await ss::max_concurrent_for_each(
       enumerate_partitions, concurrency, [&](model::partition_id p) {

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -357,6 +357,7 @@ struct compat_check<cluster::topic_properties> {
           wr, "write_caching", obj.write_caching);
         json_write(flush_ms);
         json_write(flush_bytes);
+        json_write(topic_namespace_override);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -392,6 +393,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(write_caching);
         json_read(flush_ms);
         json_read(flush_bytes);
+        json_read(topic_namespace_override);
         return obj;
     }
 
@@ -422,6 +424,7 @@ struct compat_check<cluster::topic_properties> {
         obj.write_caching = std::nullopt;
         obj.flush_bytes = std::nullopt;
         obj.flush_ms = std::nullopt;
+        obj.topic_namespace_override = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -481,6 +484,7 @@ struct compat_check<cluster::topic_configuration> {
         auto cfg = reflection::adl<cluster::topic_configuration>{}.from(iobp);
         obj.properties.read_replica = std::nullopt;
         obj.properties.read_replica_bucket = std::nullopt;
+        obj.properties.topic_namespace_override = std::nullopt;
         obj.properties.remote_topic_properties = std::nullopt;
         obj.properties.batch_max_bytes = std::nullopt;
         obj.properties.retention_local_target_bytes = tristate<size_t>{

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -357,7 +357,7 @@ struct compat_check<cluster::topic_properties> {
           wr, "write_caching", obj.write_caching);
         json_write(flush_ms);
         json_write(flush_bytes);
-        json_write(topic_namespace_override);
+        json_write(remote_topic_namespace_override);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -393,7 +393,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(write_caching);
         json_read(flush_ms);
         json_read(flush_bytes);
-        json_read(topic_namespace_override);
+        json_read(remote_topic_namespace_override);
         return obj;
     }
 
@@ -424,7 +424,7 @@ struct compat_check<cluster::topic_properties> {
         obj.write_caching = std::nullopt;
         obj.flush_bytes = std::nullopt;
         obj.flush_ms = std::nullopt;
-        obj.topic_namespace_override = std::nullopt;
+        obj.remote_topic_namespace_override = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -484,7 +484,7 @@ struct compat_check<cluster::topic_configuration> {
         auto cfg = reflection::adl<cluster::topic_configuration>{}.from(iobp);
         obj.properties.read_replica = std::nullopt;
         obj.properties.read_replica_bucket = std::nullopt;
-        obj.properties.topic_namespace_override = std::nullopt;
+        obj.properties.remote_topic_namespace_override = std::nullopt;
         obj.properties.remote_topic_properties = std::nullopt;
         obj.properties.batch_max_bytes = std::nullopt;
         obj.properties.retention_local_target_bytes = tristate<size_t>{

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -617,6 +617,7 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_optional([] { return tests::random_bool(); }),
           tests::random_optional(
             [] { return tests::random_named_string<ss::sstring>(); }),
+          model::random_topic_namespace(),
           instance_generator<cluster::remote_topic_properties>::random(),
           tests::random_optional(
             [] { return random_generators::get_int<uint32_t>(1024 * 1024); }),

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -573,7 +573,10 @@ inline void rjson_serialize(
     write_member(w, "shadow_indexing", tps.shadow_indexing);
     write_member(w, "read_replica", tps.read_replica);
     write_member(w, "read_replica_bucket", tps.read_replica_bucket);
-    write_member(w, "topic_namespace_override", tps.topic_namespace_override);
+    write_member(
+      w,
+      "remote_topic_namespace_override",
+      tps.remote_topic_namespace_override);
     write_member(w, "remote_topic_properties", tps.remote_topic_properties);
     write_member(w, "batch_max_bytes", tps.batch_max_bytes);
     write_member(
@@ -640,7 +643,10 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "shadow_indexing", obj.shadow_indexing);
     read_member(rd, "read_replica", obj.read_replica);
     read_member(rd, "read_replica_bucket", obj.read_replica_bucket);
-    read_member(rd, "topic_namespace_override", obj.topic_namespace_override);
+    read_member(
+      rd,
+      "remote_topic_namespace_override",
+      obj.remote_topic_namespace_override);
     read_member(rd, "remote_topic_properties", obj.remote_topic_properties);
     read_member(rd, "batch_max_bytes", obj.batch_max_bytes);
     read_member(

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -573,6 +573,7 @@ inline void rjson_serialize(
     write_member(w, "shadow_indexing", tps.shadow_indexing);
     write_member(w, "read_replica", tps.read_replica);
     write_member(w, "read_replica_bucket", tps.read_replica_bucket);
+    write_member(w, "topic_namespace_override", tps.topic_namespace_override);
     write_member(w, "remote_topic_properties", tps.remote_topic_properties);
     write_member(w, "batch_max_bytes", tps.batch_max_bytes);
     write_member(
@@ -639,6 +640,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "shadow_indexing", obj.shadow_indexing);
     read_member(rd, "read_replica", obj.read_replica);
     read_member(rd, "read_replica_bucket", obj.read_replica_bucket);
+    read_member(rd, "topic_namespace_override", obj.topic_namespace_override);
     read_member(rd, "remote_topic_properties", obj.remote_topic_properties);
     read_member(rd, "batch_max_bytes", obj.batch_max_bytes);
     read_member(

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4239,7 +4239,7 @@ admin_server::get_cloud_storage_anomalies(
     }
 
     cloud_storage::remote_path_provider path_provider(
-      tp->properties.remote_label);
+      tp->properties.remote_label, std::nullopt);
     auto status = co_await _partition_manager.invoke_on(
       *shard,
       [&ntp](const auto& pm) -> std::optional<cloud_storage::anomalies> {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4239,7 +4239,8 @@ admin_server::get_cloud_storage_anomalies(
     }
 
     cloud_storage::remote_path_provider path_provider(
-      tp->properties.remote_label, tp->properties.topic_namespace_override);
+      tp->properties.remote_label,
+      tp->properties.remote_topic_namespace_override);
     auto status = co_await _partition_manager.invoke_on(
       *shard,
       [&ntp](const auto& pm) -> std::optional<cloud_storage::anomalies> {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4239,7 +4239,7 @@ admin_server::get_cloud_storage_anomalies(
     }
 
     cloud_storage::remote_path_provider path_provider(
-      tp->properties.remote_label, std::nullopt);
+      tp->properties.remote_label, tp->properties.topic_namespace_override);
     auto status = co_await _partition_manager.invoke_on(
       *shard,
       [&ntp](const auto& pm) -> std::optional<cloud_storage::anomalies> {

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -23,8 +23,13 @@ def read_remote_label_serde(rdr: Reader):
     return rdr.read_envelope(lambda rdr, _: {"cluster_uuid": rdr.read_uuid()})
 
 
-def read_topic_properties_serde(rdr: Reader, version):
+def read_topic_namespace(rdr: Reader):
+    namespace = rdr.read_string()
+    topic = rdr.read_string()
+    return f"{namespace}/{topic}"
 
+
+def read_topic_properties_serde(rdr: Reader, version):
     topic_properties = {
         'compression': rdr.read_optional(Reader.read_serde_enum),
         'cleanup_policy_bitflags': rdr.read_optional(Reader.read_serde_enum),
@@ -119,7 +124,8 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
     if version >= 9:
         topic_properties |= {
-            'remote_label': rdr.read_optional(read_remote_label_serde)
+            'remote_label': rdr.read_optional(read_remote_label_serde),
+            'topic_namespace_override': rdr.read_optional(read_topic_namespace)
         }
 
     return topic_properties


### PR DESCRIPTION
This PR allows for the `remote_path_provider` to use a `topic_namespace_override` from `topic_properties` when constructing remote paths to segments, manifests, and other files.

The motivating use-case for this work is cross-cluster migrations, in which a destination cluster can refer to a migrated topic (`src`) by an alias (`dest`) for its local storage, while continuing to use the existing topic name (`src`) for the cloud storage read and write paths.

It is not currently possible to create a topic with this override through `rpk`/ the `kafka` subsystem.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
