### PR TITLE
r/stm_manager: do not warn when some of the stms did not make progress

### DIFF
--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -371,8 +371,10 @@ ss::future<> state_machine_manager::try_apply_in_foreground() {
           model::no_timeout);
 
         if (max_last_applied == model::offset{}) {
-            vlog(
-              _log.warn,
+            vlogl(
+              _log,
+              _raft->log_config().cache_enabled() ? ss::log_level::warn
+                                                  : ss::log_level::debug,
               "no progress has been made during state machine apply. Current "
               "next offset: {}",
               _next);


### PR DESCRIPTION
When a partition is created without the batch cache, the write may not be immediately visible for the reader. In this case the `raft::state_machine_manager` identifies it as an issue with the state machine not being able to make progress. Added a differentiation of the log level based on the cache configuration of the partition. For the partitions that uses the cache the `WARN` log level is kept to make it easy to recognize possibly stuck state machines.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- fixed spurious warning log entries that may be altering users