### PR TITLE
[v24.2.x] `rptest`: allow user to override `cloud_storage_api_endpoint`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -491,7 +491,7 @@ class SISettings:
                  cloud_storage_access_key: str = 'panda-user',
                  cloud_storage_secret_key: str = 'panda-secret',
                  cloud_storage_region: str = 'panda-region',
-                 cloud_storage_api_endpoint: str = 'minio-s3',
+                 cloud_storage_api_endpoint: Optional[str] = None,
                  cloud_storage_api_endpoint_port: int = 9000,
                  cloud_storage_url_style: str = 'virtual_host',
                  cloud_storage_cache_size: Optional[int] = None,
@@ -543,11 +543,17 @@ class SISettings:
             self.cloud_storage_region = cloud_storage_region
             self._cloud_storage_bucket = f'panda-bucket-{uuid.uuid1()}'
             self.cloud_storage_url_style = cloud_storage_url_style
+            self.has_cloud_storage_api_endpoint_override = False
 
-            self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
-            if test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
-                                        'aws') == 'gcp':
+            if cloud_storage_api_endpoint is not None:
+                self.has_cloud_storage_api_endpoint_override = True
+                self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
+            elif test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
+                                          'aws') == 'gcp':
                 self.cloud_storage_api_endpoint = 'storage.googleapis.com'
+            else:
+                # Endpoint defaults to minio-s3
+                self.cloud_storage_api_endpoint = 'minio-s3'
             self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
 
             if hasattr(test_context, 'injected_args') \
@@ -657,6 +663,11 @@ class SISettings:
         Update based on the test context, to e.g. consume AWS access keys in
         the globals dictionary.
         """
+        if self.has_cloud_storage_api_endpoint_override:
+            logger.info(
+                "cloud_storage_api_endpoint is overridden, skipping loading global test_context options in _load_s3_context."
+            )
+            return
         cloud_storage_credentials_source = test_context.globals.get(
             self.GLOBAL_CLOUD_STORAGE_CRED_SOURCE_KEY, 'config_file')
         cloud_storage_access_key = test_context.globals.get(

--- a/tests/rptest/tests/cluster_self_config_test.py
+++ b/tests/rptest/tests/cluster_self_config_test.py
@@ -94,25 +94,38 @@ class ClusterSelfConfigTest(EndToEndTest):
         Verify that the cloud_storage_url_style self-configuration for OCI
         backend always results in path-style.
         """
+        oracle_api_endpoint = 'mynamespace.compat.objectstorage.us-phoenix-1.oraclecloud.com'
         si_settings = SISettings(
             self.ctx,
             # Force self configuration through setting cloud_storage_url_style to None.
             cloud_storage_url_style=None,
             # Set Oracle endpoint to expected format.
             # https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm#s3-api-support
-            cloud_storage_api_endpoint=
-            'mynamespace.compat.objectstorage.us-phoenix-1.oraclecloud.com',
-            # Bypass bucket creation, cleanup, and scrubbing, as we won't actually be able to access the endpoint (Self configuration will usi the endpoint to set path-style).
+            cloud_storage_enable_remote_read=False,
+            cloud_storage_enable_remote_write=False,
+            cloud_storage_api_endpoint=oracle_api_endpoint,
+            # Bypass bucket creation, cleanup, and scrubbing, as we won't actually be
+            # able to access the endpoint (Self configuration will use the endpoint
+            # to set path-style without issuing a request).
             bypass_bucket_creation=True,
             use_bucket_cleanup_policy=False,
             skip_end_of_test_scrubbing=True)
+        extra_rp_conf = {
+            'cloud_storage_enable_scrubbing': False,
+            'cloud_storage_disable_upload_loop_for_tests': True,
+            'enable_cluster_metadata_upload_loop': False
+        }
 
-        self.start_redpanda(si_settings=si_settings)
+        self.start_redpanda(extra_rp_conf=extra_rp_conf,
+                            si_settings=si_settings)
         admin = Admin(self.redpanda)
         self.log_searcher = LogSearchLocal(self.ctx, [], self.redpanda.logger,
                                            self.redpanda.STDOUT_STDERR_CAPTURE)
 
         config = admin.get_cluster_config()
+
+        # Make sure that the endpoint was overridden.
+        assert config['cloud_storage_api_endpoint'] == oracle_api_endpoint
 
         # Even after self-configuring, the cloud_storage_url_style setting will
         # still be left unset at the cluster config level.


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22928
