### PR TITLE
CORE-6824 Schema Registry/Proto: add 5 missing checks

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -499,6 +499,13 @@ struct compatibility_checker {
             }
         }
 
+        for (int i = 0; i < reader->real_oneof_decl_count(); ++i) {
+            auto r = reader->oneof_decl(i);
+            if (!check_compatible(r, writer)) {
+                return false;
+            }
+        }
+
         // check writer fields
         for (int i = 0; i < writer->field_count(); ++i) {
             auto w = writer->field(i);
@@ -523,6 +530,19 @@ struct compatibility_checker {
             }
         }
         return true;
+    }
+
+    bool check_compatible(
+      const pb::OneofDescriptor* reader, const pb::Descriptor* writer) {
+        size_t count = 0;
+        for (int i = 0; i < reader->field_count(); ++i) {
+            auto r = reader->field(i);
+            auto w = writer->FindFieldByNumber(r->number());
+            if (w && !w->real_containing_oneof()) {
+                ++count;
+            }
+        }
+        return count <= 1;
     }
 
     bool check_compatible(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -490,6 +490,15 @@ struct compatibility_checker {
         if (!_seen_descriptors.insert(reader).second) {
             return true;
         }
+
+        for (int i = 0; i < writer->nested_type_count(); ++i) {
+            auto w = writer->nested_type(i);
+            auto r = reader->FindNestedTypeByName(w->full_name());
+            if (!r || !check_compatible(r, w)) {
+                return false;
+            }
+        }
+
         for (int i = 0; i < writer->field_count(); ++i) {
             if (reader->IsReservedNumber(i) || writer->IsReservedNumber(i)) {
                 continue;

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -522,9 +522,16 @@ struct compatibility_checker {
                                     == pb::FieldDescriptor::Type::TYPE_MESSAGE
                                   || reader->type()
                                        == pb::FieldDescriptor::Type::TYPE_GROUP;
-            return type_is_compat
-                   && check_compatible(
-                     reader->message_type(), writer->message_type());
+
+            if (
+              !type_is_compat
+              || reader->message_type()->name()
+                   != writer->message_type()->name()) {
+                return false;
+            } else {
+                return check_compatible(
+                  reader->message_type(), writer->message_type());
+            }
         }
         case pb::FieldDescriptor::Type::TYPE_FLOAT:
         case pb::FieldDescriptor::Type::TYPE_DOUBLE:

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -677,3 +677,10 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_message_removed) {
       R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; Inner x = 1; })",
       R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner x = 1; })"));
 }
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_field_name_type_changed) {
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner2 x = 1; })",
+      R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner  x = 1; })"));
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -670,3 +670,10 @@ message Bar {
 }
 )");
 }
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_message_removed) {
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; Inner x = 1; })",
+      R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner x = 1; })"));
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -744,3 +744,17 @@ SEASTAR_THREAD_TEST_CASE(
       R"(syntax = "proto3"; message Simple { int32 id = 1; int32 new_id = 2; })",
       R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } })"));
 }
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_oneof_field_removed) {
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; } })",
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_oneof_fully_removed) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Simple { int32 other = 3; })",
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } int32 other = 3; })"));
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -684,3 +684,43 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_field_name_type_changed) {
       R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner2 x = 1; })",
       R"(syntax = "proto3"; message Outer { message Inner { int32 id = 1;}; message Inner2 { int32 id = 1;}; Inner  x = 1; })"));
 }
+
+SEASTAR_THREAD_TEST_CASE(
+  test_protobuf_compatibility_required_field_added_removed) {
+    // field added
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; required int32 new_id = 2; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; })"));
+    // field removed
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; required int32 new_id = 2; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_field_made_reserved) {
+    // required
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; reserved 2; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; required int32 new_id = 2; })"));
+    // not required
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; reserved 2; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; optional int32 new_id = 2; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_field_unmade_reserved) {
+    // required
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; required int32 new_id = 2; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; reserved 2; })"));
+    // not required
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; optional int32 new_id = 2; })",
+      R"(syntax = "proto2"; message Simple { optional int32 id = 1; reserved 2; })"));
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -724,3 +724,23 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_field_unmade_reserved) {
       R"(syntax = "proto2"; message Simple { optional int32 id = 1; optional int32 new_id = 2; })",
       R"(syntax = "proto2"; message Simple { optional int32 id = 1; reserved 2; })"));
 }
+
+SEASTAR_THREAD_TEST_CASE(
+  test_protobuf_compatibility_multiple_fields_moved_to_oneof) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; } })",
+      R"(syntax = "proto3"; message Simple { int32 id = 1; })"));
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } })",
+      R"(syntax = "proto3"; message Simple { int32 id = 1; int32 new_id = 2; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(
+  test_protobuf_compatibility_fields_moved_out_of_oneof) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Simple { int32 id = 1; int32 new_id = 2; })",
+      R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } })"));
+}


### PR DESCRIPTION
This implements 5 new compatibility checks for protobuf:
* ONEOF_FIELD_REMOVED
* MULTIPLE_FIELDS_MOVED_TO_ONEOF
* REQUIRED_FIELD_{ADDED,REMOVED}
* FIELD_NAMED_TYPE_CHANGED
* MESSAGE_REMOVED

This gap was discovered and initially implemented on @oleiman's draft PR (https://github.com/redpanda-data/redpanda/pull/18332) aiming to add support for verbose logging. This PR extracts the changes of adding these new compatibility checks to make the review easier. Some unit tests are also added.

Fixes https://redpandadata.atlassian.net/browse/CORE-6824

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Improvements
* Schema Registry: 5 new compatibility checks are added for protobuf (ONEOF_FIELD_REMOVED, MULTIPLE_FIELDS_MOVED_TO_ONEOF, REQUIRED_FIELD_{ADDED,REMOVED}, FIELD_NAMED_TYPE_CHANGED, MESSAGE_REMOVED)

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
