### PR TITLE
CORE-781 k/groups: list groups v4 (group state filtering)

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -503,7 +503,6 @@ override_member_container = {
     'offset_fetch_request_topic': 'std::vector',
     'partition_produce_response': 'std::vector',
     'creatable_acl_result': 'std::vector',
-    'listed_group': 'std::vector',
     'offset_delete_request_partition': 'std::vector',
     'deletable_group_result': 'std::vector',
     'delete_acls_matching_acl': 'std::vector',

--- a/src/v/kafka/protocol/schemata/list_groups_request.json
+++ b/src/v/kafka/protocol/schemata/list_groups_request.json
@@ -20,8 +20,13 @@
   // Version 1 and 2 are the same as version 0.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds the StatesFilter field (KIP-518).
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
+    { "name": "StatesFilter", "type": "[]string", "versions": "4+",
+      "about": "The states of the groups we want to list. If empty all groups are returned with their state."
+    }
   ]
 }

--- a/src/v/kafka/protocol/schemata/list_groups_response.json
+++ b/src/v/kafka/protocol/schemata/list_groups_response.json
@@ -22,7 +22,9 @@
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds the GroupState field (KIP-518).
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
@@ -34,7 +36,9 @@
       { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
         "about": "The group ID." },
       { "name": "ProtocolType", "type": "string", "versions": "0+",
-        "about": "The group protocol type." }
+        "about": "The group protocol type." },
+      { "name": "GroupState", "type": "string", "versions": "4+", "ignorable": true,
+        "about": "The group state name." }
     ]}
   ]
 }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -37,6 +37,7 @@
 #include "raft/errc.h"
 #include "ssx/future-util.h"
 #include "storage/record_batch_builder.h"
+#include "strings/string_switch.h"
 #include "utils/to_string.h"
 
 #include <seastar/core/coroutine.hh>
@@ -2788,6 +2789,21 @@ ss::sstring group_state_to_kafka_name(group_state gs) {
     default:
         std::terminate(); // make gcc happy
     }
+}
+
+std::optional<group_state> group_state_from_kafka_name(std::string_view name) {
+    return string_switch<std::optional<group_state>>(name)
+      .match(group_state_to_kafka_name(group_state::empty), group_state::empty)
+      .match(
+        group_state_to_kafka_name(group_state::preparing_rebalance),
+        group_state::preparing_rebalance)
+      .match(
+        group_state_to_kafka_name(group_state::completing_rebalance),
+        group_state::completing_rebalance)
+      .match(
+        group_state_to_kafka_name(group_state::stable), group_state::stable)
+      .match(group_state_to_kafka_name(group_state::dead), group_state::dead)
+      .default_match(std::nullopt);
 }
 
 void group::add_pending_member(

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -107,6 +107,7 @@ using enable_group_metrics = ss::bool_class<struct enable_gr_metrics_tag>;
 std::ostream& operator<<(std::ostream&, group_state gs);
 
 ss::sstring group_state_to_kafka_name(group_state);
+std::optional<group_state> group_state_from_kafka_name(std::string_view);
 cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx::errc);
 cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx::errc);
 cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx::errc);

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1558,7 +1558,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
     co_return response;
 }
 
-std::pair<error_code, std::vector<listed_group>>
+std::pair<error_code, chunked_vector<listed_group>>
 group_manager::list_groups(const list_groups_filter_data& filter_data) const {
     auto loading = std::any_of(
       _partitions.cbegin(),
@@ -1568,7 +1568,7 @@ group_manager::list_groups(const list_groups_filter_data& filter_data) const {
           return p.second->loading;
       });
 
-    std::vector<listed_group> groups;
+    chunked_vector<listed_group> groups;
     for (const auto& it : _groups) {
         const auto& g = it.second;
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -26,6 +26,7 @@
 #include "kafka/protocol/offset_delete.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "kafka/protocol/wire.h"
+#include "kafka/server/group.h"
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/group_recovery_consumer.h"
 #include "kafka/server/logger.h"
@@ -1558,7 +1559,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
 }
 
 std::pair<error_code, std::vector<listed_group>>
-group_manager::list_groups() const {
+group_manager::list_groups(const list_groups_filter_data& filter_data) const {
     auto loading = std::any_of(
       _partitions.cbegin(),
       _partitions.cend(),
@@ -1570,14 +1571,22 @@ group_manager::list_groups() const {
     std::vector<listed_group> groups;
     for (const auto& it : _groups) {
         const auto& g = it.second;
-        groups.push_back(
-          {g->id(), g->protocol_type().value_or(protocol_type())});
+
+        auto no_filter_specified = filter_data.states_filter.empty();
+        auto matches_filter = filter_data.states_filter.contains(g->state());
+
+        if (no_filter_specified || matches_filter) {
+            groups.push_back(
+              {g->id(),
+               g->protocol_type().value_or(protocol_type()),
+               group_state_to_kafka_name(g->state())});
+        }
     }
 
     auto error = loading ? error_code::coordinator_load_in_progress
                          : error_code::none;
 
-    return std::make_pair(error, groups);
+    return std::make_pair(error, std::move(groups));
 }
 
 described_group

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -43,6 +43,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/sharded.hh>
 
+#include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_map.h>
 
 #include <span>
@@ -134,6 +135,12 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    struct list_groups_filter_data {
+        using states_filter_t = absl::flat_hash_set<group_state>;
+
+        states_filter_t states_filter;
+    };
+
 public:
     /// \brief Handle a JoinGroup request
     group::join_group_stages join_group(join_group_request&& request);
@@ -171,7 +178,8 @@ public:
 
     // returns the set of registered groups, and an error if one occurred while
     // retrieving the group list (e.g. coordinator_load_in_progress).
-    std::pair<error_code, std::vector<listed_group>> list_groups() const;
+    std::pair<error_code, std::vector<listed_group>>
+    list_groups(const list_groups_filter_data& filter_data = {}) const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -14,6 +14,7 @@
 #include "cluster/cloud_metadata/offsets_snapshot.h"
 #include "cluster/notification.h"
 #include "cluster/topic_table.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/delete_groups.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"
@@ -178,7 +179,7 @@ public:
 
     // returns the set of registered groups, and an error if one occurred while
     // retrieving the group list (e.g. coordinator_load_in_progress).
-    std::pair<error_code, std::vector<listed_group>>
+    std::pair<error_code, chunked_vector<listed_group>>
     list_groups(const list_groups_filter_data& filter_data = {}) const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -294,10 +294,12 @@ group_router::abort_tx(cluster::abort_group_tx_request request) {
 }
 
 ss::future<std::pair<error_code, std::vector<listed_group>>>
-group_router::list_groups() {
+group_router::list_groups(group_manager::list_groups_filter_data filter_data) {
     using type = std::pair<error_code, std::vector<listed_group>>;
     return get_group_manager().map_reduce0(
-      [](group_manager& mgr) { return mgr.list_groups(); },
+      [filter_data = std::move(filter_data)](group_manager& mgr) {
+          return mgr.list_groups(filter_data);
+      },
       type{},
       [](type a, type b) {
           // reduce errors into `a` and retain the first

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -16,6 +16,9 @@
 #include <seastar/core/when_all.hh>
 #include <seastar/core/with_scheduling_group.hh>
 
+#include <algorithm>
+#include <iterator>
+
 namespace kafka {
 
 template<typename Request, typename FwdFunc>
@@ -293,9 +296,9 @@ group_router::abort_tx(cluster::abort_group_tx_request request) {
     return route_tx(std::move(request), &group_manager::abort_tx);
 }
 
-ss::future<std::pair<error_code, std::vector<listed_group>>>
+ss::future<std::pair<error_code, chunked_vector<listed_group>>>
 group_router::list_groups(group_manager::list_groups_filter_data filter_data) {
-    using type = std::pair<error_code, std::vector<listed_group>>;
+    using type = std::pair<error_code, chunked_vector<listed_group>>;
     return get_group_manager().map_reduce0(
       [filter_data = std::move(filter_data)](group_manager& mgr) {
           return mgr.list_groups(filter_data);
@@ -306,7 +309,10 @@ group_router::list_groups(group_manager::list_groups_filter_data filter_data) {
           if (a.first == error_code::none) {
               a.first = b.first;
           }
-          a.second.insert(a.second.end(), b.second.begin(), b.second.end());
+          auto& av = a.second;
+          auto& bv = b.second;
+          av.reserve(av.size() + bv.size());
+          std::copy(bv.begin(), bv.end(), std::back_inserter(av));
           return a;
       });
 }

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -83,7 +83,8 @@ public:
     abort_tx(cluster::abort_group_tx_request request);
 
     // return groups from across all shards, and if any core was still loading
-    ss::future<std::pair<error_code, std::vector<listed_group>>> list_groups();
+    ss::future<std::pair<error_code, std::vector<listed_group>>>
+    list_groups(group_manager::list_groups_filter_data filter_data);
 
     ss::future<described_group> describe_group(kafka::group_id g);
 

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
 #include "cluster/shard_table.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/heartbeat.h"
 #include "kafka/protocol/join_group.h"
@@ -83,7 +84,7 @@ public:
     abort_tx(cluster::abort_group_tx_request request);
 
     // return groups from across all shards, and if any core was still loading
-    ss::future<std::pair<error_code, std::vector<listed_group>>>
+    ss::future<std::pair<error_code, chunked_vector<listed_group>>>
     list_groups(group_manager::list_groups_filter_data filter_data);
 
     ss::future<described_group> describe_group(kafka::group_id g);

--- a/src/v/kafka/server/handlers/list_groups.h
+++ b/src/v/kafka/server/handlers/list_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_groups_handler = single_stage_handler<list_groups_api, 0, 3>;
+using list_groups_handler = single_stage_handler<list_groups_api, 0, 4>;
 
 }

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -660,7 +660,7 @@ ss::future<response_ptr> list_groups_handler::handle(
                 security::acl_operation::describe, group.group_id);
           });
 
-        resp.data.groups.erase(non_visible_it, resp.data.groups.end());
+        resp.data.groups.erase_to_end(non_visible_it);
     }
 
     if (!ctx.audit()) {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -18,10 +18,13 @@
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "features/feature_table.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/list_groups_response.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/errors.h"
+#include "kafka/server/group.h"
+#include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/handlers/add_offsets_to_txn.h"
 #include "kafka/server/handlers/add_partitions_to_txn.h"
@@ -604,11 +607,31 @@ ss::future<response_ptr> list_groups_handler::handle(
     list_groups_request request{};
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
-    auto&& [error, groups] = co_await ctx.groups().list_groups();
-
     list_groups_response resp;
-    resp.data.error_code = error;
-    resp.data.groups = std::move(groups);
+
+    auto [invalid_req, filter] = [&request]() {
+        using list_groups_filter_data = group_manager::list_groups_filter_data;
+        list_groups_filter_data filter;
+        filter.states_filter.reserve(request.data.states_filter.size());
+        for (auto& state : request.data.states_filter) {
+            auto parsed = group_state_from_kafka_name(state);
+            if (!parsed) {
+                return std::make_pair(true, list_groups_filter_data{});
+            } else {
+                filter.states_filter.insert(*parsed);
+            }
+        }
+        return std::make_pair(false, std::move(filter));
+    }();
+
+    if (invalid_req) {
+        resp.data.error_code = kafka::error_code::invalid_request;
+    } else {
+        auto [error, groups] = co_await ctx.groups().list_groups(
+          std::move(filter));
+        resp.data.error_code = error;
+        resp.data.groups = std::move(groups);
+    }
 
     auto additional_resources_func = [&resp]() {
         std::vector<kafka::group_id> groups;

--- a/tests/rptest/tests/consumer_group_recovery_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_test.py
@@ -73,7 +73,7 @@ class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
         self.logger.debug(f"Issue ListGroups, expect {num_groups} groups")
 
         def do_list_groups():
-            res = rpk.group_list()
+            res = rpk.group_list_names()
 
             if res is None:
                 return False

--- a/tests/rptest/tests/consumer_group_recovery_tool_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_tool_test.py
@@ -55,7 +55,7 @@ class ConsumerOffsetsRecoveryToolTest(PreallocNodesTest):
         self.logger.debug(f"Issue ListGroups, expect {num_groups} groups")
 
         def do_list_groups():
-            res = rpk.group_list()
+            res = rpk.group_list_names()
 
             if res is None:
                 return False

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -556,14 +556,14 @@ class ConsumerGroupTest(RedpandaTest):
         ev_loop.close()
 
         rpk = RpkTool(self.redpanda)
-        list = rpk.group_list()
+        list = rpk.group_list_names()
 
         assert len(list) == groups_in_round * rounds
 
         # restart redpanda and check recovery
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
-        list = rpk.group_list()
+        list = rpk.group_list_names()
 
         assert len(list) == groups_in_round * rounds
 

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -72,7 +72,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
         kgo_group_re = re.compile(r'^kgo-verifier-[0-9]+-[0-9]+-0$')
 
         def do_list_groups():
-            res = self.rpk.group_list()
+            res = self.rpk.group_list_names()
 
             if res is None or len(res) == 0:
                 return False

--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -191,7 +191,7 @@ class TestMirrorMakerService(MirrorMakerService):
 
         src_rpk = RpkTool(self.source_broker)
 
-        groups = src_rpk.group_list()
+        groups = src_rpk.group_list_names()
         consumer_group = ""
         for g in groups:
             if g.startswith("kgo-verifier"):

--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -87,7 +87,7 @@ class RecoveryModeTest(RedpandaTest):
         # consume and create some consumer groups
 
         rpk.consume('mytopic1', n=500, group='mygroup1', quiet=True)
-        assert rpk.group_list() == ['mygroup1']
+        assert rpk.group_list_names() == ['mygroup1']
         group1 = rpk.group_describe('mygroup1')
         assert group1.total_lag == 500
         rpk.consume('mytopic1', n=1000, group='mygroup2', quiet=True)
@@ -123,7 +123,7 @@ class RecoveryModeTest(RedpandaTest):
 
         # check consumer group ops
 
-        assert rpk.group_list() == ['mygroup1', 'mygroup2']
+        assert rpk.group_list_names() == ['mygroup1', 'mygroup2']
 
         with tempfile.NamedTemporaryFile() as tf:
             # seek to the beginning of all partitions
@@ -139,7 +139,7 @@ class RecoveryModeTest(RedpandaTest):
         assert sum(p.current_offset for p in group2.partitions) == 1000
 
         rpk.group_delete('mygroup2')
-        assert rpk.group_list() == ['mygroup1']
+        assert rpk.group_list_names() == ['mygroup1']
 
         # check topic ops
 
@@ -193,7 +193,7 @@ class RecoveryModeTest(RedpandaTest):
             err_msg="failed to wait until partitions become ready")
         assert sum(p.high_watermark for p in partitions) == 2000
 
-        assert rpk.group_list() == ['mygroup1']
+        assert rpk.group_list_names() == ['mygroup1']
 
         consumed = rpk.consume('mytopic1',
                                n=2000,
@@ -219,7 +219,7 @@ class RecoveryModeTest(RedpandaTest):
         # consume and create some consumer groups
 
         rpk.consume('mytopic1', n=500, group='mygroup1', quiet=True)
-        assert rpk.group_list() == ['mygroup1']
+        assert rpk.group_list_names() == ['mygroup1']
         group1 = rpk.group_describe('mygroup1')
         assert group1.total_lag == 500
         rpk.consume('mytopic1', n=1000, group='mygroup2', quiet=True)

--- a/tests/rptest/tests/rpk_group_test.py
+++ b/tests/rptest/tests/rpk_group_test.py
@@ -67,12 +67,12 @@ class RpkGroupCommandsTest(RedpandaTest):
         self.rpk.consume(topic, group=group_2, n=10)
 
         # groups will show up until they're deleted or until all offsets expire
-        groups = self.rpk.group_list()
+        groups = self.rpk.group_list_names()
         assert group_1 in groups
         assert group_2 in groups
 
         self.rpk.group_delete(group_1)
-        groups = self.rpk.group_list()
+        groups = self.rpk.group_list_names()
         assert group_1 not in groups
 
     @cluster(num_nodes=5)


### PR DESCRIPTION
This adds support for [KIP-518](https://cwiki.apache.org/confluence/display/KAFKA/KIP-518%3A+Allow+listing+consumer+groups+per+state) in the ListGroups handler, that is:
 * Filtering consumer groups returned by ListGroups based on a list of group states in the request.
 * Returning the group state of each group in the response

Fixes: https://redpandadata.atlassian.net/browse/CORE-781
Same as: https://github.com/redpanda-data/redpanda/issues/2903

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features
* KIP-518 (ListGroups v4): adds redpanda and rpk support for printing consumer group states with `rpk group list` and filtering for specific group states with `--states`.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
