### PR TITLE
Tests logging improments

### DIFF
--- a/src/v/storage/logger.cc
+++ b/src/v/storage/logger.cc
@@ -13,4 +13,5 @@ namespace storage {
 ss::logger stlog("storage");
 ss::logger gclog("storage-gc");
 ss::logger finjectlog("finject");
+ss::logger rslog("storage-resources");
 } // namespace storage

--- a/src/v/storage/logger.h
+++ b/src/v/storage/logger.h
@@ -19,4 +19,5 @@ namespace storage {
 extern ss::logger stlog;
 extern ss::logger gclog;
 extern ss::logger finjectlog;
+extern ss::logger rslog;
 } // namespace storage

--- a/src/v/storage/storage_resources.cc
+++ b/src/v/storage/storage_resources.cc
@@ -161,7 +161,7 @@ size_t storage_resources::calc_falloc_step() {
     }
 
     vlog(
-      stlog.debug,
+      rslog.debug,
       "calc_falloc_step: step {} (max {})",
       step,
       _segment_fallocation_step());
@@ -193,7 +193,7 @@ storage_resources::get_falloc_step(std::optional<uint64_t> segment_size_hint) {
 bool storage_resources::offset_translator_take_bytes(
   int32_t bytes, ssx::semaphore_units& units) {
     vlog(
-      stlog.trace,
+      rslog.trace,
       "offset_translator_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
@@ -206,7 +206,7 @@ bool storage_resources::offset_translator_take_bytes(
 bool storage_resources::configuration_manager_take_bytes(
   size_t bytes, ssx::semaphore_units& units) {
     vlog(
-      stlog.trace,
+      rslog.trace,
       "configuration_manager_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
@@ -219,7 +219,7 @@ bool storage_resources::configuration_manager_take_bytes(
 bool storage_resources::stm_take_bytes(
   size_t bytes, ssx::semaphore_units& units) {
     vlog(
-      stlog.trace,
+      rslog.trace,
       "stm_take_bytes {} += {} (current {})",
       units.count(),
       bytes,
@@ -243,7 +243,7 @@ bool storage_resources::filter_checkpoints(
 adjustable_semaphore::take_result
 storage_resources::compaction_index_take_bytes(size_t bytes) {
     vlog(
-      stlog.trace,
+      rslog.trace,
       "compaction_index_take_bytes {} (current {})",
       bytes,
       _compaction_index_bytes.current());

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2448,11 +2448,13 @@ class RedpandaService(RedpandaServiceBase):
                     self.LOG_LEVEL_KEY, self.DEFAULT_LOG_LEVEL)
             else:
                 self._log_level = log_level
-            self._log_config = LoggingConfig(self._log_level, {
-                'exception': 'debug',
-                'io': 'debug',
-                'seastar_memory': 'debug'
-            })
+            self._log_config = LoggingConfig(
+                self._log_level, {
+                    'exception': 'debug',
+                    'io': 'debug',
+                    'seastar_memory': 'debug',
+                    'dns_resolver': 'info'
+                })
 
         self._started: Set[ClusterNode] = set()
 


### PR DESCRIPTION
Storage resource manager logs are very verbose. Added separate logger for the resource manager logging to be able to mute the logs while preserving other relevant log messages.

Muted `dns_resolver` and `storage-resources` loggers in tests.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none