### PR TITLE
cluster: fix cloud storage `self-test` start/end time output

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -44,7 +44,10 @@ cloudcheck::run(cloudcheck_opts opts) {
     if (_gate.is_closed()) {
         vlog(clusterlog.debug, "cloudcheck - gate already closed");
         auto result = self_test_result{
-          .name = _opts.name, .warning = "cloudcheck - gate already closed"};
+          .name = _opts.name,
+          .start_time = time_since_epoch(ss::lowres_system_clock::now()),
+          .end_time = time_since_epoch(ss::lowres_system_clock::now()),
+          .warning = "cloudcheck - gate already closed"};
         co_return std::vector<self_test_result>{result};
     }
     auto g = _gate.hold();
@@ -60,7 +63,10 @@ cloudcheck::run(cloudcheck_opts opts) {
           clusterlog.warn,
           "Cloud storage is not enabled, exiting cloud storage self-test.");
         auto result = self_test_result{
-          .name = _opts.name, .warning = "Cloud storage is not enabled."};
+          .name = _opts.name,
+          .start_time = time_since_epoch(ss::lowres_system_clock::now()),
+          .end_time = time_since_epoch(ss::lowres_system_clock::now()),
+          .warning = "Cloud storage is not enabled."};
         co_return std::vector<self_test_result>{result};
     }
 
@@ -71,6 +77,8 @@ cloudcheck::run(cloudcheck_opts opts) {
           "self-test.");
         auto result = self_test_result{
           .name = _opts.name,
+          .start_time = time_since_epoch(ss::lowres_system_clock::now()),
+          .end_time = time_since_epoch(ss::lowres_system_clock::now()),
           .warning = "cloud_storage_api is not initialized."};
         co_return std::vector<self_test_result>{result};
     }

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -82,42 +82,68 @@ private:
       typename R = std::invoke_result_t<Test, cloudcheck, Args...>>
     R do_run_test(Test test, Args&&... args);
 
+    struct verify_upload_result {
+        self_test_result test_result;
+    };
+
     // Verify that uploading (Put: write operation) to cloud storage works.
-    ss::future<self_test_result> verify_upload(
+    ss::future<verify_upload_result> verify_upload(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key,
       const std::optional<iobuf>& payload);
 
+    struct verify_list_result {
+        cloud_storage::remote::list_result list_result;
+        self_test_result test_result;
+    };
+
     // Verify that listing (List: read operation) from cloud storage works.
-    ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
-    verify_list(
+    ss::future<verify_list_result> verify_list(
       cloud_storage_clients::bucket_name bucket,
       std::optional<cloud_storage_clients::object_key> prefix,
-      size_t max_keys = 5);
+      size_t max_keys = num_default_objects);
+
+    struct verify_head_result {
+        self_test_result test_result;
+    };
 
     // Verify that checking if an object exists (Head: read operation) from
     // cloud storage works.
-    ss::future<self_test_result> verify_head(
+    ss::future<verify_head_result> verify_head(
       cloud_storage_clients::bucket_name bucket,
       std::optional<cloud_storage_clients::object_key> key);
+
+    struct verify_download_result {
+        std::optional<iobuf> buf;
+        self_test_result test_result;
+    };
 
     // Verify that downloading (Get: read operation) from cloud storage works.
-    ss::future<std::pair<std::optional<iobuf>, self_test_result>>
-    verify_download(
+    ss::future<verify_download_result> verify_download(
       cloud_storage_clients::bucket_name bucket,
       std::optional<cloud_storage_clients::object_key> key);
 
+    struct verify_delete_result {
+        self_test_result test_result;
+    };
+
     // Verify that deleting (Delete: write operation) from cloud storage works.
-    ss::future<self_test_result> verify_delete(
+    ss::future<verify_delete_result> verify_delete(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key);
 
+    struct verify_deletes_result {
+        self_test_result test_result;
+    };
+
     // Verify that deleting multiple (Plural Delete: write operation) from cloud
     // storage works.
-    ss::future<self_test_result> verify_deletes(
-      cloud_storage_clients::bucket_name bucket, size_t num_objects = 5);
+    ss::future<verify_deletes_result> verify_deletes(
+      cloud_storage_clients::bucket_name bucket,
+      size_t num_objects = num_default_objects);
 
 private:
+    static constexpr size_t num_default_objects = 5;
     bool _remote_read_enabled{false};
     bool _remote_write_enabled{false};
     bool _cancelled{false};

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -74,6 +74,14 @@ private:
       iobuf& payload,
       retry_chain_node& rtc);
 
+    // Wrapper around verify_tests for timing purposes, regardless of test
+    // failure or success.
+    template<
+      typename Test,
+      typename... Args,
+      typename R = std::invoke_result_t<Test, cloudcheck, Args...>>
+    R do_run_test(Test test, Args&&... args);
+
     // Verify that uploading (Put: write operation) to cloud storage works.
     ss::future<self_test_result> verify_upload(
       cloud_storage_clients::bucket_name bucket,

--- a/src/v/cluster/self_test/metrics.h
+++ b/src/v/cluster/self_test/metrics.h
@@ -22,6 +22,13 @@ class omit_metrics_measurement_exception : public std::exception {};
 
 class omit_measure_timed_out_exception : public std::exception {};
 
+template<typename Timepoint>
+uint64_t time_since_epoch(Timepoint tp) {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+             tp.time_since_epoch())
+      .count();
+}
+
 class metrics {
 public:
     explicit metrics(int64_t max_value_hist)
@@ -92,15 +99,11 @@ public:
     }
 
     uint64_t get_start_time_since_epoch() const {
-        return std::chrono::duration_cast<std::chrono::seconds>(
-                 _start_time.time_since_epoch())
-          .count();
+        return time_since_epoch(_start_time);
     }
 
     uint64_t get_end_time_since_epoch() const {
-        return std::chrono::duration_cast<std::chrono::seconds>(
-                 _end_time.time_since_epoch())
-          .count();
+        return time_since_epoch(_end_time);
     }
 
 private:


### PR DESCRIPTION
The start/end times for tests ran with the `self-test` tool were [recently added](https://github.com/redpanda-data/redpanda/commit/bc7d5bfdd831447f5dbb5b364dbf74272cad0dc3) to the output of `rpk config self-test status`.

These times were not being set in the cloud storage `self-test`, and thus the `START` and `END` times would both be epoch time, i.e

```
NAME          Cloud Storage Test
INFO          Put
TYPE          cloud
TEST ID       2cf3b181-3cb8-4502-a987-28dfd60f4f12
TIMEOUTS      0
START TIME    Thu Jan  1 00:00:00 UTC 1970
END TIME      Thu Jan  1 00:00:00 UTC 1970
AVG DURATION  7ms
```

This PR fixes the start and end time outputted for the result of the test, for either failed or successful tests.

```
NAME          Cloud Storage Test
INFO          Put
TYPE          cloud
TEST ID       0d40dc63-5a7f-43df-b175-de33411d1df9
TIMEOUTS      0
START TIME    Fri July  12 16:00:13 UTC 2024
END TIME      Fri July  12 16:00:13 UTC 2024
AVG DURATION  7ms
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Improve `rpk cluster self-test status` output for the `cloud` test.
