### PR TITLE
rpk/transform/build: fix js sdk tooling

### DIFF
--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -218,8 +218,8 @@ func buildJavaScript(ctx context.Context, fs afero.Fs, cfg project.Config) error
 	if err != nil {
 		return err
 	}
-	wasmMerge := path.Join(bpRoot, "wasm-merge")
-	jsVmWasm := path.Join(bpRoot, "redpanda_js_transform")
+	wasmMerge := path.Join(bpRoot, "bin", "wasm-merge")
+	jsVmWasm := path.Join(bpRoot, "bin", "redpanda_js_transform")
 	cmd = exec.CommandContext(
 		ctx,
 		wasmMerge,

--- a/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
@@ -53,15 +53,15 @@ var Tinygo = Buildpack{
 var JavaScript = Buildpack{
 	Name: "javascript",
 	// TODO: Find a better place to host these binaries than the tinygo repo
-	baseURL: "https://github.com/redpanda-data/tinygo/releases/download/js-sdk-placeholder",
+	baseURL: "https://github.com/redpanda-data/tinygo/releases/download/js-sdk-v1",
 	shaSums: map[string]map[string]string{
 		"darwin": {
-			"amd64": "a2a7af658e8b7bb5b213fbcd33c395ef95019c0ba018fabdc80cc4435b70b792",
-			"arm64": "3010f528ea16a212eb942fb82afd34e6af48122c494f4bb72c5333adde955c70",
+			"amd64": "03ae0af869ccdea74c5d80f187b01c797e7327abdf33e8df693836d471105dad",
+			"arm64": "fa0374389d580eb731f6274b152c4229acb15335e100800c947cf25066c76e2a",
 		},
 		"linux": {
-			"amd64": "cb657b042a32b04469acf92f33453757a137072b09c23a3fbb7e6cbe387a1d80",
-			"arm64": "80ff2e5c76da00a1ba2a5c310fa7bb31ea989fdeea8eadd8c7cda7e0534fa9b4",
+			"amd64": "8c879b804e7b5d749220e5021663bc3a710a4ff36a8a2ea93bbcaa0a311d7160",
+			"arm64": "c53dc96c5ca18cd788fb0bbff5983b7e909777928dcad3bfd8a20c0c61d654ea",
 		},
 	},
 }


### PR DESCRIPTION
Mac builds dynamically link the executable instead of static linking on
linux. Make sure the mac builds include the required dylib (in the right
directories too so rpath fiddling is not needed).

I packaged a new toolchain using `package_toolchain.py`, uploaded that
to the tinygo repo (still need a better place to upload that stuff), and
fixed the paths now that they changed in the tarball.

Fixes: CORE-5594

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fix transform JavaScript SDK tools on Darwin
