### PR TITLE
rpk transform: improve error message when loading a config

### DIFF
--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -50,7 +50,7 @@ Tinygo - By default tinygo are release builds (-opt=2) for maximum performance.
 		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, extraArgs []string) {
 			cfg, err := project.LoadCfg(fs)
-			out.MaybeDie(err, "unable to find the transform, are you in the same directory as the %q?", project.ConfigFileName)
+			out.MaybeDie(err, "unable to load configuration file %q: %v", project.ConfigFileName, err)
 			switch cfg.Language {
 			case project.WasmLangTinygoWithGoroutines:
 				fallthrough

--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -11,6 +11,7 @@ package project
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -120,8 +121,14 @@ func UnmarshalConfig(b []byte, c *Config) error {
 func LoadCfg(fs afero.Fs) (c Config, err error) {
 	b, err := afero.ReadFile(fs, ConfigFileName)
 	if err != nil {
-		return c, err
+		if os.IsNotExist(err) {
+			return c, fmt.Errorf("config file %q not found; you must be in the same directory as the %[1]q", ConfigFileName)
+		}
+		return c, fmt.Errorf("failed to read config file %q: %v", ConfigFileName, err)
 	}
 	err = UnmarshalConfig(b, &c)
-	return c, err
+	if err != nil {
+		return c, fmt.Errorf("failed to unmarshal config file %q: %v", ConfigFileName, err)
+	}
+	return c, nil
 }


### PR DESCRIPTION
We were not properly reporting the error from `LoadCfg()`. This PR aims to improve the error message, making it easier to identify the problem. 

This will help users determine if they are running the command from a location different from where the configuration file is, or if there is an issue with the configuration file itself.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
