### PR TITLE
[v24.2.x] tx: do not throw USE on expired transaction_ids

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1784,7 +1784,7 @@ ss::future<tx_gateway_frontend::op_result_t> tx_gateway_frontend::do_end_txn(
               "commit/abort",
               request.transactional_id,
               pid);
-            err = tx::errc::unknown_server_error;
+            err = tx::errc::invalid_producer_id_mapping;
         }
         outcome->set_value(err);
         co_return err;

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -420,8 +420,9 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         try:
             producer.commit_transaction()
             assert False, "transaction should have been aborted by now."
-        except ck.KafkaException:
-            pass
+        except ck.KafkaException as e:
+            assert e.args[0].code(
+            ) == ck.KafkaError.INVALID_PRODUCER_ID_MAPPING, f"Invalid error thrown on expiration {e}"
 
     @cluster(num_nodes=3)
     def expired_tx_test(self):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22912
