### PR TITLE
[v24.1.x] `cluster`: fix `partition::may_read_from_cloud()` for remote read replicas (manual backport)

### DIFF
--- a/src/v/cloud_storage/tests/read_replica_fixture.h
+++ b/src/v/cloud_storage/tests/read_replica_fixture.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/scoped_config.h"
+
+class read_replica_e2e_fixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    read_replica_e2e_fixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{},
+        httpd_port_number()) {
+        // No expectations: tests will PUT and GET organically.
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+
+        // Disable metrics to speed things up.
+        test_local_cfg.get("enable_metrics_reporter").set_value(false);
+        test_local_cfg.get("disable_metrics").set_value(true);
+        test_local_cfg.get("disable_public_metrics").set_value(true);
+
+        // Avoid background work since we'll control uploads ourselves.
+        test_local_cfg.get("cloud_storage_enable_segment_merging")
+          .set_value(false);
+        test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+          .set_value(true);
+        test_local_cfg.get("cloud_storage_disable_read_replica_loop_for_tests")
+          .set_value(true);
+    }
+
+    std::unique_ptr<redpanda_thread_fixture> start_read_replica_fixture() {
+        return std::make_unique<redpanda_thread_fixture>(
+          model::node_id(2),
+          9092 + 10,
+          33145 + 10,
+          8082 + 10,
+          8081 + 10,
+          std::vector<config::seed_server>{},
+          ssx::sformat("test.dir_read_replica{}", time(0)),
+          app.sched_groups,
+          true,
+          get_s3_config(httpd_port_number()),
+          get_archival_config(),
+          get_cloud_config(httpd_port_number()));
+    }
+    scoped_config test_local_cfg;
+};

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -13,63 +13,17 @@
 #include "archival/ntp_archiver_service.h"
 #include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/tests/produce_utils.h"
-#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/tests/read_replica_fixture.h"
 #include "cloud_storage/types.h"
 #include "config/configuration.h"
 #include "kafka/server/tests/delete_records_utils.h"
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
-#include "redpanda/tests/fixture.h"
 #include "storage/disk_log_impl.h"
 #include "test_utils/scoped_config.h"
 
 using tests::kafka_consume_transport;
-
-class read_replica_e2e_fixture
-  : public s3_imposter_fixture
-  , public redpanda_thread_fixture
-  , public enable_cloud_storage_fixture {
-public:
-    read_replica_e2e_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
-        // No expectations: tests will PUT and GET organically.
-        set_expectations_and_listen({});
-        wait_for_controller_leadership().get();
-
-        // Disable metrics to speed things up.
-        test_local_cfg.get("enable_metrics_reporter").set_value(false);
-        test_local_cfg.get("disable_metrics").set_value(true);
-        test_local_cfg.get("disable_public_metrics").set_value(true);
-
-        // Avoid background work since we'll control uploads ourselves.
-        test_local_cfg.get("cloud_storage_enable_segment_merging")
-          .set_value(false);
-        test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
-          .set_value(true);
-        test_local_cfg.get("cloud_storage_disable_read_replica_loop_for_tests")
-          .set_value(true);
-    }
-
-    std::unique_ptr<redpanda_thread_fixture> start_read_replica_fixture() {
-        return std::make_unique<redpanda_thread_fixture>(
-          model::node_id(2),
-          9092 + 10,
-          33145 + 10,
-          8082 + 10,
-          8081 + 10,
-          std::vector<config::seed_server>{},
-          ssx::sformat("test.dir_read_replica{}", time(0)),
-          app.sched_groups,
-          true,
-          get_s3_config(httpd_port_number()),
-          get_archival_config(),
-          get_cloud_config(httpd_port_number()));
-    }
-    scoped_config test_local_cfg;
-};
 
 FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     const model::topic topic_name("tapioca");

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -565,7 +565,7 @@ partition::timequery(storage::timequery_config cfg) {
 }
 
 bool partition::may_read_from_cloud() const {
-    return is_remote_fetch_enabled()
+    return (is_remote_fetch_enabled() || is_read_replica_mode_enabled())
            && (_cloud_storage_partition && _cloud_storage_partition->is_data_available());
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/22868. 

Conflict with Boost -> GTest migration that occurred in `cloud_storage_e2e_test.cc` post version `v24.2.x`.

Fixes https://github.com/redpanda-data/redpanda/issues/22884.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
