### PR TITLE
partition-allocator: default shard 0 reserved partitions to 0

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -318,7 +318,7 @@ configuration::configuration()
       "is >= topic_partitions_per_core, no data partitions will be scheduled "
       "on shard 0",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      2,
+      0,
       {
         .min = 0,     // It is not mandatory to reserve any capacity
         .max = 131072 // Same max as topic_partitions_per_shard


### PR DESCRIPTION
We have the topic_partitions_reserve_shard0 property which makes the partition allocator have as if there are that many partitions allocated to shard0, beyond the amount actually allocated. The idea is to slightly bias the partition related work on shard 0 in order to account for extra duties it has to do.

This is by default set to 2. This change sets it to 0 instead. In general the default value of 2 does not do a good job of accounting for the bias: it will either be much too high or much too low in most cases. I.e., if every shard has 500 partitions, putting "only" 498 makes no difference, despite that shard 0 might be doing significantly more work in this case. On the other hand, if someone takes our "recommendation" of using 1 or 2 shards per partition for maximum tput, they might be surprised to find that shard 0 get no partitions at all, since it has these two reserved slots. In this case shard 0 will be seriously underutilized.

Especially due to this second effect, which does come up in practice, it seems like 0 is the best default value for this property. The idea of choosing a fixed value to reduce the load on shard 0 seems appealing on the surface but does not seem to work out in practice.

CORE-6852

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* Set the default value of `topic_partitions_reserve_shard0` to zero. This means that we no longer weight shard 0 as if it has 2 more partitions than it actually has, leading to more even partition distribution in cases where the total number of partitions is close to the vCPU count.
