### PR TITLE
[CORE-2144] schema_registry/protobuf: Disable protobuf logging

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -231,10 +231,14 @@ public:
 
         // Attempt parse a .proto file
         if (!_parser.Parse(&t, &_fdp)) {
-            // base64 decode the schema
-            iobuf_istream is{base64_to_iobuf(schema.def().raw()())};
-            // Attempt parse as an encoded FileDescriptorProto.pb
-            if (!_fdp.ParseFromIstream(&is.istream())) {
+            try {
+                // base64 decode the schema
+                iobuf_istream is{base64_to_iobuf(schema.def().raw()())};
+                // Attempt parse as an encoded FileDescriptorProto.pb
+                if (!_fdp.ParseFromIstream(&is.istream())) {
+                    throw as_exception(error_collector.error());
+                }
+            } catch (const base64_decoder_exception&) {
                 throw as_exception(error_collector.error());
             }
         }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -88,3 +88,70 @@ message A1 {
   }
 })",
   pps::schema_type::protobuf};
+
+// Binary encoded protobuf descriptor:
+//
+// syntax = "proto3";
+//
+// package com.redpanda;
+//
+// option go_package = "./;main";
+// option java_multiple_files = true;
+//
+// import "google/protobuf/timestamp.proto";
+//
+// message Payload {
+//     int32 val = 1;
+//     google.protobuf.Timestamp timestamp = 2;
+// }
+//
+// message A {
+//     message B {
+//         message C {
+//             message D {
+//                 message M00 {}
+//                 message M01 {}
+//                 message M02 {}
+//                 message M03 {}
+//                 message M04 {}
+//                 message M05 {}
+//                 message M06 {}
+//                 message M07 {}
+//                 message M08 {}
+//                 message M09 {}
+//                 message M10 {}
+//                 message M11 {}
+//                 message M12 {}
+//                 message M13 {}
+//                 message M14 {}
+//                 message M15 {}
+//                 message M16 {}
+//                 message M17 {}
+//                 message NestedPayload {
+//                     int32 val = 1;
+//                     google.protobuf.Timestamp timestamp = 2;
+//                 }
+//             }
+//         }
+//     }
+// }
+//
+// message CompressiblePayload {
+//     int32 val = 1;
+//     google.protobuf.Timestamp timestamp = 2;
+//     string message = 3;
+// }
+constexpr std::string_view base64_raw_proto{
+  "Cg1wYXlsb2FkLnByb3RvEgxjb20ucmVkcGFuZGEaH2dvb2dsZS9wcm90b2J1Zi90aW1lc3RhbXAu"
+  "cHJvdG8iRQoHUGF5bG9hZBILCgN2YWwYASABKAUSLQoJdGltZXN0YW1wGAIgASgLMhouZ29vZ2xl"
+  "LnByb3RvYnVmLlRpbWVzdGFtcCLgAQoBQRraAQoBQhrUAQoBQxrOAQoBRBoFCgNNMDAaBQoDTTAx"
+  "GgUKA00wMhoFCgNNMDMaBQoDTTA0GgUKA00wNRoFCgNNMDYaBQoDTTA3GgUKA00wOBoFCgNNMDka"
+  "BQoDTTEwGgUKA00xMRoFCgNNMTIaBQoDTTEzGgUKA00xNBoFCgNNMTUaBQoDTTE2GgUKA00xNxpL"
+  "Cg1OZXN0ZWRQYXlsb2FkEgsKA3ZhbBgBIAEoBRItCgl0aW1lc3RhbXAYAiABKAsyGi5nb29nbGUu"
+  "cHJvdG9idWYuVGltZXN0YW1wImIKE0NvbXByZXNzaWJsZVBheWxvYWQSCwoDdmFsGAEgASgFEi0K"
+  "CXRpbWVzdGFtcBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASDwoHbWVzc2FnZRgD"
+  "IAEoCUILUAFaBy4vO21haW5iBnByb3RvMw=="};
+
+const pps::canonical_schema_definition base64_proto{
+  pps::canonical_schema_definition{
+    base64_raw_proto, pps::schema_type::protobuf}};

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -147,6 +147,7 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 
+#include <google/protobuf/stubs/logging.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
 
@@ -524,6 +525,12 @@ void application::initialize(
       }))
       .get();
     _cpu_profiler.invoke_on_all(&resources::cpu_profiler::start).get();
+
+    /*
+     * Disable the logger for protobuf; some interfaces don't allow a pluggable
+     * error collector.
+     */
+    google::protobuf::SetLogHandler(nullptr);
 
     /*
      * allocate per-core zstd decompression workspace and per-core


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/17682

## Notes to reviewer

There are a few (not necessarily orthogonal) options here:
* Set the sink to nullptr
* Set the log_level
* Make the log_level configurable
* Implement a new Sink.

I went with the simplest. Some of the options are not thread-safe.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Improvements

* Schema Registry: Remove spurious log entry: `No syntax specified for the proto file`