### PR TITLE
dt/acl: test kafka handler ACL requirements

### DIFF
--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -14,11 +14,13 @@ from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
+from rptest.clients.kcl import RawKCL
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError, RpkException, AclList
 from rptest.services.redpanda import SecurityConfig, TLSProvider
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.services import tls
 from typing import Optional
+from enum import Enum
 
 
 class MTLSProvider(TLSProvider):
@@ -37,6 +39,24 @@ class MTLSProvider(TLSProvider):
         return self.tls.create_cert(socket.gethostname(),
                                     name=name,
                                     common_name=name)
+
+
+class ACLOperation(Enum):
+    ALL = "all"
+    READ = "read"
+    WRITE = "write"
+    CREATE = "create"
+    # REMOVE = "remove" # Invalid cluster acl operation
+    ALTER = "alter"
+    DESCRIBE = "describe"
+    CLUSTER_ACTION = "cluster_action"
+    DESCRIBE_CONFIGS = "describe_configs"
+    ALTER_CONFIGS = "alter_configs"
+    IDEMPOTENT_WRITE = "idempotent_write"
+
+
+class KError(Enum):
+    CLUSTER_AUTHORIZATION_FAILED = 31
 
 
 class AccessControlListTestBase(RedpandaTest):
@@ -549,3 +569,86 @@ class AccessControlListTestUpgrade(AccessControlListTest):
             pass_w_cluster_user=True,
             pass_w_super_user=True,
             err_msg='check_permissions failed after upgrade')
+
+
+class AccessControlListAuthzTest(AccessControlListTestBase):
+    password = "password"
+    algorithm = "SCRAM-SHA-256"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.security = SecurityConfig()
+        self.security.enable_sasl = True
+        self.security.kafka_enable_authorization = True
+        self.security.endpoint_authn_method = 'sasl'
+
+        self.redpanda.set_security_settings(self.security)
+        self.redpanda.start()
+
+        superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.rpk_super = RpkTool(self.redpanda,
+                                 username=superuser.username,
+                                 password=superuser.password,
+                                 sasl_mechanism=superuser.algorithm)
+        self.admin = Admin(self.redpanda)
+
+        # Create some users with varying cluster ACLs
+        self.admin.create_user("base", self.password, self.algorithm)
+
+        def cluster_username(op: ACLOperation) -> str:
+            return f"cluster_{op.value}"
+
+        for op in ACLOperation:
+            username = cluster_username(op)
+            self.admin.create_user(username, self.password, self.algorithm)
+            self.rpk_super.acl_create_allow_cluster(username, op.value)
+
+        self.security_updates_barrier()
+
+        # Now that the cluster is ready, create clients for users with various ACL levels
+        self.kcl_user = {}
+        self.kcl_user["base"] = RawKCL(self.redpanda, "base", self.password,
+                                       self.algorithm)
+
+        for op in ACLOperation:
+            username = cluster_username(op)
+            self.kcl_user[username] = RawKCL(self.redpanda, username,
+                                             self.password, self.algorithm)
+
+    @cluster(num_nodes=3)
+    def test_alter_quotas(self):
+        alter_body = {
+            "Entries": [{
+                "Entity": [{
+                    "Type": "client-id-prefix",
+                }],
+                "Ops": [{
+                    "Key": "producer_byte_rate",
+                    "Value": 10.0,
+                }],
+            }],
+        }
+
+        resp = self.kcl_user["base"].raw_alter_quotas(body=alter_body)
+        assert resp['Entries'][0]['ErrorCode'] == KError.CLUSTER_AUTHORIZATION_FAILED.value, \
+                f"Response: {resp}"
+
+        resp = self.kcl_user["cluster_alter_configs"].raw_alter_quotas(
+            body=alter_body)
+        assert resp['Entries'][0]['ErrorCode'] != KError.CLUSTER_AUTHORIZATION_FAILED.value, \
+                f"Response: {resp}"
+
+    @cluster(num_nodes=3)
+    def test_describe_quotas(self):
+        describe_body = {}
+
+        resp = self.kcl_user["base"].raw_describe_quotas(body=describe_body)
+        assert resp['ErrorCode'] == KError.CLUSTER_AUTHORIZATION_FAILED.value, \
+                f"Response: {resp}"
+
+        resp = self.kcl_user["cluster_describe_configs"].raw_describe_quotas(
+            body=describe_body)
+        assert resp['ErrorCode'] != KError.CLUSTER_AUTHORIZATION_FAILED.value, \
+                f"Response: {resp}"


### PR DESCRIPTION
This adds two ducktape tests that validate that the correct ACLs are
being applied to certain kafka endpoints.

Specifically the tests are added are for the describe and alter client
quotas endpoints, but the intent of this change is to make it easy to
add new tests to validate the ACL-requirements of newly added endpoints.

Follow up to https://github.com/redpanda-data/redpanda/pull/22520#issuecomment-2252884490

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
