### PR TITLE
pp/sr/proto: disable unused alias warning

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
@@ -29,6 +29,9 @@ v_cc_library(
   DEPS protobuf::libprotobuf
 )
 
+# Disable clang tidy
+set_target_properties(v_pandaproxy_schema_registry_protobuf  PROPERTIES CXX_CLANG_TIDY "")
+
 target_include_directories(v_pandaproxy_schema_registry_protobuf
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
The latest version of protobuf has some unused aliases, disable the
warning because we don't control the output of protoc.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
