### PR TITLE
Increased tolerance in fast addition tests

### DIFF
--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -482,7 +482,7 @@ class ScalingUpTest(PreallocNodesTest):
         print_disk_usage(usage)
 
         verify_disk_usage(usage,
-                          [self.redpanda.node_id(self.redpanda.nodes[4])], 0.2)
+                          [self.redpanda.node_id(self.redpanda.nodes[4])], 0.3)
 
         # add sixth node
         self.redpanda.start_node(self.redpanda.nodes[5])
@@ -494,7 +494,7 @@ class ScalingUpTest(PreallocNodesTest):
         verify_disk_usage(usage, [
             self.redpanda.node_id(self.redpanda.nodes[4]),
             self.redpanda.node_id(self.redpanda.nodes[5])
-        ], 0.2)
+        ], 0.3)
         # verify that data can be read
         self.consumer = KgoVerifierSeqConsumer(self.test_context,
                                                self.redpanda,


### PR DESCRIPTION
In order to make the test stable increased a tolerance on the size of data on a node that joins the cluster. The slight increase doesn't influence the test correctness but makes it less vulnerable to small changes in size of partition metadata.

Fixes: #20224

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none