### PR TITLE
CORE-6845 cmake: update avro rebased to 1.12

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -134,7 +134,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "GYuImJn9zN1o4QtVkmyqJDfrWW+zUSAUPusyBckQZCI=",
+        "bzlTransitiveDigest": "LqnwQrMtm7KxqLCeJI9itm4dnKuIn/sLwGxUwRMYuec=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -335,9 +335,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:avro.BUILD",
-              "sha256": "72919e8a512ed7c57ea77bbd2a47ceab0dab123a40767309b4d22350cf2ed960",
-              "strip_prefix": "avro-121d2a86cc43e5d4037d265f221aa3b64b9db0de",
-              "url": "https://github.com/redpanda-data/avro/archive/121d2a86cc43e5d4037d265f221aa3b64b9db0de.tar.gz"
+              "sha256": "a95c1b9517493d2e09d62a428ba7b4295c5cdb76eb07a0b2466f64a268486387",
+              "strip_prefix": "avro-b3d7efe3d8bc15e7a19ee349c51e14f8795b1515",
+              "url": "https://github.com/redpanda-data/avro/archive/b3d7efe3d8bc15e7a19ee349c51e14f8795b1515.tar.gz"
             }
           },
           "xxhash": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -19,9 +19,9 @@ def data_dependency():
     http_archive(
         name = "avro",
         build_file = "//bazel/thirdparty:avro.BUILD",
-        sha256 = "72919e8a512ed7c57ea77bbd2a47ceab0dab123a40767309b4d22350cf2ed960",
-        strip_prefix = "avro-121d2a86cc43e5d4037d265f221aa3b64b9db0de",
-        url = "https://github.com/redpanda-data/avro/archive/121d2a86cc43e5d4037d265f221aa3b64b9db0de.tar.gz",
+        sha256 = "a95c1b9517493d2e09d62a428ba7b4295c5cdb76eb07a0b2466f64a268486387",
+        strip_prefix = "avro-b3d7efe3d8bc15e7a19ee349c51e14f8795b1515",
+        url = "https://github.com/redpanda-data/avro/archive/b3d7efe3d8bc15e7a19ee349c51e14f8795b1515.tar.gz",
     )
 
     http_archive(

--- a/bazel/thirdparty/avro.BUILD
+++ b/bazel/thirdparty/avro.BUILD
@@ -2,8 +2,8 @@
 # This build is a translation from the cmake build. The second link below is a
 # cleaned up version of the first.
 #
-# https://github.com/redpanda-data/avro/blob/release-1.11.1-redpanda/lang/c%2B%2B/CMakeLists.txt
-# https://github.com/redpanda-data/avro/blob/release-1.11.1-redpanda/redpanda_build/CMakeLists.txt
+# https://github.com/redpanda-data/avro/blob/release-1.12.0-redpanda/lang/c%2B%2B/CMakeLists.txt
+# https://github.com/redpanda-data/avro/blob/release-1.12.0-redpanda/redpanda_build/CMakeLists.txt
 #
 # All of the header gymnastics below is to work around the problem of the C++
 # implementation files including the headers without the "avro/" prefix. It
@@ -141,6 +141,7 @@ cc_library(
         "@boost//:format",
         "@boost//:iostreams",
         "@boost//:lexical_cast",
+        "@fmt",
         "@snappy",
     ],
 )
@@ -157,5 +158,6 @@ cc_binary(
     deps = [
         ":avro",
         "@boost//:program_options",
+        "@fmt",
     ],
 )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -51,7 +51,7 @@ fetch_dep(seastar
 
 fetch_dep(avro
   REPO https://github.com/redpanda-data/avro
-  TAG release-1.11.1-redpanda
+  TAG release-1.12.0-redpanda
   SOURCE_SUBDIR redpanda_build)
 
 fetch_dep(rapidjson


### PR DESCRIPTION
This updates the avro dependency after we have rebased it to the 1.12 release.

The primary motivation was pulling in support for name aliases.

Ref:
* https://github.com/redpanda-data/avro/pull/272
* https://github.com/redpanda-data/vtools/pull/3043

Fixes https://redpandadata.atlassian.net/browse/CORE-6845

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
