### PR TITLE
[CORE-5099] [v23.3.x] tests: wait for the leadership change metric to be updated

### DIFF
--- a/tests/rptest/services/metrics_check.py
+++ b/tests/rptest/services/metrics_check.py
@@ -94,7 +94,9 @@ class MetricCheck(object):
                     samples[sample.name] = sample.value
 
         for k, v in samples.items():
-            self.logger.info(f"  Captured {k}={v}")
+            self.logger.info(
+                f"  Captured {k}={v} from {self.node.account.hostname}(node_id = {self.redpanda.node_id(self.node)})"
+            )
 
         if len(samples) == 0:
             metrics_endpoint = ("/metrics" if self._metrics_endpoint

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -386,8 +386,12 @@ class RaftAvailabilityTest(RedpandaTest):
                                      partition=0,
                                      target_id=None,
                                      leader_id=initial_leader_id)
-        new_leader_id, _ = self._wait_for_leader(
-            lambda l: l is not None and l != initial_leader_id)
+        hosts = [n.account.hostname for n in self.redpanda.nodes]
+        new_leader_id = admin.await_stable_leader(
+            topic=self.topic,
+            partition=0,
+            hosts=hosts,
+            check=lambda l: l is not None and l != initial_leader_id)
         new_leader_node = self.redpanda.get_node_by_id(new_leader_id)
         assert new_leader_node is not None
         self.logger.info(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/20813 