### PR TITLE
[v23.3.x] [CORE-5539] Pandaproxy: Avoid large allocations whilst serializing JSON

### DIFF
--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -19,6 +19,7 @@
 #include "net/unresolved_address.h"
 #include "security/acl.h"
 #include "utils/base64.h"
+#include "utils/json.h"
 
 #include <seastar/net/inet_address.hh>
 

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -517,7 +517,7 @@ inline void rjson_serialize(
           ss.rdstate()));
     }
     w.Key("address");
-    rjson_serialize<std::string_view>(w, ss.str());
+    rjson_serialize(w, std::string_view{ss.str()});
     w.EndObject();
 }
 

--- a/src/v/json/chunked_buffer.h
+++ b/src/v/json/chunked_buffer.h
@@ -1,0 +1,59 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/encodings.h"
+
+namespace json {
+
+namespace impl {
+
+/**
+ * \brief An in-memory output stream with non-contiguous memory allocation.
+ */
+template<typename Encoding>
+struct generic_chunked_buffer {
+    using Ch = Encoding::Ch;
+
+    /**
+     * \defgroup Implement rapidjson::Stream
+     */
+    /**@{*/
+
+    void Put(Ch c) { _impl.append(&c, sizeof(Ch)); }
+    void Flush() {}
+
+    //! Get the size of string in bytes in the string buffer.
+    size_t GetSize() const { return _impl.size_bytes(); }
+
+    //! Get the length of string in Ch in the string buffer.
+    size_t GetLength() const { return _impl.size_bytes() / sizeof(Ch); }
+
+    void Reserve(size_t s) { _impl.reserve(s); }
+
+    void Clear() { _impl.clear(); }
+
+    /**@}*/
+
+    iobuf as_iobuf() && { return std::move(_impl); }
+
+private:
+    iobuf _impl;
+};
+
+} // namespace impl
+
+template<typename Encoding>
+using generic_chunked_buffer = impl::generic_chunked_buffer<Encoding>;
+
+using chunked_buffer = generic_chunked_buffer<UTF8<>>;
+
+} // namespace json

--- a/src/v/json/chunked_input_stream.h
+++ b/src/v/json/chunked_input_stream.h
@@ -1,0 +1,64 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/streambuf.h"
+#include "json/encodings.h"
+#include "json/istreamwrapper.h"
+
+namespace json {
+
+namespace impl {
+
+/**
+ * \brief An in-memory input stream with non-contiguous memory allocation.
+ */
+template<typename Encoding = ::json::UTF8<>>
+class chunked_input_stream {
+public:
+    using Ch = Encoding::Ch;
+
+    explicit chunked_input_stream(iobuf&& buf)
+      : _buf(std::move(buf))
+      , _is(_buf)
+      , _sis{&_is}
+      , _isw(_sis) {}
+
+    /**
+     * \defgroup Implement rapidjson::Stream
+     */
+    /**@{*/
+
+    Ch Peek() const { return _isw.Peek(); }
+    Ch Peek4() const { return _isw.Peek4(); }
+    Ch Take() { return _isw.Take(); }
+    size_t Tell() const { return _isw.Tell(); }
+    void Put(Ch ch) { return _isw.Put(ch); }
+    Ch* PutBegin() { return _isw.PutBegin(); }
+    size_t PutEnd(Ch* ch) { return _isw.PutEnd(ch); }
+    void Flush() { return _isw.Flush(); }
+
+    /**@}*/
+
+private:
+    iobuf _buf;
+    iobuf_istreambuf _is;
+    std::istream _sis;
+    ::json::IStreamWrapper _isw;
+};
+
+} // namespace impl
+
+template<typename Encoding>
+using generic_chunked_input_stream = impl::chunked_input_stream<Encoding>;
+
+using chunked_input_stream = generic_chunked_input_stream<UTF8<>>;
+
+} // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -9,6 +9,7 @@
 
 #include "json/json.h"
 
+#include "json/chunked_buffer.h"
 #include "json/stringbuffer.h"
 
 namespace json {
@@ -174,5 +175,44 @@ template void rjson_serialize<json::StringBuffer>(
 
 template void rjson_serialize<json::StringBuffer>(
   json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, short v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, bool v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, long long v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, int v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, unsigned int v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, long v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, unsigned long v);
+
+template void
+rjson_serialize<chunked_buffer>(json::Writer<chunked_buffer>& w, double v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, std::string_view s);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const net::unresolved_address& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::chrono::milliseconds& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::chrono::seconds& v);
+
+template void rjson_serialize<chunked_buffer>(
+  json::Writer<chunked_buffer>& w, const std::filesystem::path& path);
 
 } // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -98,4 +98,22 @@ void rjson_serialize(
     rjson_serialize(w, std::string_view{path.native()});
 }
 
+ss::sstring minify(std::string_view json) {
+    json::Reader r;
+    json::StringStream in(json.data());
+    json::StringBuffer out;
+    json::Writer<json::StringBuffer> w{out};
+    r.Parse(in, w);
+    return ss::sstring(out.GetString(), out.GetSize());
+}
+
+ss::sstring prettify(std::string_view json) {
+    json::Reader r;
+    json::StringStream in(json.data());
+    json::StringBuffer out;
+    json::PrettyWriter<json::StringBuffer> w{out};
+    r.Parse(in, w);
+    return ss::sstring(out.GetString(), out.GetSize());
+}
+
 } // namespace json

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -9,40 +9,57 @@
 
 #include "json/json.h"
 
+#include "json/stringbuffer.h"
+
 namespace json {
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, short v) { w.Int(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, short v) {
+    w.Int(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v) { w.Bool(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, bool v) {
+    w.Bool(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, int v) { w.Int(v); }
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, int v) {
+    w.Int(v);
+}
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned int v) {
     w.Uint(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long v) {
     w.Int64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned long v) {
     w.Uint64(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, double v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, double v) {
     w.Double(v);
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, std::string_view v) {
     w.String(v.data(), v.size());
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::socket_address& v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const ss::socket_address& v) {
     w.StartObject();
 
     std::ostringstream a;
@@ -68,8 +85,9 @@ void rjson_serialize(
     w.EndObject();
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v) {
+  json::Writer<Buffer>& w, const net::unresolved_address& v) {
     w.StartObject();
 
     w.Key("address");
@@ -81,20 +99,22 @@ void rjson_serialize(
     w.EndObject();
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v) {
+  json::Writer<Buffer>& w, const std::chrono::milliseconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const std::chrono::seconds& v) {
     uint64_t _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path) {
+  json::Writer<Buffer>& w, const std::filesystem::path& path) {
     rjson_serialize(w, std::string_view{path.native()});
 }
 
@@ -115,5 +135,44 @@ ss::sstring prettify(std::string_view json) {
     r.Parse(in, w);
     return ss::sstring(out.GetString(), out.GetSize());
 }
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, short v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, bool v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, long long v);
+
+template void
+rjson_serialize<json::StringBuffer>(json::Writer<json::StringBuffer>& w, int v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, unsigned int v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, long v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, unsigned long v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, double v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, std::string_view s);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v);
+
+template void rjson_serialize<json::StringBuffer>(
+  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
 
 } // namespace json

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -95,17 +95,6 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, size_t max_fragment_size>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const fragmented_vector<T, max_fragment_size>& v) {
-    w.StartArray();
-    for (const auto& e : v) {
-        rjson_serialize(w, e);
-    }
-    w.EndArray();
-}
-
 template<typename T, size_t chunk_size = 128>
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -21,9 +21,7 @@
 #include "utils/fragmented_vector.h"
 #include "utils/named_type.h"
 
-#include <seastar/net/inet_address.hh>
-#include <seastar/net/ip.hh>
-#include <seastar/net/socket_defs.hh>
+#include <seastar/core/circular_buffer.hh>
 
 #include <chrono>
 #include <type_traits>
@@ -48,9 +46,6 @@ void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v);
 void rjson_serialize(json::Writer<json::StringBuffer>& w, double v);
 
 void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view s);
-
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::socket_address& v);
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -90,7 +90,7 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, size_t chunk_size = 128>
+template<typename T, size_t chunk_size>
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const ss::chunked_fifo<T, chunk_size>& v) {

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -122,22 +122,8 @@ void rjson_serialize(
     w.EndArray();
 }
 
-inline ss::sstring minify(std::string_view json) {
-    json::Reader r;
-    json::StringStream in(json.data());
-    json::StringBuffer out;
-    json::Writer<json::StringBuffer> w{out};
-    r.Parse(in, w);
-    return ss::sstring(out.GetString(), out.GetSize());
-}
+ss::sstring minify(std::string_view json);
 
-inline ss::sstring prettify(std::string_view json) {
-    json::Reader r;
-    json::StringStream in(json.data());
-    json::StringBuffer out;
-    json::PrettyWriter<json::StringBuffer> w{out};
-    r.Parse(in, w);
-    return ss::sstring(out.GetString(), out.GetSize());
-}
+ss::sstring prettify(std::string_view json);
 
 } // namespace json

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -29,50 +29,62 @@
 
 namespace json {
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, short v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, short v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, bool v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, bool v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, int v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, int v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned int v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned int v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, unsigned long v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, unsigned long v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, double v);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, double v);
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, std::string_view s);
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, std::string_view s);
 
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const net::unresolved_address& v);
+
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const net::unresolved_address& v);
+  json::Writer<Buffer>& w, const std::chrono::milliseconds& v);
 
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const std::chrono::seconds& v);
+
+template<typename Buffer>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v);
+  json::Writer<Buffer>& w, const std::filesystem::path& path);
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v);
-
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::filesystem::path& path);
-
-template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
-void rjson_serialize(json::Writer<json::StringBuffer>& w, T v) {
+template<
+  typename Buffer,
+  typename T,
+  typename = std::enable_if_t<std::is_enum_v<T>>>
+void rjson_serialize(json::Writer<Buffer>& w, T v) {
     rjson_serialize(w, static_cast<std::underlying_type_t<T>>(v));
 }
 
-template<typename T, typename Tag>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const named_type<T, Tag>& v) {
+template<typename Buffer, typename T, typename Tag>
+void rjson_serialize(json::Writer<Buffer>& w, const named_type<T, Tag>& v) {
     rjson_serialize(w, v());
 }
 
-template<typename T>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::optional<T>& v) {
+template<typename Buffer, typename T>
+void rjson_serialize(json::Writer<Buffer>& w, const std::optional<T>& v) {
     if (v) {
         rjson_serialize(w, *v);
         return;
@@ -80,9 +92,8 @@ void rjson_serialize(
     w.Null();
 }
 
-template<typename T, typename A>
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const std::vector<T, A>& v) {
+template<typename Buffer, typename T, typename A>
+void rjson_serialize(json::Writer<Buffer>& w, const std::vector<T, A>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);
@@ -90,10 +101,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, size_t chunk_size>
+template<typename Buffer, typename T, size_t chunk_size>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const ss::chunked_fifo<T, chunk_size>& v) {
+  json::Writer<Buffer>& w, const ss::chunked_fifo<T, chunk_size>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);
@@ -101,9 +111,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T>
+template<typename Buffer, typename T>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
+  json::Writer<Buffer>& w,
   const std::unordered_map<typename T::key_type, T>& v) {
     w.StartArray();
     for (const auto& e : v) {
@@ -112,9 +122,9 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T, typename A>
+template<typename Buffer, typename T, typename A>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::circular_buffer<T, A>& v) {
+  json::Writer<Buffer>& w, const ss::circular_buffer<T, A>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -41,8 +41,8 @@ struct personne_t {
 
 } // namespace
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const personne_t::nested& obj) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const personne_t::nested& obj) {
     w.StartObject();
 
     w.Key("x");
@@ -57,11 +57,12 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(json::Writer<json::StringBuffer>& w, const personne_t& p) {
+template<typename Buffer>
+void rjson_serialize(json::Writer<Buffer>& w, const personne_t& p) {
     w.StartObject();
 
     w.Key("full_name");
-    json::rjson_serialize<std::string_view>(w, p.full_name);
+    json::rjson_serialize(w, std::string_view{p.full_name});
 
     w.Key("nic");
     json::rjson_serialize(w, p.nic);

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -15,9 +15,8 @@
 #include "bytes/iobuf_parser.h"
 #include "json/reader.h"
 #include "json/stream.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
-#include "pandaproxy/json/types.h"
+#include "pandaproxy/json/rjson_util.h"
 #include "utils/base64.h"
 
 #include <seastar/core/loop.hh>

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -65,7 +65,8 @@ public:
     explicit rjson_serialize_impl(serialization_format fmt)
       : _fmt(fmt) {}
 
-    bool operator()(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, iobuf buf) {
         switch (_fmt) {
         case serialization_format::none:
             [[fallthrough]];
@@ -80,7 +81,8 @@ public:
         }
     }
 
-    bool encode_base64(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool encode_base64(::json::Writer<Buffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }
@@ -88,7 +90,8 @@ public:
         return w.String(iobuf_to_base64(buf));
     };
 
-    bool encode_json(::json::Writer<::json::StringBuffer>& w, iobuf buf) {
+    template<typename Buffer>
+    bool encode_json(::json::Writer<Buffer>& w, iobuf buf) {
         if (buf.empty()) {
             return w.Null();
         }

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -21,8 +21,9 @@ struct get_brokers_res {
     std::vector<model::node_id> ids;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const get_brokers_res& brokers) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_brokers_res& brokers) {
     w.StartObject();
     w.Key("brokers");
     ::json::rjson_serialize(w, brokers.ids);

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include "json/stringbuffer.h"
+#include "json/json.h"
 #include "json/writer.h"
-#include "model/metadata.h"
+#include "model/fundamental.h"
 
 namespace pandaproxy::json {
 

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -11,14 +11,9 @@
 
 #pragma once
 
-#include "bytes/iobuf.h"
-#include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
-#include "kafka/protocol/errors.h"
-#include "kafka/protocol/produce.h"
-#include "kafka/types.h"
-#include "pandaproxy/json/iobuf.h"
+#include "kafka/protocol/join_group.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "seastarx.h"
 #include "utils/string_switch.h"

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -107,9 +107,9 @@ struct create_consumer_response {
     ss::sstring base_uri;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const create_consumer_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const create_consumer_response& res) {
     w.StartObject();
     w.Key("instance_id");
     w.String(res.instance_id());

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -26,8 +26,8 @@ struct error_body {
     ss::sstring message;
 };
 
-inline void
-rjson_serialize(::json::Writer<::json::StringBuffer>& w, const error_body& v) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const error_body& v) {
     w.StartObject();
     w.Key("error_code");
     ::json::rjson_serialize(w, v.ec.value());

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "json/json.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "seastarx.h"
 

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -43,8 +43,8 @@ public:
       , _tpv(tpv)
       , _base_offset(base_offset) {}
 
-    bool
-    operator()(::json::Writer<::json::StringBuffer>& w, model::record record) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, model::record record) {
         auto offset = _base_offset() + record.offset_delta();
 
         w.StartObject();
@@ -97,8 +97,8 @@ public:
     explicit rjson_serialize_impl(serialization_format fmt)
       : _fmt(fmt) {}
 
-    bool operator()(
-      ::json::Writer<::json::StringBuffer>& w, kafka::fetch_response&& res) {
+    template<typename Buffer>
+    bool operator()(::json::Writer<Buffer>& w, kafka::fetch_response&& res) {
         // Eager check for errors
         for (auto& v : res) {
             if (v.partition_response->error_code != kafka::error_code::none) {

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -11,18 +11,13 @@
 
 #pragma once
 
-#include "bytes/iobuf.h"
-#include "bytes/iobuf_parser.h"
-#include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "model/fundamental.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -40,9 +40,9 @@ partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
     return res;
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::offset_fetch_response_topic& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::offset_fetch_response_topic& v) {
     for (const auto& p : v.partitions) {
         w.StartObject();
         w.Key("topic");
@@ -57,9 +57,9 @@ inline void rjson_serialize(
     }
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::offset_fetch_response& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::offset_fetch_response& v) {
     w.StartObject();
     w.Key("offsets");
     w.StartArray();

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -11,9 +11,7 @@
 
 #pragma once
 
-#include "json/stringbuffer.h"
 #include "json/writer.h"
-#include "kafka/protocol/errors.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "seastarx.h"
 
@@ -39,6 +37,9 @@ partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
     }
     return res;
 }
+} // namespace pandaproxy::json
+
+namespace kafka {
 
 template<typename Buffer>
 void rjson_serialize(
@@ -70,4 +71,4 @@ void rjson_serialize(
     w.EndObject();
 }
 
-} // namespace pandaproxy::json
+} // namespace kafka

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "bytes/iobuf.h"
-#include "json/json.h"
 #include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
@@ -20,7 +19,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/types.h"
+#include "pandaproxy/json/rjson_util.h"
 #include "seastarx.h"
 #include "tristate.h"
 
@@ -265,6 +264,9 @@ private:
     std::optional<json_writer> _json_writer;
 };
 
+} // namespace pandaproxy::json
+
+namespace kafka {
 template<typename Buffer>
 void rjson_serialize(
   ::json::Writer<Buffer>& w, const kafka::produce_response::partition& v) {
@@ -273,7 +275,7 @@ void rjson_serialize(
     w.Int(v.partition_index);
     if (v.error_code != kafka::error_code::none) {
         w.Key("error_code");
-        ::json::rjson_serialize(w, v.error_code);
+        rjson_serialize(w, v.error_code);
     }
     w.Key("offset");
     w.Int64(v.base_offset);
@@ -293,4 +295,4 @@ void rjson_serialize(
     w.EndObject();
 }
 
-} // namespace pandaproxy::json
+} // namespace kafka

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -265,9 +265,9 @@ private:
     std::optional<json_writer> _json_writer;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::produce_response::partition& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::produce_response::partition& v) {
     w.StartObject();
     w.Key("partition");
     w.Int(v.partition_index);
@@ -280,9 +280,9 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const kafka::produce_response::topic& v) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const kafka::produce_response::topic& v) {
     w.StartObject();
     w.Key("offsets");
     w.StartArray();

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -12,14 +12,14 @@
 #pragma once
 
 #include "bytes/iobuf.h"
-#include "json/stringbuffer.h"
+#include "json/chunked_buffer.h"
 #include "json/types.h"
 #include "json/writer.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/produce.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/json/types.h"
 #include "seastarx.h"
 #include "tristate.h"
 
@@ -42,7 +42,7 @@ private:
     serialization_format _fmt = serialization_format::none;
     state state = state::empty;
 
-    using json_writer = ::json::Writer<::json::StringBuffer>;
+    using json_writer = ::json::Writer<::json::chunked_buffer>;
 
     // If we're parsing json_v2, and the field is key or value (implied by
     // _json_writer being set), then forward calls to json_writer.
@@ -55,8 +55,7 @@ private:
         auto res = std::invoke(
           mem_func, *_json_writer, std::forward<Args>(args)...);
         if (_json_writer->IsComplete()) {
-            iobuf buf;
-            buf.append(_buf.GetString(), _buf.GetSize());
+            iobuf buf = std::move(_buf).as_iobuf();
             switch (state) {
             case state::key:
                 result.back().key.emplace(std::move(buf));
@@ -260,7 +259,7 @@ public:
     }
 
 private:
-    ::json::StringBuffer _buf;
+    ::json::chunked_buffer _buf;
     std::optional<json_writer> _json_writer;
 };
 

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -13,12 +13,9 @@
 #include "json/writer.h"
 #include "kafka/client/test/utils.h"
 #include "kafka/protocol/errors.h"
-#include "kafka/protocol/fetch.h"
 #include "kafka/protocol/wire.h"
 #include "model/fundamental.h"
-#include "model/record.h"
 #include "model/timestamp.h"
-#include "pandaproxy/json/requests/fetch.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"
@@ -28,8 +25,6 @@
 
 #include <boost/test/tools/interface.hpp>
 #include <boost/test/tools/old/interface.hpp>
-
-#include <type_traits>
 
 namespace ppj = pandaproxy::json;
 

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -278,7 +278,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_response) {
       .log_append_time_ms = model::timestamp{},
       .log_start_offset = model::offset{}});
 
-    auto output = ppj::rjson_serialize(topic);
+    auto output = ppj::rjson_serialize_str(topic);
 
     BOOST_TEST(output == expected);
 }

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -46,7 +46,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_binary_request) {
         ]
       })";
 
-    auto records = ppj::rjson_parse(input, make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_binary_v2_handler());
     BOOST_TEST(records.size() == 2);
     BOOST_TEST(!!records[0].value);
 
@@ -77,7 +77,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_json_request) {
         ]
       })";
 
-    auto records = ppj::rjson_parse(input, make_json_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_json_v2_handler());
     BOOST_REQUIRE_EQUAL(records.size(), 2);
     BOOST_REQUIRE_EQUAL(records[0].partition_id, model::partition_id(0));
     BOOST_REQUIRE(!records[0].key);
@@ -111,7 +111,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_invalid_json_request) {
       })";
 
     BOOST_CHECK_THROW(
-      ppj::rjson_parse(input, make_json_v2_handler()),
+      ppj::impl::rjson_parse(input, make_json_v2_handler()),
       pandaproxy::json::parse_error);
 }
 
@@ -121,7 +121,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_empty) {
         "records": []
       })";
 
-    auto records = ppj::rjson_parse(input, make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(input, make_binary_v2_handler());
     BOOST_TEST(records.size() == 0);
 }
 
@@ -137,7 +137,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_records_name) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 25");
@@ -156,7 +156,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_name) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 99");
@@ -175,7 +175,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_type) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 112");
@@ -195,7 +195,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_before_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 28");
@@ -215,7 +215,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_after_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 152");
@@ -235,7 +235,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_between_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 144");
@@ -250,7 +250,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_no_records) {
       })";
 
     BOOST_CHECK_EXCEPTION(
-      ppj::rjson_parse(input, make_binary_v2_handler()),
+      ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
       [](ppj::parse_error const& e) {
           return e.what() == std::string_view("parse error at offset 24");

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iostream.h"
 #include "json/chunked_buffer.h"
+#include "json/chunked_input_stream.h"
 #include "json/json.h"
 #include "json/reader.h"
 #include "json/stream.h"
@@ -21,7 +22,12 @@
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/http/request.hh>
+
+#include <concepts>
 
 namespace pandaproxy::json {
 
@@ -94,18 +100,68 @@ inline rjson_serialize_fmt_impl rjson_serialize_fmt(serialization_format fmt) {
     return rjson_serialize_fmt_impl{fmt};
 }
 
+namespace impl {
+
 template<typename Handler>
-requires std::is_same_v<
-  decltype(std::declval<Handler>().result),
-  typename Handler::rjson_parse_result>
+concept RjsonParseHandler = requires {
+    std::same_as<
+      decltype(std::declval<Handler>().result),
+      typename Handler::rjson_parse_result>;
+};
+
+template<typename IStream, typename Arg, impl::RjsonParseHandler Handler>
 typename Handler::rjson_parse_result
-rjson_parse(const char* const s, Handler&& handler) {
+rjson_parse_buf(Arg&& arg, Handler&& handler) {
     ::json::Reader reader;
-    ::json::StringStream ss(s);
+    IStream ss(std::forward<Arg>(arg));
     if (!reader.Parse(ss, handler)) {
         throw parse_error(reader.GetErrorOffset());
     }
-    return std::move(handler.result);
+    return std::forward<Handler>(handler).result;
+}
+
+} // namespace impl
+
+/// \brief Parse a payload using the handler.
+///
+/// \warning rjson_parse is preferred, since it can be chunked.
+template<impl::RjsonParseHandler Handler>
+typename Handler::rjson_parse_result
+rjson_parse(const char* const s, Handler&& handler) {
+    return impl::rjson_parse_buf<::json::StringStream>(
+      s, std::forward<Handler>(handler));
+}
+
+///\brief Parse a payload using the handler.
+template<impl::RjsonParseHandler Handler>
+typename Handler::rjson_parse_result rjson_parse(iobuf buf, Handler&& handler) {
+    return impl::rjson_parse_buf<::json::chunked_input_stream>(
+      std::move(buf), std::forward<Handler>(handler));
+}
+
+///\brief Parse a request body using the handler.
+template<impl::RjsonParseHandler Handler>
+typename ss::future<typename Handler::rjson_parse_result>
+rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
+    if (!req->content.empty()) {
+        co_return rjson_parse(req->content.data(), std::move(handler));
+    }
+
+    iobuf buf;
+    auto is = req->content_stream;
+    co_await ss::repeat([&buf, &is]() {
+        return is->read().then([&buf](ss::temporary_buffer<char> tmp_buf) {
+            if (tmp_buf.empty()) {
+                return ss::make_ready_future<ss::stop_iteration>(
+                  ss::stop_iteration::yes);
+            }
+            buf.append(std::move(tmp_buf));
+            return ss::make_ready_future<ss::stop_iteration>(
+              ss::stop_iteration::no);
+        });
+    });
+
+    co_return rjson_parse(std::move(buf), std::move(handler));
 }
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -120,8 +120,6 @@ rjson_parse_buf(Arg&& arg, Handler&& handler) {
     return std::forward<Handler>(handler).result;
 }
 
-} // namespace impl
-
 /// \brief Parse a payload using the handler.
 ///
 /// \warning rjson_parse is preferred, since it can be chunked.
@@ -131,6 +129,8 @@ rjson_parse(const char* const s, Handler&& handler) {
     return impl::rjson_parse_buf<::json::StringStream>(
       s, std::forward<Handler>(handler));
 }
+
+} // namespace impl
 
 ///\brief Parse a payload using the handler.
 template<impl::RjsonParseHandler Handler>
@@ -144,7 +144,7 @@ template<impl::RjsonParseHandler Handler>
 typename ss::future<typename Handler::rjson_parse_result>
 rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
     if (!req->content.empty()) {
-        co_return rjson_parse(req->content.data(), std::move(handler));
+        co_return impl::rjson_parse(req->content.data(), std::move(handler));
     }
 
     iobuf buf;

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -48,8 +48,8 @@ struct rjson_serialize_fmt_impl {
         return rjson_serialize_impl<std::remove_reference_t<T>>{fmt}(
           std::forward<T>(t));
     }
-    template<typename T>
-    bool operator()(::json::Writer<::json::StringBuffer>& w, T&& t) {
+    template<typename Buffer, typename T>
+    bool operator()(::json::Writer<Buffer>& w, T&& t) {
         return rjson_serialize_impl<std::remove_reference_t<T>>{fmt}(
           w, std::forward<T>(t));
     }

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "json/json.h"
-#include "json/prettywriter.h"
 #include "json/reader.h"
 #include "json/stream.h"
 #include "json/stringbuffer.h"
@@ -22,9 +21,13 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <stdexcept>
-
 namespace pandaproxy::json {
+
+template<typename T>
+class rjson_parse_impl;
+
+template<typename T>
+class rjson_serialize_impl;
 
 template<typename T>
 ss::sstring rjson_serialize(const T& v) {

--- a/src/v/pandaproxy/json/test/parse.cc
+++ b/src/v/pandaproxy/json/test/parse.cc
@@ -43,7 +43,8 @@ inline void parse_test(size_t data_size) {
     auto input = gen(data_size);
 
     perf_tests::start_measuring_time();
-    auto records = ppj::rjson_parse(input.c_str(), make_binary_v2_handler());
+    auto records = ppj::impl::rjson_parse(
+      input.c_str(), make_binary_v2_handler());
     perf_tests::stop_measuring_time();
 }
 

--- a/src/v/pandaproxy/json/types.h
+++ b/src/v/pandaproxy/json/types.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 
 namespace pandaproxy::json {
 
@@ -51,11 +51,5 @@ inline std::string_view name(serialization_format fmt) {
     }
     return "(unknown format)";
 }
-
-template<typename T>
-class rjson_parse_impl;
-
-template<typename T>
-class rjson_serialize_impl;
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -71,8 +71,7 @@ errored_body(std::error_condition ec, ss::sstring msg) {
     pandaproxy::json::error_body body{.ec = ec, .message = std::move(msg)};
     auto rep = std::make_unique<ss::http::reply>();
     rep->set_status(error_code_to_status(ec));
-    auto b = json::rjson_serialize(body);
-    rep->write_body("json", b);
+    rep->write_body("json", json::rjson_serialize(body));
     return rep;
 }
 

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -92,8 +92,7 @@ get_brokers(server::request_t rq, server::reply_t rp) {
                 return b.node_id;
             });
 
-          auto json_rslt = ppj::rjson_serialize(brokers);
-          rp.rep->write_body("json", json_rslt);
+          rp.rep->write_body("json", ppj::rjson_serialize(brokers));
 
           rp.mime_type = res_fmt;
           return std::move(rp);
@@ -123,8 +122,7 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
               }
           }
 
-          auto json_rslt = ppj::rjson_serialize(names);
-          rp.rep->write_body("json", json_rslt);
+          rp.rep->write_body("json", ppj::rjson_serialize(names));
           rp.mime_type = res_fmt;
           return std::move(rp);
       });
@@ -200,8 +198,8 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
           return client.produce_records(topic, std::move(records))
             .then([rp{std::move(rp)},
                    res_fmt](kafka::produce_response res) mutable {
-                auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
-                rp.rep->write_body("json", json_rslt);
+                rp.rep->write_body(
+                  "json", ppj::rjson_serialize(res.data.responses[0]));
                 rp.mime_type = res_fmt;
                 return std::move(rp);
             });
@@ -292,8 +290,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
                             kafka::member_id name) mutable {
                         json::create_consumer_response res{
                           .instance_id = name, .base_uri = base_uri + name};
-                        auto json_rslt = ppj::rjson_serialize(res);
-                        rp.rep->write_body("json", json_rslt);
+                        rp.rep->write_body("json", ppj::rjson_serialize(res));
                         rp.mime_type = res_fmt;
                         return std::move(rp);
                     });
@@ -458,11 +455,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
           return client
             .consumer_offset_fetch(group_id, member_id, std::move(req_data))
             .then([rp{std::move(rp)}, res_fmt](auto res) mutable {
-                ::json::StringBuffer str_buf;
-                ::json::Writer<::json::StringBuffer> w(str_buf);
-                ppj::rjson_serialize(w, res);
-                ss::sstring json_rslt = str_buf.GetString();
-                rp.rep->write_body("json", json_rslt);
+                rp.rep->write_body("json", ppj::rjson_serialize(res));
                 rp.mime_type = res_fmt;
                 return std::move(rp);
             });

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -470,7 +470,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
 
     // If the request is empty, commit all offsets
-    auto req_data = rq.req->content.length() == 0
+    auto req_data = rq.req->content_length == 0
                       ? std::vector<kafka::offset_commit_request_topic>()
                       : ppj::partition_offsets_request_to_offset_commit_request(
                         co_await ppj::rjson_parse(

--- a/src/v/pandaproxy/rest/test/consumer_group.cc
+++ b/src/v/pandaproxy/rest/test/consumer_group.cc
@@ -84,7 +84,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
-        auto res_data = ppj::rjson_parse(
+        auto res_data = ppj::impl::rjson_parse(
           res.body.data(), ppj::create_consumer_response_handler());
         BOOST_REQUIRE_EQUAL(res_data.instance_id, "test_consumer");
         member_id = res_data.instance_id;
@@ -315,7 +315,7 @@ FIXTURE_TEST(
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
-        auto res_data = ppj::rjson_parse(
+        auto res_data = ppj::impl::rjson_parse(
           res.body.data(), ppj::create_consumer_response_handler());
         BOOST_REQUIRE_EQUAL(res_data.instance_id, "test_consumer");
         member_id = res_data.instance_id;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -88,8 +88,8 @@ get_config(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_compatibility();
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
     co_return rp;
 }
 
@@ -103,8 +103,7 @@ put_config(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_config(std::nullopt, config.compat);
 
-    auto json_rslt = ppj::rjson_serialize(config);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(config));
     co_return rp;
 }
 
@@ -123,8 +122,8 @@ get_config_subject(server::request_t rq, server::reply_t rp) {
     auto res = co_await rq.service().schema_store().get_compatibility(
       sub, fallback);
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
     co_return rp;
 }
 
@@ -172,8 +171,7 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_config(sub, config.compat);
 
-    auto json_rslt = ppj::rjson_serialize(config);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(config));
     co_return rp;
 }
 
@@ -202,8 +200,8 @@ delete_config_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_config(sub);
 
-    auto json_rslt = ppj::rjson_serialize(get_config_req_rep{.compat = lvl});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json", ppj::rjson_serialize(get_config_req_rep{.compat = lvl}));
     co_return rp;
 }
 
@@ -216,8 +214,7 @@ ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_mode();
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
     co_return rp;
 }
 
@@ -231,8 +228,7 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
-    auto json_rslt = ppj::rjson_serialize(res);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(res));
     co_return rp;
 }
 
@@ -250,8 +246,7 @@ get_mode_subject(server::request_t rq, server::reply_t rp) {
 
     auto res = co_await rq.service().schema_store().get_mode(sub, fallback);
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = res});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
     co_return rp;
 }
 
@@ -269,8 +264,7 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_mode(sub, res.mode, frc);
 
-    auto json_rslt = ppj::rjson_serialize(res);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(res));
     co_return rp;
 }
 
@@ -298,8 +292,7 @@ delete_mode_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_mode(sub);
 
-    auto json_rslt = ppj::rjson_serialize(mode_req_rep{.mode = m});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = m}));
     co_return rp;
 }
 
@@ -310,8 +303,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 
     static const std::vector<std::string_view> schemas_types{
       "PROTOBUF", "AVRO"};
-    auto json_rslt = ppj::rjson_serialize(schemas_types);
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(schemas_types));
     return ss::make_ready_future<server::reply_t>(std::move(rp));
 }
 
@@ -325,9 +317,10 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
         return rq.service().schema_store().get_schema_definition(id);
     });
 
-    auto json_rslt = ppj::rjson_serialize(
-      get_schemas_ids_id_response{.definition{std::move(def)}});
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(
+        get_schemas_ids_id_response{.definition{std::move(def)}}));
     co_return rp;
 }
 
@@ -457,8 +450,7 @@ get_subject_versions(server::request_t rq, server::reply_t rp) {
     auto versions = co_await rq.service().schema_store().get_versions(
       sub, inc_del);
 
-    auto json_rslt{json::rjson_serialize(versions)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(versions));
     co_return rp;
 }
 
@@ -497,11 +489,12 @@ post_subject(server::request_t rq, server::reply_t rp) {
     auto sub_schema = co_await rq.service().schema_store().has_schema(
       schema, inc_del);
 
-    auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
-      .schema{std::move(sub_schema.schema)},
-      .id{sub_schema.id},
-      .version{sub_schema.version}})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_version_response{
+        .schema{std::move(sub_schema.schema)},
+        .id{sub_schema.id},
+        .version{sub_schema.version}}));
     co_return rp;
 }
 
@@ -537,9 +530,9 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
           std::move(schema));
     }
 
-    auto json_rslt{
-      json::rjson_serialize(post_subject_versions_response{.id{schema_id}})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_response{.id{schema_id}}));
     co_return rp;
 }
 
@@ -562,11 +555,12 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
           sub, version, inc_del);
     });
 
-    auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
-      .schema = std::move(get_res.schema),
-      .id = get_res.id,
-      .version = get_res.version})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_subject_versions_version_response{
+        .schema = std::move(get_res.schema),
+        .id = get_res.id,
+        .version = get_res.version}));
     co_return rp;
 }
 
@@ -606,8 +600,7 @@ get_subject_versions_version_referenced_by(
     auto references = co_await rq.service().schema_store().referenced_by(
       sub, version);
 
-    auto json_rslt{json::rjson_serialize(references)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(references));
     co_return rp;
 }
 
@@ -630,8 +623,7 @@ delete_subject(server::request_t rq, server::reply_t rp) {
             sub, std::nullopt)
           : co_await rq.service().writer().delete_subject_impermanent(sub);
 
-    auto json_rslt{json::rjson_serialize(versions)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(versions));
     co_return rp;
 }
 
@@ -678,8 +670,7 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
         co_await rq.service().writer().delete_subject_version(sub, version);
     }
 
-    auto json_rslt{json::rjson_serialize(version)};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body("json", ppj::rjson_serialize(version));
     co_return rp;
 }
 
@@ -719,9 +710,9 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
         return rq.service().schema_store().is_compatible(version, schema);
     });
 
-    auto json_rslt{
-      json::rjson_serialize(post_compatibility_res{.is_compat = get_res})};
-    rp.rep->write_body("json", json_rslt);
+    rp.rep->write_body(
+      "json",
+      ppj::rjson_serialize(post_compatibility_res{.is_compat = get_res}));
     co_return rp;
 }
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -26,11 +26,10 @@
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/server.h"
 #include "storage/record_batch_builder.h"
-#include "utils/lw_shared_container.h"
+#include "utils/json.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 
 #include <exception>
@@ -324,41 +323,6 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     co_return rp;
 }
 
-struct schema_version_json : public ss::json::json_base {
-    ss::json::json_element<ss::sstring> subject;
-    ss::json::json_element<long> version;
-
-    void register_params() {
-        add(&subject, "subject");
-        add(&version, "version");
-    }
-
-    schema_version_json() { register_params(); }
-
-    schema_version_json(const schema_version_json& e) {
-        register_params();
-        subject = e.subject;
-        version = e.version;
-    }
-    template<class T>
-    schema_version_json& operator=(const T& e) {
-        subject = e.subject;
-        version = e.version;
-        return *this;
-    }
-    schema_version_json& operator=(const schema_version_json& e) {
-        subject = e.subject;
-        version = e.version;
-        return *this;
-    }
-    template<class T>
-    schema_version_json& update(T& e) {
-        e.subject = subject;
-        e.version = version;
-        return *this;
-    }
-};
-
 ss::future<server::reply_t>
 get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
@@ -376,14 +340,8 @@ get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
 
     rp.rep->write_body(
       "json",
-      ss::json::stream_range_as_array(
-        lw_shared_container(std::move(svs)), [](const subject_version& sv) {
-            schema_version_json j;
-            j.subject = sv.sub;
-            j.version = sv.version;
-            return j;
-        }));
-
+      ppj::rjson_serialize(get_schemas_ids_id_versions_response{
+        .subject_versions{std::move(svs)}}));
     co_return rp;
 }
 
@@ -402,13 +360,11 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
     // Force early 40403 if the schema id isn't found
     co_await rq.service().schema_store().get_schema_definition(id);
 
-    auto subjects = co_await rq.service().schema_store().get_schema_subjects(
-      id, incl_del);
     rp.rep->write_body(
       "json",
-      ss::json::stream_range_as_array(
-        lw_shared_container(std::move(subjects)),
-        [](const subject& subj) { return subj; }));
+      ppj::rjson_serialize(
+        co_await rq.service().schema_store().get_schema_subjects(
+          id, incl_del)));
     co_return rp;
 }
 
@@ -425,13 +381,10 @@ get_subjects(server::request_t rq, server::reply_t rp) {
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto subjects = co_await rq.service().schema_store().get_subjects(
-      inc_del, subject_prefix);
     rp.rep->write_body(
       "json",
-      ss::json::stream_range_as_array(
-        lw_shared_container(std::move(subjects)),
-        [](const subject& subj) { return subj; }));
+      json::rjson_serialize(co_await rq.service().schema_store().get_subjects(
+        inc_del, subject_prefix)));
     co_return rp;
 }
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -96,9 +96,8 @@ ss::future<server::reply_t>
 put_config(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    auto config = ppj::rjson_parse(
-      rq.req->content.data(), put_config_handler<>{});
-    rq.req.reset();
+    auto config = co_await ppj::rjson_parse(
+      std::move(rq.req), put_config_handler<>{});
 
     co_await rq.service().writer().write_config(std::nullopt, config.compat);
 
@@ -162,9 +161,8 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto config = ppj::rjson_parse(
-      rq.req->content.data(), put_config_handler<>{});
-    rq.req.reset();
+    auto config = co_await ppj::rjson_parse(
+      std::move(rq.req), put_config_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -222,8 +220,7 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto frc = parse::query_param<std::optional<force>>(*rq.req, "force")
                  .value_or(force::no);
-    auto res = ppj::rjson_parse(rq.req->content.data(), mode_handler<>{});
-    rq.req.reset();
+    auto res = co_await ppj::rjson_parse(std::move(rq.req), mode_handler<>{});
 
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
@@ -256,8 +253,7 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     auto frc = parse::query_param<std::optional<force>>(*rq.req, "force")
                  .value_or(force::no);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto res = ppj::rjson_parse(rq.req->content.data(), mode_handler<>{});
-    rq.req.reset();
+    auto res = co_await ppj::rjson_parse(std::move(rq.req), mode_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -424,8 +420,8 @@ post_subject(server::request_t rq, server::reply_t rp) {
 
     canonical_schema schema;
     try {
-        auto unparsed = ppj::rjson_parse(
-          rq.req->content.data(), post_subject_versions_request_handler<>{sub});
+        auto unparsed = co_await ppj::rjson_parse(
+          std::move(rq.req), post_subject_versions_request_handler<>{sub});
         schema = co_await rq.service().schema_store().make_canonical_schema(
           std::move(unparsed.def));
     } catch (const exception& e) {
@@ -436,8 +432,6 @@ post_subject(server::request_t rq, server::reply_t rp) {
     } catch (const ppj::parse_error&) {
         throw as_exception(invalid_subject_schema(sub));
     }
-
-    rq.req.reset();
 
     auto sub_schema = co_await rq.service().schema_store().has_schema(
       schema, inc_del);
@@ -460,9 +454,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().read_sync();
 
-    auto unparsed = ppj::rjson_parse(
-      rq.req->content.data(), post_subject_versions_request_handler<>{sub});
-    rq.req.reset();
+    auto unparsed = co_await ppj::rjson_parse(
+      std::move(rq.req), post_subject_versions_request_handler<>{sub});
 
     subject_schema schema{
       co_await rq.service().schema_store().make_canonical_schema(
@@ -633,9 +626,8 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto unparsed = ppj::rjson_parse(
-      rq.req->content.data(), post_subject_versions_request_handler<>{sub});
-    rq.req.reset();
+    auto unparsed = co_await ppj::rjson_parse(
+      std::move(rq.req), post_subject_versions_request_handler<>{sub});
 
     // Must read, in case we have the subject in cache with an outdated config
     co_await rq.service().writer().read_sync();

--- a/src/v/pandaproxy/schema_registry/requests/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/requests/compatibility.h
@@ -20,8 +20,9 @@ struct post_compatibility_res {
     bool is_compat{false};
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w,
   const schema_registry::post_compatibility_res& res) {
     w.StartObject();
     w.Key("is_compatible");

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -82,18 +82,18 @@ public:
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::get_config_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::get_config_req_rep& res) {
     w.StartObject();
     w.Key(get_config_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.compat));
     w.EndObject();
 }
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::put_config_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::put_config_req_rep& res) {
     w.StartObject();
     w.Key(put_config_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.compat));

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -20,9 +20,9 @@ struct get_schemas_ids_id_response {
     canonical_schema_definition definition;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const get_schemas_ids_id_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_schemas_ids_id_response& res) {
     w.StartObject();
     if (res.definition.type() != schema_type::avro) {
         w.Key("schemaType");

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
@@ -21,9 +21,9 @@ struct get_schemas_ids_id_versions_response {
     chunked_vector<subject_version> subject_versions;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const get_schemas_ids_id_versions_response& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const get_schemas_ids_id_versions_response& res) {
     w.StartArray();
     for (const auto& sv : res.subject_versions) {
         w.StartObject();

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -22,8 +22,9 @@ struct post_subject_versions_version_response {
     schema_version version;
 };
 
+template<typename Buffer>
 inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+  ::json::Writer<Buffer>& w,
   const post_subject_versions_version_response& res) {
     w.StartObject();
     w.Key("subject");

--- a/src/v/pandaproxy/schema_registry/requests/mode.h
+++ b/src/v/pandaproxy/schema_registry/requests/mode.h
@@ -77,9 +77,9 @@ public:
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_req_rep& res) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_req_rep& res) {
     w.StartObject();
     w.Key(mode_req_rep::field_name.data());
     ::json::rjson_serialize(w, to_string_view(res.mode));

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -241,8 +241,9 @@ struct post_subject_versions_response {
     schema_id id;
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w,
   const schema_registry::post_subject_versions_response& res) {
     w.StartObject();
     w.Key("id");

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -48,7 +48,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
   "schema": ")"
       + escaped_schema_def + R"("})"};
 
-    auto result{ppj::rjson_serialize(response)};
+    auto result = ppj::rjson_serialize_str(response);
 
     BOOST_REQUIRE_EQUAL(::json::minify(expected), result);
 }

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -52,7 +52,7 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
     const parse_result expected{
       {sub, expected_schema_def}, std::nullopt, std::nullopt};
 
-    auto result{ppj::rjson_parse(
+    auto result{ppj::impl::rjson_parse(
       payload.data(), pps::post_subject_versions_request_handler{sub})};
 
     // canonicalisation now requires a sharded_store, for now, minify.

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1348,9 +1348,8 @@ public:
 
 template<typename Handler, typename... Args>
 auto from_json_iobuf(iobuf&& iobuf, Args&&... args) {
-    auto p = iobuf_parser(std::move(iobuf));
-    auto str = p.read_string(p.bytes_left());
-    return json::rjson_parse(str.data(), Handler{std::forward<Args>(args)...});
+    return json::rjson_parse(
+      std::move(iobuf), Handler{std::forward<Args>(args)...});
 }
 
 template<typename T>

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -13,7 +13,6 @@
 
 #include "bytes/iobuf_parser.h"
 #include "json/json.h"
-#include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
 #include "model/metadata.h"
@@ -1355,11 +1354,8 @@ auto from_json_iobuf(iobuf&& iobuf, Args&&... args) {
 }
 
 template<typename T>
-auto to_json_iobuf(T t) {
-    auto val_js = json::rjson_serialize(t);
-    iobuf buf;
-    buf.append(val_js.data(), val_js.size());
-    return buf;
+auto to_json_iobuf(T&& t) {
+    return json::rjson_serialize_iobuf(std::forward<T>(t));
 }
 
 template<typename Key, typename Value>

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -162,9 +162,9 @@ struct schema_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::schema_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::schema_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -325,9 +325,8 @@ struct schema_value {
 using unparsed_schema_value = schema_value<unparsed_schema_defnition_tag>;
 using canonical_schema_value = schema_value<canonical_schema_definition_tag>;
 
-template<typename Tag>
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const schema_value<Tag>& val) {
+template<typename Buffer, typename Tag>
+void rjson_serialize(::json::Writer<Buffer>& w, const schema_value<Tag>& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.schema.sub());
@@ -646,9 +645,9 @@ struct config_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::config_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::config_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -784,9 +783,9 @@ struct config_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::config_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::config_value& val) {
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
@@ -882,9 +881,9 @@ struct mode_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_key& key) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -1020,9 +1019,9 @@ struct mode_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w,
-  const schema_registry::mode_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const schema_registry::mode_value& val) {
     w.StartObject();
     if (val.sub.has_value()) {
         w.Key("subject");
@@ -1119,8 +1118,8 @@ struct delete_subject_key {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const delete_subject_key& key) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const delete_subject_key& key) {
     w.StartObject();
     w.Key("keytype");
     ::json::rjson_serialize(w, to_string_view(key.keytype));
@@ -1260,8 +1259,9 @@ struct delete_subject_value {
     }
 };
 
-inline void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const delete_subject_value& val) {
+template<typename Buffer>
+void rjson_serialize(
+  ::json::Writer<Buffer>& w, const delete_subject_value& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.sub);

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -566,7 +566,7 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post company schema (expect schema_id=1)");
     auto res = post_schema(
-      client, company_req.schema.sub(), ppj::rjson_serialize(company_req));
+      client, company_req.schema.sub(), ppj::rjson_serialize_str(company_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),
@@ -574,7 +574,9 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 
     info("Post employee schema (expect schema_id=2)");
     res = post_schema(
-      client, employee_req.schema.sub(), ppj::rjson_serialize(employee_req));
+      client,
+      employee_req.schema.sub(),
+      ppj::rjson_serialize_str(employee_req));
     BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");
     BOOST_REQUIRE_EQUAL(
       res.headers.at(boost::beast::http::field::content_type),

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -8,15 +8,12 @@
 // by the Apache License, Version 2.0
 
 #include "pandaproxy/error.h"
-#include "pandaproxy/json/error.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/test/avro_payloads.h"
 #include "pandaproxy/schema_registry/test/client_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
-
-#include <array>
 
 namespace pp = pandaproxy;
 namespace ppj = pp::json;

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -26,8 +26,8 @@ struct request {
     pps::canonical_schema schema;
 };
 
-void rjson_serialize(
-  ::json::Writer<::json::StringBuffer>& w, const request& r) {
+template<typename Buffer>
+void rjson_serialize(::json::Writer<Buffer>& w, const request& r) {
     w.StartObject();
     w.Key("schema");
     ::json::rjson_serialize(w, r.schema.def().raw());

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           avro_schema_key_sv.data(), pps::schema_key_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_key, key);
 
-        auto str = ppj::rjson_serialize(avro_schema_key);
+        auto str = ppj::rjson_serialize_str(avro_schema_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_key_sv));
     }
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
-        auto str = ppj::rjson_serialize(avro_schema_value);
+        auto str = ppj::rjson_serialize_str(avro_schema_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(avro_schema_value_sv));
     }
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_key_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key, val);
 
-        auto str = ppj::rjson_serialize(config_key);
+        auto str = ppj::rjson_serialize_str(config_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sv));
     }
 
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_key_sub_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key_sub, val);
 
-        auto str = ppj::rjson_serialize(config_key_sub);
+        auto str = ppj::rjson_serialize_str(config_key_sub);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_key_sub_sv));
     }
 
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_value_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value, val);
 
-        auto str = ppj::rjson_serialize(config_value);
+        auto str = ppj::rjson_serialize_str(config_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sv));
     }
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           config_value_sub_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value_sub, val);
 
-        auto str = ppj::rjson_serialize(config_value_sub);
+        auto str = ppj::rjson_serialize_str(config_value_sub);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sub_sv));
     }
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           delete_subject_key_sv.data(), pps::delete_subject_key_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_key, val);
 
-        auto str = ppj::rjson_serialize(delete_subject_key);
+        auto str = ppj::rjson_serialize_str(delete_subject_key);
         BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_key_sv));
     }
 
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
           pps::delete_subject_value_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_value, val);
 
-        auto str = ppj::rjson_serialize(delete_subject_value);
+        auto str = ppj::rjson_serialize_str(delete_subject_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(delete_subject_value_sv));
     }
 }

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -127,7 +127,7 @@ const pps::delete_subject_value delete_subject_value{
 
 BOOST_AUTO_TEST_CASE(test_storage_serde) {
     {
-        auto key = ppj::rjson_parse(
+        auto key = ppj::impl::rjson_parse(
           avro_schema_key_sv.data(), pps::schema_key_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_key, key);
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_key_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key, val);
 
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_key_sub_sv.data(), pps::config_key_handler<>{});
         BOOST_CHECK_EQUAL(config_key_sub, val);
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_value_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value, val);
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           config_value_sub_sv.data(), pps::config_value_handler<>{});
         BOOST_CHECK_EQUAL(config_value_sub, val);
 
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           delete_subject_key_sv.data(), pps::delete_subject_key_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_key, val);
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
     }
 
     {
-        auto val = ppj::rjson_parse(
+        auto val = ppj::impl::rjson_parse(
           delete_subject_value_sv.data(),
           pps::delete_subject_value_handler<>{});
         BOOST_CHECK_EQUAL(delete_subject_value, val);

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -143,6 +143,7 @@ server::server(
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
+    _server.set_content_streaming(true);
 }
 
 /*

--- a/src/v/utils/json.h
+++ b/src/v/utils/json.h
@@ -15,10 +15,9 @@
 
 namespace json {
 
-template<typename T, size_t max_fragment_size>
+template<typename Buffer, typename T, size_t max_fragment_size>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const fragmented_vector<T, max_fragment_size>& v) {
+  json::Writer<Buffer>& w, const fragmented_vector<T, max_fragment_size>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/utils/json.h
+++ b/src/v/utils/json.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "json/json.h"
+#include "utils/fragmented_vector.h"
+
+namespace json {
+
+template<typename T, size_t max_fragment_size>
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const fragmented_vector<T, max_fragment_size>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
+} // namespace json


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/20827

Fixes https://github.com/redpanda-data/redpanda/issues/21296

I took some refactoring changes from https://github.com/redpanda-data/redpanda/pull/17403 to make life simpler.