### PR TITLE
cloud_storage_clients: fix `abs_parse_impl` error

### DIFF
--- a/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
+++ b/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
@@ -44,21 +44,21 @@ static constexpr std::string_view payload = R"XML(
 )XML";
 
 static constexpr std::string_view abs_payload = R"XML(
-<EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">  
-  <Prefix>prefix</Prefix>  
-  <Marker>string-value</Marker>  
-  <MaxResults>int-value</MaxResults>  
-  <Delimiter>string-value</Delimiter>  
-  <Blobs>  
-    <Blob>  
-      <Name>blob-name</Name>  
-      <Snapshot>date-time-value</Snapshot>  
+<EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">
+  <Prefix>prefix</Prefix>
+  <Marker>string-value</Marker>
+  <MaxResults>int-value</MaxResults>
+  <Delimiter>string-value</Delimiter>
+  <Blobs>
+    <Blob>
+      <Name>blob-name</Name>
+      <Snapshot>date-time-value</Snapshot>
       <VersionId>date-time-vlue</VersionId>
       <IsCurrentVersion>true</IsCurrentVersion>
       <Deleted>true</Deleted>
-      <Properties> 
+      <Properties>
         <Creation-Time>date-time-value</Creation-Time>
-        <Last-Modified>2021-01-10T02:00:00.000Z</Last-Modified>  
+        <Last-Modified>2021-01-10T02:00:00.000Z</Last-Modified>
         <Etag>etag</Etag>
         <Owner>owner user id</Owner>
         <Group>owning group id</Group>
@@ -66,25 +66,25 @@ static constexpr std::string_view abs_payload = R"XML(
         <Acl>access control list</Acl>
         <ResourceType>file | directory</ResourceType>
         <Placeholder>true</Placeholder>
-        <Content-Length>1112</Content-Length>  
-        <Content-Type>blob-content-type</Content-Type>  
-        <Content-Encoding />  
-        <Content-Language />  
-        <Content-MD5 />  
-        <Cache-Control />  
-        <x-ms-blob-sequence-number>sequence-number</x-ms-blob-sequence-number>  
-        <BlobType>BlockBlob|PageBlob|AppendBlob</BlobType>  
-        <AccessTier>tier</AccessTier>  
-        <LeaseStatus>locked|unlocked</LeaseStatus>  
-        <LeaseState>available | leased | expired | breaking | broken</LeaseState>  
-        <LeaseDuration>infinite | fixed</LeaseDuration>  
-        <CopyId>id</CopyId>  
-        <CopyStatus>pending | success | aborted | failed </CopyStatus>  
-        <CopySource>source url</CopySource>  
-        <CopyProgress>bytes copied/bytes total</CopyProgress>  
-        <CopyCompletionTime>datetime</CopyCompletionTime>  
-        <CopyStatusDescription>error string</CopyStatusDescription>  
-        <ServerEncrypted>true</ServerEncrypted> 
+        <Content-Length>1112</Content-Length>
+        <Content-Type>blob-content-type</Content-Type>
+        <Content-Encoding />
+        <Content-Language />
+        <Content-MD5 />
+        <Cache-Control />
+        <x-ms-blob-sequence-number>sequence-number</x-ms-blob-sequence-number>
+        <BlobType>BlockBlob|PageBlob|AppendBlob</BlobType>
+        <AccessTier>tier</AccessTier>
+        <LeaseStatus>locked|unlocked</LeaseStatus>
+        <LeaseState>available | leased | expired | breaking | broken</LeaseState>
+        <LeaseDuration>infinite | fixed</LeaseDuration>
+        <CopyId>id</CopyId>
+        <CopyStatus>pending | success | aborted | failed </CopyStatus>
+        <CopySource>source url</CopySource>
+        <CopyProgress>bytes copied/bytes total</CopyProgress>
+        <CopyCompletionTime>datetime</CopyCompletionTime>
+        <CopyStatusDescription>error string</CopyStatusDescription>
+        <ServerEncrypted>true</ServerEncrypted>
         <CustomerProvidedKeySha256>encryption-key-sha256</CustomerProvidedKeySha256>
         <EncryptionScope>encryption-scope-name</EncryptionScope>
         <IncrementalCopy>true</IncrementalCopy>
@@ -95,10 +95,10 @@ static constexpr std::string_view abs_payload = R"XML(
         <TagCount>number of tags between 1 to 10</TagCount>
         <RehydratePriority>rehydrate priority</RehydratePriority>
         <Expiry-Time>date-time-value</Expiry-Time>
-      </Properties>  
-      <Metadata>     
-        <Name>value</Name>  
-      </Metadata>  
+      </Properties>
+      <Metadata>
+        <Name>value</Name>
+      </Metadata>
       <Tags>
           <TagSet>
               <Tag>
@@ -108,53 +108,53 @@ static constexpr std::string_view abs_payload = R"XML(
           </TagSet>
       </Tags>
       <OrMetadata />
-    </Blob>  
-    <BlobPrefix>  
-      <Name>blob-prefix</Name>  
-    </BlobPrefix>  
-  </Blobs>  
-  <NextMarker />  
+    </Blob>
+    <BlobPrefix>
+      <Name>blob-prefix</Name>
+    </BlobPrefix>
+  </Blobs>
+  <NextMarker />
 </EnumerationResults>
 )XML";
 
 static constexpr std::string_view abs_payload_with_continuation = R"XML(
-<EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">  
-  <Prefix>prefix</Prefix>  
-  <Marker>string-value</Marker>  
-  <MaxResults>int-value</MaxResults>  
-  <Delimiter>string-value</Delimiter>  
-  <Blobs>  
-    <Blob>  
-      <Name>blob-name</Name>  
-      <Snapshot>date-time-value</Snapshot>  
+<EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">
+  <Prefix>prefix</Prefix>
+  <Marker>string-value</Marker>
+  <MaxResults>int-value</MaxResults>
+  <Delimiter>string-value</Delimiter>
+  <Blobs>
+    <Blob>
+      <Name>blob-name</Name>
+      <Snapshot>date-time-value</Snapshot>
       <VersionId>date-time-vlue</VersionId>
       <IsCurrentVersion>true</IsCurrentVersion>
       <Deleted>true</Deleted>
-      <Properties> 
+      <Properties>
         <Creation-Time>date-time-value</Creation-Time>
-        <Last-Modified>2021-01-10T02:00:00.000Z</Last-Modified>  
+        <Last-Modified>2021-01-10T02:00:00.000Z</Last-Modified>
         <Etag>etag</Etag>
         <Acl>access control list</Acl>
         <ResourceType>file | directory</ResourceType>
         <Placeholder>true</Placeholder>
-        <Content-Length>1112</Content-Length>  
-        <Content-Type>blob-content-type</Content-Type>  
-        <Content-Encoding />  
-        <Content-Language />  
-        <Content-MD5 />  
-        <Cache-Control />  
-        <x-ms-blob-sequence-number>sequence-number</x-ms-blob-sequence-number>  
-        <BlobType>BlockBlob|PageBlob|AppendBlob</BlobType>  
+        <Content-Length>1112</Content-Length>
+        <Content-Type>blob-content-type</Content-Type>
+        <Content-Encoding />
+        <Content-Language />
+        <Content-MD5 />
+        <Cache-Control />
+        <x-ms-blob-sequence-number>sequence-number</x-ms-blob-sequence-number>
+        <BlobType>BlockBlob|PageBlob|AppendBlob</BlobType>
         <RemainingRetentionDays>no-of-days</RemainingRetentionDays>
         <TagCount>number of tags between 1 to 10</TagCount>
         <Expiry-Time>date-time-value</Expiry-Time>
-      </Properties>  
-    </Blob>  
-    <BlobPrefix>  
-      <Name>blob-prefix</Name>  
-    </BlobPrefix>  
-  </Blobs>  
-  <NextMarker>nnn</NextMarker>  
+      </Properties>
+    </Blob>
+    <BlobPrefix>
+      <Name>blob-prefix</Name>
+    </BlobPrefix>
+  </Blobs>
+  <NextMarker>nnn</NextMarker>
 </EnumerationResults>
 )XML";
 

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -190,7 +190,9 @@ bool abs_parse_impl::is_in_blob_prefixes() const {
 }
 
 void abs_parse_impl::handle_start_element(std::string_view element_name) {
-    if (element_name == abs_tags::blob && _tags.size() == 2) {
+    if (
+      (element_name == abs_tags::blob || element_name == abs_tags::blob_prefix)
+      && _tags.size() == 2) {
         // Reinitialize the item in preparation for next values
         _current_item.emplace();
     } else if (element_name == abs_tags::name) {


### PR DESCRIPTION
We ran into a case in which the `xml_sax_parser` would throw an exception when processing a ABS `List Blobs` response like the following:

```
<?xml version="1.0" encoding="utf-8"?>
<EnumerationResults ServiceEndpoint="https://blob.core.windows.net/" ContainerName="container">
  <Prefix>cluster_metadata/bb7527f1-3227-4d55-86da-c133ec955ea9/manifests/
  </Prefix>
  <Delimiter>/</Delimiter>
  <Blobs>
    <BlobPrefix>
      <Name>cluster_metadata/bb7527f1-3227-4d55-86da-c133ec955ea9/manifests/2/
      </Name>
      <Properties>
	<Creation-Time>Thu, 25 Jul 2024 14:07:26 GMT
	</Creation-Time>
      </Properties>
    </BlobPrefix>
  </Blobs>
</EnumerationResults>
```

resulting in logged output:

```
redpanda-0  | ERROR 2024-07-19 13:51:29,995 [shard 0:main] abs - util.cc:108 - Unexpected error cloud_storage_clients::xml_parse_exception (Invalid state: parsing Last-Modified when not in Blob tag)
redpanda-0  | WARN  2024-07-19 13:51:29,995 [shard 0:main] cloud_storage - [fiber391~0|1|3599738ms] - remote.cc:1459 - ListObjectsV2 rpandatiredstorageone, unexpected error: cloud_storage_clients::error_outcome:1
```

The issue here being that no `<Blob>...</Blob>` element is returned inside the `<Blobs>` element, and when
processing the `<BlobPrefix>` element, a throw statement is triggered.

This commit corrects the parser code to anticipate this potential corner case.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which the `abs_parse_impl` used in `xml_sax_parser` would throw an exception when processing a `List Blobs` response with a `<BlobPrefix>` element within `<Blobs>`, but without any `<Blob>` elements.
