### PR TITLE
application: print command line

### DIFF
--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -62,6 +62,7 @@ redpanda_cc_library(
         "//src/v/wasm",
         "@abseil-cpp//absl/log:globals",
         "@boost//:program_options",
+        "@fmt",
         "@protobuf",
         "@protobuf//:protobuf_lite",
         "@seastar",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -148,6 +148,7 @@
 #include <seastar/util/log.hh>
 
 #include <absl/log/globals.h>
+#include <fmt/format.h>
 #if __has_include(<google/protobuf/runtime_version.h>)
 #include <google/protobuf/runtime_version.h>
 #endif
@@ -430,8 +431,12 @@ int application::run(int ac, char** av) {
     // use endl for explicit flushing
     std::cout << community_msg << std::endl;
 
-    return app.run(ac, av, [this, &app] {
+    std::string cmd_line = fmt::to_string(
+      fmt::join(std::span{av, size_t(ac)}, " "));
+
+    return app.run(ac, av, [this, &app, cmd_line = std::move(cmd_line)] {
         vlog(_log.info, "Redpanda {}", redpanda_version());
+        vlog(_log.info, "Command line: {}", cmd_line);
         struct ::utsname buf;
         ::uname(&buf);
         vlog(


### PR DESCRIPTION
Somehow we've gotten away without printing the command line all this time. In some contexts it is printed out by some other component but we should print it out ourselves in Redpanda too.

Ref CORE-6746.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* The command line is now printed to the log at startup by the Redpanda process.
