### PR TITLE
[CORE-3148] schema_registry: Fix Swagger for `POST /compatibility`

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1158,12 +1158,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer"
-                }
-              }
+              "$ref": "#/definitions/is_compatibile"
             }
           },
           "409": {

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -102,4 +102,12 @@
           ]
         },
       }
+    },
+    "is_compatibile": {
+      "type": "object",
+      "properties": {
+        "is_compatible": {
+          "type": "boolean"
+        }
+      }
     }


### PR DESCRIPTION
schema_registry: Fix Swagger for `POST /compatibility/subjects/{subject}/versions/{version}`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Bug Fixes

* Schema Registry: Fix Swagger for `POST /compatibility/subjects/{subject}/versions/{version}`
