### PR TITLE
rptest: reduce cache eviction throttling for space leak test

### DIFF
--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -59,6 +59,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
             'segment_fallocation_step': 0x1000,
             'retention_local_target_bytes_default': self._segment_size,
             'retention_bytes': self._segment_size * 5,
+            'cloud_storage_cache_check_interval': 500,
         }
         super().__init__(test_context,
                          num_brokers=3,


### PR DESCRIPTION
This test is too slow with default configuration making the test flaky. Instead of raising the timeouts I'm trying to reduce the cache eviction throttling which makes the test 3x faster.

The test became flaky after in-memory trim was introduced in https://github.com/redpanda-data/redpanda/pull/21556.

The main insight was provided by https://github.com/abhijat in a private exchange:

> I think it might be the extra throttling. With the carry over
> disabled, we always have to do a trim when reserving space, which
> results in a lot more throttling and sleep:
>
> ```
> $ grep -Ri "Cache trimming throttled" * | grep -c cache
> 139
> ```
>
> With the carryover list in place, about half of the calls to reserve
> space end up in an early return because the list provides enough room
> to clear up space, which does not cause the trimming to be throttled
> as much:
>
> ```
> $ grep -Ri "Cache trimming throttled" * | grep -c cache
> 63
> ```
>
> Although that doesn't explain how this test used to work before, IIRC
> carryover is a fairly new feature

Fixes https://github.com/redpanda-data/redpanda/issues/21597

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
