### PR TITLE
tests/controller_snapshot: fix no-op controller leadership transfers

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -583,6 +583,9 @@ class Admin:
                                                   backoff_s=backoff_s)
             if check(info.leader):
                 return True, info.leader
+
+            self.redpanda.logger.debug(
+                f"check failed (leader id: {info.leader})")
             return False
 
         return wait_until_result(

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -386,6 +386,13 @@ class ControllerSnapshotTest(RedpandaTest):
         for iter in range(5):
             self.redpanda.stop_node(joiner)
 
+            # wait for the joiner to step down in case it was the controller
+            joiner_id = self.redpanda.node_id(joiner)
+            admin.await_stable_leader(namespace='redpanda',
+                                      topic='controller',
+                                      check=lambda id: id != joiner_id,
+                                      timeout_s=30)
+
             executed = 0
             to_execute = random.randint(1, 5)
             while executed < to_execute:


### PR DESCRIPTION
Sometimes new controller leader won't be elected until a few seconds after a controller restart. This can confuse subsequent leadership transfers that will try to move controller leadership to the old controller and falsely think that it will be a no-op. Wait for the new leader after the joiner node is restarted to fix that.

Fixes https://github.com/redpanda-data/redpanda/issues/20572

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
