### PR TITLE
k/group: do not log ignoring raft configuration batches

### DIFF
--- a/src/v/kafka/server/group_data_parser.h
+++ b/src/v/kafka/server/group_data_parser.h
@@ -16,6 +16,7 @@
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/logger.h"
 #include "model/record.h"
+#include "model/record_batch_types.h"
 
 template<typename T>
 T parse_tx_batch(const model::record_batch& batch, int8_t version) {
@@ -80,6 +81,10 @@ protected:
     ss::future<> parse(model::record_batch b) {
         if (b.header().type == model::record_batch_type::raft_data) {
             return handle_raft_data(std::move(b));
+        }
+        // silently ignore raft configuration.
+        if (b.header().type == model::record_batch_type::raft_configuration) {
+            return ss::now();
         }
         if (b.header().type == model::record_batch_type::group_prepare_tx) {
             auto data = parse_tx_batch<kafka::group_tx::offsets_metadata>(


### PR DESCRIPTION
Raft configuration batches are integral part of Raft managed log. Emitting warn log message that Redpanda ignore them when parsing consumer group state machine data may be confusing as this is expected and not something that the users should worry about.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none