### PR TITLE
[dt] cluster creation payload - zones is a list already

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -547,7 +547,7 @@ class CloudCluster():
             "resource_group_id": self.current.namespace_uuid,
             "throughput_tier": self.current.product_name,
             "type": _type,
-            "zones": [self.current.zones]
+            "zones": self.current.zones
         }
 
     def _get_cluster(self, _id) -> dict[str, Any]:


### PR DESCRIPTION
GCP cloud tests are failing with:
```
[ERROR - 2024-08-05 21:18:49,224 - rpcloud_client - _handle_error - lineno:19]: 400 Client Error: Bad Request for url: https://api.ign.cloud.redpanda.com/v1beta2/clusters {"code":"INVALID_ARGUMENT","message":"proto: (line 1:325): invalid value for string type: [","details":[]}
```

The POST payload we send is:
```
[DEBUG - 2024-08-05 21:18:49,108 - redpanda_cloud - _create_new_cluster - lineno:724]: POST to /v1beta2/clusters body: {"cloud_provider": "CLOUD_PROVIDER_GCP", "connection_type": "CONNECTION_TYPE_PUBLIC", "name": "rp-ducktape-cluster-445d192c", "network_id": "cqok3bi7368qisln0580", "region": "us-central1", "resource_group_id": "96035995-abda-4763-9b51-180570985a4f", "throughput_tier": "tier-8-gcp-v2-x86-n2", "type": "TYPE_BYOC", "zones": [["us-central1-c"]]}
```
(See `zones` at the end).  It's unlikely we want to send zones as a list of lists.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none