### PR TITLE
[v24.2.x] cloud_storage: add `error_outcome::operation_not_supported`

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -303,6 +303,8 @@ ss::future<download_result> remote::do_download_manifest(
               retry_permit.delay, fib.root_abort_source());
             retry_permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             vlog(
@@ -401,6 +403,8 @@ ss::future<upload_result> remote::upload_manifest(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::key_not_found:
             // not expected during upload
             [[fallthrough]];
@@ -575,6 +579,8 @@ ss::future<upload_result> remote::upload_stream(
             }
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::key_not_found:
             // not expected during upload
             [[fallthrough]];
@@ -757,6 +763,8 @@ ss::future<download_result> remote::download_stream(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -860,6 +868,8 @@ remote::download_object(cloud_storage::download_request download_request) {
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -931,6 +941,8 @@ ss::future<download_result> remote::object_exists(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = download_result::failed;
             break;
@@ -1013,6 +1025,8 @@ ss::future<upload_result> remote::delete_object(
             co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
@@ -1172,6 +1186,8 @@ ss::future<upload_result> remote::delete_object_batch(
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = upload_result::failed;
             break;
@@ -1384,6 +1400,8 @@ ss::future<remote::list_result> remote::list_objects(
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:
             result = cloud_storage_clients::error_outcome::fail;
             break;
@@ -1466,6 +1484,8 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
             break;
+        case cloud_storage_clients::error_outcome::operation_not_supported:
+            [[fallthrough]];
         case cloud_storage_clients::error_outcome::key_not_found:
             [[fallthrough]];
         case cloud_storage_clients::error_outcome::fail:

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -46,6 +46,9 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match("ContainerNotFound", abs_error_code::container_not_found)
           .match("DirectoryNotEmpty", abs_error_code::directory_not_empty)
           .match("PathNotFound", abs_error_code::path_not_found)
+          .match(
+            "OperationNotSupportedOnDirectory",
+            abs_error_code::operation_not_supported_on_directory)
           .default_match(abs_error_code::_unknown);
 
     return i;

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -40,7 +40,8 @@ enum class abs_error_code {
     container_being_deleted,
     container_not_found,
     directory_not_empty,
-    path_not_found
+    path_not_found,
+    operation_not_supported_on_directory
 };
 
 /// Operators to use with lexical_cast

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -34,6 +34,9 @@ enum class error_outcome {
     fail,
     /// Missing key API error (only suitable for downloads and deletions)
     key_not_found,
+    /// Currently used for directory deletion errors in ABS, typically treated
+    /// as regular failure outcomes.
+    operation_not_supported
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -49,6 +52,8 @@ struct error_outcome_category final : public std::error_category {
             return "Non retriable error";
         case error_outcome::key_not_found:
             return "Key not found error";
+        case error_outcome::operation_not_supported:
+            return "Operation not supported error";
         default:
             return "Undefined error_outcome encountered";
         }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22339
