### PR TITLE
c/st: self_test_result rpc: move {start,end}_time to end of layout

### DIFF
--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -241,7 +241,7 @@ struct cloudcheck_opts
 
 struct self_test_result
   : serde::
-      envelope<self_test_result, serde::version<1>, serde::compat_version<1>> {
+      envelope<self_test_result, serde::version<1>, serde::compat_version<0>> {
     double p50{0};
     double p90{0};
     double p99{0};
@@ -288,6 +288,27 @@ struct self_test_result
           r.warning ? *r.warning : "<no_value>",
           r.error ? *r.error : "<no_value>");
         return o;
+    }
+
+    auto serde_fields() {
+        return std::tie(
+          p50,
+          p90,
+          p99,
+          p999,
+          max,
+          rps,
+          bps,
+          timeouts,
+          test_id,
+          name,
+          info,
+          test_type,
+          duration,
+          warning,
+          error,
+          start_time,
+          end_time);
     }
 };
 


### PR DESCRIPTION
Effectively turning the original change into an append and obviating the need for a compat version bump.

It's not immediately clear why the struct was laid out this way in the first place. A reasonable guess is some balance of:

- The original ordering makes good sense for the aggregate in-memory
- It's an rpc format and not intended for on-disk persistence

Still, the compat version change means that if a self test goes off during an upgrade across the compat boundary, that rpc will fail. Adjusting the layout via envelope::serde_fields means that we can maintain the nice field order semantics in the aggregate while ensuring that the diff looks like a field append from serde's view.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
