### PR TITLE
tests: Add missing override labels where needed

### DIFF
--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -58,7 +58,8 @@ public:
        retry_chain_node& parent,
        const std::string_view stream_label,
        const download_metrics& metrics,
-       std::optional<cloud_storage_clients::http_byte_range> byte_range));
+       std::optional<cloud_storage_clients::http_byte_range> byte_range),
+      (override));
 };
 
 ss::input_stream<char> make_report_stream(

--- a/src/v/cluster/archival/tests/archiver_operations_impl_gtest.cc
+++ b/src/v/cluster/archival/tests/archiver_operations_impl_gtest.cc
@@ -78,26 +78,35 @@ namespace archival {
 
 struct partition_mock : public detail::cluster_partition_api {
     MOCK_METHOD(
-      const cloud_storage::partition_manifest&, manifest, (), (const));
+      const cloud_storage::partition_manifest&,
+      manifest,
+      (),
+      (const, override));
 
-    MOCK_METHOD(model::offset, get_next_uploaded_offset, (), (const));
+    MOCK_METHOD(model::offset, get_next_uploaded_offset, (), (const, override));
 
-    MOCK_METHOD(model::offset, get_applied_offset, (), (const));
-
-    MOCK_METHOD(model::offset_delta, offset_delta, (model::offset), (const));
+    MOCK_METHOD(model::offset, get_applied_offset, (), (const, override));
 
     MOCK_METHOD(
-      std::optional<model::term_id>, get_offset_term, (model::offset), (const));
+      model::offset_delta, offset_delta, (model::offset), (const, override));
 
-    MOCK_METHOD(model::producer_id, get_highest_producer_id, (), (const));
+    MOCK_METHOD(
+      std::optional<model::term_id>,
+      get_offset_term,
+      (model::offset),
+      (const, override));
 
-    MOCK_METHOD(model::initial_revision_id, get_initial_revision, (), (const));
+    MOCK_METHOD(
+      model::producer_id, get_highest_producer_id, (), (const, override));
+
+    MOCK_METHOD(
+      model::initial_revision_id, get_initial_revision, (), (const, override));
 
     MOCK_METHOD(
       ss::future<fragmented_vector<model::tx_range>>,
       aborted_transactions,
       (model::offset, model::offset),
-      (const));
+      (const, override));
 
     MOCK_METHOD(
       ss::future<result<model::offset>>,
@@ -109,7 +118,7 @@ struct partition_mock : public detail::cluster_partition_api {
        ss::lowres_clock::time_point deadline,
        ss::abort_source& external_as,
        bool is_validated),
-      (noexcept));
+      (noexcept, override));
 
     cloud_storage::remote_segment_path
     get_remote_segment_path(const cloud_storage::segment_meta& meta) override {


### PR DESCRIPTION
For whatever reason these only get caught when compiling with sccache.
Missing in any case so add accordingly.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


