### PR TITLE
Use remote recovery when topic is configured to use remote data

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -991,7 +991,7 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
 
     vlog(
       clusterlog.debug,
-      "[{}] reconcilation step, reconciliation state: {}",
+      "[{}] reconciliation step, reconciliation state: {}",
       ntp,
       rs);
 

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -247,6 +247,8 @@ public:
 
 private:
     struct ntp_reconciliation_state;
+    using force_reconfiguration
+      = ss::bool_class<struct force_reconfiguration_tag>;
 
     // Topics
     ss::future<> bootstrap_controller_backend();
@@ -292,7 +294,8 @@ private:
       model::ntp,
       raft::group_id,
       model::revision_id log_revision,
-      replicas_t initial_replicas);
+      replicas_t initial_replicas,
+      force_reconfiguration is_force_reconfigured);
 
     ss::future<> add_to_shard_table(
       model::ntp,

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -123,6 +123,18 @@ ss::future<consensus_ptr> partition_manager::manage(
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
   std::optional<cloud_storage::remote_label> remote_label,
   std::optional<model::topic_namespace> topic_namespace_override) {
+    vlog(
+      clusterlog.trace,
+      "Creating partition with configuration: {}, raft group_id: {}, "
+      "initial_nodes: {}, remote topic properties: {}, remote label: {}, "
+      "topic_namespace_override: {}",
+      ntp_cfg,
+      group,
+      initial_nodes,
+      rtp,
+      remote_label,
+      topic_namespace_override);
+
     auto guard = _gate.hold();
     // topic_namespace_override is used in case of a cluster migration.
     // The original ("source") topic name must be used in the tiered

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -185,6 +185,11 @@ public:
             return _policy;
         }
 
+        bool is_force_reconfiguration() const {
+            return _state == reconfiguration_state::force_cancelled
+                   || _state == reconfiguration_state::force_update;
+        }
+
         friend std::ostream&
         operator<<(std::ostream&, const in_progress_update&);
 


### PR DESCRIPTION
When topic is configured to use remote data the data can be used when
force recovering partitions that lost majority. In this case instead of
creating an empty partition replica instance we customize arguments
passed into the `partition_manger::manage` method to enable remote
recovery of replica data.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- with this improvement the force reconfigured partitions will be backfilled from Tiered Storage even if they lost all local data