### PR TITLE
[CORE-2632] tiered_storage_model_test: relax requirements for SegmentRolledByTimeout TS_Read 

### DIFF
--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1391,6 +1391,7 @@ class SegmentRolledByTimeout(Expression):
         return [
             LogBasedValidator("SegmentRolledByTimeout_log",
                               "segment.ms applied, new segment start offset",
+                              confidence_threshold=4,
                               execution_stage=TestRunStage.Produce),
         ]
 

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -767,6 +767,7 @@ class TS_Read(Expression):
             MetricBasedValidator(
                 "TS_Read",
                 "vectorized_cloud_storage_successful_downloads_total",
+                confidence_threshold=4,
                 execution_stage=TestRunStage.Consume)
         ]
 


### PR DESCRIPTION
This is a test fix: in the runs linked to https://redpandadata.atlassian.net/browse/CORE-2632 the failure reason is a too-strict timeout while collecting these metrics:

SegmentRolledByTimeout looks for "segment.ms applied" in the log. in a 100 secs window, this line can appear only ~10 times (for each topic),
    and this is close to the previous threshold of 8.

TS_Read keeps track of vectorized_cloud_storage_successful_download_count

Decrease the threshold for both of them to 4 to make the test less flaky

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes [CORE-2632
](https://redpandadata.atlassian.net/browse/CORE-2632)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none