### PR TITLE
storage/index_state: use chunked_vector

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -119,9 +119,9 @@ struct index_state
     model::timestamp max_timestamp{0};
 
     /// breaking indexes into their own has a 6x latency reduction
-    fragmented_vector<uint32_t> relative_offset_index;
-    fragmented_vector<uint32_t> relative_time_index;
-    fragmented_vector<uint64_t> position_index;
+    chunked_vector<uint32_t> relative_offset_index;
+    chunked_vector<uint32_t> relative_time_index;
+    chunked_vector<uint64_t> position_index;
 
     // flag indicating whether the maximum timestamp on the batches
     // of this segment are monontonically increasing.

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -37,7 +37,7 @@ static storage::index_state make_random_index_state(
     }
 
     if (apply_offset == storage::offset_delta_time::no) {
-        fragmented_vector<uint32_t> time_index;
+        chunked_vector<uint32_t> time_index;
         for (auto i = 0; i < n; ++i) {
             time_index.push_back(random_generators::get_int<uint32_t>());
         }


### PR DESCRIPTION
In cases of lots of small indexes the overhead of many of these
fragmented_vectors can be quite high. Reduce the overhead by using
chunked_vector so the first chunk isn't full length.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* Reduce the memory overhead of many small segments.
