### PR TITLE
cst/clients: Add no such config response handling

### DIFF
--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -170,7 +170,8 @@ ss::future<op_result<bool>> aws_ops::inventory_configuration_exists(
     auto dl_res = co_await remote.download_object(
       {.transfer_details
        = {.bucket = _bucket, .key = _inventory_key, .parent_rtc = parent_rtc},
-       .payload = buf});
+       .payload = buf,
+       .expect_missing = true});
 
     if (dl_res == download_result::success) {
         co_return true;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -833,7 +833,7 @@ remote::download_object(cloud_storage::download_request download_request) {
             .is_retry = fib.retry_count() > 1},
           transfer_details.parent_rtc);
         auto resp = co_await lease.client->get_object(
-          bucket, path, fib.get_timeout());
+          bucket, path, fib.get_timeout(), download_request.expect_missing);
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -428,6 +428,7 @@ struct download_request {
     transfer_details transfer_details;
     download_type type;
     iobuf& payload;
+    bool expect_missing{false};
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -483,7 +483,9 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
     try {
         co_return co_await std::move(request_future);
     } catch (const rest_error_response& err) {
-        if (err.code() == s3_error_code::no_such_key) {
+        if (
+          err.code() == s3_error_code::no_such_key
+          || err.code() == s3_error_code::no_such_configuration) {
             // Unexpected 404s are logged by 'request_future' at warn
             // level, so only log at debug level here.
             vlog(s3_log.debug, "NoSuchKey response received {}", key);

--- a/src/v/cloud_storage_clients/s3_error.cc
+++ b/src/v/cloud_storage_clients/s3_error.cc
@@ -285,6 +285,9 @@ std::ostream& operator<<(std::ostream& o, s3_error_code code) {
     case s3_error_code::malformed_policy:
         o << "MalformedPolicy";
         break;
+    case s3_error_code::no_such_configuration:
+        o << "NoSuchConfiguration";
+        break;
     case s3_error_code::_unknown:
         o << "_unknown_error_code_";
         break;
@@ -397,7 +400,8 @@ static const std::map<ss::sstring, s3_error_code> known_aws_error_codes = {
   {"UserKeyMustBeSpecified", s3_error_code::user_key_must_be_specified},
   {"NoSuchAccessPoint", s3_error_code::no_such_access_point},
   {"InvalidTag", s3_error_code::invalid_tag},
-  {"MalformedPolicy", s3_error_code::malformed_policy}};
+  {"MalformedPolicy", s3_error_code::malformed_policy},
+  {"NoSuchConfiguration", s3_error_code::no_such_configuration}};
 
 std::istream& operator>>(std::istream& i, s3_error_code& code) {
     ss::sstring c;

--- a/src/v/cloud_storage_clients/s3_error.h
+++ b/src/v/cloud_storage_clients/s3_error.h
@@ -115,6 +115,7 @@ enum class s3_error_code {
     no_such_access_point,
     invalid_tag,
     malformed_policy,
+    no_such_configuration,
     _unknown
 };
 


### PR DESCRIPTION
A `NoSuchConfiguration` response code is returned by AWS S3 when an inventory configuration does not exist. It should be treated the same as a generic 404 response code because it indicates that the entity does not exist. 

The changes here ensure that when the presence of an inventory config is checked by the inventory service using `remote::download_object`, and a `NoSuchConfiguration` response is returned because the config does not yet exist, the code path correctly handles it like 404 and lets the inventory service ignore it rather than treating it as an error. 

This issue was seen during manual testing of the inventory config PUT api against a real S3 bucket.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
