### PR TITLE
cst/clients: accept responses from inv api

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1462,7 +1462,8 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           path,
           content_length,
           make_iobuf_input_stream(std::move(to_upload)),
-          fib.get_timeout());
+          fib.get_timeout(),
+          upload_request.accept_no_content_response);
 
         if (res) {
             transfer_details.on_success(_probe);

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -422,6 +422,7 @@ struct upload_request {
     transfer_details transfer_details;
     upload_type type;
     iobuf payload;
+    bool accept_no_content_response{false};
 };
 
 struct download_request {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -174,7 +174,8 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      ss::lowres_clock::duration timeout) override;
+      ss::lowres_clock::duration timeout,
+      bool accept_no_content = false) override;
 
     /// Send List Blobs request
     /// \param name is a container name
@@ -262,7 +263,8 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      bool accept_no_content = false);
 
     ss::future<head_object_result> do_head_object(
       bucket_name const& name,

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -80,13 +80,15 @@ public:
     /// \param payload_size is a size of the object in bytes
     /// \param body is an input_stream that can be used to read body
     /// \param timeout is a timeout of the operation
+    /// \param accept_no_content accepts a 204 response as valid
     /// \return future that becomes ready when the upload is completed
     virtual ss::future<result<no_response, error_outcome>> put_object(
       bucket_name const& name,
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      ss::lowres_clock::duration timeout)
+      ss::lowres_clock::duration timeout,
+      bool accept_no_content = false)
       = 0;
 
     struct list_bucket_item {

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -178,7 +178,8 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      ss::lowres_clock::duration timeout) override;
+      ss::lowres_clock::duration timeout,
+      bool accept_no_content = false) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
       const bucket_name& name,
@@ -218,7 +219,8 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      bool accept_no_content = false);
 
     ss::future<list_bucket_result> do_list_objects_v2(
       const bucket_name& name,


### PR DESCRIPTION
The changes in this PR optionally make 204 an acceptable response on a PUT operation, which is sometimes returned by the PutBucketInventoryConfiguration AWS operation instead of 201.

Additionally some tests are added in the same area of code to cover a previously added mapping of NoSuchConfiguration to 404 which did not have test coverage (https://github.com/redpanda-data/redpanda/pull/22529)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
