### PR TITLE
[v24.2.x] `cloud_storage`: add `topic_mount_manifest` (manual backport)

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -45,6 +45,7 @@ v_cc_library(
     segment_path_utils.cc
     topic_manifest.cc
     topic_manifest_downloader.cc
+    topic_mount_handler.cc
     topic_path_utils.cc
     async_manifest_view.cc
     materialized_manifest_cache.cc

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     access_time_tracker.cc
     cache_probe.cc
     download_exception.cc
+    topic_mount_manifest.cc
     partition_manifest.cc
     partition_manifest_downloader.cc
     partition_path_utils.cc

--- a/src/v/cloud_storage/base_manifest.cc
+++ b/src/v/cloud_storage/base_manifest.cc
@@ -31,6 +31,9 @@ std::ostream& operator<<(std::ostream& s, manifest_type t) {
     case manifest_type::spillover:
         s << "spillover";
         break;
+    case manifest_type::topic_mount:
+        s << "topic_mount";
+        break;
     }
     return s;
 }

--- a/src/v/cloud_storage/base_manifest.h
+++ b/src/v/cloud_storage/base_manifest.h
@@ -29,6 +29,7 @@ enum class manifest_type {
     tx_range,
     cluster_metadata,
     spillover,
+    topic_mount
 };
 
 std::ostream& operator<<(std::ostream& s, manifest_type t);

--- a/src/v/cloud_storage/fwd.h
+++ b/src/v/cloud_storage/fwd.h
@@ -19,6 +19,7 @@ class remote_partition;
 class remote_path_provider;
 class remote_segment;
 class partition_manifest;
+class topic_mount_manifest;
 class topic_manifest;
 class partition_probe;
 class async_manifest_view;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -277,6 +277,9 @@ ss::future<download_result> remote::do_download_manifest(
                 case manifest_type::spillover:
                     _probe.spillover_manifest_download();
                     break;
+                case manifest_type::topic_mount:
+                    _probe.topic_mount_manifest_download();
+                    break;
                 }
                 co_return download_result::success;
             } catch (...) {
@@ -382,6 +385,9 @@ ss::future<upload_result> remote::upload_manifest(
                 break;
             case manifest_type::spillover:
                 _probe.spillover_manifest_upload();
+                break;
+            case manifest_type::topic_mount:
+                _probe.topic_mount_manifest_upload();
                 break;
             }
             _probe.register_upload_size(size);

--- a/src/v/cloud_storage/remote_path_provider.cc
+++ b/src/v/cloud_storage/remote_path_provider.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage/remote_label.h"
 #include "cloud_storage/segment_path_utils.h"
 #include "cloud_storage/spillover_manifest.h"
+#include "cloud_storage/topic_mount_manifest.h"
 #include "cloud_storage/topic_path_utils.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
@@ -114,6 +115,14 @@ ss::sstring remote_path_provider::spillover_manifest_path(
       partition_manifest_prefix(
         stm_manifest.get_ntp(), stm_manifest.get_revision_id()),
       spillover_manifest::filename(c));
+}
+
+ss::sstring remote_path_provider::topic_mount_manifest_path(
+  const topic_mount_manifest& manifest) const {
+    return fmt::format(
+      "migration/{}/{}",
+      manifest.get_source_label().cluster_uuid,
+      manifest.get_tp_ns().path());
 }
 
 ss::sstring remote_path_provider::segment_path(

--- a/src/v/cloud_storage/remote_path_provider.h
+++ b/src/v/cloud_storage/remote_path_provider.h
@@ -82,6 +82,9 @@ public:
       const partition_manifest& stm_manifest,
       const spillover_manifest_path_components& c) const;
 
+    ss::sstring
+    topic_mount_manifest_path(const topic_mount_manifest& manifest) const;
+
     // Segment paths.
     ss::sstring segment_path(
       const partition_manifest& manifest, const segment_meta& segment) const;

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -117,6 +117,24 @@ public:
         return _cnt_tx_manifest_downloads;
     }
 
+    /// Register manifest (re)upload
+    void topic_mount_manifest_upload() { _cnt_topic_mount_manifest_uploads++; }
+
+    /// Get manifest (re)upload
+    uint64_t get_topic_mount_manifest_uploads() const {
+        return _cnt_topic_mount_manifest_uploads;
+    }
+
+    /// Register manifest download
+    void topic_mount_manifest_download() {
+        _cnt_topic_mount_manifest_downloads++;
+    }
+
+    /// Get manifest download
+    uint64_t get_topic_mount_manifest_downloads() const {
+        return _cnt_topic_mount_manifest_downloads;
+    }
+
     /// Register backof invocation during manifest upload
     void manifest_upload_backoff() { _cnt_manifest_upload_backoff++; }
 
@@ -295,6 +313,10 @@ private:
     uint64_t _cnt_spillover_manifest_uploads{0};
     /// Number of spillover manifest downloads
     uint64_t _cnt_spillover_manifest_downloads{0};
+    /// Number of topic_mount manifest uploads
+    uint64_t _cnt_topic_mount_manifest_uploads{0};
+    /// Number of topic_mount manifest downloads
+    uint64_t _cnt_topic_mount_manifest_downloads{0};
 
     hist_t _client_acquisition_latency;
     hist_t _segment_download_latency;

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -35,6 +35,25 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_cloud_storage
+  SOURCES
+    topic_mount_manifest_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::seastar_testing_main
+    v::cloud_storage
+    v::storage_test_utils
+    v::cloud_roles
+    v::application
+    v::kafka_test_utils
+    v::http_test_utils
+  ARGS "-- -c 1"
+  LABELS cloud_storage
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME topic_manifest
   SOURCES topic_manifest_test.cc
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cluster

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ rp_test(
     s3_imposter.cc
     topic_manifest_downloader_test.cc
     topic_namespace_override_recovery_test.cc
+    topic_mount_handler_test.cc
     util.cc
   LIBRARIES
     v::gtest_main

--- a/src/v/cloud_storage/tests/remote_path_provider_test.cc
+++ b/src/v/cloud_storage/tests/remote_path_provider_test.cc
@@ -10,6 +10,7 @@
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/spillover_manifest.h"
+#include "cloud_storage/topic_mount_manifest.h"
 #include "cloud_storage/topic_path_utils.h"
 #include "cloud_storage/types.h"
 #include "gtest/gtest.h"
@@ -377,6 +378,14 @@ TEST_P(
       test_ntp, test_rev);
     ASSERT_FALSE(path_provider.segment_path(test_ntp, test_rev, test_smeta)
                    .starts_with(partition_prefix));
+}
+
+TEST(RemotePathProviderTest, TestTopicMountManifestPath) {
+    remote_path_provider path_provider(test_label, std::nullopt);
+    topic_mount_manifest manifest(test_label, test_tp_ns);
+    EXPECT_STREQ(
+      path_provider.topic_mount_manifest_path(manifest).c_str(),
+      "migration/deadbeef-0000-0000-0000-000000000000/kafka/tp");
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/cloud_storage/tests/topic_mount_handler_test.cc
+++ b/src/v/cloud_storage/tests/topic_mount_handler_test.cc
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_storage/remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/topic_mount_handler.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/client_pool.h"
+#include "cloud_storage_clients/types.h"
+#include "cluster/data_migrated_resources.h"
+#include "cluster/topic_configuration.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "test_utils/test.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <chrono>
+
+using namespace cloud_storage;
+using namespace std::chrono_literals;
+
+namespace {
+static const ss::sstring test_uuid_str = "deadbeef-0000-0000-0000-000000000000";
+static const ss::sstring default_uuid_str = ss::sstring{
+  model::default_cluster_uuid()};
+static const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
+static const remote_label test_label{test_uuid};
+static const model::topic_namespace test_tp_ns{
+  model::ns{"kafka"}, model::topic{"tp"}};
+static const model::topic_namespace test_tp_ns_override{
+  model::ns{"kafka"}, model::topic{"override"}};
+static ss::abort_source never_abort;
+static constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+} // namespace
+
+struct TopicMountHandlerFixture
+  : public s3_imposter_fixture
+  , public testing::TestWithParam<std::tuple<bool, bool>> {
+    TopicMountHandlerFixture() {
+        pool.start(10, ss::sharded_parameter([this] { return conf; })).get();
+        remote
+          .start(
+            std::ref(pool),
+            ss::sharded_parameter([this] { return conf; }),
+            ss::sharded_parameter([] { return config_file; }))
+          .get();
+    }
+
+    ~TopicMountHandlerFixture() {
+        pool.local().shutdown_connections();
+        remote.stop().get();
+        pool.stop().get();
+    }
+
+    cluster::topic_configuration
+    get_topic_configuration(cluster::topic_properties topic_props) const {
+        auto topic_cfg = cluster::topic_configuration(
+          test_tp_ns.ns, test_tp_ns.tp, 1, 1);
+        topic_cfg.properties = std::move(topic_props);
+        return topic_cfg;
+    }
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    ss::sharded<remote> remote;
+};
+
+TEST_P(TopicMountHandlerFixture, TestMountTopicManifestDoesNotExist) {
+    set_expectations_and_listen({});
+
+    auto topic_props = cluster::topic_properties{};
+
+    auto tp_ns_override_param = std::get<0>(GetParam());
+    auto remote_label_param = std::get<1>(GetParam());
+    if (tp_ns_override_param) {
+        topic_props.remote_topic_namespace_override = test_tp_ns_override;
+    }
+    if (remote_label_param) {
+        topic_props.remote_label = test_label;
+    }
+
+    auto topic_cfg = get_topic_configuration(std::move(topic_props));
+    auto handler = topic_mount_handler(bucket_name, remote.local());
+
+    retry_chain_node rtc(never_abort, 10s, 20ms);
+    auto mount_result = handler.mount_topic(topic_cfg, rtc).get();
+    ASSERT_EQ(mount_result, topic_mount_result::mount_manifest_does_not_exist);
+}
+
+TEST_P(TopicMountHandlerFixture, TestMountTopicManifestNotDeleted) {
+    set_expectations_and_listen({});
+    retry_chain_node rtc(never_abort, 10s, 20ms);
+
+    auto tp_ns_override_param = std::get<0>(GetParam());
+    auto remote_label_param = std::get<1>(GetParam());
+
+    const auto expected_tp_ns = tp_ns_override_param
+                                  ? test_tp_ns_override.path()
+                                  : test_tp_ns.path();
+    const auto expected_label = remote_label_param ? test_uuid_str
+                                                   : default_uuid_str;
+    const auto path = cloud_storage_clients::object_key{
+      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    {
+        auto result
+          = remote.local()
+              .upload_object(
+                {.transfer_details
+                 = {.bucket = bucket_name, .key = path, .parent_rtc = rtc},
+                 .payload = iobuf{}})
+              .get();
+        ASSERT_EQ(cloud_storage::upload_result::success, result);
+    }
+
+    auto topic_props = cluster::topic_properties{};
+    if (remote_label_param) {
+        topic_props.remote_label = test_label;
+    }
+    if (tp_ns_override_param) {
+        topic_props.remote_topic_namespace_override = test_tp_ns_override;
+    }
+    auto topic_cfg = get_topic_configuration(std::move(topic_props));
+
+    static const ss::sstring delete_error = R"json(
+<Error>
+    <Code>TestFailure</Code>
+    <Key>0</Key>
+    <Message>No Deletes Allowed.</Message>
+</Error>)json";
+
+    http_test_utils::response fail_response{
+      .body = delete_error,
+      .status = http_test_utils::response::status_type::bad_request};
+    req_pred_t fail_delete_request =
+      [](const http_test_utils::request_info& info) {
+          return info.method.contains("DELETE");
+      };
+    fail_request_if(fail_delete_request, fail_response);
+
+    auto handler = topic_mount_handler(bucket_name, remote.local());
+
+    auto mount_result = handler.mount_topic(topic_cfg, rtc).get();
+    ASSERT_EQ(mount_result, topic_mount_result::mount_manifest_not_deleted);
+
+    const auto exists_result
+      = remote.local()
+          .object_exists(bucket_name, path, rtc, existence_check_type::manifest)
+          .get();
+    ASSERT_EQ(exists_result, download_result::success);
+}
+
+TEST_P(TopicMountHandlerFixture, TestMountTopicSuccess) {
+    set_expectations_and_listen({});
+    retry_chain_node rtc(never_abort, 10s, 20ms);
+
+    auto tp_ns_override_param = std::get<0>(GetParam());
+    auto remote_label_param = std::get<1>(GetParam());
+
+    const auto expected_tp_ns = tp_ns_override_param
+                                  ? test_tp_ns_override.path()
+                                  : test_tp_ns.path();
+    const auto expected_label = remote_label_param ? test_uuid_str
+                                                   : default_uuid_str;
+    const auto path = cloud_storage_clients::object_key{
+      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    {
+        auto result
+          = remote.local()
+              .upload_object(
+                {.transfer_details
+                 = {.bucket = bucket_name, .key = path, .parent_rtc = rtc},
+                 .payload = iobuf{}})
+              .get();
+        ASSERT_EQ(cloud_storage::upload_result::success, result);
+    }
+
+    auto topic_props = cluster::topic_properties{};
+    if (tp_ns_override_param) {
+        topic_props.remote_topic_namespace_override = test_tp_ns_override;
+    }
+    if (remote_label_param) {
+        topic_props.remote_label = test_label;
+    }
+    auto topic_cfg = get_topic_configuration(std::move(topic_props));
+
+    auto handler = topic_mount_handler(bucket_name, remote.local());
+
+    auto mount_result = handler.mount_topic(topic_cfg, rtc).get();
+    ASSERT_EQ(mount_result, topic_mount_result::success);
+
+    const auto exists_result
+      = remote.local()
+          .object_exists(bucket_name, path, rtc, existence_check_type::manifest)
+          .get();
+    ASSERT_EQ(exists_result, download_result::notfound);
+}
+
+TEST_P(TopicMountHandlerFixture, TestUnmountTopicManifestNotCreated) {
+    set_expectations_and_listen({});
+    retry_chain_node rtc(never_abort, 10s, 20ms);
+
+    auto tp_ns_override_param = std::get<0>(GetParam());
+    auto remote_label_param = std::get<1>(GetParam());
+
+    const auto expected_tp_ns = tp_ns_override_param
+                                  ? test_tp_ns_override.path()
+                                  : test_tp_ns.path();
+    const auto expected_label = remote_label_param ? test_uuid_str
+                                                   : default_uuid_str;
+    const auto path = cloud_storage_clients::object_key{
+      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+
+    auto topic_props = cluster::topic_properties{};
+    if (tp_ns_override_param) {
+        topic_props.remote_topic_namespace_override = test_tp_ns_override;
+    }
+    if (remote_label_param) {
+        topic_props.remote_label = test_label;
+    }
+    auto topic_cfg = get_topic_configuration(std::move(topic_props));
+
+    static const ss::sstring upload_error = R"json(
+<Error>
+    <Code>TestFailure</Code>
+    <Key>0</Key>
+    <Message>No Uploads Allowed.</Message>
+</Error>)json";
+
+    http_test_utils::response fail_response{
+      .body = upload_error,
+      .status = http_test_utils::response::status_type::bad_request};
+    req_pred_t fail_delete_request =
+      [](const http_test_utils::request_info& info) {
+          return info.method.contains("PUT");
+      };
+    fail_request_if(fail_delete_request, fail_response);
+
+    auto handler = topic_mount_handler(bucket_name, remote.local());
+
+    auto unmount_result = handler.unmount_topic(topic_cfg, rtc).get();
+    ASSERT_EQ(unmount_result, topic_unmount_result::mount_manifest_not_created);
+
+    const auto exists_result
+      = remote.local()
+          .object_exists(bucket_name, path, rtc, existence_check_type::manifest)
+          .get();
+    ASSERT_EQ(exists_result, download_result::notfound);
+}
+
+TEST_P(TopicMountHandlerFixture, TestUnmountTopicSuccess) {
+    set_expectations_and_listen({});
+    retry_chain_node rtc(never_abort, 10s, 20ms);
+
+    auto tp_ns_override_param = std::get<0>(GetParam());
+    auto remote_label_param = std::get<1>(GetParam());
+
+    const auto expected_tp_ns = tp_ns_override_param
+                                  ? test_tp_ns_override.path()
+                                  : test_tp_ns.path();
+    const auto expected_label = remote_label_param ? test_uuid_str
+                                                   : default_uuid_str;
+    const auto path = cloud_storage_clients::object_key{
+      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+
+    auto topic_props = cluster::topic_properties{};
+    if (tp_ns_override_param) {
+        topic_props.remote_topic_namespace_override = test_tp_ns_override;
+    }
+    if (remote_label_param) {
+        topic_props.remote_label = test_label;
+    }
+    auto topic_cfg = get_topic_configuration(std::move(topic_props));
+
+    auto handler = topic_mount_handler(bucket_name, remote.local());
+
+    auto unmount_result = handler.unmount_topic(topic_cfg, rtc).get();
+    ASSERT_EQ(unmount_result, topic_unmount_result::success);
+
+    const auto exists_result
+      = remote.local()
+          .object_exists(bucket_name, path, rtc, existence_check_type::manifest)
+          .get();
+    ASSERT_EQ(exists_result, download_result::success);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  TopicMountHandlerOverride,
+  TopicMountHandlerFixture,
+  testing::Combine(testing::Bool(), testing::Bool()));

--- a/src/v/cloud_storage/tests/topic_mount_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_mount_manifest_test.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/remote_label.h"
+#include "cloud_storage/remote_path_provider.h"
+#include "cloud_storage/topic_mount_manifest.h"
+#include "cloud_storage/types.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "test_utils/test.h"
+
+using namespace cloud_storage;
+
+namespace {
+const remote_path_provider path_provider(std::nullopt, std::nullopt);
+} // anonymous namespace
+
+const ss::sstring test_uuid_str = "deadbeef-0000-0000-0000-000000000000";
+const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
+const remote_label test_label{test_uuid};
+const model::topic_namespace test_tp_ns{
+  model::ns{"test_ns"}, model::topic{"test_tp"}};
+
+TEST(topic_mount_manifest, manifest_type) {
+    topic_mount_manifest m(test_label, test_tp_ns);
+    ASSERT_TRUE(m.get_manifest_type() == manifest_type::topic_mount);
+}
+
+TEST(topic_mount_manifest, serde) {
+    topic_mount_manifest m(test_label, test_tp_ns);
+    auto serialized_manifest = m.serialize().get().stream;
+
+    // Sanity check that the manifest contains the test label and
+    // topic namespace.
+    ASSERT_EQ(m.get_source_label(), test_label);
+    ASSERT_EQ(m.get_tp_ns(), test_tp_ns);
+
+    topic_mount_manifest reconstructed_m(
+      remote_label{}, model::topic_namespace{});
+
+    // Sanity check that the manifests differ.
+    ASSERT_NE(reconstructed_m.get_source_label(), m.get_source_label());
+    ASSERT_NE(reconstructed_m.get_tp_ns(), m.get_tp_ns());
+    ASSERT_NE(
+      reconstructed_m.get_manifest_path(path_provider),
+      m.get_manifest_path(path_provider));
+
+    reconstructed_m.update(std::move(serialized_manifest)).get();
+
+    // Manifests should be identical after deserialization.
+    ASSERT_EQ(reconstructed_m.get_source_label(), m.get_source_label());
+    ASSERT_EQ(reconstructed_m.get_tp_ns(), m.get_tp_ns());
+    ASSERT_EQ(
+      reconstructed_m.get_manifest_path(path_provider),
+      m.get_manifest_path(path_provider));
+}

--- a/src/v/cloud_storage/topic_mount_handler.h
+++ b/src/v/cloud_storage/topic_mount_handler.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cloud_storage/fwd.h"
+#include "cloud_storage/remote_label.h"
+#include "cloud_storage_clients/types.h"
+#include "cluster/topic_configuration.h"
+#include "model/fundamental.h"
+#include "utils/retry_chain_node.h"
+
+namespace cloud_storage {
+
+enum class topic_mount_result {
+    mount_manifest_does_not_exist,
+    mount_manifest_not_deleted,
+    success
+};
+
+std::ostream& operator<<(std::ostream& o, const topic_mount_result& r);
+
+enum class topic_unmount_result { mount_manifest_not_created, success };
+
+std::ostream& operator<<(std::ostream& o, const topic_unmount_result& r);
+
+class topic_mount_handler {
+public:
+    topic_mount_handler(
+      const cloud_storage_clients::bucket_name& bucket, remote& remote);
+
+    // Perform the mounting process by deleting the topic mount manifest.
+    // topic_cfg should be the recovered topic configuration from a topic
+    // manifest in cloud storage. If it has a value, the remote_label stored in
+    // the topic properties is used as the "source" label. Otherwise, the
+    // default uuid (all zeros) is used.
+    ss::future<topic_mount_result> mount_topic(
+      const cluster::topic_configuration& topic_cfg, retry_chain_node& parent);
+
+    // Perform the mounting process by deleting the topic mount manifest.
+    // topic_cfg should be the recovered topic configuration from a topic
+    // manifest in cloud storage. If it has a value, the remote_label stored in
+    // the topic properties is used as the "source" label. Otherwise, the
+    // default uuid (all zeros) is used.
+    ss::future<topic_unmount_result> unmount_topic(
+      const cluster::topic_configuration& topic_cfg, retry_chain_node& parent);
+
+private:
+    // Check for the existence of a topic mount manifest in tiered storage.
+    // If it exists, then the topic can be mounted.
+    ss::future<topic_mount_result> check_mount(
+      const topic_mount_manifest& manifest,
+      const remote_path_provider& path_provider,
+      retry_chain_node& parent);
+
+    // Commits to the mount of the topic by deleting the topic mount manifest in
+    // tiered storage.
+    ss::future<topic_mount_result> commit_mount(
+      const topic_mount_manifest& manifest,
+      const remote_path_provider& path_provider,
+      retry_chain_node& parent);
+
+    cloud_storage_clients::bucket_name _bucket;
+    remote& _remote;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/topic_mount_manifest.cc
+++ b/src/v/cloud_storage/topic_mount_manifest.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_storage/topic_mount_manifest.h"
+
+#include "base/vlog.h"
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "cloud_storage/logger.h"
+#include "cloud_storage/remote_path_provider.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+#include "serde/serde.h"
+
+namespace {
+
+struct topic_mount_manifest_state
+  : public serde::envelope<
+      topic_mount_manifest_state,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(label, tp_ns); }
+
+    bool operator==(const topic_mount_manifest_state&) const = default;
+
+    cloud_storage::remote_label label;
+    model::topic_namespace tp_ns;
+};
+
+} // namespace
+
+namespace cloud_storage {
+
+topic_mount_manifest::topic_mount_manifest(
+  const remote_label& label, const model::topic_namespace& tp_ns)
+  : _source_label(label)
+  , _tp_ns(tp_ns) {}
+
+ss::future<> topic_mount_manifest::update(ss::input_stream<char> is) {
+    iobuf result;
+    auto os = make_iobuf_ref_output_stream(result);
+    co_await ss::copy(is, os).finally([&is, &os]() mutable {
+        return is.close().finally([&os]() mutable { return os.close(); });
+    });
+    from_iobuf(std::move(result));
+}
+
+void topic_mount_manifest::from_iobuf(iobuf in) {
+    auto m_state = serde::from_iobuf<topic_mount_manifest_state>(std::move(in));
+    _source_label = std::move(m_state.label);
+    _tp_ns = std::move(m_state.tp_ns);
+}
+
+/// Serialize manifest object
+///
+/// \return asynchronous input_stream with the serialized json
+ss::future<serialized_data_stream> topic_mount_manifest::serialize() const {
+    auto serialized = serde::to_iobuf(
+      topic_mount_manifest_state{.label = _source_label, .tp_ns = _tp_ns});
+    const size_t size_bytes = serialized.size_bytes();
+    co_return serialized_data_stream{
+      .stream = make_iobuf_input_stream(std::move(serialized)),
+      .size_bytes = size_bytes};
+}
+
+/// Manifest object name in S3
+remote_manifest_path
+topic_mount_manifest::get_manifest_path(const remote_path_provider&) const {
+    // TODO: edit in future commit after adding remote_path_provider
+    // implementation.
+    return remote_manifest_path{};
+}
+
+manifest_type topic_mount_manifest::get_manifest_type() const {
+    return manifest_type::topic_mount;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/topic_mount_manifest.cc
+++ b/src/v/cloud_storage/topic_mount_manifest.cc
@@ -71,11 +71,9 @@ ss::future<serialized_data_stream> topic_mount_manifest::serialize() const {
 }
 
 /// Manifest object name in S3
-remote_manifest_path
-topic_mount_manifest::get_manifest_path(const remote_path_provider&) const {
-    // TODO: edit in future commit after adding remote_path_provider
-    // implementation.
-    return remote_manifest_path{};
+remote_manifest_path topic_mount_manifest::get_manifest_path(
+  const remote_path_provider& path_provider) const {
+    return remote_manifest_path{path_provider.topic_mount_manifest_path(*this)};
 }
 
 manifest_type topic_mount_manifest::get_manifest_type() const {

--- a/src/v/cloud_storage/topic_mount_manifest.h
+++ b/src/v/cloud_storage/topic_mount_manifest.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/fwd.h"
+#include "cloud_storage/remote_label.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <seastar/core/future.hh>
+
+#include <optional>
+
+namespace cloud_storage {
+
+class topic_mount_manifest final : public base_manifest {
+public:
+    topic_mount_manifest(
+      const remote_label& label, const model::topic_namespace& tp_ns);
+
+    ss::future<> update(ss::input_stream<char> is) override;
+
+    ss::future<serialized_data_stream> serialize() const override;
+
+    const remote_label& get_source_label() const { return _source_label; }
+
+    const model::topic_namespace& get_tp_ns() const { return _tp_ns; }
+
+    /// Manifest object name in S3
+    remote_manifest_path
+    get_manifest_path(const remote_path_provider& path_provider) const;
+
+    manifest_type get_manifest_type() const override;
+
+private:
+    void from_iobuf(iobuf in);
+
+    // The label for the cluster that originally created the topic to be
+    // mounted/unmounted.
+    remote_label _source_label;
+    model::topic_namespace _tp_ns;
+};
+} // namespace cloud_storage

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -92,6 +92,8 @@ namespace model {
 using node_uuid = named_type<uuid_t, struct node_uuid_type>;
 using cluster_uuid = named_type<uuid_t, struct cluster_uuid_type>;
 
+static constexpr cluster_uuid default_cluster_uuid{};
+
 using node_id = named_type<int32_t, struct node_id_model_type>;
 
 /**

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -378,6 +378,8 @@ struct topic_namespace {
     model::ns ns;
     model::topic tp;
 
+    ss::sstring path() const;
+
     friend std::ostream& operator<<(std::ostream&, const topic_namespace&);
 };
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -169,6 +169,10 @@ ss::sstring ntp::path() const {
     return ssx::sformat("{}/{}/{}", ns(), tp.topic(), tp.partition());
 }
 
+ss::sstring topic_namespace::path() const {
+    return ssx::sformat("{}/{}", ns(), tp());
+}
+
 std::filesystem::path ntp::topic_path() const {
     return fmt::format("{}/{}", ns(), tp.topic());
 }

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -30,6 +30,12 @@ SEASTAR_THREAD_TEST_CASE(test_uuid_create) {
     BOOST_REQUIRE_NE(uuid1, uuid2);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_uuid_default_construct) {
+    auto uuid = uuid_t{};
+    BOOST_REQUIRE_EQUAL(
+      uuid, uuid_t::from_string("00000000-0000-0000-0000-000000000000"));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_named_uuid_type) {
     auto uuid1 = test_uuid(uuid_t::create());
     auto uuid2 = test_uuid(uuid_t::create());


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/21582

Fixes #22681

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
