### PR TITLE
archival: Update ntp_archiver (pt.2)

### DIFF
--- a/src/v/cluster/archival/archiver_operations_impl.cc
+++ b/src/v/cluster/archival/archiver_operations_impl.cc
@@ -27,6 +27,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
+#include "ssx/future-util.h"
 #include "storage/batch_consumer_utils.h"
 #include "utils/retry_chain_node.h"
 #include "utils/stream_utils.h"
@@ -34,13 +35,63 @@
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/coroutine/all.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <exception>
 
 namespace archival {
 namespace detail {
 
+inline std::tuple<remote_segment_path, ss::sstring, remote_segment_path>
+segment_index_object_names(
+  const ss::shared_ptr<cluster_partition_api>& part,
+  const reconciled_upload_candidate_ptr& upl) {
+    auto path = part->get_remote_segment_path(upl->metadata);
+    auto ix = fmt::format("{}.index", path().native());
+    auto tx = fmt::format("{}.tx", path().native());
+    return std::make_tuple(path, ix, remote_segment_path(tx));
+}
+
+/// Cloning upload with the exception of tx data
+inline std::tuple<ss::input_stream<char>, ss::input_stream<char>>
+clone_stream(ss::input_stream<char> source, int16_t readahead) {
+    auto res = input_stream_fanout<2>(std::move(source), readahead);
+
+    auto [lhs, rhs] = std::move(res);
+    return std::make_tuple(std::move(lhs), std::move(rhs));
+}
+
 class archiver_operations_impl : public archiver_operations_api {
+    /// Combined result of several uploads
+    struct aggregated_upload_result {
+        cloud_storage::upload_result code{
+          cloud_storage::upload_result::success};
+        /// Populated on success
+        std::optional<cloud_storage::segment_record_stats> stats;
+        /// Total number of PUT requests used
+        size_t put_requests{0};
+        /// Total number of bytes sent
+        size_t bytes_sent{0};
+
+        // Combine aggregated results
+        ///
+        /// The error codes are combined using max function (the worst
+        /// error wins). The order is: success < timeout < failure < cancelled.
+        /// The 'stats' objects can't be combined so the series of aggregated
+        /// results can't contains more than one 'stats' instances.
+        void combine(const aggregated_upload_result& other) {
+            put_requests += other.put_requests;
+            bytes_sent += other.bytes_sent;
+            if (!stats.has_value()) {
+                stats = other.stats;
+            }
+            code = std::max(code, other.code);
+        }
+    };
+
 public:
     /// C-tor
     archiver_operations_impl(
@@ -171,10 +222,155 @@ public:
     /// the uploaded manifest. The state of the uploaded manifest doesn't
     /// include uploaded segments because they're not admitted yet.
     ss::future<result<upload_results_list>> schedule_uploads(
-      retry_chain_node&,
-      reconciled_upload_candidates_list,
-      bool) noexcept override {
-        co_return error_outcome::unexpected_failure;
+      retry_chain_node& workflow_rtc,
+      reconciled_upload_candidates_list bundle,
+      bool inline_manifest_upl) noexcept override {
+        try {
+            upload_results_list result;
+            auto partition = _pm->get_partition(bundle.ntp);
+            if (partition == nullptr) {
+                // maybe race condition (partition was stopped or moved)
+                vlog(
+                  _rtclog.debug,
+                  "schedule_uploads - can't find partition {}",
+                  bundle.ntp);
+                co_return error_outcome::unexpected_failure;
+            }
+            std::deque<cloud_storage::segment_meta> metadata;
+            chunked_vector<ss::future<aggregated_upload_result>>
+              segment_uploads;
+            chunked_vector<ss::future<aggregated_upload_result>>
+              manifest_uploads;
+            for (auto& upl : bundle.results) {
+                metadata.push_back(upl->metadata);
+                segment_uploads.emplace_back(
+                  upload_candidate(workflow_rtc, partition, upl));
+            }
+            model::offset projected_clean_offset
+              = partition->manifest().get_insync_offset();
+            if (inline_manifest_upl) {
+                const auto& manifest = partition->manifest();
+                const auto estimated_manifest_upl_size
+                  = manifest.estimate_serialized_size();
+                auto key = partition->get_remote_manifest_path(manifest);
+                manifest_uploads.emplace_back(
+                  _api
+                    ->upload_manifest(
+                      _bucket, manifest, std::move(key), workflow_rtc)
+                    .then([estimated_manifest_upl_size](
+                            cloud_storage::upload_result r) {
+                        return aggregated_upload_result{
+                          .code = r,
+                          .put_requests = 1,
+                          // Use size estimate instead of the actual value
+                          .bytes_sent = estimated_manifest_upl_size};
+                    }));
+            }
+
+            // Wait for all uploads to complete
+            std::vector<ss::future<aggregated_upload_result>>
+              segment_result_vec;
+            std::vector<ss::future<aggregated_upload_result>>
+              manifest_result_vec;
+            if (manifest_uploads.empty()) {
+                segment_result_vec = co_await ss::when_all(
+                  segment_uploads.begin(), segment_uploads.end());
+            } else {
+                auto [first, second] = co_await ss::coroutine::all(
+                  [&segment_uploads] {
+                      return ss::when_all(
+                        segment_uploads.begin(), segment_uploads.end());
+                  },
+                  [&manifest_uploads] {
+                      return ss::when_all(
+                        manifest_uploads.begin(), manifest_uploads.end());
+                  });
+                segment_result_vec = std::move(first);
+                manifest_result_vec = std::move(second);
+            }
+            size_t num_put_requests = 0;
+            size_t num_bytes_sent = 0;
+
+            // Process manifest upload results.
+            model::offset manifest_clean_offset;
+            if (inline_manifest_upl) {
+                vassert(
+                  manifest_result_vec.size() == 1,
+                  "Manifest upload wasn't scheduled correctly {}",
+                  manifest_result_vec.size());
+                if (manifest_result_vec.back().failed()) {
+                    // Manifest upload failed, we shouldn't add clean command
+                    vlog(
+                      _rtclog.error,
+                      "Manifest upload failed {}",
+                      manifest_result_vec.back().get_exception());
+                } else {
+                    auto m_res = manifest_result_vec.back().get();
+                    if (m_res.code != cloud_storage::upload_result::success) {
+                        // Same here
+                        vlog(
+                          _rtclog.error,
+                          "Manifest upload failed {}",
+                          m_res.code);
+                    } else {
+                        // Manifest successfully uploaded
+                        manifest_clean_offset = projected_clean_offset;
+                    }
+                    num_put_requests += m_res.put_requests;
+                    num_bytes_sent += m_res.bytes_sent;
+                }
+            }
+
+            // Process segment upload results.
+            std::deque<std::optional<cloud_storage::segment_record_stats>>
+              upload_stats;
+            std::deque<cloud_storage::upload_result> upload_results;
+            for (auto& res : segment_result_vec) {
+                if (res.failed()) {
+                    vlog(
+                      _rtclog.error,
+                      "Segment upload failed {}",
+                      res.get_exception());
+                    upload_stats.emplace_back(std::nullopt);
+                    upload_results.push_back(
+                      cloud_storage::upload_result::failed);
+                    continue;
+                }
+
+                auto op_result = std::move(res).get();
+                num_put_requests += op_result.put_requests;
+                num_bytes_sent += op_result.bytes_sent;
+
+                if (op_result.code != cloud_storage::upload_result::success) {
+                    vlog(
+                      _rtclog.error,
+                      "Segment upload failed {}",
+                      op_result.code);
+                }
+
+                upload_stats.push_back(op_result.stats);
+                upload_results.push_back(op_result.code);
+            }
+
+            upload_results_list results(
+              bundle.ntp,
+              std::move(upload_stats),
+              std::move(upload_results),
+              std::move(metadata),
+              manifest_clean_offset,
+              bundle.read_write_fence,
+              num_put_requests,
+              num_bytes_sent);
+
+            co_return std::move(results);
+        } catch (...) {
+            vlog(
+              _rtclog.error,
+              "Unexpected 'schedule_uploads' exception {}",
+              std::current_exception());
+            co_return error_outcome::unexpected_failure;
+        }
+        __builtin_unreachable();
     }
 
     /// Add metadata to the manifest by replicating archival metadata
@@ -187,7 +383,7 @@ public:
     /// Reupload manifest and replicate configuration batch
     ss::future<result<manifest_upload_result>>
     upload_manifest(retry_chain_node&, model::ntp) noexcept override {
-        co_return error_outcome::unexpected_failure;
+        co_return error_outcome::unexpected_failure; // Not implemented
     }
 
 private:
@@ -297,6 +493,240 @@ private:
       model::offset last) {
         auto guard = _gate.hold();
         co_return co_await part->aborted_transactions(base, last);
+    }
+
+    /// Generate and upload segment index
+    ///
+    /// The method consumes a segment as a stream. While the segment
+    /// index is generated it also computes segment stats. Then it compares
+    /// the stats with the metadata of the segment and returns error in case
+    //// of the mismatch. The last step is to upload the segment index.
+    ss::future<aggregated_upload_result> upload_segment_index(
+      std::reference_wrapper<retry_chain_node> workflow_rtc,
+      std::reference_wrapper<cloud_storage::segment_record_stats> stats,
+      reconciled_upload_candidate_ptr upload,
+      std::string_view index_path,
+      ss::input_stream<char> stream) noexcept {
+        try {
+            vlog(
+              _rtclog.debug, "creating remote segment index: {}", index_path);
+            auto base_kafka_offset = upload->metadata.base_kafka_offset();
+            constexpr auto index_sampling_step
+              = 64_KiB; // TODO: use proper constant
+
+            cloud_storage::offset_index ix{
+              upload->metadata.base_offset,
+              base_kafka_offset,
+              0,
+              index_sampling_step,
+              upload->metadata.base_timestamp};
+
+            auto builder = cloud_storage::make_remote_segment_index_builder(
+              upload->ntp,
+              std::move(stream),
+              ix,
+              upload->metadata.delta_offset,
+              index_sampling_step,
+              stats);
+
+            auto res = co_await builder->consume().finally(
+              [&builder] { return builder->close(); });
+
+            if (res.has_error()) {
+                vlog(
+                  _rtclog.error,
+                  "failed to create remote segment index: {}, error: {}",
+                  index_path,
+                  res.error());
+                co_return upload_result::failed;
+            }
+            // Compare stats to the expectation
+            // return upload_result.
+            const bool checks_disabled
+              = config::shard_local_cfg()
+                  .cloud_storage_disable_upload_consistency_checks.value();
+            if (!checks_disabled) {
+                // Compare against manifest
+                if (
+                  !upload->metadata.is_compacted
+                  && !segment_meta_matches_stats(
+                    upload->metadata, stats, _rtclog)) {
+                    co_return cloud_storage::upload_result::failed;
+                }
+            }
+            // Upload index
+            auto payload = ix.to_iobuf();
+            auto ix_size = payload.size_bytes();
+            auto ix_stream = make_iobuf_input_stream(std::move(payload));
+
+            // If we fail to upload the index but successfully upload the
+            // segment, the read path will create the index on the fly while
+            // downloading the segment, so it is okay to ignore the index upload
+            // failure, we still want to advance the offsets because the segment
+            // did get uploaded.
+            std::ignore = co_await _api->upload_stream(
+              cloud_storage_clients::bucket_name(_bucket()),
+              cloud_storage_clients::object_key(index_path),
+              ix_size,
+              std::move(ix_stream),
+              cloud_storage::upload_type::segment_index,
+              workflow_rtc);
+
+            co_return aggregated_upload_result{
+              .code = cloud_storage::upload_result::success,
+              .put_requests = 1,
+              .bytes_sent = ix_size,
+            };
+        } catch (...) {
+            vlog(
+              _rtclog.error,
+              "Failed to build an index, unexpected error: {}",
+              std::current_exception());
+            co_return aggregated_upload_result{
+              .code = cloud_storage::upload_result::failed};
+        }
+        vassert(false, "unreachable");
+    }
+
+    static bool segment_meta_matches_stats(
+      const cloud_storage::segment_meta& meta,
+      const cloud_storage::segment_record_stats& stats,
+      retry_chain_logger& ctxlog) {
+        // Validate segment content. The 'stats' is computed when
+        // the actual segment is scanned and represents the 'ground truth' about
+        // its content. The 'meta' is the expected segment metadata. We
+        // shouldn't replicate it if it doesn't match the 'stats'.
+        if (
+          meta.size_bytes != stats.size_bytes
+          || meta.base_offset != stats.base_rp_offset
+          || meta.committed_offset != stats.last_rp_offset
+          || static_cast<size_t>(meta.delta_offset_end - meta.delta_offset)
+               != stats.total_conf_records) {
+            vlog(
+              ctxlog.error,
+              "Metadata of the uploaded segment [size: {}, base: {}, last: {}, "
+              "begin delta: {}, end delta: {}] "
+              "doesn't match the segment [size: {}, base: {}, last: {}, total "
+              "config records: {}]",
+              meta.size_bytes,
+              meta.base_offset,
+              meta.committed_offset,
+              meta.delta_offset,
+              meta.delta_offset_end,
+              stats.size_bytes,
+              stats.base_rp_offset,
+              stats.last_rp_offset,
+              stats.total_conf_records);
+            return false;
+        }
+        return true;
+    }
+
+    /// Upload segment with index and tx-manifest
+    ///
+    /// The result is a combination of all upload results
+    /// plus the segment metadata generated during the index build
+    /// step.
+    ss::future<aggregated_upload_result> upload_candidate(
+      std::reference_wrapper<retry_chain_node> workflow_rtc,
+      ss::shared_ptr<cluster_partition_api> partition,
+      reconciled_upload_candidate_ptr upl) {
+        auto [segment_name, index_name, tx_name] = segment_index_object_names(
+          partition, upl);
+
+        cloud_storage::segment_record_stats stats{};
+
+        auto [index_stream, upload_stream] = clone_stream(
+          std::move(upl->payload), _readahead());
+
+        auto make_su_fut = upload_segment(
+          workflow_rtc, segment_name, upl, std::move(upload_stream));
+        auto make_ix_fut = upload_segment_index(
+          workflow_rtc, stats, upl, index_name, std::move(index_stream));
+
+        std::vector<ss::future<aggregated_upload_result>> uploads;
+        uploads.reserve(3);
+        uploads.emplace_back(std::move(make_su_fut));
+        uploads.emplace_back(std::move(make_ix_fut));
+
+        if (!upl->tx.empty()) {
+            auto tx = std::move(upl->tx);
+            auto txm = ss::make_shared<cloud_storage::tx_range_manifest>(
+              segment_name, std::move(tx));
+            auto tx_key = partition->get_remote_manifest_path(*txm);
+            uploads.emplace_back(
+              _api
+                ->upload_manifest(
+                  _bucket, *txm, std::move(tx_key), workflow_rtc)
+                .then([txm](cloud_storage::upload_result r) {
+                    return aggregated_upload_result{
+                      .code = r,
+                      .put_requests = 1,
+                      .bytes_sent = txm->estimate_serialized_size()};
+                }));
+        } else {
+            // put ready future into the vec
+            uploads.emplace_back(
+              ss::make_ready_future<aggregated_upload_result>(
+                aggregated_upload_result{}));
+        }
+        // Wait result and combine
+        auto fut_results = co_await ss::when_all(
+          uploads.begin(), uploads.end());
+        aggregated_upload_result result{};
+        for (auto& f : fut_results) {
+            if (f.failed()) {
+                vlog(_rtclog.error, "Upload failed {}", f.get_exception());
+                result.code = cloud_storage::upload_result::failed;
+            } else {
+                result.combine(f.get());
+            }
+        }
+        vlog(
+          _rtclog.debug,
+          "Upload complete, status code: {}, record stats: {}, bytes sent: {}, "
+          "PUT requests used: {}",
+          result.code,
+          result.stats.has_value(),
+          result.bytes_sent,
+          result.put_requests);
+        co_return result;
+    }
+
+    ss::future<aggregated_upload_result> upload_segment(
+      std::reference_wrapper<retry_chain_node> workflow_rtc,
+      remote_segment_path path,
+      reconciled_upload_candidate_ptr candidate,
+      ss::input_stream<char> payload) {
+        vlog(_rtclog.debug, "Uploading segment {} to {}", candidate, path);
+        auto response = cloud_storage::upload_result::success;
+        size_t num_bytes = 0;
+        size_t num_requests = 0;
+        auto res = co_await ss::coroutine::as_future(_api->upload_stream(
+          _bucket,
+          cloud_storage_clients::object_key(path()),
+          candidate->size_bytes,
+          std::move(payload),
+          cloud_storage::upload_type::object,
+          workflow_rtc));
+        if (!res.failed()) {
+            num_requests += 1;
+            num_bytes += candidate->size_bytes;
+            response = res.get();
+        } else {
+            auto e = res.get_exception();
+            if (ssx::is_shutdown_exception(e)) {
+                response = cloud_storage::upload_result::cancelled;
+            } else {
+                vlog(_rtclog.error, "failed to upload segment {}: {}", path, e);
+                response = cloud_storage::upload_result::failed;
+            }
+        }
+        co_return aggregated_upload_result{
+          .code = response,
+          .put_requests = num_requests,
+          .bytes_sent = num_bytes,
+        };
     }
 
     ss::gate _gate;

--- a/src/v/cluster/archival/archiver_operations_impl.cc
+++ b/src/v/cluster/archival/archiver_operations_impl.cc
@@ -489,9 +489,38 @@ public:
     }
 
     /// Reupload manifest and replicate configuration batch
-    ss::future<result<manifest_upload_result>>
-    upload_manifest(retry_chain_node&, model::ntp) noexcept override {
-        co_return error_outcome::unexpected_failure; // Not implemented
+    ss::future<result<manifest_upload_result>> upload_manifest(
+      retry_chain_node& workflow_rtc, model::ntp ntp) noexcept override {
+        auto gate = _gate.hold();
+        try {
+            auto partition = _pm->get_partition(ntp);
+            const auto& manifest = partition->manifest();
+            const auto estimated_size = manifest.estimate_serialized_size();
+            auto key = partition->get_remote_manifest_path(manifest);
+            auto res = co_await _api->upload_manifest(
+              _bucket, manifest, std::move(key), workflow_rtc);
+            switch (res) {
+            case upload_result::cancelled:
+                co_return error_outcome::shutting_down;
+            case upload_result::timedout:
+                co_return error_outcome::timed_out;
+            case upload_result::failed:
+                co_return error_outcome::unexpected_failure;
+            case upload_result::success:
+                co_return manifest_upload_result{
+                  .ntp = ntp,
+                  .num_put_requests = 1,
+                  .size_bytes = estimated_size,
+                };
+            }
+        } catch (...) {
+            vlog(
+              _rtclog.error,
+              "Can't upload manifest due to exception {}",
+              std::current_exception());
+            co_return error_outcome::unexpected_failure;
+        }
+        __builtin_unreachable();
     }
 
 private:

--- a/src/v/cluster/archival/tests/archiver_operations_impl_gtest.cc
+++ b/src/v/cluster/archival/tests/archiver_operations_impl_gtest.cc
@@ -1659,4 +1659,346 @@ TEST_CORO(
     }
 }
 
+enum class metadata_anomaly_type {
+    none = 0,
+    // gap between two segments
+    gap,
+    // overlap between two segments
+    overlap,
+    // the segment doesn't match record stats
+    record_stats_mismatch
+};
+
+ss::future<> test_admit_uploads_full_cycle(
+  std::deque<upload_result> results,
+  std::deque<metadata_anomaly_type> anomalies,
+  bool inline_manifest) {
+    scoped_config cfg;
+    cfg.get("storage_read_buffer_size").set_value(expected_read_buffer_size);
+    cfg.get("cloud_storage_segment_size_target")
+      .set_value(std::make_optional<size_t>(expected_target_size));
+    cfg.get("cloud_storage_segment_size_min")
+      .set_value(std::make_optional<size_t>(expected_min_size));
+    cfg.get("cloud_storage_bucket")
+      .set_value(std::make_optional(expected_bucket));
+
+    auto remote = ss::make_shared<remote_mock>();
+    auto pm = ss::make_shared<partition_manager_mock>();
+    auto builder = ss::make_shared<upload_builder_mock>();
+    auto partition = ss::make_shared<partition_mock>();
+
+    // set expectations
+    partition->expect_manifest(expected_manifest);
+
+    // Generate segment metadata and segments record stats
+    // which are mutually consistent if the 'add_anomaly' parameter is set to
+    // false or inconsistent otherwise.
+    auto gen_random_segment_meta = [](
+                                     const cloud_storage::segment_meta& prev,
+                                     metadata_anomaly_type add_anomaly) {
+        cloud_storage::segment_meta m;
+        m.is_compacted = false;
+        m.base_offset = model::next_offset(prev.committed_offset);
+        // Empty segments are disallowed and not tested
+        auto num_records = random_generators::get_int(1, 100);
+        auto num_configs = random_generators::get_int(num_records);
+        m.committed_offset = m.base_offset + model::offset(num_records);
+        m.delta_offset = prev.delta_offset_end;
+        m.delta_offset_end = m.delta_offset + model::offset_delta(num_configs);
+        m.size_bytes = random_generators::get_int(1, 0x8000);
+        m.base_timestamp = model::timestamp::now();
+        m.max_timestamp = model::timestamp::now();
+
+        cloud_storage::segment_record_stats s{
+          .base_rp_offset = m.base_offset,
+          .last_rp_offset = m.committed_offset,
+          .total_data_records = size_t(num_records - num_configs),
+          .total_conf_records = size_t(num_configs),
+          .size_bytes = m.size_bytes,
+          .base_timestamp = m.base_timestamp,
+          .last_timestamp = m.max_timestamp,
+        };
+        // Maybe add anomaly
+        switch (add_anomaly) {
+        case metadata_anomaly_type::none:
+            break;
+        case metadata_anomaly_type::gap:
+            m.base_offset = model::next_offset(m.base_offset);
+            s.base_rp_offset = m.base_offset;
+            s.total_data_records--;
+            break;
+        case metadata_anomaly_type::overlap:
+            m.base_offset = model::prev_offset(m.base_offset);
+            s.base_rp_offset = m.base_offset;
+            s.total_data_records++;
+            break;
+        case metadata_anomaly_type::record_stats_mismatch:
+            s.size_bytes--;
+            break;
+        }
+        return std::make_pair(m, s);
+    };
+
+    std::deque<cloud_storage::segment_meta> metadata;
+    std::vector<cloud_storage::segment_meta> expected_metadata;
+    std::deque<std::optional<cloud_storage::segment_record_stats>> stats;
+    auto prev = expected_manifest.last_segment().value();
+    size_t num_bytes_sent = 0;
+    size_t num_put_requests = 0;
+    bool truncate = false;
+    for (int ix = 0; ix < (int)results.size(); ix++) {
+        auto anomaly = anomalies.at(ix);
+        auto result = results.at(ix);
+        if (
+          anomaly != metadata_anomaly_type::none
+          || result != upload_result::success) {
+            truncate = true;
+        }
+        auto [m, s] = gen_random_segment_meta(prev, anomaly);
+        metadata.push_back(m);
+        if (!truncate) {
+            expected_metadata.push_back(m);
+        }
+        stats.emplace_back(s);
+        num_bytes_sent += m.size_bytes;
+        num_put_requests += 3;
+        prev = m;
+    }
+
+    auto clean_offset = [&]() -> std::optional<model::offset> {
+        if (inline_manifest) {
+            return std::make_optional(expected_manifest.get_insync_offset());
+        }
+        return std::nullopt;
+    }();
+
+    model::offset expected_dirty_offset
+      = expected_metadata.empty() ? model::offset{}
+                                  : expected_metadata.back().committed_offset;
+    if (!expected_metadata.empty()) {
+        partition->expect_get_highest_producer_id(expected_producer_id);
+        partition->expect_add_segments(
+          expected_metadata,
+          clean_offset,
+          expected_read_write_fence,
+          expected_producer_id,
+          true,
+          expected_dirty_offset);
+    }
+
+    pm->expect_get_partition(partition);
+
+    // create the ops api
+    auto ops = detail::make_archiver_operations_api(
+      remote, pm, builder, c_expected_bucket);
+
+    // invoke admit uploads
+    ss::abort_source as;
+    retry_chain_node rtc(as, 1s, 1ms);
+
+    upload_results_list input(
+      expected_ntp.to_ntp(),
+      stats,
+      results,
+      metadata,
+      clean_offset.value_or(model::offset{}),
+      expected_read_write_fence,
+      num_put_requests,
+      num_bytes_sent);
+    input.results = results;
+    input.metadata = metadata;
+    input.stats = stats;
+    auto result = co_await ops->admit_uploads(rtc, std::move(input));
+
+    if (!expected_metadata.empty()) {
+        ASSERT_TRUE_CORO(result.has_value());
+        ASSERT_EQ_CORO(
+          result.value().manifest_dirty_offset, expected_dirty_offset);
+        ASSERT_EQ_CORO(result.value().num_succeeded, expected_metadata.size());
+        ASSERT_EQ_CORO(
+          result.value().num_failed, results.size() - expected_metadata.size());
+    } else {
+        ASSERT_FALSE_CORO(result.has_value());
+    }
+}
+
+TEST_CORO(archiver_operations_impl_test, admit_uploads_empty) {
+    std::deque<upload_result> results = {};
+    std::deque<metadata_anomaly_type> anomalies = {};
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_1_segment_1_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, true);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_1_segment_0_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_2_segment_1_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, true);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_2_segment_0_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_3_segment_1_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, true);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_3_segment_0_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_1_segment_0_manifest_1_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::gap,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_0_segment_0_manifest_0_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::failed,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_3_segment_0_manifest_1_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::gap,
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, false);
+}
+
+TEST_CORO(
+  archiver_operations_impl_test, admit_uploads_3_segment_1_manifest_1_anomaly) {
+    std::deque<upload_result> results = {
+      upload_result::success,
+      upload_result::success,
+      upload_result::success,
+    };
+    std::deque<metadata_anomaly_type> anomalies = {
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::none,
+      metadata_anomaly_type::record_stats_mismatch,
+    };
+    co_await test_admit_uploads_full_cycle(results, anomalies, true);
+}
+
+TEST_CORO(archiver_operations_impl_test, admit_uploads_randomized) {
+    for (int i = 0; i < 1000; i++) {
+        std::deque<upload_result> results;
+        std::deque<metadata_anomaly_type> anomalies;
+        bool inline_manifest = random_generators::get_int(1);
+        int num_segments = random_generators::get_int(10);
+        for (int j = 0; j < num_segments; j++) {
+            // 70% chance to have successful upload. It's important to
+            // have relatively high success rate because otherwise the
+            // set of replicated segments will be empty and the method
+            // will return error.  In this case the test won't be able
+            // to do all validations (check all fields of the returned
+            // value).
+            bool success = random_generators::get_int(100) < 70;
+            if (success) {
+                results.push_back(upload_result::success);
+                anomalies.push_back(metadata_anomaly_type::none);
+            } else {
+                // Failed upload is either upload error, or anomaly.
+                // The anomaly could be a gap, an overlap, or a metadata
+                // mismatch (segment doesn't match the metadata).
+                int type = random_generators::get_int(4);
+                if (type == 0) {
+                    results.push_back(upload_result::failed);
+                    anomalies.push_back(metadata_anomaly_type::none);
+                } else if (type == 1) {
+                    results.push_back(upload_result::success);
+                    anomalies.push_back(metadata_anomaly_type::gap);
+                } else if (type == 2) {
+                    results.push_back(upload_result::success);
+                    anomalies.push_back(metadata_anomaly_type::overlap);
+                } else if (type == 3) {
+                    results.push_back(upload_result::success);
+                    anomalies.push_back(
+                      metadata_anomaly_type::record_stats_mismatch);
+                }
+            }
+        }
+        co_await test_admit_uploads_full_cycle(
+          results, anomalies, inline_manifest);
+    }
+}
+
 } // namespace archival


### PR DESCRIPTION

Pull-requests in a series:
- https://github.com/redpanda-data/redpanda/pull/21309

This PR implements `schedule_uploads` and `admit_uploads` methods. The `schedule_uploads` method accepts the result of the `find_upload_candidates` which contains a series of candidates. It uploads the series of segments with the index and tx manifest.  The method can also upload the manifest concurrently with the segments. The result contains the metadata of the uploaded segments, the upload results and the record-level stats from every upload which is used for validation in the `admit_uploads` method.

The `admit_uploads` accepts the output of the `schedule_uploads` and validates it by comparing metadata of the uploaded segment with its record-level stats. After that it check if the metadata can be safely added to the manifest. After that the `archival_metadata_stm` batch is replicated. The batch contains read-write fence to prevent races. The `admit_uploads` can deal with partial failures. E.g. if last upload in the list failed or can't be applied it will still apply the first ones. If the failed upload is in the middle of a series it will truncate the series.

This PR is a part of the larger change and the code is not reachable yet.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none