### PR TITLE
Improved error logging of API responses

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -406,8 +406,13 @@ class CloudCluster():
     def _get_cluster_console_url(self):
         cluster = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.current.cluster_id}')
-        return cluster['status']['listeners']['redpandaConsole']['default'][
-            'urls'][0]
+        try:
+            return cluster['status']['listeners']['redpandaConsole'][
+                'default']['urls'][0]
+        except KeyError as e:
+            error_message = f"KeyError: {e} not found in API response"
+            self._logger.info(error_message)
+            raise RuntimeError(f"Failed to get cluster console URL: {e}")
 
     def _get_network_id(self):
         """
@@ -416,7 +421,12 @@ class CloudCluster():
         """
         _cluster = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.current.cluster_id}')
-        return _cluster['spec']['networkId']
+        try:
+            return _cluster['spec']['networkId']
+        except KeyError as e:
+            error_message = f"KeyError: {e} not found in API response"
+            self._logger.info(error_message)
+            raise RuntimeError(f"Failed to get network ID: {e}")
 
     def _get_network(self):
         return self.cloudv2._http_get(


### PR DESCRIPTION


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none

### Improvements

Improved error logging for _get_cluster_console_url and _get_network_id

In our redpanda_cloud tests, if we get an unexpcted result back from the API (i.e., default key does not exist), we should include the response in the error output, rather than just KeyError: 'default'.

Current Error:
"/home/ubuntu/redpanda/tests/rptest/services/redpanda_cloud.py", line 409, in _get_cluster_console_url return cluster['status']['listeners']['redpandaConsole']['default'][ KeyError: 'default'
