### PR TITLE
rpk: add `rpk cluster quotas import`

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/quotas/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/describe.go
@@ -22,13 +22,13 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 )
 
-type quotaValues struct {
+type quotaValue struct {
 	Key   string `json:"key" yaml:"key"`
-	Value string `json:"values" yaml:"values"`
+	Value string `json:"value" yaml:"value"`
 }
 type describedQuota struct {
-	Entity []entityData  `json:"entity" yaml:"entity"`
-	Values []quotaValues `json:"values" yaml:"values"`
+	Entity []entityData `json:"entity" yaml:"entity"`
+	Values []quotaValue `json:"values" yaml:"values"`
 
 	entityStr string
 }
@@ -137,9 +137,9 @@ func printDescribedQuotas(f config.OutFormatter, quotas []kadm.DescribedClientQu
 	var described []describedQuota
 	for _, q := range quotas {
 		entity, entityStr := parseEntityData(q.Entity)
-		var qv []quotaValues
+		var qv []quotaValue
 		for _, v := range q.Values {
-			qv = append(qv, quotaValues{
+			qv = append(qv, quotaValue{
 				Key:   v.Key,
 				Value: strconv.FormatFloat(v.Value, 'f', -1, 64),
 			})

--- a/src/go/rpk/pkg/cli/cluster/quotas/import.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/import.go
@@ -1,0 +1,304 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package quotas
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/types"
+	"gopkg.in/yaml.v3"
+)
+
+// quotasDiff represents a delta in the quotas after importing a quota.
+type quotasDiff struct {
+	EntityStr string `json:"entity,omitempty" yaml:"entity,omitempty"`
+	QuotaType string `json:"quota-type,omitempty" yaml:"quota-type,omitempty"`
+	OldValue  string `json:"old-value,omitempty" yaml:"old-value,omitempty"`
+	NewValue  string `json:"new-value,omitempty" yaml:"new-value,omitempty"`
+}
+
+func importCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		from      string
+		noConfirm bool
+	)
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import client quotas",
+		Long: `Import client quotas.
+
+Use this command to import client quotas in the format produced by 
+'rpk cluster quotas describe --format json/yaml'.
+
+The schema of the import string matches the schema from
+'rpk cluster quotas describe --format help':
+
+{
+  quotas: []{
+    entity: []{
+      name: string
+      type: string
+    }
+    values: []{
+      key: string
+      values: string
+    }
+  }
+}
+
+Use the '--no-confirm' flag if you wish to avoid the confirmation prompt.
+`,
+		Example: `
+Import client quotas from a file:
+  rpk cluster quotas import --from /path/to/file
+
+Import client quotas from a string:
+  rpk cluster quotas import --from '{"quotas":...}'
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]quotasDiff{}); ok {
+				out.Exit(h)
+			}
+
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			var quotas describeResponse
+			var source []byte
+			// --from flag accepts either a file, or a string, we try first
+			// to read as a file as is the most expected usage.
+			file, err := afero.ReadFile(fs, from)
+			if err == nil {
+				source = file
+			} else {
+				if os.IsNotExist(err) || strings.Contains(err.Error(), "file name too long") {
+					source = []byte(from)
+				} else {
+					out.Exit("unable to read file: %v", err)
+				}
+			}
+			if err = json.Unmarshal(source, &quotas); err != nil {
+				yamlErr := yaml.Unmarshal(source, &quotas)
+				out.MaybeDie(yamlErr, "unable to parse quotas from %q: %v: %v", from, err, yamlErr)
+			}
+
+			importedQuotas, err := responseToDescribed(quotas)
+			out.MaybeDie(err, "unable to parse quotas: %v", err)
+
+			// Describe all quotas.
+			currentQuotas, err := adm.DescribeClientQuotas(cmd.Context(), false, []kadm.DescribeClientQuotaComponent{})
+			out.MaybeDie(err, "unable to describe client quotas: %v", err)
+
+			diff := calculateQuotasDiff(currentQuotas, importedQuotas)
+			if len(diff) == 0 {
+				out.Exit("No changes detected from import")
+			}
+			printDiff(f, diff)
+
+			if !noConfirm {
+				ok, err := out.Confirm("Confirm client quotas import above?")
+				out.MaybeDie(err, "unable to confirm deletion: %v", err)
+				if !ok {
+					out.Exit("Import canceled.")
+				}
+			}
+			_, err = adm.AlterClientQuotas(cmd.Context(), describedToAlterEntry(currentQuotas, importedQuotas))
+			out.MaybeDie(err, "unable to alter quotas: %v", err)
+
+			if f.Kind == "text" {
+				fmt.Println("Successfully imported the client quotas")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&from, "from", "", "Either the quotas or a path to a file containing the quotas to import; check help text for more information")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+
+	cmd.MarkFlagRequired("from")
+	return cmd
+}
+
+// responseToDescribed converts the describeResponse quota (imported source) to
+// a []kadm.DescribedClientQuota.
+func responseToDescribed(quotas describeResponse) ([]kadm.DescribedClientQuota, error) {
+	var resp []kadm.DescribedClientQuota
+	for _, q := range quotas.DescribedQuotas {
+		var (
+			entity []kadm.ClientQuotaEntityComponent
+			values []kadm.ClientQuotaValue
+		)
+		for _, e := range q.Entity {
+			e := e
+			entity = append(entity, kadm.ClientQuotaEntityComponent{
+				Type: e.Type,
+				Name: &e.Name,
+			})
+		}
+		for _, v := range q.Values {
+			floatVal, err := strconv.ParseFloat(v.Value, 64)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse client quota value %q: %v", v.Value, err)
+			}
+			values = append(values, kadm.ClientQuotaValue{
+				Key:   v.Key,
+				Value: floatVal,
+			})
+		}
+		resp = append(resp, kadm.DescribedClientQuota{
+			Entity: entity,
+			Values: values,
+		})
+	}
+	return resp, nil
+}
+
+// describedToAlterEntry creates a []kadm.AlterClientQuotaEntry based on the
+// toDelete and toAdd described client quotas. The entry can be used to issue
+// an alter client quota request.
+func describedToAlterEntry(toDelete, toAdd []kadm.DescribedClientQuota) []kadm.AlterClientQuotaEntry {
+	var entries []kadm.AlterClientQuotaEntry
+	addEntries := func(described []kadm.DescribedClientQuota, delete bool) {
+		for _, d := range described {
+			var (
+				entity     []kadm.ClientQuotaEntityComponent
+				operations []kadm.AlterClientQuotaOp
+			)
+			for _, e := range d.Entity {
+				entity = append(entity, kadm.ClientQuotaEntityComponent{
+					Type: e.Type,
+					Name: e.Name,
+				})
+			}
+			for _, o := range d.Values {
+				if delete {
+					operations = append(operations, kadm.AlterClientQuotaOp{
+						Key:    o.Key,
+						Remove: true,
+					})
+				} else {
+					operations = append(operations, kadm.AlterClientQuotaOp{
+						Key:   o.Key,
+						Value: o.Value,
+					})
+				}
+			}
+			entries = append(entries, kadm.AlterClientQuotaEntry{
+				Entity: entity,
+				Ops:    operations,
+			})
+		}
+	}
+	addEntries(toDelete, true)
+	addEntries(toAdd, false)
+	return entries
+}
+
+// calculateQuotasDiff calculates the diff between 'before' and 'after', any
+// value that is not present will be marked as '-' in the result string.
+func calculateQuotasDiff(before, after []kadm.DescribedClientQuota) []quotasDiff {
+	type delta struct {
+		oldValue string
+		newValue string
+	}
+	type quotaTypeMap map[string]delta
+
+	entityMap := make(map[string]quotaTypeMap)
+
+	// Fill the map with old values.
+	for _, q := range before {
+		e := q.Entity
+		types.Sort(e)
+		_, entityStr := parseEntityData(e)
+		qMap := entityMap[entityStr]
+		if qMap == nil {
+			qMap = quotaTypeMap{}
+			entityMap[entityStr] = qMap
+		}
+		for _, v := range q.Values {
+			qMap[v.Key] = delta{
+				oldValue: strconv.FormatFloat(v.Value, 'f', -1, 64),
+			}
+		}
+	}
+
+	// Update map with new values and track differences.
+	for _, q := range after {
+		e := q.Entity
+		types.Sort(e)
+		_, entityStr := parseEntityData(e)
+		qMap := entityMap[entityStr]
+		if qMap == nil {
+			qMap = quotaTypeMap{}
+			entityMap[entityStr] = qMap
+		}
+		for _, v := range q.Values {
+			newVal := strconv.FormatFloat(v.Value, 'f', -1, 64)
+			if d, exists := qMap[v.Key]; exists {
+				// If the value changed, we add it to the map.
+				if newVal != d.oldValue {
+					qMap[v.Key] = delta{oldValue: d.oldValue, newValue: newVal}
+				} else {
+					// If not, we remove it, we do nothing if the values are
+					// the same.
+					delete(qMap, v.Key)
+				}
+			} else {
+				qMap[v.Key] = delta{oldValue: "-", newValue: newVal}
+			}
+		}
+	}
+
+	// Prepare the result
+	var diffResult []quotasDiff
+	for entityStr, qMap := range entityMap {
+		for key, d := range qMap {
+			newValue := d.newValue
+			if newValue == "" {
+				newValue = "-"
+			}
+			diffResult = append(diffResult, quotasDiff{
+				EntityStr: entityStr,
+				QuotaType: key,
+				OldValue:  d.oldValue,
+				NewValue:  newValue,
+			})
+		}
+	}
+	return diffResult
+}
+
+func printDiff(f config.OutFormatter, diff []quotasDiff) {
+	if isText, _, formatted, err := f.Format(diff); !isText {
+		out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+		fmt.Println(formatted)
+		return
+	}
+	tw := out.NewTable("ENTITY", "QUOTA-TYPE", "OLD-VALUE", "NEW-VALUE")
+	defer tw.Flush()
+
+	for _, d := range diff {
+		tw.PrintStructFields(d)
+	}
+}

--- a/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
@@ -29,6 +29,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(
 		alterCommand(fs, p),
 		describeCommand(fs, p),
+		importCommand(fs, p),
 	)
 	p.InstallKafkaFlags(cmd)
 	p.InstallFormatFlag(cmd)

--- a/src/go/rpk/pkg/out/in.go
+++ b/src/go/rpk/pkg/out/in.go
@@ -201,3 +201,16 @@ func ParsePartitionString(ntp string) (ns, topic string, partitions []int, rerr 
 	}
 	return ns, match[2], partitions, nil
 }
+
+// ParseFileOrStringFlag parses a flag string, if it starts with '@' it
+// will treat it as a filepath and will attempt to read the file.
+func ParseFileOrStringFlag(fs afero.Fs, flag string) ([]byte, error) {
+	if strings.HasPrefix(flag, "@") {
+		file, err := afero.ReadFile(fs, strings.TrimPrefix(flag, "@"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file: %v", err)
+		}
+		return file, nil
+	}
+	return []byte(flag), nil
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1910,6 +1910,10 @@ class RpkTool:
                                         output_format=output_format,
                                         node=node)
 
+    def import_cluster_quota(self, source, output_format="json"):
+        cmd = ["import", "--no-confirm", "--from", source]
+        return self._run_cluster_quotas(cmd, output_format=output_format)
+
     def _run_cluster_quotas(self,
                             cmd,
                             output_format="json",

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -99,7 +99,7 @@ class QuotaValue(NamedTuple):
 
     @classmethod
     def from_dict(cls, d: dict):
-        return cls(key=QuotaValueType(d['key']), values=d['values'])
+        return cls(key=QuotaValueType(d['key']), values=d['value'])
 
 
 class Quota(NamedTuple):

--- a/tests/rptest/tests/rpk_cluster_quota_test.py
+++ b/tests/rptest/tests/rpk_cluster_quota_test.py
@@ -1,0 +1,154 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import tempfile
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+
+class RpkClusterQuotaTest(RedpandaTest):
+    def __init__(self, ctx):
+        super(RpkClusterQuotaTest, self).__init__(test_context=ctx)
+        self._ctx = ctx
+        self._rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_import_describe_quotas(self):
+        """
+        Test that asserts the correct handling of imported quotas
+        either using the source as a string, or passing a file
+        to rpk.
+        """
+        q1 = self._rpk.describe_cluster_quotas()
+        assert len(q1) == 0
+
+        self._rpk.alter_cluster_quotas(default=["client-id"],
+                                       add=["producer_byte_rate=11111"])
+        self._rpk.alter_cluster_quotas(name=["client-id-prefix=foo-"],
+                                       add=["consumer_byte_rate=2222"])
+
+        q2 = self._rpk.describe_cluster_quotas()
+        assert len(
+            q2["quotas"]) == 2  # Quick check, just that we have something.
+
+        # Same values, NoOp:
+        import1 = '''
+{
+   "quotas":[
+      {
+         "entity":[
+            {
+               "name":"foo-",
+               "type":"client-id-prefix"
+            }
+         ],
+         "values":[
+            {
+               "key":"consumer_byte_rate",
+               "value":"2222"
+            }
+         ]
+      },
+      {
+         "entity":[
+            {
+               "name":"<default>",
+               "type":"client-id"
+            }
+         ],
+         "values":[
+            {
+               "key":"producer_byte_rate",
+               "value":"11111"
+            }
+         ]
+      }
+   ]
+}
+'''
+        out = self._rpk.import_cluster_quota(import1, output_format="text")
+        assert "No changes detected from import" in out
+
+        # Remove 1 (default client-id), Add 1 (producer byte rate).
+        import2 = '''
+{
+   "quotas":[
+      {
+         "entity":[
+            {
+               "name":"foo-",
+               "type":"client-id-prefix"
+            }
+         ],
+         "values":[
+            {
+               "key":"consumer_byte_rate",
+               "value":"2222"
+            },
+            {
+               "key":"producer_byte_rate",
+               "value":"3333"
+            }
+         ]
+      }
+   ]
+}
+'''
+
+        def assertChanges(quotas, entity, quotaType, old, new):
+            found = False
+            for q in quotas:
+                if q["entity"] == entity and q["quota-type"] == quotaType:
+                    assert q["old-value"] == old
+                    assert q["new-value"] == new
+                    found = True
+            if not found:
+                raise Exception(f"unable to find quota entity {entity}")
+
+        with tempfile.NamedTemporaryFile() as tf:
+            tf.write(bytes(import2, 'UTF-8'))
+            tf.seek(0)
+            out = self._rpk.import_cluster_quota(tf.name)
+            assertChanges(out,
+                          "client-id=<default>",
+                          "producer_byte_rate",
+                          old="11111",
+                          new="-")  # New Value as '-' means it was deleted
+            assertChanges(out,
+                          "client-id-prefix=foo-",
+                          "producer_byte_rate",
+                          old="-",
+                          new="3333")
+
+        # Retry with same value, it should not detect any changes:
+        out = self._rpk.import_cluster_quota(import2, output_format="text")
+        assert "No changes detected from import" in out
+
+        # Assert that the imported quotas match what we can describe:
+        q3 = self._rpk.describe_cluster_quotas()
+        quotas = q3["quotas"]
+        assert len(quotas) == 1 and len(quotas[0]["entity"]) == 1
+        assert quotas[0]["entity"][0]["type"] == "client-id-prefix" and quotas[
+            0]["entity"][0]["name"] == "foo-"
+
+        def assertValues(values, key, expectedVal):
+            found = False
+            for v in values:
+                if v["key"] == key:
+                    assert v["value"] == expectedVal
+                    found = True
+            if not found:
+                raise Exception(f"unable to find {key}")
+
+        values = quotas[0]["values"]
+        assert len(values) == 2
+        assertValues(values, "consumer_byte_rate", "2222")
+        assertValues(values, "producer_byte_rate", "3333")


### PR DESCRIPTION
This PR introduces a new command: `rpk cluster quotas import`

### Usage:

`import` uses a string source that should be formatted as the output of `rpk cluster quotas describe --format <json/yaml>`. It accepts either the string, or a file containing the json (or yaml) representation of the import source:
```
$ rpk cluster quotas import --from {quotas:[...]}

$ rpk cluster quotas import --from /path/to/file
```

The command issues an alterQuotas request, deleting the old quotas, hence, a confirmation prompt is needed:
```
$ rpk cluster quotas import --from /tmp/foo.json
ENTITY                 QUOTA-TYPE          OLD-VALUE  NEW-VALUE
client-id=<default>    consumer_byte_rate  3333       -
client-id-prefix=bar-  consumer_byte_rate  32333123   23123123
? Confirm client quotas import above? Yes
Successfully imported the client quotas
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* rpk: introduce a command to import cluster client quotas: `rpk cluster quotas import`.
