### PR TITLE
iceberg: add value representation

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -184,3 +184,26 @@ redpanda_cc_library(
         "//src/v/json",
     ],
 )
+
+redpanda_cc_library(
+    name = "values",
+    srcs = [
+        "values.cc",
+    ],
+    hdrs = [
+        "values.h",
+    ],
+    implementation_deps = [
+        "//src/v/bytes:hash",
+        "//src/v/bytes:iobuf_parser",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/container:fragmented_vector",
+        "//src/v/utils:uuid",
+        "@abseil-cpp//absl/numeric:int128",
+        "@boost//:container_hash",
+        "@fmt",
+    ],
+)

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -140,6 +140,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "logger",
+    srcs = [
+        "logger.cc",
+    ],
+    hdrs = [
+        "logger.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "schema",
     hdrs = [
         "schema.h",

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -31,6 +31,7 @@ v_cc_library(
     datatypes.cc
     datatypes_json.cc
     json_utils.cc
+    logger.cc
     manifest_avro.cc
     partition.cc
     schema_json.cc

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -35,12 +35,14 @@ v_cc_library(
     manifest_avro.cc
     partition.cc
     schema_json.cc
+    values.cc
   DEPS
     Avro::avro
     v::bytes
     v::container
     v::json
     v::strings
+    v::utils
 )
 
 add_subdirectory(tests)

--- a/src/v/iceberg/logger.cc
+++ b/src/v/iceberg/logger.cc
@@ -1,0 +1,13 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/logger.h"
+
+namespace iceberg {
+ss::logger log("iceberg");
+} // namespace iceberg

--- a/src/v/iceberg/logger.h
+++ b/src/v/iceberg/logger.h
@@ -1,0 +1,17 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace iceberg {
+extern ss::logger log;
+} // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -97,3 +97,18 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "values_test",
+    timeout = "short",
+    srcs = [
+        "values_test.cc",
+    ],
+    deps = [
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:fragmented_vector",
+        "//src/v/iceberg:values",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ rp_test(
     partition_test.cc
     schema_json_test.cc
     test_schemas.cc
+    values_test.cc
   LIBRARIES
     Avro::avro
     Boost::iostreams

--- a/src/v/iceberg/tests/values_test.cc
+++ b/src/v/iceberg/tests/values_test.cc
@@ -1,0 +1,422 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "container/chunked_hash_map.h"
+#include "container/fragmented_vector.h"
+#include "iceberg/values.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+// Returns a list of unique primitive values.
+chunked_vector<value> unique_values_primitive_types() {
+    chunked_vector<value> vals;
+    vals.emplace_back(boolean_value{true});
+    vals.emplace_back(boolean_value{false});
+
+    vals.emplace_back(int_value{0});
+    vals.emplace_back(int_value{1});
+
+    vals.emplace_back(long_value{0});
+    vals.emplace_back(long_value{1});
+
+    vals.emplace_back(float_value{0.0});
+    vals.emplace_back(float_value{1.0});
+
+    vals.emplace_back(double_value{0.0});
+    vals.emplace_back(double_value{1.0});
+
+    vals.emplace_back(decimal_value{0});
+    vals.emplace_back(decimal_value{1});
+
+    vals.emplace_back(date_value{0});
+    vals.emplace_back(date_value{1});
+
+    vals.emplace_back(time_value{0});
+    vals.emplace_back(time_value{1});
+
+    vals.emplace_back(timestamp_value{0});
+    vals.emplace_back(timestamp_value{1});
+
+    vals.emplace_back(timestamptz_value{0});
+    vals.emplace_back(timestamptz_value{1});
+
+    vals.emplace_back(string_value{iobuf{}});
+    vals.emplace_back(string_value{iobuf::from("0")});
+    vals.emplace_back(string_value{iobuf::from("1")});
+
+    vals.emplace_back(binary_value{iobuf{}});
+    vals.emplace_back(binary_value{iobuf::from("0")});
+    vals.emplace_back(binary_value{iobuf::from("1")});
+
+    vals.emplace_back(uuid_value{uuid_t{}});
+    vals.emplace_back(uuid_value{uuid_t::create()});
+
+    vals.emplace_back(fixed_value{iobuf{}});
+    vals.emplace_back(fixed_value{iobuf::from("0")});
+    vals.emplace_back(fixed_value{iobuf::from("1")});
+    return vals;
+};
+
+void check_single_value_exists(
+  const value& expected_val, const chunked_vector<value>& all_unique_vals) {
+    size_t num_eq = 0;
+    size_t num_ne = 0;
+    for (const auto& v : all_unique_vals) {
+        if (v == expected_val) {
+            ++num_eq;
+        }
+        if (v != expected_val) {
+            ++num_ne;
+        }
+    }
+    ASSERT_EQ(num_eq, 1);
+    ASSERT_EQ(num_ne, all_unique_vals.size() - 1);
+}
+
+TEST(ValuesTest, TestPrimitiveValuesEquality) {
+    auto vals = unique_values_primitive_types();
+    for (const auto& v : vals) {
+        ASSERT_NO_FATAL_FAILURE(check_single_value_exists(v, vals));
+    }
+}
+
+TEST(ValuesTest, TestStructEquality) {
+    struct_value v1;
+    v1.fields.emplace_back(int_value{0});
+    v1.fields.emplace_back(boolean_value{false});
+    ASSERT_EQ(v1, v1);
+
+    struct_value v1_copy;
+    v1_copy.fields.emplace_back(int_value{0});
+    v1_copy.fields.emplace_back(boolean_value{false});
+    ASSERT_EQ(v1, v1_copy);
+
+    struct_value v2;
+    v2.fields.emplace_back(int_value{0});
+    v2.fields.emplace_back(boolean_value{true});
+    ASSERT_NE(v1, v2);
+
+    struct_value v3;
+    v3.fields.emplace_back(int_value{1});
+    v3.fields.emplace_back(boolean_value{false});
+    ASSERT_NE(v1, v3);
+
+    struct_value v4;
+    v4.fields.emplace_back(int_value{0});
+    ASSERT_NE(v1, v4);
+
+    struct_value v5;
+    v5.fields.emplace_back(boolean_value{false});
+    ASSERT_NE(v1, v5);
+
+    struct_value v6;
+    v6.fields.emplace_back(int_value{0});
+    v6.fields.emplace_back(std::nullopt);
+    ASSERT_NE(v1, v6);
+
+    struct_value v1_nested;
+    v1_nested.fields.emplace_back(
+      std::make_unique<struct_value>(std::move(v1_copy)));
+    ASSERT_EQ(
+      v1, *std::get<std::unique_ptr<struct_value>>(*v1_nested.fields[0]));
+    ASSERT_NE(v1, v1_nested);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    ASSERT_NE(v1, v1_copy);
+
+    struct_value v_null;
+    v_null.fields.emplace_back(std::nullopt);
+    v_null.fields.emplace_back(std::nullopt);
+    ASSERT_NE(v1, v_null);
+    ASSERT_EQ(v_null, v_null);
+}
+
+TEST(ValuesTest, TestListEquality) {
+    list_value v1;
+    v1.elements.emplace_back(int_value{0});
+    v1.elements.emplace_back(int_value{1});
+    ASSERT_EQ(v1, v1);
+
+    list_value v1_copy;
+    v1_copy.elements.emplace_back(int_value{0});
+    v1_copy.elements.emplace_back(int_value{1});
+    ASSERT_EQ(v1, v1_copy);
+
+    list_value v2;
+    v2.elements.emplace_back(int_value{0});
+    v2.elements.emplace_back(int_value{2});
+    ASSERT_NE(v1, v2);
+
+    list_value v3;
+    v3.elements.emplace_back(int_value{2});
+    v3.elements.emplace_back(int_value{0});
+    ASSERT_NE(v1, v3);
+
+    list_value v4;
+    v4.elements.emplace_back(int_value{0});
+    ASSERT_NE(v1, v4);
+
+    list_value v5;
+    v5.elements.emplace_back(int_value{0});
+    v5.elements.emplace_back(std::nullopt);
+    ASSERT_NE(v1, v5);
+
+    list_value v1_nested;
+    v1_nested.elements.emplace_back(
+      std::make_unique<list_value>(std::move(v1_copy)));
+    ASSERT_EQ(
+      v1, *std::get<std::unique_ptr<list_value>>(*v1_nested.elements[0]));
+    ASSERT_NE(v1, v1_nested);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    ASSERT_NE(v1, v1_copy);
+
+    list_value v_null;
+    v_null.elements.emplace_back(std::nullopt);
+    v_null.elements.emplace_back(std::nullopt);
+    ASSERT_NE(v1, v_null);
+    ASSERT_EQ(v_null, v_null);
+}
+
+TEST(ValuesTest, TestMapEquality) {
+    map_value v1;
+    v1.kvs.emplace_back(kv_value{int_value{0}, boolean_value{false}});
+    v1.kvs.emplace_back(kv_value{int_value{1}, boolean_value{true}});
+    ASSERT_EQ(v1, v1);
+
+    map_value v1_copy;
+    v1_copy.kvs.emplace_back(kv_value{int_value{0}, boolean_value{false}});
+    v1_copy.kvs.emplace_back(kv_value{int_value{1}, boolean_value{true}});
+    ASSERT_EQ(v1, v1_copy);
+
+    map_value v2;
+    v2.kvs.emplace_back(kv_value{int_value{0}, boolean_value{false}});
+    v2.kvs.emplace_back(kv_value{int_value{2}, boolean_value{true}});
+    ASSERT_NE(v1, v2);
+
+    map_value v3;
+    v3.kvs.emplace_back(kv_value{int_value{0}, boolean_value{false}});
+    v3.kvs.emplace_back(kv_value{int_value{1}, boolean_value{false}});
+    ASSERT_NE(v1, v3);
+
+    map_value v4;
+    v4.kvs.emplace_back(kv_value{int_value{1}, boolean_value{false}});
+    v4.kvs.emplace_back(kv_value{int_value{1}, boolean_value{true}});
+    ASSERT_NE(v1, v4);
+
+    map_value v5;
+    v5.kvs.emplace_back(kv_value{int_value{0}, boolean_value{false}});
+    ASSERT_NE(v1, v5);
+
+    map_value v6;
+    v6.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    v6.kvs.emplace_back(kv_value{int_value{1}, boolean_value{true}});
+    ASSERT_NE(v1, v6);
+
+    map_value v1_nested;
+    v1_nested.kvs.emplace_back(
+      kv_value{std::make_unique<map_value>(std::move(v1_copy)), std::nullopt});
+    ASSERT_NE(v1, v1_nested);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    ASSERT_NE(v1, v1_copy);
+
+    map_value v_null_1;
+    v_null_1.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    map_value v_null_2;
+    v_null_2.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    ASSERT_EQ(v_null_1, v_null_2);
+
+    map_value v_empty;
+    ASSERT_EQ(v_empty, v_empty);
+    ASSERT_EQ(v_empty, map_value{});
+    ASSERT_NE(v_empty, v_null_1);
+    ASSERT_NE(v_empty, v1);
+}
+
+TEST(ValuesTest, TestPrimitiveTypesOStream) {
+    EXPECT_STREQ("boolean(true)", fmt::to_string(boolean_value{true}).c_str());
+    EXPECT_STREQ(
+      "boolean(false)", fmt::to_string(boolean_value{false}).c_str());
+
+    EXPECT_STREQ(
+      "int(-2147483648)",
+      fmt::to_string(int_value{std::numeric_limits<int32_t>::min()}).c_str());
+    EXPECT_STREQ(
+      "int(2147483647)",
+      fmt::to_string(int_value{std::numeric_limits<int32_t>::max()}).c_str());
+
+    EXPECT_STREQ(
+      "long(-9223372036854775808)",
+      fmt::to_string(long_value{std::numeric_limits<long>::min()}).c_str());
+    EXPECT_STREQ(
+      "long(9223372036854775807)",
+      fmt::to_string(long_value{std::numeric_limits<long>::max()}).c_str());
+
+    EXPECT_STREQ(
+      "double(-1.7976931348623157e+308)",
+      fmt::to_string(double_value{-std::numeric_limits<double>::max()})
+        .c_str());
+    EXPECT_STREQ(
+      "double(2.2250738585072014e-308)",
+      fmt::to_string(double_value{std::numeric_limits<double>::min()}).c_str());
+    EXPECT_STREQ(
+      "double(1.7976931348623157e+308)",
+      fmt::to_string(double_value{std::numeric_limits<double>::max()}).c_str());
+
+    EXPECT_STREQ(
+      "decimal(-170141183460469231731687303715884105728)",
+      fmt::to_string(decimal_value{std::numeric_limits<absl::int128>::min()})
+        .c_str());
+    EXPECT_STREQ(
+      "decimal(170141183460469231731687303715884105727)",
+      fmt::to_string(decimal_value{std::numeric_limits<absl::int128>::max()})
+        .c_str());
+
+    EXPECT_STREQ(
+      "date(-2147483648)",
+      fmt::to_string(date_value{std::numeric_limits<int32_t>::min()}).c_str());
+    EXPECT_STREQ(
+      "date(2147483647)",
+      fmt::to_string(date_value{std::numeric_limits<int32_t>::max()}).c_str());
+
+    EXPECT_STREQ(
+      "time(-9223372036854775808)",
+      fmt::to_string(time_value{std::numeric_limits<long>::min()}).c_str());
+    EXPECT_STREQ(
+      "time(9223372036854775807)",
+      fmt::to_string(time_value{std::numeric_limits<long>::max()}).c_str());
+    EXPECT_STREQ(
+      "timestamp(-9223372036854775808)",
+      fmt::to_string(timestamp_value{std::numeric_limits<long>::min()})
+        .c_str());
+    EXPECT_STREQ(
+      "timestamp(9223372036854775807)",
+      fmt::to_string(timestamp_value{std::numeric_limits<long>::max()})
+        .c_str());
+    EXPECT_STREQ(
+      "timestamptz(-9223372036854775808)",
+      fmt::to_string(timestamptz_value{std::numeric_limits<long>::min()})
+        .c_str());
+    EXPECT_STREQ(
+      "timestamptz(9223372036854775807)",
+      fmt::to_string(timestamptz_value{std::numeric_limits<long>::max()})
+        .c_str());
+
+    EXPECT_STREQ("string(\"\")", fmt::to_string(string_value{}).c_str());
+    EXPECT_STREQ(
+      "string(\"0000000000000000\")",
+      fmt::to_string(string_value{iobuf::from("0000000000000000")}).c_str());
+    EXPECT_STREQ(
+      "string(\"0000000000000000...\")",
+      fmt::to_string(string_value{iobuf::from("00000000000000000")}).c_str());
+
+    EXPECT_STREQ(
+      "uuid(00000000-0000-0000-0000-000000000000)",
+      fmt::to_string(uuid_value{}).c_str());
+    EXPECT_STREQ(
+      "uuid(deadbeef-0000-0000-0000-000000000000)",
+      fmt::to_string(
+        uuid_value{uuid_t::from_string("deadbeef-0000-0000-0000-000000000000")})
+        .c_str());
+
+    EXPECT_STREQ(
+      "binary(size_bytes=0)", fmt::to_string(binary_value{}).c_str());
+    EXPECT_STREQ(
+      "binary(size_bytes=16)",
+      fmt::to_string(binary_value{iobuf::from("0000000000000000")}).c_str());
+
+    EXPECT_STREQ("fixed(size_bytes=0)", fmt::to_string(fixed_value{}).c_str());
+    EXPECT_STREQ(
+      "fixed(size_bytes=16)",
+      fmt::to_string(fixed_value{iobuf::from("0000000000000000")}).c_str());
+}
+
+TEST(ValuesTest, TestStructOStream) {
+    struct_value val;
+    EXPECT_STREQ("struct{}", fmt::to_string(val).c_str());
+    val.fields.emplace_back(std::nullopt);
+    EXPECT_STREQ("struct{none, }", fmt::to_string(val).c_str());
+    val.fields.emplace_back(int_value{1});
+    EXPECT_STREQ("struct{none, int(1), }", fmt::to_string(val).c_str());
+    val.fields.emplace_back(long_value{1});
+    val.fields.emplace_back(long_value{1});
+    val.fields.emplace_back(long_value{1});
+    EXPECT_STREQ(
+      "struct{none, int(1), long(1), long(1), long(1), }",
+      fmt::to_string(val).c_str());
+    val.fields.emplace_back(int_value{1});
+    EXPECT_STREQ(
+      "struct{none, int(1), long(1), long(1), long(1), ...}",
+      fmt::to_string(val).c_str());
+}
+
+TEST(ValuesTest, TestListOStream) {
+    list_value val;
+    EXPECT_STREQ("list{}", fmt::to_string(val).c_str());
+    val.elements.emplace_back(std::nullopt);
+    EXPECT_STREQ("list{none, }", fmt::to_string(val).c_str());
+    val.elements.emplace_back(int_value{1});
+    EXPECT_STREQ("list{none, int(1), }", fmt::to_string(val).c_str());
+    val.elements.emplace_back(int_value{1});
+    val.elements.emplace_back(int_value{1});
+    val.elements.emplace_back(int_value{1});
+    EXPECT_STREQ(
+      "list{none, int(1), int(1), int(1), int(1), }",
+      fmt::to_string(val).c_str());
+    val.elements.emplace_back(int_value{1});
+    EXPECT_STREQ(
+      "list{none, int(1), int(1), int(1), int(1), ...}",
+      fmt::to_string(val).c_str());
+}
+
+TEST(ValuesTest, TestMapOStream) {
+    map_value val;
+    EXPECT_STREQ("map{}", fmt::to_string(val).c_str());
+    val.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    EXPECT_STREQ("map{(k=int(0), v=none), }", fmt::to_string(val).c_str());
+    val.kvs.emplace_back(kv_value{int_value{0}, int_value{1}});
+    EXPECT_STREQ(
+      "map{(k=int(0), v=none), (k=int(0), v=int(1)), }",
+      fmt::to_string(val).c_str());
+    val.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    val.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    val.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    EXPECT_STREQ(
+      "map{(k=int(0), v=none), (k=int(0), v=int(1)), (k=int(0), v=none), "
+      "(k=int(0), v=none), (k=int(0), v=none), }",
+      fmt::to_string(val).c_str());
+    val.kvs.emplace_back(kv_value{int_value{0}, std::nullopt});
+    EXPECT_STREQ(
+      "map{(k=int(0), v=none), (k=int(0), v=int(1)), (k=int(0), v=none), "
+      "(k=int(0), v=none), (k=int(0), v=none), ...}",
+      fmt::to_string(val).c_str());
+}
+
+TEST(ValuesTest, TestHashContainerStructs) {
+    // Test that we can also keep a container of structs, which will roughly be
+    // equivalent to a Kafka record.
+    chunked_hash_set<struct_value> vs;
+    auto unique_vals = unique_values_primitive_types();
+    struct_value val;
+    for (auto& v : unique_vals) {
+        val.fields.emplace_back(std::move(v));
+    }
+    vs.emplace(std::move(val));
+    ASSERT_EQ(1, vs.size());
+}
+
+TEST(ValuesTest, TestHashContainer) {
+    chunked_hash_set<value> vs;
+    auto unique_vals = unique_values_primitive_types();
+    auto expected_size = unique_vals.size();
+    for (auto& v : unique_vals) {
+        vs.emplace(value(std::move(v)));
+    }
+    ASSERT_EQ(expected_size, vs.size());
+}

--- a/src/v/iceberg/values.cc
+++ b/src/v/iceberg/values.cc
@@ -1,0 +1,387 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/values.h"
+
+#include "bytes/hash.h"
+#include "bytes/iobuf_parser.h"
+
+#include <boost/container_hash/hash_fwd.hpp>
+#include <fmt/format.h>
+
+namespace iceberg {
+
+namespace {
+
+struct primitive_hashing_visitor {
+    size_t operator()(const boolean_value& v) const {
+        return std::hash<bool>()(v.val);
+    }
+    size_t operator()(const int_value& v) const {
+        return std::hash<int>()(v.val);
+    }
+    size_t operator()(const long_value& v) const {
+        return std::hash<int64_t>()(v.val);
+    }
+    size_t operator()(const float_value& v) const {
+        return std::hash<float>()(v.val);
+    }
+    size_t operator()(const double_value& v) const {
+        return std::hash<double>()(v.val);
+    }
+    size_t operator()(const date_value& v) const {
+        return std::hash<int32_t>()(v.val);
+    }
+    size_t operator()(const time_value& v) const {
+        return std::hash<int64_t>()(v.val);
+    }
+    size_t operator()(const timestamp_value& v) const {
+        return std::hash<int64_t>()(v.val);
+    }
+    size_t operator()(const timestamptz_value& v) const {
+        return std::hash<int64_t>()(v.val);
+    }
+    size_t operator()(const string_value& v) const {
+        return std::hash<iobuf>()(v.val);
+    }
+    size_t operator()(const uuid_value& v) const {
+        return absl::Hash<uuid_t>()(v.val);
+    }
+    size_t operator()(const fixed_value& v) const {
+        return std::hash<iobuf>()(v.val);
+    }
+    size_t operator()(const binary_value& v) const {
+        return std::hash<iobuf>()(v.val);
+    }
+    size_t operator()(const decimal_value& v) const {
+        return absl::Hash<absl::int128>()(v.val);
+    }
+};
+
+struct hashing_visitor {
+    size_t operator()(const primitive_value& v) const {
+        return std::visit(primitive_hashing_visitor{}, v);
+    }
+
+    size_t operator()(const std::unique_ptr<struct_value>& v) const {
+        if (!v) {
+            return 0;
+        }
+        return value_hash(*v);
+    }
+    size_t operator()(const std::unique_ptr<list_value>& v) const {
+        if (!v) {
+            return 0;
+        }
+        size_t h = 0;
+        for (const auto& e : v->elements) {
+            if (!e) {
+                continue;
+            }
+            boost::hash_combine(h, std::hash<value>()(*e));
+        }
+        return h;
+    }
+    size_t operator()(const std::unique_ptr<map_value>& v) const {
+        if (!v) {
+            return 0;
+        }
+        size_t h = 0;
+        for (const auto& kv : v->kvs) {
+            boost::hash_combine(h, std::hash<value>()(kv.key));
+            if (kv.val) {
+                boost::hash_combine(h, std::hash<value>()(*kv.val));
+            }
+        }
+        return h;
+    }
+};
+
+void ostream_val_ptr(std::ostream& o, const std::optional<value>& v) {
+    if (v) {
+        o << *v;
+        return;
+    }
+    o << "none";
+}
+
+} // namespace
+
+struct primitive_value_comparison_visitor {
+    template<typename T, typename U>
+    bool operator()(const T&, const U&) const {
+        static_assert(!std::is_same<T, U>::value);
+        return false;
+    }
+    template<typename T>
+    requires requires(T t) { t.val; }
+    bool operator()(const T& lhs, const T& rhs) const {
+        return lhs.val == rhs.val;
+    }
+};
+
+bool operator==(const primitive_value& lhs, const primitive_value& rhs) {
+    return std::visit(primitive_value_comparison_visitor{}, lhs, rhs);
+}
+
+bool operator==(const struct_value& lhs, const struct_value& rhs) {
+    if (lhs.fields.size() != rhs.fields.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.fields.size(); i++) {
+        auto has_lhs = lhs.fields[i] != std::nullopt;
+        auto has_rhs = rhs.fields[i] != std::nullopt;
+        if (has_lhs != has_rhs) {
+            return false;
+        }
+        if (!has_lhs) {
+            // Both are null.
+            continue;
+        }
+        if (*lhs.fields[i] != *rhs.fields[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+bool operator==(
+  const std::unique_ptr<struct_value>& lhs,
+  const std::unique_ptr<struct_value>& rhs) {
+    if ((lhs == nullptr) != (rhs == nullptr)) {
+        return false;
+    }
+    if (lhs == nullptr) {
+        // Both null.
+        return true;
+    }
+    return *lhs == *rhs;
+}
+
+bool operator==(const list_value& lhs, const list_value& rhs) {
+    if (lhs.elements.size() != rhs.elements.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.elements.size(); i++) {
+        auto has_lhs = lhs.elements[i] != std::nullopt;
+        auto has_rhs = rhs.elements[i] != std::nullopt;
+        if (has_lhs != has_rhs) {
+            return false;
+        }
+        if (!has_lhs) {
+            // Both are null.
+            continue;
+        }
+        if (*lhs.elements[i] != *rhs.elements[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+bool operator==(
+  const std::unique_ptr<list_value>& lhs,
+  const std::unique_ptr<list_value>& rhs) {
+    if ((lhs == nullptr) != (rhs == nullptr)) {
+        return false;
+    }
+    if (lhs == nullptr) {
+        // Both null.
+        return true;
+    }
+    return *lhs == *rhs;
+}
+
+bool operator==(const kv_value& lhs, const kv_value& rhs) {
+    auto has_lhs_val = lhs.val != std::nullopt;
+    auto has_rhs_val = rhs.val != std::nullopt;
+    if (has_lhs_val != has_rhs_val) {
+        return false;
+    }
+    if (lhs.key != rhs.key) {
+        return false;
+    }
+    if (has_lhs_val && *lhs.val != *rhs.val) {
+        return false;
+    }
+    return true;
+}
+
+bool operator==(const map_value& lhs, const map_value& rhs) {
+    if (lhs.kvs.size() != rhs.kvs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.kvs.size(); i++) {
+        if (lhs.kvs[i] != rhs.kvs[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+bool operator==(
+  const std::unique_ptr<map_value>& lhs,
+  const std::unique_ptr<map_value>& rhs) {
+    if ((lhs == nullptr) != (rhs == nullptr)) {
+        return false;
+    }
+    if (lhs == nullptr) {
+        // Both null.
+        return true;
+    }
+    return *lhs == *rhs;
+}
+
+std::ostream& operator<<(std::ostream& o, const boolean_value& v) {
+    o << fmt::format("boolean({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const int_value& v) {
+    o << fmt::format("int({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const long_value& v) {
+    o << fmt::format("long({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const float_value& v) {
+    o << fmt::format("float({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const double_value& v) {
+    o << fmt::format("double({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const date_value& v) {
+    o << fmt::format("date({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const time_value& v) {
+    o << fmt::format("time({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const timestamp_value& v) {
+    o << fmt::format("timestamp({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const timestamptz_value& v) {
+    o << fmt::format("timestamptz({})", v.val);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const string_value& v) {
+    iobuf_const_parser buf_parser{v.val};
+    static constexpr auto max_len = 16;
+    auto size_bytes = v.val.size_bytes();
+    if (size_bytes > max_len) {
+        o << fmt::format("string(\"{}...\")", buf_parser.read_string(max_len));
+    } else {
+        o << fmt::format("string(\"{}\")", buf_parser.read_string(size_bytes));
+    }
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const uuid_value& v) {
+    o << fmt::format("uuid({})", ss::sstring(v.val));
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const fixed_value& v) {
+    o << fmt::format("fixed(size_bytes={})", v.val.size_bytes());
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const binary_value& v) {
+    o << fmt::format("binary(size_bytes={})", v.val.size_bytes());
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const decimal_value& v) {
+    o << fmt::format("decimal({})", v.val);
+    return o;
+}
+namespace {
+struct value_ostream_visitor {
+    explicit value_ostream_visitor(std::ostream& o)
+      : o_(o) {}
+
+    std::ostream& o_;
+
+    template<typename T>
+    void operator()(const T& v) {
+        o_ << v;
+    }
+};
+} // namespace
+
+std::ostream& operator<<(std::ostream& o, const primitive_value& v) {
+    std::visit(value_ostream_visitor{o}, v);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const list_value& v) {
+    o << "list{";
+    static constexpr size_t max_to_log = 5;
+    size_t logged = 0;
+    for (const auto& e : v.elements) {
+        if (logged == max_to_log) {
+            o << "...";
+            break;
+        }
+        ostream_val_ptr(o, e);
+        o << ", ";
+        logged++;
+    }
+    o << "}";
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const map_value& v) {
+    o << "map{";
+    static constexpr size_t max_to_log = 5;
+    size_t logged = 0;
+    for (const auto& kv : v.kvs) {
+        if (logged == max_to_log) {
+            o << "...";
+            break;
+        }
+        o << fmt::format("(k={}, v=", kv.key);
+        ostream_val_ptr(o, kv.val);
+        o << "), ";
+        logged++;
+    }
+    o << "}";
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const struct_value& v) {
+    o << "struct{";
+    static constexpr size_t max_to_log = 5;
+    size_t logged = 0;
+    for (const auto& f : v.fields) {
+        if (logged == max_to_log) {
+            o << "...";
+            break;
+        }
+        ostream_val_ptr(o, f);
+        o << ", ";
+        logged++;
+    }
+    o << "}";
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const value& v) {
+    std::visit(value_ostream_visitor{o}, v);
+    return o;
+}
+
+size_t value_hash(const struct_value& v) {
+    size_t h = 0;
+    for (const auto& f : v.fields) {
+        if (!f) {
+            continue;
+        }
+        boost::hash_combine(h, std::hash<value>()(*f));
+    }
+    return h;
+}
+
+size_t value_hash(const value& v) { return std::visit(hashing_visitor{}, v); }
+
+} // namespace iceberg

--- a/src/v/iceberg/values.h
+++ b/src/v/iceberg/values.h
@@ -1,0 +1,179 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "container/fragmented_vector.h"
+#include "utils/uuid.h"
+
+#include <absl/numeric/int128.h>
+
+#include <optional>
+#include <variant>
+
+namespace iceberg {
+
+struct boolean_value {
+    bool val;
+};
+
+struct int_value {
+    int32_t val;
+};
+
+struct long_value {
+    int64_t val;
+};
+
+struct float_value {
+    float val;
+};
+
+struct double_value {
+    double val;
+};
+
+struct date_value {
+    // Days since 1970-01-01.
+    int32_t val;
+};
+
+struct time_value {
+    // Microseconds since midnight.
+    int64_t val;
+};
+
+struct timestamp_value {
+    // Microseconds since 1970-01-01 00:00:00.
+    int64_t val;
+};
+
+struct timestamptz_value {
+    // Microseconds since 1970-01-01 00:00:00 UTC.
+    int64_t val;
+};
+
+struct string_value {
+    iobuf val;
+};
+
+struct uuid_value {
+    uuid_t val;
+};
+
+struct fixed_value {
+    iobuf val;
+};
+
+struct binary_value {
+    iobuf val;
+};
+
+struct decimal_value {
+    absl::int128 val;
+};
+
+using primitive_value = std::variant<
+  boolean_value,
+  int_value,
+  long_value,
+  float_value,
+  double_value,
+  date_value,
+  time_value,
+  timestamp_value,
+  timestamptz_value,
+  string_value,
+  uuid_value,
+  fixed_value,
+  binary_value,
+  decimal_value>;
+bool operator==(const primitive_value&, const primitive_value&);
+
+struct struct_value;
+struct list_value;
+struct map_value;
+using value = std::variant<
+  primitive_value,
+  std::unique_ptr<struct_value>,
+  std::unique_ptr<list_value>,
+  std::unique_ptr<map_value>>;
+
+struct struct_value {
+    chunked_vector<std::optional<value>> fields;
+};
+bool operator==(const struct_value&, const struct_value&);
+bool operator==(
+  const std::unique_ptr<struct_value>&, const std::unique_ptr<struct_value>&);
+
+struct list_value {
+    chunked_vector<std::optional<value>> elements;
+};
+bool operator==(const list_value&, const list_value&);
+bool operator==(
+  const std::unique_ptr<struct_value>&, const std::unique_ptr<struct_value>&);
+
+struct kv_value {
+    // Shouldn't be null, according to the Iceberg spec.
+    value key;
+
+    // May be null if the value is null.
+    std::optional<value> val;
+};
+bool operator==(const kv_value&, const kv_value&);
+
+struct map_value {
+    chunked_vector<kv_value> kvs;
+};
+bool operator==(const map_value&, const map_value&);
+bool operator==(
+  const std::unique_ptr<map_value>&, const std::unique_ptr<map_value>&);
+
+std::ostream& operator<<(std::ostream&, const boolean_value&);
+std::ostream& operator<<(std::ostream&, const int_value&);
+std::ostream& operator<<(std::ostream&, const long_value&);
+std::ostream& operator<<(std::ostream&, const float_value&);
+std::ostream& operator<<(std::ostream&, const double_value&);
+std::ostream& operator<<(std::ostream&, const date_value&);
+std::ostream& operator<<(std::ostream&, const time_value&);
+std::ostream& operator<<(std::ostream&, const timestamp_value&);
+std::ostream& operator<<(std::ostream&, const timestamptz_value&);
+std::ostream& operator<<(std::ostream&, const string_value&);
+std::ostream& operator<<(std::ostream&, const uuid_value&);
+std::ostream& operator<<(std::ostream&, const fixed_value&);
+std::ostream& operator<<(std::ostream&, const binary_value&);
+std::ostream& operator<<(std::ostream&, const decimal_value&);
+std::ostream& operator<<(std::ostream&, const primitive_value&);
+std::ostream& operator<<(std::ostream&, const struct_value&);
+std::ostream& operator<<(std::ostream&, const list_value&);
+std::ostream& operator<<(std::ostream&, const map_value&);
+std::ostream& operator<<(std::ostream&, const value&);
+
+size_t value_hash(const struct_value&);
+size_t value_hash(const value&);
+
+} // namespace iceberg
+
+namespace std {
+
+template<>
+struct hash<iceberg::struct_value> {
+    size_t operator()(const iceberg::struct_value& v) const {
+        return iceberg::value_hash(v);
+    }
+};
+
+template<>
+struct hash<iceberg::value> {
+    size_t operator()(const iceberg::value& v) const {
+        return iceberg::value_hash(v);
+    }
+};
+
+} // namespace std


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This adds a representation of record values, for use in Iceberg
integration. Some expected usage of these values are:
- When converting Kafka data records to an intermediary format before
  converting to parquet, that format can be these values, rather than a
  thirdparty representation like Arrow (which may not play well with
  Seastar's allocator, e.g. doesn't use iobufs).
- We can represent manifest entries as these values, and then serialize
  the values to Avro dynamically, rather than using fixed-schema
  codegen. This allows us to include a partition key to the manifest
  entries, which we wouldn't be able to do with the current codegen.

The latter here is my primary motivator, but the implementation is
enough to serve the former use case too.

The structure of the values roughly resembles the Rust Literal
implementation[1], but using variants instead of Rust enums. There is
1:1 correspondence between each value and the types in
iceberg/datatypes.h, though note that there is no strict relationship
between the types and values encoded anywhere (yet?).

This commit includes the definition, an equality operator, a stream
operator, and  a hashing function.

[1] https://github.com/apache/iceberg-rust/blob/main/crates/iceberg/src/spec/values.rs

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
