### PR TITLE
cst/ducktape: Change assertion for deleted chunks

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -232,12 +232,6 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
             self._assert_not_in_cache(
                 fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
 
-            # We cannot assert that there are chunks in cache because the deleting thread
-            # could delete them all before we run the assertion, causing it to fail.
-            # We can check that the thread deleted some chunks.
-            assert rm_chunks.deleted_chunks > 0, "Expected to delete some chunk files during rand-cons, none deleted"
-            rm_chunks.deleted_chunks = 0
-
             consumer = KgoVerifierSeqConsumer(self.test_context,
                                               self.redpanda,
                                               self.topic,
@@ -247,7 +241,7 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
             consumer.wait(timeout_sec=120)
             rm_chunks.stop()
             rm_chunks.join(timeout=10)
-            assert rm_chunks.deleted_chunks > 0, "Expected to delete some chunk files during seq-cons, none deleted"
+            assert rm_chunks.deleted_chunks > 0, "Expected to delete some chunk files, none deleted"
 
             self._assert_not_in_cache(
                 fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')


### PR DESCRIPTION
Because chunk readers keep open the handle to a chunk file even if the file itself is deleted, during the test_read_chunks it is possible that the sequential consumer is entirely served by these open file handles while all chunk files in the directory have been removed. This results in the assertion that some chunks must have been removed during sequential consumer to fail.

As the count of chunks deleted is not important as an assertion and the purpose of deleting chunks randomly was to exercise failed materialization code path which should happen during the random consumer run, the assertion is changed to only test once for both seq and random consumers.

Another alternative would be a more fine grained check, eg assert if some chunks are removed only if some files are written to the cache during a consumer run, but such checks do not buy extra value.

FIXES #21376 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
