### PR TITLE
k/group: match kafka heartbeat expiry handling

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -525,8 +525,7 @@ public:
     void complete_join();
 
     /// Handle a heartbeat expiration.
-    void heartbeat_expire(
-      kafka::member_id member_id, clock_type::time_point deadline);
+    void heartbeat_expire(kafka::member_id member_id);
 
     /// Send response to joining member.
     void try_finish_joining_member(

--- a/src/v/kafka/server/member.cc
+++ b/src/v/kafka/server/member.cc
@@ -62,17 +62,16 @@ const bytes& group_member::get_protocol_metadata(
     }
 }
 
-bool group_member::should_keep_alive(
-  clock_type::time_point deadline, clock_type::duration new_join_timeout) {
-    if (is_joining()) {
-        return _is_new || (_latest_heartbeat + new_join_timeout) > deadline;
+bool group_member::should_keep_alive() {
+    if (_is_new) {
+        // <kafka>New members can be expired even while awaiting join, so we
+        // check this first</kafka>
+        return false;
+    } else {
+        // <kafka>Members that are awaiting a rebalance automatically satisfy
+        // expected heartbeats</kafka>
+        return is_joining() || is_syncing();
     }
-
-    if (is_syncing()) {
-        return (_latest_heartbeat + session_timeout()) > deadline;
-    }
-
-    return false;
 }
 
 std::ostream& operator<<(std::ostream& o, const group_member& m) {

--- a/src/v/kafka/server/member.h
+++ b/src/v/kafka/server/member.h
@@ -208,8 +208,7 @@ public:
     const bytes&
     get_protocol_metadata(const kafka::protocol_name& protocol) const;
 
-    bool should_keep_alive(
-      clock_type::time_point deadline, clock_type::duration new_join_timeout);
+    bool should_keep_alive();
 
     void set_latest_heartbeat(clock_type::time_point t) {
         _latest_heartbeat = t;


### PR DESCRIPTION
This changes the heartbeat expiry logic to match the logic Apache Kafka implements.

In particular, the behaviour changes are that:
 * For new members joining the group for the first time, we always remove them from the group when the group hasn't completed the join phase within `group_new_member_join_timeout`. The reasoning for this is that new joining members haven't received their member id yet, so if they time out client-side waiting for the join response, they would retry and leave behind member ids. Instead, it's better to time out these members server-side, remove the member and have the client re-issue the join group request. (There is an existing comment above where this timeout is scheduled stating this intention, but the behaviour did not match that comment.)
 * For members that are joining or syncing, that is, they have issued a JoinGroup or SyncGroup request and the client is waiting for a response from the broker, we should not time the client out since at this point the client won't try to keep sending heartbeats but instead keep the member around until the end of the join phase.

Ref: https://github.com/apache/kafka/blob/2ae524ed625438c5fee89e78648bd73e64a3ada0/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java#L202-L216

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
