### PR TITLE
[v24.1.x] [CORE-5632] cluster: Reset cloud storage metric in the `cluster::partition::remove_persistent_state`

### DIFF
--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -34,6 +34,8 @@ public:
     uint64_t get_records_read() const noexcept { return _records_read; }
     uint64_t get_chunk_size() const noexcept { return _chunk_size; }
 
+    void clear_metrics() { _metrics.clear(); }
+
 private:
     // Number of bytes that partition reader have received
     uint64_t _bytes_read = 0;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -838,6 +838,7 @@ partition::get_cloud_term_last_offset(model::term_id term) const {
 }
 
 ss::future<> partition::remove_persistent_state() {
+    _cloud_storage_probe->clear_metrics();
     co_await _raft->stm_manager()->remove_local_state();
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21581
