### PR TITLE
[CORE-6464] schema_registry/json: compatibility check for `$schema`

### DIFF
--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -539,6 +539,20 @@ static constexpr auto compatibility_test_cases = std::to_array<
     = R"({"oneOf": [{"type":"number", "multipleOf": 10}, {"type": "number", "multipleOf": 1.1}]})",
     .reader_is_compatible_with_writer = false,
   },
+  // different dialects
+  {
+    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
+    .writer_schema
+    = R"({"$schema": "http://json-schema.org/draft-06/schema#"})",
+    .reader_is_compatible_with_writer = false,
+    .expected_exception = true,
+  },
+  {
+    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
+    .writer_schema = "true",
+    .reader_is_compatible_with_writer = false,
+    .expected_exception = true,
+  },
   //***** compatible section *****
   // atoms
   {
@@ -747,6 +761,13 @@ static constexpr auto compatibility_test_cases = std::to_array<
     = R"({"oneOf": [{"type":"number", "multipleOf": 3}, {"type": "boolean"}]})",
     .writer_schema
     = R"({"oneOf": [{"type":"boolean"}, {"type": "number", "multipleOf": 9}]})",
+    .reader_is_compatible_with_writer = true,
+  },
+  // dialects
+  {
+    .reader_schema = R"({"$schema": "http://json-schema.org/draft-06/schema"})",
+    .writer_schema
+    = R"({"$schema": "http://json-schema.org/draft-06/schema#"})",
     .reader_is_compatible_with_writer = true,
   },
 });


### PR DESCRIPTION
this PR implements a basic check:

If both schemas have a "$schema" member, it must be the same dialect.

Different dialects could be conditionally compatible, but this check is not implemented here

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes https://redpandadata.atlassian.net/browse/CORE-6464

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none