### PR TITLE
CORE-2807 kafka: revert faking DEFAULT_CONFIG for properties 

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -895,7 +895,7 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
     // Disable remote fetch, forcing local data usage only.
     auto disable_fetch_override = storage::ntp_config::default_overrides{
       .shadow_indexing_mode = model::shadow_indexing_mode::archival};
-    log->update_configuration(disable_fetch_override).get();
+    log->set_overrides(disable_fetch_override);
 
     auto make_and_verify_timequery =
       [partition](
@@ -940,7 +940,7 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
     // Enable remote fetch.
     auto allow_fetch_override = storage::ntp_config::default_overrides{
       .shadow_indexing_mode = model::shadow_indexing_mode::fetch};
-    log->update_configuration(allow_fetch_override).get();
+    log->set_overrides(allow_fetch_override);
 
     // Now, timequeries should be able to read over the whole domain [0,
     // max_timestamp]

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -734,6 +734,7 @@ ss::future<> partition::update_configuration(topic_properties properties) {
                         && model::is_archival_enabled(
                           new_ntp_config.shadow_indexing_mode.value());
 
+    bool old_compaction_status = old_ntp_config.has_compacted_override();
     bool new_compaction_status
       = new_ntp_config.cleanup_policy_bitflags.has_value()
         && model::is_compaction_enabled(
@@ -742,7 +743,7 @@ ss::future<> partition::update_configuration(topic_properties properties) {
       old_ntp_config.is_archival_enabled() != new_archival
       || old_ntp_config.is_read_replica_mode_enabled()
            != new_ntp_config.read_replica
-      || old_ntp_config.is_compacted() != new_compaction_status) {
+      || old_compaction_status != new_compaction_status) {
         cloud_storage_changed = true;
     }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -736,9 +736,8 @@ ss::future<> partition::update_configuration(topic_properties properties) {
 
     bool new_compaction_status
       = new_ntp_config.cleanup_policy_bitflags.has_value()
-        && (new_ntp_config.cleanup_policy_bitflags.value()
-            & model::cleanup_policy_bitflags::compaction)
-             == model::cleanup_policy_bitflags::compaction;
+        && model::is_compaction_enabled(
+          new_ntp_config.cleanup_policy_bitflags.value());
     if (
       old_ntp_config.is_archival_enabled() != new_archival
       || old_ntp_config.is_read_replica_mode_enabled()

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -739,11 +739,24 @@ ss::future<> partition::update_configuration(topic_properties properties) {
       = new_ntp_config.cleanup_policy_bitflags.has_value()
         && model::is_compaction_enabled(
           new_ntp_config.cleanup_policy_bitflags.value());
+
+    auto old_retention_ms = old_ntp_config.has_overrides()
+                              ? old_ntp_config.get_overrides().retention_time
+                              : tristate<std::chrono::milliseconds>(
+                                std::nullopt);
+    auto new_retention_ms = new_ntp_config.retention_time;
+
+    auto old_retention_bytes
+      = old_ntp_config.has_overrides()
+          ? old_ntp_config.get_overrides().retention_bytes
+          : tristate<size_t>(std::nullopt);
+    auto new_retention_bytes = new_ntp_config.retention_bytes;
+
     if (
       old_ntp_config.is_archival_enabled() != new_archival
-      || old_ntp_config.is_read_replica_mode_enabled()
-           != new_ntp_config.read_replica
-      || old_compaction_status != new_compaction_status) {
+      || old_compaction_status != new_compaction_status
+      || old_retention_ms != new_retention_ms
+      || old_retention_bytes != new_retention_bytes) {
         cloud_storage_changed = true;
     }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -347,6 +347,11 @@ private:
     ss::future<std::optional<storage::timequery_result>>
     local_timequery(storage::timequery_config, bool allow_cloud_fallback);
 
+    // Restarts the archiver
+    // If should_notify_topic_config is set, it marks the topic_manifest as
+    // dirty so that it gets reuploaded
+    ss::future<> restart_archiver(bool should_notify_topic_config);
+
     consensus_ptr _raft;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -382,6 +382,7 @@ private:
     std::unique_ptr<cluster::topic_configuration> _topic_cfg;
 
     ss::sharded<archival::upload_housekeeping_service>& _upload_housekeeping;
+    config::binding<model::cleanup_policy_bitflags> _log_cleanup_policy;
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -21,6 +21,7 @@
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/replicate.h"
+#include "storage/ntp_config.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
 

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -248,10 +248,7 @@ std::ostream& operator<<(std::ostream& o, const retention& r) {
 static retention
 get_retention_policy(const storage::ntp_config::default_overrides& prop) {
     auto flags = prop.cleanup_policy_bitflags;
-    if (
-      flags
-      && (flags.value() & model::cleanup_policy_bitflags::deletion)
-           == model::cleanup_policy_bitflags::deletion) {
+    if (flags && model::is_deletion_enabled(*flags)) {
         // If a space constraint is set on the topic, use that: otherwise
         // use time based constraint if present.  If total retention setting
         // is less than local retention setting, take the smallest.

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -132,18 +132,6 @@ ss::future<std::vector<topic_result>> topics_frontend::create_topics(
             tp.cfg.properties.shadow_indexing
               = _metadata_cache.get_default_shadow_indexing_mode();
         }
-
-        /**
-         * We always override cleanup policy. i.e. topic cleanup policy will
-         * stay the same even if it was changed in defaults (broker
-         * configuration) and there was no override passed by client while
-         * creating a topic. The the same policy is applied in Kafka.
-         */
-
-        if (!tp.cfg.properties.cleanup_policy_bitflags.has_value()) {
-            tp.cfg.properties.cleanup_policy_bitflags
-              = _metadata_cache.get_default_cleanup_policy_bitflags();
-        }
     }
 
     vlog(clusterlog.info, "Create topics {}", topics);

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -9,7 +9,6 @@
 
 #include "kafka/server/handlers/alter_configs.h"
 
-#include "cluster/metadata_cache.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
@@ -56,8 +55,7 @@ static void parse_and_set_shadow_indexing_mode(
 }
 
 checked<cluster::topic_properties_update, alter_configs_resource_response>
-create_topic_properties_update(
-  const request_context& ctx, alter_configs_resource& resource) {
+create_topic_properties_update(alter_configs_resource& resource) {
     model::topic_namespace tp_ns(
       model::kafka_namespace, model::topic(resource.resource_name));
     cluster::topic_properties_update update(tp_ns);
@@ -87,15 +85,6 @@ create_topic_properties_update(
       = cluster::incremental_update_operation::none;
     update.custom_properties.data_policy.op
       = cluster::incremental_update_operation::none;
-
-    /**
-     * Since 'cleanup.policy' is always defaulted to 'delete' at topic creation,
-     * we must special case the handling to preserve this default.
-     */
-    update.properties.cleanup_policy_bitflags.op
-      = cluster::incremental_update_operation::set;
-    update.properties.cleanup_policy_bitflags.value
-      = ctx.metadata_cache().get_default_cleanup_policy_bitflags();
 
     update.properties.record_key_schema_id_validation.op
       = cluster::incremental_update_operation::set;
@@ -324,11 +313,8 @@ alter_topic_configuration(
     return do_alter_topics_configuration<
       alter_configs_resource,
       alter_configs_resource_response>(
-      ctx,
-      std::move(resources),
-      validate_only,
-      [&ctx](alter_configs_resource& r) {
-          return create_topic_properties_update(ctx, r);
+      ctx, std::move(resources), validate_only, [](alter_configs_resource& r) {
+          return create_topic_properties_update(r);
       });
 }
 

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -519,8 +519,7 @@ config_response_container_t make_topic_configs(
       maybe_make_documentation(
         include_documentation,
         config::shard_local_cfg().log_cleanup_policy.desc()),
-      &describe_as_string<model::cleanup_policy_bitflags>,
-      true);
+      &describe_as_string<model::cleanup_policy_bitflags>);
 
     const std::string_view docstring{
       topic_properties.is_compacted()

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -294,12 +294,8 @@ static void add_topic_config(
 
 /**
  * For faking DEFAULT_CONFIG status for properties that are actually
- * topic overrides: cloud storage properties.  We do not support cluster
- * defaults for these, the values are always "sticky" to topics, but
- * some Kafka clients insist that after an AlterConfig RPC, anything
- * they didn't set should be DEFAULT_CONFIG.
- *
- * See https://github.com/redpanda-data/redpanda/issues/7451
+ * topic overrides: schema registry properties. This should be avoided for new
+ * properties to be Kafka-compatible.
  */
 template<typename T>
 std::optional<T>
@@ -648,8 +644,7 @@ config_response_container_t make_topic_configs(
       maybe_make_documentation(
         include_documentation,
         config::shard_local_cfg().cloud_storage_enable_remote_read.desc()),
-      &describe_as_string<bool>,
-      true);
+      &describe_as_string<bool>);
 
     add_topic_config_if_requested(
       config_keys,
@@ -665,8 +660,7 @@ config_response_container_t make_topic_configs(
       maybe_make_documentation(
         include_documentation,
         config::shard_local_cfg().cloud_storage_enable_remote_write.desc()),
-      &describe_as_string<bool>,
-      true);
+      &describe_as_string<bool>);
 
     add_topic_config_if_requested(
       config_keys,
@@ -699,9 +693,7 @@ config_response_container_t make_topic_configs(
           topic_property_remote_delete,
           storage::ntp_config::default_remote_delete,
           topic_property_remote_delete,
-          override_if_not_default(
-            std::make_optional<bool>(topic_properties.remote_delete),
-            storage::ntp_config::default_remote_delete),
+          std::make_optional(topic_properties.remote_delete),
           true,
           maybe_make_documentation(
             include_documentation,

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -147,7 +147,8 @@ FIXTURE_TEST(conditional_retention_test, consumer_offsets_fixture) {
     storage::ntp_config::default_overrides ov;
     ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion
                                  | model::cleanup_policy_bitflags::compaction;
-    log->update_configuration(ov).get();
+    log->set_overrides(ov);
+    log->notify_compaction_update();
     log->flush().get();
     log->force_roll(ss::default_priority_class()).get();
     for (auto retention_enabled : {false, true}) {

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -129,6 +129,16 @@ inline void operator&=(cleanup_policy_bitflags& a, cleanup_policy_bitflags b) {
     a = (a & b);
 }
 
+inline bool is_compaction_enabled(cleanup_policy_bitflags flags) {
+    return (flags & cleanup_policy_bitflags::compaction)
+           == cleanup_policy_bitflags::compaction;
+}
+
+inline bool is_deletion_enabled(cleanup_policy_bitflags flags) {
+    return (flags & cleanup_policy_bitflags::deletion)
+           == cleanup_policy_bitflags::deletion;
+}
+
 std::ostream& operator<<(std::ostream&, cleanup_policy_bitflags);
 std::istream& operator>>(std::istream&, cleanup_policy_bitflags&);
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -146,7 +146,8 @@ public:
 
     size_t size_bytes() const override { return _probe->partition_size(); }
     uint64_t size_bytes_after_offset(model::offset o) const override;
-    ss::future<> update_configuration(ntp_config::default_overrides) final;
+    void set_overrides(ntp_config::default_overrides) final;
+    bool notify_compaction_update() final;
 
     int64_t compaction_backlog() const final;
 
@@ -380,6 +381,7 @@ private:
     std::optional<model::offset> _cloud_gc_offset;
     std::optional<model::offset> _last_compaction_window_start_offset;
     size_t _reclaimable_size_bytes{0};
+    bool _compaction_enabled;
 };
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -189,8 +189,13 @@ public:
     virtual bool is_compacted(model::offset first, model::offset last) const
       = 0;
 
-    virtual ss::future<>
-      update_configuration(ntp_config::default_overrides) = 0;
+    /// Mutates the ntp_config stored in the log with the new
+    /// topic/partition-level overrides
+    virtual void set_overrides(ntp_config::default_overrides) = 0;
+
+    /// Notifies the log about a possible change to the log compaction config.
+    /// Returns true if the log compaction changed.
+    virtual bool notify_compaction_update() = 0;
 
     virtual int64_t compaction_backlog() const = 0;
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -136,9 +136,7 @@ public:
 
     bool is_compacted() const {
         if (_overrides && _overrides->cleanup_policy_bitflags) {
-            return (_overrides->cleanup_policy_bitflags.value()
-                    & model::cleanup_policy_bitflags::compaction)
-                   == model::cleanup_policy_bitflags::compaction;
+            return model::is_compaction_enabled(_overrides->cleanup_policy_bitflags.value());
         }
         return false;
     }
@@ -149,9 +147,7 @@ public:
             return true;
         }
         // check if deletion bitflag is set
-        return (_overrides->cleanup_policy_bitflags.value()
-                & model::cleanup_policy_bitflags::deletion)
-               == model::cleanup_policy_bitflags::deletion;
+        return model::is_deletion_enabled(_overrides->cleanup_policy_bitflags.value());
     }
 
     ss::sstring work_directory() const {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -134,20 +134,20 @@ public:
 
     bool has_overrides() const { return _overrides != nullptr; }
 
-    bool is_compacted() const {
-        if (_overrides && _overrides->cleanup_policy_bitflags) {
-            return model::is_compaction_enabled(_overrides->cleanup_policy_bitflags.value());
+    bool has_compacted_override() const {
+        auto cp_override = cleanup_policy_override();
+        if (!cp_override) {
+            return false;
         }
-        return false;
+        return model::is_compaction_enabled(cp_override.value());
+    }
+
+    bool is_compacted() const {
+        return model::is_compaction_enabled(cleanup_policy());
     }
 
     bool is_collectable() const {
-        // has no overrides
-        if (!_overrides || !_overrides->cleanup_policy_bitflags) {
-            return true;
-        }
-        // check if deletion bitflag is set
-        return model::is_deletion_enabled(_overrides->cleanup_policy_bitflags.value());
+        return model::is_deletion_enabled(cleanup_policy());
     }
 
     ss::sstring work_directory() const {
@@ -286,6 +286,17 @@ public:
           std::numeric_limits<size_t>::max());
         return _overrides ? _overrides->flush_bytes.value_or(cluster_default)
                           : cluster_default;
+    }
+
+    std::optional<model::cleanup_policy_bitflags>
+    cleanup_policy_override() const {
+        return _overrides ? _overrides->cleanup_policy_bitflags : std::nullopt;
+    }
+
+    model::cleanup_policy_bitflags cleanup_policy() const {
+        const auto& cluster_default
+          = config::shard_local_cfg().log_cleanup_policy();
+        return cleanup_policy_override().value_or(cluster_default);
     }
 
 private:

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1434,7 +1434,7 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     // override segment size with ntp_config
     overrides_t ov;
     ov.segment_size = 40_KiB;
-    disk_log->update_configuration(ov).get();
+    disk_log->set_overrides(ov);
     disk_log->force_roll(ss::default_priority_class()).get();
 
     // 60 * 1_KiB batches should yield 2 segments.
@@ -2367,7 +2367,8 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     overrides.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::deletion;
     // update cleanup policy to deletion
-    log->update_configuration(overrides).get();
+    log->set_overrides(overrides);
+    log->notify_compaction_update();
 
     // read all batches again
     auto second_read = read_and_validate_all_batches(log);

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -363,7 +363,7 @@ public:
 
     ss::future<> update_configuration(ntp_config::default_overrides o) {
         if (_log) {
-            return _log->update_configuration(o);
+            _log->set_overrides(o);
         }
 
         return ss::make_ready_future<>();

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -95,7 +95,7 @@ class TopicSpec:
             name: str | None = None,
             partition_count: int = 1,
             replication_factor: int = 3,
-            cleanup_policy: str = CLEANUP_DELETE,
+            cleanup_policy: str | None = CLEANUP_DELETE,
             compression_type: CompressionTypes = COMPRESSION_PRODUCER,
             message_timestamp_type: TIMESTAMP_TYPE = TIMESTAMP_CREATE_TIME,
             segment_bytes: int | None = None,

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -190,20 +190,12 @@ class ControllerState:
 
             # Newer versions include a bugfix to change the source type of cleanup.policy from
             # DYNAMIC_TOPIC_CONFIG to DEFAULT_CONFIG if the cleanup.policy wasn't specified as
-            # a config value when the topic is created. Versions that include the bugfix:
-            #  * v23.3.12+
-            #  * v24.1.*
-            #  * v23.3.11* versions, except for the v23.3.11 release, i.e. all development and
-            #    PR builder redpanda versions built off of v23.3.11 before v23.3.12.
-            def contains_config_fix(version: RedpandaVersionTriple,
-                                    version_line: RedpandaVersionLine) -> bool:
-                V23_3_11_RELEASE = "v23.3.11 - 93f88bf377e558132eba04f81e4f83b033cec6e7"
-                return version >= RedpandaVersionTriple((23, 3, 12)) or \
-                    (version == RedpandaVersionTriple((23, 3, 11)) and version_line != V23_3_11_RELEASE)
-
-            if contains_config_fix(self.version, self.version_line) ^ \
-                contains_config_fix(other.version, other.version_line):
-
+            # a config value when the topic is created.
+            # All versions newer that are at least as new as 24.2.1 will have the fix, and so
+            # they don't need this explicit ignore.
+            MIN_VERSION_WITH_ALL_LATER_VERSIONS_FIXED = RedpandaVersionTriple(
+                (24, 2, 1))
+            if self.version < MIN_VERSION_WITH_ALL_LATER_VERSIONS_FIXED:
                 symdiff -= set({('cleanup.policy', ('delete',
                                                     'DYNAMIC_TOPIC_CONFIG'))})
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -76,7 +76,8 @@ class DescribeTopicsTest(RedpandaTest):
             "cleanup.policy":
             ConfigProperty(config_type="STRING",
                            value="DELETE",
-                           doc_string="Default topic cleanup policy"),
+                           doc_string="Default topic cleanup policy",
+                           source_type="DYNAMIC_TOPIC_CONFIG"),
             "compression.type":
             ConfigProperty(config_type="STRING",
                            value="producer",

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -98,17 +98,20 @@ class DescribeTopicsTest(RedpandaTest):
                 config_type="BOOLEAN",
                 value="true",
                 doc_string=
-                "Controls whether topic deletion should imply deletion in S3"),
+                "Controls whether topic deletion should imply deletion in S3",
+                source_type="DYNAMIC_TOPIC_CONFIG"),
             "redpanda.remote.read":
             ConfigProperty(
                 config_type="BOOLEAN",
                 value="false",
-                doc_string="Default remote read config value for new topics"),
+                doc_string="Default remote read config value for new topics",
+                source_type="DYNAMIC_TOPIC_CONFIG"),
             "redpanda.remote.write":
             ConfigProperty(
                 config_type="BOOLEAN",
                 value="false",
-                doc_string="Default remote write value for new topics"),
+                doc_string="Default remote write value for new topics",
+                source_type="DYNAMIC_TOPIC_CONFIG"),
             "retention.bytes":
             ConfigProperty(
                 config_type="LONG",

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -647,20 +647,6 @@ class CreateSITopicsTest(RedpandaTest):
         for k, v in examples.items():
             kcl.alter_topic_config({k: v}, incremental=False, topic=topic)
 
-        # 'cleanup.policy' is defaulted to 'delete' upon topic creation.
-        # AlterConfigs handling should preserve this default, unless explicitly
-        # overriden.
-        topic_config = rpk.describe_topic_configs(topic)
-        value, src = topic_config["cleanup.policy"]
-        assert value == "delete" and src == "DEFAULT_CONFIG"
-
-        kcl.alter_topic_config({"cleanup.policy": "compact"},
-                               incremental=False,
-                               topic=topic)
-        topic_config = rpk.describe_topic_configs(topic)
-        value, src = topic_config["cleanup.policy"]
-        assert value == "compact" and src == "DYNAMIC_TOPIC_CONFIG"
-
         # As a control, confirm that if we did pass an invalid property, we would have got an error
         with expect_exception(RuntimeError, lambda e: "invalid" in str(e)):
             kcl.alter_topic_config({"redpanda.invalid.property": 'true'},

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -605,13 +605,11 @@ class CreateSITopicsTest(RedpandaTest):
 
         # This topic has topic-level properties set from the cluster defaults
         # and the values should _not_ have been changed by the intervening
-        # change to those defaults.  Properties which still match the current
-        # default will be reported as DEFAULT, even though they are sticky,
-        # per issue https://github.com/redpanda-data/redpanda/issues/7451
+        # change to those defaults.
         assert default_si_configs["redpanda.remote.read"] == (
             "true", "DYNAMIC_TOPIC_CONFIG")
         assert default_si_configs["redpanda.remote.write"] == (
-            "true", "DEFAULT_CONFIG")
+            "true", "DYNAMIC_TOPIC_CONFIG")
 
         # This topic was created with explicit properties that differed
         # from the defaults.  Both properties differ from the present


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-2807

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
