### PR TITLE
Backport for "Merged Guard from concurrent elections" #21361 

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -276,6 +276,7 @@ ss::future<> consensus::stop() {
     co_await _append_requests_buffer.stop();
     co_await _batcher.stop();
 
+    _election_lock.broken();
     _op_lock.broken();
     co_await _bg.close();
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1801,7 +1801,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request r) {
         _term = r.term;
         _voted_for = {};
         term_changed = true;
-        do_step_down("voter_term_greater");
+        do_step_down("candidate_term_greater");
         if (_leader_id) {
             _leader_id = std::nullopt;
             trigger_leadership_notification();
@@ -1809,7 +1809,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request r) {
 
         // do not grant vote if log isn't ok
         if (!reply.log_ok) {
-            // even tough we step down we do not want to update the hbeat as it
+            // even though we step down we do not want to update the hbeat as it
             // would cause subsequent votes to fail (_hbeat is updated by the
             // leader)
             _hbeat = clock_type::time_point::min();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -815,7 +815,7 @@ private:
     bool _transferring_leadership{false};
 
     /// useful for when we are not the leader
-    clock_type::time_point _hbeat = clock_type::now();
+    clock_type::time_point _hbeat = clock_type::now(); // is max() iff leader
     clock_type::time_point _became_leader_at = clock_type::now();
     clock_type::time_point _instantiated_at = clock_type::now();
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -833,15 +833,22 @@ private:
     /// used to wait for background ops before shutting down
     ss::gate _bg;
 
+    /**
+     * Locks listed in the order of nestedness, election being the outermost
+     * and snapshot the innermost. I.e. if any of these locks are used at the
+     * same time, they should be acquired in the listed order and released in
+     * reverse order.
+     */
+    /// guards from concurrent election where this instance is a candidate
+    mutex _election_lock{"consensus::election_lock"};
     /// all raft operations must happen exclusively since the common case
     /// is for the operation to touch the disk
     mutex _op_lock;
     /// since snapshot state is orthogonal to raft state when writing snapshot
     /// it is enough to grab the snapshot mutex, there is no need to keep
-    /// oplock, if the two locks are expected to be acquired at the same time
-    /// the snapshot lock should always be an internal (taken after the
-    /// _op_lock)
-    mutex _snapshot_lock;
+    /// oplock
+    mutex _snapshot_lock{"consensus::snapshot_lock"};
+
     /// used for notifying when commits happened to log
     event_manager _event_manager;
     std::unique_ptr<probe> _probe;

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -203,7 +203,7 @@ ss::future<> vote_stm::process_replies() {
 ss::future<> vote_stm::wait() { return _vote_bg.close(); }
 
 ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
-    // use reply term to update voter term
+    // use reply term to update our term
     for (auto& [_, r] : _replies) {
         if (r.value && r.value->has_value()) {
             auto term = r.value->value().term;
@@ -268,7 +268,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
 
     auto ec = co_await replicate_config_as_new_leader(std::move(u));
 
-    // if we didn't replicated configuration, step down
+    // even if failed to replicate, don't step down: followers may be behind
     if (ec) {
         vlog(
           _ctxlog.info,

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -78,6 +78,8 @@ private:
         std::unique_ptr<result<vote_reply>> value;
     };
 
+    void fail_election();
+
     friend std::ostream& operator<<(std::ostream&, const vmeta&);
 
     ss::future<> do_vote();


### PR DESCRIPTION
backport of https://github.com/redpanda-data/redpanda/pull/21361

the [first commit](https://github.com/redpanda-data/redpanda/pull/21361/commits/cafb4458f7fe29071ddc2d4e9ffa1a4224b6cfae) of the original PR is not relevant here (and actually explains where the removed dead code came from)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
