### PR TITLE
test/random_node_operations: tolerate lost produces

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -598,8 +598,13 @@ class KgoVerifierProducer(KgoVerifierService):
             # the same topic, or that Redpanda showed a buggy behavior with
             # idempotency: producer records should always land at the next offset
             # after the last record they wrote.
-            raise RuntimeError(
-                f"{self.who_am_i()} possible idempotency bug: {self._status}")
+            if self._tolerate_data_loss:
+                self._redpanda.logger.warn(
+                    f"{self.who_am_i()} observed data loss: {self._status}")
+            else:
+                raise RuntimeError(
+                    f"{self.who_am_i()} possible idempotency bug: {self._status}"
+                )
 
         return super().wait_node(node, timeout_sec=timeout_sec)
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -249,7 +249,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             )
             self.producer.wait()
 
-            assert self.producer.produce_status.bad_offsets == 0
+            assert self.producer.produce_status.bad_offsets == 0 or self.tolerate_data_loss
             # Await the consumer that is reading only the subset of data that
             # was written before it started.
             self.consumer.wait()


### PR DESCRIPTION
When set to tolerate data loss, we should ignore idempotency bugs, as they may happen because data recently produced has been lost.
Fixes https://github.com/redpanda-data/redpanda/issues/18272, which seems to be a combination of node failure injections, node decommissions and write caching. The latter was introduced in April 2024.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
