### PR TITLE
[v24.1.x] archival: keep locks until outcome is known

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
 using cloud_storage::segment_name;
@@ -279,6 +280,151 @@ TEST_F_CORO(
       });
 
     co_await reached_dispatch_append->get_future();
+
+    // Expecting this to fail as we have the replication blocked.
+    auto sync_result_before_replication = co_await with_leader(
+      10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+          return get_leader_stm().sync(10ms);
+      });
+    ASSERT_FALSE_CORO(sync_result_before_replication);
+
+    // Subsequent calls to sync should fail too.
+    auto second_sync_result_before_replication = co_await with_leader(
+      10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+          return get_leader_stm().sync(10ms);
+      });
+    ASSERT_FALSE_CORO(second_sync_result_before_replication);
+
+    // Allow replication to progress.
+    may_resume_append->set_value();
+
+    // This sync will succeed and will wait for replication to progress.
+    auto synced = co_await with_leader(
+      10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+          return get_leader_stm().sync(10s);
+      });
+
+    ASSERT_TRUE_CORO(synced);
+
+    auto slow_replication_res = co_await std::move(slow_replication_fut);
+    ASSERT_TRUE_CORO(!slow_replication_res);
+
+    auto [committed_offset, term] = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) mutable {
+          return std::make_tuple(
+            node.raft()->committed_offset(), node.raft()->term());
+      });
+
+    ASSERT_EQ_CORO(committed_offset, model::offset{2});
+    ASSERT_EQ_CORO(term, model::term_id{1});
+
+    co_await wait_for_apply();
+}
+
+TEST_F_CORO(
+  archival_metadata_stm_gtest_fixture, test_same_term_sync_abort_source) {
+    /*
+     * Test that archival_metadata_stm::sync is able to sync
+     * within the same term and that it will wait for on-going
+     * replication futures to complete before doing so. To simulate
+     * this scenario we introduce a small delay on append entries
+     * response processing.
+     *
+     * Like the test above, but this time we break out of the replicate call
+     * by using an abort source.
+     */
+
+    ss::abort_source never_abort;
+
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    co_await start();
+
+    auto res = co_await with_leader(
+      10s, [this, &m, &never_abort](raft::raft_node_instance&) {
+          return get_leader_stm().add_segments(
+            m,
+            std::nullopt,
+            model::producer_id{},
+            ss::lowres_clock::now() + 10s,
+            never_abort,
+            cluster::segment_validated::yes);
+      });
+
+    ASSERT_TRUE_CORO(!res);
+
+    // Allocated on the heap as the lambda will outlive the scope of the test.
+    auto may_resume_append = ss::make_shared<ss::shared_promise<>>();
+    auto reached_dispatch_append = ss::make_shared<available_promise<bool>>();
+
+    // Ensure that we always resume the append operation to allow the test to
+    // exit in case of failure.
+    auto deferred_fix_nodes = ss::defer([may_resume_append] {
+        if (!may_resume_append->available()) {
+            may_resume_append->set_value();
+        }
+    });
+
+    auto plagued_node = co_await with_leader(
+      10s,
+      [&reached_dispatch_append,
+       &may_resume_append](raft::raft_node_instance& node) {
+          node.on_dispatch([reached_dispatch_append, may_resume_append](
+                             model::node_id, raft::msg_type t) {
+              if (t == raft::msg_type::append_entries) {
+                  if (!reached_dispatch_append->available()) {
+                      reached_dispatch_append->set_value(true);
+                  }
+                  return may_resume_append->get_shared_future();
+              }
+
+              return ss::now();
+          });
+
+          return node.get_vnode();
+      });
+
+    m.clear();
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(1)});
+
+    ss::abort_source replication_abort_source;
+    auto slow_replication_fut = with_leader(
+      10s,
+      [this, &m, &replication_abort_source, &plagued_node](
+        raft::raft_node_instance& node) {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+
+          return get_leader_stm().add_segments(
+            m,
+            std::nullopt,
+            model::producer_id{},
+            ss::lowres_clock::now() + 10s,
+            replication_abort_source,
+            cluster::segment_validated::yes);
+      });
+
+    co_await reached_dispatch_append->get_future();
+    replication_abort_source.request_abort();
 
     // Expecting this to fail as we have the replication blocked.
     auto sync_result_before_replication = co_await with_leader(

--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -224,20 +224,29 @@ TEST_F_CORO(
 
     ASSERT_TRUE_CORO(!res);
 
-    ss::shared_promise<> may_resume_append;
-    available_promise<bool> reached_dispatch_append;
+    // Allocated on the heap as the lambda will outlive the scope of the test.
+    auto may_resume_append = ss::make_shared<ss::shared_promise<>>();
+    auto reached_dispatch_append = ss::make_shared<available_promise<bool>>();
+
+    // Ensure that we always resume the append operation to allow the test to
+    // exit in case of failure.
+    auto deferred_fix_nodes = ss::defer([may_resume_append] {
+        if (!may_resume_append->available()) {
+            may_resume_append->set_value();
+        }
+    });
 
     auto plagued_node = co_await with_leader(
       10s,
       [&reached_dispatch_append,
        &may_resume_append](raft::raft_node_instance& node) {
-          node.on_dispatch([&reached_dispatch_append, &may_resume_append](
+          node.on_dispatch([reached_dispatch_append, may_resume_append](
                              model::node_id, raft::msg_type t) {
               if (t == raft::msg_type::append_entries) {
-                  if (!reached_dispatch_append.available()) {
-                      reached_dispatch_append.set_value(true);
+                  if (!reached_dispatch_append->available()) {
+                      reached_dispatch_append->set_value(true);
                   }
-                  return may_resume_append.get_shared_future();
+                  return may_resume_append->get_shared_future();
               }
 
               return ss::now();
@@ -269,7 +278,7 @@ TEST_F_CORO(
             cluster::segment_validated::yes);
       });
 
-    co_await reached_dispatch_append.get_future();
+    co_await reached_dispatch_append->get_future();
 
     // Expecting this to fail as we have the replication blocked.
     auto sync_result_before_replication = co_await with_leader(
@@ -292,7 +301,7 @@ TEST_F_CORO(
     ASSERT_FALSE_CORO(second_sync_result_before_replication);
 
     // Allow replication to progress.
-    may_resume_append.set_value();
+    may_resume_append->set_value();
 
     // This sync will succeed and will wait for replication to progress.
     auto synced = co_await with_leader(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21348
Fixes: https://github.com/redpanda-data/redpanda/issues/21520,