### PR TITLE
[v23.3.x] `cluster`: fix `partition::may_read_from_cloud()` for remote read replicas (manual backport)

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/tests/manual_fixture.h"
 #include "cloud_storage/tests/produce_utils.h"
+#include "cloud_storage/tests/read_replica_fixture.h"
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cluster/cloud_metadata/tests/manual_mixin.h"
 #include "cluster/health_monitor_frontend.h"
@@ -827,6 +828,97 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
 
     // This will attempt to timequery from local disk since cloud storage cannot
     // answer it, but won't have a value anyways.
+    make_and_verify_timequery(
+      model::timestamp{
+        base_timestamp() + (batch_time_delta_ms * total_records)},
+      model::offset{total_records},
+      false);
+}
+
+FIXTURE_TEST(
+  test_cloud_storage_timequery_read_replica_mode, read_replica_e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
+
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.retention_local_target_bytes = tristate<size_t>(0);
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto log = partition->log();
+    auto& archiver = partition->archiver().value().get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+    archiver.upload_topic_manifest().get();
+
+    const auto batches_per_segment = 1;
+    const auto num_segs = 5;
+    const auto batch_time_delta_ms = 10;
+    const auto base_timestamp = model::timestamp{0};
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(batches_per_segment)
+                           .base_timestamp(base_timestamp)
+                           .batch_time_delta_ms(batch_time_delta_ms)
+                           .produce()
+                           .get();
+    BOOST_REQUIRE_EQUAL(total_records, 5);
+
+    auto rr_rp = start_read_replica_fixture();
+
+    cluster::topic_properties read_replica_props;
+    read_replica_props.shadow_indexing = model::shadow_indexing_mode::disabled;
+    read_replica_props.read_replica = true;
+    read_replica_props.read_replica_bucket = "test-bucket";
+    rr_rp
+      ->add_topic({model::kafka_namespace, topic_name}, 1, read_replica_props)
+      .get();
+    rr_rp->wait_for_leader(ntp).get();
+    auto rr_partition = rr_rp->app.partition_manager.local().get(ntp).get();
+    auto rr_archiver_ref = rr_partition->archiver();
+    BOOST_REQUIRE(rr_archiver_ref.has_value());
+    auto& rr_archiver = rr_partition->archiver()->get();
+    BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
+    rr_archiver.sync_manifest().get();
+    BOOST_REQUIRE_EQUAL(rr_archiver.manifest().size(), 5);
+
+    auto make_and_verify_timequery =
+      [rr_partition](
+        model::timestamp t,
+        model::offset o,
+        bool expect_value = false,
+        std::optional<model::offset> expected_o = std::nullopt) {
+          auto timequery_conf = storage::timequery_config(
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
+
+          auto result = rr_partition->timequery(timequery_conf).get();
+
+          if (expect_value) {
+              BOOST_REQUIRE(result.has_value());
+              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+          } else {
+              BOOST_REQUIRE(!result.has_value());
+          }
+      };
+
+    make_and_verify_timequery(
+      base_timestamp, model::offset{0}, true, model::offset{0});
+
+    for (int i = 1; i < total_records; ++i) {
+        const auto min_timestamp = base_timestamp()
+                                   + batch_time_delta_ms * (i - 1);
+        const auto max_timestamp = min_timestamp + batch_time_delta_ms;
+        const auto query_timestamp = random_generators::get_int(
+          min_timestamp + 1, max_timestamp);
+        make_and_verify_timequery(
+          model::timestamp{query_timestamp},
+          model::offset{i},
+          true,
+          model::offset{i});
+    }
+
+    // This won't have a valid result in cloud storage.
     make_and_verify_timequery(
       model::timestamp{
         base_timestamp() + (batch_time_delta_ms * total_records)},

--- a/src/v/cloud_storage/tests/read_replica_fixture.h
+++ b/src/v/cloud_storage/tests/read_replica_fixture.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/scoped_config.h"
+
+class read_replica_e2e_fixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public enable_cloud_storage_fixture {
+public:
+    read_replica_e2e_fixture()
+      : redpanda_thread_fixture(
+        redpanda_thread_fixture::init_cloud_storage_tag{},
+        httpd_port_number()) {
+        // No expectations: tests will PUT and GET organically.
+        set_expectations_and_listen({});
+        wait_for_controller_leadership().get();
+
+        // Disable metrics to speed things up.
+        test_local_cfg.get("enable_metrics_reporter").set_value(false);
+        test_local_cfg.get("disable_metrics").set_value(true);
+        test_local_cfg.get("disable_public_metrics").set_value(true);
+
+        // Avoid background work since we'll control uploads ourselves.
+        test_local_cfg.get("cloud_storage_enable_segment_merging")
+          .set_value(false);
+        test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+          .set_value(true);
+        test_local_cfg.get("cloud_storage_disable_read_replica_loop_for_tests")
+          .set_value(true);
+    }
+
+    std::unique_ptr<redpanda_thread_fixture> start_read_replica_fixture() {
+        return std::make_unique<redpanda_thread_fixture>(
+          model::node_id(2),
+          9092 + 10,
+          33145 + 10,
+          8082 + 10,
+          8081 + 10,
+          std::vector<config::seed_server>{},
+          ssx::sformat("test.dir_read_replica{}", time(0)),
+          app.sched_groups,
+          true,
+          get_s3_config(httpd_port_number()),
+          get_archival_config(),
+          get_cloud_config(httpd_port_number()));
+    }
+    scoped_config test_local_cfg;
+};

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -12,63 +12,17 @@
 #include "archival/ntp_archiver_service.h"
 #include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/tests/produce_utils.h"
-#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/tests/read_replica_fixture.h"
 #include "cloud_storage/types.h"
 #include "config/configuration.h"
 #include "kafka/server/tests/delete_records_utils.h"
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
-#include "redpanda/tests/fixture.h"
 #include "storage/disk_log_impl.h"
 #include "test_utils/scoped_config.h"
 
 using tests::kafka_consume_transport;
-
-class read_replica_e2e_fixture
-  : public s3_imposter_fixture
-  , public redpanda_thread_fixture
-  , public enable_cloud_storage_fixture {
-public:
-    read_replica_e2e_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
-        // No expectations: tests will PUT and GET organically.
-        set_expectations_and_listen({});
-        wait_for_controller_leadership().get();
-
-        // Disable metrics to speed things up.
-        test_local_cfg.get("enable_metrics_reporter").set_value(false);
-        test_local_cfg.get("disable_metrics").set_value(true);
-        test_local_cfg.get("disable_public_metrics").set_value(true);
-
-        // Avoid background work since we'll control uploads ourselves.
-        test_local_cfg.get("cloud_storage_enable_segment_merging")
-          .set_value(false);
-        test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
-          .set_value(true);
-        test_local_cfg.get("cloud_storage_disable_read_replica_loop_for_tests")
-          .set_value(true);
-    }
-
-    std::unique_ptr<redpanda_thread_fixture> start_read_replica_fixture() {
-        return std::make_unique<redpanda_thread_fixture>(
-          model::node_id(2),
-          9092 + 10,
-          33145 + 10,
-          8082 + 10,
-          8081 + 10,
-          std::vector<config::seed_server>{},
-          ssx::sformat("test.dir_read_replica{}", time(0)),
-          app.sched_groups,
-          true,
-          get_s3_config(httpd_port_number()),
-          get_archival_config(),
-          get_cloud_config(httpd_port_number()));
-    }
-    scoped_config test_local_cfg;
-};
 
 FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     const model::topic topic_name("tapioca");

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -677,7 +677,7 @@ partition::timequery(storage::timequery_config cfg) {
 }
 
 bool partition::may_read_from_cloud() const {
-    return is_remote_fetch_enabled()
+    return (is_remote_fetch_enabled() || is_read_replica_mode_enabled())
            && (_cloud_storage_partition && _cloud_storage_partition->is_data_available());
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/22868. 

Conflict with Boost -> GTest migration that occurred in `cloud_storage_e2e_test.cc` post version `v24.2.x`.

Fixes https://github.com/redpanda-data/redpanda/issues/22883.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
