### PR TITLE
rpk cloud byoc: register azure as valid option

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
@@ -163,9 +163,7 @@ and then come back to this command to complete the process.
 					i++
 				case arg == "validate":
 					isKnown, isValidate = true, true
-				case arg == "aws":
-					isKnown = true
-				case arg == "gcp":
+				case arg == "aws" || arg == "gcp" || arg == "azure":
 					isKnown = true
 				}
 			}


### PR DESCRIPTION
Mark `rpk cloud byoc azure` as a registered command for rpk. It activates the current login + download flow.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes



* none
