### PR TITLE
c/shard_placement_table: fix rare race condition during x-shard transfer

### DIFF
--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -1221,11 +1221,15 @@ shard_placement_table::prepare_transfer(
         }
 
         if (is_initial) {
-            state._is_initial_for = std::nullopt;
-            if (state.is_empty()) {
-                _states.erase(ntp);
+            if (state._is_initial_for == expected_log_rev) {
+                state._is_initial_for = std::nullopt;
+                if (state.is_empty()) {
+                    _states.erase(ntp);
+                }
             }
+
             ret.is_finished = true;
+
             co_return ret;
         }
 


### PR DESCRIPTION
If `prepare_transfer` is called concurrently with shard reassignment that increases log revision, `placement_state::_is_initial_for` can change while we were checking that the destination shard is ready. In this case we shouldn't reset `_is_initial_for`.

Example test run where this happens: https://buildkite.com/redpanda/redpanda/builds/52605#01912cd3-d868-4dba-adcd-d619c3a416d2

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none