### PR TITLE
iceberg: add missing field to manifest_entry avro

### DIFF
--- a/src/v/iceberg/avroschemas/manifest_entry.schema.json
+++ b/src/v/iceberg/avroschemas/manifest_entry.schema.json
@@ -26,6 +26,15 @@
      "field-id": 3
    },
    {
+     "name": "file_sequence_number",
+     "type": [
+       "null",
+       "long"
+     ],
+     "default": null,
+     "field-id": 4
+   },
+   {
      "name": "data_file",
      "type": {
        "type": "record",


### PR DESCRIPTION
Adds the file_sequence_number to the manifest_entry schema, as indicated by the spec[1].

It's unclear why the schema didn't have them in the first place (the schema was taken from DuckDB), but it's clearly defined upstream[2] and is important for efficiently writing metadata[3].

There is another field, distinct_counts, in the spec that is not in the manifest_entry schema. Interestingly enough, it doesn't appear to be defined at all in upstream Java code[4] (it is defined in iceberg-go, but not iceberg-python or iceberg-rust), so I'm leaving it out.

[1] https://iceberg.apache.org/spec/#manifests
[2] https://github.com/apache/iceberg/blob/319f29ea860e42e7cc21cda8c05d882134e6431f/core/src/main/java/org/apache/iceberg/ManifestEntry.java#L48-L49
[3] https://iceberg.apache.org/spec/#manifest-entry-fields
[4] https://github.com/apache/iceberg/blob/319f29ea860e42e7cc21cda8c05d882134e6431f/api/src/main/java/org/apache/iceberg/DataFile.java#L37-L105

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
