### PR TITLE
Revert "[v24.1.x] cmake: tweaks for vtools trunk-based development"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Redirect control for internal Redpanda builds
-if(REDPANDA_CMAKE_DIR)
+if(VECTORIZED_CMAKE_DIR)
   cmake_minimum_required(VERSION 3.22)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-  include(${REDPANDA_CMAKE_DIR}/main.cmake)
+  include(${VECTORIZED_CMAKE_DIR}/main.cmake)
   return()
 endif()
 

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -149,11 +149,11 @@ class BacktraceCapture(threading.Thread):
             return ci_location
 
         # Workstation: find our build directory by searching back from binary
-        vbuild = find_vbuild_path_from_binary(self.binary, 5)
+        vbuild = find_vbuild_path_from_binary(self.binary, 3)
         if vbuild:
             location = os.path.join(
                 vbuild,
-                "deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
+                "v_deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
             )
 
             if not os.path.exists(location):


### PR DESCRIPTION
Reverts redpanda-data/redpanda#19858

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none