### PR TITLE
cst/inv: Fix aws ops prefix handling

### DIFF
--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -15,7 +15,9 @@
 #include "cloud_storage/remote.h"
 #include "json/istreamwrapper.h"
 
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <rapidjson/error/en.h>
@@ -70,26 +72,38 @@ iobuf to_xml(const aws_report_configuration& cfg) {
     return b;
 }
 
-// YYYY-MM-DDTHH-MMZ/
-const re2::RE2 trailing_date_expression{R"(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}Z/)"};
+// Ends with YYYY-MM-DDTHH-MMZ/
+const re2::RE2 trailing_date_expression{
+  R"(.*/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}Z/$)"};
 
 struct path_with_datetime {
     cloud_storage::inventory::report_datetime datetime;
     cloud_storage_clients::object_key path;
 };
 
-bool is_datetime(std::string_view path) {
+bool ends_with_datetime(std::string_view path) {
     return RE2::FullMatch(path, trailing_date_expression);
 }
 
-path_with_datetime
-checksum_path(std::string_view prefix, std::string_view date_string) {
-    date_string.remove_suffix(1);
+path_with_datetime checksum_path(std::string_view datetime_path) {
+    // We should have previously checked with a regex that the path ends with
+    // a /date/ pattern. Throw an error here if that invariant is broken.
+    if (!ends_with_datetime(datetime_path)) {
+        throw std::invalid_argument{fmt::format(
+          "unexpected path ending with datetime: {}", datetime_path)};
+    }
+
+    std::vector<std::string> parts;
+    // prefix/bucket/inv-id/datetime
+    parts.reserve(4);
+    boost::split(parts, datetime_path, boost::is_any_of("/"));
+
+    const auto& date_string = *(parts.end() - 2);
     return {
       .datetime = cloud_storage::inventory::
         report_datetime{date_string.data(), date_string.size()},
       .path = cloud_storage_clients::object_key{
-        fmt::format("{}{}/manifest.checksum", prefix, date_string)}};
+        fmt::format("{}manifest.checksum", datetime_path)}};
 }
 
 constexpr auto max_logged_json_size = 128;
@@ -226,17 +240,14 @@ ss::future<op_result<report_metadata>> aws_ops::do_fetch_latest_report_metadata(
       cst_log.trace,
       "Found common prefixes: {}",
       list_result.value().common_prefixes);
-    auto transform_to_checksum = [&full_prefix](auto datetime) {
-        return checksum_path(full_prefix().native(), datetime);
-    };
 
     // The prefix may contain non-datetime folders such as hive data, which we
     // ignore. The datetime folders are normalized with the prefix, and then the
     // checksum file path is appended to them. The final result is a series of
     // paths to checksums which we need to probe.
     auto filtered = list_result.value().common_prefixes
-                    | std::views::filter(is_datetime)
-                    | std::views::transform(transform_to_checksum);
+                    | std::views::filter(ends_with_datetime)
+                    | std::views::transform(checksum_path);
 
     std::vector<path_with_datetime> checksum_paths{
       filtered.begin(), filtered.end()};
@@ -306,7 +317,7 @@ ss::future<op_result<report_metadata>> aws_ops::do_fetch_latest_report_metadata(
           .datetime = path_with_datetime.datetime};
     }
 
-    co_return error_outcome::failed;
+    co_return error_outcome::no_reports_found;
 }
 
 ss::future<op_result<report_paths>> aws_ops::fetch_and_parse_metadata(

--- a/src/v/cloud_storage/inventory/tests/inv_svc_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/inv_svc_tests.cc
@@ -146,7 +146,8 @@ ss::future<cst::cloud_storage_api::list_result> validate_list_objs(
     EXPECT_FALSE(continuation_token.has_value());
 
     co_return cloud_storage_clients::client::list_bucket_result{
-      .common_prefixes = {fmt::format("{}/", expected_date)}};
+      .common_prefixes = {fmt::format(
+        "{}/{}/{}/{}/", prefix, bucket(), inv_id(), expected_date)}};
 }
 
 constexpr auto manifest_json = R"(
@@ -370,10 +371,14 @@ TEST(Service, OlderReportIsSkipped) {
       []() -> ss::future<csi::MockRemote::list_result> {
         co_return cloud_storage_clients::client::list_bucket_result{
           .common_prefixes = {
-            "1111-11-11T11-19Z/",
-            "1111-11-11T11-22Z/",
-            "1111-11-11T11-83Z/",
-            "1111-00-11T11-15Z/"}};
+            fmt::format(
+              "{}/{}/{}/1111-11-11T11-19Z/", prefix, bucket(), inv_id()),
+            fmt::format(
+              "{}/{}/{}/1111-11-11T11-22Z/", prefix, bucket(), inv_id()),
+            fmt::format(
+              "{}/{}/{}/1111-11-11T11-83Z/", prefix, bucket(), inv_id()),
+            fmt::format(
+              "{}/{}/{}/1111-00-11T11-15Z/", prefix, bucket(), inv_id())}};
     };
     EXPECT_CALL(
       remote, list_objects(bucket, t::_, t::_, t::_, t::_, t::_, t::_))

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -37,6 +37,7 @@ enum class error_outcome {
     manifest_download_failed,
     manifest_files_parse_failed,
     manifest_deserialization_failed,
+    no_reports_found,
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -45,21 +46,24 @@ struct error_outcome_category final : public std::error_category {
     }
 
     std::string message(int c) const final {
+        using enum error_outcome;
         switch (static_cast<error_outcome>(c)) {
-        case error_outcome::success:
+        case success:
             return "Success";
-        case error_outcome::failed:
+        case failed:
             return "Failed";
-        case error_outcome::create_inv_cfg_failed:
+        case create_inv_cfg_failed:
             return "Failed to create inventory configuration";
-        case error_outcome::failed_to_check_inv_status:
+        case failed_to_check_inv_status:
             return "Failed to check inventory configuration status";
-        case error_outcome::manifest_download_failed:
+        case manifest_download_failed:
             return "Failed to download manifest";
-        case error_outcome::manifest_files_parse_failed:
+        case manifest_files_parse_failed:
             return "Failed to extract files object from manifest";
-        case error_outcome::manifest_deserialization_failed:
+        case manifest_deserialization_failed:
             return "Failed to parse manifest to JSON";
+        case no_reports_found:
+            return "No reports found";
         default:
             return fmt::format("Unknown outcome ({})", c);
         }


### PR DESCRIPTION
The aws ops methods assumed that if a prefix is supplied to listv2, the result contains common-prefixes which start after the prefix. The result actually contains the full path from the bucket root.

For example if prefix=foo/bar and there is a directory called 1 within foo/bar then the common-prefix in list-result is foo/bar/1/ and not 1/. This mistake is fixed in this change, and the associated tests are also fixed.

Note on backports: while aws ops is present in previous branches, it is not wired into the service which is not present, and one of the tests changed in this PR is inventory service test. So backporting this PR as it is would not work and is not required as the service is not wired up.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
