### PR TITLE
c/tx_gateway: made `end_txn` fully idempotent when committing transaction

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1831,6 +1831,19 @@ tx_gateway_frontend::handle_commit_tx(
         co_return tx::errc::fenced;
     }
 
+    /**
+     * Completed commit transaction do not require any further steps, simply
+     * return success to make the end_txn request fully idempotent.
+     */
+    if (tx.status == tx_status::completed_commit) {
+        vlog(
+          txlog.warn,
+          "[tx_id={}] transaction is {} already committed",
+          tx.id,
+          tx);
+        co_return tx::errc::none;
+    }
+
     if (is_state_transition_valid(tx, tx_status::preparing_commit)) {
         try {
             auto r = co_await do_commit_tm_tx(term, stm, tx, timeout, outcome);


### PR DESCRIPTION
When transaction is committed the process may be interrupted in any of the steps i.e. before replicating the `preparing_commit` state update, before requesting data partitions to commit transaction or before replicating `completed_commit` state update. When an `end_txn` request is retried by the client `tx_gateway` try to progress the transaction before it is returned for further processing in either commit or abort handling method. It may be the case that the transaction progress all the way to `completed_commit` state, in this case Redpanda should return a success to client as the transaction was finished.

Fixed a bug leading to the situation in which an invalid transaction state error was returned when transaction was progressed to `completed_commit` phase before entering a commit transaction handler. The fix makes the `EndTxn` request fully idempotent.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- Made `EndTxnRequest` fully idempotent 