### PR TITLE
bazel: disable github workflow for pull requests

### DIFF
--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -12,21 +12,7 @@ on:
   push:
     branches:
       - dev
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    paths:
-      - 'src/v/**'
-      - 'bazel/**'
-      - 'MODULE.bazel'
-      - '.bazelrc'
-      - '.bazelversion'
-      - 'BUILD'
-      - '.github/workflows/build-bazel.yml'
-
+      
 jobs:
   build:
     name: build redpanda with bazel


### PR DESCRIPTION
There is an issue loading secrets from repository forks. The only real viable solution is to ask all engineers to submit PRs from branches pushed to the upstream repo, but this is a major change given that we'll move to buildkite soon anyway. So the plan now is to just re-home the workflow to buildkite in the short term.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
