### PR TITLE
Add v24.2.x and remove v23.2.x from PR template for backports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,9 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v24.2.x
 - [ ] v24.1.x
 - [ ] v23.3.x
-- [ ] v23.2.x
 
 ## Release Notes
 


### PR DESCRIPTION
Add v24.2.x and remove v23.2.x from PR template for backports

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes ##
* None