### PR TITLE
Cluster+Kafka: add static checks to help adding new topic properties

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -323,6 +323,14 @@ topic_properties metadata_cache::get_default_properties() const {
     tp.retention_local_target_ms = tristate<std::chrono::milliseconds>{
       get_default_retention_local_target_ms()};
 
+    // TODO(gellert.nagy): explicitly state all of the defaults here and add the
+    // missing defaults
+
+    static_assert(
+      std::tuple_size_v<decltype(tp.serde_fields())> == 31,
+      "Reminder to update this method (returning the default value of each "
+      "topic property) when a new topic property is introduced");
+
     return tp;
 }
 

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -407,6 +407,11 @@ static cluster::topic_configuration make_topic_config(
         topic_properties.retention_local_target_bytes = {};
     }
 
+    static_assert(
+      std::tuple_size_v<decltype(topic_properties.serde_fields())> == 31,
+      "Reminder to update this method (setting a recovered topic's properties "
+      "from the manifest) when a new topic property is introduced");
+
     return topic_to_create_cfg;
 }
 

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -357,6 +357,11 @@ struct compat_check<cluster::topic_properties> {
           wr, "write_caching", obj.write_caching);
         json_write(flush_ms);
         json_write(flush_bytes);
+
+        static_assert(
+          std::tuple_size_v<decltype(obj.serde_fields())> == 31,
+          "Reminder to update this method when a new topic property is "
+          "introduced");
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -392,6 +397,12 @@ struct compat_check<cluster::topic_properties> {
         json_read(write_caching);
         json_read(flush_ms);
         json_read(flush_bytes);
+
+        static_assert(
+          std::tuple_size_v<decltype(obj.serde_fields())> == 31,
+          "Reminder to update this method when a new topic property is "
+          "introduced");
+
         return obj;
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cluster/health_monitor_types.h"
+#include "cluster/topic_properties.h"
 #include "cluster/types.h"
 #include "compat/json.h"
 #include "compat/model_json.h"
@@ -624,6 +625,14 @@ inline void rjson_serialize(
     write_exceptional_member_type(w, "write_caching", tps.write_caching);
     write_member(w, "flush_bytes", tps.flush_bytes);
     write_member(w, "flush_ms", tps.flush_ms);
+
+    static_assert(
+      std::tuple_size_v<
+        decltype(std::declval<cluster::topic_properties>().serde_fields())>
+        == 31,
+      "Reminder to update this method when a new topic property is "
+      "introduced");
+
     w.EndObject();
 }
 
@@ -690,6 +699,11 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "write_caching", obj.write_caching);
     read_member(rd, "flush_bytes", obj.flush_bytes);
     read_member(rd, "flush_ms", obj.flush_ms);
+
+    static_assert(
+      std::tuple_size_v<decltype(obj.serde_fields())> == 31,
+      "Reminder to update this method when a new topic property is "
+      "introduced");
 }
 
 inline void rjson_serialize(

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -71,13 +71,13 @@ create_topic_properties_update(
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.compaction_strategy.op = op_t::set;
-    update.properties.compression.op = op_t::set;
-    update.properties.segment_size.op = op_t::set;
-    update.properties.timestamp_type.op = op_t::set;
-    update.properties.retention_bytes.op = op_t::set;
-    update.properties.retention_duration.op = op_t::set;
-    update.properties.shadow_indexing.op = op_t::set;
+    update.properties.compaction_strategy.op = op_t::remove;
+    update.properties.compression.op = op_t::remove;
+    update.properties.segment_size.op = op_t::remove;
+    update.properties.timestamp_type.op = op_t::remove;
+    update.properties.retention_bytes.op = op_t::remove;
+    update.properties.retention_duration.op = op_t::remove;
+    update.properties.shadow_indexing.op = op_t::remove;
 
     update.custom_properties.replication_factor.op = op_t::none;
     update.custom_properties.data_policy.op = op_t::none;
@@ -90,14 +90,16 @@ create_topic_properties_update(
     update.properties.cleanup_policy_bitflags.value
       = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
 
-    update.properties.record_key_schema_id_validation.op = op_t::set;
-    update.properties.record_key_schema_id_validation_compat.op = op_t::set;
-    update.properties.record_key_subject_name_strategy.op = op_t::set;
-    update.properties.record_key_subject_name_strategy_compat.op = op_t::set;
-    update.properties.record_value_schema_id_validation.op = op_t::set;
-    update.properties.record_value_schema_id_validation_compat.op = op_t::set;
-    update.properties.record_value_subject_name_strategy.op = op_t::set;
-    update.properties.record_value_subject_name_strategy_compat.op = op_t::set;
+    update.properties.record_key_schema_id_validation.op = op_t::remove;
+    update.properties.record_key_schema_id_validation_compat.op = op_t::remove;
+    update.properties.record_key_subject_name_strategy.op = op_t::remove;
+    update.properties.record_key_subject_name_strategy_compat.op = op_t::remove;
+    update.properties.record_value_schema_id_validation.op = op_t::remove;
+    update.properties.record_value_schema_id_validation_compat.op
+      = op_t::remove;
+    update.properties.record_value_subject_name_strategy.op = op_t::remove;
+    update.properties.record_value_subject_name_strategy_compat.op
+      = op_t::remove;
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -228,15 +228,6 @@ create_topic_properties_update(
                     continue;
                 }
             }
-            if (
-              std::find(
-                std::begin(allowlist_topic_noop_confs),
-                std::end(allowlist_topic_noop_confs),
-                cfg.name)
-              != std::end(allowlist_topic_noop_confs)) {
-                // Skip unsupported Kafka config
-                continue;
-            };
             if (cfg.name == topic_property_write_caching) {
                 parse_and_set_optional(
                   update.properties.write_caching,
@@ -267,6 +258,16 @@ create_topic_properties_update(
               supported_topic_properties.size() == 29,
               "Reminder to update the alter configs handler when a new topic "
               "property is introduced");
+
+            // Skip unsupported Kafka configs that are on the allowlist
+            if (
+              std::find(
+                std::begin(allowlist_topic_noop_confs),
+                std::end(allowlist_topic_noop_confs),
+                cfg.name)
+              != std::end(allowlist_topic_noop_confs)) {
+                continue;
+            };
 
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -76,20 +76,8 @@ create_topic_properties_update(
     update.properties.segment_size.op = op_t::remove;
     update.properties.timestamp_type.op = op_t::remove;
     update.properties.retention_bytes.op = op_t::remove;
-    update.properties.retention_duration.op = op_t::remove;
     update.properties.shadow_indexing.op = op_t::remove;
-
-    update.custom_properties.replication_factor.op = op_t::none;
-    update.custom_properties.data_policy.op = op_t::none;
-
-    /**
-     * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
-     * we must special case the handling to preserve this default.
-     */
-    update.properties.cleanup_policy_bitflags.op = op_t::set;
-    update.properties.cleanup_policy_bitflags.value
-      = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
-
+    update.properties.retention_duration.op = op_t::remove;
     update.properties.record_key_schema_id_validation.op = op_t::remove;
     update.properties.record_key_schema_id_validation_compat.op = op_t::remove;
     update.properties.record_key_subject_name_strategy.op = op_t::remove;
@@ -100,6 +88,17 @@ create_topic_properties_update(
     update.properties.record_value_subject_name_strategy.op = op_t::remove;
     update.properties.record_value_subject_name_strategy_compat.op
       = op_t::remove;
+
+    /**
+     * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
+     * we must special case the handling to preserve this default.
+     */
+    update.properties.cleanup_policy_bitflags.op = op_t::set;
+    update.properties.cleanup_policy_bitflags.value
+      = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
+
+    update.custom_properties.replication_factor.op = op_t::none;
+    update.custom_properties.data_policy.op = op_t::none;
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -76,8 +76,15 @@ create_topic_properties_update(
     update.properties.segment_size.op = op_t::remove;
     update.properties.timestamp_type.op = op_t::remove;
     update.properties.retention_bytes.op = op_t::remove;
+    update.properties.remote_delete.op = op_t::remove;
+    update.properties.segment_ms.op = op_t::remove;
     update.properties.shadow_indexing.op = op_t::remove;
     update.properties.retention_duration.op = op_t::remove;
+    update.properties.batch_max_bytes.op = op_t::remove;
+    update.properties.retention_local_target_ms.op = op_t::remove;
+    update.properties.retention_local_target_bytes.op = op_t::remove;
+    update.properties.initial_retention_local_target_ms.op = op_t::remove;
+    update.properties.initial_retention_local_target_bytes.op = op_t::remove;
     update.properties.record_key_schema_id_validation.op = op_t::remove;
     update.properties.record_key_schema_id_validation_compat.op = op_t::remove;
     update.properties.record_key_subject_name_strategy.op = op_t::remove;
@@ -88,6 +95,9 @@ create_topic_properties_update(
     update.properties.record_value_subject_name_strategy.op = op_t::remove;
     update.properties.record_value_subject_name_strategy_compat.op
       = op_t::remove;
+    update.properties.write_caching.op = op_t::remove;
+    update.properties.flush_ms.op = op_t::remove;
+    update.properties.flush_bytes.op = op_t::remove;
 
     /**
      * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -58,6 +58,8 @@ static void parse_and_set_shadow_indexing_mode(
 checked<cluster::topic_properties_update, alter_configs_resource_response>
 create_topic_properties_update(
   const request_context& ctx, alter_configs_resource& resource) {
+    using op_t = cluster::incremental_update_operation;
+
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
@@ -69,50 +71,33 @@ create_topic_properties_update(
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.compaction_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.compression.op
-      = cluster::incremental_update_operation::set;
-    update.properties.segment_size.op
-      = cluster::incremental_update_operation::set;
-    update.properties.timestamp_type.op
-      = cluster::incremental_update_operation::set;
-    update.properties.retention_bytes.op
-      = cluster::incremental_update_operation::set;
-    update.properties.retention_duration.op
-      = cluster::incremental_update_operation::set;
-    update.properties.shadow_indexing.op
-      = cluster::incremental_update_operation::set;
-    update.custom_properties.replication_factor.op
-      = cluster::incremental_update_operation::none;
-    update.custom_properties.data_policy.op
-      = cluster::incremental_update_operation::none;
+    update.properties.compaction_strategy.op = op_t::set;
+    update.properties.compression.op = op_t::set;
+    update.properties.segment_size.op = op_t::set;
+    update.properties.timestamp_type.op = op_t::set;
+    update.properties.retention_bytes.op = op_t::set;
+    update.properties.retention_duration.op = op_t::set;
+    update.properties.shadow_indexing.op = op_t::set;
+
+    update.custom_properties.replication_factor.op = op_t::none;
+    update.custom_properties.data_policy.op = op_t::none;
 
     /**
      * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
      * we must special case the handling to preserve this default.
      */
-    update.properties.cleanup_policy_bitflags.op
-      = cluster::incremental_update_operation::set;
+    update.properties.cleanup_policy_bitflags.op = op_t::set;
     update.properties.cleanup_policy_bitflags.value
       = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
 
-    update.properties.record_key_schema_id_validation.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_schema_id_validation_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_subject_name_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_key_subject_name_strategy_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_schema_id_validation.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_schema_id_validation_compat.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_subject_name_strategy.op
-      = cluster::incremental_update_operation::set;
-    update.properties.record_value_subject_name_strategy_compat.op
-      = cluster::incremental_update_operation::set;
+    update.properties.record_key_schema_id_validation.op = op_t::set;
+    update.properties.record_key_schema_id_validation_compat.op = op_t::set;
+    update.properties.record_key_subject_name_strategy.op = op_t::set;
+    update.properties.record_key_subject_name_strategy_compat.op = op_t::set;
+    update.properties.record_value_schema_id_validation.op = op_t::set;
+    update.properties.record_value_schema_id_validation_compat.op = op_t::set;
+    update.properties.record_value_subject_name_strategy.op = op_t::set;
+    update.properties.record_value_subject_name_strategy_compat.op = op_t::set;
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -71,33 +71,11 @@ create_topic_properties_update(
      * configuration in topic table, the only difference is the replication
      * factor, if not set in the request explicitly it will not be overriden.
      */
-    update.properties.compaction_strategy.op = op_t::remove;
-    update.properties.compression.op = op_t::remove;
-    update.properties.segment_size.op = op_t::remove;
-    update.properties.timestamp_type.op = op_t::remove;
-    update.properties.retention_bytes.op = op_t::remove;
-    update.properties.remote_delete.op = op_t::remove;
-    update.properties.segment_ms.op = op_t::remove;
-    update.properties.shadow_indexing.op = op_t::remove;
-    update.properties.retention_duration.op = op_t::remove;
-    update.properties.batch_max_bytes.op = op_t::remove;
-    update.properties.retention_local_target_ms.op = op_t::remove;
-    update.properties.retention_local_target_bytes.op = op_t::remove;
-    update.properties.initial_retention_local_target_ms.op = op_t::remove;
-    update.properties.initial_retention_local_target_bytes.op = op_t::remove;
-    update.properties.record_key_schema_id_validation.op = op_t::remove;
-    update.properties.record_key_schema_id_validation_compat.op = op_t::remove;
-    update.properties.record_key_subject_name_strategy.op = op_t::remove;
-    update.properties.record_key_subject_name_strategy_compat.op = op_t::remove;
-    update.properties.record_value_schema_id_validation.op = op_t::remove;
-    update.properties.record_value_schema_id_validation_compat.op
-      = op_t::remove;
-    update.properties.record_value_subject_name_strategy.op = op_t::remove;
-    update.properties.record_value_subject_name_strategy_compat.op
-      = op_t::remove;
-    update.properties.write_caching.op = op_t::remove;
-    update.properties.flush_ms.op = op_t::remove;
-    update.properties.flush_bytes.op = op_t::remove;
+    constexpr auto apply_op = [](op_t op) {
+        return [op](auto&&... prop) { ((prop.op = op), ...); };
+    };
+    std::apply(apply_op(op_t::remove), update.properties.serde_fields());
+    std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     /**
      * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
@@ -106,9 +84,6 @@ create_topic_properties_update(
     update.properties.cleanup_policy_bitflags.op = op_t::set;
     update.properties.cleanup_policy_bitflags.value
       = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
-
-    update.custom_properties.replication_factor.op = op_t::none;
-    update.custom_properties.data_policy.op = op_t::none;
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       update.properties};

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -263,6 +263,11 @@ create_topic_properties_update(
                 continue;
             }
 
+            static_assert(
+              supported_topic_properties.size() == 29,
+              "Reminder to update the alter configs handler when a new topic "
+              "property is introduced");
+
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<
               alter_configs_resource_response>(

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -898,6 +898,11 @@ config_response_container_t make_topic_configs(
         config::shard_local_cfg()
           .initial_retention_local_target_ms_default.desc()));
 
+    static_assert(
+      supported_topic_properties.size() == 29,
+      "Reminder to update this method constructing the DescribeConfigs "
+      "response when a new topic property is introduced");
+
     return result;
 }
 

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -39,41 +39,10 @@
 
 namespace kafka {
 
-static constexpr auto supported_configs = std::to_array(
-  {topic_property_compression,
-   topic_property_cleanup_policy,
-   topic_property_timestamp_type,
-   topic_property_segment_size,
-   topic_property_compaction_strategy,
-   topic_property_retention_bytes,
-   topic_property_retention_duration,
-   topic_property_recovery,
-   topic_property_remote_write,
-   topic_property_remote_read,
-   topic_property_remote_delete,
-   topic_property_read_replica,
-   topic_property_max_message_bytes,
-   topic_property_retention_local_target_bytes,
-   topic_property_retention_local_target_ms,
-   topic_property_segment_ms,
-   topic_property_record_key_schema_id_validation,
-   topic_property_record_key_schema_id_validation_compat,
-   topic_property_record_key_subject_name_strategy,
-   topic_property_record_key_subject_name_strategy_compat,
-   topic_property_record_value_schema_id_validation,
-   topic_property_record_value_schema_id_validation_compat,
-   topic_property_record_value_subject_name_strategy,
-   topic_property_record_value_subject_name_strategy_compat,
-   topic_property_initial_retention_local_target_bytes,
-   topic_property_initial_retention_local_target_ms,
-   topic_property_write_caching,
-   topic_property_flush_ms,
-   topic_property_flush_bytes});
-
 bool is_supported(std::string_view name) {
     return std::any_of(
-      supported_configs.begin(),
-      supported_configs.end(),
+      supported_topic_properties.begin(),
+      supported_topic_properties.end(),
       [name](std::string_view p) { return name == p; });
 }
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -267,15 +267,6 @@ create_topic_properties_update(
                     continue;
                 }
             }
-            if (
-              std::find(
-                std::begin(allowlist_topic_noop_confs),
-                std::end(allowlist_topic_noop_confs),
-                cfg.name)
-              != std::end(allowlist_topic_noop_confs)) {
-                // Skip unsupported Kafka config
-                continue;
-            }
             if (cfg.name == topic_property_write_caching) {
                 parse_and_set_optional(
                   update.properties.write_caching,
@@ -305,6 +296,16 @@ create_topic_properties_update(
               supported_topic_properties.size() == 29,
               "Reminder to update the incremental alter configs handler when a "
               "new topic property is introduced");
+
+            // Skip unsupported Kafka configs that are on the allowlist
+            if (
+              std::find(
+                std::begin(allowlist_topic_noop_confs),
+                std::end(allowlist_topic_noop_confs),
+                cfg.name)
+              != std::end(allowlist_topic_noop_confs)) {
+                continue;
+            }
 
         } catch (const validation_error& e) {
             vlog(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -301,6 +301,11 @@ create_topic_properties_update(
                 continue;
             }
 
+            static_assert(
+              supported_topic_properties.size() == 29,
+              "Reminder to update the incremental alter configs handler when a "
+              "new topic property is introduced");
+
         } catch (const validation_error& e) {
             vlog(
               klog.debug,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -259,6 +259,11 @@ to_cluster_type(const creatable_topic& t) {
           p, kafka::config_resource_operation::set);
     }
 
+    static_assert(
+      supported_topic_properties.size() == 29,
+      "Reminder to update this method parsing the CreateTopic request when a "
+      "new topic property is introduced");
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -111,6 +111,39 @@ static constexpr std::string_view
 static constexpr std::string_view topic_property_mpx_virtual_cluster_id
   = "redpanda.virtual.cluster.id";
 
+// Kafka topic properties that are supported by CreateTopic, AlterConfig,
+// IncrementalAlterConfig, DescribeConfigs requests
+static constexpr auto supported_topic_properties = std::to_array(
+  {topic_property_compression,
+   topic_property_cleanup_policy,
+   topic_property_timestamp_type,
+   topic_property_segment_size,
+   topic_property_compaction_strategy,
+   topic_property_retention_bytes,
+   topic_property_retention_duration,
+   topic_property_recovery,
+   topic_property_remote_write,
+   topic_property_remote_read,
+   topic_property_remote_delete,
+   topic_property_read_replica,
+   topic_property_max_message_bytes,
+   topic_property_retention_local_target_bytes,
+   topic_property_retention_local_target_ms,
+   topic_property_segment_ms,
+   topic_property_record_key_schema_id_validation,
+   topic_property_record_key_schema_id_validation_compat,
+   topic_property_record_key_subject_name_strategy,
+   topic_property_record_key_subject_name_strategy_compat,
+   topic_property_record_value_schema_id_validation,
+   topic_property_record_value_schema_id_validation_compat,
+   topic_property_record_value_subject_name_strategy,
+   topic_property_record_value_subject_name_strategy_compat,
+   topic_property_initial_retention_local_target_bytes,
+   topic_property_initial_retention_local_target_ms,
+   topic_property_write_caching,
+   topic_property_flush_ms,
+   topic_property_flush_bytes});
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {


### PR DESCRIPTION
**Note: this PR stacks on https://github.com/redpanda-data/redpanda/pull/21291. Only review the last 3 commits.**

This adds a set of `static_assert`'s across the codebase that add reminders of every place that needs to be updated/considered when a new topic property is introduced. As you can see from the PR, there are many such places, so it is easy to miss them. We should also try to reduce the number of places to the minimum afterwards.

Note: I haven't added static assertions to `topic_properties.cc` since it is close to definition of `topic_properties` already, so it should be hard to miss.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
