### PR TITLE
archival: fix `purger::collect_manifest_paths()`

### DIFF
--- a/src/v/cluster/archival/purger.cc
+++ b/src/v/cluster/archival/purger.cc
@@ -225,7 +225,23 @@ purger::collect_manifest_paths(
             continue;
         }
 
-        collected.spillover.push_back(std::move(item.key));
+        // The spillover manifest path is of the form
+        // "{prefix}/{manifest.bin().x.x.x.x.x.x}" Find the index of the last
+        // '/' in the path, so we can check just the filename (starting from the
+        // first character after '/').
+        const size_t filename_idx = path.rfind('/');
+        if (filename_idx == std::string_view::npos) {
+            continue;
+        }
+
+        // File should start with "manifest.bin()", but it should have
+        // additional spillover components as well.
+        std::string_view file = path.substr(filename_idx + 1);
+        if (
+          file.starts_with(cloud_storage::partition_manifest::filename())
+          && !file.ends_with(cloud_storage::partition_manifest::filename())) {
+            collected.spillover.push_back(std::move(item.key));
+        }
     }
 
     co_return collected;


### PR DESCRIPTION
Before, the `purger` would push back what it assumed was the spillover manifest file by default to its list of `collected_manifests`.

In the case of ABS, `_api.list_objects` might actually return the directory itself as a `Blob`. This would lead to the `purger` attempting to download the directory as if it were a manifest, which would always fail.

This would completely block the `purger` from progressing and deleting other partitions in the deleted topic, as it would retry the same doomed manifest download.

Correct the logic in `collect_manifest_paths()` by checking the path for `manifest.bin`, which should be contained within the spillover filename (e.g `.../5_21/manifest.bin.10.11.0.1.999.1000`).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes


### Bug Fixes

* Fixes a bug in the `purger`, which when used with `ABS` may attempt to download a directory `Blob` as a manifest. This would completely block the `purger` from purging partitions for a deleted topic. 