### PR TITLE
CORE-6859 bazel: update seastar with prometheus fix

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -160,7 +160,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "tKz6AQ3inIHipQWvfPiqMjprjkod4GGo1t77eXNkSgg=",
+        "bzlTransitiveDigest": "/MqP0N0rJqOQIVgvSLEn/DUIwqwpedDP2S/k48jYYuQ=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -311,9 +311,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "e0d8e86be89cb1459d5e70ac9e4adb300a1a97437e58a6c0e34e8186c40fd414",
-              "strip_prefix": "seastar-2994105f6160087c61494c951d2e40910d31c55a",
-              "url": "https://github.com/redpanda-data/seastar/archive/2994105f6160087c61494c951d2e40910d31c55a.tar.gz"
+              "sha256": "18204fa9a6db7cf7695ad017a0850f58ebf385e9d0f4b05e8770fe4316a45ea2",
+              "strip_prefix": "seastar-6499285ac3899809712124da7a50fbb21f9409f2",
+              "url": "https://github.com/redpanda-data/seastar/archive/6499285ac3899809712124da7a50fbb21f9409f2.tar.gz"
             }
           },
           "jsoncons": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -161,9 +161,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "e0d8e86be89cb1459d5e70ac9e4adb300a1a97437e58a6c0e34e8186c40fd414",
-        strip_prefix = "seastar-2994105f6160087c61494c951d2e40910d31c55a",
-        url = "https://github.com/redpanda-data/seastar/archive/2994105f6160087c61494c951d2e40910d31c55a.tar.gz",
+        sha256 = "18204fa9a6db7cf7695ad017a0850f58ebf385e9d0f4b05e8770fe4316a45ea2",
+        strip_prefix = "seastar-6499285ac3899809712124da7a50fbb21f9409f2",
+        url = "https://github.com/redpanda-data/seastar/archive/6499285ac3899809712124da7a50fbb21f9409f2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Uses:
* https://github.com/redpanda-data/seastar/pull/136
* https://github.com/redpanda-data/seastar/pull/139

Fixes https://redpandadata.atlassian.net/browse/CORE-6859

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in metrics reporting where label values containing special characters (`"`, `\`, `\n`) could lead to a malformed metrics response.


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
