### PR TITLE
Add fetch path micro-benchmark

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1485,6 +1485,10 @@ ss::future<> do_fetch(op_context& octx) {
 }
 } // namespace
 
+namespace testing {
+ss::future<> do_fetch(op_context& octx) { return ::kafka::do_fetch(octx); }
+} // namespace testing
+
 template<>
 ss::future<response_ptr>
 fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -427,5 +427,7 @@ read_result::memory_units_t reserve_memory_units(
   const size_t max_bytes,
   const bool obligatory_batch_read);
 
+ss::future<> do_fetch(op_context& octx);
+
 } // namespace testing
 } // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -108,6 +108,20 @@ rp_test(
 
 rp_test(
   BENCHMARK_TEST
+  BINARY_NAME kafka_fetch
+  SOURCES fetch_bench.cc
+  LIBRARIES 
+    Seastar::seastar_perf_testing 
+    Boost::unit_test_framework 
+    v::application 
+    v::kafka_test_utils
+  # the args below are just to keep it fast
+  ARGS "-c 1 --duration=1 --runs=1 --memory=4G"
+  LABELS kafka
+)
+
+rp_test(
+  BENCHMARK_TEST
   BINARY_NAME kafka_produce_partition
   SOURCES produce_partition_bench.cc
   LIBRARIES Seastar::seastar_perf_testing Boost::unit_test_framework v::application

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/vassert.h"
+#include "base/vlog.h"
+#include "kafka/protocol/kafka_batch_adapter.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/server/handlers/fetch.h"
+#include "kafka/server/handlers/produce.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+#include "test_utils/scoped_config.h"
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <tuple>
+
+ss::logger flog("fetch_bench");
+
+struct fetch_bench_config {
+    int num_fetches;
+
+    // Topic settings
+    size_t topic_name_length;
+
+    // Message settings
+    size_t batch_size;
+    size_t batch_overhead;
+};
+
+// This config makes data and ktp copying more noticeable in the
+// benchmark results.
+static constexpr auto large_fetch_config = fetch_bench_config{
+  .num_fetches = 100,
+  .topic_name_length = 128,
+  .batch_size = 500ul * 1024,
+  .batch_overhead = 72,
+};
+
+static constexpr auto small_fetch_config = fetch_bench_config{
+  .num_fetches = 100,
+  .topic_name_length = 30,
+  .batch_size = 1024,
+  .batch_overhead = 70,
+};
+
+template<fetch_bench_config cfg>
+struct fetch_bench_fixture : redpanda_thread_fixture {
+    struct fetch_part {
+        model::partition_id pid;
+        model::offset offset;
+        size_t num_batches;
+    };
+
+    struct fetch_topic {
+        model::topic name;
+        std::vector<fetch_part> partitions;
+    };
+
+    ss::future<size_t>
+    fetch_from(model::topic t, std::vector<fetch_part> parts) {
+        std::optional<size_t> total_batches_per_fetch = std::nullopt;
+        auto conn_context = make_connection_context();
+        co_await conn_context->start();
+
+        auto make_rctx = [&] {
+            size_t total_batches = 0;
+
+            // make the fetch topic
+            kafka::fetch_topic ft;
+            ft.name = t;
+
+            // add the partitions to the fetch request
+            for (const auto& part : parts) {
+                kafka::fetch_partition fp;
+                fp.partition_index = model::partition_id(part.pid);
+                fp.fetch_offset = part.offset;
+                fp.current_leader_epoch = kafka::leader_epoch(-1);
+                fp.log_start_offset = model::offset(-1);
+                fp.max_bytes = part.num_batches
+                               * (cfg.batch_size + cfg.batch_overhead);
+                ft.fetch_partitions.push_back(std::move(fp));
+                total_batches += part.num_batches;
+            }
+
+            if (!total_batches_per_fetch) {
+                total_batches_per_fetch = total_batches;
+            }
+
+            // create a request
+            kafka::fetch_request_data frq_data;
+            frq_data.replica_id = kafka::client::consumer_replica_id;
+            frq_data.max_wait_ms = 500ms;
+            frq_data.min_bytes = total_batches
+                                 * (cfg.batch_size + cfg.batch_overhead);
+            frq_data.max_bytes = 52428800;
+            frq_data.isolation_level = model::isolation_level::read_uncommitted;
+            frq_data.session_id = kafka::invalid_fetch_session_id;
+            frq_data.session_epoch = kafka::final_fetch_session_epoch;
+            frq_data.topics.push_back(std::move(ft));
+
+            auto request = kafka::fetch_request{.data = std::move(frq_data)};
+
+            kafka::request_header header{
+              .key = kafka::fetch_handler::api::key,
+              .version = kafka::fetch_handler::max_supported};
+
+            return make_request_context(
+              std::move(request), header, conn_context);
+        };
+
+        std::vector<std::unique_ptr<kafka::op_context>> octxs;
+        for (int i = 0; i < cfg.num_fetches + 1; i++) {
+            octxs.emplace_back(std::make_unique<kafka::op_context>(
+              make_rctx(), ss::default_smp_service_group()));
+        }
+
+        // Drain task queue before running the measured region in order to
+        // reduce noise from unrelated tasks.
+        co_await tests::drain_task_queue();
+
+        // Do a single fetch outside of the measured region first to ensure the
+        // fetched batches are in the batch cache in the subsequent fetches.
+        co_await kafka::testing::do_fetch(*octxs[cfg.num_fetches]);
+
+        perf_tests::start_measuring_time();
+        for (int i = 0; i < cfg.num_fetches; i++) {
+            co_await kafka::testing::do_fetch(*octxs[i]);
+        }
+        perf_tests::stop_measuring_time();
+
+        auto expected_response_size = total_batches_per_fetch.value_or(0)
+                                      * (cfg.batch_size + cfg.batch_overhead);
+        for (int i = 0; i < cfg.num_fetches + 1; i++) {
+            auto& octx = *octxs[i];
+            vassert(!octx.response_error, "fetch wasn't successful");
+            vassert(
+              octx.response_size == expected_response_size,
+              "not the expected response size. expected {} actual {}",
+              expected_response_size,
+              octx.response_size);
+        }
+
+        co_return cfg.num_fetches;
+    }
+
+    ss::future<> produce_to_topic(
+      model::topic t,
+      size_t total_partition_count,
+      size_t batches_per_partition) {
+        auto client = co_await make_kafka_client();
+        tests::kafka_produce_transport producer(std::move(client));
+        co_await producer.start();
+        for (int pid = 0; pid < total_partition_count; pid++) {
+            for (int i = 0; i < batches_per_partition; i++) {
+                tests::kv_t msg{
+                  "", random_generators::gen_alphanum_string(cfg.batch_size)};
+                co_await producer.produce_to_partition(
+                  t, model::partition_id(pid), {std::move(msg)});
+            }
+        }
+    }
+
+    ss::future<model::topic> create_topic(size_t total_partition_count) {
+        auto t = model::topic(
+          random_generators::gen_alphanum_string(cfg.topic_name_length));
+        co_await add_topic(
+          model::topic_namespace_view(model::kafka_namespace, t),
+          total_partition_count);
+
+        for (auto i = 0; i < total_partition_count; i++) {
+            auto ntp = model::ntp(
+              model::kafka_namespace,
+              model::topic_partition(t, model::partition_id(i)));
+            co_await wait_for_leader(ntp);
+        }
+
+        co_return t;
+    }
+
+    ss::future<> assert_on_different_shards(
+      model::topic t, model::partition_id pid_1, model::partition_id pid_2) {
+        auto get_ntp = [&](auto pid) {
+            return model::ntp(
+              model::kafka_namespace,
+              model::topic_partition(t, model::partition_id(pid)));
+        };
+        auto s1 = app.shard_table.local().shard_for(get_ntp(pid_1));
+        auto s2 = app.shard_table.local().shard_for(get_ntp(pid_2));
+
+        vassert(*s1 != *s2, "ntps should be on different shards");
+        co_return;
+    }
+
+    fetch_bench_fixture() {
+        wait_for_controller_leadership().get0();
+
+        // Disable as many background processes as possible to reduce noise.
+        test_local_cfg.get("log_disable_housekeeping_for_tests")
+          .set_value(true);
+        test_local_cfg.get("disable_cluster_recovery_loop_for_tests")
+          .set_value(true);
+        test_local_cfg.get("retention_local_strict").set_value(true);
+        test_local_cfg.get("enable_metrics_reporter").set_value(false);
+
+        test_local_cfg.get("fetch_read_strategy")
+          .set_value(model::fetch_read_strategy::non_polling);
+
+        restart();
+        wait_for_controller_leadership().get();
+    }
+
+    ss::future<model::topic> initialize_single_partition_topic() {
+        auto t = co_await create_topic(1);
+        co_await produce_to_topic(t, 1, 1);
+        co_return t;
+    }
+
+    ss::future<model::topic> initialize_multi_partition_topic() {
+        auto t = co_await create_topic(2);
+        co_await produce_to_topic(t, 2, 1);
+        co_await assert_on_different_shards(
+          t, model::partition_id(0), model::partition_id(1));
+        co_return t;
+    }
+
+    scoped_config test_local_cfg;
+};
+
+using large_fetch_t = fetch_bench_fixture<large_fetch_config>;
+using small_fetch_t = fetch_bench_fixture<small_fetch_config>;
+
+PERF_TEST_CN(large_fetch_t, single_partition_fetch) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      t, {fetch_part{model::partition_id(0), model::offset(0), 1}});
+}
+
+PERF_TEST_CN(small_fetch_t, single_partition_fetch) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      t, {fetch_part{model::partition_id(0), model::offset(0), 1}});
+}
+
+PERF_TEST_CN(large_fetch_t, multi_partition_fetch) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      t,
+      {fetch_part{model::partition_id(0), model::offset(0), 1},
+       fetch_part{model::partition_id(1), model::offset(0), 1}});
+}
+
+PERF_TEST_CN(small_fetch_t, multi_partition_fetch) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      t,
+      {fetch_part{model::partition_id(0), model::offset(0), 1},
+       fetch_part{model::partition_id(1), model::offset(0), 1}});
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Results from running locally;
```
[brandonallard@fedora redpanda-4]$ sudo cset shield -c 1,2,13,14 -k on              
cset: --> activating shielding:                                                                                                                                                               
cset: moving 300 tasks from root into system cpuset...                                                                                                                                        
[==================================================]%                                                                                                                                         
cset: kthread shield activated, moving 133 tasks into system cpuset...                                                                                                                        
[==================================================]%                                                                                                                                         
cset: **> 83 tasks are not movable, impossible to move                                                                                                                                        
cset: "system" cpuset of CPUSPEC(0,3-12,15-23) with 350 tasks running                                                                                                                         
cset: "user" cpuset of CPUSPEC(1-2,13-14) with 0 tasks running                 
                                                                                                                                                                                                                         
[brandonallard@fedora redpanda-4]$ sudo cset shield -e $(pwd)/vbuild/release/clang/bin/kafka_fetch_rpbench -- --log-to-stdout=0                                                               
cset: --> last message, executed args into cpuset "/user", new pid is: 101818
single run iterations:    0                                                                                                                                                                   
single run duration:      1.000s                                                                                                                                                              
number of runs:           5                                                                                                                                                                   
number of cores:          4                                                                                                                                                                   
random seed:              3928944110                                                                                                                                                          

test                                        iterations      median         mad         min         max      allocs       tasks        inst
fetch_bench_fixture.single_partition_fetch       46833    11.263us     6.924ns    11.231us    11.270us      47.015      16.028     99128.0
fetch_bench_fixture.multi_partition_fetch        38313    14.914us    26.105ns    14.888us    15.049us      74.954      26.504    125716.0
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
