### PR TITLE
[v23.3.x] kafka: fix timequery when local log is empty

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -633,6 +633,13 @@ partition::timequery(storage::timequery_config cfg) {
           _raft->get_offset_translator_state()->from_log_offset(
             _raft->start_offset()),
           local_query_cfg.min_offset);
+
+        // If the min_offset is ahead of max_offset, the local log is empty
+        // or was truncated since the timequery_config was created.
+        if (local_query_cfg.min_offset > local_query_cfg.max_offset) {
+            co_return std::nullopt;
+        }
+
         auto result = co_await local_timequery(
           local_query_cfg, may_answer_from_cloud);
         if (result.has_value()) {
@@ -657,6 +664,13 @@ partition::timequery(storage::timequery_config cfg) {
               _raft->get_offset_translator_state()->from_log_offset(
                 _raft->start_offset()),
               local_query_cfg.min_offset);
+
+            // If the min_offset is ahead of max_offset, the local log is empty
+            // or was truncated since the timequery_config was created.
+            if (local_query_cfg.min_offset > local_query_cfg.max_offset) {
+                co_return std::nullopt;
+            }
+
             co_return co_await local_timequery(local_query_cfg, false);
         }
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21312
