### PR TITLE
[CORE-3182] Schema registry/json: Reject a schema if a reference doesn't exist

### DIFF
--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -164,6 +164,9 @@ inline error_info has_references(const subject& sub, schema_version ver) {
         ver())};
 }
 
+error_info no_reference_found_for(
+  canonical_schema const& schema, const subject& sub, schema_version ver);
+
 inline error_info compatibility_not_found(const subject& sub) {
     return error_info{
       error_code::compatibility_not_found,

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -65,8 +65,7 @@ std::ostream& operator<<(
 }
 
 std::ostream& operator<<(std::ostream& os, const schema_reference& ref) {
-    fmt::print(
-      os, "name: {}, subject: {}, version: {}", ref.name, ref.sub, ref.version);
+    fmt::print(os, "{:l}", ref);
     return os;
 }
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -489,3 +489,44 @@ from_string_view<compatibility_level>(std::string_view sv) {
 }
 
 } // namespace pandaproxy::schema_registry
+
+template<>
+struct fmt::formatter<pandaproxy::schema_registry::schema_reference> {
+    constexpr auto parse(fmt::format_parse_context& ctx)
+      -> decltype(ctx.begin()) {
+        auto it = ctx.begin();
+        auto end = ctx.end();
+        if (it != end && (*it == 'l' || *it == 'e')) {
+            presentation = *it++;
+        }
+        if (it != end && *it != '}') {
+            throw fmt::format_error("invalid format");
+        }
+        return it;
+    }
+
+    template<typename FormatContext>
+    auto format(
+      const pandaproxy::schema_registry::schema_reference& s,
+      FormatContext& ctx) const -> decltype(ctx.out()) {
+        if (presentation == 'l') {
+            return fmt::format_to(
+              ctx.out(),
+              "name: {}, subject: {}, version: {}",
+              s.name,
+              s.sub,
+              s.version);
+        } else {
+            return fmt::format_to(
+              ctx.out(),
+              "name='{}', subject='{}', version={}",
+              s.name,
+              s.sub,
+              s.version);
+        }
+    }
+
+    // l : format for logging
+    // e : format for error_reporting
+    char presentation{'l'};
+};


### PR DESCRIPTION
This is a small part of CORE-3182

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
