### PR TITLE
[v23.3.x] producer_state: add request::set_error and make it idempotent

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -17,6 +17,17 @@
 
 namespace cluster {
 
+std::ostream& operator<<(std::ostream& os, request_state state) {
+    switch (state) {
+    case request_state::initialized:
+        return os << "initialized";
+    case request_state::in_progress:
+        return os << "in_progress";
+    case request_state::completed:
+        return os << "completed";
+    }
+}
+
 result_promise_t::future_type request::result() const {
     return _result.get_shared_future();
 }
@@ -235,6 +246,18 @@ producer_state::producer_state(
 bool producer_state::operator==(const producer_state& other) const {
     return _id == other._id && _group == other._group
            && _evicted == other._evicted && _requests == other._requests;
+}
+
+std::ostream& operator<<(std::ostream& o, const request& request) {
+    fmt::print(
+      o,
+      "{{ first: {}, last: {}, term: {}, result_available: {}, state: {} }}",
+      request._first_sequence,
+      request._last_sequence,
+      request._term,
+      request._result.available(),
+      request._state);
+    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const requests& requests) {

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -347,8 +347,21 @@ result<request_ptr> producer_state::try_emplace_request(
       current_term,
       reset,
       _requests);
-    return _requests.try_emplace(
+
+    auto result = _requests.try_emplace(
       bid.first_seq, bid.last_seq, current_term, reset);
+
+    if (unlikely(result.has_error())) {
+        vlog(
+          clusterlog.warn,
+          "[{}] error {} processing request {}, term: {}, reset: {}",
+          *this,
+          result.error(),
+          bid,
+          current_term,
+          reset);
+    }
+    return result;
 }
 
 void producer_state::update(

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -32,6 +32,29 @@ result_promise_t::future_type request::result() const {
     return _result.get_shared_future();
 }
 
+void request::set_value(request_result_t::value_type value) {
+    vassert(
+      _state <= request_state::in_progress && !_result.available(),
+      "unexpected request state during result set: {}",
+      *this);
+    _result.set_value(value);
+    _state = request_state::completed;
+}
+
+void request::set_error(request_result_t::error_type error) {
+    // This is idempotent as different fibers can mark the result error
+    // at different times in some edge cases.
+    if (_state != request_state::completed) {
+        _result.set_value(error);
+        _state = request_state::completed;
+        return;
+    }
+    vassert(
+      _result.available() && result().get0().has_error(),
+      "Invalid result state, expected to be available and errored out: {}",
+      *this);
+}
+
 bool request::operator==(const request& other) const {
     bool compare = _first_sequence == other._first_sequence
                    && _last_sequence == other._last_sequence
@@ -120,7 +143,7 @@ result<request_ptr> requests::try_emplace(
         // checks for sequence tracking.
         while (!_inflight_requests.empty()) {
             if (!_inflight_requests.front()->has_completed()) {
-                _inflight_requests.front()->set_value(errc::timeout);
+                _inflight_requests.front()->set_error(errc::timeout);
             }
             _inflight_requests.pop_front();
         }
@@ -134,7 +157,7 @@ result<request_ptr> requests::try_emplace(
             if (!_inflight_requests.front()->has_completed()) {
                 // Here we know for sure the term change, these in flight
                 // requests are going to fail anyway, mark them so.
-                _inflight_requests.front()->set_value(errc::timeout);
+                _inflight_requests.front()->set_error(errc::timeout);
             }
             _inflight_requests.pop_front();
         }
@@ -215,7 +238,7 @@ bool requests::stm_apply(
 void requests::shutdown() {
     for (auto& request : _inflight_requests) {
         if (!request->has_completed()) {
-            request->_result.set_value(errc::shutting_down);
+            request->set_error(errc::shutting_down);
         }
     }
     _inflight_requests.clear();

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -42,7 +42,8 @@ using producer_ptr = ss::lw_shared_ptr<producer_state>;
 // right after set_value(), this is an implementation quirk, be
 // mindful of that behavior when using it. We have a test for
 // it in expiring_promise_test
-using result_promise_t = ss::shared_promise<result<kafka_result>>;
+using request_result_t = result<kafka_result>;
+using result_promise_t = ss::shared_promise<request_result_t>;
 using request_ptr = ss::lw_shared_ptr<request>;
 using seq_t = int32_t;
 
@@ -71,15 +72,8 @@ public:
         }
     }
 
-    template<class ValueType>
-    void set_value(ValueType&& value) {
-        vassert(
-          _state <= request_state::in_progress && !_result.available(),
-          "unexpected request state during result set: {}",
-          *this);
-        _result.set_value(std::forward<ValueType>(value));
-        _state = request_state::completed;
-    }
+    void set_value(request_result_t::value_type);
+    void set_error(request_result_t::error_type);
     void mark_request_in_progress() { _state = request_state::in_progress; }
     request_state state() const { return _state; }
     result_promise_t::future_type result() const;

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -52,6 +52,8 @@ enum class request_state : uint8_t {
     completed = 2
 };
 
+std::ostream& operator<<(std::ostream&, request_state);
+
 /// A request for a given sequence range, both inclusive.
 /// The sequence numbers are stamped by the client and are a part
 /// of batch header. A request can either be in progress or completed
@@ -73,10 +75,8 @@ public:
     void set_value(ValueType&& value) {
         vassert(
           _state <= request_state::in_progress && !_result.available(),
-          "unexpected request state during set: state: {}, result available: "
-          "{}",
-          static_cast<std::underlying_type_t<request_state>>(_state),
-          _result.available());
+          "unexpected request state during result set: {}",
+          *this);
         _result.set_value(std::forward<ValueType>(value));
         _state = request_state::completed;
     }
@@ -85,6 +85,8 @@ public:
     result_promise_t::future_type result() const;
 
     bool operator==(const request&) const;
+
+    friend std::ostream& operator<<(std::ostream&, const request&);
 
 private:
     request_state _state{request_state::initialized};


### PR DESCRIPTION
A request can be marked as errored multiple times, consider the example
below.

```
replicate_f : waiting for replication
term change and leadership change
requests from old terms gc-ed: set_err(ec) -- separate fiber
replicate_f: set_err(ec)
```

Current assert assumes that a request can be set only once, which is
true for setting a successful result but not for errors. This commit
splits set_value() into set_value() and set_error() and adjusts
assert conditions accordingly.

This was identified in a chaos build. Also included some logging improvements noticed while debugging, most notably printing the transaction state correctly (currently printing the pointer instead of value).

Fixes https://github.com/redpanda-data/redpanda/issues/19842

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
