### PR TITLE
[v24.1.x] tests/controller_snapshot: fix no-op controller leadership transfers

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -487,6 +487,9 @@ class Admin:
                                                   backoff_s=backoff_s)
             if check(info.leader):
                 return True, info.leader
+
+            self.redpanda.logger.debug(
+                f"check failed (leader id: {info.leader})")
             return False
 
         return wait_until_result(

--- a/tests/rptest/tests/controller_snapshot_test.py
+++ b/tests/rptest/tests/controller_snapshot_test.py
@@ -429,6 +429,13 @@ class ControllerSnapshotTest(RedpandaTest):
         for iter in range(5):
             self.redpanda.stop_node(joiner)
 
+            # wait for the joiner to step down in case it was the controller
+            joiner_id = self.redpanda.node_id(joiner)
+            admin.await_stable_leader(namespace='redpanda',
+                                      topic='controller',
+                                      check=lambda id: id != joiner_id,
+                                      timeout_s=30)
+
             executed = 0
             to_execute = random.randint(1, 5)
             while executed < to_execute:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21428
Fixes: https://github.com/redpanda-data/redpanda/issues/21476,