### PR TITLE
Logging improvements in cluster `members` subsystem

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -426,7 +426,7 @@ members_manager::apply_update(model::record_batch b) {
       [this, update_offset](add_node_cmd cmd) {
           vlog(
             clusterlog.info,
-            "processing node add command - broker: {}, offset: {}",
+            "applying node add command - broker: {}, offset: {}",
             cmd.value,
             update_offset);
           _first_node_operation_command_offset = std::min(
@@ -436,7 +436,7 @@ members_manager::apply_update(model::record_batch b) {
       [this, update_offset](update_node_cfg_cmd cmd) {
           vlog(
             clusterlog.info,
-            "processing node update command - broker: {}, offset: {}",
+            "applying node update command - broker: {}, offset: {}",
             cmd.value,
             update_offset);
           _first_node_operation_command_offset = std::min(
@@ -446,7 +446,7 @@ members_manager::apply_update(model::record_batch b) {
       [this, update_offset](remove_node_cmd cmd) {
           vlog(
             clusterlog.info,
-            "processing node delete command - node: {}, offset: {}",
+            "applying node delete command - node: {}, offset: {}",
             cmd.key,
             update_offset);
           _first_node_operation_command_offset = std::min(

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -922,6 +922,14 @@ ss::future<std::error_code> members_manager::dispatch_updates_to_cores(
       "expected result: {}, have: {}",
       error,
       results);
+    if (error) {
+        vlog(
+          clusterlog.warn,
+          "error applying command with type {} at offset {} - {}",
+          Cmd::type,
+          update_offset,
+          error.message());
+    }
 
     co_return error;
 }

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -79,12 +79,12 @@ members_table::get_removed_node_metadata_ref(model::node_id id) const {
 }
 
 std::error_code members_table::apply(model::offset o, add_node_cmd cmd) {
+    vlog(clusterlog.info, "applying node add command for: {}", cmd.value);
     _version = model::revision_id(o);
     auto it = _nodes.find(cmd.value.id());
     if (it != _nodes.end()) {
         return errc::invalid_node_operation;
     }
-    vlog(clusterlog.info, "adding node {}", cmd.value);
     _nodes.emplace(cmd.value.id(), node_metadata{.broker = cmd.value});
 
     _waiters.notify(cmd.value.id());
@@ -105,12 +105,15 @@ void members_table::set_initial_brokers(std::vector<model::broker> brokers) {
 }
 
 std::error_code members_table::apply(model::offset o, update_node_cfg_cmd cmd) {
+    vlog(
+      clusterlog.info,
+      "applying update node config command for: {}",
+      cmd.value);
     _version = model::revision_id(o);
     auto it = _nodes.find(cmd.value.id());
     if (it == _nodes.end()) {
         return errc::node_does_not_exists;
     }
-    vlog(clusterlog.info, "updating node configuration {}", cmd.value);
     it->second.broker = std::move(cmd.value);
 
     notify_member_updated(cmd.value.id(), model::membership_state::active);
@@ -118,6 +121,8 @@ std::error_code members_table::apply(model::offset o, update_node_cfg_cmd cmd) {
 }
 
 std::error_code members_table::apply(model::offset o, remove_node_cmd cmd) {
+    vlog(
+      clusterlog.info, "applying remove node config command for: {}", cmd.key);
     _version = model::revision_id(o);
     auto it = _nodes.find(cmd.key);
     if (it == _nodes.end()) {
@@ -129,7 +134,6 @@ std::error_code members_table::apply(model::offset o, remove_node_cmd cmd) {
         return errc::invalid_node_operation;
     }
 
-    vlog(clusterlog.info, "removing node {}", cmd.key);
     auto handle = _nodes.extract(it);
 
     handle.mapped().state.set_membership_state(
@@ -143,6 +147,8 @@ std::error_code members_table::apply(model::offset o, remove_node_cmd cmd) {
 std::error_code
 members_table::apply(model::offset version, decommission_node_cmd cmd) {
     _version = model::revision_id(version());
+    vlog(
+      clusterlog.info, "applying decommission node command for: {}", cmd.key);
 
     if (auto it = _nodes.find(cmd.key); it != _nodes.end()) {
         auto& [id, metadata] = *it;
@@ -151,11 +157,6 @@ members_table::apply(model::offset version, decommission_node_cmd cmd) {
           != model::membership_state::active) {
             return errc::invalid_node_operation;
         }
-        vlog(
-          clusterlog.info,
-          "changing node {} membership state to: {}",
-          id,
-          model::membership_state::draining);
         metadata.state.set_membership_state(model::membership_state::draining);
         notify_member_updated(cmd.key, model::membership_state::draining);
         return errc::success;
@@ -166,6 +167,8 @@ members_table::apply(model::offset version, decommission_node_cmd cmd) {
 std::error_code
 members_table::apply(model::offset version, recommission_node_cmd cmd) {
     _version = model::revision_id(version());
+    vlog(
+      clusterlog.info, "applying recommission node command for: {}", cmd.key);
 
     if (auto it = _nodes.find(cmd.key); it != _nodes.end()) {
         auto& [id, metadata] = *it;
@@ -174,11 +177,6 @@ members_table::apply(model::offset version, recommission_node_cmd cmd) {
           != model::membership_state::draining) {
             return errc::invalid_node_operation;
         }
-        vlog(
-          clusterlog.info,
-          "changing node {} membership state to: {}",
-          id,
-          model::membership_state::active);
         metadata.state.set_membership_state(model::membership_state::active);
         notify_member_updated(cmd.key, model::membership_state::active);
         return errc::success;
@@ -189,6 +187,12 @@ members_table::apply(model::offset version, recommission_node_cmd cmd) {
 std::error_code
 members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
     _version = model::revision_id(version());
+    vlog(
+      clusterlog.info,
+      "applying maintenance mode command for: {} with enable maintenance "
+      "mode: {}",
+      cmd.key,
+      cmd.value);
 
     const auto target = _nodes.find(cmd.key);
     if (target == _nodes.end()) {
@@ -207,7 +211,6 @@ members_table::apply(model::offset version, maintenance_mode_cmd cmd) {
             return errc::success;
         }
 
-        vlog(clusterlog.info, "marking node {} not in maintenance state", id);
         metadata.state.set_maintenance_state(
           model::maintenance_state::inactive);
         notify_maintenance_state_change(id, model::maintenance_state::inactive);
@@ -289,6 +292,11 @@ void members_table::apply_snapshot(
     std::swap(old_nodes, _nodes);
 
     for (const auto& [id, node] : snap.nodes) {
+        vlog(
+          clusterlog.trace,
+          "adding node {} with state {} from snapshot",
+          node.broker,
+          node.state);
         _nodes.emplace(id, node_metadata{node.broker, node.state});
         _waiters.notify(id);
         notify_member_updated(id, node.state.get_membership_state());
@@ -297,6 +305,7 @@ void members_table::apply_snapshot(
     _removed_nodes.clear();
 
     for (const auto& [id, node] : snap.removed_nodes) {
+        vlog(clusterlog.trace, "removed node {} from snapshot", node.broker);
         _removed_nodes.emplace(id, node_metadata{node.broker, node.state});
         notify_member_updated(id, model::membership_state::removed);
     }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4586,7 +4586,8 @@ class RedpandaService(RedpandaServiceBase):
     def wait_for_controller_snapshot(self,
                                      node,
                                      prev_mtime=0,
-                                     prev_start_offset=0):
+                                     prev_start_offset=0,
+                                     timeout_sec=30):
         def check():
             snap_path = os.path.join(self.DATA_DIR,
                                      'redpanda/controller/0_0/snapshot')
@@ -4606,7 +4607,7 @@ class RedpandaService(RedpandaServiceBase):
             so = controller_status['start_offset']
             return (mtime > prev_mtime and so > prev_start_offset, (mtime, so))
 
-        return wait_until_result(check, timeout_sec=30, backoff_sec=1)
+        return wait_until_result(check, timeout_sec=timeout_sec, backoff_sec=1)
 
     def _get_object_storage_report(self,
                                    tolerate_empty_object_storage=False,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3005,7 +3005,8 @@ class RedpandaService(RedpandaServiceBase):
                    expect_fail: bool = False,
                    auto_assign_node_id: bool = False,
                    omit_seeds_on_idx_one: bool = True,
-                   skip_readiness_check: bool = False):
+                   skip_readiness_check: bool = False,
+                   node_id_override: int | None = None):
         """
         Start a single instance of redpanda. This function will not return until
         redpanda appears to have started successfully. If redpanda does not
@@ -3022,7 +3023,8 @@ class RedpandaService(RedpandaServiceBase):
                 node,
                 override_cfg_params,
                 auto_assign_node_id=auto_assign_node_id,
-                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
+                omit_seeds_on_idx_one=omit_seeds_on_idx_one,
+                node_id_override=node_id_override)
 
         if timeout is None:
             timeout = self.node_ready_timeout_s
@@ -3936,7 +3938,8 @@ class RedpandaService(RedpandaServiceBase):
                              node,
                              override_cfg_params=None,
                              auto_assign_node_id=False,
-                             omit_seeds_on_idx_one=True):
+                             omit_seeds_on_idx_one=True,
+                             node_id_override: int | None = None):
         """
         Write the node config file for a redpanda node: this is the YAML representation
         of Redpanda's `node_config` class.  Distinct from Redpanda's _cluster_ configuration
@@ -3945,7 +3948,11 @@ class RedpandaService(RedpandaServiceBase):
         node_info = {self.idx(n): n for n in self.nodes}
 
         include_seed_servers = True
-        node_id = self.idx(node)
+        if node_id_override:
+            assert auto_assign_node_id == False, "Can not use node id override when auto assigning node ids"
+            node_id = node_id_override
+        else:
+            node_id = self.idx(node)
         if omit_seeds_on_idx_one and node_id == 1:
             include_seed_servers = False
 

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -950,6 +950,131 @@ class NodesDecommissioningTest(PreallocNodesTest):
 
             self._check_state_consistent(to_decommission_id)
 
+    @cluster(num_nodes=6)
+    @matrix(auto_assign_node_id=[True, False])
+    def test_recycle_all_nodes(self, auto_assign_node_id):
+
+        # start redpanda on initial pool of nodes
+        self.redpanda.start(nodes=self.redpanda.nodes,
+                            auto_assign_node_id=auto_assign_node_id,
+                            omit_seeds_on_idx_one=(not auto_assign_node_id))
+        # configure controller not to take snapshot
+        self.redpanda.set_cluster_config(
+            {"controller_snapshot_max_age_sec": 20000})
+
+        spec = TopicSpec(name=f"migration-test-workload",
+                         partition_count=32,
+                         replication_factor=3)
+
+        self.client().create_topic(spec)
+        self._topic = spec.name
+
+        self.start_producer()
+        self.start_consumer()
+
+        # wait for some messages before executing actions
+        self.producer.wait_for_acks(0.2 * self.msg_count,
+                                    timeout_sec=60,
+                                    backoff_sec=2)
+
+        current_replicas = {
+            self.redpanda.node_id(n)
+            for n in self.redpanda.nodes
+        }
+        left_to_decommission = [
+            self.redpanda.node_id(n) for n in self.redpanda.nodes
+        ]
+
+        next_id = 10
+        admin = Admin(self.redpanda)
+
+        def cluster_view_is_consistent():
+            versions = set()
+            for n in self.redpanda.started_nodes():
+                node_id = self.redpanda.node_id(n)
+                cv = admin.get_cluster_view(node=n)
+                cv_nodes = {b['node_id'] for b in cv['brokers']}
+                versions.add(cv['version'])
+                self.logger.info(
+                    f"cluster view from node {node_id} - {cv_nodes}, version: {cv['version']}"
+                )
+                if cv_nodes != current_replicas:
+                    self.logger.warn(
+                        f"inconsistent cluster view from {node_id}, expected: {current_replicas}, current: {cv_nodes}"
+                    )
+                    return False
+
+                controller = admin.get_partition(ns="redpanda",
+                                                 topic="controller",
+                                                 id=0,
+                                                 node=n)
+                controller_replicas = {
+                    r['node_id']
+                    for r in controller['replicas']
+                }
+                self.logger.info(
+                    f"controller partition replicas from node {node_id} - {controller_replicas}"
+                )
+                if controller_replicas != current_replicas:
+                    self.logger.warn(
+                        f"inconsistent controller replicas {node_id}, expected: {current_replicas}, current: {cv_nodes}"
+                    )
+                    return False
+
+            return len(versions) == 1
+
+        while len(left_to_decommission) > 0:
+            decommissioned_id = left_to_decommission.pop()
+            n = self.redpanda.get_node_by_id(decommissioned_id)
+            assert n is not None
+            self.logger.info(
+                f"decommissioning node with id: {decommissioned_id} - {n.account.hostname}"
+            )
+            # force taking controller snapshot after first node is decommissioned
+            if len(left_to_decommission) == (len(self.redpanda.nodes) - 1):
+                self.redpanda.set_cluster_config(
+                    {"controller_snapshot_max_age_sec": 10})
+                self.redpanda.wait_for_controller_snapshot(
+                    self.redpanda.controller(),
+                    prev_start_offset=0,
+                    timeout_sec=60)
+
+            admin.decommission_broker(decommissioned_id)
+            if len(left_to_decommission) == 5:
+                self.redpanda.set_cluster_config(
+                    {"controller_snapshot_max_age_sec": 20000})
+
+            current_replicas.remove(decommissioned_id)
+            # wait until node is decommissioned
+            waiter = NodeDecommissionWaiter(
+                self.redpanda,
+                decommissioned_id,
+                self.logger,
+                60,
+                decommissioned_node_ids=[decommissioned_id])
+            waiter.wait_for_removal()
+
+            # clean the node data
+            self.redpanda.clean_node(n,
+                                     preserve_logs=True,
+                                     preserve_current_install=True)
+
+            # start with new id
+            self.logger.info(f"adding {n.account.hostname} with id {next_id}")
+
+            self.redpanda.start_node(
+                n,
+                auto_assign_node_id=auto_assign_node_id,
+                omit_seeds_on_idx_one=(not auto_assign_node_id),
+                node_id_override=None if auto_assign_node_id else next_id)
+            current_replicas.add(self.redpanda.node_id(n, force_refresh=True))
+            next_id += 1
+
+            wait_until(cluster_view_is_consistent, 60, 1,
+                       "error waiting for consistent view of the cluster")
+
+        self.verify()
+
 
 class NodeDecommissionFailureReportingTest(RedpandaTest):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Added some improvements making it easier to track the cluster membership issues. Additionally,  added a test decommissioning each cluster node and then adding it back to the cluster, either with an overridden node id or with the new node id assigned by the controller. This test is similar to the chaos tests using `recycle_all` failure.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none