### PR TITLE
CORE-6859 k/group_probe: sanitize group names in metrics

### DIFF
--- a/src/v/kafka/server/group_probe.h
+++ b/src/v/kafka/server/group_probe.h
@@ -46,8 +46,8 @@ public:
         auto topic_label = sm::label("topic");
         auto partition_label = sm::label("partition");
         std::vector<sm::label_instance> labels{
-          group_label(group_id()),
-          topic_label(tp.topic()),
+          group_label(prometheus_sanitize::metrics_name(group_id())),
+          topic_label(prometheus_sanitize::metrics_name(tp.topic())),
           partition_label(tp.partition())};
         _metrics.add_group(
           prometheus_sanitize::metrics_name("kafka:group"),
@@ -70,8 +70,8 @@ public:
         auto topic_label = metrics::make_namespaced_label("topic");
         auto partition_label = metrics::make_namespaced_label("partition");
         std::vector<sm::label_instance> labels{
-          group_label(group_id()),
-          topic_label(tp.topic()),
+          group_label(prometheus_sanitize::metrics_name(group_id())),
+          topic_label(prometheus_sanitize::metrics_name(tp.topic())),
           partition_label(tp.partition())};
 
         _public_metrics.add_group(
@@ -121,7 +121,8 @@ public:
 
         auto group_label = metrics::make_namespaced_label("group");
 
-        std::vector<sm::label_instance> labels{group_label(group_id())};
+        std::vector<sm::label_instance> labels{
+          group_label(prometheus_sanitize::metrics_name(group_id()))};
 
         _public_metrics.add_group(
           prometheus_sanitize::metrics_name("kafka:consumer:group"),


### PR DESCRIPTION
The group name label returns the group name as-is in the prometheus metrics output on the `/metrics` and `/public_metric` endpoints. This means that the metrics response can be malformed if the group name contains a `"` character.

This fixes this problem by sanitising the generated metric labels.

As a follow-up, we should also validate consumer group names when the group is created, matching Kafka's validation logic.

Fixes https://redpandadata.atlassian.net/browse/CORE-6859

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
### Bug Fixes

* Sanitize prometheus metric label names created from consumer group names to avoid a malformed metrics response.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
