### PR TITLE
Leadership transfer delay test fix

### DIFF
--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -820,11 +820,11 @@ TEST_F_CORO(raft_fixture, leadership_transfer_delay) {
         co_await stop_node(vn.id());
     }
 
-    auto tolerance = 0.15;
+    auto tolerance_multiplier = 1.3;
     /**
-     * Validate that election time  after reconfiguration is simillar to the
+     * Validate that election time after reconfiguration is simillar to the
      * time needed for leadership transfer
      */
-    ASSERT_LE_CORO(election_time, transfer_time * (1.0 + tolerance));
-    ASSERT_GE_CORO(election_time, transfer_time * (1.0 - tolerance));
+    ASSERT_LE_CORO(election_time * 1.0, transfer_time * tolerance_multiplier);
+    ASSERT_GE_CORO(election_time * 1.0, transfer_time / tolerance_multiplier);
 }

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -41,8 +41,9 @@ std::ostream& operator<<(std::ostream& os, const std::variant<T...>& v) {
     return os;
 }
 
+template<typename Rep, typename Period>
 inline std::ostream&
-operator<<(std::ostream& o, const ss::lowres_clock::duration& d) {
+operator<<(std::ostream& o, const std::chrono::duration<Rep, Period>& d) {
     fmt::print(
       o,
       "{}",


### PR DESCRIPTION
I came across this problem when testing a modification in `vote_stm`. It would fail intermittently, but never with much of a gap.
I gathered some stats and came to a conclusion that we should allow for a little glitch:
```
Modified:
      4 leadership_transfer 43ms
     40 leadership_transfer 44ms
    110 leadership_transfer 45ms
    238 leadership_transfer 46ms
    336 leadership_transfer 47ms
     67 leadership_transfer 48ms
      9 leadership_transfer 49ms
      3 leadership_transfer 50ms
      2 leadership_transfer 51ms
*     1 leadership_transfer 57ms
*     1 leadership_transfer 58ms
*     2 leadership_transfer 60ms
*     1 leadership_transfer 61ms
      1 reconfiguration 42ms
     11 reconfiguration 45ms
     44 reconfiguration 46ms
    205 reconfiguration 47ms
    299 reconfiguration 48ms
    150 reconfiguration 49ms
     86 reconfiguration 50ms
      9 reconfiguration 51ms
      4 reconfiguration 52ms
*     1 reconfiguration 59ms
*     2 reconfiguration 60ms
*     2 reconfiguration 61ms

Unmodified:
      3 leadership_transfer 43ms
      8 leadership_transfer 44ms
     56 leadership_transfer 45ms
    166 leadership_transfer 46ms
    297 leadership_transfer 47ms
     36 leadership_transfer 48ms
      7 leadership_transfer 49ms
      4 leadership_transfer 50ms
      1 leadership_transfer 52ms
*     1 leadership_transfer 57ms
*     1 leadership_transfer 58ms
*     1 leadership_transfer 59ms
*     2 leadership_transfer 60ms
*     1 leadership_transfer 61ms
      1 reconfiguration 43ms
      2 reconfiguration 44ms
     12 reconfiguration 45ms
     51 reconfiguration 46ms
    152 reconfiguration 47ms
    170 reconfiguration 48ms
    100 reconfiguration 49ms
     75 reconfiguration 50ms
     15 reconfiguration 51ms
      2 reconfiguration 53ms
*     1 reconfiguration 57ms
*     1 reconfiguration 58ms
*     2 reconfiguration 62ms
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
