### PR TITLE
CORE-6479 dt/random_node_ops: suppress method_not_found log 

### DIFF
--- a/src/v/rpc/include/rpc/errc.h
+++ b/src/v/rpc/include/rpc/errc.h
@@ -47,6 +47,10 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::missing_node_rpc_client";
         case errc::client_request_timeout:
             return "rpc::errc::client_request_timeout";
+        case errc::service_error:
+            return "rpc::errc::service_error";
+        case errc::method_not_found:
+            return "rpc::errc::method_not_found";
         case errc::version_not_supported:
             return "rpc::errc::version_not_supported";
         case errc::connection_timeout:
@@ -55,9 +59,10 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::shutting_down";
         case errc::service_unavailable:
             return "rpc::errc::service_unavailable";
-        default:
-            return "rpc::errc::unknown(" + std::to_string(c) + ")";
+        case errc::unknown:
+            break;
         }
+        return "rpc::errc::unknown(" + std::to_string(c) + ")";
     }
 };
 inline const std::error_category& error_category() noexcept {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -139,6 +139,10 @@ CHAOS_LOG_ALLOW_LIST = [
     re.compile(
         "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
     ),
+    # Failure to handle an internal RPC because the RPC server already handles connections but doesn't yet handle this method. This can happen while the node is still starting up/restarting.
+    # e.g. "admin_api_server - server.cc:655 - [_anonymous] exception intercepted - url: [http://ip-172-31-9-208:9644/v1/brokers/7/decommission] http_return_status[500] reason - seastar::httpd::server_error_exception (Unexpected error: rpc::errc::method_not_found)"
+    re.compile(
+        "admin_api_server - .*Unexpected error: rpc::errc::method_not_found")
 ]
 
 # Log errors emitted by refresh credentials system when cloud storage is enabled with IAM roles


### PR DESCRIPTION
We recently had the `RandomNodeOperationsTest` fail in CI because the following error-level log showed up in the redpanda node logs. After inspecting the test flow, I believe this error log line and the failure it represents is expected, and so this PR fixes the CI failure by suppressing the error log.

```
<BadLogLines nodes=ip-172-31-9-208(1) example="ERROR 2024-07-24 23:13:14,081 [shard 1:admi] admin_api_server - server.cc:655 - [_anonymous] exception intercepted - url: [http://ip-172-31-9-208:9644/v1/brokers/7/decommission] http_return_status[500] reason - seastar::httpd::server_error_exception (Unexpected error: rpc::errc::unknown(6))">
Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 184, in _do_run
    data = self.run_test()
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 276, in run_test
    return self.test_context.function(self.test)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/mark/_mark.py", line 535, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 190, in wrapped
    redpanda.raise_on_bad_logs(
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 1576, in raise_on_bad_logs
    lsearcher.search_logs(_searchable_nodes)
  File "/home/ubuntu/redpanda/tests/rptest/services/utils.py", line 197, in search_logs
    raise BadLogLines(bad_loglines)
rptest.services.utils.BadLogLines: <BadLogLines nodes=ip-172-31-9-208(1) example="ERROR 2024-07-24 23:13:14,081 [shard 1:admi] admin_api_server - server.cc:655 - [_anonymous] exception intercepted - url: [http://ip-172-31-9-208:9644/v1/brokers/7/decommission] http_return_status[500] reason - seastar::httpd::server_error_exception (Unexpected error: rpc::errc::unknown(6))">
```

For all the context and reasoning for why I believe this is expected see the referenced ticket. The summary is that for the `RandomNodeOperationsTest` and other chaos tests that can have restarting nodes we can observe this error when a
controller leader node is starting up and another node sends an internal RPC request to the controller leader which the starting node can't yet handle.

Note that the `rpc::errc::method_not_found` error was misleadingly printed as `rpc::errc::unknown(6)` because the method turning the `rpc::errc_category::message(...)` method was missing two switch cases.

Fixes https://redpandadata.atlassian.net/browse/CORE-6479

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
