### PR TITLE
net: fix unused parameter warnings

### DIFF
--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -83,8 +83,7 @@ struct conn_quota_fixture {
 
     void drop_shard_units() {
         for (ss::shard_id i = 0; i < ss::smp::count; ++i) {
-            scq
-              .invoke_on(i, [i, this](conn_quota& cq) { shard_units.erase(i); })
+            scq.invoke_on(i, [i, this](conn_quota&) { shard_units.erase(i); })
               .get();
         }
     }
@@ -123,7 +122,7 @@ struct conn_quota_fixture {
         scq
           .invoke_on(
             shard,
-            [shard, this, take_units](conn_quota& cq) {
+            [shard, this, take_units](conn_quota&) {
                 for (size_t i = 0; i < take_units; ++i) {
                     shard_units[shard].pop_back();
                 }
@@ -242,16 +241,14 @@ void conn_quota_fixture::test_borrows(
     // All shards should now see no units available
     vlog(logger.debug, "Check allowances used up");
     for (ss::shard_id i = 0; i < core_count; ++i) {
-        scq
-          .invoke_on(
-            i, [this](conn_quota& cq) { return expect_no_units(addr1); })
+        scq.invoke_on(i, [this](conn_quota&) { return expect_no_units(addr1); })
           .get();
     }
 
     // Release a unit, then try taking it on a different shard.  This triggers
     // a reclaim.
     vlog(logger.debug, "Trigger a reclaim");
-    scq.invoke_on(1, [this](conn_quota& cq) { shard_units.erase(1); }).get();
+    scq.invoke_on(1, [this](conn_quota&) { shard_units.erase(1); }).get();
     scq
       .invoke_on(
         2,


### PR DESCRIPTION
net: fix unused parameter warnings

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

