### PR TITLE
[v24.2.x] `cluster`: remove cloud storage self-test checks

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -59,7 +59,7 @@ Available tests to run:
      *** The test pushes as much data over the wire, within the test parameters.
 * Cloud storage tests
   ** Configuration/Latency test: 1024-byte object.
-  ** Depending on cluster read/write permissions ('cloud_storage_enable_remote_read', 'cloud_storage_enable_remote_write'), a series of cloud storage operations are performed:
+  ** If cloud storage is enabled ('cloud_storage_enabled'), a series of remote operations are performed:
      *** Upload an object (a random buffer of 1024 bytes) to the cloud storage bucket/container.
      *** List objects in the bucket/container.
      *** Download the uploaded object from the bucket/container.

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -90,7 +90,7 @@ private:
     ss::future<verify_upload_result> verify_upload(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key,
-      const std::optional<iobuf>& payload);
+      const iobuf& payload);
 
     struct verify_list_result {
         cloud_storage::remote::list_result list_result;
@@ -144,8 +144,6 @@ private:
 
 private:
     static constexpr size_t num_default_objects = 5;
-    bool _remote_read_enabled{false};
-    bool _remote_write_enabled{false};
     bool _cancelled{false};
     ss::abort_source _as;
     ss::gate _gate;

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -61,41 +61,12 @@ class SelfTestTest(EndToEndTest):
         # Wait for completion
         node_reports = self.wait_for_self_test_completion()
 
-        # Verify returned results
-        def assert_pass(report):
-            assert 'error' not in report
-            assert 'warning' not in report
-
-        def assert_fail(report, error_msg):
-            assert 'error' in report
-            assert report['error'] == error_msg
-
-        read_tests = ['List', 'Head', 'Get']
-        write_tests = ['Put', 'Delete', 'Plural Delete']
-
         for node in node_reports:
             assert node['status'] == 'idle'
             assert node.get('results') is not None
             for report in node['results']:
-                if report['test_type'] == 'cloud':
-                    if report['info'] in read_tests:
-                        if remote_read:
-                            assert_pass(report)
-                        else:
-                            assert_fail(
-                                report,
-                                'Remote read is not enabled for this cluster.')
-                    else:
-                        assert report['info'] in write_tests
-                        if remote_write:
-                            assert_pass(report)
-                        else:
-                            assert_fail(
-                                report,
-                                'Remote write is not enabled for this cluster.'
-                            )
-                else:
-                    assert_pass(report)
+                assert 'error' not in report
+                assert 'warning' not in report
 
         # Ensure the results appear as expected. Assertions aren't performed
         # on specific results, but rather what tests are oberved to have run
@@ -112,6 +83,9 @@ class SelfTestTest(EndToEndTest):
         network_results = [r for r in reports if r['test_type'] == 'network']
 
         cloud_results = [r for r in reports if r['test_type'] == 'cloud']
+
+        read_tests = ['List', 'Head', 'Get']
+        write_tests = ['Put', 'Delete', 'Plural Delete']
 
         num_expected_cloud_storage_read_tests = num_nodes * len(read_tests)
         num_expected_cloud_storage_write_tests = num_nodes * len(write_tests)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22667
