### PR TITLE
[CORE-5542] s/segment_utils: pass abort source into compacted index reader

### DIFF
--- a/src/v/storage/compacted_index_chunk_reader.h
+++ b/src/v/storage/compacted_index_chunk_reader.h
@@ -28,7 +28,8 @@ public:
       segment_full_path,
       ss::file,
       ss::io_priority_class,
-      size_t max_chunk_memory) noexcept;
+      size_t max_chunk_memory,
+      ss::abort_source* _as) noexcept;
 
     ss::future<> close() final;
 
@@ -57,6 +58,7 @@ private:
     std::optional<compacted_index::footer> _footer;
     bool _end_of_stream{false};
     std::optional<ss::input_stream<char>> _cursor;
+    ss::abort_source* _as;
 
     friend std::ostream&
     operator<<(std::ostream&, const compacted_index_chunk_reader&);

--- a/src/v/storage/compacted_index_reader.h
+++ b/src/v/storage/compacted_index_reader.h
@@ -166,7 +166,8 @@ compacted_index_reader make_file_backed_compacted_reader(
   segment_full_path filename,
   ss::file,
   ss::io_priority_class,
-  size_t step_chunk);
+  size_t step_chunk,
+  ss::abort_source*);
 
 inline ss::future<ss::circular_buffer<compacted_index::entry>>
 compaction_index_reader_to_memory(compacted_index_reader rdr) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -65,7 +65,7 @@ ss::future<bool> build_offset_map_for_segment(
       compaction_idx_path, cfg.sanitizer_config);
     std::exception_ptr eptr;
     auto rdr = make_file_backed_compacted_reader(
-      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB);
+      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB, cfg.asrc);
     try {
         co_await rdr.verify_integrity();
     } catch (...) {


### PR DESCRIPTION
Segment compaction is a process that may take a significant amount of time, especially when segment size is large as it was merged with other segments during compaction. Added checking an abort source while reading the compacted index to make the operation interruptible. This way when requested Redpanda will be able to stop faster.

Fixes: CORE-5542
Fixes: CORE-5532
Fixes: CORE-1994

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none