### PR TITLE
bazel: add tests for wasm/parser

### DIFF
--- a/src/v/wasm/parser/BUILD
+++ b/src/v/wasm/parser/BUILD
@@ -1,25 +1,44 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "leb128",
+    hdrs = [
+        "leb128.h",
+    ],
+    include_prefix = "wasm/parser",
+    visibility = [
+        "//src/v/wasm/parser:__pkg__",
+        "//src/v/wasm/parser/tests:__pkg__",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+    ],
+)
+
+redpanda_cc_library(
     name = "parser",
     srcs = [
-        "leb128.h",
         "parser.cc",
     ],
     hdrs = [
         "parser.h",
     ],
+    implementation_deps = [
+        ":leb128",
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/strings:utf8",
+        "@abseil-cpp//absl/algorithm:container",
+        "@fmt",
+    ],
     include_prefix = "wasm/parser",
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
-        "//src/v/bytes",
         "//src/v/bytes:iobuf",
-        "//src/v/bytes:iobuf_parser",
         "//src/v/container:fragmented_vector",
-        "//src/v/strings:utf8",
-        "@abseil-cpp//absl/algorithm:container",
-        "@fmt",
         "@seastar",
     ],
 )

--- a/src/v/wasm/parser/parser.cc
+++ b/src/v/wasm/parser/parser.cc
@@ -13,8 +13,8 @@
 
 #include "base/units.h"
 #include "bytes/iobuf_parser.h"
-#include "leb128.h"
 #include "strings/utf8.h"
+#include "wasm/parser/leb128.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>

--- a/src/v/wasm/parser/tests/BUILD
+++ b/src/v/wasm/parser/tests/BUILD
@@ -1,0 +1,37 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "leb128_test",
+    timeout = "short",
+    srcs = [
+        "leb128_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/test_utils:gtest",
+        "//src/v/wasm/parser:leb128",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "parser_test",
+    timeout = "short",
+    srcs = [
+        "parser_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/container:fragmented_vector",
+        "//src/v/test_utils:gtest",
+        "//src/v/wasm/parser",
+        "@crates//:wasmtime_c",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)


### PR DESCRIPTION
Add some tests to Bazel

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
