### PR TITLE
cloud tests: run all OMB validation tests

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -15,8 +15,6 @@ cloud:
     - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
     - redpanda_cloud_tests/observe_test.py
     - redpanda_cloud_tests/rolling_restart_test.py
-    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_connections
-    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_partitions
-    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_common_workload
+    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest
     - redpanda_cloud_tests/cloud_self_test.py
     - tests/services_self_test.py::SimpleSelfTest.test_cloud


### PR DESCRIPTION
This test was disabled while we were trying to get all the cloud tests green and we had the latency spike issue. Per redpanda-data/redpanda#15334 we now have retry logic and in any case this test is only "just as affected" as test_common which are successfully running (for the most part).

So re-enable it by specifying the entire OMBValidationTest class in the suite.


## Backports Required

- [x] none - don't backport cloud DT tests

## Release Notes


* none
