### PR TITLE
[v24.2.x] tx/gateway: set outcome result when sync in end_txn failed

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1754,7 +1754,7 @@ ss::future<tx_gateway_frontend::op_result_t> tx_gateway_frontend::do_end_txn(
           request.transactional_id,
           pid,
           sync_result.error());
-
+        outcome->set_value(sync_result.error());
         co_return sync_result.error();
     }
     auto term = sync_result.value();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21559
