### PR TITLE
`storage`: fix condition in `disk_log_impl::have_segments_to_evict()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -396,7 +396,7 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
       max_offset);
     // we only notify eviction monitor if there are segments to evict
     auto have_segments_to_evict
-      = _segs.size() > 1
+      = !_segs.empty()
         && _segs.front()->offsets().get_committed_offset() <= max_offset;
 
     if (_eviction_monitor && have_segments_to_evict) {

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/server/tests/produce_consume_utils.h"
+#include "model/fundamental.h"
+#include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "test_utils/fixture.h"
 #include "test_utils/scoped_config.h"
@@ -16,10 +18,10 @@
 
 #include <boost/test/tools/old/interface.hpp>
 
+#include <chrono>
 #include <vector>
 
 using namespace std::chrono_literals;
-using std::vector;
 
 struct storage_e2e_fixture : public redpanda_thread_fixture {
     scoped_config test_local_cfg;
@@ -82,4 +84,95 @@ FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
         std::move(p).get();
     }
     app.stress_fiber_manager.local().stop().get();
+}
+
+FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
+    const auto topic_name = model::topic("tapioca");
+    const auto ntp = model::ntp(model::kafka_namespace, topic_name, 0);
+    // We will be running housekeeping locally in a loop.
+    test_local_cfg.get("log_disable_housekeeping_for_tests").set_value(true);
+    cluster::topic_properties props;
+    // Try to ensure we stay at 1 segment during our eviction/appending loop.
+    props.segment_size = 1_MiB;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
+
+    ss::abort_source as;
+
+    // Config is set up to always garbage collect as much as possible.
+    storage::housekeeping_config cfg(
+      /*gc_upper=*/model::timestamp::max(),
+      /*max_bytes_in_log=*/1,
+      /*max_collect_offset=*/model::offset::min(),
+      ss::default_priority_class(),
+      as);
+
+    const auto num_records = 100;
+    model::offset produce_base_offset{0};
+    model::offset stop_after{num_records * 100};
+    tests::kafka_produce_transport producer(make_kafka_client().get());
+    producer.start().get();
+    auto produce = [&] {
+        return producer
+          .produce_to_partition(
+            topic_name,
+            model::partition_id(0),
+            tests::kv_t::sequence(produce_base_offset(), num_records))
+          .then([&](model::offset base_offset) {
+              BOOST_REQUIRE_EQUAL(base_offset, produce_base_offset);
+              produce_base_offset += model::offset{num_records};
+              if (produce_base_offset >= stop_after) {
+                  as.request_abort();
+              }
+          })
+          .then([] {
+              return ss::sleep(
+                std::chrono::milliseconds(random_generators::get_int(10, 100)));
+          });
+    };
+
+    auto read = [&] {
+        auto lstats = log->offsets();
+        return log
+          ->make_reader(storage::log_reader_config(
+            lstats.start_offset,
+            model::offset::max(),
+            ss::default_priority_class()))
+          .then([](auto reader) {
+              return ss::sleep(std::chrono::milliseconds(
+                                 random_generators::get_int(15, 30)))
+                .then([r = std::move(reader)]() mutable {
+                    return model::consume_reader_to_memory(
+                      std::move(r), model::no_timeout);
+                })
+                .then([](ss::circular_buffer<model::record_batch> batches) {
+                    model::offset prev_base_offset{model::offset::min()};
+                    for (const auto& batch : batches) {
+                        BOOST_REQUIRE_GT(batch.base_offset(), prev_base_offset);
+                        prev_base_offset = batch.base_offset();
+                    }
+                });
+          });
+    };
+
+    auto gc = [&] { return log->housekeeping(cfg); };
+
+    // Concurrent operations
+    auto produce_fut = ss::do_until(
+      [&] { return as.abort_requested(); }, [&] { return produce(); });
+    auto read_fut = ss::do_until(
+      [&] { return as.abort_requested(); }, [&] { return read(); });
+    auto gc_fut = ss::do_until(
+      [&] { return as.abort_requested(); }, [&] { return gc(); });
+
+    ss::when_all(std::move(produce_fut), std::move(read_fut), std::move(gc_fut))
+      .get();
+
+    // log_eviction_stm may have removed the active segment after we finished
+    // final round of eviction.
+    BOOST_REQUIRE_LE(log->segment_count(), 1);
 }

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -705,8 +705,9 @@ class BogusTimestampTest(RedpandaTest):
             cleanup_policy=TopicSpec.CLEANUP_DELETE,
             # 1 megabyte segments
             segment_bytes=segment_size,
-            # 1 second retention: any non-open segment should be collected almost immediately
-            retention_ms=1000), )
+            # 10 second retention: in the case of mixed timestamps,
+            # give active segment time to help adjust retention timestamps and show up in log monitor.
+            retention_ms=10000), )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args,


### PR DESCRIPTION
Currently, we check that there is more than one segment in a `disk_log_impl`'s `segment_set` for determining it as having segments for eviction.

This gets us into a situation in which we can evict all segments in a log if we were to have `_segs.size() > 1`, but none if `_segs.size() == 1`.

This is an overly restrictive condition, and is corrected here.

We openly admit that we may delete the active segment [here in `disk_log_impl::do_truncate_prefix()`](https://github.com/redpanda-data/redpanda/blob/35cedc84bcb553b5adb08bd6dc172252e8b34291/src/v/storage/disk_log_impl.cc#L2555-L2558), so there is no reason to be so restrictive with the condition in `request_eviction_until_offset()`

Fixes https://github.com/redpanda-data/redpanda/issues/18014.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a condition in `disk_log_impl` that resulted in the `log_eviction_stm` being unable to evict from a log with a single segment in it.
