### PR TITLE
rpk: fix --default example in alter quotas command

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/quotas/alter.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/alter.go
@@ -66,8 +66,7 @@ Add quota (consumer_byte_rate) to client ID starting with 'bar-':
     --name client-id-prefix=bar-
 
 Add quota (producer_byte_rate) to default client ID:
-  rpk cluster quotas alter --add producer_byte_rate=180000 \
-    --default client-id=foo
+  rpk cluster quotas alter --add producer_byte_rate=180000 --default client-id
 
 Remove quota (producer_byte_rate) from client ID 'foo':
   rpk cluster quotas alter --delete producer_byte_rate \


### PR DESCRIPTION
--default flag should not have a name

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none