### PR TITLE
cst/cache: fix in mem trim termination condition

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -390,7 +390,7 @@ ss::future<> cache::trim(
     vlog(
       cst_log.debug,
       "in-memory trim: set target_size {}/{}, size {}/{}, reserved {}/{}, "
-      "pending {}/{}), candidates for deletion: {}, size to delete: {}, "
+      "pending {}/{}, candidates for deletion: {}, size to delete: {}, "
       "objects to delete: {}",
       target_size,
       target_objects,
@@ -430,6 +430,14 @@ ss::future<> cache::trim(
     if (
       size_to_delete <= undeletable_bytes
       && objects_to_delete <= undeletable_objects) {
+        vlog(
+          cst_log.debug,
+          "in-memory trim finished: size/objects to delete: {}/{}, undeletable "
+          "size/objects: {}/{}",
+          size_to_delete,
+          objects_to_delete,
+          undeletable_bytes,
+          undeletable_objects);
         _last_clean_up = ss::lowres_clock::now();
         _last_trim_failed = false;
         co_return;
@@ -465,7 +473,7 @@ ss::future<> cache::trim(
     vlog(
       cst_log.debug,
       "trim: set target_size {}/{}, size {}/{}, walked size {} (max {}/{}), "
-      " reserved {}/{}, pending {}/{}), candidates for deletion: {}, filtered "
+      " reserved {}/{}, pending {}/{}, candidates for deletion: {}, filtered "
       "out: {}",
       target_size,
       target_objects,
@@ -482,10 +490,8 @@ ss::future<> cache::trim(
       filtered_out_files);
 
     // Sort by atime for the subsequent LRU trimming loop
-    std::sort(
-      candidates_for_deletion.begin(),
-      candidates_for_deletion.end(),
-      [](auto& a, auto& b) { return a.access_time < b.access_time; });
+    std::ranges::sort(
+      candidates_for_deletion, {}, &file_list_item::access_time);
 
     vlog(
       cst_log.debug,
@@ -1758,6 +1764,12 @@ ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
                 // do the trim.
                 co_await trim_throttled_unlocked();
                 did_trim = true;
+            } else {
+                vlog(
+                  cst_log.debug,
+                  "Did not trim, may_trim_now: {}, may_exceed: {}",
+                  may_trim_now,
+                  may_exceed);
             }
 
             if (!may_reserve_space(bytes, objects)) {
@@ -1768,6 +1780,10 @@ ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
                     if (may_exceed) {
                         // Tip off the next caller that they may proactively
                         // exceed the cache size without waiting for a trim.
+                        vlog(
+                          cst_log.debug,
+                          "Last trim failed to free up space, will exceed max "
+                          "bytes");
                         _last_trim_failed = true;
                     }
                 }

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -428,8 +428,8 @@ ss::future<> cache::trim(
     auto undeletable_bytes = (co_await access_time_tracker_size()).value_or(0);
 
     if (
-      size_to_delete < undeletable_bytes
-      && objects_to_delete < undeletable_objects) {
+      size_to_delete <= undeletable_bytes
+      && objects_to_delete <= undeletable_objects) {
         _last_clean_up = ss::lowres_clock::now();
         _last_trim_failed = false;
         co_return;


### PR DESCRIPTION
At the end of an in-memory trim if the size to delete is equal to or less than undeletable bytes the trim should finish, because further trimming will not result in extra space being freed up. The undeletable bytes are from the access tracker size. 

In particular where tracker is not yet saved to disk, the size to delete and undeletable bytes can both be zero and the existing `0 < 0` check fails, resulting in an expensive disk based walk being wasted as the subsequent trim runs with 0 size to delete.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
