### PR TITLE
tests/tiered_sotage: ability to get test case from name

### DIFF
--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1432,7 +1432,7 @@ class TestCase(dict):
         dict.__init__(self, name=name)
 
     def __str__(self):
-        return self.__name
+        return self.name
 
     def validators(self) -> List[EffectValidator]:
         """All validators which are needed to be checked by the test case"""
@@ -1457,6 +1457,18 @@ class TestCase(dict):
             else:
                 test.get_logger().info(f"Result of {v.name()} is None")
         assert num_failed == 0, f"{num_failed} validators failed"
+
+    @property
+    def name(self):
+        return self.__name
+
+
+def get_test_case_from_name(name):
+    tc_list = get_tiered_storage_test_cases(False)
+    for tc in tc_list:
+        if tc.name == name:
+            return tc
+    return None
 
 
 def get_tiered_storage_test_cases(fast_run=False):

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -32,7 +32,7 @@ from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
 from rptest.services.redpanda import SISettings, CloudStorageTypeAndUrlStyle, get_cloud_storage_type, get_cloud_storage_type_and_url_style, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
-from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD
+from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD, get_test_case_from_name
 
 MAX_RETRIES = 20
 
@@ -563,6 +563,10 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
             - Consuming the data (use timequery)
             - Shutting down
         """
+        if not isinstance(test_case, TestCase):
+            test_case_name = json.loads(test_case)["name"]
+            test_case = get_test_case_from_name(test_case_name)
+            assert test_case is not None, f"no test case found with name {test_case_name}"
         # Configuration phase
         self.start_inputs(test_case)
         self.start_validators(test_case)


### PR DESCRIPTION
the `test_case` parametrization of `test_tiered_storage` test is of a custom type `TestCase`. that doesn't work when we need to run a specific parametrization of that test (eg `ducktape tests/rptest/tests/tiered_storage_model_test.py::TieredStorageTest.test_tiered_storage@{"test_case": {"name": "(TS_Read == True, SegmentRolledByTimeout == True)"}}`). So, ducktape can't retry a failed test_case of that test

This PR adds the ability to get the test_case object given a name to enable retries on that test

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none