### PR TITLE
datalake: add event multiplexer

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -9,6 +9,8 @@ v_cc_library(
     protobuf_to_arrow_converter.cc
     proto_to_arrow_scalar.cc
     proto_to_arrow_struct.cc
+    record_multiplexer.cc
+    schemaless_translator.cc
   DEPS
     v::storage
     Seastar::seastar

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/schemaless_translator.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <cstddef>
+#include <memory>
+
+#pragma once
+
+namespace datalake {
+struct data_writer_result {
+    size_t row_count = 0;
+};
+
+class data_writer {
+public:
+    virtual ~data_writer() = default;
+
+    // TODO: error type?
+    virtual bool add_data_struct(
+      iceberg::struct_value /* data */, int64_t /* approx_size */)
+      = 0;
+
+    virtual data_writer_result finish() = 0;
+};
+
+class data_writer_factory {
+public:
+    virtual ~data_writer_factory() = default;
+
+    virtual std::unique_ptr<data_writer>
+      create_writer(iceberg::struct_type /* schema */) = 0;
+};
+} // namespace datalake

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/record_multiplexer.h"
+
+#include "datalake/data_writer_interface.h"
+#include "iceberg/values.h"
+#include "model/record.h"
+#include "storage/parser_utils.h"
+
+namespace datalake {
+record_multiplexer::record_multiplexer(
+  std::unique_ptr<data_writer_factory> writer_factory)
+  : _translator{schemaless_translator()}
+  , _writer_factory{std::move(writer_factory)} {}
+
+ss::future<ss::stop_iteration>
+record_multiplexer::operator()(model::record_batch batch) {
+    if (batch.compressed()) {
+        batch = co_await storage::internal::decompress_batch(std::move(batch));
+    }
+    batch.for_each_record([&batch, this](model::record&& record) {
+        iobuf key = record.release_key();
+        iobuf val = record.release_value();
+        // *1000: Redpanda timestamps are milliseconds. Iceberg uses
+        // microseconds.
+        int64_t timestamp = (batch.header().first_timestamp.value()
+                             + record.timestamp_delta())
+                            * 1000;
+        int64_t offset = static_cast<int64_t>(batch.base_offset())
+                         + record.offset_delta();
+        int64_t estimated_size = key.size_bytes() + val.size_bytes() + 16;
+
+        // Translate the record
+        auto& translator = get_translator();
+        iceberg::struct_value data = std::visit(
+          [&key, &val, timestamp, offset](schemaless_translator& tr) {
+              return tr.translate_event(
+                std::move(key), std::move(val), timestamp, offset);
+          },
+          translator);
+
+        // Send it to the writer
+        auto& writer = get_writer();
+        writer.add_data_struct(std::move(data), estimated_size);
+    });
+    co_return ss::stop_iteration::no;
+}
+
+ss::future<chunked_vector<data_writer_result>>
+record_multiplexer::end_of_stream() {
+    // TODO: once we have multiple _writers this should be a loop
+    if (_writer) {
+        chunked_vector<data_writer_result> ret;
+        data_writer_result res = _writer->finish();
+        ret.push_back(res);
+        co_return ret;
+    } else {
+        co_return chunked_vector<data_writer_result>{};
+    }
+}
+
+record_multiplexer::translator& record_multiplexer::get_translator() {
+    return _translator;
+}
+
+data_writer& record_multiplexer::get_writer() {
+    if (!_writer) {
+        auto schema = std::visit(
+          [](schemaless_translator& tr) { return tr.get_schema(); },
+          _translator);
+        _writer = _writer_factory->create_writer(std::move(schema));
+    }
+    return *_writer;
+}
+} // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/data_writer_interface.h"
+#include "datalake/schemaless_translator.h"
+#include "model/record.h"
+
+#include <seastar/core/future.hh>
+
+#include <memory>
+
+namespace datalake {
+
+/*
+Consumes logs and sends records to the appropriate translator
+based on the schema ID. This is meant to be called with a
+read_committed_reader created from a kafka::partition_proxy.
+
+This is a skeleton class. Currently it only uses the trivial
+schemaless_translator.
+
+pseudocode:
+for each record {
+    t = get_translator(record.schema_id);
+    d = t.translate(record);
+    w = get_data_writer(record.schema_id);
+    w.record(d);
+}
+*/
+class record_multiplexer {
+public:
+    explicit record_multiplexer(
+      std::unique_ptr<data_writer_factory> writer_factory);
+    ss::future<ss::stop_iteration> operator()(model::record_batch batch);
+    ss::future<chunked_vector<data_writer_result>> end_of_stream();
+
+private:
+    using translator = std::variant<schemaless_translator>;
+
+    translator& get_translator();
+    data_writer& get_writer();
+
+    // TODO: in a future PR this will be a map of translators keyed by schema_id
+    translator _translator;
+    std::unique_ptr<data_writer_factory> _writer_factory;
+
+    // TODO: similarly this will be a map keyed by schema_id
+    std::unique_ptr<data_writer> _writer;
+};
+
+} // namespace datalake

--- a/src/v/datalake/schemaless_translator.cc
+++ b/src/v/datalake/schemaless_translator.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/schemaless_translator.h"
+
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+namespace datalake {
+
+iceberg::struct_value schemaless_translator::translate_event(
+  iobuf key, iobuf value, int64_t timestamp, int64_t offset) const {
+    using namespace iceberg;
+    struct_value res;
+    res.fields.emplace_back(long_value(offset));
+    res.fields.emplace_back(timestamp_value(timestamp));
+    res.fields.emplace_back(string_value(std::move(key)));
+    res.fields.emplace_back(string_value(std::move(value)));
+    return res;
+}
+
+iceberg::struct_type schemaless_translator::get_schema() const {
+    using namespace iceberg;
+    struct_type res;
+    res.fields.emplace_back(nested_field::create(
+      1, "redpanda_offset", field_required::yes, long_type{}));
+    res.fields.emplace_back(nested_field::create(
+      2, "redpanda_timestamp", field_required::yes, timestamp_type{}));
+    res.fields.emplace_back(nested_field::create(
+      3, "redpanda_key", field_required::no, string_type{}));
+    res.fields.emplace_back(nested_field::create(
+      4, "redpanda_value", field_required::no, string_type{}));
+
+    return res;
+}
+
+} // namespace datalake

--- a/src/v/datalake/schemaless_translator.h
+++ b/src/v/datalake/schemaless_translator.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <cstdint>
+#include <utility>
+
+namespace datalake {
+class schemaless_translator {
+public:
+    iceberg::struct_value translate_event(
+      iobuf key, iobuf value, int64_t timestamp, int64_t offset) const;
+
+    iceberg::struct_type get_schema() const;
+};
+} // namespace datalake

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -9,5 +9,16 @@ rp_test(
       v::datalake
     LABELS datalake
     ARGS "-- -c 1"
-  )
-  
+)
+
+rp_test(
+  GTEST
+  BINARY_NAME gtest_record_multiplexer
+  SOURCES gtest_record_multiplexer_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::datalake
+    v::model_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/record_multiplexer.h"
+#include "datalake/tests/test_data_writer.h"
+#include "model/tests/random_batch.h"
+
+#include <gtest/gtest.h>
+
+TEST(DatalakeMultiplexerTest, TestMultiplexer) {
+    int record_count = 10;
+    int batch_count = 10;
+    auto writer_factory
+      = std::make_unique<datalake::test_data_writer_factory>();
+    datalake::record_multiplexer multiplexer(std::move(writer_factory));
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    ss::circular_buffer<model::record_batch> batches
+      = model::test::make_random_batches(batch_spec).get0();
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+
+    auto result
+      = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].row_count, record_count * batch_count);
+}

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -1,0 +1,52 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "datalake/data_writer_interface.h"
+#include "datalake/schemaless_translator.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <cstdint>
+#include <memory>
+namespace datalake {
+
+class test_data_writer : public data_writer {
+public:
+    explicit test_data_writer(iceberg::struct_type schema)
+      : _schema(std::move(schema))
+      , _result{} {}
+
+    bool add_data_struct(
+      iceberg::struct_value /* data */, int64_t /* approx_size */) override {
+        _result.row_count++;
+        return false;
+    }
+
+    data_writer_result finish() override { return _result; }
+
+private:
+    iceberg::struct_type _schema;
+    data_writer_result _result{};
+};
+
+class test_data_writer_factory : public data_writer_factory {
+public:
+    std::unique_ptr<data_writer>
+    create_writer(iceberg::struct_type schema) override {
+        return std::make_unique<test_data_writer>(std::move(schema));
+    }
+
+private:
+    iceberg::struct_type _schema;
+};
+
+} // namespace datalake


### PR DESCRIPTION
This is a skeleton implementation of the event multiplexer. This is a log consumer that will determine the schema ID and type (Protobuf, JSON, Avro) of each event, and sends them to the correct translator and writer.

In this version it translates schemaless events and sends them to a test writer that simply counts them.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
