### PR TITLE
[v24.1.x] pandaproxy: fix spelling of `operation`

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -144,7 +144,7 @@ struct reply_error_category final : std::error_category {
             return "Invalid compatibility level";
         case reply_error_code::mode_invalid:
             return "Invalid mode";
-        case reply_error_code::subject_version_operaton_not_permitted:
+        case reply_error_code::subject_version_operation_not_permitted:
             return "Overwrite new schema is not permitted.";
         case reply_error_code::subject_version_has_references:
             return "One or more references exist to the schema";

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -85,7 +85,7 @@ enum class reply_error_code : uint16_t {
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,
     mode_invalid = 42204,
-    subject_version_operaton_not_permitted = 42205,
+    subject_version_operation_not_permitted = 42205,
     subject_version_has_references = 42206,
     subject_version_schema_id_already_exists = 42207,
     write_collision = 50301,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -55,7 +55,7 @@ struct error_category final : std::error_category {
                    "configured";
         case error_code::mode_not_found:
             return "Subject does not have subject-level mode configured";
-        case error_code::subject_version_operaton_not_permitted:
+        case error_code::subject_version_operation_not_permitted:
             return "Overwrite new schema is not permitted.";
         case error_code::subject_version_has_references:
             return "One or more references exist to the schema";
@@ -109,9 +109,9 @@ struct error_category final : std::error_category {
             return reply_error_code::schema_empty; // 42201
         case error_code::schema_version_invalid:
             return reply_error_code::schema_version_invalid; // 42202
-        case error_code::subject_version_operaton_not_permitted:
+        case error_code::subject_version_operation_not_permitted:
             return reply_error_code::
-              subject_version_operaton_not_permitted; // 42205
+              subject_version_operation_not_permitted; // 42205
         case error_code::subject_version_has_references:
             return reply_error_code::subject_version_has_references; // 42206
         case error_code::subject_version_schema_id_already_exists:

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -30,7 +30,7 @@ enum class error_code {
     subject_version_not_deleted,
     compatibility_not_found,
     mode_not_found,
-    subject_version_operaton_not_permitted,
+    subject_version_operation_not_permitted,
     subject_version_has_references,
     subject_version_schema_id_already_exists,
     subject_schema_invalid,

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -177,13 +177,13 @@ inline error_info mode_not_found(const subject& sub) {
 
 inline error_info mode_not_readwrite(const subject& sub) {
     return error_info{
-      error_code::subject_version_operaton_not_permitted,
+      error_code::subject_version_operation_not_permitted,
       fmt::format("Subject {} is not in read-write mode", sub())};
 }
 
 inline error_info mode_is_readonly(const std::optional<subject>& sub) {
     return error_info{
-      error_code::subject_version_operaton_not_permitted,
+      error_code::subject_version_operation_not_permitted,
       fmt::format(
         "Subject {} is in read-only mode", sub.value_or(subject{"null"}))};
 }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -699,7 +699,7 @@ public:
     result<void> check_mode_mutability(force f) const {
         if (!_mutable && !f) {
             return error_info{
-              error_code::subject_version_operaton_not_permitted,
+              error_code::subject_version_operation_not_permitted,
               "Mode changes are not allowed"};
         }
         return outcome::success();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21256
