### PR TITLE
Node-local core assignment: fast leader re-election

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -320,7 +320,10 @@ void archiver_fixture::initialize_shard(
             storage::ntp_config(
               ntp.first, data_dir.string(), std::move(defaults)),
             raft::group_id(1),
-            {nm->broker})
+            {nm->broker},
+            raft::with_learner_recovery_throttle::yes,
+            raft::keep_snapshotted_log::no,
+            std::nullopt)
           .get();
         BOOST_CHECK_EQUAL(
           api.log_mgr().get(ntp.first)->segment_count(), ntp.second);

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1397,6 +1397,12 @@ ss::future<std::error_code> controller_backend::create_partition(
             read_replica_bucket = cloud_storage_clients::bucket_name(
               cfg->properties.read_replica_bucket.value());
         }
+
+        std::optional<xshard_transfer_state> xst_state;
+        if (auto it = _xst_states.find(ntp); it != _xst_states.end()) {
+            xst_state = it->second;
+        }
+
         // we use offset as an rev as it is always increasing and it
         // increases while ntp is being created again
         try {
@@ -1408,12 +1414,15 @@ ss::future<std::error_code> controller_backend::create_partition(
                 initial_rev.value()),
               group_id,
               std::move(initial_brokers),
-              cfg->properties.remote_topic_properties,
-              read_replica_bucket,
               raft::with_learner_recovery_throttle::yes,
               raft::keep_snapshotted_log::no,
+              std::move(xst_state),
+              cfg->properties.remote_topic_properties,
+              read_replica_bucket,
               cfg->properties.remote_label,
               cfg->properties.remote_topic_namespace_override);
+
+            _xst_states.erase(ntp);
 
             co_await add_to_shard_table(
               ntp, group_id, ss::this_shard_id(), log_revision);
@@ -1757,9 +1766,22 @@ ss::future<std::error_code> controller_backend::transfer_partition(
     }
     ss::shard_id destination = transfer_info.destination.value();
 
+    std::optional<xshard_transfer_state> xst_state;
+
     auto partition = _partition_manager.local().get(ntp);
     if (partition) {
-        co_await shutdown_partition(std::move(partition));
+        xst_state = co_await shutdown_partition(std::move(partition));
+    } else if (auto it = _xst_states.find(ntp); it != _xst_states.end()) {
+        // We didn't get to start the partition before it was transferred again.
+        xst_state = std::move(it->second);
+        _xst_states.erase(it);
+    }
+
+    if (xst_state) {
+        co_await container().invoke_on(
+          destination, [&ntp, &xst_state](controller_backend& dest) {
+              dest._xst_states[ntp] = *xst_state;
+          });
     }
 
     co_await copy_persistent_state(
@@ -1883,7 +1905,7 @@ ss::future<> controller_backend::transfer_partition_from_extra_shard(
       ntp, log_rev, _shard_placement.container(), [](const model::ntp&) {});
 }
 
-ss::future<>
+ss::future<xshard_transfer_state>
 controller_backend::shutdown_partition(ss::lw_shared_ptr<partition> partition) {
     vlog(
       clusterlog.debug,
@@ -1899,7 +1921,7 @@ controller_backend::shutdown_partition(ss::lw_shared_ptr<partition> partition) {
         co_await remove_from_shard_table(
           ntp, gr, partition->get_log_revision_id());
         // shutdown partition
-        co_await _partition_manager.local().shutdown(ntp);
+        co_return co_await _partition_manager.local().shutdown(ntp);
     } catch (...) {
         /**
          * If partition shutdown failed we should crash, this error is
@@ -1956,7 +1978,7 @@ ss::future<std::error_code> controller_backend::delete_partition(
         co_await _partition_manager.local().remove(ntp, mode);
     } else {
         // TODO: delete log directory even when there is no partition object
-
+        _xst_states.erase(ntp);
         co_await remove_persistent_state(
           ntp, placement->current->group, _storage.local().kvs());
     }
@@ -1973,6 +1995,7 @@ ss::future<> controller_backend::remove_partition_kvstore_state(
       ntp,
       log_revision);
 
+    _xst_states.erase(ntp);
     co_await remove_persistent_state(ntp, group, _storage.local().kvs());
     co_await _shard_placement.finish_delete(ntp, log_revision);
 }

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -14,6 +14,7 @@
 #include "base/outcome.h"
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
+#include "cluster/partition_manager.h"
 #include "cluster/shard_placement_table.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
@@ -301,7 +302,8 @@ private:
     ss::future<> remove_from_shard_table(
       model::ntp, raft::group_id, model::revision_id log_revision);
 
-    ss::future<> shutdown_partition(ss::lw_shared_ptr<partition>);
+    ss::future<xshard_transfer_state>
+      shutdown_partition(ss::lw_shared_ptr<partition>);
 
     ss::future<std::error_code> transfer_partition(
       model::ntp, raft::group_id, model::revision_id log_revision);
@@ -405,6 +407,9 @@ private:
 
     absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>>
       _states;
+    // Will hold xshard_transfer_state for partitions that are being transferred
+    // to this shard.
+    chunked_hash_map<model::ntp, xshard_transfer_state> _xst_states;
 
     cluster::notification_id_type _topic_table_notify_handle
       = notification_id_type_invalid;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -30,6 +30,14 @@
 namespace cluster {
 class partition_manager;
 
+// A struct holding in-memory state that can make starting the partition
+// instance on the destination shard of the x-shard transfer easier. Note that
+// it is strictly an optimization, as the partition must always be able to
+// perform a "cold start" from persistent state only.
+struct xshard_transfer_state {
+    raft::xshard_transfer_state raft;
+};
+
 /// holds cluster logic that is not raft related
 /// all raft logic is proxied transparently
 class partition : public ss::enable_lw_shared_from_this<partition> {
@@ -47,7 +55,8 @@ public:
     ~partition() = default;
 
     raft::group_id group() const;
-    ss::future<> start(state_machine_registry&);
+    ss::future<>
+    start(state_machine_registry&, const std::optional<xshard_transfer_state>&);
     ss::future<> stop();
 
     /// This method exposes reset mutex for the external subsystem

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -91,15 +91,15 @@ public:
       storage::ntp_config,
       raft::group_id,
       std::vector<model::broker>,
+      raft::with_learner_recovery_throttle,
+      raft::keep_snapshotted_log,
+      std::optional<xshard_transfer_state>,
       std::optional<remote_topic_properties> = std::nullopt,
       std::optional<cloud_storage_clients::bucket_name> = std::nullopt,
-      raft::with_learner_recovery_throttle
-      = raft::with_learner_recovery_throttle::yes,
-      raft::keep_snapshotted_log = raft::keep_snapshotted_log::no,
       std::optional<cloud_storage::remote_label> = std::nullopt,
       std::optional<model::topic_namespace> = std::nullopt);
 
-    ss::future<> shutdown(const model::ntp& ntp);
+    ss::future<xshard_transfer_state> shutdown(const model::ntp& ntp);
 
     ss::future<> remove(const model::ntp& ntp, partition_removal_mode mode);
 
@@ -254,7 +254,7 @@ private:
       std::optional<remote_topic_properties> rtp,
       cloud_storage::remote_path_provider& path_provider);
 
-    ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
+    ss::future<xshard_transfer_state> do_shutdown(ss::lw_shared_ptr<partition>);
 
     void check_partitions_shutdown_state();
 

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -35,10 +35,9 @@ static ss::future<consensus_ptr> create_raft0(
         storage::ntp_config(model::controller_ntp, data_directory),
         raft::group_id(0),
         std::move(initial_brokers),
-        std::nullopt,
-        std::nullopt,
         raft::with_learner_recovery_throttle::no,
-        raft::keep_snapshotted_log::no)
+        raft::keep_snapshotted_log::no,
+        std::nullopt)
       .then([&st](consensus_ptr p) {
           // Add raft 0 to shard table
           return st

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -301,7 +301,11 @@ ss::future<xshard_transfer_state> consensus::stop() {
     _metrics.clear();
     _probe->clear();
 
-    co_return xshard_transfer_state{};
+    std::optional<model::term_id> leader_term;
+    if (is_elected_leader()) {
+        leader_term = _term;
+    }
+    co_return xshard_transfer_state{.leader_term = leader_term};
 }
 
 consensus::success_reply consensus::update_follower_index(
@@ -1383,7 +1387,8 @@ ss::future<> consensus::start(
       });
 }
 
-ss::future<> consensus::do_start(std::optional<xshard_transfer_state>) {
+ss::future<>
+consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
     try {
         auto u = co_await _op_lock.get_units();
 
@@ -1504,28 +1509,36 @@ ss::future<> consensus::do_start(std::optional<xshard_transfer_state>) {
             co_await _configuration_manager.adjust_configuration_idx(new_idx);
         }
 
-        auto next_election = clock_type::now();
         // set last heartbeat timestamp to prevent skipping first
         // election
         _hbeat = clock_type::time_point::min();
-        auto conf = _configuration_manager.get_latest().current_config();
-        if (!conf.voters.empty() && _self == conf.voters.front()) {
-            // Arm immediate election for single node scenarios
-            // or for the very first start of the preferred leader
-            // in a multi-node group.  Otherwise use standard election
-            // timeout.
-            if (conf.voters.size() > 1 && _term > model::term_id{0}) {
-                next_election += _jit.next_duration();
-            }
+
+        if (xst_state && xst_state->leader_term == _term) {
+            // we were the leader before the x-shard transfer, try re-electing
+            // immediately.
+            dispatch_vote(true);
         } else {
-            // current node is not a preselected leader, add 2x jitter
-            // to give opportunity to the preselected leader to win
-            // the first round
-            next_election += _jit.base_duration()
-                             + 2 * _jit.next_jitter_duration();
-        }
-        if (!_bg.is_closed()) {
-            _vote_timeout.rearm(next_election);
+            auto next_election = clock_type::now();
+            auto conf = _configuration_manager.get_latest().current_config();
+            if (!conf.voters.empty() && _self == conf.voters.front()) {
+                // Arm immediate election for single node scenarios
+                // or for the very first start of the preferred leader
+                // in a multi-node group.  Otherwise use standard election
+                // timeout.
+                if (conf.voters.size() > 1 && _term > model::term_id{0}) {
+                    next_election += _jit.next_duration();
+                }
+            } else {
+                // current node is not a preselected leader, add 2x jitter
+                // to give opportunity to the preselected leader to win
+                // the first round
+                next_election += _jit.base_duration()
+                                 + 2 * _jit.next_jitter_duration();
+            }
+
+            if (!_bg.is_closed()) {
+                _vote_timeout.rearm(next_election);
+            }
         }
 
         auto const last_applied = read_last_applied();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -113,11 +113,12 @@ public:
       keep_snapshotted_log = keep_snapshotted_log::no);
 
     /// Initial call. Allow for internal state recovery
-    ss::future<>
-      start(std::optional<state_machine_manager_builder> = std::nullopt);
+    ss::future<> start(
+      std::optional<state_machine_manager_builder> = std::nullopt,
+      std::optional<xshard_transfer_state> = std::nullopt);
 
     /// Stop all communications.
-    ss::future<> stop();
+    ss::future<xshard_transfer_state> stop();
 
     /// Stop consensus instance from accepting requests
     void shutdown_input();
@@ -557,7 +558,7 @@ private:
     do_append_entries(append_entries_request&&);
     ss::future<install_snapshot_reply>
     do_install_snapshot(install_snapshot_request r);
-    ss::future<> do_start();
+    ss::future<> do_start(std::optional<xshard_transfer_state>);
 
     ss::future<result<replicate_result>> dispatch_replicate(
       append_entries_request,

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -74,7 +74,8 @@ public:
       with_learner_recovery_throttle enable_learner_recovery_throttle,
       keep_snapshotted_log = keep_snapshotted_log::no);
 
-    ss::future<> shutdown(ss::lw_shared_ptr<raft::consensus>);
+    ss::future<xshard_transfer_state>
+      shutdown(ss::lw_shared_ptr<raft::consensus>);
 
     ss::future<> remove(ss::lw_shared_ptr<raft::consensus>);
 

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -260,7 +260,7 @@ struct raft_node {
           })
           .then([this] {
               tstlog.info("Stopping raft at {}", broker.id());
-              return consensus->stop();
+              return consensus->stop().discard_result();
           })
           .then([this] {
               if (kill_eviction_stm_cb) {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -761,7 +761,12 @@ using keep_snapshotted_log = ss::bool_class<struct keep_snapshotted_log_tag>;
 
 // Raft part of the struct that makes starting the partition
 // instance on the destination shard of the x-shard transfer easier.
-struct xshard_transfer_state {};
+struct xshard_transfer_state {
+    // If before the transfer, this partition was the leader, will contain the
+    // corresponding term. It will be used to try to immediately regain the
+    // leadership on the destination shard.
+    std::optional<model::term_id> leader_term;
+};
 
 } // namespace raft
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -759,6 +759,10 @@ using with_learner_recovery_throttle
 
 using keep_snapshotted_log = ss::bool_class<struct keep_snapshotted_log_tag>;
 
+// Raft part of the struct that makes starting the partition
+// instance on the destination shard of the x-shard transfer easier.
+struct xshard_transfer_state {};
+
 } // namespace raft
 
 namespace reflection {

--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -1,0 +1,142 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.tests.prealloc_nodes import RedpandaTest
+from rptest.utils.mode_checks import skip_debug_mode
+from rptest.services.redpanda import SISettings, LoggingConfig
+from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
+from rptest.services.openmessaging_benchmark_configs import \
+    OMBSampleConfigurations
+
+
+class ShardPlacementScaleTest(RedpandaTest):
+    def __init__(self, ctx, *args, **kwargs):
+        si_settings = SISettings(test_context=ctx)
+        super().__init__(
+            *args,
+            test_context=ctx,
+            num_brokers=5,
+            si_settings=si_settings,
+            # trace logging kills preformance, so we run with info level.
+            log_config=LoggingConfig('info'),
+            **kwargs)
+
+    def setUp(self):
+        # start the nodes manually
+        pass
+
+    def start_omb(self):
+        workload = {
+            "name": "CommonWorkload",
+            "topics": 1,
+            "partitions_per_topic": 1000,
+            "subscriptions_per_topic": 1,
+            "consumer_per_subscription": 25,
+            "producers_per_topic": 5,
+            "producer_rate": 100 * 1024,
+            "message_size": 1024,
+            "payload_file": "payload/payload-1Kb.data",
+            "key_distributor": "KEY_ROUND_ROBIN",
+            "consumer_backlog_size_GB": 0,
+            "test_duration_minutes": 3,
+            "warmup_duration_minutes": 1,
+        }
+        driver = {
+            "name": "CommonWorkloadDriver",
+            "replication_factor": 3,
+            "request_timeout": 300000,
+            "topic_config": {
+                "cleanup.policy": "compact,delete",
+            },
+            "producer_config": {
+                "enable.idempotence": "true",
+                "acks": "all",
+                # producer settings to ensure batches of decent size
+                # (otherwise most of the batches contain just 1 message
+                # which leads to unreasonably high reactor util)
+                "max.request.size": 5 * 2**20,
+                "linger.ms": 500,
+            },
+            "consumer_config": {
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": "false",
+                "max.partition.fetch.bytes": 131072
+            },
+        }
+        validator = {
+            OMBSampleConfigurations.AVG_THROUGHPUT_MBPS:
+            [OMBSampleConfigurations.gte(100)]
+        }
+
+        self._benchmark = OpenMessagingBenchmark(ctx=self.test_context,
+                                                 redpanda=self.redpanda,
+                                                 driver=driver,
+                                                 workload=(workload,
+                                                           validator),
+                                                 topology="ensemble")
+        self._benchmark.start()
+        self.logger.info(f"OMB started")
+
+    def omb_topics(self):
+        rpk = RpkTool(self.redpanda)
+        return [t for t in rpk.list_topics() if t.startswith('test-topic-')]
+
+    def finish_omb(self):
+        benchmark_time_min = self._benchmark.benchmark_time() + 2
+        self._benchmark.wait(timeout_sec=benchmark_time_min * 60)
+        self._benchmark.check_succeed()
+
+    @cluster(num_nodes=8)
+    @skip_debug_mode
+    def test_manual_moves(self):
+        self.redpanda.start()
+
+        self.start_omb()
+
+        time.sleep(100)
+
+        # trigger random xshard moves for 20% of partitions on the first node
+
+        admin = Admin(self.redpanda)
+
+        node = self.redpanda.nodes[0]
+        node_id = self.redpanda.node_id(node)
+        n_cores = self.redpanda.get_node_cpu_count()
+
+        omb_topic = self.omb_topics()[0]
+
+        partitions = [
+            p["partition_id"] for p in admin.get_partitions(node=node)
+            if p["topic"] == omb_topic
+        ]
+        partitions = random.sample(partitions, len(partitions) // 5)
+
+        self.logger.info(
+            f"moving {len(partitions)} partitions of topic {omb_topic}"
+            f" on node {node.name}")
+        for partition in partitions:
+            core = random.randrange(n_cores)
+            self.logger.info(f"moving {omb_topic}/{partition} to core {core}")
+            admin.set_partition_replica_core(omb_topic,
+                                             partition,
+                                             node_id,
+                                             core=core)
+        self.logger.info("finished moving")
+
+        time.sleep(100)
+        admin.trigger_cores_rebalance(node)
+        self.logger.info("triggered manual rebalance")
+
+        self.finish_omb()

--- a/tests/rptest/services/templates/omb_workload.yaml
+++ b/tests/rptest/services/templates/omb_workload.yaml
@@ -2,6 +2,9 @@ name: {{name}}
 
 topics: {{topics}}
 partitionsPerTopic: {{partitions_per_topic}}
+{% if key_distributor is defined %}
+keyDistributor: {{key_distributor}}
+{% endif %}
 {% if message_size is defined %}
 messageSize: {{message_size}}
 {% if use_randomized_payloads is defined %}


### PR DESCRIPTION
When we move a partition that was a leader to another core, it will cease to be a leader and we will have to wait for the full re-election timeout before the leader is elected again. Instead, we can use the fact that it was the leader to start re-election immediately upon startup on the new core.

Note that we could continue with the same term instead (without re-election), but this looks a bit dangerous as downstream users (such as STMs) could be unprepared for the leader in the same term to reappear on another core.

Also add scale tests that allow observing latencies associated with x-core movements in the presence of substantial client load (openmessaging benchmark).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
