### PR TITLE
cst/config: Disable trim carryover

### DIFF
--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -31,6 +31,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <fstream>
 #include <optional>
 #include <stdexcept>
@@ -565,6 +566,10 @@ FIXTURE_TEST(test_log_segment_cleanup, cache_test_fixture) {
 }
 
 FIXTURE_TEST(test_cache_carryover_trim, cache_test_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_cache_trim_carryover_bytes")
+      .set_value(uint32_t{256_KiB});
+
     std::string write_buf(1_MiB, ' ');
     random_generators::fill_buffer_randomchars(
       write_buf.data(), write_buf.size());

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2436,10 +2436,11 @@ configuration::configuration()
       "over to the next trim operation. This parameter sets a limit on the "
       "memory occupied by objects that can be carried over from one trim to "
       "next, and allows cache to quickly unblock readers before starting the "
-      "directory inspection.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      "directory inspection (deprecated)",
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::deprecated},
       // This roughly translates to around 1000 carryover file names
-      256_KiB)
+      0_KiB)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",


### PR DESCRIPTION
The trim carryover feature remembers items to be trimmed to quickly free up space on trim without going to disk.

With access tracker based trim, carryover can remove files, the updates to the inner data structure of access tracker can be pending and the tracker can try to delete these files again. This can potentially result in error logs due to double-delete of files.

The carryover limit is set to 0 so that the list does not carry any items. A user can still set the list to some value and enable the feature, but this can result in error logs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
