### PR TITLE
Schema registry/json: Ignore some keywords

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -1387,17 +1387,13 @@ bool is_superset(
            "definitions",
            "dependencies",
            // draft 6 unhandled keywords:
-           "$comment",
            "$ref",
            "const",
            "contains",
-           "examples",
            "propertyNames",
            // draft 7 unhandled keywords
            "contentEncoding",
            "contentMediaType",
-           "readOnly",
-           "writeOnly",
            // draft 2019-09 unhandled keywords:
            "$anchor",
            "$recursiveRef",
@@ -1407,7 +1403,6 @@ bool is_superset(
            "dependentRequired",
            "maxContains",
            "minContains",
-           "deprecated",
            // draft 2020-12 unhandled keywords:
            "$dynamicRef",
            "$dynamicAnchor",

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -1388,24 +1388,9 @@ bool is_superset(
            "dependencies",
            // draft 6 unhandled keywords:
            "$ref",
-           "const",
-           "contains",
-           "propertyNames",
-           // draft 7 unhandled keywords
-           "contentEncoding",
-           "contentMediaType",
            // draft 2019-09 unhandled keywords:
-           "$anchor",
-           "$recursiveRef",
-           "$recursiveAnchor",
-           "unevaluatedItems",
-           "unevaluatedProperties",
            "dependentRequired",
-           "maxContains",
-           "minContains",
            // draft 2020-12 unhandled keywords:
-           "$dynamicRef",
-           "$dynamicAnchor",
            "prefixItems",
          }) {
         if (

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -1390,6 +1390,7 @@ bool is_superset(
            "$ref",
            // draft 2019-09 unhandled keywords:
            "dependentRequired",
+           "dependentSchemas",
            // draft 2020-12 unhandled keywords:
            "prefixItems",
          }) {


### PR DESCRIPTION
Increase compatibility of compatibility checks for JSON by not being overly strict by rejecting keywords.
 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
