### PR TITLE
bazel: add misc libraries

### DIFF
--- a/bazel/build.bzl
+++ b/bazel/build.bzl
@@ -18,6 +18,7 @@ def redpanda_cc_library(
         visibility = None,
         include_prefix = None,
         exclude_layering_check = False,
+        copts = [],
         deps = []):
     """
     Define a Redpanda C++ library.
@@ -41,6 +42,6 @@ def redpanda_cc_library(
         include_prefix = include_prefix,
         strip_include_prefix = strip_include_prefix,
         deps = deps,
-        copts = redpanda_copts(),
+        copts = redpanda_copts() + copts,
         features = features,
     )

--- a/src/v/hashing/BUILD
+++ b/src/v/hashing/BUILD
@@ -41,3 +41,18 @@ redpanda_cc_library(
         "@xxhash",
     ],
 )
+
+redpanda_cc_library(
+    name = "murmur",
+    srcs = [
+        "murmur.cc",
+    ],
+    hdrs = [
+        "include/hashing/murmur.h",
+    ],
+    copts = [
+        "-Wno-implicit-fallthrough",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/src/v/hashing/BUILD
+++ b/src/v/hashing/BUILD
@@ -1,6 +1,18 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "crc32",
+    hdrs = [
+        "include/hashing/crc32.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@zlib",
+    ],
+)
+
+redpanda_cc_library(
     name = "crc32c",
     hdrs = [
         "include/hashing/crc32c.h",

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -558,3 +558,16 @@ redpanda_cc_library(
         "//src/v/base",
     ],
 )
+
+redpanda_cc_library(
+    name = "truncating_logger",
+    hdrs = [
+        "truncating_logger.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:sformat",
+        "@seastar",
+    ],
+)


### PR DESCRIPTION
Adds some misc libraries. Unfortunately there are no tests in the trees for these, but they are dependencies to other code which will be added in subsequent PRs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
