### PR TITLE
tools/olv: fixed a bug in reading ntp

### DIFF
--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -1130,8 +1130,7 @@ class ControllerSnapshot():
 
     def read_topics(self, rdr: Reader, version: int):
         def read_tp_ns_to_str(rdr: Reader):
-            v = read_topic_namespace(rdr)
-            return f"{v['namespace']}/{v['topic']}"
+            return read_topic_namespace(rdr)
 
         def read_partition_t(rdr: Reader, version: int):
             v = {}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

OLV reported the following error when reading controller snapshot being generated by Redpanda v24.1.8. This commit addressed the `TypeError`. 
```
INFO:viewer:starting metadata viewer with options: Namespace(path='data', type='controller_snapshot', topic=None, verbose=False, dump=False, force=False)
Traceback (most recent call last):
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/viewer.py", line 235, in <module>
    main()
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/viewer.py", line 215, in main
    print_controller_snapshot(store, options.dump)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/viewer.py", line 70, in print_controller_snapshot
    SerializableGenerator(snap.to_dict().items()))
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1346, in to_dict
    return self.parse_snapshot(sf)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1336, in parse_snapshot
    data = reader.read_checksum_envelope(
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/reader.py", line 139, in read_checksum_envelope
    return self.read_envelope_inner(envelope, type_read, max_version)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/reader.py", line 144, in read_envelope_inner
    v = type_read(self, envelope.version)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1337, in <lambda>
    type_read=lambda r, _: self.read_snapshot(r), max_version=2)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1305, in read_snapshot
    data['topics'] = rdr.read_envelope(
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/reader.py", line 133, in read_envelope
    return self.read_envelope_inner(envelope, type_read, max_version)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/reader.py", line 144, in read_envelope_inner
    v = type_read(self, envelope.version)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1306, in <lambda>
    type_read=lambda r, v: self.read_topics(r, v), max_version=1)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1186, in read_topics
    rdr.read_serde_map(
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/reader.py", line 204, in read_serde_map
    key = k_reader(self)
  File "/redpanda/src/dev-redpanda/tools/offline_log_viewer/controller.py", line 1134, in read_tp_ns_to_str
    return f"{v['namespace']}/{v['topic']}"
TypeError: string indices must be integers
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
