### PR TITLE
[rptest] always clean up object stores (that are small) for non-GCP

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -70,12 +70,22 @@ from rptest.services.storage_failure_injection import FailureInjectionConfig
 from rptest.services.utils import NodeCrash, LogSearchLocal, LogSearchCloud, Stopwatch
 from rptest.util import inject_remote_script, ssh_output_stderr, wait_until_result
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
+import enum
 
 Partition = collections.namedtuple('Partition',
                                    ['topic', 'index', 'leader', 'replicas'])
 
 MetricSample = collections.namedtuple(
     'MetricSample', ['family', 'sample', 'node', 'value', 'labels'])
+
+
+class CloudStorageCleanupStrategy(enum.Enum):
+    # I.e. if we are using a lifecycle rule, then we do NOT clean the bucket
+    IF_NOT_USING_LIFECYCLE_RULE = "IF_NOT_USING_LIFECYCLE_RULE"
+
+    # Ignore large buckets (based on number of objects). For small buckets, ALWAYS clean.
+    ALWAYS_SMALL_BUCKETS_ONLY = "ALWAYS_SMALL_BUCKETS_ONLY"
+
 
 SaslCredentials = redpanda_types.SaslCredentials
 
@@ -541,6 +551,10 @@ class SISettings:
                     CloudStorageType, test_context.
                     injected_args['cloud_storage_type_and_url_style'][0])
 
+        # For most cloud storage backends, we clean up small buckets always.
+        # In some cases, we will modify this strategy in the block below.
+        self.cloud_storage_cleanup_strategy = CloudStorageCleanupStrategy.ALWAYS_SMALL_BUCKETS_ONLY
+
         if self.cloud_storage_type == CloudStorageType.S3:
             self.cloud_storage_credentials_source = cloud_storage_credentials_source
             self.cloud_storage_access_key = cloud_storage_access_key
@@ -556,6 +570,10 @@ class SISettings:
             elif test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
                                           'aws') == 'gcp':
                 self.cloud_storage_api_endpoint = 'storage.googleapis.com'
+                # For GCP, we currently use S3 compat API over boto3, which does not support batch deletes
+                # This makes cleanup slow, even for small-ish buckets.
+                # Therefore, we maintain logic of skipping bucket cleaning completely, if we are using lifecycle rule.
+                self.cloud_storage_cleanup_strategy = CloudStorageCleanupStrategy.IF_NOT_USING_LIFECYCLE_RULE
             else:
                 # Endpoint defaults to minio-s3
                 self.cloud_storage_api_endpoint = 'minio-s3'
@@ -594,6 +612,7 @@ class SISettings:
         self.endpoint_url = f'http://{self.cloud_storage_api_endpoint}:{self.cloud_storage_api_endpoint_port}'
         self.bypass_bucket_creation = bypass_bucket_creation
         self.use_bucket_cleanup_policy = use_bucket_cleanup_policy
+
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
         self.cloud_storage_spillover_manifest_max_segments = cloud_storage_spillover_manifest_max_segments
         self.retention_local_strict = retention_local_strict
@@ -3286,11 +3305,42 @@ class RedpandaService(RedpandaServiceBase):
         return self._cloud_storage_client
 
     def delete_bucket_from_si(self):
-        if self.si_settings.use_bucket_cleanup_policy:
-            self.logger.info(
-                f"Skipping deletion of bucket/container: {self.si_settings.cloud_storage_bucket}."
-                "Using a cleanup policy instead. Please delete it manually")
-            return
+        self.logger.info(
+            f"cloud_storage_cleanup_strategy = {self.si_settings.cloud_storage_cleanup_strategy}"
+        )
+
+        if self.si_settings.cloud_storage_cleanup_strategy == CloudStorageCleanupStrategy.ALWAYS_SMALL_BUCKETS_ONLY:
+            bucket_is_small = True
+            max_object_count = 3000
+
+            # See if the bucket is small enough
+            for i, m in enumerate(
+                    self.cloud_storage_client.list_objects(
+                        self.si_settings.cloud_storage_bucket)):
+                if i >= max_object_count:
+                    bucket_is_small = False
+                    break
+            if bucket_is_small:
+                self.logger.info(
+                    f"Always deleting bucket {self.si_settings.cloud_storage_bucket} (if it's small), even though we might use lifecycle policy also"
+                )
+            else:
+                self.logger.info(
+                    f"Bucket contains more than {max_object_count} objects, NOT cleaning."
+                )
+                return
+
+        elif self.si_settings.cloud_storage_cleanup_strategy == CloudStorageCleanupStrategy.IF_NOT_USING_LIFECYCLE_RULE:
+            if self.si_settings.use_bucket_cleanup_policy:
+                self.logger.info(
+                    f"Skipping deletion of bucket/container: {self.si_settings.cloud_storage_bucket}."
+                    "Using a cleanup policy instead. Please delete it manually"
+                )
+                return
+        else:
+            raise ValueError(
+                f"Unimplemented cloud storage cleanup strategy {self.si_settings.cloud_storage_cleanup_strategy}"
+            )
 
         self.logger.debug(
             f"Deleting bucket/container: {self.si_settings.cloud_storage_bucket}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3321,7 +3321,7 @@ class RedpandaService(RedpandaServiceBase):
                 if i >= max_object_count:
                     bucket_is_small = False
                     break
-            print(
+            self.logger.info(
                 f"Determining bucket count for {self.si_settings.cloud_storage_bucket} up to {max_object_count} objects took {time.time() - t}s"
             )
             if bucket_is_small:
@@ -3356,7 +3356,7 @@ class RedpandaService(RedpandaServiceBase):
             self.si_settings.cloud_storage_bucket,
             parallel=self.dedicated_nodes)
 
-        print(
+        self.logger.info(
             f"Emptying and deleting bucket {self.si_settings.cloud_storage_bucket} took {time.time() - t}s"
         )
 


### PR DESCRIPTION
We want to scale up CDT parallelism by way of increasing number of nodes.  One existing risk today is the number of S3 storage buckets that get accumulated during a test session (about 300).  With a hard limit of 1000 buckets per AWS account, we cannot safely run more than 3 CDT runs in between our async cleanup schedules (hours).  This is too limiting - with much faster CDT runs, we may run more frequently and hit the bucket count limit more often (heck even today we hit it sometimes).

Cleaning buckets inline as part of each test case teardown was always ideal.  But we know that certain buckets become very populous and can take a long time (many tens of minutes for millions of objects even with batch requests).

This PR provides a compromise.  The important thing is keeping bucket accumulation and peak bucket count low.  So:
* For small buckets (<3000 objects), we perform inline cleanup.  This will take seconds only.
* For large / mega buckets, we skip inline cleanup as usual.  We continue to depend on async clean up.

For GCP, even small buckets might take significant time to clean up right now, so for GCP we will not change the existing async-cleanup-only behavior.  We can revisit once we migrate to the real GCS API / SDK which has batch deletes operation.

**Just to give an indication of the prize here - during prototyping, CDT speed up can take CDT duration from about 8-9 hours down to 2.5 hours.**

Consider this PR something that helps derisk the "too many buckets" side effect of having much faster CDT's.  It is also a simpler pattern to align bucket creation and bucket cleanup to each test (for most buckets at least), rather than having it split into a inline creation + async garbage collect.

This change needs to be backported, this benefits all cloud accounts we run CDT in (which are shared across release branches).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none