### PR TITLE
[v24.1.x] `admin`: remove throw on unknown self test type in `admin_server` (manual backport)

### DIFF
--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -74,7 +74,9 @@ public:
 
 private:
     ss::future<std::vector<self_test_result>> do_start_test(
-      std::vector<diskcheck_opts> dtos, std::vector<netcheck_opts> ntos);
+      std::vector<diskcheck_opts> dtos,
+      std::vector<netcheck_opts> ntos,
+      std::vector<unknown_check> unknown_checks);
 
     struct previous_netcheck_entity {
         static const inline model::node_id unassigned{-1};

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -133,7 +133,7 @@ ss::future<uuid_t> self_test_frontend::start_test(
     if (ids.empty()) {
         throw self_test_exception("No node ids provided");
     }
-    if (req.dtos.empty() && req.ntos.empty()) {
+    if (req.dtos.empty() && req.ntos.empty() && req.unknown_checks.empty()) {
         throw self_test_exception("No tests specified to run");
     }
     /// Validate input
@@ -185,7 +185,10 @@ ss::future<uuid_t> self_test_frontend::start_test(
               }
           }
           return handle->start_test(start_test_request{
-            .id = test_id, .dtos = req.dtos, .ntos = new_ntos});
+            .id = test_id,
+            .dtos = std::move(req.dtos),
+            .ntos = std::move(new_ntos),
+            .unknown_checks = std::move(req.unknown_checks)});
       });
     co_return test_id;
 }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2767,9 +2767,13 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
                 } else if (test_type == "network") {
                     r.ntos.push_back(cluster::netcheck_opts::from_json(obj));
                 } else {
-                    throw ss::httpd::bad_param_exception(
-                      "Unknown self_test 'type', valid options are 'disk' or "
-                      "'network'");
+                    rapidjson::StringBuffer buffer;
+                    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                    element.Accept(writer);
+                    r.unknown_checks.push_back(cluster::unknown_check{
+                      .test_type = test_type,
+                      .test_json = ss::sstring{
+                        buffer.GetString(), buffer.GetSize()}});
                 }
             }
         } else {


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/21370. Fixes https://github.com/redpanda-data/redpanda/issues/22699.

Some cloudcheck related conflicts, due to it not existing in `v24.1.x`. 

We are still interested in having the other changes, namely `unknown_check` support, in this previous version of `redpanda` for compatibility.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none