### PR TITLE
tests/ducktape: check redpanda can stop

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -216,6 +216,9 @@ def cluster(log_allow_list: LogAllowList | None = None,
                     except:
                         self.redpanda.cloud_storage_diagnostics()
                         raise
+                else:
+                    # stop here explicitly to fail if stop times out, otherwise ducktape won't catch it
+                    self.redpanda.stop()
 
                 # Finally, if the test passed and all post-test checks
                 # also passed, we may trim the logs to INFO level to

--- a/tests/rptest/tests/e2e_finjector.py
+++ b/tests/rptest/tests/e2e_finjector.py
@@ -95,3 +95,4 @@ class EndToEndFinjectorTest(EndToEndTest):
         if self.finjector_thread:
             self.finjector_thread.join()
         make_failure_injector(self.redpanda)._heal_all()
+        make_failure_injector(self.redpanda)._continue_all()


### PR DESCRIPTION
Stop redpanda explicitly to fail if it times out. Ducktape swallows this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
