### PR TITLE
Shard placement table: add metrics

### DIFF
--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -121,19 +121,21 @@ public:
             return _assigned;
         }
 
-        /// Current shard-local state for this ntp. Will be non-null if
-        /// some kvstore state for this ntp exists on this shard.
-        std::optional<shard_local_state> current;
+        const std::optional<shard_local_state>& current() const {
+            return _current;
+        }
 
     private:
         friend class shard_placement_table;
 
         /// If placement_state is in the _states map, then is_empty() is false.
         bool is_empty() const {
-            return !current && !_is_initial_for && !_assigned;
+            return !_current && !_is_initial_for && !_assigned;
         }
 
         void set_assigned(std::optional<shard_local_assignment>);
+        void set_current(std::optional<shard_local_state>);
+        void set_hosted_status(hosted_status);
 
         struct versioned_shard {
             ss::shard_id shard;
@@ -147,6 +149,9 @@ public:
         /// log revision. Invariant: if both _is_initial_for and current
         /// are present, _is_initial_for > current.log_revision
         std::optional<model::revision_id> _is_initial_for;
+        /// Current shard-local state for this ntp. Will be non-null if
+        /// some kvstore state for this ntp exists on this shard.
+        std::optional<shard_local_state> _current;
         /// If x-shard transfer is in progress, will hold the destination. Note
         /// that it is initialized from target but in contrast to target, it
         /// can't change mid-transfer.

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -117,25 +117,31 @@ public:
 
         placement_state() = default;
 
+        const std::optional<shard_local_assignment>& assigned() const {
+            return _assigned;
+        }
+
         /// Current shard-local state for this ntp. Will be non-null if
         /// some kvstore state for this ntp exists on this shard.
         std::optional<shard_local_state> current;
-        /// If non-null, the ntp is expected to exist on this shard.
-        std::optional<shard_local_assignment> assigned;
 
     private:
         friend class shard_placement_table;
 
         /// If placement_state is in the _states map, then is_empty() is false.
         bool is_empty() const {
-            return !current && !_is_initial_for && !assigned;
+            return !current && !_is_initial_for && !_assigned;
         }
+
+        void set_assigned(std::optional<shard_local_assignment>);
 
         struct versioned_shard {
             ss::shard_id shard;
             model::shard_revision_id revision;
         };
 
+        /// If non-null, the ntp is expected to exist on this shard.
+        std::optional<shard_local_assignment> _assigned;
         /// If this shard is the initial shard for some incarnation of this
         /// partition on this node, this field will contain the corresponding
         /// log revision. Invariant: if both _is_initial_for and current

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -895,15 +895,15 @@ public:
                       placement.current->status,
                       shard_placement_table::hosted_status::hosted)
                       << "ntp: " << ntp << ", shard: " << s;
-                    ASSERT_TRUE_CORO(placement.assigned)
+                    ASSERT_TRUE_CORO(placement.assigned())
                       << "ntp: " << ntp << ", shard: " << s;
                     ASSERT_EQ_CORO(
-                      placement.assigned->log_revision, meta.log_revision)
+                      placement.assigned()->log_revision, meta.log_revision)
                       << "ntp: " << ntp << ", shard: " << s;
                 } else {
                     ASSERT_TRUE_CORO(!placement.current)
                       << "ntp: " << ntp << ", shard: " << s;
-                    ASSERT_TRUE_CORO(!placement.assigned)
+                    ASSERT_TRUE_CORO(!placement.assigned())
                       << "ntp: " << ntp << ", shard: " << s;
                 }
             }
@@ -958,14 +958,14 @@ public:
             }
             for (const auto& [s, placement] : shard2state) {
                 if (expected.target && s == expected.target->shard) {
-                    ASSERT_TRUE_CORO(placement.assigned)
+                    ASSERT_TRUE_CORO(placement.assigned())
                       << "ntp: " << ntp << ", shard: " << s;
                     ASSERT_EQ_CORO(
-                      placement.assigned->log_revision,
+                      placement.assigned()->log_revision,
                       expected.target->log_revision)
                       << "ntp: " << ntp << ", shard: " << s;
                 } else {
-                    ASSERT_TRUE_CORO(!placement.assigned)
+                    ASSERT_TRUE_CORO(!placement.assigned())
                       << "ntp: " << ntp << ", shard: " << s;
                 }
             }


### PR DESCRIPTION
Add metrics tracking the number of partition replicas assigned to a shard, hosted on a shard, and the number of partitions needing reconciliation of shard-local state.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none