### PR TITLE
tx: enforce limit on client set transaction timeout

### DIFF
--- a/src/v/cluster/tx_errc.cc
+++ b/src/v/cluster/tx_errc.cc
@@ -70,6 +70,8 @@ std::ostream& operator<<(std::ostream& o, errc err) {
         return o << "tx::errc::partition_disabled";
     case errc::concurrent_transactions:
         return o << "tx::errc::concurrent_transactions";
+    case errc::invalid_timeout:
+        return o << "tx::errc::invalid_timeout";
     }
     return o;
 }

--- a/src/v/cluster/tx_errc.h
+++ b/src/v/cluster/tx_errc.h
@@ -48,6 +48,8 @@ enum class errc {
     tx_id_not_found,
     partition_disabled,
     concurrent_transactions,
+    // invalid timeout requested by the client.
+    invalid_timeout,
 };
 
 std::ostream& operator<<(std::ostream& o, errc err);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -708,6 +708,19 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx_locally(
       tx_id,
       transaction_timeout_ms);
 
+    if (unlikely(
+          transaction_timeout_ms
+          > config::shard_local_cfg().transaction_max_timeout_ms())) {
+        vlog(
+          txlog.warn,
+          "[tx_id={}] Transactional timeout requested {}ms exceeds configured "
+          "maximum timeout {}ms",
+          tx_id,
+          transaction_timeout_ms,
+          config::shard_local_cfg().transaction_max_timeout_ms());
+        co_return init_tm_tx_reply{tx::errc::invalid_timeout};
+    }
+
     model::ntp tx_ntp(model::tx_manager_nt.ns, model::tx_manager_nt.tp, tm);
     auto shard = _shard_table.local().shard_for(tx_ntp);
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -923,6 +923,15 @@ configuration::configuration()
       "How often look for the inactive transactions and abort them",
       {.visibility = visibility::tunable},
       10s)
+  , transaction_max_timeout_ms(
+      *this,
+      "transaction_max_timeout_ms",
+      "The maximum allowed timeout for transactions. If a client requested "
+      "transaction timeout exceeds this configuration, the broker will return "
+      "an error during transactional producer initialization. This guardrail "
+      "prevents hanging transactions from blocking consumer progress.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      15min)
   , tx_log_stats_interval_s(
       *this,
       "tx_log_stats_interval_s",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -195,6 +195,8 @@ struct configuration final : public config_store {
     property<uint64_t> transaction_coordinator_log_segment_size;
     property<std::chrono::milliseconds>
       abort_timed_out_transactions_interval_ms;
+    // same as transaction.max.timeout.ms in Apache Kafka.
+    property<std::chrono::milliseconds> transaction_max_timeout_ms;
     property<std::chrono::seconds> tx_log_stats_interval_s;
     property<std::chrono::milliseconds> create_topic_timeout_ms;
     property<std::chrono::milliseconds> wait_for_leader_timeout_ms;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -161,6 +161,8 @@ constexpr error_code map_tx_errc(cluster::tx::errc ec) {
     case cluster::tx::errc::request_rejected:
     case cluster::tx::errc::unknown_server_error:
         return error_code::unknown_server_error;
+    case cluster::tx::errc::invalid_timeout:
+        return error_code::invalid_transaction_timeout;
     }
 }
 

--- a/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/Verifier.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/tx_verifier/Verifier.java
@@ -15,6 +15,7 @@ class Verifier {
   }
 
   final static int RETRY_TIMEOUT_SEC = 5;
+  final static int MAX_TRANSACTION_TIMEOUT_MS = 900000;
   final static String txId1 = "tx1";
   final static String txId2 = "tx2";
   final static String topic1 = "topic1";
@@ -407,7 +408,7 @@ class Verifier {
     TxProducer producer = null;
     TxConsumer consumer = null;
     try {
-      producer = new TxProducer(connection, txId1, Integer.MAX_VALUE);
+      producer = new TxProducer(connection, txId1, MAX_TRANSACTION_TIMEOUT_MS);
       producer.initTransactions();
       producer.beginTransaction();
       long offset = producer.send(topic1, "key1", "value1");

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -391,7 +391,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 3600000,  # to avoid timing out
+            'transaction.timeout.ms': 900000,  # to avoid timing out
         })
         producer.init_transactions()
         producer.begin_transaction()
@@ -574,7 +574,7 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': str(i),
-                'transaction.timeout.ms': 1000000,
+                'transaction.timeout.ms': 900000,
             }) for i in range(0, p_count)
         ]
 

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -191,6 +191,33 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                 assert node.account.isdir(path)
 
     @cluster(num_nodes=3)
+    def test_max_timeout(self):
+        rpk = RpkTool(self.redpanda)
+        max_timeout_ms = int(
+            rpk.cluster_config_get("transaction_max_timeout_ms"))
+        test_timeout_ms = max_timeout_ms + 100
+
+        def init_producer(timeout_ms: int):
+            producer = ck.Producer({
+                'bootstrap.servers': self.redpanda.brokers(),
+                'transactional.id': '0',
+                'transaction.timeout.ms': test_timeout_ms,
+            })
+            producer.init_transactions()
+
+        try:
+            init_producer(test_timeout_ms)
+            assert False, "producer session established with a timeout larger than allowed limit"
+        except ck.cimpl.KafkaException as e:
+            kafka_error = e.args[0]
+            assert kafka_error.code(
+            ) == ck.KafkaError.INVALID_TRANSACTION_TIMEOUT, f"Unexpected error {kafka_error.code()}"
+
+        # Bump timeout and check again.
+        rpk.cluster_config_set("transaction_max_timeout_ms", test_timeout_ms)
+        init_producer(test_timeout_ms)
+
+    @cluster(num_nodes=3)
     def simple_test(self):
         self.generate_data(self.input_t, self.max_records)
 

--- a/tests/rptest/transactions/tx_admin_api_test.py
+++ b/tests/rptest/transactions/tx_admin_api_test.py
@@ -93,12 +93,12 @@ class TxAdminTest(RedpandaTest):
         producer1 = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 3600000,  # avoid auto timeout
+            'transaction.timeout.ms': 900000,  # avoid auto timeout
         })
         producer2 = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '1',
-            'transaction.timeout.ms': 3600000,  # avoid auto timeout
+            'transaction.timeout.ms': 900000,  # avoid auto timeout
         })
         producer1.init_transactions()
         producer2.init_transactions()


### PR DESCRIPTION
Adds a new configuration `transaction_max_timeout_ms` defaulting to 15mins.
Producers with transaction timeout greater than this configuration are rejected.
Hanging transactions (from producers with unset transaction timeouts) can potentially
cause blocked consumer due to LSO being blocked, so enforcing this limit on how long
a transaction can hang before it is auto aborted prevents such situations.

Fixes https://github.com/redpanda-data/redpanda/issues/17984

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Features

* Adds a new broker configuration transaction_max_timeout_ms. The configuration controls the maximum allowed user set timeout for transactions. If a client requested transaction timeout exceeds this configuration, the broker will return
an error during transactional producer initialization. This guardrail prevents hanging transactions from blocking consumer progress. The default value is 15mins.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
