### PR TITLE
storage: split batch_cache into separate bazel library

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -106,11 +106,36 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "batch_cache",
+    srcs = [
+        "batch_cache.cc",
+    ],
+    hdrs = [
+        "batch_cache.h",
+    ],
+    implementation_deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/ssx:future_util",
+        "//src/v/utils:to_string",
+        "@fmt",
+    ],
+    include_prefix = "storage",
+    deps = [
+        "//src/v/base",
+        "//src/v/container:intrusive",
+        "//src/v/model",
+        "//src/v/resource_mgmt:available_memory",
+        "//src/v/ssx:semaphore",
+        "@abseil-cpp//absl/container:btree",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "storage",
     srcs = [
         "api.cc",
         "backlog_controller.cc",
-        "batch_cache.cc",
         "compacted_index_chunk_reader.cc",
         "compaction_controller.cc",
         "compaction_reducers.cc",
@@ -147,7 +172,6 @@ redpanda_cc_library(
     hdrs = [
         "api.h",
         "backlog_controller.h",
-        "batch_cache.h",
         "batch_consumer_utils.h",
         "chunk_cache.h",
         "compacted_index.h",
@@ -211,6 +235,7 @@ redpanda_cc_library(
     include_prefix = "storage",
     visibility = ["//visibility:public"],
     deps = [
+        ":batch_cache",
         ":index_state",
         ":parser_utils",
         ":record_batch_builder",

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -15,7 +15,6 @@
 #include "model/fundamental.h"
 #include "resource_mgmt/available_memory.h"
 #include "ssx/future-util.h"
-#include "storage/logger.h"
 #include "utils/to_string.h"
 
 #include <seastar/core/coroutine.hh>

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -27,7 +27,6 @@
 #include <seastar/core/weak_ptr.hh>
 
 #include <absl/container/btree_map.h>
-#include <absl/container/flat_hash_map.h>
 
 #include <limits>
 #include <type_traits>

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -70,3 +70,22 @@ redpanda_cc_btest(
         "@boost//:test",
     ],
 )
+
+redpanda_cc_btest(
+    name = "batch_cache_test",
+    timeout = "short",
+    srcs = [
+        "batch_cache_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:random",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/storage:batch_cache",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -8,11 +8,11 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/random.h"
-#include "cluster/simple_batch_builder.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "random/generators.h"
 #include "storage/batch_cache.h"
+#include "storage/record_batch_builder.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/sharded.hh>
@@ -32,17 +32,24 @@ using is_dirty_entry = storage::batch_cache::is_dirty_entry;
 
 static model::record_batch
 make_batch(size_t size = 10, model::offset offset = model::offset(0)) {
-    cluster::simple_batch_builder b(model::record_batch_type(1), offset);
+    storage::record_batch_builder b(model::record_batch_type(1), offset);
     for (size_t i = 0; i < size; i++) {
-        b.add_kv("key", "value");
+        std::string_view key_data = "key";
+        std::string_view val_data = "value";
+        iobuf key;
+        iobuf val;
+        key.append(key_data.data(), key_data.size());
+        val.append(val_data.data(), val_data.size());
+        b.add_raw_kv(std::move(key), std::move(val));
     }
     return std::move(b).build();
 }
 
 static model::record_batch make_random_batch(
   size_t max_size = 10, model::offset offset = model::offset(0)) {
-    cluster::simple_batch_builder b(model::record_batch_type(1), offset);
-    b.add_kv(iobuf{}, bytes_to_iobuf(random_generators::get_bytes(max_size)));
+    storage::record_batch_builder b(model::record_batch_type(1), offset);
+    b.add_raw_kv(
+      iobuf{}, bytes_to_iobuf(random_generators::get_bytes(max_size)));
 
     return std::move(b).build();
 }

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -34,13 +34,7 @@ static model::record_batch
 make_batch(size_t size = 10, model::offset offset = model::offset(0)) {
     storage::record_batch_builder b(model::record_batch_type(1), offset);
     for (size_t i = 0; i < size; i++) {
-        std::string_view key_data = "key";
-        std::string_view val_data = "value";
-        iobuf key;
-        iobuf val;
-        key.append(key_data.data(), key_data.size());
-        val.append(val_data.data(), val_data.size());
-        b.add_raw_kv(std::move(key), std::move(val));
+        b.add_raw_kv(iobuf::from("key"), iobuf::from("value"));
     }
     return std::move(b).build();
 }


### PR DESCRIPTION
storage: split batch_cache into separate bazel library and adds bazel test for batch cache.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

