### PR TITLE
utils: fix token bucket underflow after rate decrease

### DIFF
--- a/src/v/utils/token_bucket.h
+++ b/src/v/utils/token_bucket.h
@@ -117,7 +117,7 @@ public:
 
         if (_rate > new_rate) {
             if (_sem.current() <= _rate) {
-                _sem.consume(_rate - new_rate);
+                _sem.consume(std::min(_rate - new_rate, _sem.current()));
             } else {
                 /*
                  * if current > rate it means that we have accumulated tokens


### PR DESCRIPTION
Problem: If token_bucket rate is set to a high value (e.g. _rate=1000) and later decreased (e.g. new_rate=10), then the new semaphore value is adjusted by -(_rate - new_rate). If nothing consumed from the semaphore, its new value becomes new_rate (e.g. 10). However, if the semaphore is at a lower value (e.g. 0) then it is set to a negative value (e.g. -990).

(TIL: semaphores can be negative.)

Now, the caller has to wait 99 seconds to at least becomes 0 again.

This is unexpected.

To fix this, we don't allow the semaphore to become negative.

The resulting behavior can be illustrated by the following example.

A token bucket is consumed/replenished in discrete time windows (_refresh_interval in code). It also starts at full capacity, meaning that the whole _rate amount is available instantaneously (burst).

If we have a throttler at 1 GiB/s and the whole capacity (burst) was consumed in the current time window it is O.K. as it had the right to. If we set a new rate, say 1 MiB/s, that's the rate we will replenish the throttler bucket at from now on (starting with the next time interval) and allow all future callers this new rate.

If nothing was consumed from the throttler, we just cap it to the new_rate.

If 1 MiB was consumed, nothing more can be consumed from the throttler in this time window.

---

PS. The code contains additional problems but we can ignore them for now.

E.g. the semaphore should be capped at throttler burst capacity rather than at rate.

It also should consider if there are waiters. E.g.  when rate was 1000 tokens/s and a waiter is waiting for 10 000 tokens for 9.950 seconds the _sem is nearly at 10 000 and ready to give the waiter the tokens but here (see next code block) we reset the semaphore to new rate (e.g. 10 tokens/s) forcing the caller that waited for 10 seconds to wait from start again. The caller had the right to the tokens we replenished in previous time windows as we did it under a different rate setting.

This last point might be debatable but consider what happens when you constantly change the rate of the token_bucket. The waiters with requests higher than rate won't make progress as we will cap the semaphore at rate every single time.

This gets more complicated when you take into the account the possibility of aborting the wait and whether the waiter that did abort was waiting before the rate change or after...

```
/*
 * if current > rate it means that we have accumulated tokens
 * we should change current to new_rate to start accumulation
 * from begining
 */
_sem.consume(_sem.current() - new_rate);
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
