### PR TITLE
[v24.1.x] cloud storage: Fix deleted_count in clean_up_at_start

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -229,7 +229,7 @@ ss::future<> cache::clean_up_at_start() {
             try {
                 co_await delete_file_and_empty_parents(filepath_to_remove);
                 deleted_bytes += file_item.size;
-                deleted_bytes++;
+                deleted_count++;
             } catch (std::exception& e) {
                 vlog(
                   cst_log.error,

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -481,6 +481,7 @@ FIXTURE_TEST(test_clean_up_on_start, cache_test_fixture) {
     BOOST_CHECK(!ss::file_exists((CACHE_DIR / tmp_key).native()).get());
     BOOST_CHECK(!ss::file_exists(empty_dir_path.native()).get());
     BOOST_CHECK(ss::file_exists(populated_dir_path.native()).get());
+    BOOST_CHECK_EQUAL(get_object_count(), 2);
 }
 
 /**


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21569
