### PR TITLE
Use `ss::socket_address` instead of `ss::sstring` for `client_address_t`

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1295,10 +1295,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
 
         plan.reserve_from_partition_count(octx.fetch_partition_count());
 
-        const auto client_address = fmt::format(
-          "{}:{}",
-          octx.rctx.connection()->client_host(),
-          octx.rctx.connection()->client_port());
+        const auto client_address = octx.rctx.connection()->local_address();
 
         /**
          * group fetch requests by shard

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -191,7 +191,7 @@ struct fetch_config {
           cfg.abort_source.has_value()
             ? cfg.abort_source.value().get().abort_requested()
             : false,
-          cfg.client_address.value_or(model::client_address_t{"unknown"}));
+          cfg.client_address.value_or(model::client_address_t{}));
         return o;
     }
 };

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -23,6 +23,7 @@
 #include "utils/uuid.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/net/socket_defs.hh>
 #include <seastar/util/bool_class.hh>
 
 #include <boost/container_hash/hash.hpp>
@@ -504,7 +505,7 @@ static_assert(
 
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
-using client_address_t = named_type<ss::sstring, struct client_address_tag>;
+using client_address_t = ss::socket_address;
 
 enum class fips_mode_flag : uint8_t {
     // FIPS mode disabled


### PR DESCRIPTION
Calling `fmt::format` to create the address string, then copying that string, ends up consuming ~0.5% of overall reactor utilization;
![Screenshot from 2024-07-23 18-39-11](https://github.com/user-attachments/assets/3d6a7e4d-60dc-4d98-8cf7-cba3a5c0dee4)
This address string is only used in the cloud storage layer's debug/info logs. So this change defers the formatting of the 
address until then and instead passes around `ss::socket_address`.   This greatly reduces the reactor utilization in the normal case;
![Screenshot from 2024-07-23 19-36-34](https://github.com/user-attachments/assets/84fe889b-4bf1-4ec6-b9a3-a0a20ce006d0)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
