### PR TITLE
rptest/kgo: avoid extra wait on shutdown

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -414,7 +414,7 @@ class StatusThread(threading.Thread):
                 # status read
                 return
             else:
-                self._stop_requested.wait(self.INTERVAL)
+                self._shutdown_requested.wait(self.INTERVAL)
 
     def join_with_timeout(self):
         """
@@ -436,6 +436,7 @@ class StatusThread(threading.Thread):
         """
         Drop out of poll loop as soon as possible, and join.
         """
+        self._shutdown_requested.set()
         self._stop_requested.set()
         self.join_with_timeout()
 


### PR DESCRIPTION
There are 2 ways to stop a kgo service. One is graceful shutdown and another one is hard stop. We use 2 `threading.Event` objects to signal this.

Before this change, the polling thread would only wait on the `_stop_requested` and if it was set or if a timeout is hit (self.INTERVAL=5s) it would run the loop again and check if stop or shutdown was requested.

This leads for shutdown taking 5s more than it should in worst case.

We avoid this extra wait but settling on a single threading.Event object (_shutdown_requested) for signaling that the loop should run again. Then we signal that event from both, shutdown and hard stop.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
