### PR TITLE
[backport] [24.1.x] tx: do not throw USE on expired transaction_ids

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2004,7 +2004,7 @@ tx_gateway_frontend::do_end_txn(
               "abort",
               request.transactional_id,
               pid);
-            err = tx_errc::unknown_server_error;
+            err = tx_errc::invalid_producer_id_mapping;
         }
         outcome->set_value(err);
         co_return err;

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -401,8 +401,9 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         try:
             producer.commit_transaction()
             assert False, "transaction should have been aborted by now."
-        except ck.KafkaException:
-            pass
+        except ck.KafkaException as e:
+            assert e.args[0].code(
+            ) == ck.KafkaError.INVALID_PRODUCER_ID_MAPPING, f"Invalid error thrown on expiration {e}"
 
     @cluster(num_nodes=3)
     def expired_tx_test(self):


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/22912

Instead return INVALID_PRODUCER_ID_MAPPING like Apache Kafka https://github.com/apache/kafka/blob/cd47b3c1cce7a9f1881e40d38742b9ec8b30cf32/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala#L513C23-L513C50

(cherry picked from commit 84f42dba01dc3c1633145e14dd0c64a6ff61a59c)

Fixes https://github.com/redpanda-data/redpanda/issues/22918

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
