### PR TITLE
`cluster`: bump `serde::version` of `start_test_request` to 2

### DIFF
--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -341,7 +341,7 @@ struct empty_request
 struct start_test_request
   : serde::envelope<
       start_test_request,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 


### PR DESCRIPTION
This `serde::version<>` needed bumping to `serde::version<2>`, since `serde::version<0>` is the version of `start_test_request` with just `diskcheck_opts` and `netcheck_opts` (pre `v24.2.x`), while `serde::version<1>` is the version with `unknown_checks` added, and `serde::version<2>` needs to reflect the most recently added `cloudcheck_opts` (since version `v24.2.x`).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
