### PR TITLE
rpk: add `rpk registry mode` command

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/twmb/franz-go v1.17.0
 	github.com/twmb/franz-go/pkg/kadm v1.12.0
 	github.com/twmb/franz-go/pkg/kmsg v1.8.0
-	github.com/twmb/franz-go/pkg/sr v1.0.0
+	github.com/twmb/franz-go/pkg/sr v1.0.1
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/tlscfg v1.2.1
 	github.com/twmb/types v1.1.6

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -258,8 +258,8 @@ github.com/twmb/franz-go/pkg/kadm v1.12.0 h1:I8P/gpXFzhl73QcAYmJu+1fOXvrynyH/MAo
 github.com/twmb/franz-go/pkg/kadm v1.12.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kmsg v1.8.0 h1:lAQB9Z3aMrIP9qF9288XcFf/ccaSxEitNA1CDTEIeTA=
 github.com/twmb/franz-go/pkg/kmsg v1.8.0/go.mod h1:HzYEb8G3uu5XevZbtU0dVbkphaKTHk0X68N5ka4q6mU=
-github.com/twmb/franz-go/pkg/sr v1.0.0 h1:4FUatTSTEuG2xievT0iDrgnpErgRg7kFLNioJYqfrqs=
-github.com/twmb/franz-go/pkg/sr v1.0.0/go.mod h1:aUFRRLI5WYKpKzmWDztzZFecx5eOkCNuuamd91jUV5c=
+github.com/twmb/franz-go/pkg/sr v1.0.1 h1:hf3eRFDUWSfmR7JQCS/3JiqZEQwqbiDSS/DooewMHCE=
+github.com/twmb/franz-go/pkg/sr v1.0.1/go.mod h1:aUFRRLI5WYKpKzmWDztzZFecx5eOkCNuuamd91jUV5c=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=

--- a/src/go/rpk/pkg/cli/registry/mode/get.go
+++ b/src/go/rpk/pkg/cli/registry/mode/get.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package mode
+
+import (
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+func getCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var global bool
+	cmd := &cobra.Command{
+		Use:   "get [SUBJECT...]",
+		Short: "Get schema registry mode",
+		Long: `Get schema registry mode
+
+Running this command with no subject returns the global mode, alternatively
+you can use the --global flag to get the global mode at the same time as
+per-subject modes.
+`,
+		Run: func(cmd *cobra.Command, subjects []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]modeResult{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			if len(subjects) > 0 && global {
+				subjects = append(subjects, sr.GlobalSubject)
+			}
+			ctx := sr.WithParams(cmd.Context(), sr.DefaultToGlobal)
+			modeResult := cl.Mode(ctx, subjects...)
+			exit1, err := printModeResult(f, modeResult)
+			out.MaybeDieErr(err)
+			if exit1 {
+				os.Exit(1)
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&global, "global", false, "Return the global mode in addition to subject modes")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/registry/mode/mode.go
+++ b/src/go/rpk/pkg/cli/registry/mode/mode.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package mode
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mode",
+		Short: "Manage schema registry mode",
+		Args:  cobra.ExactArgs(0),
+	}
+	cmd.AddCommand(
+		getCommand(fs, p),
+		resetCommand(fs, p),
+		setCommand(fs, p),
+	)
+	p.InstallFormatFlag(cmd)
+	return cmd
+}
+
+type modeResult struct {
+	Subject string `json:"subject,omitempty" yaml:"subject,omitempty"`
+	Mode    string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	ErrMsg  string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+// printModeResult prints the []sr.ModeResult in the given format, it replaces
+// empty subjects for {GLOBAL}, and returns a boolean if encounters an error
+// in the ModeResult slice.
+func printModeResult(f config.OutFormatter, res []sr.ModeResult) (bool, error) {
+	var (
+		response []modeResult
+		exit1    bool
+	)
+	for _, r := range res {
+		result := modeResult{Mode: r.Mode.String(), Subject: r.Subject}
+		if r.Subject == "" {
+			result.Subject = "{GLOBAL}"
+		}
+		if r.Err != nil {
+			result.ErrMsg = r.Err.Error()
+			// If there is an error, the mode can be empty (0) and it defaults
+			// to IMPORT in the sr package. We override that to avoid confusion.
+			result.Mode = "-"
+			exit1 = true
+		}
+		response = append(response, result)
+	}
+	if isText, _, s, err := f.Format(response); !isText {
+		if err != nil {
+			return exit1, fmt.Errorf("unable to print in the required format %q: %v", f.Kind, err)
+		}
+		fmt.Println(s)
+		return exit1, nil
+	}
+	tw := out.NewTable("subject", "mode", "error")
+	defer tw.Flush()
+	for _, r := range response {
+		tw.PrintStructFields(r)
+	}
+	return exit1, nil
+}

--- a/src/go/rpk/pkg/cli/registry/mode/reset.go
+++ b/src/go/rpk/pkg/cli/registry/mode/reset.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package mode
+
+import (
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func resetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset [SUBJECT...]",
+		Short: "Reset schema registry mode",
+		Long: `Reset schema registry mode
+	
+This command deletes any subject modes and reverts to the global default. 
+
+The command also prints the subject mode before reverting to the global default.
+`,
+		Run: func(cmd *cobra.Command, subjects []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]modeResult{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			resetModeResult := cl.ResetMode(cmd.Context(), subjects...)
+			exit1, err := printModeResult(f, resetModeResult)
+			out.MaybeDieErr(err)
+			if exit1 {
+				os.Exit(1)
+			}
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package mode
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+var supportedModes = []string{"READONLY", "READWRITE"}
+
+func setCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var modeFlag string
+	var global bool
+	cmd := &cobra.Command{
+		Use:   "set [SUBJECT...]",
+		Short: "Set schema registry mode",
+		Long: `Set schema registry mode
+
+Running this command with no subject sets the global schema registry mode, 
+alternatively you can use the --global flag to set the global schema registry 
+mode at the same time as per-subject mode.
+
+Acceptable mode values: 
+  - READONLY
+  - READWRITE
+`,
+		Example: `
+Set the global schema registry mode to READONLY
+  rpk registry mode set --mode READONLY
+
+Set the schema registry mode to READWRITE in subjects foo and bar
+  rpk registry mode set foo bar --mode READWRITE
+`,
+		Run: func(cmd *cobra.Command, subjects []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]modeResult{}); ok {
+				out.Exit(h)
+			}
+			isValidMode := slices.ContainsFunc(supportedModes, func(s string) bool {
+				return strings.ToLower(s) == strnorm(modeFlag)
+			})
+			if !isValidMode {
+				out.Die("invalid mode %q; supported modes: %v", modeFlag, strings.Join(supportedModes, ", "))
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			mode := new(sr.Mode)
+			err = mode.UnmarshalText([]byte(modeFlag))
+			out.MaybeDie(err, "unable to parse mode flag: %v", err)
+
+			if len(subjects) > 0 && global {
+				subjects = append(subjects, sr.GlobalSubject)
+			}
+			setModeResult := cl.SetMode(cmd.Context(), *mode, subjects...)
+
+			exit1, err := printModeResult(f, setModeResult)
+			out.MaybeDieErr(err)
+			if exit1 {
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&global, "global", false, "Set the global schema registry mode in addition to subject modes")
+	cmd.Flags().StringVar(&modeFlag, "mode", "", fmt.Sprintf("Schema registry mode to set. Supported values: %v (case insensitive)", strings.Join(supportedModes, ", ")))
+	cmd.MarkFlagRequired("mode")
+	cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return supportedModes, cobra.ShellCompDirectiveDefault
+	})
+	return cmd
+}
+
+func strnorm(s string) string {
+	s = strings.ReplaceAll(s, ".", "")
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	return s
+}

--- a/src/go/rpk/pkg/cli/registry/registry.go
+++ b/src/go/rpk/pkg/cli/registry/registry.go
@@ -10,6 +10,7 @@
 package registry
 
 import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/mode"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry/schema"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
@@ -25,6 +26,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	}
 	cmd.AddCommand(
 		compatibilityLevelCommand(fs, p),
+		mode.NewCommand(fs, p),
 		schema.NewCommand(fs, p),
 		subjectCommand(fs, p),
 	)

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1713,6 +1713,33 @@ class RpkTool:
 
         return self._run_registry(cmd)
 
+    def get_mode(self, subjects=[], includeGlobal=True, format="json"):
+        cmd = ["mode", "get"]
+
+        if includeGlobal:
+            cmd += ["--global"]
+
+        if len(subjects) > 0:
+            cmd += subjects
+
+        return self._run_registry(cmd, output_format=format)
+
+    def set_mode(self, mode, subjects=[], format="json"):
+        cmd = ["mode", "set", "--mode", mode]
+
+        if len(subjects) > 0:
+            cmd += subjects
+
+        return self._run_registry(cmd, output_format=format)
+
+    def reset_mode(self, subjects=[], format="json"):
+        cmd = ["mode", "reset"]
+
+        if len(subjects) > 0:
+            cmd += subjects
+
+        return self._run_registry(cmd, output_format=format)
+
     def _run_wasm(self, rest):
         cmd = [self._rpk_binary(), "transform"]
         cmd += ["-X", "admin.hosts=" + self._redpanda.admin_endpoints()]


### PR DESCRIPTION
This PR adds the new `rpk registry mode` command

Fixes https://github.com/redpanda-data/devex/issues/29

### Examples
**Set a mode**
```
$ rpk registry mode set foo bar --mode READWRITE        
SUBJECT  MODE      ERROR
foo      READWRITE  
bar      READWRITE  
```

**Set the global mode**
```
$ rpk registry mode set --mode READONLY 
SUBJECT   MODE      ERROR
{GLOBAL}  READONLY  
```

**Get the mode of foo, bar, and the global mode**
```
$ rpk registry mode get foo bar --global
SUBJECT   MODE       ERROR
foo       READWRITE
bar       READWRITE  
{GLOBAL}  READONLY  
```

All new commands include support for the `--format` flag.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Features

* rpk: Add `rpk registry mode` to manage the schema registry mode.