### PR TITLE
bazel: add additional utils libraries

### DIFF
--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -265,3 +265,16 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "expiring_promise",
+    hdrs = [
+        "expiring_promise.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -297,3 +297,20 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "bottomless_token_bucket",
+    srcs = [
+        "bottomless_token_bucket.cc",
+    ],
+    hdrs = [
+        "bottomless_token_bucket.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -249,3 +249,19 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "directory_walker",
+    srcs = [
+        "directory_walker.cc",
+    ],
+    hdrs = [
+        "directory_walker.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -323,3 +323,31 @@ redpanda_cc_library(
     include_prefix = "utils",
     visibility = ["//visibility:public"],
 )
+
+redpanda_cc_library(
+    name = "exceptions",
+    hdrs = [
+        "exceptions.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "stable_iterator",
+    hdrs = [
+        "stable_iterator_adaptor.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":exceptions",
+        "//src/v/base",
+        "@boost//:iterator",
+        "@fmt",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -314,3 +314,12 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "move_canary",
+    hdrs = [
+        "move_canary.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -278,3 +278,22 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "retry_chain_node",
+    srcs = [
+        "retry_chain_node.cc",
+    ],
+    hdrs = [
+        "retry_chain_node.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/random:fast_prng",
+        "//src/v/ssx:sformat",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -194,3 +194,14 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest_no_seastar(
+    name = "bottomless_token_bucket_test",
+    timeout = "short",
+    srcs = [
+        "bottomless_token_bucket_test.cc",
+    ],
+    deps = [
+        "//src/v/utils:bottomless_token_bucket",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -179,3 +179,18 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "retry_chain_node_test",
+    timeout = "short",
+    srcs = [
+        "retry_chain_node_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:retry_chain_node",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -220,3 +220,18 @@ redpanda_cc_btest_no_seastar(
         "@boost//:test",
     ],
 )
+
+redpanda_cc_btest_no_seastar(
+    name = "stable_iterator_test",
+    timeout = "short",
+    srcs = [
+        "stable_iterator_test.cc",
+    ],
+    defines = [
+        "BOOST_TEST_MODULE=stable_iterator_test",
+    ],
+    deps = [
+        "//src/v/utils:stable_iterator",
+        "@boost//:test",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -148,3 +148,19 @@ redpanda_cc_btest(
         "@boost//:test",
     ],
 )
+
+redpanda_cc_btest(
+    name = "directory_walker_test",
+    timeout = "short",
+    srcs = [
+        "directory_walker_test.cc",
+    ],
+    deps = [
+        "//src/v/random:generators",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:directory_walker",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -205,3 +205,18 @@ redpanda_cc_btest_no_seastar(
         "//src/v/utils:bottomless_token_bucket",
     ],
 )
+
+redpanda_cc_btest_no_seastar(
+    name = "move_canary_test",
+    timeout = "short",
+    srcs = [
+        "move_canary_test.cc",
+    ],
+    defines = [
+        "BOOST_TEST_MODULE=move_canary",
+    ],
+    deps = [
+        "//src/v/utils:move_canary",
+        "@boost//:test",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -164,3 +164,18 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "expiring_promise_test",
+    timeout = "short",
+    srcs = [
+        "expiring_promise_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:expiring_promise",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/tools/docker/bazel.dockerfile
+++ b/tools/docker/bazel.dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE_OS_NAME=fedora
+ARG BASE_IMAGE_OS_VERSION=38
+FROM ${BASE_IMAGE_OS_NAME}:${BASE_IMAGE_OS_VERSION}
+
+COPY --chown=0:0 bazel/install-deps.sh /
+
+RUN dnf install -y wget || { apt-get update && apt install -y wget; }
+RUN wget -O /usr/local/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
+        chmod +x /usr/local/bin/bazel
+
+# run after wget installation to take advantage of pkg cache cleaning
+RUN CLEAN_PKG_CACHE=true /install-deps.sh && rm /install-deps.sh


### PR DESCRIPTION
* Adds some v::utils bits to Bazel
* Adds a dockerfile for buildkite CI

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

