### PR TITLE
CORE-6835 Fix first time compacted segment upload

### DIFF
--- a/src/v/cluster/archival/archival_policy.cc
+++ b/src/v/cluster/archival/archival_policy.cc
@@ -185,17 +185,19 @@ archival_policy::lookup_result archival_policy::find_segment(
     const auto& set = log->segments();
     const auto& ntp_conf = log->config();
     auto it = set.lower_bound(start_offset);
-    if (it == set.end() || eligible_for_compacted_reupload(**it)) {
-        // Skip forward if we hit a gap or compacted segment
-        for (auto i = set.begin(); i != set.end(); i++) {
-            const auto& sg = *i;
-            if (start_offset < sg->offsets().get_base_offset()) {
-                // Move last offset forward
-                it = i;
-                start_offset = sg->offsets().get_base_offset();
-                break;
-            }
-        }
+    if (it == set.end() && start_offset < log->offsets().committed_offset) {
+        // The 'start_offset' is in the gap. Normally this shouldn't happen.
+        vlog(
+          archival_log.warn,
+          "Upload policy for {}: can't find segment with base_offset={}",
+          _ntp,
+          start_offset);
+        it = std::find_if(
+          set.begin(),
+          set.end(),
+          [start_offset](const ss::lw_shared_ptr<storage::segment>& s) {
+              return s->offsets().get_base_offset() >= start_offset;
+          });
     }
     if (it == set.end()) {
         vlog(

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -963,11 +963,10 @@ FIXTURE_TEST(
                          .get())
                        .candidate;
 
-    // The search is expected to find the next segment after the compacted
-    // segment, skipping the compacted one.
+    // The search is expected to find first compacted segment
     BOOST_REQUIRE(!candidate.sources.empty());
-    BOOST_REQUIRE_GT(candidate.starting_offset(), 0);
-    BOOST_REQUIRE_GT(
+    BOOST_REQUIRE_EQUAL(candidate.starting_offset(), 0);
+    BOOST_REQUIRE_EQUAL(
       candidate.sources.front()->offsets().get_base_offset(), model::offset{0});
 }
 


### PR DESCRIPTION
This PR fixes the issue which manifests if the TS is enabled for pre-existing compacted topic. Normally, the TS prevents compaction from compacting any offset range which is not uploaded to the cloud storage yet. Our upload path always deals with non-compacted data without gaps. The only exception is when the compaction is enabled for existing compacted topic. In this case the data is already compacted but has to be uploaded to the cloud storage anyway. And the upload is performed by the normal upload path (not compacted reupload).

The problem is that there is a bug in the `archival_policy::find_segment` which makes it skip compacted segment. If the segment that the policy have found is compacted it just increments the iterator once and creates a gap. The segment can't be added to the archival STM. `New segment does not line up with previous segment` error is added to the log and the operation is retried later. The uploads for the topic can't progress.

This PR fixes the bug and adds a ducktape test that reproduces the problem.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix `New segment does not line up with previous segment` error for compacted topics.