### PR TITLE
CORE-3091 Fix non-incremental AlterConfig resetting

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -126,9 +126,20 @@ ss::future<std::vector<topic_result>> topics_frontend::create_topics(
   model::timeout_clock::time_point timeout) {
     for (auto& tp : topics) {
         /**
+         * The shadow_indexing properties
+         * ('redpanda.remote.(read|write|delete)') are special "sticky" topic
+         * properties that are always set as a topic-level override.
+         *
+         * See: https://github.com/redpanda-data/redpanda/issues/7451
+         *
          * Note that a manually created topic will have this assigned already by
          * kafka/server/handlers/topics/types.cc::to_cluster_type, dependent on
          * client-provided topic properties.
+         *
+         * tp.cfg.properties.remote_delete is stored as a bool (not
+         * std::optional<bool>) defaulted to its default value
+         * (ntp_config::default_remote_delete) on the construction of
+         * topic_properties(), so there is no need to overwrite it here.
          */
         if (!tp.cfg.properties.shadow_indexing.has_value()) {
             tp.cfg.properties.shadow_indexing

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -42,6 +42,7 @@ static void parse_and_set_shadow_indexing_mode(
     property_update,
   const std::optional<ss::sstring>& value,
   model::shadow_indexing_mode enabled_value) {
+    property_update.op = cluster::incremental_update_operation::set;
     if (!value) {
         property_update.value = model::shadow_indexing_mode::disabled;
     }
@@ -69,24 +70,20 @@ create_topic_properties_update(alter_configs_resource& resource) {
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.compaction_strategy.op = op_t::set;
-    update.properties.compression.op = op_t::set;
-    update.properties.segment_size.op = op_t::set;
-    update.properties.timestamp_type.op = op_t::set;
-    update.properties.retention_bytes.op = op_t::set;
-    update.properties.shadow_indexing.op = op_t::set;
-    update.properties.retention_duration.op = op_t::set;
-    update.properties.record_key_schema_id_validation.op = op_t::set;
-    update.properties.record_key_schema_id_validation_compat.op = op_t::set;
-    update.properties.record_key_subject_name_strategy.op = op_t::set;
-    update.properties.record_key_subject_name_strategy_compat.op = op_t::set;
-    update.properties.record_value_schema_id_validation.op = op_t::set;
-    update.properties.record_value_schema_id_validation_compat.op = op_t::set;
-    update.properties.record_value_subject_name_strategy.op = op_t::set;
-    update.properties.record_value_subject_name_strategy_compat.op = op_t::set;
+    constexpr auto apply_op = [](op_t op) {
+        return [op](auto&&... prop) { ((prop.op = op), ...); };
+    };
+    std::apply(apply_op(op_t::remove), update.properties.serde_fields());
+    std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
-    update.custom_properties.replication_factor.op = op_t::none;
-    update.custom_properties.data_policy.op = op_t::none;
+    static_assert(
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 26,
+      "If you added a property, please decide on it's default alter config "
+      "policy, and handle the update in the loop below");
+    static_assert(
+      std::tuple_size_v<decltype(update.custom_properties.serde_fields())> == 2,
+      "If you added a property, please decide on it's default alter config "
+      "policy, and handle the update in the loop below");
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -56,6 +56,8 @@ static void parse_and_set_shadow_indexing_mode(
 
 checked<cluster::topic_properties_update, alter_configs_resource_response>
 create_topic_properties_update(alter_configs_resource& resource) {
+    using op_t = cluster::incremental_update_operation;
+
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
@@ -67,41 +69,24 @@ create_topic_properties_update(alter_configs_resource& resource) {
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.compaction_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.compression.op
-      = cluster::incremental_update_operation::set;
-    update.properties.segment_size.op
-      = cluster::incremental_update_operation::set;
-    update.properties.timestamp_type.op
-      = cluster::incremental_update_operation::set;
-    update.properties.retention_bytes.op
-      = cluster::incremental_update_operation::set;
-    update.properties.retention_duration.op
-      = cluster::incremental_update_operation::set;
-    update.properties.shadow_indexing.op
-      = cluster::incremental_update_operation::set;
-    update.custom_properties.replication_factor.op
-      = cluster::incremental_update_operation::none;
-    update.custom_properties.data_policy.op
-      = cluster::incremental_update_operation::none;
+    update.properties.compaction_strategy.op = op_t::set;
+    update.properties.compression.op = op_t::set;
+    update.properties.segment_size.op = op_t::set;
+    update.properties.timestamp_type.op = op_t::set;
+    update.properties.retention_bytes.op = op_t::set;
+    update.properties.shadow_indexing.op = op_t::set;
+    update.properties.retention_duration.op = op_t::set;
+    update.properties.record_key_schema_id_validation.op = op_t::set;
+    update.properties.record_key_schema_id_validation_compat.op = op_t::set;
+    update.properties.record_key_subject_name_strategy.op = op_t::set;
+    update.properties.record_key_subject_name_strategy_compat.op = op_t::set;
+    update.properties.record_value_schema_id_validation.op = op_t::set;
+    update.properties.record_value_schema_id_validation_compat.op = op_t::set;
+    update.properties.record_value_subject_name_strategy.op = op_t::set;
+    update.properties.record_value_subject_name_strategy_compat.op = op_t::set;
 
-    update.properties.record_key_schema_id_validation.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_schema_id_validation_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_subject_name_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_subject_name_strategy_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_schema_id_validation.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_schema_id_validation_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_subject_name_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_subject_name_strategy_compat.op
-      = cluster::incremental_update_operation::set;
+    update.custom_properties.replication_factor.op = op_t::none;
+    update.custom_properties.data_policy.op = op_t::none;
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/server/handlers/alter_configs.h"
 
+#include "cluster/metadata_cache.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
@@ -84,6 +85,20 @@ create_topic_properties_update(alter_configs_resource& resource) {
       std::tuple_size_v<decltype(update.custom_properties.serde_fields())> == 2,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
+
+    /**
+     * The shadow_indexing properties ('redpanda.remote.(read|write|delete)')
+     * are special "sticky" topic properties that are always set as a
+     * topic-level override. We should prevent changing them unless explicitly
+     * requested.
+     *
+     * See: https://github.com/redpanda-data/redpanda/issues/7451
+     */
+    update.properties.shadow_indexing.op = op_t::none;
+    update.properties.remote_delete.op = op_t::none;
+
+    // Now that the defaults are set, continue to set properties from the
+    // request
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -22,6 +22,7 @@
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "storage/ntp_config.h"
 #include "strings/string_switch.h"
 
 #include <seastar/core/do_with.hh>
@@ -223,7 +224,7 @@ create_topic_properties_update(
                   cfg.value,
                   op,
                   // Topic deletion is enabled by default
-                  true);
+                  storage::ntp_config::default_remote_delete);
                 continue;
             }
             if (cfg.name == topic_property_max_message_bytes) {


### PR DESCRIPTION
The AlterConfigs API differs from the IncrementalAlterConfigs API in that it is supposed to clear all configs not specified in the request. This was implemented incorrectly, so this PR fixes the behaviour by:
 * Removing the topic-level config overrides for unspecified fields instead of setting them to their type's default value.
 * Doing this for all topic configs, including the currently missing ones:
    - `remote_delete`
    - `segment_ms`
    - `batch_max_bytes`
    - `retention_local_target_ms`
    - `retention_local_target_bytes`
    - `initial_retention_local_target_ms`
    - `initial_retention_local_target_bytes`
    - `write_caching`
    - `flush_ms`
    - `flush_bytes`

Note that an exception is made for the shadow indexing topic configs `redpanda.remote.(read|write|delete)` to not reset them. These configs  are intentionally sticky topic configs which should only be changed when explicitly asked as the risk of deleting tiered storage data is too large otherwise. Ref: https://github.com/redpanda-data/redpanda/issues/7451.

Fixes https://redpandadata.atlassian.net/browse/CORE-3091

While this PR is a bug fix, it is intentionally not backported as this would be too large a change for a patch release.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes
* Fixes a bug in the legacy AlterConfig (not IncrementalAlterConfig) API to reset non-specified topic-level overrides to their defaults.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
