### PR TITLE
[v24.1.x] `cluster`: add `serde_fields()` to `start_test_request`

### DIFF
--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -263,6 +263,8 @@ struct start_test_request
     std::vector<netcheck_opts> ntos;
     std::vector<unknown_check> unknown_checks;
 
+    auto serde_fields() { return std::tie(id, dtos, ntos, unknown_checks); }
+
     friend std::ostream&
     operator<<(std::ostream& o, const start_test_request& r) {
         std::stringstream ss;


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
