### PR TITLE
Giving state machine implementers a way to opt out from being forced to support snapshotting at arbitrary offset. 

### DIFF
--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -95,7 +95,7 @@ public:
     static constexpr std::string_view name = Name;
     explicit distributed_kv_stm(
       size_t max_partitions, ss::logger& logger, raft::consensus* raft)
-      : persisted_stm<>("distributed_kv_stm.snapshot", logger, raft)
+      : raft::persisted_stm<>("distributed_kv_stm.snapshot", logger, raft)
       , _default_max_partitions(max_partitions)
       , _is_routing_partition(_raft->ntp().tp.partition == routing_partition) {}
 

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -41,14 +41,14 @@ id_allocator_stm::id_allocator_stm(ss::logger& logger, raft::consensus* c)
 
 id_allocator_stm::id_allocator_stm(
   ss::logger& logger, raft::consensus* c, config::configuration& cfg)
-  : persisted_stm(id_allocator_snapshot, logger, c)
+  : raft::persisted_stm<>(id_allocator_snapshot, logger, c)
   , _batch_size(cfg.id_allocator_batch_size.value())
   , _log_capacity(cfg.id_allocator_log_capacity.value()) {}
 
 ss::future<bool>
 id_allocator_stm::sync(model::timeout_clock::duration timeout) {
     auto term = _insync_term;
-    auto is_synced = co_await persisted_stm::sync(timeout);
+    auto is_synced = co_await raft::persisted_stm<>::sync(timeout);
     if (is_synced) {
         if (term != _insync_term) {
             _curr_id = _state;

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -118,6 +118,7 @@ protected:
     virtual ss::future<model::offset> storage_eviction_event();
 
 private:
+    using base_t = raft::persisted_stm<raft::kvstore_backed_stm_snapshot>;
     void increment_start_offset(model::offset);
     bool should_process_evict(model::offset);
 

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -301,11 +301,10 @@ TEST_F_CORO(
         auto base_offset = co_await node->random_batch_base_offset(
           node->raft()->committed_offset(), model::offset(100));
         auto snapshot_offset = model::prev_offset(base_offset);
-
-        co_await node->raft()->write_snapshot(raft::write_snapshot_cfg(
-          snapshot_offset,
-          co_await node->raft()->stm_manager()->take_snapshot(
-            snapshot_offset)));
+        auto result = co_await node->raft()->stm_manager()->take_snapshot(
+          snapshot_offset);
+        co_await node->raft()->write_snapshot(
+          raft::write_snapshot_cfg(snapshot_offset, std::move(result.data)));
     }
 
     // test follower recovery with snapshot

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -64,7 +64,7 @@ tm_stm::tm_stm(
   , _feature_table(feature_table)
   , _ctx_log(logger, ssx::sformat("[{}]", _raft->ntp())) {}
 
-ss::future<> tm_stm::start() { co_await persisted_stm::start(); }
+ss::future<> tm_stm::start() { co_await raft::persisted_stm<>::start(); }
 
 uint8_t tm_stm::active_snapshot_version() { return tm_snapshot::version; }
 
@@ -179,7 +179,7 @@ tm_stm::do_sync(model::timeout_clock::duration timeout) {
         co_return tm_stm::op_status::not_leader;
     }
 
-    auto ready = co_await persisted_stm::sync(timeout);
+    auto ready = co_await raft::persisted_stm<>::sync(timeout);
     if (!ready) {
         co_return tm_stm::op_status::unknown;
     }

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -159,13 +159,13 @@ concept supported_stm_snapshot = requires(T s, stm_snapshot&& snapshot) {
  * and uses it as a base for replaying the commands.
  */
 
-template<supported_stm_snapshot T = file_backed_stm_snapshot>
-class persisted_stm
-  : public raft::state_machine_base
+template<typename BaseT, supported_stm_snapshot T = file_backed_stm_snapshot>
+class persisted_stm_base
+  : public BaseT
   , public storage::snapshotable_stm {
 public:
     template<typename... Args>
-    explicit persisted_stm(
+    explicit persisted_stm_base(
       ss::sstring, ss::logger&, raft::consensus*, Args&&...);
 
     /**
@@ -262,6 +262,9 @@ private:
     T _snapshot_backend;
     model::offset _last_snapshot_offset;
 };
+
+template<supported_stm_snapshot T = file_backed_stm_snapshot>
+using persisted_stm = persisted_stm_base<state_machine_base, T>;
 /**
  * Helper to copy persisted_stm kvstore snapshot from the source kvstore to
  * target shard

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -79,6 +79,7 @@ private:
       const follower_index_metadata& follower_metadata) const;
     bool is_recovery_finished();
     flush_after_append should_flush(model::offset) const;
+    bool is_snapshot_at_offset_supported() const;
     consensus* _ptr;
     vnode _node_id;
     model::offset _base_batch_offset;

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -64,6 +64,15 @@ concept StateMachineIterateFunc = requires(
  */
 class state_machine_manager final {
 public:
+    /**
+     * A result returned after taking a snapshot it contains a serde serialized
+     * snapshot data and last offset included into the snapshot.
+     */
+    struct snapshot_result {
+        iobuf data;
+        model::offset last_included_offset;
+    };
+
     // wait until at least offset is applied to all the state machines
     ss::future<> wait(
       model::offset,
@@ -75,13 +84,28 @@ public:
      * state i.e last snapshot index is derived from last_applied_offset. In
      * Redpanda we use different approach. Data eviction policy forces us to
      * allow state machines to take snapshot at arbitrary offsets.
+     *
+     * IMPORTANT: This API is only supported if all state machines support
+     * taking snapshots at arbitrary offset.
      */
-    ss::future<iobuf> take_snapshot(model::offset);
+    ss::future<snapshot_result> take_snapshot(model::offset);
+
+    /**
+     * If any of the state machines in the manager doesn't support fast
+     * reconfigurations this is the only API that the user is allowed to call,
+     * the take snapshot with offset other than _last_applied_offset will fail.
+     */
+    ss::future<snapshot_result> take_snapshot();
 
     ss::future<> start();
     ss::future<> stop();
 
     model::offset last_applied() const { return model::prev_offset(_next); }
+
+    snapshot_at_offset_supported supports_snapshot_at_offset() const {
+        return _supports_snapshot_at_offset;
+    }
+
     /**
      * Returns a pointer to specific type of state machine.
      *
@@ -192,6 +216,7 @@ private:
     ss::gate _gate;
     ss::abort_source _as;
     ss::scheduling_group _apply_sg;
+    snapshot_at_offset_supported _supports_snapshot_at_offset{true};
 };
 
 /**


### PR DESCRIPTION
To support fast partition movement in Redpanda the
`raft::state_machine_base` interface requires state machine implementer
to provide support for taking snapshot at arbitrary, already applied
offset. This requirement is easy to achieve for all existing state
machines as they do not require raft snapshots at all.

In future we may leverage the Raft protocol snapshot as they provide a
nice way to maintain the bounded log size without compromising
consistency.

This PR introduces changes to `state_machine_manager` and
`state_machine_base` interfaces allowing state machine implementer to
opt out from the requirement to provide snapshot at offset capability.
Without this feature the partition that the STM is build at will not be
fast movable but the `take_snapshot` implementation will be very simple
as it will require simply serializing the current in memory state of the
state machine.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none