### PR TITLE
tests: fix some unused parameter warnings in clang-18

### DIFF
--- a/src/v/cloud_storage/tests/segment_chunk_test.cc
+++ b/src/v/cloud_storage/tests/segment_chunk_test.cc
@@ -88,7 +88,7 @@ SEASTAR_THREAD_TEST_CASE(test_eager_chunk_eviction) {
     protected:
         ss::future<> close_files(
           std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
-          retry_chain_logger& rtc) override {
+          retry_chain_logger&) override {
             evicted = files_to_close.size();
             co_return;
         }
@@ -120,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(test_capped_chunk_eviction) {
     protected:
         ss::future<> close_files(
           std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
-          retry_chain_logger& rtc) override {
+          retry_chain_logger&) override {
             evicted = files_to_close.size();
             co_return;
         }
@@ -154,7 +154,7 @@ SEASTAR_THREAD_TEST_CASE(test_predictive_chunk_eviction) {
     protected:
         ss::future<> close_files(
           std::vector<ss::lw_shared_ptr<ss::file>> files_to_close,
-          retry_chain_logger& rtc) override {
+          retry_chain_logger&) override {
             evicted = files_to_close.size();
             co_return;
         }

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -841,7 +841,7 @@ public:
 };
 
 static ss::future<> test_client_pool_payload(
-  ss::shared_ptr<ss::httpd::http_server_control> server,
+  ss::shared_ptr<ss::httpd::http_server_control>,
   cloud_storage_clients::client_pool::client_lease lease) {
     auto client = lease.client;
     iobuf payload;
@@ -877,7 +877,7 @@ FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
 }
 
 static ss::future<bool> test_client_pool_reconnect_helper(
-  ss::shared_ptr<ss::httpd::http_server_control> server,
+  ss::shared_ptr<ss::httpd::http_server_control>,
   cloud_storage_clients::client_pool::client_lease lease) {
     auto client = lease.client;
     co_await ss::sleep(100ms);


### PR DESCRIPTION
Fix some clang-18 warnings

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
