### PR TITLE
ci: update mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,13 +6,13 @@ pull_request_rules:
     actions:
       queue:
         name: dev
-        merge_bot_account: vbotbuildovich
-        update_bot_account: vbotbuildovich
 queue_rules:
   - name: dev
     speculative_checks: 2
     batch_size: 4
     draft_bot_account: vbotbuildovich
-    conditions:
+    merge_bot_account: vbotbuildovich
+    update_bot_account: vbotbuildovich
+    merge_conditions:
       - base=dev
       - label=merge-queue


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

### Improvements

Some Mergify configuration options are deprecated.

https://changelog.mergify.com/changelog/queue-action-options-deprecation

This change uses the new ones.
