### PR TITLE
tests: minimize OMB producer retries in shard_placement_scale_test

### DIFF
--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -38,6 +38,8 @@ class ShardPlacementScaleTest(RedpandaTest):
         pass
 
     def start_omb(self):
+        producer_rate_mbps = 100
+
         workload = {
             "name": "CommonWorkload",
             "topics": 1,
@@ -45,7 +47,7 @@ class ShardPlacementScaleTest(RedpandaTest):
             "subscriptions_per_topic": 1,
             "consumer_per_subscription": 25,
             "producers_per_topic": 5,
-            "producer_rate": 100 * 1024,
+            "producer_rate": producer_rate_mbps * 1024,
             "message_size": 1024,
             "payload_file": "payload/payload-1Kb.data",
             "key_distributor": "KEY_ROUND_ROBIN",
@@ -68,6 +70,7 @@ class ShardPlacementScaleTest(RedpandaTest):
                 # which leads to unreasonably high reactor util)
                 "max.request.size": 5 * 2**20,
                 "linger.ms": 500,
+                "max.in.flight.requests.per.connection": 1,
             },
             "consumer_config": {
                 "auto.offset.reset": "earliest",
@@ -77,7 +80,7 @@ class ShardPlacementScaleTest(RedpandaTest):
         }
         validator = {
             OMBSampleConfigurations.AVG_THROUGHPUT_MBPS:
-            [OMBSampleConfigurations.gte(100)]
+            [OMBSampleConfigurations.gte(producer_rate_mbps)]
         }
 
         self._benchmark = OpenMessagingBenchmark(ctx=self.test_context,


### PR DESCRIPTION
Producer retries lead to increased load for two reasons:
1) they are additional requests
2) for some reason, new batches that are formed during the period of retries are smaller than usual and lead to "small batches problem"

This can lead to OMB failing to achieve desired throughput and therefore to test failure.

Another reason why they may lead to a test failure is this client bug: https://issues.apache.org/jira/browse/KAFKA-7848 - it looks like for very large linger.ms values, old batches can get stuck in the producer queue until after the idempotency window slides past them. These batches will be rejected by the broker, therefore the client will get stuck.

Fix both of these problems by limiting the number of concurrent requests per connection.

Fixes https://github.com/redpanda-data/redpanda/issues/21542

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none