### PR TITLE
archival: Update ntp_archiver (pt.1)

### DIFF
--- a/src/v/archival/archiver_operations_api.cc
+++ b/src/v/archival/archiver_operations_api.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/archiver_operations_api.h"
+
+namespace archival {
+
+archiver_operations_api::~archiver_operations_api() {}
+
+bool reconciled_upload_candidate::operator==(
+  const reconciled_upload_candidate& o) const noexcept {
+    return ntp == o.ntp && size_bytes == o.size_bytes && metadata == o.metadata;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const reconciled_upload_candidate& s) {
+    fmt::print(
+      o,
+      "reconciled_upload_candidate({}, {}, {})",
+      s.ntp,
+      s.size_bytes,
+      s.metadata);
+    return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const upload_candidate_search_parameters& s) {
+    fmt::print(
+      o,
+      "upload_candidate_search_parameters(ntp={}, target_size={}, min_size={}, "
+      "upload_size_quota={}, upload_requests_quota={}, compacted_reupload={}, "
+      "inline_manifest={})",
+      s.ntp,
+      s.target_size,
+      s.min_size,
+      s.upload_size_quota,
+      s.upload_requests_quota,
+      s.compacted_reupload,
+      s.inline_manifest);
+    return o;
+}
+
+upload_candidate_search_parameters::upload_candidate_search_parameters(
+  model::ntp ntp,
+  model::term_id archiver_term,
+  size_t target_size,
+  size_t min_size,
+  std::optional<size_t> upload_size_quota,
+  std::optional<size_t> upload_requests_quota,
+  bool compacted_reupload,
+  bool inline_manifest)
+  : ntp(std::move(ntp))
+  , archiver_term(archiver_term)
+  , target_size(target_size)
+  , min_size(min_size)
+  , upload_size_quota(upload_size_quota)
+  , upload_requests_quota(upload_requests_quota)
+  , compacted_reupload(compacted_reupload)
+  , inline_manifest(inline_manifest) {}
+
+bool reconciled_upload_candidates_list::operator==(
+  const reconciled_upload_candidates_list& rhs) const {
+    return read_write_fence == rhs.read_write_fence
+           && std::equal(
+             results.begin(),
+             results.end(),
+             rhs.results.begin(),
+             [](
+               const reconciled_upload_candidate_ptr& lhs,
+               const reconciled_upload_candidate_ptr& rhs) {
+                 return *lhs == *rhs;
+             });
+}
+
+std::ostream&
+operator<<(std::ostream& o, const reconciled_upload_candidates_list& r) {
+    fmt::print(
+      o,
+      "reconciled_upload_candidates_list(num_results={}, "
+      "read_write_fence={})",
+      r.results.size(),
+      r.read_write_fence);
+    return o;
+}
+
+bool upload_results_list::operator==(
+  const upload_results_list& o) const noexcept {
+    return manifest_clean_offset == o.manifest_clean_offset && stats == o.stats
+           && results == o.results && num_put_requests == o.num_put_requests
+           && num_bytes_sent == o.num_bytes_sent;
+}
+
+std::ostream& operator<<(std::ostream& o, const upload_results_list& s) {
+    std::stringstream str;
+    for (auto r : s.results) {
+        str << r << ' ';
+    }
+    fmt::print(
+      o,
+      "upload_results_list(results={}, clean_offset={}, "
+      "read_write_fence={}, num_put_request={}, bytes_sent={})",
+      str.str(),
+      s.manifest_clean_offset,
+      s.read_write_fence,
+      s.num_put_requests,
+      s.num_bytes_sent);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const admit_uploads_result& s) {
+    fmt::print(
+      "admit_uploads_result(num_succeeded={}, num_failed={}, "
+      "dirty_offset={})",
+      s.num_succeeded,
+      s.num_failed,
+      s.manifest_dirty_offset);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const manifest_upload_result& arg) {
+    fmt::print(
+      o,
+      "manifest_upload_result(ntp={}, num_put_requests={}, "
+      "size_bytes={})",
+      arg.ntp,
+      arg.num_put_requests,
+      arg.size_bytes);
+    return o;
+}
+
+} // namespace archival

--- a/src/v/archival/archiver_operations_api.h
+++ b/src/v/archival/archiver_operations_api.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/async_data_uploader.h"
+#include "base/outcome.h"
+#include "cloud_storage/remote_segment_index.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+
+namespace ss = seastar;
+
+namespace archival {
+
+struct manifest_upload_result {
+    model::ntp ntp;
+    size_t num_put_requests{0};
+    size_t size_bytes{0};
+
+    bool operator==(const manifest_upload_result& other) const = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const manifest_upload_result& arg);
+};
+
+struct reconciled_upload_candidate {
+    /// Partition
+    model::ntp ntp;
+    /// Stream of log data in cloud-storage format
+    ss::input_stream<char> payload;
+    /// Size of the data stream
+    size_t size_bytes;
+    /// Segment metadata
+    cloud_storage::segment_meta metadata;
+    // Transactional metadata
+    fragmented_vector<model::tx_range> tx;
+
+    reconciled_upload_candidate() = default;
+
+    reconciled_upload_candidate(
+      model::ntp ntp,
+      ss::input_stream<char> payload,
+      size_t size_bytes,
+      cloud_storage::segment_meta metadata,
+      fragmented_vector<model::tx_range> tx)
+      : ntp(std::move(ntp))
+      , payload(std::move(payload))
+      , size_bytes(size_bytes)
+      , metadata(metadata)
+      , tx(std::move(tx)) {}
+
+    reconciled_upload_candidate(const reconciled_upload_candidate&) = delete;
+    reconciled_upload_candidate(reconciled_upload_candidate&&) noexcept
+      = default;
+    reconciled_upload_candidate& operator=(const reconciled_upload_candidate&)
+      = delete;
+    reconciled_upload_candidate&
+    operator=(reconciled_upload_candidate&&) noexcept
+      = default;
+
+    // NOTE: the operator is needed for tests only, it doesn't check
+    // equality of byte streams.
+    bool operator==(const reconciled_upload_candidate& o) const noexcept;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const reconciled_upload_candidate& s);
+};
+
+struct upload_candidate_search_parameters {
+    upload_candidate_search_parameters() = default;
+    upload_candidate_search_parameters(
+      model::ntp ntp,
+      model::term_id archiver_term,
+      size_t target_size,
+      size_t min_size,
+      std::optional<size_t> upload_size_quota,
+      std::optional<size_t> upload_requests_quota,
+      bool compacted_reupload,
+      bool inline_manifest);
+
+    upload_candidate_search_parameters(
+      const upload_candidate_search_parameters&)
+      = default;
+    upload_candidate_search_parameters&
+    operator=(const upload_candidate_search_parameters&)
+      = default;
+    upload_candidate_search_parameters(
+      upload_candidate_search_parameters&&) noexcept
+      = default;
+    upload_candidate_search_parameters&
+    operator=(upload_candidate_search_parameters&&) noexcept
+      = default;
+
+    bool operator==(const upload_candidate_search_parameters&) const = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const upload_candidate_search_parameters& s);
+    model::ntp ntp;
+    // Current term of the archiver
+    model::term_id archiver_term;
+    // Optimal segment upload size
+    size_t target_size;
+    // Smallest acceptable upload size (can be set to 0 by the scheduler if
+    // upload interval expired)
+    size_t min_size;
+
+    // Upload size quota. The 'find_upload_candidates' method can find
+    // multiple upload candidates but their total size shouldn't exceed the
+    // quota. If set to 'nullopt' then there is no limit.
+    std::optional<size_t> upload_size_quota;
+    // PUT requests quota. Value 'nullopt' means no limit.
+    std::optional<size_t> upload_requests_quota;
+
+    // Set to true if compacted reupload is enabled in the config
+    bool compacted_reupload{false};
+    // Set to true if the manifest upload has to be performed in parallel
+    // with segment upload
+    bool inline_manifest{false};
+};
+
+using reconciled_upload_candidate_ptr
+  = ss::lw_shared_ptr<reconciled_upload_candidate>;
+
+struct reconciled_upload_candidates_list {
+    model::ntp ntp;
+    std::deque<reconciled_upload_candidate_ptr> results;
+    model::offset read_write_fence;
+
+    reconciled_upload_candidates_list(
+      model::ntp ntp,
+      std::deque<reconciled_upload_candidate_ptr> results,
+      model::offset read_write_fence)
+      : ntp(std::move(ntp))
+      , results(std::move(results))
+      , read_write_fence(read_write_fence) {}
+
+    reconciled_upload_candidates_list(const reconciled_upload_candidates_list&)
+      = delete;
+    reconciled_upload_candidates_list(
+      reconciled_upload_candidates_list&&) noexcept
+      = default;
+    reconciled_upload_candidates_list&
+    operator=(const reconciled_upload_candidates_list&)
+      = delete;
+    reconciled_upload_candidates_list&
+    operator=(reconciled_upload_candidates_list&&) noexcept
+      = default;
+
+    bool operator==(const reconciled_upload_candidates_list& rhs) const;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const reconciled_upload_candidates_list& r);
+};
+
+struct upload_results_list {
+    model::ntp ntp;
+    std::deque<std::optional<cloud_storage::segment_record_stats>> stats;
+    std::deque<cloud_storage::upload_result> results;
+    std::deque<cloud_storage::segment_meta> metadata;
+
+    // Last uploaded offset of the partition for which we persisted metadata
+    // (manifest) to the cloud storage
+    model::offset manifest_clean_offset;
+    // The field is used for concurrency control. This is the offset of the last
+    // archival_metadata_stm command applied to the manifest.
+    model::offset read_write_fence;
+
+    size_t num_put_requests{0};
+    size_t num_bytes_sent{0};
+
+    upload_results_list() = default;
+
+    upload_results_list(
+      model::ntp ntp,
+      std::deque<std::optional<cloud_storage::segment_record_stats>> stats,
+      std::deque<cloud_storage::upload_result> results,
+      std::deque<cloud_storage::segment_meta> metadata,
+      model::offset manifest_clean_offset,
+      model::offset read_write_fence,
+      size_t num_put_requests,
+      size_t num_bytes_sent)
+      : ntp(std::move(ntp))
+      , stats(std::move(stats))
+      , results(std::move(results))
+      , metadata(std::move(metadata))
+      , manifest_clean_offset(manifest_clean_offset)
+      , read_write_fence(read_write_fence)
+      , num_put_requests(num_put_requests)
+      , num_bytes_sent(num_bytes_sent) {}
+
+    upload_results_list(const upload_results_list&) = delete;
+    upload_results_list(upload_results_list&&) noexcept = default;
+    upload_results_list& operator=(const upload_results_list&) = delete;
+    upload_results_list& operator=(upload_results_list&&) noexcept = default;
+
+    bool operator==(const upload_results_list& o) const noexcept;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const upload_results_list& s);
+};
+
+struct admit_uploads_result {
+    model::ntp ntp;
+    size_t num_succeeded{0};
+    size_t num_failed{0};
+
+    // The in-sync offset of the manifest after update
+    model::offset manifest_dirty_offset;
+
+    bool operator==(const admit_uploads_result&) const = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const admit_uploads_result& s);
+};
+
+/// The API provides operations that can be used by different
+/// upload workflows. The object is not specific to any particular
+/// NTP. Multiple workflows can use single API instance.
+class archiver_operations_api {
+public:
+    archiver_operations_api() = default;
+    archiver_operations_api(const archiver_operations_api&) = delete;
+    archiver_operations_api(archiver_operations_api&&) noexcept = delete;
+    archiver_operations_api& operator=(const archiver_operations_api&) = delete;
+    archiver_operations_api& operator=(archiver_operations_api&&) noexcept
+      = delete;
+    virtual ~archiver_operations_api();
+
+public:
+    /// Return upload candidate(s) if data is available or nullopt
+    /// if there is not enough data to start an upload.
+    virtual ss::future<result<reconciled_upload_candidates_list>>
+    find_upload_candidates(
+      retry_chain_node&, upload_candidate_search_parameters) noexcept
+      = 0;
+
+    /// Upload data to S3 and return results
+    ///
+    /// The method uploads segments with their corresponding tx-manifests and
+    /// indexes and also the manifest. The result contains the insync offset of
+    /// the uploaded manifest. The state of the uploaded manifest doesn't
+    /// include uploaded segments because they're not admitted yet.
+    virtual ss::future<result<upload_results_list>> schedule_uploads(
+      retry_chain_node&,
+      reconciled_upload_candidates_list,
+      bool embed_manifest) noexcept
+      = 0;
+
+    /// Add metadata to the manifest by replicating archival metadata
+    /// configuration batch
+    virtual ss::future<result<admit_uploads_result>>
+    admit_uploads(retry_chain_node&, upload_results_list) noexcept = 0;
+
+    // Metadata management
+
+    /// Reupload manifest and replicate configuration batch
+    virtual ss::future<result<manifest_upload_result>>
+    upload_manifest(retry_chain_node&, model::ntp) noexcept = 0;
+};
+
+} // namespace archival

--- a/src/v/archival/archiver_operations_impl.cc
+++ b/src/v/archival/archiver_operations_impl.cc
@@ -78,12 +78,9 @@ public:
                   arg.ntp);
                 co_return error_outcome::unexpected_failure;
             }
-            reconciled_upload_candidates_list result{
-              .ntp = arg.ntp,
-              .read_write_fence = partition->get_applied_offset(),
-            };
-            auto base_offset = model::next_offset(
-              partition->get_uploaded_offset());
+            reconciled_upload_candidates_list result(
+              arg.ntp, {}, partition->get_applied_offset());
+            auto base_offset = partition->get_next_uploaded_offset();
 
             // If not limit is specified (quota is set to nullopt) we don't want
             // to upload unlimited amount of data in one iteration. The defaults
@@ -174,17 +171,16 @@ public:
     /// the uploaded manifest. The state of the uploaded manifest doesn't
     /// include uploaded segments because they're not admitted yet.
     ss::future<result<upload_results_list>> schedule_uploads(
-      retry_chain_node& workflow_rtc,
-      reconciled_upload_candidates_list bundle,
-      bool inline_manifest_upl) noexcept override {
+      retry_chain_node&,
+      reconciled_upload_candidates_list,
+      bool) noexcept override {
         co_return error_outcome::unexpected_failure;
     }
 
     /// Add metadata to the manifest by replicating archival metadata
     /// configuration batch
-    ss::future<result<admit_uploads_result>> admit_uploads(
-      retry_chain_node& workflow_rtc,
-      upload_results_list upl_res) noexcept override {
+    ss::future<result<admit_uploads_result>>
+    admit_uploads(retry_chain_node&, upload_results_list) noexcept override {
         co_return error_outcome::unexpected_failure;
     }
 

--- a/src/v/archival/archiver_operations_impl.cc
+++ b/src/v/archival/archiver_operations_impl.cc
@@ -61,12 +61,109 @@ public:
       , _bucket(std::move(bucket))
       , _sg(sg) {}
 
-    /// Return upload candidate(s) if data is available or not_enough_data error
-    /// if there is not enough data to start an upload.
+    /// Return upload candidate(s) if data is available or not_enough_data
+    /// error if there is not enough data to start an upload.
     ss::future<result<reconciled_upload_candidates_list>>
     find_upload_candidates(
       retry_chain_node& workflow_rtc,
       upload_candidate_search_parameters arg) noexcept override {
+        vlog(_rtclog.debug, "find_upload_candidates {}", arg);
+        try {
+            auto partition = _pm->get_partition(arg.ntp);
+            if (partition == nullptr) {
+                // maybe race condition (partition was stopped or moved)
+                vlog(
+                  _rtclog.debug,
+                  "find_upload_candidates - can't find partition {}",
+                  arg.ntp);
+                co_return error_outcome::unexpected_failure;
+            }
+            reconciled_upload_candidates_list result{
+              .ntp = arg.ntp,
+              .read_write_fence = partition->get_applied_offset(),
+            };
+            auto base_offset = model::next_offset(
+              partition->get_uploaded_offset());
+
+            // If not limit is specified (quota is set to nullopt) we don't want
+            // to upload unlimited amount of data in one iteration. The defaults
+            // in this case are configured to allow only three segments to be
+            // uploaded.
+            auto size_quota = arg.upload_size_quota.value_or(
+              arg.target_size * 3);
+            // By default we will be uploading up to 4 segments
+            // with up to 3 requests to upload one segment.
+            constexpr size_t default_req_quota = 12;
+
+            auto req_quota = arg.upload_requests_quota.value_or(
+              default_req_quota);
+
+            size_limited_offset_range range(
+              base_offset, arg.target_size, arg.min_size);
+
+            retry_chain_node op_rtc(&workflow_rtc);
+
+            vlog(
+              _rtclog.debug,
+              "start collecting segments, base_offset {}, size quota {}, "
+              "requests "
+              "quota {}",
+              base_offset,
+              size_quota,
+              req_quota);
+
+            while (size_quota > 0 && req_quota > 0) {
+                auto upload = co_await make_non_compacted_upload(
+                  base_offset, partition, arg, _sg, op_rtc.get_deadline());
+
+                if (
+                  upload.has_error()
+                  && upload.error() == error_outcome::not_enough_data) {
+                    vlog(
+                      _rtclog.debug,
+                      "make_non_compacted_upload failed {}",
+                      upload.error());
+                    break;
+                }
+                if (upload.has_error()) {
+                    vlog(
+                      _rtclog.error,
+                      "make_non_compacted_upload failed {}",
+                      upload.error());
+                    co_return upload.error();
+                }
+                vlog(
+                  _rtclog.debug,
+                  "make_non_compacted_upload success {}",
+                  upload.value());
+                base_offset = model::next_offset(
+                  upload.value()->metadata.committed_offset);
+                size_quota -= upload.value()->size_bytes;
+                // 2 PUT requests for segment upload + index upload
+                req_quota -= 2;
+                if (upload.value()->metadata.metadata_size_hint > 0) {
+                    // another PUT request if tx-manifest is not empty
+                    req_quota -= 1;
+                }
+                result.results.push_back(std::move(upload.value()));
+            }
+
+            vlog(
+              _rtclog.debug,
+              "find_upload_candidates completed with {} results, read-write "
+              "fence "
+              "{}",
+              result.results.size(),
+              result.read_write_fence);
+            // TODO: compacted upload (if possible)
+            // TODO: merge adjacent segments
+            co_return std::move(result);
+        } catch (...) {
+            vlog(
+              _rtclog.error,
+              "Failed to create upload candidate: {}",
+              std::current_exception());
+        }
         co_return error_outcome::unexpected_failure;
     }
 
@@ -98,17 +195,125 @@ public:
     }
 
 private:
-    ss::gate _gate [[maybe_unused]];
-    ss::abort_source _as [[maybe_unused]];
-    retry_chain_node _rtc [[maybe_unused]];
-    retry_chain_logger _rtclog [[maybe_unused]];
-    ss::shared_ptr<cloud_storage_remote_api> _api [[maybe_unused]];
-    ss::shared_ptr<segment_upload_builder_api> _upl_builder [[maybe_unused]];
-    ss::shared_ptr<cluster_partition_manager_api> _pm [[maybe_unused]];
-    config::binding<size_t> _read_buffer_size [[maybe_unused]];
-    config::binding<int16_t> _readahead [[maybe_unused]];
-    cloud_storage_clients::bucket_name _bucket [[maybe_unused]];
-    ss::scheduling_group _sg [[maybe_unused]]; // TODO: remove unused
+    ss::future<result<ss::lw_shared_ptr<reconciled_upload_candidate>>>
+    make_non_compacted_upload(
+      model::offset base_offset,
+      ss::shared_ptr<cluster_partition_api> part,
+      upload_candidate_search_parameters arg,
+      ss::scheduling_group sg,
+      ss::lowres_clock::time_point deadline) noexcept {
+        vlog(
+          _rtclog.debug,
+          "make_non_compacted_upload base_offset {}, arg {}",
+          base_offset,
+          arg);
+        try {
+            auto guard = _gate.hold();
+            auto candidate = ss::make_lw_shared<reconciled_upload_candidate>();
+            size_limited_offset_range range(
+              base_offset, arg.target_size, arg.min_size);
+            auto upload = co_await _upl_builder->prepare_segment_upload(
+              part, range, _read_buffer_size(), sg, deadline);
+            if (upload.has_error()) {
+                vlog(
+                  _rtclog.warn,
+                  "prepare_segment_upload failed {}",
+                  upload.error());
+                co_return upload.error();
+            }
+            auto res = std::move(upload.value());
+            vlog(
+              _rtclog.debug,
+              "prepare_segment_upload returned meta {}, offsets {}, payload "
+              "size "
+              "{}",
+              res->meta,
+              res->offsets,
+              res->size_bytes);
+
+            // Convert metadata
+            auto delta_offset = part->offset_delta(res->offsets.base);
+
+            auto delta_offset_next = part->offset_delta(
+              model::next_offset(res->offsets.last));
+
+            // FIXME: make sure that the upload doesn't cross the term boundary
+            auto segment_term = part->get_offset_term(res->offsets.base);
+            if (!segment_term.has_value()) {
+                vlog(
+                  _rtclog.error,
+                  "Can't find term for offset {}",
+                  res->offsets.base);
+                co_return error_outcome::offset_not_found;
+            }
+
+            cloud_storage::segment_meta segm_meta{
+              .is_compacted = res->is_compacted,
+              .size_bytes = res->size_bytes,
+              .base_offset = res->offsets.base,
+              .committed_offset = res->offsets.last,
+              // Timestamps will be populated during the upload
+              .base_timestamp = {},
+              .max_timestamp = {},
+              .delta_offset = delta_offset,
+              .ntp_revision = part->get_initial_revision(),
+              .archiver_term = arg.archiver_term,
+              /// Term of the segment (included in segment file name)
+              .segment_term = segment_term.value(),
+              .delta_offset_end = delta_offset_next,
+              .sname_format = cloud_storage::segment_name_format::v3,
+              /// Size of the tx-range (in v3 format)
+              .metadata_size_hint = 0,
+            };
+
+            candidate->ntp = arg.ntp;
+            candidate->size_bytes = res->size_bytes;
+            candidate->metadata = segm_meta;
+
+            // Generate payload
+            candidate->payload = std::move(res->payload);
+
+            // Generate tx-manifest data
+            auto tx = co_await get_aborted_transactions(
+              part, res->offsets.base, res->offsets.last);
+            candidate->tx = std::move(tx);
+
+            if (candidate->tx.size() > 0) {
+                // This value has to be set to 0 by default to avoid
+                // downloading the tx-manifest in case if there were
+                // no transactions in the offset range.
+                candidate->metadata.metadata_size_hint = candidate->tx.size();
+            }
+
+            co_return std::move(candidate);
+        } catch (...) {
+            vlog(
+              _rtclog.error,
+              "Failed to create non-compacted upload candidate {}",
+              std::current_exception());
+        }
+        co_return error_outcome::unexpected_failure;
+    }
+
+    ss::future<fragmented_vector<model::tx_range>> get_aborted_transactions(
+      ss::shared_ptr<cluster_partition_api> part,
+      model::offset base,
+      model::offset last) {
+        auto guard = _gate.hold();
+        co_return co_await part->aborted_transactions(base, last);
+    }
+
+    ss::gate _gate;
+    ss::abort_source _as;
+    retry_chain_node _rtc;
+    retry_chain_logger _rtclog;
+    ss::shared_ptr<cloud_storage_remote_api> _api;
+    ss::shared_ptr<segment_upload_builder_api> _upl_builder;
+    ss::shared_ptr<cluster_partition_manager_api> _pm;
+    config::binding<size_t> _read_buffer_size;
+    config::binding<int16_t> _readahead;
+    cloud_storage_clients::bucket_name _bucket;
+    ss::scheduling_group _sg;
 };
 
 ss::shared_ptr<archiver_operations_api> make_archiver_operations_api(

--- a/src/v/archival/archiver_operations_impl.cc
+++ b/src/v/archival/archiver_operations_impl.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "archival/archiver_operations_impl.h"
+
+#include "archival/archiver_operations_api.h"
+#include "archival/async_data_uploader.h"
+#include "archival/types.h"
+#include "bytes/bytes.h"
+#include "bytes/iostream.h"
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_segment_index.h"
+#include "cloud_storage/tx_range_manifest.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/types.h"
+#include "cluster/partition_manager.h"
+#include "config/configuration.h"
+#include "errc.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "storage/batch_consumer_utils.h"
+#include "utils/retry_chain_node.h"
+#include "utils/stream_utils.h"
+
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <exception>
+
+namespace archival {
+namespace detail {
+
+class archiver_operations_impl : public archiver_operations_api {
+public:
+    /// C-tor
+    archiver_operations_impl(
+      ss::shared_ptr<cloud_storage_remote_api> api,
+      ss::shared_ptr<cluster_partition_manager_api> pm,
+      ss::shared_ptr<segment_upload_builder_api> upl_builder,
+      ss::scheduling_group sg,
+      cloud_storage_clients::bucket_name bucket)
+      : _rtc(_as)
+      , _rtclog(archival_log, _rtc)
+      , _api(std::move(api))
+      , _upl_builder(std::move(upl_builder))
+      , _pm(std::move(pm))
+      , _read_buffer_size(
+          config::shard_local_cfg().storage_read_buffer_size.bind())
+      , _readahead(
+          config::shard_local_cfg().storage_read_readahead_count.bind())
+      , _bucket(std::move(bucket))
+      , _sg(sg) {}
+
+    /// Return upload candidate(s) if data is available or not_enough_data error
+    /// if there is not enough data to start an upload.
+    ss::future<result<reconciled_upload_candidates_list>>
+    find_upload_candidates(
+      retry_chain_node& workflow_rtc,
+      upload_candidate_search_parameters arg) noexcept override {
+        co_return error_outcome::unexpected_failure;
+    }
+
+    /// Upload data to S3 and return results
+    ///
+    /// The method uploads segments with their corresponding tx-manifests and
+    /// indexes and also the manifest. The result contains the insync offset of
+    /// the uploaded manifest. The state of the uploaded manifest doesn't
+    /// include uploaded segments because they're not admitted yet.
+    ss::future<result<upload_results_list>> schedule_uploads(
+      retry_chain_node& workflow_rtc,
+      reconciled_upload_candidates_list bundle,
+      bool inline_manifest_upl) noexcept override {
+        co_return error_outcome::unexpected_failure;
+    }
+
+    /// Add metadata to the manifest by replicating archival metadata
+    /// configuration batch
+    ss::future<result<admit_uploads_result>> admit_uploads(
+      retry_chain_node& workflow_rtc,
+      upload_results_list upl_res) noexcept override {
+        co_return error_outcome::unexpected_failure;
+    }
+
+    /// Reupload manifest and replicate configuration batch
+    ss::future<result<manifest_upload_result>>
+    upload_manifest(retry_chain_node&, model::ntp) noexcept override {
+        co_return error_outcome::unexpected_failure;
+    }
+
+private:
+    ss::gate _gate [[maybe_unused]];
+    ss::abort_source _as [[maybe_unused]];
+    retry_chain_node _rtc [[maybe_unused]];
+    retry_chain_logger _rtclog [[maybe_unused]];
+    ss::shared_ptr<cloud_storage_remote_api> _api [[maybe_unused]];
+    ss::shared_ptr<segment_upload_builder_api> _upl_builder [[maybe_unused]];
+    ss::shared_ptr<cluster_partition_manager_api> _pm [[maybe_unused]];
+    config::binding<size_t> _read_buffer_size [[maybe_unused]];
+    config::binding<int16_t> _readahead [[maybe_unused]];
+    cloud_storage_clients::bucket_name _bucket [[maybe_unused]];
+    ss::scheduling_group _sg [[maybe_unused]]; // TODO: remove unused
+};
+
+ss::shared_ptr<archiver_operations_api> make_archiver_operations_api(
+  ss::shared_ptr<cloud_storage_remote_api> remote,
+  ss::shared_ptr<cluster_partition_manager_api> pm,
+  ss::shared_ptr<segment_upload_builder_api> upl,
+  cloud_storage_clients::bucket_name bucket) {
+    return ss::make_shared<archiver_operations_impl>(
+      std::move(remote),
+      std::move(pm),
+      std::move(upl),
+      ss::default_scheduling_group(), // TODO: use proper scheduling group
+      std::move(bucket));
+}
+
+} // namespace detail
+
+} // namespace archival

--- a/src/v/archival/archiver_operations_impl.h
+++ b/src/v/archival/archiver_operations_impl.h
@@ -40,7 +40,7 @@ struct cluster_partition_api {
 
     virtual ~cluster_partition_api() = default;
     virtual const cloud_storage::partition_manifest& manifest() const = 0;
-    virtual model::offset get_uploaded_offset() const = 0;
+    virtual model::offset get_next_uploaded_offset() const = 0;
     virtual model::offset get_applied_offset() const = 0;
     virtual model::producer_id get_highest_producer_id() const = 0;
 

--- a/src/v/archival/archiver_operations_impl.h
+++ b/src/v/archival/archiver_operations_impl.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/archiver_operations_api.h"
+#include "archival/async_data_uploader.h"
+#include "archival/logger.h"
+#include "archival/types.h"
+#include "cloud_storage/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/shared_ptr.hh>
+
+namespace archival {
+
+namespace detail {
+// Note: here we have several interfaces for easy mocking. They are used by the
+// archiver_operations_api implementation instead of the real redpanda services.
+
+struct cluster_partition_api {
+    cluster_partition_api() = default;
+    cluster_partition_api(const cluster_partition_api&) = delete;
+    cluster_partition_api(cluster_partition_api&&) = delete;
+    cluster_partition_api& operator=(const cluster_partition_api&) = delete;
+    cluster_partition_api& operator=(cluster_partition_api&&) = delete;
+
+    virtual ~cluster_partition_api() = default;
+    virtual const cloud_storage::partition_manifest& manifest() const = 0;
+    virtual model::offset get_uploaded_offset() const = 0;
+    virtual model::offset get_applied_offset() const = 0;
+    virtual model::producer_id get_highest_producer_id() const = 0;
+
+    /// Same as log->offset_delta
+    /// \throws std::runtime_error if offset is out of range
+    virtual model::offset_delta offset_delta(model::offset o) const = 0;
+
+    virtual std::optional<model::term_id>
+      get_offset_term(model::offset) const = 0;
+
+    virtual model::initial_revision_id get_initial_revision() const = 0;
+
+    // aborted transactions
+    virtual ss::future<fragmented_vector<model::tx_range>>
+    aborted_transactions(model::offset base, model::offset last) const = 0;
+
+    // Replicate archival metadata add_segment command
+    //
+    // The method accepts 'clean_offset' which is the insync offset of the
+    // last uploaded manifest. This is a projected clean offset. It is possible
+    // for the archiver to upload the manifest  in parallel with segments.
+    // This means that when the `add_segments` command is called the uploaded
+    // version of the manifest becomes out of sync. The manifest upload is going
+    // one step behind the replication. Instead of uploading manifest after
+    // replication we're doing this before the replication to pipeline
+    // operations.
+    //
+    // The data upload workflow keeps track of this by storing two offsets.
+    // - clean offset is the offset of the last uploaded manifest
+    // - dirty offset is the current offset of the STM manifest
+    //
+    // If clean != dirty then the manifest in the cloud doesn't match the STM.
+    // The 'clean' offset is passed into this method and triggers 'mark_clean'
+    // command to be added to the replicated batch. When the commands are
+    // applied to the STM the 'dirty' offset is propagated forward. This offset
+    // is returned from this method and passed back to the workflow so the
+    // workflow could track this offset and inform the scheduler about the out
+    // of sync manifest.
+    virtual ss::future<result<model::offset>> add_segments(
+      std::vector<cloud_storage::segment_meta>,
+      std::optional<model::offset> clean_offset,
+      std::optional<model::offset> read_write_fence,
+      model::producer_id highest_pid,
+      ss::lowres_clock::time_point deadline,
+      ss::abort_source& external_as,
+      bool is_validated) noexcept
+      = 0;
+
+    virtual cloud_storage::remote_segment_path
+    get_remote_segment_path(const cloud_storage::segment_meta&)
+      = 0;
+
+    virtual cloud_storage::remote_manifest_path
+    get_remote_manifest_path(const cloud_storage::base_manifest&)
+      = 0;
+};
+
+struct cluster_partition_manager_api {
+    cluster_partition_manager_api() = default;
+    virtual ~cluster_partition_manager_api() = default;
+    cluster_partition_manager_api(const cluster_partition_manager_api&)
+      = delete;
+    cluster_partition_manager_api(cluster_partition_manager_api&&) = delete;
+    cluster_partition_manager_api&
+    operator=(const cluster_partition_manager_api&)
+      = delete;
+    cluster_partition_manager_api& operator=(cluster_partition_manager_api&&)
+      = delete;
+
+    virtual ss::shared_ptr<cluster_partition_api>
+    get_partition(const model::ktp&) = 0;
+};
+
+using upload_result = cloud_storage::upload_result;
+
+/// Wrapper for the cloud_storage::remote
+struct cloud_storage_remote_api {
+    cloud_storage_remote_api() = default;
+    cloud_storage_remote_api(const cloud_storage_remote_api&) = delete;
+    cloud_storage_remote_api(cloud_storage_remote_api&&) = delete;
+    cloud_storage_remote_api& operator=(const cloud_storage_remote_api&)
+      = delete;
+    cloud_storage_remote_api& operator=(cloud_storage_remote_api&&) = delete;
+    virtual ~cloud_storage_remote_api() = default;
+
+    /// Upload object to the cloud storage
+    ///
+    /// This method is similar to 'cloud_storage::remote::upload_segment' but
+    /// it's not performing any retries. The upload workflow should retry in
+    /// case of error. Otherwise the retries are invisible to the scheduler and
+    /// the workflow. The method can be used to upload different types of
+    /// objects. Not only segments. The type of object is encoded in the 'type'
+    /// parameter and the key is generic.
+    virtual ss::future<upload_result> upload_stream(
+      const cloud_storage_clients::bucket_name& bucket,
+      cloud_storage_clients::object_key key,
+      uint64_t content_length,
+      ss::input_stream<char> stream,
+      cloud_storage::upload_type type,
+      retry_chain_node& parent)
+      = 0;
+
+    /// Upload manifest to the cloud storage location
+    ///
+    /// The location is defined by the manifest itself
+    virtual ss::future<upload_result> upload_manifest(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage::base_manifest& manifest,
+      cloud_storage::remote_manifest_path path,
+      retry_chain_node& parent)
+      = 0;
+};
+
+struct prepared_segment_upload {
+    inclusive_offset_range offsets;
+    size_t size_bytes{0};
+    bool is_compacted{false};
+    cloud_storage::segment_meta meta;
+    ss::input_stream<char> payload;
+};
+
+/// Wrapper for the archival::segment_upload
+struct segment_upload_builder_api {
+    segment_upload_builder_api() = default;
+    segment_upload_builder_api(const segment_upload_builder_api&) = default;
+    segment_upload_builder_api(segment_upload_builder_api&&) = default;
+    segment_upload_builder_api& operator=(const segment_upload_builder_api&)
+      = default;
+    segment_upload_builder_api& operator=(segment_upload_builder_api&&)
+      = default;
+    virtual ~segment_upload_builder_api() = default;
+
+    virtual ss::future<result<std::unique_ptr<prepared_segment_upload>>>
+    prepare_segment_upload(
+      ss::shared_ptr<cluster_partition_api> part,
+      size_limited_offset_range range,
+      size_t read_buffer_size,
+      ss::scheduling_group sg,
+      model::timeout_clock::time_point deadline)
+      = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& o, const cluster_partition_api&) {
+    return o << "cluster_partition_api";
+}
+inline std::ostream&
+operator<<(std::ostream& o, const cloud_storage_remote_api&) {
+    return o << "cloud_storage_remote_api";
+}
+inline std::ostream&
+operator<<(std::ostream& o, const cluster_partition_manager_api&) {
+    return o << "cluster_partition_manager_api";
+}
+inline std::ostream&
+operator<<(std::ostream& o, const segment_upload_builder_api&) {
+    return o << "segment_upload_builder_api";
+}
+
+/// Create archiver_operations_api instance with mock objects
+ss::shared_ptr<archiver_operations_api> make_archiver_operations_api(
+  ss::shared_ptr<cloud_storage_remote_api>,
+  ss::shared_ptr<cluster_partition_manager_api>,
+  ss::shared_ptr<segment_upload_builder_api>,
+  cloud_storage_clients::bucket_name);
+
+} // namespace detail
+
+} // namespace archival

--- a/src/v/archival/archiver_operations_impl.h
+++ b/src/v/archival/archiver_operations_impl.h
@@ -111,7 +111,7 @@ struct cluster_partition_manager_api {
       = delete;
 
     virtual ss::shared_ptr<cluster_partition_api>
-    get_partition(const model::ktp&) = 0;
+    get_partition(const model::ntp&) = 0;
 };
 
 using upload_result = cloud_storage::upload_result;

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -68,12 +68,14 @@ else()
       BINARY_NAME gtest_archival
       SOURCES
         archival_metadata_stm_gtest.cc
+        archiver_operations_impl_gtest.cc
       LIBRARIES
         v::raft
         v::raft_fixture
         v::cluster
         v::cloud_roles
         v::http_test_utils
+        v::storage_test_utils
         v::gtest_main
       LABELS archival
       ARGS "-- -c 1"

--- a/src/v/archival/tests/archiver_operations_impl_gtest.cc
+++ b/src/v/archival/tests/archiver_operations_impl_gtest.cc
@@ -1,0 +1,667 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "archival/archiver_operations_api.h"
+#include "archival/archiver_operations_impl.h"
+#include "archival/async_data_uploader.h"
+#include "archival/logger.h"
+#include "archival/types.h"
+#include "base/vlog.h"
+#include "bytes/bytes.h"
+#include "bytes/iostream.h"
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_segment.h"
+#include "cloud_storage/remote_segment_index.h"
+#include "cloud_storage/tx_range_manifest.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/types.h"
+#include "config/configuration.h"
+#include "consensus.h"
+#include "container/fragmented_vector.h"
+#include "gmock/gmock.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/tests/random_batch.h"
+#include "model/timestamp.h"
+#include "random/generators.h"
+#include "storage/record_batch_utils.h"
+#include "test_utils/scoped_config.h"
+#include "test_utils/test.h"
+#include "utils/available_promise.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/log.hh>
+
+#include <gmock/gmock.h>
+
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <system_error>
+
+inline ss::logger test_log("arch_op_impl_test");
+
+namespace {
+cloud_storage::remote_path_provider null_path_provider(std::nullopt);
+const model::ktp
+  expected_ntp(model::topic("panda-topic"), model::partition_id(137));
+const model::initial_revision_id expected_revision_id(42);
+} // anonymous namespace
+
+namespace seastar {
+// Print seastar strings in gmock error messages
+template<typename Ch, typename Size, Size max_size, bool null_terminate>
+void PrintTo(
+  const basic_sstring<Ch, Size, max_size, null_terminate>& s, std::ostream* o) {
+    *o << s;
+}
+} // namespace seastar
+
+using namespace cloud_storage;
+namespace archival {
+
+struct partition_mock : public detail::cluster_partition_api {
+    MOCK_METHOD(
+      const cloud_storage::partition_manifest&, manifest, (), (const));
+
+    MOCK_METHOD(model::offset, get_uploaded_offset, (), (const));
+
+    MOCK_METHOD(model::offset, get_applied_offset, (), (const));
+
+    MOCK_METHOD(model::offset_delta, offset_delta, (model::offset), (const));
+
+    MOCK_METHOD(
+      std::optional<model::term_id>, get_offset_term, (model::offset), (const));
+
+    MOCK_METHOD(model::producer_id, get_highest_producer_id, (), (const));
+
+    MOCK_METHOD(model::initial_revision_id, get_initial_revision, (), (const));
+
+    MOCK_METHOD(
+      ss::future<fragmented_vector<model::tx_range>>,
+      aborted_transactions,
+      (model::offset, model::offset),
+      (const));
+
+    MOCK_METHOD(
+      ss::future<result<model::offset>>,
+      add_segments,
+      (std::vector<cloud_storage::segment_meta>,
+       std::optional<model::offset> clean_offset,
+       std::optional<model::offset> read_write_fence,
+       model::producer_id highest_pid,
+       ss::lowres_clock::time_point deadline,
+       ss::abort_source& external_as,
+       bool is_validated),
+      (noexcept));
+
+    cloud_storage::remote_segment_path
+    get_remote_segment_path(const cloud_storage::segment_meta& meta) override {
+        auto path = null_path_provider.segment_path(
+          expected_ntp.to_ntp(), expected_revision_id, meta);
+        return cloud_storage::remote_segment_path(path);
+    }
+
+    cloud_storage::remote_manifest_path
+    get_remote_manifest_path(const cloud_storage::base_manifest& m) override {
+        using namespace cloud_storage;
+        switch (m.get_manifest_type()) {
+        case manifest_type::partition:
+            return dynamic_cast<const partition_manifest&>(m).get_manifest_path(
+              null_path_provider);
+        case manifest_type::tx_range:
+            return dynamic_cast<const tx_range_manifest&>(m)
+              .get_manifest_path();
+        default:
+            break;
+        }
+        vassert(false, "Unexpected manifest type");
+    }
+
+    void expect_aborted_transactions(
+      model::offset base,
+      model::offset last,
+      fragmented_vector<model::tx_range> tx) {
+        auto f = ss::make_ready_future<fragmented_vector<model::tx_range>>(
+          std::move(tx));
+        EXPECT_CALL(*this, aborted_transactions(base, last))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(f)));
+    }
+
+    void expect_aborted_transactions(
+      model::offset base, model::offset last, std::exception_ptr err) {
+        auto f = ss::make_exception_future<fragmented_vector<model::tx_range>>(
+          std::move(err));
+        EXPECT_CALL(*this, aborted_transactions(base, last))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(f)));
+    }
+
+    void
+    expect_manifest(const cloud_storage::partition_manifest& m, int times = 1) {
+        EXPECT_CALL(*this, manifest)
+          .Times(times)
+          .WillRepeatedly(::testing::ReturnRef(m));
+    }
+
+    void expect_get_uploaded_offset(model::offset o) {
+        EXPECT_CALL(*this, get_uploaded_offset)
+          .Times(1)
+          .WillOnce(::testing::Return(o));
+    }
+
+    void
+    expect_get_offset_term(model::offset o, std::optional<model::term_id> t) {
+        EXPECT_CALL(*this, get_offset_term(o))
+          .Times(1)
+          .WillOnce(::testing::Return(t));
+    }
+
+    void expect_get_offset_term(model::offset o, std::exception_ptr e) {
+        EXPECT_CALL(*this, get_offset_term(o))
+          .Times(1)
+          .WillOnce(::testing::Throw(e));
+    }
+
+    void expect_offset_delta(model::offset o, model::offset_delta d) {
+        EXPECT_CALL(*this, offset_delta(o))
+          .Times(1)
+          .WillOnce(::testing::Return(d));
+    }
+
+    void expect_offset_delta(model::offset o, std::exception_ptr e) {
+        EXPECT_CALL(*this, offset_delta(o))
+          .Times(1)
+          .WillOnce(::testing::Throw(e));
+    }
+
+    void expect_get_applied_offset(model::offset o) {
+        EXPECT_CALL(*this, get_applied_offset)
+          .Times(1)
+          .WillOnce(::testing::Return(o));
+    }
+
+    void expect_offset_delta(model::offset_delta d) {
+        EXPECT_CALL(*this, offset_delta)
+          .Times(1)
+          .WillOnce(::testing::Return(d));
+    }
+
+    void expect_get_offset_term(model::term_id t) {
+        EXPECT_CALL(*this, get_offset_term)
+          .Times(1)
+          .WillOnce(::testing::Return(t));
+    }
+
+    void
+    expect_get_initial_revision(model::initial_revision_id id, int times = 1) {
+        EXPECT_CALL(*this, get_initial_revision)
+          .Times(times)
+          .WillOnce(::testing::Return(id));
+    }
+
+    void expect_add_segments(
+      std::vector<cloud_storage::segment_meta> meta,
+      std::optional<model::offset> clean_offset,
+      std::optional<model::offset> read_write_fence,
+      model::producer_id highest_pid,
+      bool is_validated,
+      result<model::offset> ec) {
+        auto ret = ss::make_ready_future<result<model::offset>>(ec);
+        EXPECT_CALL(
+          *this,
+          add_segments(
+            std::move(meta),
+            clean_offset,
+            read_write_fence,
+            highest_pid,
+            testing::_,
+            testing::_,
+            is_validated))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+
+    void expect_add_segments(
+      std::vector<cloud_storage::segment_meta> meta,
+      std::optional<model::offset> clean_offset,
+      std::optional<model::offset> read_write_fence,
+      model::producer_id highest_pid,
+      bool is_validated,
+      std::exception_ptr err) {
+        auto ret = ss::make_exception_future<result<model::offset>>(err);
+        EXPECT_CALL(
+          *this,
+          add_segments(
+            std::move(meta),
+            clean_offset,
+            read_write_fence,
+            highest_pid,
+            testing::_,
+            testing::_,
+            is_validated))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+
+    void expect_get_highest_producer_id(model::producer_id expected_id) {
+        EXPECT_CALL(*this, get_highest_producer_id())
+          .Times(1)
+          .WillOnce(testing::Return(expected_id));
+    }
+};
+
+struct partition_manager_mock : public detail::cluster_partition_manager_api {
+    MOCK_METHOD(
+      ss::shared_ptr<detail::cluster_partition_api>,
+      get_partition,
+      (const model::ntp&),
+      ());
+
+    void
+    expect_get_partition(ss::shared_ptr<detail::cluster_partition_api> result) {
+        EXPECT_CALL(*this, get_partition)
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
+};
+
+struct remote_mock_base {
+    // This method is supposed to be mocked instead of the
+    // 'upload_stream'. The 'upload_stream' accepts stream
+    // object that has to be consumed asynchronously. This is
+    // not a trivial thing to do in the mock. So instead the
+    // 'upload_stream' mock implementation will redirect the
+    // call to `_upload_stream' but will pass bytes instead
+    // of the stream.
+    virtual ss::future<upload_result> _upload_stream(
+      ss::sstring bucket,
+      ss::sstring key,
+      uint64_t content_length,
+      bytes payload,
+      cloud_storage::upload_type type)
+      = 0;
+};
+
+struct remote_mock
+  : public detail::cloud_storage_remote_api
+  , remote_mock_base {
+    ss::future<upload_result> upload_manifest(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage::base_manifest& manifest,
+      cloud_storage::remote_manifest_path path,
+      retry_chain_node& parent) {
+        auto payload = co_await manifest.serialize();
+        iobuf outbuf;
+        auto out_str = make_iobuf_ref_output_stream(outbuf);
+        co_await ss::copy(payload.stream, out_str);
+        auto buf = iobuf_to_bytes(outbuf);
+        co_return co_await _upload_stream(
+          bucket(),
+          path().native(),
+          payload.size_bytes,
+          std::move(buf),
+          cloud_storage::upload_type::manifest);
+    }
+
+    static ss::sstring hexdump(const bytes& b, size_t sz = 512) {
+        auto ib = bytes_to_iobuf(b);
+        return ib.hexdump(sz);
+    }
+
+    ss::future<upload_result> upload_stream(
+      const cloud_storage_clients::bucket_name& bucket,
+      cloud_storage_clients::object_key key,
+      uint64_t content_length,
+      ss::input_stream<char> stream,
+      cloud_storage::upload_type type,
+      retry_chain_node& parent) {
+        iobuf outbuf;
+        auto out_str = make_iobuf_ref_output_stream(outbuf);
+
+        // Consume the stream and propagate its content to the
+        // _upload_stream method.
+        co_await ss::copy(stream, out_str);
+        auto buf = iobuf_to_bytes(outbuf);
+
+        vlog(
+          test_log.debug,
+          "Mock upload_stream invoked, key: {}, size: {}, payload: {}",
+          key,
+          content_length,
+          hexdump(buf));
+
+        co_return co_await _upload_stream(
+          bucket(), key().native(), content_length, std::move(buf), type);
+    }
+
+    MOCK_METHOD(
+      ss::future<upload_result>,
+      _upload_stream,
+      (ss::sstring bucket,
+       ss::sstring key,
+       uint64_t content_length,
+       bytes payload,
+       cloud_storage::upload_type type),
+      ());
+
+    void expect_upload_stream(
+      ss::sstring bucket,
+      ss::sstring key,
+      uint64_t content_length,
+      bytes expected,
+      cloud_storage::upload_type type,
+      cloud_storage::upload_result expected_result) {
+        auto ret = ss::make_ready_future<upload_result>(expected_result);
+        vlog(
+          test_log.debug,
+          "Expect upload_stream invoked, key: {}, size: {}, payload: {}",
+          key,
+          content_length,
+          hexdump(expected));
+        EXPECT_CALL(
+          *this,
+          _upload_stream(
+            std::move(bucket),
+            std::move(key),
+            content_length,
+            std::move(expected),
+            type))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+
+    void expect_upload_stream(
+      ss::sstring bucket,
+      ss::sstring key,
+      uint64_t content_length,
+      bytes expected,
+      cloud_storage::upload_type type,
+      std::exception_ptr error) {
+        auto ret = ss::make_exception_future<upload_result>(error);
+        vlog(
+          test_log.debug,
+          "Expect upload_stream to fail, key: {}, size: {}, payload: {}",
+          key,
+          content_length,
+          hexdump(expected));
+        EXPECT_CALL(
+          *this,
+          _upload_stream(
+            std::move(bucket),
+            std::move(key),
+            content_length,
+            std::move(expected),
+            type))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+
+    void expect_upload_manifest(
+      ss::sstring bucket,
+      ss::sstring key,
+      bytes payload,
+      upload_result ret_val) {
+        auto ret = ss::make_ready_future<upload_result>(ret_val);
+        size_t content_length = payload.size();
+        EXPECT_CALL(
+          *this,
+          _upload_stream(
+            bucket,
+            std::move(key),
+            content_length,
+            std::move(payload),
+            cloud_storage::upload_type::manifest))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+
+    void expect_upload_manifest(
+      ss::sstring bucket,
+      ss::sstring key,
+      bytes payload,
+      std::exception_ptr err) {
+        auto ret = ss::make_exception_future<upload_result>(err);
+        size_t content_length = payload.size();
+        EXPECT_CALL(
+          *this,
+          _upload_stream(
+            bucket,
+            std::move(key),
+            content_length,
+            std::move(payload),
+            cloud_storage::upload_type::manifest))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(ret)));
+    }
+};
+
+struct upload_builder_mock : public detail::segment_upload_builder_api {
+    MOCK_METHOD(
+      ss::future<result<std::unique_ptr<detail::prepared_segment_upload>>>,
+      prepare_segment_upload,
+      (ss::shared_ptr<detail::cluster_partition_api> part,
+       size_limited_offset_range range,
+       size_t read_buffer_size,
+       ss::scheduling_group sg,
+       model::timeout_clock::time_point deadline),
+      ());
+
+    void expect_prepare_segment_upload(
+      size_limited_offset_range range,
+      size_t read_buffer_size,
+      result<std::unique_ptr<detail::prepared_segment_upload>> res) {
+        auto fut = ss::make_ready_future<
+          result<std::unique_ptr<detail::prepared_segment_upload>>>(
+          std::move(res));
+        EXPECT_CALL(
+          *this,
+          prepare_segment_upload(
+            testing::_, range, read_buffer_size, testing::_, testing::_))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(fut)));
+    }
+
+    void expect_prepare_segment_upload(std::exception_ptr res) {
+        auto fut = ss::make_exception_future<
+          result<std::unique_ptr<detail::prepared_segment_upload>>>(
+          std::move(res));
+        EXPECT_CALL(
+          *this,
+          prepare_segment_upload(
+            testing::_, testing::_, testing::_, testing::_, testing::_))
+          .Times(1)
+          .WillOnce(testing::Return(std::move(fut)));
+    }
+};
+
+const model::term_id expected_archiver_term{91};
+const model::term_id expected_segment_term{81};
+const model::offset expected_applied_offset{10};
+const model::offset expected_uploaded_offset{100};
+const model::offset expected_read_write_fence{45};
+const model::offset expected_insync_offset{55};
+const model::producer_id expected_producer_id{1234};
+const size_t expected_read_buffer_size = 4096;
+const size_t expected_target_size{80000};
+const size_t expected_min_size{30000};
+const size_t expected_upload_size_quota{160000};
+const size_t expected_upload_requests_quota{4};
+const ss::sstring expected_bucket{"test-bucket"};
+const cloud_storage_clients::bucket_name c_expected_bucket{"test-bucket"};
+const auto expected_manifest = []() noexcept {
+    partition_manifest m(expected_ntp.to_ntp(), expected_revision_id);
+
+    m.add(segment_meta{
+      .is_compacted = false,
+      .size_bytes = 1024,
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(100),
+      .base_timestamp = model::timestamp(1000000),
+      .max_timestamp = model::timestamp(1000100),
+      .delta_offset = model::offset_delta(0),
+      .archiver_term = expected_archiver_term,
+      .segment_term = expected_segment_term,
+      .delta_offset_end = model::offset_delta(1),
+    });
+    m.advance_applied_offset(expected_applied_offset);
+    m.advance_highest_producer_id(expected_producer_id);
+    m.advance_insync_offset(expected_insync_offset);
+    return m;
+}();
+
+// Condensed version of the record batch header
+struct record_batch_desc_t {
+    model::offset base;
+    model::offset last;
+    model::timestamp ts_base;
+    model::timestamp ts_last;
+    size_t size_bytes;
+    model::record_batch_type type;
+    size_t physical_offset;
+};
+
+struct payload_t {
+    ss::input_stream<char> stream;
+    size_t size;
+    bytes content;
+    std::vector<record_batch_desc_t> batches;
+};
+
+// Generate payload that contains only data batches
+payload_t expected_data_payload(model::offset base, model::offset last) {
+    iobuf payload;
+    std::vector<record_batch_desc_t> batches;
+    for (size_t i = base(); i <= last(); i++) {
+        auto batch = model::test::make_random_batch(model::offset(i), 1, false);
+        auto header_iobuf = storage::batch_header_to_disk_iobuf(batch.header());
+        batches.push_back(record_batch_desc_t{
+          .base = batch.base_offset(),
+          .last = batch.last_offset(),
+          .ts_base = batch.header().first_timestamp,
+          .ts_last = batch.header().max_timestamp,
+          .size_bytes = header_iobuf.size_bytes() + batch.data().size_bytes(),
+          .type = batch.header().type,
+          .physical_offset = payload.size_bytes(),
+        });
+        payload.append(std::move(header_iobuf));
+        payload.append(batch.data().copy());
+    }
+    auto size = payload.size_bytes();
+    auto content = iobuf_to_bytes(payload);
+    auto stream = make_iobuf_input_stream(std::move(payload));
+    //
+    return payload_t{
+      .stream = std::move(stream),
+      .size = size,
+      .content = std::move(content),
+      .batches = std::move(batches)};
+}
+
+struct index_payload_t {
+    cloud_storage::segment_record_stats stats;
+    bytes content;
+};
+
+// Generate index payload based on segment content
+index_payload_t expected_index_payload(
+  model::offset_delta initial_delta, std::vector<record_batch_desc_t> bts) {
+    auto filter = raft::offset_translator_batch_types(expected_ntp.to_ntp());
+    index_payload_t result;
+    const auto sampling_step = 64_KiB;
+    auto first = bts.front();
+    offset_index ix(
+      first.base,
+      first.base - initial_delta,
+      initial_delta(),
+      sampling_step,
+      first.ts_base);
+    size_t window = 0;
+    model::offset_delta running_delta = initial_delta;
+    auto it = std::next(bts.begin());
+    for (; it < bts.end(); it++) {
+        auto is_config = std::ranges::find(filter, it->type) != filter.end();
+        auto delta = it->last - it->base + model::offset(1);
+        if (is_config) {
+            running_delta += delta;
+        } else {
+            // only add batch after the step interval (64KiB)
+            if (window >= sampling_step) {
+                auto ko = it->base - running_delta;
+                ix.add(it->base, ko, int64_t(it->physical_offset), it->ts_last);
+                window = 0;
+            }
+        }
+        window += it->size_bytes;
+
+        // Update stats
+        if (is_config) {
+            result.stats.total_conf_records += delta;
+        } else {
+            result.stats.total_data_records += delta;
+        }
+        if (result.stats.base_rp_offset == model::offset{}) {
+            result.stats.base_rp_offset = it->base;
+        }
+        result.stats.last_rp_offset = it->last;
+        if (result.stats.base_timestamp == model::timestamp{}) {
+            result.stats.base_timestamp = it->ts_base;
+        }
+        result.stats.last_timestamp = it->ts_last;
+        result.stats.size_bytes += it->size_bytes;
+    }
+
+    result.content = iobuf_to_bytes(ix.to_iobuf());
+    return result;
+}
+
+struct segment_desc {
+    model::offset base;
+    model::offset last;
+    model::offset_delta base_delta;
+    model::offset_delta last_delta;
+    model::timestamp base_ts;
+    model::timestamp last_ts;
+};
+
+auto make_upload(
+  const segment_desc& d, size_t upload_size, ss::input_stream<char> stream) {
+    auto prep_upl = std::make_unique<detail::prepared_segment_upload>();
+    prep_upl->is_compacted = false;
+    prep_upl->meta = segment_meta{
+      .is_compacted = false,
+      .size_bytes = upload_size,
+      .base_offset = d.base,
+      .committed_offset = d.last,
+      .base_timestamp = d.base_ts,
+      .max_timestamp = d.last_ts,
+      .delta_offset = d.base_delta,
+      .ntp_revision = expected_revision_id,
+      .archiver_term = expected_archiver_term,
+      .segment_term = expected_segment_term,
+      .delta_offset_end = d.last_delta,
+      .sname_format = segment_name_format::v3,
+    };
+    prep_upl->size_bytes = upload_size;
+    prep_upl->payload = std::move(stream);
+    prep_upl->offsets = inclusive_offset_range(d.base, d.last);
+    return prep_upl;
+}
+
+} // namespace archival

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -403,6 +403,11 @@ size_t partition_manifest::segments_metadata_bytes() const {
     return _segments.inflated_actual_size().second;
 }
 
+size_t partition_manifest::estimate_serialized_size() const {
+    constexpr auto bytes_per_segment = 10;
+    return _segments.size() * bytes_per_segment;
+}
+
 void partition_manifest::flush_write_buffer() {
     _segments.flush_write_buffer();
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -264,6 +264,9 @@ public:
     // manifest, or 0 if the memory is not being tracked.
     size_t segments_metadata_bytes() const;
 
+    // Return very rough estimate of the size of the serialized manifest
+    size_t estimate_serialized_size() const;
+
     /// Return map that contains spillover manifests.
     /// It stores 'segment_meta' objects but the meaning of fields are
     /// different.

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -129,4 +129,10 @@ void tx_range_manifest::serialize(std::ostream& out) const {
     w.EndArray();
     w.EndObject();
 }
+
+size_t tx_range_manifest::estimate_serialized_size() const {
+    constexpr auto total_keys_size_per_range = 36;
+    constexpr auto avg_value_bytes = 40;
+    return _ranges.size() * (total_keys_size_per_range + avg_value_bytes);
+}
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -64,6 +64,9 @@ public:
         return std::move(_ranges);
     }
 
+    /// Return approximate size of the serialized manifest
+    size_t estimate_serialized_size() const;
+
 private:
     void do_update(const rapidjson::Document& is);
 

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -225,6 +225,7 @@ v_cc_library(
     ../archival/archiver_manager.cc
     ../archival/async_data_uploader.cc
     ../archival/archiver_operations_api.cc
+    ../archival/archiver_operations_impl.cc
     cloud_metadata/cluster_manifest.cc
     cloud_metadata/cluster_recovery_backend.cc
     cloud_metadata/key_utils.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -224,6 +224,7 @@ v_cc_library(
     ../archival/scrubber.cc
     ../archival/archiver_manager.cc
     ../archival/async_data_uploader.cc
+    ../archival/archiver_operations_api.cc
     cloud_metadata/cluster_manifest.cc
     cloud_metadata/cluster_recovery_backend.cc
     cloud_metadata/key_utils.cc


### PR DESCRIPTION
Introduce `archiver_operations_api` interface. The interface is responsible for the data upload operations. There are three main steps there
- find upload candidates (find offset range that exists only locally and has to be uploaded to the cloud)
- schedule uploads (for every upload candidate upload the segment object, the index and transactional manifest)
- admit uploads (check results of the previous operations, validate the metadata and replicate archival STM commands)

This interface can use read-write fence for concurrency control. 
The PR also adds implementation `archiver_operations_impl` but implements only the first operation. The implementation uses `storage::log_reader` to get data from disk instead of reading data directly.



<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none