### PR TITLE
[v24.1.x] test/random_node_operations: tolerate lost produces

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -598,8 +598,13 @@ class KgoVerifierProducer(KgoVerifierService):
             # the same topic, or that Redpanda showed a buggy behavior with
             # idempotency: producer records should always land at the next offset
             # after the last record they wrote.
-            raise RuntimeError(
-                f"{self.who_am_i()} possible idempotency bug: {self._status}")
+            if self._tolerate_data_loss:
+                self._redpanda.logger.warn(
+                    f"{self.who_am_i()} observed data loss: {self._status}")
+            else:
+                raise RuntimeError(
+                    f"{self.who_am_i()} possible idempotency bug: {self._status}"
+                )
 
         return super().wait_node(node, timeout_sec=timeout_sec)
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -249,7 +249,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             )
             self.producer.wait()
 
-            assert self.producer.produce_status.bad_offsets == 0
+            assert self.producer.produce_status.bad_offsets == 0 or self.tolerate_data_loss
             # Await the consumer that is reading only the subset of data that
             # was written before it started.
             self.consumer.wait()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21305
Fixes: https://github.com/redpanda-data/redpanda/issues/21373,