### PR TITLE
miscellaneous idempotency fixes

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -226,6 +226,7 @@ redpanda_cc_library(
         "drain_manager.cc",
         "ephemeral_credential_frontend.cc",
         "ephemeral_credential_service.cc",
+        "errors.cc",
         "feature_backend.cc",
         "feature_barrier.cc",
         "feature_manager.cc",

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -107,6 +107,7 @@ v_cc_library(
   HDRS
     topic_recovery_validator.h
   SRCS
+    errors.cc
     metadata_cache.cc
     partition_manager.cc
     scheduling/partition_allocator.cc

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -96,6 +96,9 @@ enum class errc : int16_t {
     data_migration_invalid_resources,
     resource_is_being_migrated,
 };
+
+std::ostream& operator<<(std::ostream& o, errc err);
+
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
 

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/errc.h"
+
+#include <iostream>
+
+namespace cluster {
+std::ostream& operator<<(std::ostream& o, cluster::errc err) {
+    switch (err) {
+    case errc::success:
+        return o << "cluster::errc::success";
+    case errc::notification_wait_timeout:
+        return o << "cluster::errc::notification_wait_timeout";
+    case errc::topic_invalid_partitions:
+        return o << "cluster::errc::topic_invalid_partitions";
+    case errc::topic_invalid_replication_factor:
+        return o << "cluster::errc::topic_invalid_replication_factor";
+    case errc::topic_invalid_config:
+        return o << "cluster::errc::topic_invalid_config";
+    case errc::not_leader_controller:
+        return o << "cluster::errc::not_leader_controller";
+    case errc::topic_already_exists:
+        return o << "cluster::errc::topic_already_exists";
+    case errc::replication_error:
+        return o << "cluster::errc::replication_error";
+    case errc::shutting_down:
+        return o << "cluster::errc::shutting_down";
+    case errc::no_leader_controller:
+        return o << "cluster::errc::no_leader_controller";
+    case errc::join_request_dispatch_error:
+        return o << "cluster::errc::join_request_dispatch_error";
+    case errc::seed_servers_exhausted:
+        return o << "cluster::errc::seed_servers_exhausted";
+    case errc::auto_create_topics_exception:
+        return o << "cluster::errc::auto_create_topics_exception";
+    case errc::timeout:
+        return o << "cluster::errc::timeout";
+    case errc::topic_not_exists:
+        return o << "cluster::errc::topic_not_exists";
+    case errc::invalid_topic_name:
+        return o << "cluster::errc::invalid_topic_name";
+    case errc::partition_not_exists:
+        return o << "cluster::errc::partition_not_exists";
+    case errc::not_leader:
+        return o << "cluster::errc::not_leader";
+    case errc::partition_already_exists:
+        return o << "cluster::errc::partition_already_exists";
+    case errc::waiting_for_recovery:
+        return o << "cluster::errc::waiting_for_recovery";
+    case errc::waiting_for_reconfiguration_finish:
+        return o << "cluster::errc::waiting_for_reconfiguration_finish";
+    case errc::update_in_progress:
+        return o << "cluster::errc::update_in_progress";
+    case errc::user_exists:
+        return o << "cluster::errc::user_exists";
+    case errc::user_does_not_exist:
+        return o << "cluster::errc::user_does_not_exist";
+    case errc::invalid_producer_epoch:
+        return o << "cluster::errc::invalid_producer_epoch";
+    case errc::sequence_out_of_order:
+        return o << "cluster::errc::sequence_out_of_order";
+    case errc::generic_tx_error:
+        return o << "cluster::errc::generic_tx_error";
+    case errc::node_does_not_exists:
+        return o << "cluster::errc::node_does_not_exists";
+    case errc::invalid_node_operation:
+        return o << "cluster::errc::invalid_node_operation";
+    case errc::invalid_configuration_update:
+        return o << "cluster::errc::invalid_configuration_update";
+    case errc::topic_operation_error:
+        return o << "cluster::errc::topic_operation_error";
+    case errc::no_eligible_allocation_nodes:
+        return o << "cluster::errc::no_eligible_allocation_nodes";
+    case errc::allocation_error:
+        return o << "cluster::errc::allocation_error";
+    case errc::partition_configuration_revision_not_updated:
+        return o
+               << "cluster::errc::partition_configuration_revision_not_updated";
+    case errc::partition_configuration_in_joint_mode:
+        return o << "cluster::errc::partition_configuration_in_joint_mode";
+    case errc::partition_configuration_leader_config_not_committed:
+        return o << "cluster::errc::partition_configuration_leader_config_not_"
+                    "committed";
+    case errc::partition_configuration_differs:
+        return o << "cluster::errc::partition_configuration_differs";
+    case errc::data_policy_already_exists:
+        return o << "cluster::errc::data_policy_already_exists";
+    case errc::data_policy_not_exists:
+        return o << "cluster::errc::data_policy_not_exists";
+    case errc::source_topic_not_exists:
+        return o << "cluster::errc::source_topic_not_exists";
+    case errc::source_topic_still_in_use:
+        return o << "cluster::errc::source_topic_still_in_use";
+    case errc::waiting_for_partition_shutdown:
+        return o << "cluster::errc::waiting_for_partition_shutdown";
+    case errc::error_collecting_health_report:
+        return o << "cluster::errc::error_collecting_health_report";
+    case errc::leadership_changed:
+        return o << "cluster::errc::leadership_changed";
+    case errc::feature_disabled:
+        return o << "cluster::errc::feature_disabled";
+    case errc::invalid_request:
+        return o << "cluster::errc::invalid_request";
+    case errc::no_update_in_progress:
+        return o << "cluster::errc::no_update_in_progress";
+    case errc::unknown_update_interruption_error:
+        return o << "cluster::errc::unknown_update_interruption_error";
+    case errc::throttling_quota_exceeded:
+        return o << "cluster::errc::throttling_quota_exceeded";
+    case errc::cluster_already_exists:
+        return o << "cluster::errc::cluster_already_exists";
+    case errc::no_partition_assignments:
+        return o << "cluster::errc::no_partition_assignments";
+    case errc::failed_to_create_partition:
+        return o << "cluster::errc::failed_to_create_partition";
+    case errc::partition_operation_failed:
+        return o << "cluster::errc::partition_operation_failed";
+    case errc::transform_does_not_exist:
+        return o << "cluster::errc::transform_does_not_exist";
+    case errc::transform_invalid_update:
+        return o << "cluster::errc::transform_invalid_update";
+    case errc::transform_invalid_create:
+        return o << "cluster::errc::transform_invalid_create";
+    case errc::transform_invalid_source:
+        return o << "cluster::errc::transform_invalid_source";
+    case errc::transform_invalid_environment:
+        return o << "cluster::errc::transform_invalid_environment";
+    case errc::trackable_keys_limit_exceeded:
+        return o << "cluster::errc::trackable_keys_limit_exceeded";
+    case errc::topic_disabled:
+        return o << "cluster::errc::topic_disabled";
+    case errc::partition_disabled:
+        return o << "cluster::errc::partition_disabled";
+    case errc::invalid_partition_operation:
+        return o << "cluster::errc::invalid_partition_operation";
+    case errc::concurrent_modification_error:
+        return o << "cluster::errc::concurrent_modification_error";
+    case errc::transform_count_limit_exceeded:
+        return o << "cluster::errc::transform_count_limit_exceeded";
+    case errc::role_exists:
+        return o << "cluster::errc::role_exists";
+    case errc::role_does_not_exist:
+        return o << "cluster::errc::role_does_not_exist";
+    case errc::inconsistent_stm_update:
+        return o << "cluster::errc::inconsistent_stm_update";
+    case errc::waiting_for_shard_placement_update:
+        return o << "cluster::errc::waiting_for_shard_placement_update";
+    case errc::topic_invalid_partitions_core_limit:
+        return o << "cluster::errc::topic_invalid_partitions_core_limit";
+    case errc::topic_invalid_partitions_memory_limit:
+        return o << "cluster::errc::topic_invalid_partitions_memory_limit";
+    case errc::topic_invalid_partitions_fd_limit:
+        return o << "cluster::errc::topic_invalid_partitions_fd_limit";
+    case errc::topic_invalid_partitions_decreased:
+        return o << "cluster::errc::topic_invalid_partitions_decreased";
+    case errc::producer_ids_vcluster_limit_exceeded:
+        return o << "cluster::errc::producer_ids_vcluster_limit_exceeded";
+    case errc::validation_of_recovery_topic_failed:
+        return o << "cluster::errc::validation_of_recovery_topic_failed";
+    case errc::replica_does_not_exist:
+        return o << "cluster::errc::replica_does_not_exist";
+    case errc::invalid_data_migration_state:
+        return o << "cluster::errc::invalid_data_migration_state";
+    case errc::data_migration_not_exists:
+        return o << "cluster::errc::data_migration_not_exists";
+    case errc::data_migration_already_exists:
+        return o << "cluster::errc::data_migration_already_exists";
+    case errc::data_migration_invalid_resources:
+        return o << "cluster::errc::data_migration_invalid_resources";
+    case errc::resource_is_being_migrated:
+        return o << "cluster::errc::resource_is_being_migrated";
+    }
+}
+} // namespace cluster

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -32,12 +32,10 @@ result_promise_t::future_type request::result() const {
 }
 
 void request::set_value(request_result_t::value_type value) {
-    vassert(
-      _state <= request_state::in_progress && !_result.available(),
-      "unexpected request state during result set: {}",
-      *this);
-    _result.set_value(value);
-    _state = request_state::completed;
+    if (_state != request_state::completed) {
+        _result.set_value(value);
+        _state = request_state::completed;
+    }
 }
 
 void request::set_error(request_result_t::error_type error) {

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -377,6 +377,9 @@ void producer_state::apply_data(
     if (!bid.is_idempotent() || _evicted) {
         return;
     }
+    if (!bid.is_transactional && bid.pid.epoch > _id.epoch) {
+        reset_with_new_epoch(bid.pid.epoch);
+    }
     _requests.stm_apply(bid, header.ctx.term, offset);
     if (bid.is_transactional) {
         if (!_transaction_state) {

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -263,6 +263,14 @@ public:
           ss::lowres_system_clock::now() - _last_updated_ts);
     }
 
+    // Resets the producer to use a new epoch. The new epoch should be strictly
+    // larger than the current epoch. This is only used by the idempotent
+    // producers trying to bump epoch of the existing producer based on the
+    // incoming request with a higher epoch. Transactions follow a separate
+    // fencing based approach to bump epochs as it requires aborting any in
+    // progress transactions with older epoch.
+    void reset_with_new_epoch(model::producer_epoch new_epoch);
+
 private:
     prefix_logger& _logger;
 

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -126,6 +126,7 @@ private:
     bool is_valid_sequence(seq_t incoming) const;
     std::optional<request_ptr> last_request() const;
     void gc_requests_from_older_terms(model::term_id current);
+    void reset(request_result_t::error_type);
     ss::chunked_fifo<request_ptr, chunk_size> _inflight_requests;
     ss::chunked_fifo<request_ptr, chunk_size> _finished_requests;
     friend producer_state;

--- a/src/v/cluster/producer_state_manager.cc
+++ b/src/v/cluster/producer_state_manager.cc
@@ -25,9 +25,9 @@ namespace cluster::tx {
 
 producer_state_manager::producer_state_manager(
   config::binding<uint64_t> max_producer_ids,
-  std::chrono::milliseconds producer_expiration_ms,
+  config::binding<std::chrono::milliseconds> producer_expiration_ms,
   config::binding<size_t> virtual_cluster_min_producer_ids)
-  : _producer_expiration_ms(producer_expiration_ms)
+  : _producer_expiration_ms(std::move(producer_expiration_ms))
   , _max_ids(std::move(max_producer_ids))
   , _virtual_cluster_min_producer_ids(
       std::move(virtual_cluster_min_producer_ids))
@@ -95,7 +95,7 @@ void producer_state_manager::touch(
 }
 void producer_state_manager::evict_excess_producers() {
     _cache.evict_older_than<ss::lowres_system_clock>(
-      ss::lowres_system_clock::now() - _producer_expiration_ms);
+      ss::lowres_system_clock::now() - _producer_expiration_ms());
     if (!_gate.is_closed()) {
         _reaper.arm(period);
     }

--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -25,7 +25,7 @@ public:
     explicit producer_state_manager(
 
       config::binding<uint64_t> max_producer_ids,
-      std::chrono::milliseconds producer_expiration_ms,
+      config::binding<std::chrono::milliseconds> producer_expiration_ms,
       config::binding<size_t> virtual_cluster_min_producer_ids);
 
     ss::future<> start();
@@ -75,7 +75,7 @@ private:
     void evict_excess_producers();
     size_t _eviction_counter = 0;
     // if a producer is inactive for this long, it will be gc-ed
-    std::chrono::milliseconds _producer_expiration_ms;
+    config::binding<std::chrono::milliseconds> _producer_expiration_ms;
     // maximum number of active producers allowed on this shard across
     // all partitions. When exceeded, producers are evicted on an
     // LRU basis.

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -912,6 +912,10 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued,
   ssx::semaphore_units& units) {
+    // Check if the producer bumped the epoch and reset accordingly.
+    if (bid.pid.epoch > producer->id().epoch()) {
+        producer->reset_with_new_epoch(bid.pid.epoch);
+    }
     auto request = producer->try_emplace_request(bid, synced_term);
     if (!request) {
         co_return request.error();

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -128,7 +128,8 @@ ss::future<model::offset> rm_stm::bootstrap_committed_offset() {
       .then([this] { return _raft->committed_offset(); });
 }
 
-producer_ptr rm_stm::maybe_create_producer(model::producer_identity pid) {
+std::pair<producer_ptr, rm_stm::producer_previously_known>
+rm_stm::maybe_create_producer(model::producer_identity pid) {
     // Double lookup because of two reasons
     // 1. we are forced to use a ptr as map value_type because producer_state is
     // not movable
@@ -136,7 +137,7 @@ producer_ptr rm_stm::maybe_create_producer(model::producer_identity pid) {
     // as it is memory friendly.
     auto it = _producers.find(pid.get_id());
     if (it != _producers.end()) {
-        return it->second;
+        return std::make_pair(it->second, producer_previously_known::yes);
     }
     auto producer = ss::make_lw_shared<producer_state>(
       _ctx_log, pid, _raft->group(), [pid, this] {
@@ -145,7 +146,7 @@ producer_ptr rm_stm::maybe_create_producer(model::producer_identity pid) {
     _producer_state_manager.local().register_producer(*producer, _vcluster_id);
     _producers.emplace(pid.get_id(), producer);
 
-    return producer;
+    return std::make_pair(producer, producer_previously_known::no);
 }
 
 void rm_stm::cleanup_producer_state(model::producer_identity pid) {
@@ -190,7 +191,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::begin_tx(
         co_return tx::errc::stale;
     }
     auto synced_term = _insync_term;
-    auto producer = maybe_create_producer(new_pid);
+    auto [producer, _] = maybe_create_producer(new_pid);
     co_return co_await producer->run_with_lock(
       [this,
        synced_term,
@@ -357,7 +358,7 @@ ss::future<tx::errc> rm_stm::commit_tx(
         co_return tx::errc::stale;
     }
     auto synced_term = _insync_term;
-    auto producer = maybe_create_producer(pid);
+    auto [producer, _] = maybe_create_producer(pid);
     if (pid != producer->id()) {
         co_return tx::errc::fenced;
     }
@@ -492,7 +493,7 @@ ss::future<tx::errc> rm_stm::abort_tx(
         co_return tx::errc::stale;
     }
     auto synced_term = _insync_term;
-    auto producer = maybe_create_producer(pid);
+    auto [producer, _] = maybe_create_producer(pid);
     if (pid != producer->id()) {
         co_return cluster::errc::invalid_producer_epoch;
     }
@@ -844,7 +845,7 @@ ss::future<result<kafka_result>> rm_stm::transactional_replicate(
         co_return cluster::errc::not_leader;
     }
     auto synced_term = _insync_term;
-    auto producer = maybe_create_producer(bid.pid);
+    auto [producer, _] = maybe_create_producer(bid.pid);
     co_return co_await producer->run_with_lock(
       [&, synced_term](ssx::semaphore_units units) {
           return do_transactional_replicate(
@@ -860,7 +861,8 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
   model::record_batch_reader br,
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued,
-  ssx::semaphore_units units) {
+  ssx::semaphore_units units,
+  producer_previously_known producer_known) {
     auto result = co_await do_idempotent_replicate(
       synced_term,
       producer,
@@ -868,7 +870,8 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
       std::move(br),
       opts,
       std::move(enqueued),
-      units);
+      units,
+      producer_known);
 
     if (!result) {
         vlog(
@@ -911,12 +914,31 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
   model::record_batch_reader br,
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued,
-  ssx::semaphore_units& units) {
+  ssx::semaphore_units& units,
+  producer_previously_known known_producer) {
     // Check if the producer bumped the epoch and reset accordingly.
     if (bid.pid.epoch > producer->id().epoch()) {
         producer->reset_with_new_epoch(bid.pid.epoch);
     }
-    auto request = producer->try_emplace_request(bid, synced_term);
+    // If the producer is unknown and is producing with a non zero
+    // sequence number, it is possible that the producer has been evicted
+    // from the broker memory. Instead of rejecting the request, we accept
+    // the current sequence and move on. This logic is similar to what
+    // Apache Kafka does.
+    // Ref:
+    // https://github.com/apache/kafka/blob/704476885ffb40cd3bf9b8f5c368c01eaee0a737
+    // storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java#L135
+    auto skip_sequence_checks = !known_producer && bid.first_seq > 0;
+    if (unlikely(skip_sequence_checks)) {
+        vlog(
+          _ctx_log.warn,
+          "Accepting batch from unknown producer that likely got evicted: {}, "
+          "term: {}",
+          bid,
+          synced_term);
+    }
+    auto request = producer->try_emplace_request(
+      bid, synced_term, skip_sequence_checks);
     if (!request) {
         co_return request.error();
     }
@@ -973,9 +995,9 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
     }
     try {
         auto synced_term = _insync_term;
-        auto producer = maybe_create_producer(bid.pid);
+        auto [producer, known_producer] = maybe_create_producer(bid.pid);
         co_return co_await producer->run_with_lock(
-          [&](ssx::semaphore_units units) {
+          [&, known_producer](ssx::semaphore_units units) {
               return idempotent_replicate(
                 synced_term,
                 producer,
@@ -983,7 +1005,8 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
                 std::move(br),
                 opts,
                 std::move(enqueued),
-                std::move(units));
+                std::move(units),
+                known_producer);
           });
     } catch (const cache_full_error& e) {
         vlog(
@@ -1400,7 +1423,7 @@ void rm_stm::maybe_rearm_autoabort_timer(time_point_type deadline) {
 }
 
 void rm_stm::apply_fence(model::producer_identity pid, model::record_batch b) {
-    auto producer = maybe_create_producer(pid);
+    auto [producer, _] = maybe_create_producer(pid);
     auto header = b.header();
     auto batch_data = read_fence_batch(std::move(b));
     vlog(
@@ -1449,7 +1472,7 @@ void rm_stm::apply_control(
   model::producer_identity pid, model::control_record_type crt) {
     vlog(
       _ctx_log.trace, "applying control batch of type {}, pid: {}", crt, pid);
-    auto producer = maybe_create_producer(pid);
+    auto [producer, _] = maybe_create_producer(pid);
     auto tx_range = producer->apply_transaction_end(crt);
     if (tx_range && crt == model::control_record_type::tx_abort) {
         // Aborted transaction
@@ -1497,7 +1520,7 @@ void rm_stm::apply_data(
     if (bid.is_idempotent()) {
         _highest_producer_id = std::max(_highest_producer_id, bid.pid.get_id());
         const auto last_kafka_offset = from_log_offset(header.last_offset());
-        auto producer = maybe_create_producer(bid.pid);
+        auto [producer, _] = maybe_create_producer(bid.pid);
         producer->apply_data(header, last_kafka_offset);
         _producer_state_manager.local().touch(*producer, _vcluster_id);
         if (

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -64,10 +64,13 @@ namespace cluster {
  *
  * 2. Idempotent requests - Provides single session idempotency guarantees. Each
  * idempotent produce request is associated with a producer_identity
- * (producer_id + epoch=0). Idempotency is implemented by tracking sequence
+ * (producer_id + epoch=N). Idempotency is implemented by tracking sequence
  * numbers of last 5 inflight/processed requests and ensuring that the new
  * requests maintain the sequence order. Client stamps the record batches with
- * sequence numbers.
+ * sequence numbers. Idempotent producer may choose to increment epoch on the
+ * client side to reset the sequence tracking when it deems safe
+ * (check kip-360). The state machine detects such situations and resets the
+ * tracked sequence number state.
  *
  * 3. Transactional requests - Provides EOS semantics across multiple sessions
  * by implementing fencing as defined in the Kafka protocol. Transactional

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -317,42 +317,6 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
       r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }
 
-FIXTURE_TEST(test_rm_stm_prevents_odd_session_start_off, rm_stm_test_fixture) {
-    create_stm_and_start_raft();
-    auto& stm = *_stm;
-    stm.testing_only_disable_auto_abort();
-
-    stm.start().get0();
-
-    wait_for_confirmed_leader();
-    wait_for_meta_initialized();
-
-    auto count = 5;
-    auto rdr = random_batches_reader(model::test::record_batch_spec{
-                                       .offset = model::offset(0),
-                                       .allow_compression = true,
-                                       .count = count,
-                                       .enable_idempotence = true,
-                                       .producer_id = 0,
-                                       .producer_epoch = 0,
-                                       .base_sequence = 1})
-                 .get();
-
-    auto bid = model::batch_identity{
-      .pid = model::producer_identity{0, 0},
-      .first_seq = 1,
-      .last_seq = 1 + (count - 1)};
-
-    auto r = stm
-               .replicate(
-                 bid,
-                 std::move(rdr),
-                 raft::replicate_options(raft::consistency_level::quorum_ack))
-               .get0();
-    BOOST_REQUIRE(
-      r == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
-}
-
 FIXTURE_TEST(test_rm_stm_passes_immediate_retry, rm_stm_test_fixture) {
     create_stm_and_start_raft();
     auto& stm = *_stm;

--- a/src/v/cluster/tests/producer_state_tests.cc
+++ b/src/v/cluster/tests/producer_state_tests.cc
@@ -55,7 +55,7 @@ struct test_fixture {
       size_t max_producers, size_t min_producers_per_vcluster) {
         _psm = std::make_unique<producer_state_manager>(
           config::mock_binding<size_t>(max_producers),
-          std::chrono::milliseconds::max(),
+          config::mock_binding(std::chrono::milliseconds::max()),
           config::mock_binding<size_t>(min_producers_per_vcluster));
         _psm->start().get();
         validate_producer_count(0);

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -24,7 +24,7 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         producer_state_manager
           .start(
             config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            std::chrono::milliseconds::max(),
+            config::mock_binding(std::chrono::milliseconds::max()),
             config::mock_binding(std::numeric_limits<uint64_t>::max()))
           .get();
         producer_state_manager

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2498,7 +2498,7 @@ void tx_gateway_frontend::expire_old_txs() {
           model::tx_manager_nt);
         if (!ntp_meta) {
             vlog(
-              txlog.error,
+              txlog.debug,
               "Topic {} doesn't exist in metadata cache,",
               model::tx_manager_nt);
             return ss::now();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1518,7 +1518,10 @@ void application::wire_up_redpanda_services(
       ss::sharded_parameter([]() {
           return config::shard_local_cfg().max_concurrent_producer_ids.bind();
       }),
-      config::shard_local_cfg().transactional_id_expiration_ms.value(),
+      ss::sharded_parameter([]() {
+          return config::shard_local_cfg()
+            .transactional_id_expiration_ms.bind();
+      }),
       ss::sharded_parameter([]() {
           return config::shard_local_cfg()
             .virtual_cluster_min_producer_ids.bind();

--- a/tests/java/verifiers/pom.xml
+++ b/tests/java/verifiers/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>kafka-clients</artifactId>
             <version>3.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${buildDir}</directory>

--- a/tests/java/verifiers/src/main/java/idempotency/App.java
+++ b/tests/java/verifiers/src/main/java/idempotency/App.java
@@ -1,0 +1,189 @@
+package io.vectorized.idempotency;
+
+import static spark.Spark.*;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.lang.String;
+import java.lang.Thread;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.Semaphore;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import spark.*;
+
+// A simple pausable idempotent producer for sanity testing a Java based
+// producer from ducktape. This is a not a verfier but rather a simple pausable
+// load generating utility that can start, pause and resume a single idempotency
+// session using a single producer on demand.
+//
+//  Supported REST APIs
+//  - /start-producer - start a new or resume existing idempotent producer
+//  session
+//  - /pause-producer - pauses the producer
+//  - /stop-producer  - stops the producer
+public class App {
+
+  static Logger logger = Logger.getLogger(App.class);
+
+  static void setupLogging() {
+    org.apache.log4j.BasicConfigurator.configure();
+    Logger.getRootLogger().setLevel(Level.WARN);
+    Logger.getLogger("io.vectorized").setLevel(Level.DEBUG);
+    Logger.getLogger("org.apache.kafka").setLevel(Level.DEBUG);
+  }
+
+  public static class Params {
+    public String brokers;
+    public String topic;
+    public long partitions;
+  }
+
+  public static class Progress {
+    public long num_produced;
+  };
+
+  static Producer<String, String> createIdempotentProducer(String brokers) {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+    props.put(ProducerConfig.ACKS_CONFIG, "all");
+    props.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringSerializer");
+    props.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringSerializer");
+    props.put(ProducerConfig.LINGER_MS_CONFIG, 0);
+    props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+    props.put(ProducerConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
+    props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    return new KafkaProducer<String, String>(props);
+  }
+
+  public static class JsonTransformer implements ResponseTransformer {
+    private Gson gson = new Gson();
+
+    @Override
+    public String render(Object model) {
+      return gson.toJson(model);
+    }
+  }
+
+  volatile Params params = null;
+  volatile Thread produceThread = null;
+  volatile Semaphore sem = new Semaphore(1, true);
+  volatile boolean started = false;
+  volatile boolean stopped = false;
+  volatile Exception ex = null;
+  volatile long counter = 0;
+
+  void produceLoop() {
+    var random = new Random();
+    Producer<String, String> idempotentProducer
+        = createIdempotentProducer(this.params.brokers);
+    while (!stopped) {
+      try {
+        sem.acquire();
+        long partition
+            = random.longs(0, this.params.partitions).findFirst().getAsLong();
+        String kv = Long.toString(counter);
+        ProducerRecord<String, String> record
+            = new ProducerRecord<>(this.params.topic, kv, kv);
+        idempotentProducer.send(record).get();
+      } catch (Exception e) {
+        ex = e;
+        logger.error("Exception in produce loop: ", e);
+      } finally {
+        sem.release();
+      }
+      counter++;
+    }
+    idempotentProducer.close();
+  }
+
+  void run() throws Exception {
+
+    port(8080);
+
+    get("/ping", (req, res) -> {
+      res.status(200);
+      return "";
+    });
+
+    get("/progress", (req, res) -> {
+      Progress progress = new Progress();
+      progress.num_produced = counter;
+      return progress;
+    }, new JsonTransformer());
+
+    post("/start-producer", (req, res) -> {
+      if (this.started && !this.stopped) {
+        logger.info("Producer already started. unpausing it.");
+        if (this.sem.availablePermits() == 0) {
+          this.sem.release();
+        }
+        res.status(200);
+        return "";
+      }
+      logger.info("Starting producer");
+      try {
+        this.params = (new Gson()).fromJson(req.body(), Params.class);
+        this.produceThread = new Thread(() -> { this.produceLoop(); });
+        this.produceThread.start();
+
+      } catch (Exception e) {
+        logger.error("Exception starting produce thread ", e);
+        throw e;
+      }
+      this.started = true;
+      this.stopped = false;
+      res.status(200);
+      return "";
+    });
+
+    post("/pause-producer", (req, res) -> {
+      if (!this.started) {
+        logger.info("Pause failed, not started.");
+        res.status(500);
+        return "";
+      }
+      logger.info("Pausing producer");
+      this.sem.acquire();
+      res.status(200);
+      return "";
+    });
+
+    post("/stop-producer", (req, res) -> {
+      logger.info("Stopping producer");
+      this.stopped = true;
+      if (this.sem.availablePermits() == 0) {
+        this.sem.release();
+      }
+      try {
+        if (produceThread != null) {
+          produceThread.join();
+        }
+      } catch (Exception e) {
+        logger.error("Exception stopping producer", e);
+        throw e;
+      }
+
+      if (ex != null) {
+        System.exit(1);
+      }
+
+      res.status(200);
+      return "";
+    });
+  }
+
+  public static void main(String[] args) throws Exception {
+    setupLogging();
+    new App().run();
+  }
+}

--- a/tests/rptest/transactions/idempotency_test.py
+++ b/tests/rptest/transactions/idempotency_test.py
@@ -1,0 +1,146 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from collections import defaultdict
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.transactions.verifiers.idempotency_load_generator import PausableIdempotentProducer
+from time import sleep
+from rptest.util import wait_until
+import confluent_kafka as ck
+
+
+class IdempotentProducerRecoveryTest(RedpandaTest):
+    """This test ensures that various client implementations can recover
+    from scenario in which the producers get evicted on the brokers.
+    When a producer is evicted it loses all old state including the
+    sequence numbers. So the client attempting to produce after that
+    should still recover and be able to make progress. There are subtle
+    variations among client implementations around how they deal
+    with this situation, so this test acts a regression test ensuring that we
+    do not break this behavior."""
+    def __init__(self, test_context):
+        super(IdempotentProducerRecoveryTest,
+              self).__init__(test_context=test_context, num_brokers=1)
+        self.test_topic = TopicSpec(name="test",
+                                    partition_count=1,
+                                    replication_factor=1)
+
+    def wait_for_eviction(self, active_producers_remaining,
+                          expected_to_be_evicted):
+        def do_wait():
+            samples = [
+                "idempotency_pid_cache_size",
+                "producer_state_manager_evicted_producers"
+            ]
+            brokers = self.redpanda.started_nodes()
+            metrics = self.redpanda.metrics_samples(samples, brokers)
+            producers_per_node = defaultdict(int)
+            evicted_per_node = defaultdict(int)
+            for pattern, metric in metrics.items():
+                for m in metric.samples:
+                    id = self.redpanda.node_id(m.node)
+                    if pattern == "idempotency_pid_cache_size":
+                        producers_per_node[id] += int(m.value)
+                    elif pattern == "producer_state_manager_evicted_producers":
+                        evicted_per_node[id] += int(m.value)
+
+            self.redpanda.logger.debug(
+                f"active producers: {producers_per_node}")
+            self.redpanda.logger.debug(
+                f"evicted producers: {evicted_per_node}")
+
+            remaining_match = all([
+                num == active_producers_remaining
+                for num in producers_per_node.values()
+            ])
+
+            evicted_match = all([
+                val == expected_to_be_evicted
+                for val in evicted_per_node.values()
+            ])
+
+            return len(producers_per_node) == len(
+                brokers) and remaining_match and evicted_match
+
+        wait_until(do_wait,
+                   timeout_sec=20,
+                   backoff_sec=1,
+                   err_msg=f"Not all producers were evicted in 20secs.",
+                   retry_on_exc=False)
+
+    @cluster(num_nodes=2)
+    def test_java_client_recovery_on_producer_eviction(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.test_topic.name, self.test_topic.partition_count,
+                         self.test_topic.replication_factor)
+
+        workload_svc = PausableIdempotentProducer(self.test_context,
+                                                  self.redpanda)
+        workload_svc.start()
+
+        workload_svc.start_producer(self.test_topic.name,
+                                    self.test_topic.partition_count)
+        # Generate some load
+        workload_svc.ensure_progress(expected=1000, timeout_sec=20)
+
+        # Pause the producer to evict the producer sessions
+        workload_svc.pause_producer()
+
+        progress_so_far = workload_svc.get_progress().json()["num_produced"]
+
+        # Evict all producers
+        rpk.cluster_config_set("transactional_id_expiration_ms", 0)
+        self.wait_for_eviction(active_producers_remaining=0,
+                               expected_to_be_evicted=1)
+        rpk.cluster_config_set("transactional_id_expiration_ms", 3600000)
+
+        # Resume the idempotency session again.
+        workload_svc.start_producer(self.test_topic.name,
+                                    self.test_topic.partition_count)
+
+        workload_svc.ensure_progress(expected=progress_so_far + 1000,
+                                     timeout_sec=20)
+        # Verify the producer can make progress without exceptions
+        workload_svc.stop_producer()
+
+    @cluster(num_nodes=1)
+    def test_librdkafka_recovery_on_producer_eviction(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.test_topic.name, self.test_topic.partition_count,
+                         self.test_topic.replication_factor)
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'enable.idempotence': True,
+        })
+
+        def produce_some():
+            def on_delivery(err, _):
+                assert err is None, err
+
+            for i in range(1000):
+                producer.produce(self.test_topic.name,
+                                 str(i),
+                                 str(i),
+                                 on_delivery=on_delivery)
+            producer.flush()
+
+        produce_some()
+
+        # Evict all producers
+        rpk.cluster_config_set("transactional_id_expiration_ms", 0)
+        self.wait_for_eviction(active_producers_remaining=0,
+                               expected_to_be_evicted=1)
+        rpk.cluster_config_set("transactional_id_expiration_ms", 3600000)
+
+        # Ensure producer can recover.
+        produce_some()

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -905,14 +905,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                    backoff_sec=2,
                    err_msg="Producers not evicted in time")
 
-        try:
-            _produce_one(producers[0], 0)
-            assert False, "We can not produce after cleaning in rm_stm"
-        except ck.cimpl.KafkaException as e:
-            kafka_error = e.args[0]
-            kafka_error.code(
-            ) == ck.cimpl.KafkaError.OUT_OF_ORDER_SEQUENCE_NUMBER
-
         # validate that the producers are evicted with LRU policy,
         # starting from this producer there should be no sequence
         # number errors as those producer state should not be evicted

--- a/tests/rptest/transactions/verifiers/idempotency_load_generator.py
+++ b/tests/rptest/transactions/verifiers/idempotency_load_generator.py
@@ -1,0 +1,147 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.services.service import Service
+from rptest.util import wait_until
+import requests
+import sys
+
+OUTPUT_LOG = "/opt/remote/var/pausable_idempotent_producer.log"
+
+
+class IdempotencyClientFailure(Exception):
+    pass
+
+
+class PausableIdempotentProducer(Service):
+    logs = {
+        "pausable_idempotent_producer_stdout_stderr": {
+            "path": OUTPUT_LOG,
+            "collect_default": True
+        }
+    }
+
+    def __init__(self, context, redpanda):
+        super(PausableIdempotentProducer, self).__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+
+    def is_alive(self, node):
+        result = node.account.ssh_output(
+            "bash /opt/remote/control/alive.sh pausable_idempotent_producer")
+        result = result.decode("utf-8")
+        return "YES" in result
+
+    def is_ready(self):
+        try:
+            self.remote_ping()
+            return True
+        except requests.exceptions.ConnectionError:
+            return False
+
+    def raise_on_violation(self, node):
+        self.logger.info(
+            f"Scanning node {node.account.hostname} log for violations...")
+
+        for line in node.account.ssh_capture(
+                f"grep -e Exception {OUTPUT_LOG} || true"):
+            raise IdempotencyClientFailure(line)
+
+    def start_node(self, node, timeout_sec=10):
+        node.account.ssh(
+            f"bash /opt/remote/control/start.sh pausable_idempotent_producer \"java -cp /opt/verifiers/verifiers.jar io.vectorized.idempotency.App\""
+        )
+        wait_until(
+            lambda: self.is_alive(node),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to start within {timeout_sec} sec",
+            retry_on_exc=False)
+        self._node = node
+        wait_until(
+            lambda: self.is_ready(),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to become ready within {timeout_sec} sec",
+            retry_on_exc=False)
+
+    def stop_node(self, node):
+        node.account.ssh(
+            "bash /opt/remote/control/stop.sh pausable_idempotent_producer")
+        self.raise_on_violation(node)
+
+    def clean_node(self, node):
+        pass
+
+    def wait_node(self, node, timeout_sec=sys.maxsize):
+        wait_until(
+            lambda: not (self.is_alive(node)),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to stop within {timeout_sec} sec",
+            retry_on_exc=False)
+        return True
+
+    def remote_ping(self):
+        ip = self._node.account.hostname
+        r = requests.get(f"http://{ip}:8080/ping")
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def start_producer(self, topic, partitions):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/start-producer",
+                          json={
+                              "brokers": self._redpanda.brokers(),
+                              "topic": topic,
+                              "partitions": partitions,
+                          })
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )
+
+    def get_progress(self):
+        ip = self._node.account.hostname
+        return requests.get(f"http://{ip}:8080/progress")
+
+    def ensure_progress(self, expected=1000, timeout_sec=10):
+        def check_progress():
+            r = self.get_progress()
+            if r.status_code != 200:
+                return False
+            output = r.json()
+            self._redpanda.logger.debug(f"progress response: {output}")
+            return output["num_produced"] >= expected
+
+        wait_until(
+            check_progress,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {self._node.account.hostname} failed to make progress in {timeout_sec} sec",
+            retry_on_exc=False)
+
+    def pause_producer(self):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/pause-producer")
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )
+
+    def stop_producer(self):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/stop-producer")
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )


### PR DESCRIPTION
Two main changes in this patch

* Broker can now handle epoch bumps for idempotent producers. A client can independently bump the producer epoch in certain situations (check kip-360 and related code) as idempotency only pertains to the single session. The broker code had issues handling epoch bumps which is fixed.

* For evicted producer state on the broker (eg: log prefix truncation, producer expiration etc), there are subtle differences among clients around how they handle the producer reset scenario. Java client, for example bumps the epoch on OOOSN and if there are no other requests in flight while librdkafka is pretty strict and only does it on UNKNOWN_PRODUCER_ID error code (which explicitly tells the client that the broker has no state for the producer and it should reset). Changed the code to what Apache Kafka does, upon encountering an unknown producer id, any sequence number is accepted to make forward progress because the only way a broker doesn't know about the producer is when it got evicted from memory, doesn't seem fool proof but consistent with AK behavior and more importantly works with all the client implementations.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
