### PR TITLE
config: update docs for cloud_storage_azure_hierarchical_namespace_enabled

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2225,12 +2225,13 @@ configuration::configuration()
   , cloud_storage_azure_hierarchical_namespace_enabled(
       *this,
       "cloud_storage_azure_hierarchical_namespace_enabled",
-      "Whether or not Azure Hierarchical Namespaces are enabled on the "
-      "cloud_storage_azure_storage_account. If this property is not set, "
-      "cloud_storage_azure_shared_key must be set, and each node will try to "
-      "determine at startup if HNS is enabled. Setting this property to True "
-      "will disable the check and assume HNS is active. Setting to False will "
-      "disable the check and assume that HNS is not active.",
+      "Force Redpanda to use or not use an \"Azure Data Lake Storage Gen2 "
+      "hierarchical namespace\" compliant client. When this property is not "
+      "set, each node infers at startup if HNS is enabled. When set to True, "
+      "this property disables the check and assumes HNS is enabled. When set "
+      "to False, this property disables the check and assumes HNS is not "
+      "enabled. This setting should be used only in emergencies where Redpanda "
+      "fails to detect the correct HNS status.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(


### PR DESCRIPTION
Since https://github.com/redpanda-data/redpanda/pull/17840/ we should be able to always infer the correct setting. Update the docs accordingly to avoid confusing users into thinking that they must set this setting if `cloud_storage_azure_shared_key` is not set.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
