### PR TITLE
`admin`: add `key` param to `get_cluster_config` endpoint

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
-	github.com/redpanda-data/common-go/rpadmin v0.1.2
+	github.com/redpanda-data/common-go/rpadmin v0.1.3
 	github.com/rs/xid v1.5.0
 	github.com/safchain/ethtool v0.4.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -208,8 +208,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.2 h1:TGdV7ZUcwOt9Z6uTtQK7KrxoIlWnX9rDAe666eLthFk=
-github.com/redpanda-data/common-go/rpadmin v0.1.2/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
+github.com/redpanda-data/common-go/rpadmin v0.1.3 h1:JRdr4rHcdr+A0hHr+viJYnPm+dP01bsgVUoQLM7Kz44=
+github.com/redpanda-data/common-go/rpadmin v0.1.3/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -40,7 +40,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			client, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			currentConfig, err := client.Config(cmd.Context(), true)
+			currentConfig, err := client.SingleKeyConfig(cmd.Context(), key)
 			out.MaybeDie(err, "unable to query current config: %v", err)
 
 			val, exists := currentConfig[key]

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -155,6 +155,20 @@ public:
         w.EndObject();
     }
 
+    // Write a single key out to json::Writer.
+    void to_json_single_key(
+      json::Writer<json::StringBuffer>& w,
+      redact_secrets redact,
+      std::string_view key) {
+        // Whether key was either an original property name or an
+        // alias, we will obtain the original property here.
+        const auto& property = get(key);
+        w.StartObject();
+        w.Key(key.data(), key.size());
+        property.to_json(w, redact);
+        w.EndObject();
+    }
+
     void to_json_for_metrics(json::Writer<json::StringBuffer>& w) {
         w.StartObject();
 

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -50,6 +50,14 @@
           "produces": ["application/json"],
           "parameters": [
             {
+              "name": "key",
+              "in": "query",
+              "schema": {"type": "string"},
+              "required": false,
+              "allowMultiple": false,
+             "description": "The name of the (sole) property to read from the config. Respects property aliases."
+            },
+            {
               "name": "include_defaults",
               "in": "query",
               "schema": {"type": "boolean"},

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -46,6 +46,7 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
+#include "config/base_property.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "container/fragmented_vector.h"
@@ -1267,12 +1268,20 @@ void admin_server::register_config_routes() {
               include_defaults = str_to_bool(include_defaults_str);
           }
 
-          config::shard_local_cfg().to_json(
-            writer,
-            config::redact_secrets::yes,
-            [include_defaults](config::base_property& p) {
-                return include_defaults || !p.is_default();
-            });
+          auto key_str = req.get_query_param("key");
+          if (!key_str.empty()) {
+              // Write a single key to json.
+              config::shard_local_cfg().to_json_single_key(
+                writer, config::redact_secrets::yes, key_str);
+          } else {
+              // Write the entire config to json.
+              config::shard_local_cfg().to_json(
+                writer,
+                config::redact_secrets::yes,
+                [include_defaults](config::base_property& p) {
+                    return include_defaults || !p.is_default();
+                });
+          }
 
           reply.set_status(ss::http::reply::status_type::ok, buf.GetString());
           return "";

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -691,8 +691,10 @@ class Admin:
     def get_status_ready(self, node=None):
         return self._request("GET", "status/ready", node=node).json()
 
-    def get_cluster_config(self, node=None, include_defaults=None):
-        if include_defaults is not None:
+    def get_cluster_config(self, node=None, include_defaults=None, key=None):
+        if key is not None:
+            kwargs = {"params": {"key": key}}
+        elif include_defaults is not None:
             kwargs = {"params": {"include_defaults": include_defaults}}
         else:
             kwargs = {}


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/22666, depends on https://github.com/redpanda-data/common-go/pull/11

`rpk cluster config get` makes a request for a single property from the cluster. However, `redpanda` currently returns the cluster `configuration` in whole, and allows `rpk` to index the desired property.

This makes dealing with aliased property names tricky, as the `configuration` json contains only key-value information.
Since `rpk cluster config get` is only concerned with one parameter, we add the optional `key` query parameter, which will be used to handle the possibility of an aliased property name internally by `redpanda` and return only one key-value pair in the regular json object. 

The returned JSON will reference the alias's name, i.e a `GET` request to `/v1/cluster_config?key=data_transforms_per_core_memory_reservation` will return

```
{'data_transforms_per_core_memory_reservation': 123456789},
```

and a request to `/v1/cluster_config?key=wasm_per_core_memory_reservation` will return 

```
{'wasm_per_core_memory_reservation': 123456789}.
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* Allows users to query the value of a cluster property with `rpk cluster config get` using either the original property name, or any of its aliases. Whereas before, `rpk cluster config get` using a property's aliased name would return a `Property {} not found` result.

Before Example: 

```
$ rpk cluster config set wasm_per_core_memory_reservation=123456789
Successfully updated configuration. New configuration version is 3.

Cluster needs to be restarted. See more details with 'rpk cluster config status'.

$ rpk cluster config get  wasm_per_core_memory_reservation
Property 'wasm_per_core_memory_reservation' not found

$ rpk cluster config get  data_transforms_per_core_memory_reservation
123456789
```

After Example:

```
$ rpk cluster config set wasm_per_core_memory_reservation=123456789
Successfully updated configuration. New configuration version is 3.

Cluster needs to be restarted. See more details with 'rpk cluster config status'.

$ rpk cluster config get  wasm_per_core_memory_reservation
123456789

$ rpk cluster config get  data_transforms_per_core_memory_reservation
123456789
```