### PR TITLE
bazel: Globally set some seastar options

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -581,6 +581,9 @@ cc_library(
     }) + select({
         ":use_openssl": ["SEASTAR_WITH_TLS_OSSL"],
         "//conditions:default": [],
+    }) + select({
+        ":with_debug": ["SEASTAR_DEBUG"],
+        "//conditions:default": [],
     }),
     includes = [
         "include",
@@ -608,9 +611,6 @@ cc_library(
         "//conditions:default": [],
     }) + select({
         ":use_system_allocator": ["SEASTAR_DEFAULT_ALLOCATOR"],
-        "//conditions:default": [],
-    }) + select({
-        ":with_debug": ["SEASTAR_DEBUG"],
         "//conditions:default": [],
     }) + select({
         ":with_shuffle_task_queue": ["SEASTAR_SHUFFLE_TASK_QUEUE"],


### PR DESCRIPTION
These seastar options are referenced in public header files, so not
defining them could cause strange errors vs the seastar library and
external consumers of this header. Namely the debug one causes
`need_preempt` to differ from seastar internally and most of those
checks.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
