### PR TITLE
kafka: use raw strings in kafka protocol generator

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -671,17 +671,17 @@ class VersionRange:
         self.min, self.max = self._parse(spec)
 
     def _parse(self, spec):
-        match = re.match("^(?P<min>\d+)$", spec)
+        match = re.match(r"^(?P<min>\d+)$", spec)
         if match:
             min = int(match.group("min"))
             return min, min
 
-        match = re.match("^(?P<min>\d+)\+$", spec)
+        match = re.match(r"^(?P<min>\d+)\+$", spec)
         if match:
             min = int(match.group("min"))
             return min, None
 
-        match = re.match("^(?P<min>\d+)\-(?P<max>\d+)$", spec)
+        match = re.match(r"^(?P<min>\d+)\-(?P<max>\d+)$", spec)
         if match:
             min = int(match.group("min"))
             max = int(match.group("max"))
@@ -742,7 +742,7 @@ def snake_case(name):
 
 
 class FieldType:
-    ARRAY_RE = re.compile("^\[\](?P<type>.+)$")
+    ARRAY_RE = re.compile(r"^\[\](?P<type>.+)$")
 
     def __init__(self, name):
         self._name = name
@@ -1809,15 +1809,15 @@ SCHEMA = {
             "oneOf": [
                 {
                     "type": "string",
-                    "pattern": "^\d+$"
+                    "pattern": r"^\d+$"
                 },
                 {
                     "type": "string",
-                    "pattern": "^\d+\-\d+$"
+                    "pattern": r"^\d+\-\d+$"
                 },
                 {
                     "type": "string",
-                    "pattern": "^\d+\+$"
+                    "pattern": r"^\d+\+$"
                 },
             ],
         },
@@ -1946,7 +1946,7 @@ def codegen(schema_path):
     schema = io.StringIO()
     with open(schema_path, "r") as f:
         for line in f.readlines():
-            line = re.sub("\/\/.*", "", line)
+            line = re.sub(r"//.*", "", line)
             if line.strip():
                 schema.write(line)
 


### PR DESCRIPTION
Fixes stuff like this which show up with newer version of python like 3.12.

```
generator.py:1949: SyntaxWarning: invalid escape sequence '\/'
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

