### PR TITLE
[CORE-5092] Transform SDK: Schema Registry client in C++

### DIFF
--- a/src/transform-sdk/cpp/examples/CMakeLists.txt
+++ b/src/transform-sdk/cpp/examples/CMakeLists.txt
@@ -43,3 +43,12 @@ target_link_libraries(
   identity_logging_transform
   Redpanda::transform_sdk
 )
+
+add_executable(
+  schema_registry_transform
+  schema_registry.cc
+)
+target_link_libraries(
+  schema_registry_transform
+  Redpanda::transform_sdk
+)

--- a/src/transform-sdk/cpp/examples/schema_registry.cc
+++ b/src/transform-sdk/cpp/examples/schema_registry.cc
@@ -1,0 +1,104 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <redpanda/transform_sdk.h>
+
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace {
+
+namespace sr = redpanda::sr;
+
+std::error_code
+do_transform(redpanda::write_event event, redpanda::record_writer* writer);
+
+std::unique_ptr<sr::schema_registry_client> sr_client;
+
+constexpr std::string_view schema_def = R"({
+	"type": "record",
+	"name": "Example",
+	"fields": [
+		{"name": "a", "type": "long", "default": 0},
+		{"name": "b", "type": "string", "default": ""}
+	]
+})";
+
+} // namespace
+
+int main() {
+    sr_client = sr::new_client();
+    if (auto res = sr_client->create_schema(
+          "avro-value",
+          sr::schema::new_avro(
+            std::string{schema_def.data(), schema_def.size()}));
+        !res.has_value()) {
+        return 0;
+    }
+    redpanda::on_record_written(do_transform);
+}
+
+namespace {
+
+std::error_code
+do_transform(redpanda::write_event event, redpanda::record_writer* writer) {
+    auto rec_bytes = event.record.value;
+    if (!rec_bytes.has_value()) {
+        return std::make_error_code(std::errc::illegal_byte_sequence);
+    }
+    std::optional<sr::schema_id> id;
+    if (auto id_e = sr::decode_schema_id(rec_bytes.value()); id_e.has_value()) {
+        id.emplace(id_e.value().first);
+        rec_bytes = id_e.value().second;
+    } else {
+        return id_e.error();
+    }
+    std::optional<sr::schema> raw_schema;
+    if (auto rs_e = sr_client->lookup_schema_by_id(id.value());
+        rs_e.has_value()) {
+        raw_schema.emplace(std::move(rs_e).value());
+    } else {
+        return rs_e.error();
+    }
+    // ?????
+    // auto schema = avro::schema::parse_str(raw_schema.value().schema());
+
+    std::optional<sr::subject_schema> latest_schema;
+    if (auto latest_e = sr_client->lookup_latest_schema("avro-value");
+        latest_e.has_value()) {
+        latest_schema.emplace(std::move(latest_e).value());
+    } else {
+        return latest_e.error();
+    }
+
+    std::optional<sr::subject_schema> latest_direct;
+    if (auto latest_e = sr_client->lookup_schema_by_version(
+          "avro-value", latest_schema->version);
+        latest_e.has_value()) {
+        latest_direct.emplace(std::move(latest_e).value());
+    } else {
+        return latest_e.error();
+    }
+
+    if (latest_schema != latest_direct) {
+        return std::make_error_code(std::errc::io_error);
+    }
+    std::cerr << "ALL IS GOOD" << std::endl;
+
+    return writer->write(event.record);
+}
+
+} // namespace

--- a/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
+++ b/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
@@ -25,6 +25,26 @@
 #include <system_error>
 #include <vector>
 
+namespace detail {
+
+template<typename T, typename Tag>
+struct simple_named_type {
+    using type = T;
+    explicit simple_named_type(type val)
+      : _val(val) {}
+    [[nodiscard]] type value() const { return _val; }
+    constexpr operator type() const { return _val; }
+    type* data() { return &_val; }
+
+private:
+    friend bool operator==(
+      const simple_named_type<type, Tag>&, const simple_named_type<type, Tag>&)
+      = default;
+    type _val;
+};
+
+} // namespace detail
+
 namespace redpanda {
 
 /**

--- a/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
+++ b/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <expected>
 #include <functional>
 #include <optional>
 #include <ranges>
@@ -321,6 +322,22 @@ struct subject_schema {
     friend bool operator==(const subject_schema&, const subject_schema&)
       = default;
 };
+
+/**
+ * Extract and decode the schema ID from an arbitrary array of bytes.
+ * buf must be at least 5B long:
+ *   - buf[0]: magic byte (must be 0x00)
+ *   - buf[1..5]: the id, in network byte order (big endian)
+ */
+std::expected<std::pair<schema_id, bytes_view>, std::error_code>
+decode_schema_id(bytes_view buf);
+
+/**
+ * Encode and prepend the schema ID to a byte array.
+ * Creates and returns a copy of the buffer.
+ * The result will be at least 5B long.
+ */
+bytes encode_schema_id(schema_id sid, bytes_view buf);
 
 } // namespace sr
 

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -464,6 +464,34 @@ on_record_written(const on_record_written_callback& callback) {
     }
 }
 
+namespace sr {
+
+schema
+schema::new_avro(std::string schema, std::optional<reference_container> refs) {
+    return {
+      std::move(schema),
+      schema_format::avro,
+      std::move(refs).value_or(reference_container{})};
+}
+
+schema schema::new_protobuf(
+  std::string schema, std::optional<reference_container> refs) {
+    return {
+      std::move(schema),
+      schema_format::protobuf,
+      std::move(refs).value_or(reference_container{})};
+}
+
+schema
+schema::new_json(std::string schema, std::optional<reference_container> refs) {
+    return {
+      std::move(schema),
+      schema_format::json,
+      std::move(refs).value_or(reference_container{})};
+}
+
+} // namespace sr
+
 } // namespace redpanda
 
 #ifdef REDPANDA_TRANSFORM_SDK_ENABLE_TESTING

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -108,6 +108,54 @@ WASM_IMPORT(redpanda_transform, write_record)
 int32_t redpanda_transform_write_record(uint8_t* buf, uint32_t len);
 constexpr auto write_record = redpanda_transform_write_record;
 
+/**
+ * Schema Registry ABI
+ */
+namespace sr {
+
+WASM_IMPORT(redpanda_schema_registry, check_abi_version_0)
+void redpanda_schema_registry_check();
+constexpr auto check = redpanda_schema_registry_check;
+
+WASM_IMPORT(redpanda_schema_registry, get_schema_definition_len)
+int32_t redpanda_schema_registry_get_schema_definition_len(
+  int32_t schemaId, int32_t* len);
+constexpr auto get_schema_definition_len
+  = redpanda_schema_registry_get_schema_definition_len;
+
+WASM_IMPORT(redpanda_schema_registry, get_schema_definition)
+int32_t redpanda_schema_registry_get_schema_definition(
+  int32_t schema_id, uint8_t* buf, int32_t len);
+constexpr auto get_schema_definition
+  = redpanda_schema_registry_get_schema_definition;
+
+WASM_IMPORT(redpanda_schema_registry, get_subject_schema_len)
+int32_t redpanda_schema_registry_get_subject_schema_len(
+  const uint8_t* subject, int32_t subject_len, int32_t version, int32_t* len);
+constexpr auto get_subject_schema_len
+  = redpanda_schema_registry_get_subject_schema_len;
+
+WASM_IMPORT(redpanda_schema_registry, get_subject_schema)
+int32_t redpanda_schema_registry_get_subject_schema(
+  const uint8_t* subject,
+  int32_t subject_len,
+  int32_t version,
+  uint8_t* buf,
+  int32_t len);
+constexpr auto get_subject_schema = redpanda_schema_registry_get_subject_schema;
+
+WASM_IMPORT(redpanda_schema_registry, create_subject_schema)
+int32_t redpanda_schema_registry_create_subject_schema(
+  const uint8_t* subject,
+  int32_t subject_len,
+  uint8_t* buf,
+  int32_t len,
+  int32_t* schema_id_out);
+constexpr auto create_subject_schema
+  = redpanda_schema_registry_create_subject_schema;
+
+} // namespace sr
+
 #undef WASM_IMPORT
 }
 
@@ -141,6 +189,46 @@ int32_t read_next_record(
 int32_t write_record(const uint8_t* /*unused*/, uint32_t /*unused*/) {
     abort("write_record - stub");
 }
+
+namespace sr {
+
+void check() { abort("sr_check_abi - stub"); }
+
+int32_t get_schema_definition_len(int32_t /*unused*/, int32_t* /*unused*/) {
+    abort("get_schema_definition_len - stub");
+}
+
+int32_t get_schema_definition(
+  int32_t /*unused*/, uint8_t* /*unused*/, int32_t /*unused*/) {
+    abort("get_schema_definition - stub");
+}
+
+int32_t get_subject_schema_len(
+  const uint8_t* /*unused*/,
+  int32_t /*unused*/,
+  int32_t /*unused*/,
+  int32_t* /*unused*/) {
+    abort("get_subject_schema_len - stub");
+}
+
+int32_t get_subject_schema(
+  const uint8_t* /*unused*/,
+  int32_t /*unused*/,
+  int32_t /*unused*/,
+  uint8_t* /*unused*/,
+  int32_t /*unused*/) {
+    abort("get_subject_schema - stub");
+}
+
+int32_t create_subject_schema(
+  const uint8_t* /*unused*/,
+  int32_t /*unused*/,
+  uint8_t* /*unused*/,
+  int32_t /*unused*/,
+  int32_t* /*unused*/) {
+    abort("create_subject_schema - stub");
+}
+} // namespace sr
 
 #endif
 } // namespace abi


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Primarily in service of extending Schema Registry support to the JavaScript SDK, this commit implements the full SR ABI v0 in the C++ SDK.

TODO (exclusive of mundane cleanup):
- [x] Type documentation
- [x] improve error code forwarding across SDK API boundary
- [x] organization of namespces could use a second look
- [x] `schema_registry_client::new_client()` could be a free function
- [x] ~Finish building out `examples/schema_registry.cc`~ punting on this as the javascript version will test a superset of functionality.
   - [ ] ~Avro dependency for deser (ingress)~
   - [ ] ~JSON dependency for ser (egress)~
   - [ ] ~Enable SR integration test~

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Add schema registry support to experimental Data Transforms C++ SDK

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
