### PR TITLE
[v24.2.x] [CORE-5542] s/segment_utils: pass abort source into compacted index reader

### DIFF
--- a/src/v/storage/compacted_index_chunk_reader.h
+++ b/src/v/storage/compacted_index_chunk_reader.h
@@ -28,7 +28,8 @@ public:
       segment_full_path,
       ss::file,
       ss::io_priority_class,
-      size_t max_chunk_memory) noexcept;
+      size_t max_chunk_memory,
+      ss::abort_source* _as) noexcept;
 
     ss::future<> close() final;
 
@@ -57,6 +58,7 @@ private:
     std::optional<compacted_index::footer> _footer;
     bool _end_of_stream{false};
     std::optional<ss::input_stream<char>> _cursor;
+    ss::abort_source* _as;
 
     friend std::ostream&
     operator<<(std::ostream&, const compacted_index_chunk_reader&);

--- a/src/v/storage/compacted_index_reader.h
+++ b/src/v/storage/compacted_index_reader.h
@@ -166,7 +166,8 @@ compacted_index_reader make_file_backed_compacted_reader(
   segment_full_path filename,
   ss::file,
   ss::io_priority_class,
-  size_t step_chunk);
+  size_t step_chunk,
+  ss::abort_source*);
 
 inline ss::future<ss::circular_buffer<compacted_index::entry>>
 compaction_index_reader_to_memory(compacted_index_reader rdr) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -65,7 +65,7 @@ ss::future<bool> build_offset_map_for_segment(
       compaction_idx_path, cfg.sanitizer_config);
     std::exception_ptr eptr;
     auto rdr = make_file_backed_compacted_reader(
-      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB);
+      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB, cfg.asrc);
     try {
         co_await rdr.verify_integrity();
     } catch (...) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22938
