### PR TITLE
bazel: allow wasmtime build to access network

### DIFF
--- a/bazel/thirdparty/wasmtime.BUILD
+++ b/bazel/thirdparty/wasmtime.BUILD
@@ -21,6 +21,7 @@ cmake(
     },
     lib_source = ":srcs",
     out_static_libs = ["libwasmtime.a"],
+    tags = ["requires-network"],
     visibility = [
         "//visibility:public",
     ],

--- a/bazel/thirdparty/wasmtime.BUILD
+++ b/bazel/thirdparty/wasmtime.BUILD
@@ -21,7 +21,7 @@ cmake(
     },
     lib_source = ":srcs",
     out_static_libs = ["libwasmtime.a"],
-    tags = ["requires-network"],
+    tags = ["no-sandbox"],
     visibility = [
         "//visibility:public",
     ],


### PR DESCRIPTION
bazel: allow wasmtime build to access network

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
