### PR TITLE
iceberg: add initial schema struct

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -77,3 +77,16 @@ redpanda_cc_library(
         "//src/v/strings:string_switch",
     ],
 )
+
+redpanda_cc_library(
+    name = "schema",
+    hdrs = [
+        "schema.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":datatypes",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/utils:named_type",
+    ],
+)

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -90,3 +90,21 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
     ],
 )
+
+redpanda_cc_library(
+    name = "schema_json",
+    srcs = [
+        "schema_json.cc",
+    ],
+    hdrs = [
+        "schema_json.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":datatypes",
+        ":datatypes_json",
+        ":json_utils",
+        ":schema",
+        "//src/v/json",
+    ],
+)

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -31,6 +31,7 @@ v_cc_library(
     datatypes.cc
     datatypes_json.cc
     json_utils.cc
+    schema_json.cc
   DEPS
     v::container
     v::json

--- a/src/v/iceberg/schema.h
+++ b/src/v/iceberg/schema.h
@@ -1,0 +1,27 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "iceberg/datatypes.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace iceberg {
+
+struct schema {
+    using id_t = named_type<int32_t, struct schema_id_tag>;
+    struct_type schema_struct;
+    id_t schema_id;
+    chunked_hash_set<nested_field::id_t> identifier_field_ids;
+    friend bool operator==(const schema& lhs, const schema& rhs) = default;
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/schema_json.cc
+++ b/src/v/iceberg/schema_json.cc
@@ -1,0 +1,80 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/schema_json.h"
+
+#include "iceberg/datatypes.h"
+#include "iceberg/datatypes_json.h"
+#include "iceberg/json_utils.h"
+#include "iceberg/schema.h"
+#include "json/document.h"
+
+namespace iceberg {
+
+schema parse_schema(const json::Value& v) {
+    auto type = parse_required_str(v, "type");
+    if (type != "struct") {
+        throw std::invalid_argument(
+          fmt::format("Schema has type '{}' instead of 'struct'", type));
+    }
+    int32_t schema_id = parse_required_i32(v, "schema-id");
+    auto identifier_fids_json = parse_optional(v, "identifier-field-ids");
+    chunked_hash_set<nested_field::id_t> identifier_fids;
+    if (identifier_fids_json.has_value()) {
+        if (!identifier_fids_json->get().IsArray()) {
+            throw std::invalid_argument(
+              fmt::format("Schema has type '{}' instead of 'array'", type));
+        }
+        for (const auto& id_json : identifier_fids_json->get().GetArray()) {
+            if (!id_json.IsInt()) {
+                throw std::invalid_argument(fmt::format(
+                  "Schema has non-int 'identifier-field-ids' type: {}",
+                  id_json.GetType()));
+            }
+            identifier_fids.emplace(id_json.GetInt());
+        }
+    }
+    auto struct_type = parse_struct(v);
+    return schema{
+      .schema_struct = std::move(struct_type),
+      .schema_id = schema::id_t{schema_id},
+      .identifier_field_ids = std::move(identifier_fids),
+    };
+}
+
+} // namespace iceberg
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const iceberg::schema& s) {
+    w.StartObject();
+    w.Key("type");
+    w.String("struct");
+
+    w.Key("schema-id");
+    w.Int(s.schema_id());
+    if (!s.identifier_field_ids.empty()) {
+        w.Key("identifier-field-ids");
+        w.StartArray();
+        for (auto id : s.identifier_field_ids) {
+            w.Int(id());
+        }
+        w.EndArray();
+    }
+    w.Key("fields");
+    w.StartArray();
+    for (const auto& f : s.schema_struct.fields) {
+        rjson_serialize(w, *f);
+    }
+    w.EndArray();
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/iceberg/schema_json.h
+++ b/src/v/iceberg/schema_json.h
@@ -1,0 +1,28 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/schema.h"
+#include "json/_include_first.h"
+#include "json/document.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+
+namespace iceberg {
+
+schema parse_schema(const json::Value&);
+
+} // namespace iceberg
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const iceberg::schema& s);
+
+} // namespace json

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -1,4 +1,18 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "test_schemas",
+    srcs = [
+        "test_schemas.cc",
+    ],
+    hdrs = [
+        "test_schemas.h",
+    ],
+    include_prefix = "iceberg/tests",
+    deps = [
+        "//src/v/iceberg:datatypes",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "datatypes_test",
@@ -20,6 +34,7 @@ redpanda_cc_gtest(
         "datatypes_json_test.cc",
     ],
     deps = [
+        ":test_schemas",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:datatypes_json",
         "//src/v/json",

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -61,3 +61,19 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "schema_json_test",
+    timeout = "short",
+    srcs = [
+        "schema_json_test.cc",
+    ],
+    deps = [
+        ":test_schemas",
+        "//src/v/iceberg:schema",
+        "//src/v/iceberg:schema_json",
+        "//src/v/json",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     datatypes_test.cc
     manifest_serialization_test.cc
     datatypes_json_test.cc
+    test_schemas.cc
   LIBRARIES
     Avro::avro
     Boost::iostreams

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -6,9 +6,10 @@ rp_test(
   USE_CWD
   BINARY_NAME iceberg
   SOURCES
+    datatypes_json_test.cc
     datatypes_test.cc
     manifest_serialization_test.cc
-    datatypes_json_test.cc
+    schema_json_test.cc
     test_schemas.cc
   LIBRARIES
     Avro::avro

--- a/src/v/iceberg/tests/datatypes_json_test.cc
+++ b/src/v/iceberg/tests/datatypes_json_test.cc
@@ -9,6 +9,7 @@
 
 #include "iceberg/datatypes.h"
 #include "iceberg/datatypes_json.h"
+#include "iceberg/tests/test_schemas.h"
 #include "json/document.h"
 #include "json/stringbuffer.h"
 
@@ -28,161 +29,11 @@ ss::sstring type_to_json_str(const field_type& t) {
 // Round trip test for the struct type of a schema taken from
 // https://github.com/apache/iceberg-go/blob/704a6e78c13ea63f1ff4bb387f7d4b365b5f0f82/schema_test.go#L644
 TEST(DataTypeJsonSerde, TestFieldType) {
-    struct_type expected_struct;
-    expected_struct.fields.emplace_back(
-      nested_field::create(1, "foo", field_required::no, string_type{}));
-    expected_struct.fields.emplace_back(
-      nested_field::create(2, "bar", field_required::yes, int_type{}));
-    expected_struct.fields.emplace_back(
-      nested_field::create(3, "baz", field_required::no, boolean_type{}));
-
-    expected_struct.fields.emplace_back(nested_field::create(
-      4,
-      "qux",
-      field_required::yes,
-      list_type::create(5, field_required::yes, string_type{})));
-
-    expected_struct.fields.emplace_back(nested_field::create(
-      6,
-      "quux",
-      field_required::yes,
-      map_type::create(
-        7,
-        string_type{},
-        8,
-        field_required::yes,
-        map_type::create(
-          9, string_type{}, 10, field_required::yes, int_type{}))));
-
-    struct_type location_struct;
-    location_struct.fields.emplace_back(
-      nested_field::create(13, "latitude", field_required::no, float_type{}));
-    location_struct.fields.emplace_back(
-      nested_field::create(14, "longitude", field_required::no, float_type{}));
-    expected_struct.fields.emplace_back(nested_field::create(
-      11,
-      "location",
-      field_required::yes,
-      list_type::create(12, field_required::yes, std::move(location_struct))));
-
-    struct_type person_struct;
-    person_struct.fields.emplace_back(
-      nested_field::create(16, "name", field_required::no, string_type{}));
-    person_struct.fields.emplace_back(
-      nested_field::create(17, "age", field_required::yes, int_type{}));
-    expected_struct.fields.emplace_back(nested_field::create(
-      15, "person", field_required::no, std::move(person_struct)));
-    field_type expected_type = std::move(expected_struct);
-
-    const char* json_data = R"JSON({
-    "type": "struct",
-    "schema-id": 1,
-    "identifier-field-ids": [1],
-    "fields": [
-      {
-        "type": "string",
-        "id": 1,
-        "name": "foo",
-        "required": false
-      },
-      {
-        "type": "int",
-        "id": 2,
-        "name": "bar",
-        "required": true
-      },
-      {
-        "type": "boolean",
-        "id": 3,
-        "name": "baz",
-        "required": false
-      },
-      {
-        "id": 4,
-        "name": "qux",
-        "required": true,
-        "type": {
-          "type": "list",
-          "element-id": 5,
-          "element-required": true,
-          "element": "string"
-        }
-      },
-      {
-        "id": 6,
-        "name": "quux",
-        "required": true,
-        "type": {
-          "type": "map",
-          "key-id": 7,
-          "key": "string",
-          "value-id": 8,
-          "value": {
-            "type": "map",
-            "key-id": 9,
-            "key": "string",
-            "value-id": 10,
-            "value": "int",
-            "value-required": true
-          },
-          "value-required": true
-        }
-      },
-      {
-        "id": 11,
-        "name": "location",
-        "required": true,
-        "type": {
-          "type": "list",
-          "element-id": 12,
-          "element-required": true,
-          "element": {
-            "type": "struct",
-            "fields": [
-              {
-                "id": 13,
-                "name": "latitude",
-                "type": "float",
-                "required": false
-              },
-              {
-                "id": 14,
-                "name": "longitude",
-                "type": "float",
-                "required": false
-              }
-            ]
-          }
-        }
-      },
-      {
-        "id": 15,
-        "name": "person",
-        "required": false,
-        "type": {
-          "type": "struct",
-          "fields": [
-            {
-              "id": 16,
-              "name": "name",
-              "type": "string",
-              "required": false
-            },
-            {
-              "id": 17,
-              "name": "age",
-              "type": "int",
-              "required": true
-            }
-          ]
-        }
-      }
-    ]
-  })JSON";
+    field_type expected_type = test_nested_schema_type();
     const ss::sstring expected_type_str = type_to_json_str(expected_type);
 
     json::Document parsed_orig_json;
-    parsed_orig_json.Parse(json_data);
+    parsed_orig_json.Parse(test_nested_schema_json_str);
     auto parsed_orig_type = parse_type(parsed_orig_json);
     const ss::sstring parsed_orig_as_str = type_to_json_str(parsed_orig_type);
     ASSERT_EQ(expected_type, parsed_orig_type)

--- a/src/v/iceberg/tests/schema_json_test.cc
+++ b/src/v/iceberg/tests/schema_json_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/schema.h"
+#include "iceberg/schema_json.h"
+#include "iceberg/tests/test_schemas.h"
+#include "json/document.h"
+#include "json/stringbuffer.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+namespace {
+ss::sstring schema_to_json_str(const schema& t) {
+    json::StringBuffer buf;
+    json::Writer<json::StringBuffer> w(buf);
+    rjson_serialize(w, t);
+    return buf.GetString();
+}
+} // namespace
+
+TEST(SchemaJsonSerde, TestNestedSchema) {
+    json::Document parsed_orig_json;
+    parsed_orig_json.Parse(test_nested_schema_json_str);
+    auto parsed_schema = parse_schema(parsed_orig_json);
+
+    field_type expected_type = test_nested_schema_type();
+    ASSERT_EQ(
+      parsed_schema.schema_struct, std::get<struct_type>(expected_type));
+    ASSERT_EQ(parsed_schema.schema_id(), 1);
+    ASSERT_EQ(parsed_schema.identifier_field_ids.size(), 1);
+    ASSERT_EQ((*parsed_schema.identifier_field_ids.begin())(), 1);
+
+    const ss::sstring parsed_orig_as_str = schema_to_json_str(parsed_schema);
+    json::Document parsed_roundtrip_json;
+    parsed_roundtrip_json.Parse(parsed_orig_as_str);
+    auto parsed_roundtrip_schema = parse_schema(parsed_roundtrip_json);
+
+    ASSERT_EQ(parsed_roundtrip_schema, parsed_schema);
+}

--- a/src/v/iceberg/tests/test_schemas.cc
+++ b/src/v/iceberg/tests/test_schemas.cc
@@ -1,0 +1,174 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/tests/test_schemas.h"
+
+#include "iceberg/datatypes.h"
+
+namespace iceberg {
+
+// Expected type from test_nested_schema_json_str.
+field_type test_nested_schema_type() {
+    struct_type nested_struct;
+    nested_struct.fields.emplace_back(
+      nested_field::create(1, "foo", field_required::no, string_type{}));
+    nested_struct.fields.emplace_back(
+      nested_field::create(2, "bar", field_required::yes, int_type{}));
+    nested_struct.fields.emplace_back(
+      nested_field::create(3, "baz", field_required::no, boolean_type{}));
+
+    nested_struct.fields.emplace_back(nested_field::create(
+      4,
+      "qux",
+      field_required::yes,
+      list_type::create(5, field_required::yes, string_type{})));
+
+    nested_struct.fields.emplace_back(nested_field::create(
+      6,
+      "quux",
+      field_required::yes,
+      map_type::create(
+        7,
+        string_type{},
+        8,
+        field_required::yes,
+        map_type::create(
+          9, string_type{}, 10, field_required::yes, int_type{}))));
+
+    struct_type location_struct;
+    location_struct.fields.emplace_back(
+      nested_field::create(13, "latitude", field_required::no, float_type{}));
+    location_struct.fields.emplace_back(
+      nested_field::create(14, "longitude", field_required::no, float_type{}));
+    nested_struct.fields.emplace_back(nested_field::create(
+      11,
+      "location",
+      field_required::yes,
+      list_type::create(12, field_required::yes, std::move(location_struct))));
+
+    struct_type person_struct;
+    person_struct.fields.emplace_back(
+      nested_field::create(16, "name", field_required::no, string_type{}));
+    person_struct.fields.emplace_back(
+      nested_field::create(17, "age", field_required::yes, int_type{}));
+    nested_struct.fields.emplace_back(nested_field::create(
+      15, "person", field_required::no, std::move(person_struct)));
+    field_type nested_type = std::move(nested_struct);
+    return nested_type;
+}
+
+// Schema taken from
+// https://github.com/apache/iceberg-go/blob/704a6e78c13ea63f1ff4bb387f7d4b365b5f0f82/schema_test.go#L644
+const char* test_nested_schema_json_str = R"JSON({
+    "type": "struct",
+    "schema-id": 1,
+    "identifier-field-ids": [1],
+    "fields": [
+      {
+        "type": "string",
+        "id": 1,
+        "name": "foo",
+        "required": false
+      },
+      {
+        "type": "int",
+        "id": 2,
+        "name": "bar",
+        "required": true
+      },
+      {
+        "type": "boolean",
+        "id": 3,
+        "name": "baz",
+        "required": false
+      },
+      {
+        "id": 4,
+        "name": "qux",
+        "required": true,
+        "type": {
+          "type": "list",
+          "element-id": 5,
+          "element-required": true,
+          "element": "string"
+        }
+      },
+      {
+        "id": 6,
+        "name": "quux",
+        "required": true,
+        "type": {
+          "type": "map",
+          "key-id": 7,
+          "key": "string",
+          "value-id": 8,
+          "value": {
+            "type": "map",
+            "key-id": 9,
+            "key": "string",
+            "value-id": 10,
+            "value": "int",
+            "value-required": true
+          },
+          "value-required": true
+        }
+      },
+      {
+        "id": 11,
+        "name": "location",
+        "required": true,
+        "type": {
+          "type": "list",
+          "element-id": 12,
+          "element-required": true,
+          "element": {
+            "type": "struct",
+            "fields": [
+              {
+                "id": 13,
+                "name": "latitude",
+                "type": "float",
+                "required": false
+              },
+              {
+                "id": 14,
+                "name": "longitude",
+                "type": "float",
+                "required": false
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": 15,
+        "name": "person",
+        "required": false,
+        "type": {
+          "type": "struct",
+          "fields": [
+            {
+              "id": 16,
+              "name": "name",
+              "type": "string",
+              "required": false
+            },
+            {
+              "id": 17,
+              "name": "age",
+              "type": "int",
+              "required": true
+            }
+          ]
+        }
+      }
+    ]
+  })JSON";
+
+} // namespace iceberg

--- a/src/v/iceberg/tests/test_schemas.h
+++ b/src/v/iceberg/tests/test_schemas.h
@@ -1,0 +1,22 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/datatypes.h"
+
+namespace iceberg {
+
+// Expected type from test_nested_schema_json_str.
+field_type test_nested_schema_type();
+
+// Nested schema taken from
+// https://github.com/apache/iceberg-go/blob/704a6e78c13ea63f1ff4bb387f7d4b365b5f0f82/schema_test.go#L644
+extern const char* test_nested_schema_json_str;
+
+} // namespace iceberg


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds a schema struct to represent the schema[1] that will be included in Iceberg manifests and table metadata. In the Iceberg spec, the schema is composed of a struct type, and a few other fields that get serialized as JSON[2].

Compared to other Iceberg implementations, this is fairly minimal, only including state that gets serialized explicitly as a part of the spec. My intent is that that as additional maps become needed (as is the case for other implementations), they are added in wrapper structs, leaving this struct as is, focused on just state that needs to be serialized.

A future PR will exercise serializing the schema's JSON as a part of manifest metadata.

Here are some reference implementations of a schemas in other languages:
- Rust: https://github.com/apache/iceberg-rust/blob/f30d8723f4fc6038272cf8ad6beca65ce83d1ea6/crates/iceberg/src/spec/schema.rs#L47-L61
- Go: https://github.com/apache/iceberg-go/blob/fad5d8228bef04d756df000678772301abb91ce3/schema.go#L35-L51
- Java: https://github.com/apache/iceberg/blob/e02b5c90ef305b4d1ca5c19f0b9b2e99f9392e44/api/src/main/java/org/apache/iceberg/Schema.java#L58-L71

[1] https://iceberg.apache.org/spec/#schemas-and-data-types
[2] https://iceberg.apache.org/spec/#schemas

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
