### PR TITLE
[backport] [v24.1.x] miscellaneous idempotency fixes #22687

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -88,6 +88,7 @@ v_cc_library(
   HDRS
     topic_recovery_validator.h
   SRCS
+    errors.cc
     metadata_cache.cc
     partition_manager.cc
     scheduling/partition_allocator.cc

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -90,6 +90,9 @@ enum class errc : int16_t {
     producer_ids_vcluster_limit_exceeded,
     validation_of_recovery_topic_failed,
 };
+
+std::ostream& operator<<(std::ostream& o, errc err);
+
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
 

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/errc.h"
+
+#include <iostream>
+
+namespace cluster {
+std::ostream& operator<<(std::ostream& o, cluster::errc err) {
+    switch (err) {
+    case errc::success:
+        return o << "cluster::errc::success";
+    case errc::notification_wait_timeout:
+        return o << "cluster::errc::notification_wait_timeout";
+    case errc::topic_invalid_partitions:
+        return o << "cluster::errc::topic_invalid_partitions";
+    case errc::topic_invalid_replication_factor:
+        return o << "cluster::errc::topic_invalid_replication_factor";
+    case errc::topic_invalid_config:
+        return o << "cluster::errc::topic_invalid_config";
+    case errc::not_leader_controller:
+        return o << "cluster::errc::not_leader_controller";
+    case errc::topic_already_exists:
+        return o << "cluster::errc::topic_already_exists";
+    case errc::replication_error:
+        return o << "cluster::errc::replication_error";
+    case errc::shutting_down:
+        return o << "cluster::errc::shutting_down";
+    case errc::no_leader_controller:
+        return o << "cluster::errc::no_leader_controller";
+    case errc::join_request_dispatch_error:
+        return o << "cluster::errc::join_request_dispatch_error";
+    case errc::seed_servers_exhausted:
+        return o << "cluster::errc::seed_servers_exhausted";
+    case errc::auto_create_topics_exception:
+        return o << "cluster::errc::auto_create_topics_exception";
+    case errc::timeout:
+        return o << "cluster::errc::timeout";
+    case errc::topic_not_exists:
+        return o << "cluster::errc::topic_not_exists";
+    case errc::invalid_topic_name:
+        return o << "cluster::errc::invalid_topic_name";
+    case errc::partition_not_exists:
+        return o << "cluster::errc::partition_not_exists";
+    case errc::not_leader:
+        return o << "cluster::errc::not_leader";
+    case errc::partition_already_exists:
+        return o << "cluster::errc::partition_already_exists";
+    case errc::waiting_for_recovery:
+        return o << "cluster::errc::waiting_for_recovery";
+    case errc::waiting_for_reconfiguration_finish:
+        return o << "cluster::errc::waiting_for_reconfiguration_finish";
+    case errc::update_in_progress:
+        return o << "cluster::errc::update_in_progress";
+    case errc::user_exists:
+        return o << "cluster::errc::user_exists";
+    case errc::user_does_not_exist:
+        return o << "cluster::errc::user_does_not_exist";
+    case errc::invalid_producer_epoch:
+        return o << "cluster::errc::invalid_producer_epoch";
+    case errc::sequence_out_of_order:
+        return o << "cluster::errc::sequence_out_of_order";
+    case errc::generic_tx_error:
+        return o << "cluster::errc::generic_tx_error";
+    case errc::node_does_not_exists:
+        return o << "cluster::errc::node_does_not_exists";
+    case errc::invalid_node_operation:
+        return o << "cluster::errc::invalid_node_operation";
+    case errc::invalid_configuration_update:
+        return o << "cluster::errc::invalid_configuration_update";
+    case errc::topic_operation_error:
+        return o << "cluster::errc::topic_operation_error";
+    case errc::no_eligible_allocation_nodes:
+        return o << "cluster::errc::no_eligible_allocation_nodes";
+    case errc::allocation_error:
+        return o << "cluster::errc::allocation_error";
+    case errc::partition_configuration_revision_not_updated:
+        return o
+               << "cluster::errc::partition_configuration_revision_not_updated";
+    case errc::partition_configuration_in_joint_mode:
+        return o << "cluster::errc::partition_configuration_in_joint_mode";
+    case errc::partition_configuration_leader_config_not_committed:
+        return o << "cluster::errc::partition_configuration_leader_config_not_"
+                    "committed";
+    case errc::partition_configuration_differs:
+        return o << "cluster::errc::partition_configuration_differs";
+    case errc::data_policy_already_exists:
+        return o << "cluster::errc::data_policy_already_exists";
+    case errc::data_policy_not_exists:
+        return o << "cluster::errc::data_policy_not_exists";
+    case errc::source_topic_not_exists:
+        return o << "cluster::errc::source_topic_not_exists";
+    case errc::source_topic_still_in_use:
+        return o << "cluster::errc::source_topic_still_in_use";
+    case errc::waiting_for_partition_shutdown:
+        return o << "cluster::errc::waiting_for_partition_shutdown";
+    case errc::error_collecting_health_report:
+        return o << "cluster::errc::error_collecting_health_report";
+    case errc::leadership_changed:
+        return o << "cluster::errc::leadership_changed";
+    case errc::feature_disabled:
+        return o << "cluster::errc::feature_disabled";
+    case errc::invalid_request:
+        return o << "cluster::errc::invalid_request";
+    case errc::no_update_in_progress:
+        return o << "cluster::errc::no_update_in_progress";
+    case errc::unknown_update_interruption_error:
+        return o << "cluster::errc::unknown_update_interruption_error";
+    case errc::throttling_quota_exceeded:
+        return o << "cluster::errc::throttling_quota_exceeded";
+    case errc::cluster_already_exists:
+        return o << "cluster::errc::cluster_already_exists";
+    case errc::no_partition_assignments:
+        return o << "cluster::errc::no_partition_assignments";
+    case errc::failed_to_create_partition:
+        return o << "cluster::errc::failed_to_create_partition";
+    case errc::partition_operation_failed:
+        return o << "cluster::errc::partition_operation_failed";
+    case errc::transform_does_not_exist:
+        return o << "cluster::errc::transform_does_not_exist";
+    case errc::transform_invalid_update:
+        return o << "cluster::errc::transform_invalid_update";
+    case errc::transform_invalid_create:
+        return o << "cluster::errc::transform_invalid_create";
+    case errc::transform_invalid_source:
+        return o << "cluster::errc::transform_invalid_source";
+    case errc::transform_invalid_environment:
+        return o << "cluster::errc::transform_invalid_environment";
+    case errc::trackable_keys_limit_exceeded:
+        return o << "cluster::errc::trackable_keys_limit_exceeded";
+    case errc::topic_disabled:
+        return o << "cluster::errc::topic_disabled";
+    case errc::partition_disabled:
+        return o << "cluster::errc::partition_disabled";
+    case errc::invalid_partition_operation:
+        return o << "cluster::errc::invalid_partition_operation";
+    case errc::concurrent_modification_error:
+        return o << "cluster::errc::concurrent_modification_error";
+    case errc::transform_count_limit_exceeded:
+        return o << "cluster::errc::transform_count_limit_exceeded";
+    case errc::role_exists:
+        return o << "cluster::errc::role_exists";
+    case errc::role_does_not_exist:
+        return o << "cluster::errc::role_does_not_exist";
+    case errc::inconsistent_stm_update:
+        return o << "cluster::errc::inconsistent_stm_update";
+    case errc::waiting_for_shard_placement_update:
+        return o << "cluster::errc::waiting_for_shard_placement_update";
+    case errc::topic_invalid_partitions_core_limit:
+        return o << "cluster::errc::topic_invalid_partitions_core_limit";
+    case errc::topic_invalid_partitions_memory_limit:
+        return o << "cluster::errc::topic_invalid_partitions_memory_limit";
+    case errc::topic_invalid_partitions_fd_limit:
+        return o << "cluster::errc::topic_invalid_partitions_fd_limit";
+    case errc::topic_invalid_partitions_decreased:
+        return o << "cluster::errc::topic_invalid_partitions_decreased";
+    case errc::producer_ids_vcluster_limit_exceeded:
+        return o << "cluster::errc::producer_ids_vcluster_limit_exceeded";
+    case errc::validation_of_recovery_topic_failed:
+        return o << "cluster::errc::validation_of_recovery_topic_failed";
+    }
+}
+} // namespace cluster

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -359,6 +359,9 @@ bool producer_state::update(
     if (_evicted) {
         return false;
     }
+    if (!bid.is_transactional && bid.pid.epoch > _id.epoch) {
+        reset_with_new_epoch(model::producer_epoch{bid.pid.epoch});
+    }
     bool relink_producer = _requests.stm_apply(bid, offset);
     vlog(
       clusterlog.trace,

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -311,6 +311,17 @@ bool producer_state::can_evict() {
     return true;
 }
 
+void producer_state::reset_with_new_epoch(model::producer_epoch new_epoch) {
+    vassert(
+      new_epoch > _id.get_epoch(),
+      "Invalid epoch bump to {} for producer {}",
+      new_epoch,
+      *this);
+    vlog(clusterlog.info, "[{}] Reseting epoch to {}", *this, new_epoch);
+    _requests.reset(errc::timeout);
+    _id = model::producer_identity(_id.id, new_epoch);
+}
+
 result<request_ptr> producer_state::try_emplace_request(
   const model::batch_identity& bid, model::term_id current_term, bool reset) {
     if (bid.first_seq > bid.last_seq) {

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -130,6 +130,7 @@ private:
       static_cast<unsigned long>(requests_cached_max));
     bool is_valid_sequence(seq_t incoming) const;
     std::optional<request_ptr> last_request() const;
+    void reset(request_result_t::error_type);
     ss::chunked_fifo<request_ptr, chunk_size> _inflight_requests;
     ss::chunked_fifo<request_ptr, chunk_size> _finished_requests;
     friend producer_state;

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -209,6 +209,17 @@ public:
     void update_current_txn_start_offset(std::optional<kafka::offset> offset) {
         _current_txn_start_offset = offset;
     }
+
+    model::producer_identity id() const { return _id; }
+
+    // Resets the producer to use a new epoch. The new epoch should be strictly
+    // larger than the current epoch. This is only used by the idempotent
+    // producers trying to bump epoch of the existing producer based on the
+    // incoming request with a higher epoch. Transactions follow a separate
+    // fencing based approach to bump epochs as it requires aborting any in
+    // progress transactions with older epoch.
+    void reset_with_new_epoch(model::producer_epoch new_epoch);
+
     safe_intrusive_list_hook _hook;
 
 private:

--- a/src/v/cluster/producer_state_manager.cc
+++ b/src/v/cluster/producer_state_manager.cc
@@ -25,9 +25,9 @@ namespace cluster {
 
 producer_state_manager::producer_state_manager(
   config::binding<uint64_t> max_producer_ids,
-  std::chrono::milliseconds producer_expiration_ms,
+  config::binding<std::chrono::milliseconds> producer_expiration_ms,
   config::binding<size_t> virtual_cluster_min_producer_ids)
-  : _producer_expiration_ms(producer_expiration_ms)
+  : _producer_expiration_ms(std::move(producer_expiration_ms))
   , _max_ids(std::move(max_producer_ids))
   , _virtual_cluster_min_producer_ids(
       std::move(virtual_cluster_min_producer_ids))
@@ -95,7 +95,7 @@ void producer_state_manager::touch(
 }
 void producer_state_manager::evict_excess_producers() {
     _cache.evict_older_than<ss::lowres_system_clock>(
-      ss::lowres_system_clock::now() - _producer_expiration_ms);
+      ss::lowres_system_clock::now() - _producer_expiration_ms());
     if (!_gate.is_closed()) {
         _reaper.arm(period);
     }

--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -25,7 +25,7 @@ public:
     explicit producer_state_manager(
 
       config::binding<uint64_t> max_producer_ids,
-      std::chrono::milliseconds producer_expiration_ms,
+      config::binding<std::chrono::milliseconds> producer_expiration_ms,
       config::binding<size_t> virtual_cluster_min_producer_ids);
 
     ss::future<> start();
@@ -75,7 +75,7 @@ private:
     void evict_excess_producers();
     size_t _eviction_counter = 0;
     // if a producer is inactive for this long, it will be gc-ed
-    std::chrono::milliseconds _producer_expiration_ms;
+    config::binding<std::chrono::milliseconds> _producer_expiration_ms;
     // maximum number of active producers allowed on this shard across
     // all partitions. When exceeded, producers are evicted on an
     // LRU basis.

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1179,6 +1179,10 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued,
   ssx::semaphore_units& units) {
+    // Check if the producer bumped the epoch and reset accordingly.
+    if (bid.pid.epoch > producer->id().epoch) {
+        producer->reset_with_new_epoch(model::producer_epoch{bid.pid.epoch});
+    }
     auto request = producer->try_emplace_request(bid, synced_term);
     if (!request) {
         co_return request.error();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -273,7 +273,12 @@ private:
     ss::future<> do_remove_persistent_state();
     ss::future<fragmented_vector<rm_stm::tx_range>>
       do_aborted_transactions(model::offset, model::offset);
-    producer_ptr maybe_create_producer(model::producer_identity);
+    // Tells whether the producer is already known or is created
+    // for the first time from the incoming request.
+    using producer_previously_known
+      = ss::bool_class<struct new_producer_created_tag>;
+    std::pair<producer_ptr, producer_previously_known>
+      maybe_create_producer(model::producer_identity);
     void cleanup_producer_state(model::producer_identity);
     ss::future<> reset_producers();
     model::record_batch make_fence_batch(
@@ -333,7 +338,8 @@ private:
       model::record_batch_reader,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>,
-      ssx::semaphore_units&);
+      ssx::semaphore_units&,
+      producer_previously_known);
 
     ss::future<result<kafka_result>> do_sync_and_idempotent_replicate(
       producer_ptr,
@@ -341,7 +347,8 @@ private:
       model::record_batch_reader,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>,
-      ssx::semaphore_units);
+      ssx::semaphore_units,
+      producer_previously_known);
 
     ss::future<result<kafka_result>> replicate_msg(
       model::record_batch_reader,

--- a/src/v/cluster/tests/producer_state_tests.cc
+++ b/src/v/cluster/tests/producer_state_tests.cc
@@ -52,7 +52,7 @@ struct test_fixture {
       size_t max_producers, size_t min_producers_per_vcluster) {
         _psm = std::make_unique<cluster::producer_state_manager>(
           config::mock_binding<size_t>(max_producers),
-          std::chrono::milliseconds::max(),
+          config::mock_binding(std::chrono::milliseconds::max()),
           config::mock_binding<size_t>(min_producers_per_vcluster));
         _psm->start().get();
         validate_producer_count(0);

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -23,7 +23,7 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         producer_state_manager
           .start(
             config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            std::chrono::milliseconds::max(),
+            config::mock_binding(std::chrono::milliseconds::max()),
             config::mock_binding(std::numeric_limits<uint64_t>::max()))
           .get();
         producer_state_manager

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3135,7 +3135,7 @@ void tx_gateway_frontend::expire_old_txs() {
           model::tx_manager_nt);
         if (!ntp_meta) {
             vlog(
-              txlog.error,
+              txlog.debug,
               "Topic {} doesn't exist in metadata cache,",
               model::tx_manager_nt);
             return ss::now();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1452,7 +1452,10 @@ void application::wire_up_redpanda_services(
       ss::sharded_parameter([]() {
           return config::shard_local_cfg().max_concurrent_producer_ids.bind();
       }),
-      config::shard_local_cfg().transactional_id_expiration_ms.value(),
+      ss::sharded_parameter([]() {
+          return config::shard_local_cfg()
+            .transactional_id_expiration_ms.bind();
+      }),
       ss::sharded_parameter([]() {
           return config::shard_local_cfg()
             .virtual_cluster_min_producer_ids.bind();

--- a/tests/java/verifiers/pom.xml
+++ b/tests/java/verifiers/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>kafka-clients</artifactId>
             <version>3.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${buildDir}</directory>

--- a/tests/java/verifiers/src/main/java/idempotency/App.java
+++ b/tests/java/verifiers/src/main/java/idempotency/App.java
@@ -1,0 +1,189 @@
+package io.vectorized.idempotency;
+
+import static spark.Spark.*;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.lang.String;
+import java.lang.Thread;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.Semaphore;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import spark.*;
+
+// A simple pausable idempotent producer for sanity testing a Java based
+// producer from ducktape. This is a not a verfier but rather a simple pausable
+// load generating utility that can start, pause and resume a single idempotency
+// session using a single producer on demand.
+//
+//  Supported REST APIs
+//  - /start-producer - start a new or resume existing idempotent producer
+//  session
+//  - /pause-producer - pauses the producer
+//  - /stop-producer  - stops the producer
+public class App {
+
+  static Logger logger = Logger.getLogger(App.class);
+
+  static void setupLogging() {
+    org.apache.log4j.BasicConfigurator.configure();
+    Logger.getRootLogger().setLevel(Level.WARN);
+    Logger.getLogger("io.vectorized").setLevel(Level.DEBUG);
+    Logger.getLogger("org.apache.kafka").setLevel(Level.DEBUG);
+  }
+
+  public static class Params {
+    public String brokers;
+    public String topic;
+    public long partitions;
+  }
+
+  public static class Progress {
+    public long num_produced;
+  };
+
+  static Producer<String, String> createIdempotentProducer(String brokers) {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+    props.put(ProducerConfig.ACKS_CONFIG, "all");
+    props.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringSerializer");
+    props.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringSerializer");
+    props.put(ProducerConfig.LINGER_MS_CONFIG, 0);
+    props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+    props.put(ProducerConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
+    props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    return new KafkaProducer<String, String>(props);
+  }
+
+  public static class JsonTransformer implements ResponseTransformer {
+    private Gson gson = new Gson();
+
+    @Override
+    public String render(Object model) {
+      return gson.toJson(model);
+    }
+  }
+
+  volatile Params params = null;
+  volatile Thread produceThread = null;
+  volatile Semaphore sem = new Semaphore(1, true);
+  volatile boolean started = false;
+  volatile boolean stopped = false;
+  volatile Exception ex = null;
+  volatile long counter = 0;
+
+  void produceLoop() {
+    var random = new Random();
+    Producer<String, String> idempotentProducer
+        = createIdempotentProducer(this.params.brokers);
+    while (!stopped) {
+      try {
+        sem.acquire();
+        long partition
+            = random.longs(0, this.params.partitions).findFirst().getAsLong();
+        String kv = Long.toString(counter);
+        ProducerRecord<String, String> record
+            = new ProducerRecord<>(this.params.topic, kv, kv);
+        idempotentProducer.send(record).get();
+      } catch (Exception e) {
+        ex = e;
+        logger.error("Exception in produce loop: ", e);
+      } finally {
+        sem.release();
+      }
+      counter++;
+    }
+    idempotentProducer.close();
+  }
+
+  void run() throws Exception {
+
+    port(8080);
+
+    get("/ping", (req, res) -> {
+      res.status(200);
+      return "";
+    });
+
+    get("/progress", (req, res) -> {
+      Progress progress = new Progress();
+      progress.num_produced = counter;
+      return progress;
+    }, new JsonTransformer());
+
+    post("/start-producer", (req, res) -> {
+      if (this.started && !this.stopped) {
+        logger.info("Producer already started. unpausing it.");
+        if (this.sem.availablePermits() == 0) {
+          this.sem.release();
+        }
+        res.status(200);
+        return "";
+      }
+      logger.info("Starting producer");
+      try {
+        this.params = (new Gson()).fromJson(req.body(), Params.class);
+        this.produceThread = new Thread(() -> { this.produceLoop(); });
+        this.produceThread.start();
+
+      } catch (Exception e) {
+        logger.error("Exception starting produce thread ", e);
+        throw e;
+      }
+      this.started = true;
+      this.stopped = false;
+      res.status(200);
+      return "";
+    });
+
+    post("/pause-producer", (req, res) -> {
+      if (!this.started) {
+        logger.info("Pause failed, not started.");
+        res.status(500);
+        return "";
+      }
+      logger.info("Pausing producer");
+      this.sem.acquire();
+      res.status(200);
+      return "";
+    });
+
+    post("/stop-producer", (req, res) -> {
+      logger.info("Stopping producer");
+      this.stopped = true;
+      if (this.sem.availablePermits() == 0) {
+        this.sem.release();
+      }
+      try {
+        if (produceThread != null) {
+          produceThread.join();
+        }
+      } catch (Exception e) {
+        logger.error("Exception stopping producer", e);
+        throw e;
+      }
+
+      if (ex != null) {
+        System.exit(1);
+      }
+
+      res.status(200);
+      return "";
+    });
+  }
+
+  public static void main(String[] args) throws Exception {
+    setupLogging();
+    new App().run();
+  }
+}

--- a/tests/rptest/services/idempotency_load_generator.py
+++ b/tests/rptest/services/idempotency_load_generator.py
@@ -1,0 +1,147 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.services.service import Service
+from rptest.util import wait_until
+import requests
+import sys
+
+OUTPUT_LOG = "/opt/remote/var/pausable_idempotent_producer.log"
+
+
+class IdempotencyClientFailure(Exception):
+    pass
+
+
+class PausableIdempotentProducer(Service):
+    logs = {
+        "pausable_idempotent_producer_stdout_stderr": {
+            "path": OUTPUT_LOG,
+            "collect_default": True
+        }
+    }
+
+    def __init__(self, context, redpanda):
+        super(PausableIdempotentProducer, self).__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+
+    def is_alive(self, node):
+        result = node.account.ssh_output(
+            "bash /opt/remote/control/alive.sh pausable_idempotent_producer")
+        result = result.decode("utf-8")
+        return "YES" in result
+
+    def is_ready(self):
+        try:
+            self.remote_ping()
+            return True
+        except requests.exceptions.ConnectionError:
+            return False
+
+    def raise_on_violation(self, node):
+        self.logger.info(
+            f"Scanning node {node.account.hostname} log for violations...")
+
+        for line in node.account.ssh_capture(
+                f"grep -e Exception {OUTPUT_LOG} || true"):
+            raise IdempotencyClientFailure(line)
+
+    def start_node(self, node, timeout_sec=10):
+        node.account.ssh(
+            f"bash /opt/remote/control/start.sh pausable_idempotent_producer \"java -cp /opt/verifiers/verifiers.jar io.vectorized.idempotency.App\""
+        )
+        wait_until(
+            lambda: self.is_alive(node),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to start within {timeout_sec} sec",
+            retry_on_exc=False)
+        self._node = node
+        wait_until(
+            lambda: self.is_ready(),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to become ready within {timeout_sec} sec",
+            retry_on_exc=False)
+
+    def stop_node(self, node):
+        node.account.ssh(
+            "bash /opt/remote/control/stop.sh pausable_idempotent_producer")
+        self.raise_on_violation(node)
+
+    def clean_node(self, node):
+        pass
+
+    def wait_node(self, node, timeout_sec=sys.maxsize):
+        wait_until(
+            lambda: not (self.is_alive(node)),
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {node.account.hostname} failed to stop within {timeout_sec} sec",
+            retry_on_exc=False)
+        return True
+
+    def remote_ping(self):
+        ip = self._node.account.hostname
+        r = requests.get(f"http://{ip}:8080/ping")
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def start_producer(self, topic, partitions):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/start-producer",
+                          json={
+                              "brokers": self._redpanda.brokers(),
+                              "topic": topic,
+                              "partitions": partitions,
+                          })
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )
+
+    def get_progress(self):
+        ip = self._node.account.hostname
+        return requests.get(f"http://{ip}:8080/progress")
+
+    def ensure_progress(self, expected=1000, timeout_sec=10):
+        def check_progress():
+            r = self.get_progress()
+            if r.status_code != 200:
+                return False
+            output = r.json()
+            self._redpanda.logger.debug(f"progress response: {output}")
+            return output["num_produced"] >= expected
+
+        wait_until(
+            check_progress,
+            timeout_sec=timeout_sec,
+            backoff_sec=1,
+            err_msg=
+            f"pausable_idempotent_producer service {self._node.account.hostname} failed to make progress in {timeout_sec} sec",
+            retry_on_exc=False)
+
+    def pause_producer(self):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/pause-producer")
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )
+
+    def stop_producer(self):
+        ip = self._node.account.hostname
+        r = requests.post(f"http://{ip}:8080/stop-producer")
+        if r.status_code != 200:
+            raise Exception(
+                f"unexpected status code: {r.status_code} content: {r.content}"
+            )

--- a/tests/rptest/tests/idempotency_recovery_test.py
+++ b/tests/rptest/tests/idempotency_recovery_test.py
@@ -1,0 +1,146 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from collections import defaultdict
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.idempotency_load_generator import PausableIdempotentProducer
+from time import sleep
+from rptest.util import wait_until
+import confluent_kafka as ck
+
+
+class IdempotentProducerRecoveryTest(RedpandaTest):
+    """This test ensures that various client implementations can recover
+    from scenario in which the producers get evicted on the brokers.
+    When a producer is evicted it loses all old state including the
+    sequence numbers. So the client attempting to produce after that
+    should still recover and be able to make progress. There are subtle
+    variations among client implementations around how they deal
+    with this situation, so this test acts a regression test ensuring that we
+    do not break this behavior."""
+    def __init__(self, test_context):
+        super(IdempotentProducerRecoveryTest,
+              self).__init__(test_context=test_context, num_brokers=1)
+        self.test_topic = TopicSpec(name="test",
+                                    partition_count=1,
+                                    replication_factor=1)
+
+    def wait_for_eviction(self, active_producers_remaining,
+                          expected_to_be_evicted):
+        def do_wait():
+            samples = [
+                "idempotency_pid_cache_size",
+                "producer_state_manager_evicted_producers"
+            ]
+            brokers = self.redpanda.started_nodes()
+            metrics = self.redpanda.metrics_samples(samples, brokers)
+            producers_per_node = defaultdict(int)
+            evicted_per_node = defaultdict(int)
+            for pattern, metric in metrics.items():
+                for m in metric.samples:
+                    id = self.redpanda.node_id(m.node)
+                    if pattern == "idempotency_pid_cache_size":
+                        producers_per_node[id] += int(m.value)
+                    elif pattern == "producer_state_manager_evicted_producers":
+                        evicted_per_node[id] += int(m.value)
+
+            self.redpanda.logger.debug(
+                f"active producers: {producers_per_node}")
+            self.redpanda.logger.debug(
+                f"evicted producers: {evicted_per_node}")
+
+            remaining_match = all([
+                num == active_producers_remaining
+                for num in producers_per_node.values()
+            ])
+
+            evicted_match = all([
+                val == expected_to_be_evicted
+                for val in evicted_per_node.values()
+            ])
+
+            return len(producers_per_node) == len(
+                brokers) and remaining_match and evicted_match
+
+        wait_until(do_wait,
+                   timeout_sec=20,
+                   backoff_sec=1,
+                   err_msg=f"Not all producers were evicted in 20secs.",
+                   retry_on_exc=False)
+
+    @cluster(num_nodes=2)
+    def test_java_client_recovery_on_producer_eviction(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.test_topic.name, self.test_topic.partition_count,
+                         self.test_topic.replication_factor)
+
+        workload_svc = PausableIdempotentProducer(self.test_context,
+                                                  self.redpanda)
+        workload_svc.start()
+
+        workload_svc.start_producer(self.test_topic.name,
+                                    self.test_topic.partition_count)
+        # Generate some load
+        workload_svc.ensure_progress(expected=1000, timeout_sec=20)
+
+        # Pause the producer to evict the producer sessions
+        workload_svc.pause_producer()
+
+        progress_so_far = workload_svc.get_progress().json()["num_produced"]
+
+        # Evict all producers
+        rpk.cluster_config_set("transactional_id_expiration_ms", 0)
+        self.wait_for_eviction(active_producers_remaining=0,
+                               expected_to_be_evicted=1)
+        rpk.cluster_config_set("transactional_id_expiration_ms", 3600000)
+
+        # Resume the idempotency session again.
+        workload_svc.start_producer(self.test_topic.name,
+                                    self.test_topic.partition_count)
+
+        workload_svc.ensure_progress(expected=progress_so_far + 1000,
+                                     timeout_sec=20)
+        # Verify the producer can make progress without exceptions
+        workload_svc.stop_producer()
+
+    @cluster(num_nodes=1)
+    def test_librdkafka_recovery_on_producer_eviction(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.test_topic.name, self.test_topic.partition_count,
+                         self.test_topic.replication_factor)
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'enable.idempotence': True,
+        })
+
+        def produce_some():
+            def on_delivery(err, _):
+                assert err is None, err
+
+            for i in range(1000):
+                producer.produce(self.test_topic.name,
+                                 str(i),
+                                 str(i),
+                                 on_delivery=on_delivery)
+            producer.flush()
+
+        produce_some()
+
+        # Evict all producers
+        rpk.cluster_config_set("transactional_id_expiration_ms", 0)
+        self.wait_for_eviction(active_producers_remaining=0,
+                               expected_to_be_evicted=1)
+        rpk.cluster_config_set("transactional_id_expiration_ms", 3600000)
+
+        # Ensure producer can recover.
+        produce_some()

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -868,14 +868,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                    backoff_sec=2,
                    err_msg="Producers not evicted in time")
 
-        try:
-            _produce_one(producers[0], 0)
-            assert False, "We can not produce after cleaning in rm_stm"
-        except ck.cimpl.KafkaException as e:
-            kafka_error = e.args[0]
-            kafka_error.code(
-            ) == ck.cimpl.KafkaError.OUT_OF_ORDER_SEQUENCE_NUMBER
-
         # validate that the producers are evicted with LRU policy,
         # starting from this producer there should be no sequence
         # number errors as those producer state should not be evicted


### PR DESCRIPTION
Two main changes in this patch

* Broker can now handle epoch bumps for idempotent producers. A client can independently bump the producer epoch in certain situations (check kip-360 and related code) as idempotency only pertains to the single session. The broker code had issues handling epoch bumps which is fixed.

* For evicted producer state on the broker (eg: log prefix truncation, producer expiration etc), there are subtle differences among clients around how they handle the producer reset scenario. Java client, for example bumps the epoch on OOOSN and if there are no other requests in flight while librdkafka is pretty strict and only does it on UNKNOWN_PRODUCER_ID error code (which explicitly tells the client that the broker has no state for the producer and it should reset). Changed the code to what Apache Kafka does, upon encountering an unknown producer id, any sequence number is accepted to make forward progress because the only way a broker doesn't know about the producer is when it got evicted from memory, doesn't seem fool proof but consistent with AK behavior and more importantly works with all the client implementations.

Fixes https://github.com/redpanda-data/redpanda/issues/22754
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
