### PR TITLE
storage: make logger a Bazel private library

### DIFF
--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -122,7 +122,7 @@ ss::future<> disk_space_manager::run_loop() {
             co_await manage_data_disk(_target_size);
         } catch (...) {
             vlog(
-              stlog.info,
+              rlog.info,
               "Recoverable error running space management loop: {}",
               std::current_exception());
         }

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -198,6 +198,7 @@ redpanda_cc_library(
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",
+        "//src/v/syschecks",
         "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:directory_walker",
         "//src/v/utils:file_io",

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -1,5 +1,11 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
+package(
+    default_visibility = [
+        "//src/v/storage/tests:__pkg__",
+    ],
+)
+
 redpanda_cc_library(
     name = "config",
     hdrs = [
@@ -54,6 +60,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "logger",
+    srcs = [
+        "logger.cc",
+    ],
+    hdrs = [
+        "logger.h",
+    ],
+    include_prefix = "storage",
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "storage",
     srcs = [
         "api.cc",
@@ -73,7 +94,6 @@ redpanda_cc_library(
         "log_manager.cc",
         "log_reader.cc",
         "log_replayer.cc",
-        "logger.cc",
         "node.cc",
         "offset_to_filepos.cc",
         "offset_translator.cc",
@@ -128,7 +148,6 @@ redpanda_cc_library(
         "log_manager.h",
         "log_reader.h",
         "log_replayer.h",
-        "logger.h",
         "node.h",
         "ntp_config.h",
         "offset_assignment.h",
@@ -156,6 +175,10 @@ redpanda_cc_library(
         "translating_reader.h",
         "types.h",
         "version.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        "//src/v/syschecks",
     ],
     include_prefix = "storage",
     visibility = ["//visibility:public"],
@@ -198,7 +221,6 @@ redpanda_cc_library(
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",
-        "//src/v/syschecks",
         "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:directory_walker",
         "//src/v/utils:file_io",

--- a/src/v/storage/api.cc
+++ b/src/v/storage/api.cc
@@ -10,6 +10,9 @@
  */
 #include "storage/api.h"
 
+#include "base/vlog.h"
+#include "storage/logger.h"
+
 namespace storage {
 
 ss::future<usage_report> api::disk_usage() {
@@ -35,5 +38,20 @@ void api::handle_disk_notification(
 }
 
 void api::trigger_gc() { _log_mgr->trigger_gc(); }
+
+ss::future<bool> api::wait_for_cluster_uuid() {
+    if (_cluster_uuid.has_value()) {
+        co_return true;
+    }
+    try {
+        co_await _has_cluster_uuid_cond.wait();
+        vassert(
+          _cluster_uuid.has_value(), "Expected cluster UUID after waiting");
+        co_return true;
+    } catch (ss::broken_condition_variable&) {
+        vlog(stlog.info, "Stopped waiting for cluster UUID");
+    }
+    co_return false;
+}
 
 } // namespace storage

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -12,13 +12,10 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "base/vlog.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
-#include "storage/logger.h"
-#include "storage/probe.h"
 #include "storage/storage_resources.h"
 #include "utils/notification_list.h"
 
@@ -87,20 +84,7 @@ public:
         return _cluster_uuid;
     }
 
-    ss::future<bool> wait_for_cluster_uuid() {
-        if (_cluster_uuid.has_value()) {
-            co_return true;
-        }
-        try {
-            co_await _has_cluster_uuid_cond.wait();
-            vassert(
-              _cluster_uuid.has_value(), "Expected cluster UUID after waiting");
-            co_return true;
-        } catch (ss::broken_condition_variable&) {
-            vlog(stlog.info, "Stopped waiting for cluster UUID");
-        }
-        co_return false;
-    }
+    ss::future<bool> wait_for_cluster_uuid();
 
     kvstore& kvs() { return *_kvstore; }
     log_manager& log_mgr() { return *_log_mgr; }

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -1,10 +1,8 @@
 #pragma once
 #include "base/seastarx.h"
 #include "base/vassert.h"
-#include "base/vlog.h"
 #include "resource_mgmt/memory_groups.h"
 #include "ssx/semaphore.h"
-#include "storage/logger.h"
 #include "storage/segment_appender_chunk.h"
 
 #include <seastar/core/chunked_fifo.hh>

--- a/src/v/storage/directories.h
+++ b/src/v/storage/directories.h
@@ -12,27 +12,12 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "base/vlog.h"
-#include "storage/logger.h"
-#include "syschecks/syschecks.h"
 
 #include <seastar/core/future.hh>
-#include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
 
 namespace storage::directories {
 
-inline ss::future<> initialize(ss::sstring dir) {
-    return recursive_touch_directory(dir)
-      .handle_exception([dir](std::exception_ptr ep) {
-          stlog.error(
-            "Directory `{}` cannot be initialized. Failed with {}", dir, ep);
-          return ss::make_exception_future<>(std::move(ep));
-      })
-      .then([dir] {
-          vlog(stlog.info, "Checking `{}` for supported filesystems", dir);
-          return syschecks::disk(dir);
-      });
-}
+ss::future<> initialize(ss::sstring dir);
 
 } // namespace storage::directories

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -10,6 +10,8 @@
  */
 #include "storage/node.h"
 
+#include "storage/logger.h"
+
 #include <seastar/core/reactor.hh>
 
 namespace storage {

--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -11,6 +11,8 @@
 
 #include "storage/offset_to_filepos.h"
 
+#include "base/vlog.h"
+#include "storage/logger.h"
 #include "storage/parser.h"
 #include "storage/segment.h"
 #include "storage/segment_utils.h"

--- a/src/v/storage/offset_to_filepos.h
+++ b/src/v/storage/offset_to_filepos.h
@@ -16,7 +16,6 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "storage/fwd.h"
-#include "storage/logger.h"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/io_priority_class.hh>

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -11,6 +11,7 @@
 
 #include "config/configuration.h"
 #include "metrics/prometheus_sanitize.h"
+#include "storage/logger.h"
 #include "storage/readers_cache_probe.h"
 #include "storage/segment.h"
 
@@ -185,6 +186,11 @@ void probe::add_initial_segment(const segment& s) {
 }
 void probe::delete_segment(const segment& s) {
     _partition_bytes -= s.file_size();
+}
+
+void probe::batch_write_error(const std::exception_ptr& e) {
+    stlog.error("Error writing record batch {}", e);
+    ++_batch_write_errors;
 }
 
 void readers_cache_probe::setup_metrics(const model::ntp& ntp) {

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -13,7 +13,6 @@
 #include "metrics/metrics.h"
 #include "model/fundamental.h"
 #include "storage/fwd.h"
-#include "storage/logger.h"
 #include "storage/types.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -90,10 +89,7 @@ public:
         _compaction_removed_bytes += bytes;
     }
 
-    void batch_write_error(const std::exception_ptr& e) {
-        stlog.error("Error writing record batch {}", e);
-        ++_batch_write_errors;
-    }
+    void batch_write_error(const std::exception_ptr& e);
 
     void add_batches_read(uint32_t batches) { _batches_read += batches; }
     void add_cached_batches_read(uint32_t batches) {

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -14,6 +14,7 @@
 #include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
+#include "storage/logger.h"
 #include "storage/types.h"
 #include "utils/mutex.h"
 

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -9,11 +9,13 @@
 
 #include "storage/snapshot.h"
 
+#include "base/vlog.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
 #include "hashing/crc32c.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
+#include "storage/logger.h"
 #include "storage/segment_utils.h"
 #include "utils/directory_walker.h"
 


### PR DESCRIPTION
storage: make logger a Bazel private library

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
