### PR TITLE
[tests] Add public_api_url to CloudClusterConfig

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -101,6 +101,7 @@ class CloudClusterConfig:
     oauth_audience: str = ""
     api_url: str = ""
     admin_api_url: str = ""
+    public_api_url: str = ""
     teleport_auth_server: str = ""
     teleport_bot_token: str = ""
     id: str = ""  # empty string makes it easier to pass thru default value from duck.py


### PR DESCRIPTION
Should fix #20863.

- [x] none - not a product bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none