### PR TITLE
schema_registry: Remove extraneous log

### DIFF
--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -105,7 +105,6 @@ ss::future<std::optional<ss::sstring>> get_record_name(
   subject_name_strategy sns,
   canonical_schema_definition schema,
   std::optional<std::vector<int32_t>>& offsets) {
-    vlog(plog.warn, "get_record_name: sns: {}, schema: {}", sns, schema);
     if (sns == subject_name_strategy::topic_name) {
         // Result is succesfully nothing
         co_return "";


### PR DESCRIPTION
The log was used for debugging during https://github.com/redpanda-data/redpanda/pull/21323 and should not have been pushed.

I removed it from the [backport to v23.3](https://github.com/redpanda-data/redpanda/pull/21469)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
