### PR TITLE
cloud storage: Fix deleted_count in clean_up_at_start

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -230,7 +230,7 @@ ss::future<> cache::clean_up_at_start() {
             try {
                 co_await delete_file_and_empty_parents(filepath_to_remove);
                 deleted_bytes += file_item.size;
-                deleted_bytes++;
+                deleted_count++;
             } catch (std::exception& e) {
                 vlog(
                   cst_log.error,

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -480,6 +480,7 @@ FIXTURE_TEST(test_clean_up_on_start, cache_test_fixture) {
     BOOST_CHECK(!ss::file_exists((CACHE_DIR / tmp_key).native()).get());
     BOOST_CHECK(!ss::file_exists(empty_dir_path.native()).get());
     BOOST_CHECK(ss::file_exists(populated_dir_path.native()).get());
+    BOOST_CHECK_EQUAL(get_object_count(), 2);
 }
 
 /**


### PR DESCRIPTION
`clean_up_at_start` deletes files that are not in the access time tracker. While doing so it keeps a count of the total bytes deleted as well as the number of files deleted. Before this change, the number of files deleted was tracked incorrectly, causing the cache to start with incorrect values for `_current_cache_size` and `_current_cache_objects`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
