### PR TITLE
[v24.1.x] cst/config: Disable trim carryover

### DIFF
--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -31,6 +31,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <fstream>
 #include <optional>
 #include <stdexcept>
@@ -565,6 +566,10 @@ FIXTURE_TEST(test_log_segment_cleanup, cache_test_fixture) {
 }
 
 FIXTURE_TEST(test_cache_carryover_trim, cache_test_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_cache_trim_carryover_bytes")
+      .set_value(uint32_t{256_KiB});
+
     std::string write_buf(1_MiB, ' ');
     random_generators::fill_buffer_randomchars(
       write_buf.data(), write_buf.size());

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2379,10 +2379,11 @@ configuration::configuration()
       "over to the next trim operation. This parameter sets a limit on the "
       "memory occupied by objects that can be carried over from one trim to "
       "next, and allows cache to quickly unblock readers before starting the "
-      "directory inspection.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      "directory inspection (deprecated)",
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::deprecated},
       // This roughly translates to around 1000 carryover file names
-      256_KiB)
+      0_KiB)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21556
