### PR TITLE
datalake: support newer protobuf versions

### DIFF
--- a/src/v/datalake/protobuf_to_arrow_converter.h
+++ b/src/v/datalake/protobuf_to_arrow_converter.h
@@ -22,12 +22,18 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 
 namespace datalake {
 
 struct error_collector : ::google::protobuf::io::ErrorCollector {
+#if PROTOBUF_VERSION < 5027000
     void AddError(int line, int column, const std::string& message) override;
     void AddWarning(int line, int column, const std::string& message) override;
+#else
+    void RecordError(int line, int column, std::string_view message) override;
+    void RecordWarning(int line, int column, std::string_view message) override;
+#endif
 };
 
 /** Top-level interface for parsing Protobuf messages to an Arrow table


### PR DESCRIPTION
See: #22777

This is needed so we can upgrade protobuf in vtools

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
