### PR TITLE
ducktape/cst-inv: wait for hashes to appear

### DIFF
--- a/tests/rptest/tests/cloud_storage_inventory_test.py
+++ b/tests/rptest/tests/cloud_storage_inventory_test.py
@@ -94,7 +94,7 @@ class CloudStorageInventoryTest(PreallocNodesTest):
                 expected.add(NTP(ns="kafka", topic=spec.name, partition=pid))
         for node in self.redpanda.started_nodes():
             found |= self._find_ntp_hashes_on_node(node)
-        self.logger.debug(f"{found=} |= {expected=}")
+        self.logger.debug(f"{found=}, {expected=}")
         return found == expected
 
     def _find_ntp_hashes_on_node(self, node):

--- a/tests/rptest/tests/cloud_storage_inventory_test.py
+++ b/tests/rptest/tests/cloud_storage_inventory_test.py
@@ -82,11 +82,11 @@ class CloudStorageInventoryTest(PreallocNodesTest):
         self.start_redpanda()
         self._create_initial_topics()
         self.populate_bucket()
-        wait_until(lambda: self._assert_hashes_are_found_on_leaders(),
+        wait_until(lambda: self._hashes_are_found_on_leaders(),
                    timeout_sec=60,
                    backoff_sec=5)
 
-    def _assert_hashes_are_found_on_leaders(self):
+    def _hashes_are_found_on_leaders(self):
         found = set()
         expected = set()
         for spec in self.topics:

--- a/tests/rptest/tests/cloud_storage_inventory_test.py
+++ b/tests/rptest/tests/cloud_storage_inventory_test.py
@@ -1,6 +1,8 @@
 import base64
 from pathlib import Path
 
+from ducktape.utils.util import wait_until
+
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings
@@ -80,7 +82,9 @@ class CloudStorageInventoryTest(PreallocNodesTest):
         self.start_redpanda()
         self._create_initial_topics()
         self.populate_bucket()
-        self._assert_hashes_are_found_on_leaders()
+        wait_until(lambda: self._assert_hashes_are_found_on_leaders(),
+                   timeout_sec=60,
+                   backoff_sec=5)
 
     def _assert_hashes_are_found_on_leaders(self):
         found = set()
@@ -90,7 +94,8 @@ class CloudStorageInventoryTest(PreallocNodesTest):
                 expected.add(NTP(ns="kafka", topic=spec.name, partition=pid))
         for node in self.redpanda.started_nodes():
             found |= self._find_ntp_hashes_on_node(node)
-        assert found == expected, f"{found=} |= {expected=}"
+        self.logger.debug(f"{found=} |= {expected=}")
+        return found == expected
 
     def _find_ntp_hashes_on_node(self, node):
         """


### PR DESCRIPTION
Previously the test did not wait for hashes to appear to disk. Now it waits for 60 seconds for the report to be processed so the test has time to finish.

FIXES #22934

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
