### PR TITLE
cloud_storage: miscellaneous non-functional changes

### DIFF
--- a/src/v/cloud_storage/remote_path_provider.cc
+++ b/src/v/cloud_storage/remote_path_provider.cc
@@ -22,6 +22,11 @@ namespace cloud_storage {
 remote_path_provider::remote_path_provider(std::optional<remote_label> label)
   : label_(label) {}
 
+remote_path_provider remote_path_provider::copy() const {
+    remote_path_provider ret(label_);
+    return ret;
+}
+
 ss::sstring remote_path_provider::topic_manifest_prefix(
   const model::topic_namespace& topic) const {
     if (label_.has_value()) {

--- a/src/v/cloud_storage/remote_path_provider.h
+++ b/src/v/cloud_storage/remote_path_provider.h
@@ -22,7 +22,25 @@ namespace cloud_storage {
 
 class remote_path_provider {
 public:
+    // Discourage accidental copies to encourage referencing of a single path
+    // provider (e.g. the one owned by the archival STM).
+    remote_path_provider(const remote_path_provider&) = delete;
+    remote_path_provider& operator=(const remote_path_provider&) = delete;
+    remote_path_provider& operator=(remote_path_provider&&) = delete;
+    ~remote_path_provider() = default;
+
     explicit remote_path_provider(std::optional<remote_label> label);
+
+    // An explicit copy method. Callers should think twice about using this and
+    // instead consider if there is an existing path provider that makes sense
+    // to reference instead (e.g. the one owned by the archival STM).
+    //
+    // One may not exist e.g. when doing background finalization after the
+    // partition and STM is destructed.
+    remote_path_provider copy() const;
+
+    // For use in copy() and in coroutines.
+    remote_path_provider(remote_path_provider&&) = default;
 
     // Prefix of the topic manifest path. This can be used to filter objects to
     // find topic manifests.

--- a/src/v/cloud_storage/topic_manifest_downloader.cc
+++ b/src/v/cloud_storage/topic_manifest_downloader.cc
@@ -31,6 +31,22 @@ bool bin_manifest_filter(
     return i.key.ends_with("topic_manifest.bin");
 };
 } // namespace
+
+std::ostream& operator<<(std::ostream& os, find_topic_manifest_outcome o) {
+    switch (o) {
+    case find_topic_manifest_outcome::success:
+        os << "find_topic_manifest_outcome::success";
+        break;
+    case find_topic_manifest_outcome::no_matching_manifest:
+        os << "find_topic_manifest_outcome::no_matching_manifest";
+        break;
+    case find_topic_manifest_outcome::multiple_matching_manifests:
+        os << "find_topic_manifest_outcome::multiple_matching_manifests";
+        break;
+    }
+    return os;
+}
+
 topic_manifest_downloader::topic_manifest_downloader(
   const cloud_storage_clients::bucket_name bucket,
   std::optional<ss::sstring> hint,

--- a/src/v/cloud_storage/topic_manifest_downloader.h
+++ b/src/v/cloud_storage/topic_manifest_downloader.h
@@ -27,6 +27,7 @@ enum class find_topic_manifest_outcome {
     // and a hint must be provided to determine winner.
     multiple_matching_manifests,
 };
+std::ostream& operator<<(std::ostream&, find_topic_manifest_outcome);
 
 // Encapsulates downloading manifests for a given topic.
 //

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -122,6 +122,11 @@ ss::future<consensus_ptr> partition_manager::manage(
   raft::keep_snapshotted_log keep_snapshotted_log,
   std::optional<cloud_storage::remote_label> remote_label) {
     auto guard = _gate.hold();
+    // NOTE: while the source cluster UUIDs of the path providers will
+    // ultimately be the same, this is a different path provider than what will
+    // be used at runtime by the partition. The latter is owned by the archival
+    // metadata STM and its lifecycle is therefore tied to the partition, which
+    // hasn't been constructed yet.
     cloud_storage::remote_path_provider path_provider(remote_label);
     auto dl_result = co_await maybe_download_log(ntp_cfg, rtp, path_provider);
     auto& [logs_recovered, clean_download, min_offset, max_offset, manifest, ot_state]

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -560,6 +560,12 @@ ss::future<topic_result> topics_frontend::do_create_topic(
     bool configured_label_from_manifest
       = assignable_config.is_read_replica()
         || assignable_config.is_recovery_enabled();
+    // We set a remote label if:
+    // - we haven't got a remote label from the cloud (i.e. this isn't a read
+    //   replica or recovery topic),
+    // - there is a cluster UUID (always expected),
+    // - the remote labels feature is active,
+    // - the config to disable remote labels is False
     if (
       !configured_label_from_manifest
       && !assignable_config.cfg.properties.remote_label.has_value()

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -119,7 +119,7 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
     if version >= 9:
         topic_properties |= {
-            'remote_labels': rdr.read_optional(read_remote_label_serde)
+            'remote_label': rdr.read_optional(read_remote_label_serde)
         }
 
     return topic_properties


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Review follow-up to https://github.com/redpanda-data/redpanda/pull/20778

- Adds logging to the topic_manifest_downloader. I considered adding more logging to the partition_manifest_downloader, which is in contrast much simpler, but it seems less complicated and has less context to log.
- Fixes typo in offline_log_viewer.
- Makes remote_path_provider harder to copy around, to encourage code authors to hopefully make it clearer that the archival metadata STM is the primary provider used across archival and cloud_storage subsystems.
- Adds a comment clarifying usage of path provider at partition-creation time.
- Adds a comment clarifying condition of setting the remote lable.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
