### PR TITLE
cloud_storage: add param names to cache ctor

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -107,12 +107,12 @@ public:
     /// \param cache_dir is a directory where cached data is stored
     cache(
       std::filesystem::path cache_dir,
-      size_t,
-      config::binding<double>,
-      config::binding<uint64_t>,
-      config::binding<std::optional<double>>,
-      config::binding<uint32_t>,
-      config::binding<uint16_t>) noexcept;
+      size_t disk_size,
+      config::binding<double> disk_reservation,
+      config::binding<uint64_t> max_bytes_cfg,
+      config::binding<std::optional<double>> max_percent,
+      config::binding<uint32_t> max_objects,
+      config::binding<uint16_t> walk_concurrency) noexcept;
 
     cache(const cache&) = delete;
     cache(cache&& rhs) = delete;


### PR DESCRIPTION
Slightly improve readability of the constructor.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
