### PR TITLE
[v24.2.x] admin: remove `throw` on unknown self test type in `admin_server`

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -45,6 +45,7 @@ cloudcheck::run(cloudcheck_opts opts) {
         vlog(clusterlog.debug, "cloudcheck - gate already closed");
         auto result = self_test_result{
           .name = _opts.name,
+          .test_type = "cloud",
           .start_time = time_since_epoch(ss::lowres_system_clock::now()),
           .end_time = time_since_epoch(ss::lowres_system_clock::now()),
           .warning = "cloudcheck - gate already closed"};
@@ -64,6 +65,7 @@ cloudcheck::run(cloudcheck_opts opts) {
           "Cloud storage is not enabled, exiting cloud storage self-test.");
         auto result = self_test_result{
           .name = _opts.name,
+          .test_type = "cloud",
           .start_time = time_since_epoch(ss::lowres_system_clock::now()),
           .end_time = time_since_epoch(ss::lowres_system_clock::now()),
           .warning = "Cloud storage is not enabled."};
@@ -77,6 +79,7 @@ cloudcheck::run(cloudcheck_opts opts) {
           "self-test.");
         auto result = self_test_result{
           .name = _opts.name,
+          .test_type = "cloud",
           .start_time = time_since_epoch(ss::lowres_system_clock::now()),
           .end_time = time_since_epoch(ss::lowres_system_clock::now()),
           .warning = "cloud_storage_api is not initialized."};

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -79,7 +79,8 @@ private:
     ss::future<std::vector<self_test_result>> do_start_test(
       std::vector<diskcheck_opts> dtos,
       std::vector<netcheck_opts> ntos,
-      std::vector<cloudcheck_opts> ctos);
+      std::vector<cloudcheck_opts> ctos,
+      std::vector<unknown_check> unknown_checks);
 
     struct previous_netcheck_entity {
         static const inline model::node_id unassigned{-1};

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -140,7 +140,9 @@ ss::future<uuid_t> self_test_frontend::start_test(
     if (ids.empty()) {
         throw self_test_exception("No node ids provided");
     }
-    if (req.dtos.empty() && req.ntos.empty() && req.ctos.empty()) {
+    if (
+      req.dtos.empty() && req.ntos.empty() && req.ctos.empty()
+      && req.unknown_checks.empty()) {
         throw self_test_exception("No tests specified to run");
     }
     /// Validate input
@@ -195,7 +197,8 @@ ss::future<uuid_t> self_test_frontend::start_test(
             .id = test_id,
             .dtos = std::move(req.dtos),
             .ntos = std::move(new_ntos),
-            .ctos = std::move(req.ctos)});
+            .ctos = std::move(req.ctos),
+            .unknown_checks = std::move(req.unknown_checks)});
       });
     co_return test_id;
 }

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -239,6 +239,26 @@ struct cloudcheck_opts
     }
 };
 
+// Captures unknown test types passed to self test frontend for logging
+// purposes.
+struct unknown_check
+  : serde::
+      envelope<unknown_check, serde::version<0>, serde::compat_version<0>> {
+    ss::sstring test_type;
+    ss::sstring test_json;
+    auto serde_fields() { return std::tie(test_type, test_json); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const unknown_check& unknown_check) {
+        fmt::print(
+          o,
+          "{{test_type: {}, test_json: {}}}",
+          unknown_check.test_type,
+          unknown_check.test_json);
+        return o;
+    }
+};
+
 struct self_test_result
   : serde::
       envelope<self_test_result, serde::version<1>, serde::compat_version<0>> {
@@ -321,7 +341,7 @@ struct empty_request
 struct start_test_request
   : serde::envelope<
       start_test_request,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -329,6 +349,7 @@ struct start_test_request
     std::vector<diskcheck_opts> dtos;
     std::vector<netcheck_opts> ntos;
     std::vector<cloudcheck_opts> ctos;
+    std::vector<unknown_check> unknown_checks;
 
     friend std::ostream&
     operator<<(std::ostream& o, const start_test_request& r) {
@@ -341,6 +362,9 @@ struct start_test_request
         }
         for (const auto& v : r.ctos) {
             fmt::print(ss, "cloudcheck_opts: {}", v);
+        }
+        for (const auto& v : r.unknown_checks) {
+            fmt::print(ss, "unknown_check: {}", v);
         }
         fmt::print(o, "{{id: {} {}}}", r.id, ss.str());
         return o;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2819,9 +2819,13 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
                 } else if (test_type == "cloud") {
                     r.ctos.push_back(cluster::cloudcheck_opts::from_json(obj));
                 } else {
-                    throw ss::httpd::bad_param_exception(
-                      "Unknown self_test 'type', valid options are 'disk', "
-                      "'network', or 'cloud'.");
+                    rapidjson::StringBuffer buffer;
+                    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                    element.Accept(writer);
+                    r.unknown_checks.push_back(cluster::unknown_check{
+                      .test_type = test_type,
+                      .test_json = ss::sstring{
+                        buffer.GetString(), buffer.GetSize()}});
                 }
             }
         } else {

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -207,3 +207,66 @@ class SelfTestTest(EndToEndTest):
                 # cancelled before it even had a chance to start, resulting in
                 # a 0 value for duration
                 assert report['duration'] >= 0
+
+    @cluster(num_nodes=3)
+    def test_self_test_unknown_test_type(self):
+        """Assert the self test still runs when an invalid test type is passed.
+           This helps ensure the self test will still work in a cluster
+           with mixed versions of Redpanda."""
+        num_nodes = 3
+
+        self.start_redpanda(num_nodes=num_nodes,
+                            si_settings=SISettings(
+                                test_context=self.test_context,
+                                cloud_storage_enable_remote_read=True,
+                                cloud_storage_enable_remote_write=True))
+
+        #Attempt to run with an unknown test type "pandatest"
+        #and possibly unknown "cloud" test.
+        #The rest of the tests should proceed as normal.
+        request_json = {
+            'tests': [{
+                'type': 'pandatest'
+            }, {
+                'type': 'disk'
+            }, {
+                'type': 'network'
+            }, {
+                'type': 'cloud'
+            }]
+        }
+
+        #Manually invoke self test admin endpoint.
+        self.redpanda._admin._request('POST',
+                                      'debug/self_test/start',
+                                      json=request_json)
+
+        #Populate list of unknown reports.
+        unknown_report_types = ['pandatest']
+        redpanda_versions = [
+            self.redpanda.get_version_int_tuple(node)
+            for node in self.redpanda.nodes
+        ]
+
+        #All nodes should have the same version of
+        #Redpanda running.
+        assert len(set(redpanda_versions)) == 1
+
+        #Cloudcheck was introduced in 24.2.1.
+        #Expect that it will be unknown to nodes running
+        #earlier versions of redpanda.
+        if redpanda_versions[0] < (24, 2, 1):
+            unknown_report_types.append('cloud')
+
+        # Wait for self test completion.
+        node_reports = self.wait_for_self_test_completion()
+
+        #Assert reports are passing, with the exception of unknown tests.
+        reports = flat_map(lambda node: node['results'], node_reports)
+        assert len(reports) > 0
+        for report in reports:
+            if report['test_type'] in unknown_report_types:
+                assert 'error' in report
+            else:
+                assert 'error' not in report
+                assert 'warning' not in report


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21370
