### PR TITLE
Fixing zones format for clusters API requirement

### DIFF
--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -188,8 +188,9 @@ class GCPClient:
         # _r contains iterator to zone items among other fields
         # Object returned is ListPager: https://cloud.google.com/python/docs/reference/compute/latest/google.cloud.compute_v1.services.zones.pagers.ListPager
         _available = [i.name for i in _r]
-        # Return single zone
-        return _available[:1]
+
+        # Return a single zone as a string
+        return _available[0]
 
     def get_instance_meta(self, target='localhost'):
         """

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -690,8 +690,9 @@ class CloudCluster():
         # Multi-zone not supported, so get a single one from the list
         self.current.region = self.config.region
         self.current.region_id = self._get_region_id()
-        self.current.zones = self.provider_cli.get_single_zone(
-            self.current.region)
+        self.current.zones = [
+            self.provider_cli.get_single_zone(self.current.region)
+        ]
         # Call CloudV2 API to determine Product ID
         self.current.product_name = self._get_product_name(
             self.config.config_profile_name)


### PR DESCRIPTION


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

### Improvements

* Fixing zones formatting for cluster API requirements. Making it consistent across cloud provider clients
This should fix multiple CI jobs for different cloud providers
