### PR TITLE
rptest: tolerate leadership changes in chunk read tests

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -506,10 +506,6 @@ class DeleteRandomChunks(Thread):
         self.n_delete = n_delete
         self.deleted_chunks = 0
 
-        leader_id = Admin(self.redpanda).get_partition_leader(
-            namespace='kafka', topic=self.topic, partition=0)
-        self.leader = self.redpanda.get_node_by_id(leader_id)
-
     def run(self) -> None:
         cmd = f"""
 find {self.redpanda.DATA_DIR}/cloud_storage_cache -regex '.*kafka/{self.topic}/.*_chunks/[0-9]+' -print0 |\
@@ -518,11 +514,15 @@ find {self.redpanda.DATA_DIR}/cloud_storage_cache -regex '.*kafka/{self.topic}/.
  xargs --no-run-if-empty --null rm -v"""
         while not self.stop_requested:
             sleep(self.sleep_interval)
-            if self.leader in self.redpanda.started_nodes():
+            leader_id = Admin(self.redpanda).get_partition_leader(
+                namespace='kafka', topic=self.topic, partition=0)
+            leader_node = self.redpanda.get_node_by_id(leader_id)
+
+            if leader_node in self.redpanda.started_nodes():
                 try:
-                    for row in self.leader.account.ssh_capture(cmd):
+                    for row in leader_node.account.ssh_capture(cmd):
                         self.redpanda.logger.debug(
-                            f'{self.leader.account.hostname}: {row.strip()}')
+                            f'{leader_node.account.hostname}: {row.strip()}')
                         self.deleted_chunks += 1
                 except Exception as ex:
                     self.redpanda.logger.info(


### PR DESCRIPTION
DeleteRandomChunks worker must refresh knowledge about current leader otherwise it might act on an unrelated node, report that it was unable to delete any chunks, and fail the test.

Spotted in a backport build https://buildkite.com/redpanda/redpanda/builds/51354#0190a1a8-8687-4687-b3c6-e0ac3c9f55cc

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
