### PR TITLE
CORE-5589 Add config to select minimum TLS version

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -17,6 +17,7 @@
 #include "base/vlog.h"
 #include "cloud_roles/logger.h"
 #include "config/configuration.h"
+#include "config/tls_config.h"
 #include "gcp_refresh_impl.h"
 #include "model/metadata.h"
 #include "net/tls.h"
@@ -346,6 +347,8 @@ ss::future<http::client> refresh_credentials::impl::make_api_client(
 ss::future<> refresh_credentials::impl::init_tls_certs(ss::sstring name) {
     ss::tls::credentials_builder b;
     b.set_client_auth(ss::tls::client_auth::NONE);
+    b.set_minimum_tls_version(
+      config::from_config(config::shard_local_cfg().tls_min_version()));
 
     if (auto trust_file_path
         = config::shard_local_cfg().cloud_storage_trust_file.value();

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -33,6 +33,8 @@ build_tls_credentials(
     cred_builder.set_ciphersuites(
       {config::tlsv1_3_ciphersuites.data(),
        config::tlsv1_3_ciphersuites.size()});
+    cred_builder.set_minimum_tls_version(
+      from_config(config::shard_local_cfg().tls_min_version()));
     if (trust_file.has_value()) {
         auto file = trust_file.value();
         vlog(log.info, "Use non-default trust file {}", file());

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -374,6 +374,8 @@ ss::future<http::client> metrics_reporter::make_http_client() {
     if (_address.protocol == "https") {
         ss::tls::credentials_builder builder;
         builder.set_client_auth(ss::tls::client_auth::NONE);
+        builder.set_minimum_tls_version(
+          config::from_config(config::shard_local_cfg().tls_min_version()));
         auto ca_file = co_await net::find_ca_file();
         if (ca_file) {
             vlog(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3275,7 +3275,17 @@ configuration::configuration()
       "internal-only configuration and should be enabled only after consulting "
       "with Redpanda Support or engineers.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      false) {}
+      false)
+  , tls_min_version(
+      *this,
+      "tls_min_version",
+      "The minimum TLS version that Redpanda supports.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      tls_version::v1_2,
+      {tls_version::v1_0,
+       tls_version::v1_1,
+       tls_version::v1_2,
+       tls_version::v1_3}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -608,6 +608,8 @@ struct configuration final : public config_store {
     // temporary - to be deprecated
     property<bool> unsafe_enable_consumer_offsets_delete_retention;
 
+    enum_property<tls_version> tls_min_version;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -605,4 +605,24 @@ struct convert<config::fips_mode_flag> {
     }
 };
 
+template<>
+struct convert<config::tls_version> {
+    using type = config::tls_version;
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+        auto out = string_switch<std::optional<type>>(std::string_view{value})
+                     .match(to_string_view(type::v1_0), type::v1_0)
+                     .match(to_string_view(type::v1_1), type::v1_1)
+                     .match(to_string_view(type::v1_2), type::v1_2)
+                     .match(to_string_view(type::v1_3), type::v1_3)
+                     .default_match(std::nullopt);
+        if (out.has_value()) {
+            rhs = out.value();
+        }
+        return out.has_value();
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -651,6 +651,8 @@ consteval std::string_view property_type_name() {
         return "recovery_validation_mode";
     } else if constexpr (std::is_same_v<type, config::fips_mode_flag>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, config::tls_version>) {
+        return "string";
     } else {
         static_assert(
           base::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -217,4 +217,9 @@ void rjson_serialize(
     stringize(w, f);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::tls_version& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -119,4 +119,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, const config::fips_mode_flag& f);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, const config::tls_version& v);
+
 } // namespace json

--- a/src/v/config/tls_config.cc
+++ b/src/v/config/tls_config.cc
@@ -11,6 +11,7 @@
 
 #include "tls_config.h"
 
+#include "config/configuration.h"
 #include "config/convert.h"
 #include "utils/to_string.h"
 
@@ -29,6 +30,8 @@ tls_config::get_credentials_builder() const& {
                 {tlsv1_2_cipher_string.data(), tlsv1_2_cipher_string.size()});
               builder.set_ciphersuites(
                 {tlsv1_3_ciphersuites.data(), tlsv1_3_ciphersuites.size()});
+              builder.set_minimum_tls_version(
+                from_config(config::shard_local_cfg().tls_min_version()));
               builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
               if (_require_client_auth) {
                   builder.set_client_auth(ss::tls::client_auth::REQUIRE);

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "config/types.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -22,6 +23,19 @@
 #include <optional>
 
 namespace config {
+
+inline ss::tls::tls_version from_config(tls_version v) {
+    switch (v) {
+    case tls_version::v1_0:
+        return ss::tls::tls_version::tlsv1_0;
+    case tls_version::v1_1:
+        return ss::tls::tls_version::tlsv1_1;
+    case tls_version::v1_2:
+        return ss::tls::tls_version::tlsv1_2;
+    case tls_version::v1_3:
+        return ss::tls::tls_version::tlsv1_3;
+    }
+}
 
 struct key_cert {
     ss::sstring key_file;

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -99,4 +99,23 @@ inline bool fips_mode_enabled(fips_mode_flag f) {
     return f != fips_mode_flag::disabled;
 }
 
+enum class tls_version { v1_0 = 0, v1_1, v1_2, v1_3 };
+
+constexpr std::string_view to_string_view(tls_version v) {
+    switch (v) {
+    case tls_version::v1_0:
+        return "v1.0";
+    case tls_version::v1_1:
+        return "v1.1";
+    case tls_version::v1_2:
+        return "v1.2";
+    case tls_version::v1_3:
+        return "v1.3";
+    }
+}
+
+inline std::ostream& operator<<(std::ostream& os, const tls_version& v) {
+    return os << to_string_view(v);
+}
+
 } // namespace config

--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -9,6 +9,8 @@
  */
 #include "security/oidc_service.h"
 
+#include "config/configuration.h"
+#include "config/tls_config.h"
 #include "http/client.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
@@ -340,6 +342,8 @@ struct service::impl {
             if (!_creds) {
                 ss::tls::credentials_builder builder;
                 builder.set_client_auth(ss::tls::client_auth::NONE);
+                builder.set_minimum_tls_version(config::from_config(
+                  config::shard_local_cfg().tls_min_version()));
                 co_await builder.set_system_trust();
                 _creds = co_await net::build_reloadable_credentials_with_probe<
                   ss::tls::certificate_credentials>(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -685,6 +685,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 valid_value = random.choice(
                     [e for e in p['enum_values'] if e != initial_value])
 
+            if name == "tls_min_version":
+                valid_value = random.choice(
+                    [e for e in p['enum_values'] if e != initial_value])
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -1,0 +1,152 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import socket
+import subprocess
+
+from enum import IntEnum
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.mark import matrix
+from ducktape.services.service import Service
+
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import TLSProvider, SecurityConfig
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.services.tls import Certificate, CertificateAuthority, TLSCertManager
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class TLSVersionTestProvider(TLSProvider):
+    def __init__(self, tls: TLSCertManager):
+        self._tls = tls
+
+    @property
+    def ca(self) -> CertificateAuthority:
+        return self._tls.ca
+
+    def create_broker_cert(self, service: Service,
+                           node: ClusterNode) -> Certificate:
+        assert node in service.nodes
+        return self._tls.create_cert(node.name)
+
+    def create_service_client_cert(self, _: Service, name: str) -> Certificate:
+        return self._tls.create_cert(socket.gethostname(), name=name)
+
+
+PERMITTED_ERROR_MESSAGE = [
+    "seastar::tls::verification_error", "SSL routines::unsupported protocol"
+]
+
+
+class TLSVersion(IntEnum):
+    v1_0 = 0
+    v1_1 = 1
+    v1_2 = 2
+    v1_3 = 3
+
+
+def tls_version_to_openssl(ver: TLSVersion) -> str:
+    if ver == TLSVersion.v1_0:
+        return "-tls1"
+    elif ver == TLSVersion.v1_1:
+        return "-tls1_1"
+    elif ver == TLSVersion.v1_2:
+        return "-tls1_2"
+    elif ver == TLSVersion.v1_3:
+        return "-tls1_3"
+    else:
+        raise ValueError(f"Unknown TLS Version: {ver}")
+
+
+def tls_version_to_config(ver: TLSVersion) -> str:
+    if ver == TLSVersion.v1_0:
+        return "v1.0"
+    elif ver == TLSVersion.v1_1:
+        return "v1.1"
+    elif ver == TLSVersion.v1_2:
+        return "v1.2"
+    elif ver == TLSVersion.v1_3:
+        return "v1.3"
+    else:
+        raise ValueError(f"Unknown TLS Version: {ver}")
+
+
+class TLSVersionTestBase(RedpandaTest):
+    """
+    Base test class that sets up TLS on the Kafka API interface
+    """
+    def __init__(self, test_context):
+        super(TLSVersionTestBase, self).__init__(test_context=test_context)
+        self.security = SecurityConfig()
+        self.tls = TLSCertManager(self.logger)
+        self.admin = Admin(self.redpanda)
+        self.installer = self.redpanda._installer
+
+    def setUp(self):
+        self.security.tls_provider = TLSVersionTestProvider(tls=self.tls)
+        self.redpanda.set_security_settings(self.security)
+
+        super().setUp()
+
+    def _output_good(self, output: str) -> bool:
+        return "Verify return code: 0" in output or "Verify return code: 19" in output
+
+    def _output_error(self, output: str) -> bool:
+        return "no protocols available" in output or "tlsv1 alert protocol version" in output
+
+    def verify_tls_version(self, node: ClusterNode, tls_version: TLSVersion,
+                           expect_fail: bool):
+        tls_version_str = tls_version_to_openssl(tls_version)
+        try:
+            cmd = f"openssl s_client {tls_version_str} -CAfile {self.tls.ca.crt} -connect {node.name}:9092"
+            self.logger.debug(f"Running: {cmd}")
+            _ = subprocess.check_output(cmd.split(),
+                                        stderr=subprocess.STDOUT,
+                                        stdin=subprocess.DEVNULL)
+            if expect_fail:
+                assert False, f"Expected openssl s_client to fail with TLS version string {tls_version_str}"
+        except subprocess.CalledProcessError as e:
+            if not expect_fail:
+                assert self._output_good(
+                    e.output.decode()
+                ), f"Invalid output for good case detected: {e.output.decode()}"
+            else:
+                assert self._output_error(e.output.decode(
+                )), f"Output not expected for failure: {e.output.decode()}"
+
+
+class TLSVersionTest(TLSVersionTestBase):
+    @cluster(num_nodes=3, log_allow_list=PERMITTED_ERROR_MESSAGE)
+    @matrix(version=[0, 1, 2, 3])
+    def test_change_version(self, version: int):
+        """
+        This test steps through each valid setting of tls_min_version and uses
+        OpenSSL s_client to verify that any versions before the minimum selected version
+        are rejected during handshake.
+        """
+
+        # Validate that by default it's v1.2
+        cluster_cfg = self.admin.get_cluster_config()
+        assert cluster_cfg["tls_min_version"] == tls_version_to_config(
+            TLSVersion.v1_2
+        ), f"Invalid cluster config: {cluster_cfg['tls_min_version']} != {tls_version_to_config(TLSVersion.v1_2)}"
+        ver = TLSVersion(version)
+        # Change the version
+        self.admin.patch_cluster_config(
+            {"tls_min_version": tls_version_to_config(ver)})
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        # Step through each node and each version and verify whether or not we get a failure
+        for n in self.redpanda.nodes:
+            for v in TLSVersion:
+                expect_failure = v < ver
+                self.verify_tls_version(node=n,
+                                        tls_version=v,
+                                        expect_fail=expect_failure)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Adds new cluster config `tls_min_version` that allows users of Redpanda to specify the minimum version of TLS Redpanda will support.  By default, the value is TLS v1.2.
