### PR TITLE
Handle Kafka ListGroupsRequest v4

### DIFF
--- a/src/v/kafka/protocol/schemata/list_groups_request.json
+++ b/src/v/kafka/protocol/schemata/list_groups_request.json
@@ -20,8 +20,13 @@
   // Version 1 and 2 are the same as version 0.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds the StatesFilter field (KIP-518).
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
+    { "name": "StatesFilter", "type": "[]string", "versions": "4+",
+      "about": "The states of the groups we want to list. If empty all groups are returned with their state."
+    }
   ]
 }

--- a/src/v/kafka/protocol/schemata/list_groups_response.json
+++ b/src/v/kafka/protocol/schemata/list_groups_response.json
@@ -22,7 +22,9 @@
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds the GroupState field (KIP-518).
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
@@ -34,7 +36,9 @@
       { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
         "about": "The group ID." },
       { "name": "ProtocolType", "type": "string", "versions": "0+",
-        "about": "The group protocol type." }
+        "about": "The group protocol type." },
+      { "name": "GroupState", "type": "string", "versions": "4+", "ignorable": true,
+        "about": "The group state name." }
     ]}
   ]
 }

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -107,10 +107,27 @@ using enable_group_metrics = ss::bool_class<struct enable_gr_metrics_tag>;
 std::ostream& operator<<(std::ostream&, group_state gs);
 
 ss::sstring group_state_to_kafka_name(group_state);
+group_state parse_group_state(const ss::sstring&);
 cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx::errc);
 cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx::errc);
 cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx::errc);
 kafka::error_code map_store_offset_error_code(std::error_code);
+/**
+ * Helper class allowing to express a set of group state and efficiently match
+ * state against the requested set.
+ */
+class group_state_filter {
+public:
+    bool matches(group_state) const;
+    static group_state_filter from_strings(const chunked_vector<ss::sstring>&);
+    group_state_filter() = default;
+
+private:
+    static constexpr size_t group_state_count = 5;
+
+    bool _is_empty = true;
+    std::bitset<group_state_count> _requested_states;
+};
 
 /// \brief A Kafka group.
 ///

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -171,7 +171,8 @@ public:
 
     // returns the set of registered groups, and an error if one occurred while
     // retrieving the group list (e.g. coordinator_load_in_progress).
-    std::pair<error_code, std::vector<listed_group>> list_groups() const;
+    std::pair<error_code, std::vector<listed_group>>
+    list_groups(const group_state_filter& = group_state_filter{}) const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);
 

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -294,10 +294,12 @@ group_router::abort_tx(cluster::abort_group_tx_request request) {
 }
 
 ss::future<std::pair<error_code, std::vector<listed_group>>>
-group_router::list_groups() {
+group_router::list_groups(group_state_filter state_filter) {
     using type = std::pair<error_code, std::vector<listed_group>>;
     return get_group_manager().map_reduce0(
-      [](group_manager& mgr) { return mgr.list_groups(); },
+      [state_filter](group_manager& mgr) {
+          return mgr.list_groups(state_filter);
+      },
       type{},
       [](type a, type b) {
           // reduce errors into `a` and retain the first

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -83,7 +83,8 @@ public:
     abort_tx(cluster::abort_group_tx_request request);
 
     // return groups from across all shards, and if any core was still loading
-    ss::future<std::pair<error_code, std::vector<listed_group>>> list_groups();
+    ss::future<std::pair<error_code, std::vector<listed_group>>>
+      list_groups(group_state_filter);
 
     ss::future<described_group> describe_group(kafka::group_id g);
 

--- a/src/v/kafka/server/handlers/list_groups.h
+++ b/src/v/kafka/server/handlers/list_groups.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using list_groups_handler = single_stage_handler<list_groups_api, 0, 3>;
+using list_groups_handler = single_stage_handler<list_groups_api, 0, 4>;
 
 }


### PR DESCRIPTION
Added support for Kafka list consumer groups request in version 4.

Version 4 of list group requests introduces a possibility to filter
consumer groups with state. Additionally reply listed group struct now
contains group state.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- support for ListGroupsRequests v4
