### PR TITLE
rpk: make mechanism flag required in user update

### DIFF
--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -45,8 +45,9 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&newPass, "new-password", "", "New user's password.")
-	cmd.Flags().StringVar(&mechanism, "mechanism", adminapi.ScramSha256, "SASL mechanism to use for the user you are creating (scram-sha-256, scram-sha-512, case insensitive)")
+	cmd.Flags().StringVar(&mechanism, "mechanism", adminapi.ScramSha256, "SASL mechanism to use for the user you are updating (scram-sha-256, scram-sha-512, case insensitive)")
 	cmd.MarkFlagRequired("new-password")
+	cmd.MarkFlagRequired("mechanism")
 
 	return cmd
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -517,10 +517,11 @@ class RpkTool:
 
         return self._run(cmd)
 
-    def sasl_update_user(self, user, new_password):
+    def sasl_update_user(self, user, new_password, new_mechanism):
         cmd = [
             "acl", "user", "update", user, "--new-password", new_password,
-            "-X", "admin.hosts=" + self._redpanda.admin_endpoints()
+            "--mechanism", new_mechanism, "-X",
+            "admin.hosts=" + self._redpanda.admin_endpoints()
         ]
         return self._run(cmd)
 

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -123,7 +123,8 @@ class RpkACLTest(RedpandaTest):
         # We check that we can list the topics:
         assert topic in topic_list
 
-        out = self._rpk.sasl_update_user(self.username, new_password)
+        out = self._rpk.sasl_update_user(self.username, new_password,
+                                         self.mechanism)
         assert f'Updated user "{self.username}" successfully' in out
 
         with expect_exception(


### PR DESCRIPTION
Without this, a user could inadvertently change the mechanism because we default the flag to
SCRAM-SHA-256.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [X] v23.3.x
- [X] v23.2.x

## Release Notes

### Improvements

* rpk: --mechanism flag is now required to update users when using `rpk security user update`.
