### PR TITLE
Use shards from health report in Admin API cluster partition results

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -637,14 +637,14 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
         if (report.has_value()) {
             std::vector<size_t> sizes;
             for (auto& node_report : report.value().node_reports) {
-                for (auto& topic : node_report->topics) {
+                for (auto& [tp_ns, partitions] : node_report->topics) {
                     if (
-                      topic.tp_ns
+                      tp_ns
                       != model::topic_namespace_view(
                         model::kafka_namespace, topic_name)) {
                         continue;
                     }
-                    for (auto partition : topic.partitions) {
+                    for (auto partition : partitions) {
                         sizes.push_back(
                           partition.reclaimable_size_bytes.value_or(0));
                     }

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -360,9 +360,9 @@ controller_api::get_partitions_reconfiguration_state(
     auto& report = result.value();
 
     for (auto& node_report : report.node_reports) {
-        for (auto& tp : node_report->topics) {
-            for (auto& p : tp.partitions) {
-                model::ntp ntp(tp.tp_ns.ns, tp.tp_ns.tp, p.id);
+        for (auto& [tp_ns, partitions] : node_report->topics) {
+            for (auto& p : partitions) {
+                model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);
                 auto it = states.find(ntp);
                 if (it == states.end()) {
                     continue;

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -201,7 +201,6 @@ std::optional<node_health_report_ptr> health_monitor_backend::build_node_report(
     }
 
     report.drain_status = it->second->drain_status;
-    report.include_drain_status = true;
 
     return ss::make_foreign(
       ss::make_lw_shared<const node_health_report>(std::move(report)));
@@ -529,7 +528,6 @@ health_monitor_backend::collect_current_node_health() {
       = features::feature_table::get_latest_logical_version();
 
     ret.drain_status = co_await _drain_manager.local().status();
-    ret.include_drain_status = true;
     ret.topics = co_await collect_topic_status();
 
     auto [it, _] = _status.try_emplace(ret.id);

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -73,7 +73,7 @@ public:
      * Return cached version of current node health of collects it if it is not
      * available in cache.
      */
-    ss::future<result<node_health_report>> get_current_node_health();
+    ss::future<result<node_health_report_ptr>> get_current_node_health();
 
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -67,7 +67,7 @@ storage::disk_space_alert health_monitor_frontend::get_cluster_disk_health() {
 /**
  * Gets cached or collects a node health report.
  */
-ss::future<result<node_health_report>>
+ss::future<result<node_health_report_ptr>>
 health_monitor_frontend::get_current_node_health() {
     return dispatch_to_backend([](health_monitor_backend& be) mutable {
         return be.get_current_node_health();

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -60,7 +60,7 @@ public:
     storage::disk_space_alert get_cluster_disk_health();
 
     // Collects or return cached version of current node health report.
-    ss::future<result<node_health_report>> get_current_node_health();
+    ss::future<result<node_health_report_ptr>> get_current_node_health();
 
     /**
      * Return drain status for a given node.

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -84,29 +84,8 @@ node_health_report::node_health_report(
   , topics(std::move(topics))
   , drain_status(drain_status) {}
 
-node_health_report::node_health_report(const node_health_report& other)
-  : id(other.id)
-  , local_state(other.local_state)
-  , topics()
-  , drain_status(other.drain_status) {
-    std::copy(
-      other.topics.cbegin(), other.topics.cend(), std::back_inserter(topics));
-}
-
-node_health_report&
-node_health_report::operator=(const node_health_report& other) {
-    if (this == &other) {
-        return *this;
-    }
-    id = other.id;
-    local_state = other.local_state;
-    drain_status = other.drain_status;
-    chunked_vector<topic_status> t;
-    t.reserve(other.topics.size());
-    std::copy(
-      other.topics.cbegin(), other.topics.cend(), std::back_inserter(t));
-    topics = std::move(t);
-    return *this;
+node_health_report node_health_report::copy() const {
+    return {id, local_state, topics.copy(), drain_status};
 }
 
 std::ostream& operator<<(std::ostream& o, const node_health_report& r) {

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -78,19 +78,16 @@ node_health_report::node_health_report(
   model::node_id id,
   node::local_state local_state,
   chunked_vector<topic_status> topics,
-  bool include_drain_status,
   std::optional<drain_manager::drain_status> drain_status)
   : id(id)
   , local_state(std::move(local_state))
   , topics(std::move(topics))
-  , include_drain_status(include_drain_status)
   , drain_status(drain_status) {}
 
 node_health_report::node_health_report(const node_health_report& other)
   : id(other.id)
   , local_state(other.local_state)
   , topics()
-  , include_drain_status(other.include_drain_status)
   , drain_status(other.drain_status) {
     std::copy(
       other.topics.cbegin(), other.topics.cend(), std::back_inserter(topics));
@@ -103,7 +100,6 @@ node_health_report::operator=(const node_health_report& other) {
     }
     id = other.id;
     local_state = other.local_state;
-    include_drain_status = other.include_drain_status;
     drain_status = other.drain_status;
     chunked_vector<topic_status> t;
     t.reserve(other.topics.size());

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -89,6 +89,10 @@ node_health_report node_health_report::copy() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
+    return o << node_health_report_serde{r};
+}
+
+std::ostream& operator<<(std::ostream& o, const node_health_report_serde& r) {
     fmt::print(
       o,
       "{{id: {}, topics: {}, local_state: {}, drain_status: {}}}",
@@ -98,7 +102,9 @@ std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
       r.drain_status);
     return o;
 }
-bool operator==(const node_health_report& a, const node_health_report& b) {
+
+bool operator==(
+  const node_health_report_serde& a, const node_health_report_serde& b) {
     return a.id == b.id && a.local_state == b.local_state
            && a.drain_status == b.drain_status
            && a.topics.size() == b.topics.size()
@@ -180,13 +186,7 @@ cluster_health_report cluster_health_report::copy() const {
     r.bytes_in_cloud_storage = bytes_in_cloud_storage;
     r.node_reports.reserve(node_reports.size());
     for (auto& nr : node_reports) {
-        node_health_report nr_copy;
-        nr_copy.id = nr->id;
-        nr_copy.drain_status = nr->drain_status;
-        nr_copy.topics = nr->topics.copy();
-        nr_copy.local_state = nr->local_state;
-
-        r.node_reports.emplace_back(ss::make_lw_shared(std::move(nr_copy)));
+        r.node_reports.emplace_back(ss::make_lw_shared(nr->copy()));
     }
     return r;
 }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -157,12 +157,11 @@ struct topic_status
  * Node health report is collected built based on node local state at given
  * instance of time
  */
-struct node_health_report
-  : serde::envelope<
-      node_health_report,
-      serde::version<0>,
-      serde::compat_version<0>> {
-    node_health_report() = default;
+struct node_health_report {
+    model::node_id id;
+    node::local_state local_state;
+    chunked_vector<topic_status> topics;
+    std::optional<drain_manager::drain_status> drain_status;
 
     node_health_report(
       model::node_id,
@@ -172,6 +171,22 @@ struct node_health_report
 
     node_health_report copy() const;
 
+    friend std::ostream& operator<<(std::ostream&, const node_health_report&);
+};
+
+using node_health_report_ptr
+  = ss::foreign_ptr<ss::lw_shared_ptr<const node_health_report>>;
+
+// This struct is different from node_health_report because for the latter we
+// want additional flexibility in how we store partition replica statuses (so
+// that searching for a replica status doesn't require a full scan). The _serde
+// variant is used for RPC serde and is more constrained for the reasons of
+// backwards compat.
+struct node_health_report_serde
+  : serde::envelope<
+      node_health_report_serde,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::node_id id;
     node::local_state local_state;
     chunked_vector<topic_status> topics;
@@ -181,14 +196,41 @@ struct node_health_report
         return std::tie(id, local_state, topics, drain_status);
     }
 
-    friend std::ostream& operator<<(std::ostream&, const node_health_report&);
+    node_health_report_serde() = default;
 
-    friend bool
-    operator==(const node_health_report& a, const node_health_report& b);
+    node_health_report_serde(
+      model::node_id id,
+      node::local_state local_state,
+      chunked_vector<topic_status> topics,
+      std::optional<drain_manager::drain_status> drain_status)
+      : id(id)
+      , local_state(std::move(local_state))
+      , topics(std::move(topics))
+      , drain_status(drain_status) {}
+
+    node_health_report_serde copy() const {
+        return {id, local_state, topics.copy(), drain_status};
+    }
+
+    explicit node_health_report_serde(const node_health_report& hr)
+      : node_health_report_serde(
+        hr.id, hr.local_state, hr.topics.copy(), hr.drain_status) {}
+
+    node_health_report to_in_memory() && {
+        return node_health_report{
+          id,
+          std::move(local_state),
+          std::move(topics),
+          std::move(drain_status)};
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const node_health_report_serde&);
+
+    friend bool operator==(
+      const node_health_report_serde& a, const node_health_report_serde& b);
 };
 
-using node_health_report_ptr
-  = ss::foreign_ptr<ss::lw_shared_ptr<const node_health_report>>;
 struct cluster_health_report
   : serde::envelope<
       cluster_health_report,
@@ -224,7 +266,7 @@ struct cluster_health_report
         write(out, node_states);
         write(out, static_cast<serde::serde_size_t>(node_reports.size()));
         for (auto& nr : node_reports) {
-            co_await write_async(out, nr->copy());
+            co_await write_async(out, node_health_report_serde{*nr});
         }
         write(out, bytes_in_cloud_storage);
     }
@@ -240,10 +282,10 @@ struct cluster_health_report
           in, h._bytes_left_limit);
         node_reports.reserve(sz);
         for (auto i = 0U; i < sz; ++i) {
-            auto r = co_await read_async_nested<node_health_report>(
+            auto r = co_await read_async_nested<node_health_report_serde>(
               in, h._bytes_left_limit);
-            node_reports.emplace_back(
-              ss::make_lw_shared<node_health_report>(std::move(r)));
+            node_reports.emplace_back(ss::make_lw_shared<node_health_report>(
+              std::move(r).to_in_memory()));
         }
         bytes_in_cloud_storage = read_nested<std::optional<size_t>>(
           in, h._bytes_left_limit);
@@ -262,7 +304,7 @@ struct cluster_health_report
         write(out, node_states);
         write(out, static_cast<serde::serde_size_t>(node_reports.size()));
         for (auto& nr : node_reports) {
-            write(out, nr->copy());
+            write(out, node_health_report_serde{*nr});
         }
         write(out, bytes_in_cloud_storage);
     }
@@ -277,9 +319,10 @@ struct cluster_health_report
           in, h._bytes_left_limit);
         node_reports.reserve(sz);
         for (auto i = 0U; i < sz; ++i) {
-            auto r = read_nested<node_health_report>(in, h._bytes_left_limit);
-            node_reports.emplace_back(
-              ss::make_lw_shared<node_health_report>(std::move(r)));
+            auto r = read_nested<node_health_report_serde>(
+              in, h._bytes_left_limit);
+            node_reports.emplace_back(ss::make_lw_shared<node_health_report>(
+              std::move(r).to_in_memory()));
         }
         bytes_in_cloud_storage = read_nested<std::optional<size_t>>(
           in, h._bytes_left_limit);
@@ -430,7 +473,7 @@ struct get_node_health_reply
     using rpc_adl_exempt = std::true_type;
 
     errc error = cluster::errc::success;
-    std::optional<node_health_report> report;
+    std::optional<node_health_report_serde> report;
 
     friend bool
     operator==(const get_node_health_reply&, const get_node_health_reply&)

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -388,9 +388,9 @@ void partition_balancer_planner::init_per_node_state(
 ss::future<> partition_balancer_planner::init_ntp_sizes_from_health_report(
   const cluster_health_report& health_report, request_context& ctx) {
     for (const auto& node_report : health_report.node_reports) {
-        for (const auto& tp_ns : node_report->topics) {
-            for (const auto& partition : tp_ns.partitions) {
-                model::ntp ntp{tp_ns.tp_ns.ns, tp_ns.tp_ns.tp, partition.id};
+        for (const auto& [tp_ns, partitions] : node_report->topics) {
+            for (const auto& partition : partitions) {
+                model::ntp ntp{tp_ns.ns, tp_ns.tp, partition.id};
                 size_t reclaimable = partition.reclaimable_size_bytes.value_or(
                   0);
                 vlog(

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -714,8 +714,8 @@ leader_balancer::collect_group_replicas_from_health_report(
     group_replicas_t group_replicas;
     ssx::async_counter counter;
     for (const auto& node : hr.node_reports) {
-        for (const auto& topic : node->topics) {
-            auto maybe_meta = _topics.get_topic_metadata_ref(topic.tp_ns);
+        for (const auto& [tp_ns, partitions] : node->topics) {
+            auto maybe_meta = _topics.get_topic_metadata_ref(tp_ns);
             if (!maybe_meta) {
                 continue;
             }
@@ -723,8 +723,8 @@ leader_balancer::collect_group_replicas_from_health_report(
 
             co_await ssx::async_for_each_counter(
               counter,
-              topic.partitions.begin(),
-              topic.partitions.end(),
+              partitions.begin(),
+              partitions.end(),
               [&](const partition_status& partition) {
                   auto as_it = meta.get_assignments().find(partition.id);
                   if (as_it != meta.get_assignments().end()) {

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -522,7 +522,7 @@ service::do_collect_node_health_report(get_node_health_request) {
     }
     co_return get_node_health_reply{
       .error = errc::success,
-      .report = res.value()->copy(),
+      .report = node_health_report_serde{*res.value()},
     };
 }
 

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -522,7 +522,7 @@ service::do_collect_node_health_report(get_node_health_request) {
     }
     co_return get_node_health_reply{
       .error = errc::success,
-      .report = *res.value(),
+      .report = res.value()->copy(),
     };
 }
 

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -522,7 +522,7 @@ service::do_collect_node_health_report(get_node_health_request) {
     }
     co_return get_node_health_reply{
       .error = errc::success,
-      .report = std::move(res.value()),
+      .report = *res.value(),
     };
 }
 

--- a/src/v/cluster/tests/health_monitor_bench.cc
+++ b/src/v/cluster/tests/health_monitor_bench.cc
@@ -30,25 +30,26 @@ cluster::topic_status make_topic_status(size_t id, size_t num_partitions) {
     return ts;
 }
 
-cluster::node_health_report
+cluster::node_health_report_serde
 make_node_health_report(size_t num_topics, size_t partitions_per_topic) {
-    cluster::node_health_report hr;
-    hr.id = model::node_id(1);
+    model::node_id id = model::node_id(1);
 
-    hr.local_state.redpanda_version = cluster::node::application_version(
+    cluster::node::local_state local_state;
+    local_state.redpanda_version = cluster::node::application_version(
       "v21.1.1");
-    hr.local_state.logical_version = cluster::cluster_version(1);
-    hr.local_state.uptime = std::chrono::milliseconds(100);
+    local_state.logical_version = cluster::cluster_version(1);
+    local_state.uptime = std::chrono::milliseconds(100);
 
-    hr.local_state.data_disk.path = "/bar/baz/foo/foo/foo/foo/foo/foo/foo/bar";
-    hr.local_state.data_disk.total = 1000;
-    hr.local_state.data_disk.free = 500;
+    local_state.data_disk.path = "/bar/baz/foo/foo/foo/foo/foo/foo/foo/bar";
+    local_state.data_disk.total = 1000;
+    local_state.data_disk.free = 500;
 
+    chunked_vector<cluster::topic_status> topics;
     for (size_t i = 0; i < num_topics; ++i) {
-        hr.topics.push_back(make_topic_status(i, partitions_per_topic));
+        topics.push_back(make_topic_status(i, partitions_per_topic));
     }
 
-    return hr;
+    return {id, local_state, std::move(topics), std::nullopt};
 }
 
 template<typename T>

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -371,10 +371,11 @@ make_ts(ss::sstring name, const std::vector<part_status>& status_list) {
 
 node_health_report
 make_nhr(int nid, const std::vector<topic_status>& statuses) {
-    node_health_report nhr;
-    nhr.id = node_id{nid};
-    std::move(statuses.begin(), statuses.end(), std::back_inserter(nhr.topics));
-    return nhr;
+    return {
+      node_id(nid),
+      node::local_state{},
+      chunked_vector<topic_status>(statuses.begin(), statuses.end()),
+      std::nullopt};
 };
 
 struct node_and_status {
@@ -436,7 +437,12 @@ FIXTURE_TEST(test_aggregate, health_report_unit) {
     model::ntp ntp2_b{model::kafka_namespace, topic_b, 2};
 
     report_cache_t empty_reports{
-      {model::node_id(0), ss::make_lw_shared<node_health_report>()}};
+      {model::node_id(0),
+       ss::make_lw_shared<node_health_report>(
+         model::node_id(0),
+         node::local_state{},
+         chunked_vector<topic_status>{},
+         std::nullopt)}};
 
     {
         // empty input, empty report

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -528,9 +528,9 @@ FIXTURE_TEST(
     nr_0.local_state.log_data_size.value().data_current_size += 1_MiB;
 
     // Set partition sizes
-    for (auto& topic : nr_0.topics) {
-        if (topic.tp_ns.tp == "topic-1") {
-            for (auto& partition : topic.partitions) {
+    for (auto& [tp_ns, partitions] : nr_0.topics) {
+        if (tp_ns.tp == "topic-1") {
+            for (auto& partition : partitions) {
                 if (partition.id == 1) {
                     partition.size_bytes = default_partition_size - 1_KiB;
                 }

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -470,8 +470,8 @@ FIXTURE_TEST(test_move_part_of_replicas, partition_balancer_planner_fixture) {
     auto hr = create_health_report(full_nodes);
 
     populate_node_status_table().get();
-    auto nr_1 = *hr.node_reports[1];
-    auto nr_2 = *hr.node_reports[2];
+    auto nr_1 = hr.node_reports[1]->copy();
+    auto nr_2 = hr.node_reports[2]->copy();
     // Set order of full nodes
 
     nr_1.local_state.log_data_size.value().data_current_size += 1_MiB;
@@ -522,7 +522,7 @@ FIXTURE_TEST(
     std::set<size_t> full_nodes = {0, 1};
     auto hr = create_health_report(full_nodes);
     populate_node_status_table().get();
-    auto nr_0 = *hr.node_reports[0];
+    auto nr_0 = hr.node_reports[0]->copy();
 
     // Set order of full nodes
     nr_0.local_state.log_data_size.value().data_current_size += 1_MiB;
@@ -709,7 +709,7 @@ FIXTURE_TEST(test_rack_awareness, partition_balancer_planner_fixture) {
     auto hr = create_health_report();
     // Make node_4 disk free size less to make partition allocator disk usage
     // constraint prefer node_3 rather than node_4
-    auto nr_4 = *hr.node_reports[4];
+    auto nr_4 = hr.node_reports[4]->copy();
     nr_4.local_state.log_data_size.value().data_current_size
       = hr.node_reports[3]->local_state.log_data_size.value().data_current_size
         - 10_MiB;

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -725,7 +725,8 @@ private:
             }
 
             return ss::make_foreign(
-              ss::make_lw_shared<const cluster::node_health_report>(report));
+              ss::make_lw_shared<const cluster::node_health_report>(
+                std::move(report)));
         }
     };
 

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -94,7 +94,6 @@ inline node_health_report random_node_health_report() {
       tests::random_named_int<model::node_id>(),
       node::random_local_state(),
       tests::random_chunked_vector(random_topic_status),
-      random_ds.has_value(),
       random_ds};
 }
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1604,7 +1604,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // test ADL roundtrip.
         data.local_state.cache_disk = std::nullopt;
 
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         chunked_vector<cluster::topic_status> topics;
@@ -1620,14 +1620,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // Squash to ADL-understood disk state
         report.local_state.cache_disk = report.local_state.data_disk;
 
-        cluster::get_node_health_reply data{
-          .report = report,
-        };
-        roundtrip_test(data);
+        roundtrip_test(cluster::get_node_health_reply{
+          .report = report.copy(),
+        });
         // try serde with non-default error code. adl doesn't encode error so
         // this is a serde only test.
-        data.error = cluster::errc::error_collecting_health_report;
-        roundtrip_test(data);
+        roundtrip_test(cluster::get_node_health_reply{
+          .error = cluster::errc::error_collecting_health_report,
+          .report = report.copy(),
+        });
     }
     {
         std::vector<model::node_id> nodes;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1604,7 +1604,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // test ADL roundtrip.
         data.local_state.cache_disk = std::nullopt;
 
-        roundtrip_test(std::move(data));
+        roundtrip_test(cluster::node_health_report_serde{data});
     }
     {
         chunked_vector<cluster::topic_status> topics;
@@ -1621,13 +1621,13 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         report.local_state.cache_disk = report.local_state.data_disk;
 
         roundtrip_test(cluster::get_node_health_reply{
-          .report = report.copy(),
+          .report = cluster::node_health_report_serde{report},
         });
         // try serde with non-default error code. adl doesn't encode error so
         // this is a serde only test.
         roundtrip_test(cluster::get_node_health_reply{
           .error = cluster::errc::error_collecting_health_report,
-          .report = report.copy(),
+          .report = cluster::node_health_report_serde{report},
         });
     }
     {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -748,7 +748,6 @@ cluster::cluster_health_report random_cluster_health_report() {
           tests::random_named_int<model::node_id>(),
           random_local_state(),
           std::move(topics),
-          /*include_drain_status=*/true,
           random_drain_status());
 
         // Reduce to an ADL-encodable state
@@ -1599,7 +1598,6 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           tests::random_named_int<model::node_id>(),
           random_local_state(),
           std::move(topics),
-          true,
           random_drain_status());
 
         // Squash local_state to a form that ADL represents, since we will
@@ -1617,7 +1615,6 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           tests::random_named_int<model::node_id>(),
           random_local_state(),
           std::move(topics),
-          true,
           random_drain_status());
 
         // Squash to ADL-understood disk state

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1645,10 +1645,10 @@ ss::future<topics_frontend::capacity_info> topics_frontend::get_health_info(
 
     for (auto& node_report : health_report.value().node_reports) {
         co_await ss::max_concurrent_for_each(
-          std::move(node_report->topics),
+          node_report->topics,
           32,
-          [&info](const topic_status& status) {
-              for (const auto& partition : status.partitions) {
+          [&info](const node_health_report::topics_t::value_type& status) {
+              for (const auto& partition : status.second) {
                   info.ntp_sizes[partition.id] = partition.size_bytes;
               }
               return ss::now();

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -440,11 +440,7 @@ read_value(json::Value const& rd, cluster::node_health_report& obj) {
     read_member(rd, "topics", topics);
     read_member(rd, "drain_status", drain_status);
     obj = cluster::node_health_report(
-      id,
-      local_state,
-      std::move(topics),
-      drain_status.has_value(),
-      drain_status);
+      id, local_state, std::move(topics), drain_status);
 }
 
 inline void read_value(json::Value const& rd, cluster::node_state& obj) {

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -296,7 +296,8 @@ inline void rjson_serialize(
 }
 
 inline void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const cluster::node_health_report& f) {
+  json::Writer<json::StringBuffer>& w,
+  const cluster::node_health_report_serde& f) {
     w.StartObject();
     w.Key("id");
     rjson_serialize(w, f.id);
@@ -335,7 +336,7 @@ inline void rjson_serialize(
     w.Key("node_reports");
     w.StartArray();
     for (auto& r : f.node_reports) {
-        rjson_serialize(w, *r);
+        rjson_serialize(w, cluster::node_health_report_serde{*r});
     }
     w.EndArray();
     w.EndObject();
@@ -429,7 +430,7 @@ inline void read_value(json::Value const& rd, cluster::node::local_state& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::node_health_report& obj) {
+read_value(json::Value const& rd, cluster::node_health_report_serde& obj) {
     model::node_id id;
     cluster::node::local_state local_state;
     chunked_vector<cluster::topic_status> topics;
@@ -439,7 +440,7 @@ read_value(json::Value const& rd, cluster::node_health_report& obj) {
     read_member(rd, "local_state", local_state);
     read_member(rd, "topics", topics);
     read_member(rd, "drain_status", drain_status);
-    obj = cluster::node_health_report(
+    obj = cluster::node_health_report_serde(
       id, local_state, std::move(topics), drain_status);
 }
 
@@ -466,11 +467,11 @@ read_value(json::Value const& rd, cluster::cluster_health_report& obj) {
     auto reports_v = rd.FindMember("node_reports");
     if (reports_v != rd.MemberEnd()) {
         for (auto const& e : reports_v->value.GetArray()) {
-            cluster::node_health_report report;
+            cluster::node_health_report_serde report;
             read_value(e, report);
             node_reports.emplace_back(
               ss::make_lw_shared<cluster::node_health_report>(
-                std::move(report)));
+                std::move(report).to_in_memory()));
         }
     }
     obj = cluster::cluster_health_report{

--- a/src/v/compat/get_node_health_compat.h
+++ b/src/v/compat/get_node_health_compat.h
@@ -44,7 +44,7 @@ struct compat_check<cluster::get_node_health_reply> {
 
     static std::vector<compat_binary>
     to_binary(cluster::get_node_health_reply obj) {
-        return {compat_binary::serde(obj)};
+        return {compat_binary::serde(std::move(obj))};
     }
 
     static void

--- a/src/v/compat/get_node_health_generator.h
+++ b/src/v/compat/get_node_health_generator.h
@@ -31,8 +31,10 @@ struct instance_generator<cluster::get_node_health_reply> {
     static cluster::get_node_health_reply random() {
         return {
           .error = instance_generator<cluster::errc>::random(),
-          .report = tests::random_optional(
-            [] { return cluster::random_node_health_report(); }),
+          .report = tests::random_optional([] {
+              return cluster::node_health_report_serde{
+                cluster::random_node_health_report()};
+          }),
         };
     }
     static std::vector<cluster::get_node_health_reply> limits() { return {}; }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3259,12 +3259,17 @@ struct cluster_partition_info {
     }
 };
 
-fragmented_vector<cluster_partition_info> topic2cluster_partitions(
+// Use contiguous_range_map for the ease of indexing when joining with the
+// health report.
+using cluster_partitions_t
+  = contiguous_range_map<model::partition_id::type, cluster_partition_info>;
+
+cluster_partitions_t topic2cluster_partitions(
   model::topic_namespace ns_tp,
   const cluster::assignments_set& assignments,
   const cluster::topic_disabled_partitions_set* disabled_set,
   std::optional<bool> disabled_filter) {
-    fragmented_vector<cluster_partition_info> ret;
+    cluster_partitions_t ret;
 
     if (disabled_filter) {
         // fast exits
@@ -3297,12 +3302,14 @@ fragmented_vector<cluster_partition_info> topic2cluster_partitions(
               *shared_ns_tp,
               id);
 
-            ret.push_back(cluster_partition_info{
-              .ns_tp = shared_ns_tp,
-              .id = id,
-              .replicas = as_it->second.replicas,
-              .disabled = true,
-            });
+            ret.emplace(
+              id,
+              cluster_partition_info{
+                .ns_tp = shared_ns_tp,
+                .id = id,
+                .replicas = as_it->second.replicas,
+                .disabled = true,
+              });
         }
     } else {
         for (const auto& [_, p_as] : assignments) {
@@ -3312,20 +3319,48 @@ fragmented_vector<cluster_partition_info> topic2cluster_partitions(
                 continue;
             }
 
-            ret.push_back(cluster_partition_info{
-              .ns_tp = shared_ns_tp,
-              .id = p_as.id,
-              .replicas = p_as.replicas,
-              .disabled = disabled,
-            });
+            ret.emplace(
+              p_as.id,
+              cluster_partition_info{
+                .ns_tp = shared_ns_tp,
+                .id = p_as.id,
+                .replicas = p_as.replicas,
+                .disabled = disabled,
+              });
         }
     }
 
-    std::sort(ret.begin(), ret.end(), [](const auto& l, const auto& r) {
-        return l.id < r.id;
-    });
-
     return ret;
+}
+
+void collect_shards_from_health_report(
+  model::topic_namespace_view ns_tp,
+  cluster_partitions_t& partitions,
+  const cluster::cluster_health_report& hr) {
+    for (const auto& node : hr.node_reports) {
+        auto topic_it = node->topics.find(ns_tp);
+        if (topic_it == node->topics.end()) {
+            continue;
+        }
+
+        for (const auto& replica : topic_it->second) {
+            auto partition_it = partitions.find(replica.id);
+            if (partition_it == partitions.end()) {
+                continue;
+            }
+            auto& part = partition_it->second;
+
+            auto bs_it = std::find_if(
+              part.replicas.begin(),
+              part.replicas.end(),
+              [node_id = node->id](const model::broker_shard& bs) {
+                  return bs.node_id == node_id;
+              });
+            if (bs_it != part.replicas.end()) {
+                bs_it->shard = replica.shard;
+            }
+        }
+    }
 }
 
 } // namespace
@@ -3342,7 +3377,7 @@ admin_server::get_cluster_partitions_handler(
 
     const auto& topics_state = _controller->get_topics_state().local();
 
-    fragmented_vector<model::topic_namespace> topics;
+    chunked_vector<model::topic_namespace> topics;
     auto fill_topics = [&](const auto& map) {
         for (const auto& [ns_tp, _] : map) {
             if (!with_internal && !model::is_user_topic(ns_tp)) {
@@ -3362,6 +3397,28 @@ admin_server::get_cluster_partitions_handler(
 
     std::sort(topics.begin(), topics.end());
 
+    std::optional<cluster::cluster_health_report> health_report;
+    if (_controller->get_topics_frontend()
+          .local()
+          .node_local_core_assignment_enabled()) {
+        // We'll need to get core assignments from the health report
+        auto hr_result = co_await _controller->get_health_monitor()
+                           .local()
+                           .get_cluster_health(
+                             cluster::cluster_report_filter{},
+                             cluster::force_refresh::no,
+                             model::timeout_clock::now() + 5s);
+        if (hr_result.has_error()) {
+            throw ss::httpd::base_exception{
+              ssx::sformat(
+                "Error getting cluster health report: {}",
+                hr_result.error().message()),
+              ss::http::reply::status_type::internal_server_error};
+        }
+
+        health_report = std::move(hr_result.value());
+    }
+
     ss::chunked_fifo<cluster_partition_info> partitions;
     for (const auto& ns_tp : topics) {
         auto topic_it = topics_state.topics_map().find(ns_tp);
@@ -3376,10 +3433,14 @@ admin_server::get_cluster_partitions_handler(
           topics_state.get_topic_disabled_set(ns_tp),
           disabled_filter);
 
-        std::move(
-          topic_partitions.begin(),
-          topic_partitions.end(),
-          std::back_inserter(partitions));
+        if (health_report) {
+            collect_shards_from_health_report(
+              ns_tp, topic_partitions, health_report.value());
+        }
+
+        for (auto& [id, part] : topic_partitions) {
+            partitions.push_back(std::move(part));
+        }
 
         co_await ss::coroutine::maybe_yield();
     }
@@ -3415,9 +3476,29 @@ admin_server::get_cluster_partitions_topic_handler(
       topics_state.get_topic_disabled_set(ns_tp),
       disabled_filter);
 
+    if (_controller->get_topics_frontend()
+          .local()
+          .node_local_core_assignment_enabled()) {
+        // We'll need to get core assignments from the health report
+        auto hr_result = co_await _controller->get_health_monitor()
+                           .local()
+                           .get_cluster_health(
+                             cluster::cluster_report_filter{},
+                             cluster::force_refresh::no,
+                             model::timeout_clock::now() + 5s);
+        if (hr_result.has_error()) {
+            throw ss::httpd::base_exception{
+              ssx::sformat(
+                "Error getting cluster health report: {}",
+                hr_result.error().message()),
+              ss::http::reply::status_type::internal_server_error};
+        }
+        collect_shards_from_health_report(ns_tp, partitions, hr_result.value());
+    }
+
     co_return ss::json::json_return_type(ss::json::stream_range_as_array(
       lw_shared_container{std::move(partitions)},
-      [](const auto& p) { return p.to_json(); }));
+      [](const auto& kv) { return kv.second.to_json(); }));
 }
 
 void admin_server::register_cluster_routes() {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1590,6 +1590,7 @@ class Admin:
                                ns: str | None = None,
                                topic: str | None = None,
                                disabled: bool | None = None,
+                               with_internal: bool | None = None,
                                node=None):
         if topic is not None:
             assert ns is not None
@@ -1600,6 +1601,9 @@ class Admin:
 
         if disabled is not None:
             req += f"?disabled={disabled}"
+
+        if with_internal is not None:
+            req += f"?with_internal={with_internal}"
 
         return self._request("GET", req, node=node).json()
 


### PR DESCRIPTION
If node-local core assignment is enabled, return core assignments from health report in `/v1/cluster/partitions` admin API output. These will better reflect reality, instead of obsolete assignments queried from the topic table.

Additionally, do some `node_health_report` refactoring that enables more efficient querying of node health reports.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
### Improvements
* Return core assignments from health report in `/v1/cluster/partitions` admin API output.