### PR TITLE
`cloud_storage_clients`: remove remote perm checks from `s3_client::self_configure()`

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -248,14 +248,11 @@ private:
       const bucket_name& bucket,
       const object_key& key);
 
-    // Performs testing as part of the self-configuration step.
-    // If remote_read is true, the test will use list_objects().
-    // If remote_read is false, the test will instead use put_object() and
-    // delete_object(). If both remote_read and remote_write are false, the test
-    // will fail a vassert() call.
-    // Returns true if the test ran was succesfully and false otherwise.
-    ss::future<bool> self_configure_test(
-      const bucket_name& bucket, bool remote_read, bool remote_write);
+    // Performs testing as part of the self-configuration step. Returns true if
+    // the test was successful (indicating that the current addressing style is
+    // compatible with the configured cloud storage provider), and false
+    // otherwise.
+    ss::future<bool> self_configure_test(const bucket_name& bucket);
 
 private:
     request_creator _requestor;

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1455,19 +1455,22 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 'cloud_storage_enabled': True,
                 'cloud_storage_credentials_source': 'aws_instance_metadata',
                 'cloud_storage_region': 'us-east-1',
-                'cloud_storage_bucket': 'dearliza'
+                'cloud_storage_bucket': 'dearliza',
+                'cloud_storage_url_style': 'virtual_host'
             },
             {
                 'cloud_storage_enabled': True,
                 'cloud_storage_credentials_source': 'gcp_instance_metadata',
                 'cloud_storage_region': 'us-east-1',
-                'cloud_storage_bucket': 'dearliza'
+                'cloud_storage_bucket': 'dearliza',
+                'cloud_storage_url_style': 'virtual_host'
             },
             {
                 'cloud_storage_enabled': True,
                 'cloud_storage_credentials_source': 'sts',
                 'cloud_storage_region': 'us-east-1',
-                'cloud_storage_bucket': 'dearliza'
+                'cloud_storage_bucket': 'dearliza',
+                'cloud_storage_url_style': 'virtual_host'
             },
             {
                 'cloud_storage_enabled': True,
@@ -1475,7 +1478,8 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 'cloud_storage_access_key': 'sesame',
                 'cloud_storage_credentials_source': 'config_file',
                 'cloud_storage_region': 'us-east-1',
-                'cloud_storage_bucket': 'dearliza'
+                'cloud_storage_bucket': 'dearliza',
+                'cloud_storage_url_style': 'virtual_host'
             },
         ]
         for payload in valid_updates:
@@ -1504,7 +1508,8 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             'cloud_storage_secret_key': 'open',
             'cloud_storage_access_key': 'sesame',
             'cloud_storage_region': 'us-east-1',
-            'cloud_storage_bucket': 'dearliza'
+            'cloud_storage_bucket': 'dearliza',
+            'cloud_storage_url_style': 'virtual_host'
         }
         patch_result = self.admin.patch_cluster_config(upsert=static_config,
                                                        remove=[])

--- a/tests/rptest/tests/cluster_self_config_test.py
+++ b/tests/rptest/tests/cluster_self_config_test.py
@@ -47,12 +47,8 @@ class ClusterSelfConfigTest(EndToEndTest):
 
     @cluster(num_nodes=1)
     @matrix(cloud_storage_type=get_cloud_storage_type(
-        applies_only_on=[CloudStorageType.S3]),
-            cloud_storage_enable_remote_read=[True, False],
-            cloud_storage_enable_remote_write=[True, False])
-    def test_s3_self_config(self, cloud_storage_type,
-                            cloud_storage_enable_remote_read,
-                            cloud_storage_enable_remote_write):
+        applies_only_on=[CloudStorageType.S3]))
+    def test_s3_self_config(self, cloud_storage_type):
         """
         Verify that cloud_storage_url_style self configuration occurs for the s3_client
         when it is not specified. There aren't any endpoints for testing this, so
@@ -61,10 +57,7 @@ class ClusterSelfConfigTest(EndToEndTest):
         si_settings = SISettings(
             self.ctx,
             # Force self configuration through setting cloud_storage_url_style to None.
-            cloud_storage_url_style=None,
-            cloud_storage_enable_remote_read=cloud_storage_enable_remote_read,
-            cloud_storage_enable_remote_write=cloud_storage_enable_remote_write
-        )
+            cloud_storage_url_style=None)
 
         self.start_redpanda(si_settings=si_settings)
         admin = Admin(self.redpanda)
@@ -81,10 +74,6 @@ class ClusterSelfConfigTest(EndToEndTest):
             # Assert that self configuration started.
             assert self.self_config_start_in_logs(node)
 
-            # If neither remote_read or remote_write are enabled, check for the "defaulting" output
-            if not cloud_storage_enable_remote_read and not cloud_storage_enable_remote_write:
-                assert self.self_config_default_in_logs(node)
-
             # Assert that self configuration returned a result.
             self_config_result = self.self_config_result_from_logs(node)
 
@@ -98,12 +87,8 @@ class ClusterSelfConfigTest(EndToEndTest):
 
     @cluster(num_nodes=1)
     @matrix(cloud_storage_type=get_cloud_storage_type(
-        applies_only_on=[CloudStorageType.S3]),
-            cloud_storage_enable_remote_read=[True, False],
-            cloud_storage_enable_remote_write=[True, False])
-    def test_s3_oracle_self_config(self, cloud_storage_type,
-                                   cloud_storage_enable_remote_read,
-                                   cloud_storage_enable_remote_write):
+        applies_only_on=[CloudStorageType.S3]))
+    def test_s3_oracle_self_config(self, cloud_storage_type):
         """
         Verify that the cloud_storage_url_style self-configuration for OCI
         backend always results in path-style.
@@ -116,8 +101,6 @@ class ClusterSelfConfigTest(EndToEndTest):
             # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm#s3-api-support
             cloud_storage_api_endpoint=
             'mynamespace.compat.objectstorage.us-phoenix-1.oraclecloud.com',
-            cloud_storage_enable_remote_read=cloud_storage_enable_remote_read,
-            cloud_storage_enable_remote_write=cloud_storage_enable_remote_write,
             # Bypass bucket creation, cleanup, and scrubbing, as we won't actually be able to access the endpoint (Self configuration will usi the endpoint to set path-style).
             bypass_bucket_creation=True,
             use_bucket_cleanup_policy=False,

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -46,16 +46,12 @@ class SelfTestTest(EndToEndTest):
         return wait_until_result(all_idle, timeout_sec=90, backoff_sec=1)
 
     @cluster(num_nodes=3)
-    @matrix(remote_read=[True, False], remote_write=[True, False])
-    def test_self_test(self, remote_read, remote_write):
+    def test_self_test(self):
         """Assert the self test starts/completes with success."""
         num_nodes = 3
         self.start_redpanda(
             num_nodes=num_nodes,
-            si_settings=SISettings(
-                test_context=self.test_context,
-                cloud_storage_enable_remote_read=remote_read,
-                cloud_storage_enable_remote_write=remote_write))
+            si_settings=SISettings(test_context=self.test_context))
         self.rpk_client().self_test_start(2000, 2000, 5000, 100)
 
         # Wait for completion
@@ -215,11 +211,9 @@ class SelfTestTest(EndToEndTest):
            with mixed versions of Redpanda."""
         num_nodes = 3
 
-        self.start_redpanda(num_nodes=num_nodes,
-                            si_settings=SISettings(
-                                test_context=self.test_context,
-                                cloud_storage_enable_remote_read=True,
-                                cloud_storage_enable_remote_write=True))
+        self.start_redpanda(
+            num_nodes=num_nodes,
+            si_settings=SISettings(test_context=self.test_context))
 
         #Attempt to run with an unknown test type "pandatest"
         #and possibly unknown "cloud" test.


### PR DESCRIPTION
These permission checks were unnecessary and lead to confusing behaviour.

Default to using a `ListObjects` request for self-configuring the addressing style used for the `s3_client`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none