### PR TITLE
rptest: wait for leader after restart

### DIFF
--- a/tests/rptest/tests/write_caching_fi_test.py
+++ b/tests/rptest/tests/write_caching_fi_test.py
@@ -145,7 +145,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
                                     num_msg_per_round - 1)
 
         self._crash_and_restart_all()
-
+        self._wait_for_leader()
         hwm = next(self.rpk.describe_topic(self.topic)).high_watermark
         lost = num_msg_per_round - hwm
         assert lost > 0, "This test must observe data loss" \
@@ -306,7 +306,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
         self.logger.debug(f"Starting back old leader node: {node.name}")
         self.redpanda.start_node(node)
 
-    def _wait_for_leader(self, *, timeout_sec=10, backoff_sec=1):
+    def _wait_for_leader(self, *, timeout_sec=30, backoff_sec=3):
         admin = Admin(self.redpanda)
         wait_until(
             lambda: admin.get_partition_leader(namespace="kafka",


### PR DESCRIPTION
Sometimes redpanda needs a bit more time to start.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
