### PR TITLE
r/persisted_stm: serialize apply and taking local snapshot with a mutex

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1015,7 +1015,8 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
     co_return errc::success;
 }
 
-ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
+ss::future<>
+archival_metadata_stm::apply_with_lock(const model::record_batch& b) {
     if (
       b.header().type != model::record_batch_type::archival_metadata
       && b.header().type != model::record_batch_type::prefix_truncate) {

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -302,7 +302,7 @@ private:
     ss::future<std::error_code>
     do_replicate_commands(model::record_batch, ss::abort_source&);
 
-    ss::future<> apply(const model::record_batch& batch) override;
+    ss::future<> apply_with_lock(const model::record_batch& batch) override;
     ss::future<> apply_raft_snapshot(const iobuf&) override;
 
     ss::future<>

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -102,7 +102,8 @@ public:
     ss::future<> start() override { co_await raft::persisted_stm<>::start(); }
     ss::future<> stop() override { co_await _gate.close(); }
 
-    ss::future<> apply(const model::record_batch& record_batch) override {
+    ss::future<>
+    apply_with_lock(const model::record_batch& record_batch) override {
         if (record_batch.header().type != model::record_batch_type::raft_data) {
             co_return;
         }

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -152,7 +152,7 @@ id_allocator_stm::do_allocate_id(model::timeout_clock::duration timeout) {
     co_return stm_allocation_result{id};
 }
 
-ss::future<> id_allocator_stm::apply(const model::record_batch& b) {
+ss::future<> id_allocator_stm::apply_with_lock(const model::record_batch& b) {
     if (b.header().type != model::record_batch_type::id_allocator) {
         return ss::now();
     }

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -98,7 +98,7 @@ private:
       do_allocate_id(model::timeout_clock::duration);
     ss::future<bool> set_state(int64_t, model::timeout_clock::duration);
 
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> apply_with_lock(const model::record_batch&) final;
 
     // Moves the state forward to the given value if the curent id is lower
     // than it.

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -379,7 +379,8 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
     co_return result.value().last_offset;
 }
 
-ss::future<> log_eviction_stm::apply(const model::record_batch& batch) {
+ss::future<>
+log_eviction_stm::apply_with_lock(const model::record_batch& batch) {
     if (likely(
           batch.header().type != model::record_batch_type::prefix_truncate)) {
         co_return;

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -123,7 +123,7 @@ private:
     ss::future<> monitor_log_eviction();
     ss::future<> do_write_raft_snapshot(model::offset);
     ss::future<> handle_log_eviction_events();
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> apply_with_lock(const model::record_batch&) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
     ss::future<offset_result> replicate_command(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1442,7 +1442,7 @@ void rm_stm::apply_fence(model::producer_identity pid, model::record_batch b) {
     _producer_state_manager.local().touch(*producer, _vcluster_id);
 }
 
-ss::future<> rm_stm::apply(const model::record_batch& b) {
+ss::future<> rm_stm::apply_with_lock(const model::record_batch& b) {
     const auto& hdr = b.header();
     const auto bid = model::batch_identity::from(hdr);
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -330,7 +330,7 @@ private:
 
     abort_origin get_abort_origin(tx::producer_ptr, model::tx_seq) const;
 
-    ss::future<> apply(const model::record_batch&) override;
+    ss::future<> apply_with_lock(const model::record_batch&) override;
     void apply_fence(model::producer_identity, model::record_batch);
     void apply_control(model::producer_identity, model::control_record_type);
     void apply_data(model::batch_identity, const model::record_batch_header&);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -713,7 +713,7 @@ tm_stm::apply_tm_update(model::record_batch_header hdr, model::record_batch b) {
     return ss::now();
 }
 
-ss::future<> tm_stm::apply(const model::record_batch& b) {
+ss::future<> tm_stm::apply_with_lock(const model::record_batch& b) {
     const auto& hdr = b.header();
 
     if (hdr.type == model::record_batch_type::tm_update) {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -364,7 +364,7 @@ private:
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
     ss::future<raft::stm_snapshot> take_local_snapshot() override;
 
-    ss::future<> apply(const model::record_batch& b) final;
+    ss::future<> apply_with_lock(const model::record_batch& b) final;
 
     ss::future<>
     apply_tm_update(model::record_batch_header hdr, model::record_batch b);

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -45,7 +45,8 @@ void group_tx_tracker_stm::maybe_end_tx(
     }
 }
 
-ss::future<> group_tx_tracker_stm::apply(const model::record_batch& b) {
+ss::future<>
+group_tx_tracker_stm::apply_with_lock(const model::record_batch& b) {
     auto holder = _gate.hold();
     co_await parse(b.copy());
 }

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -44,7 +44,7 @@ public:
         return ss::make_ready_future<fragmented_vector<model::tx_range>>();
     }
 
-    ss::future<> apply(const model::record_batch&) override;
+    ss::future<> apply_with_lock(const model::record_batch&) override;
 
     model::offset max_collectible_offset() override;
 

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -293,7 +293,9 @@ ss::future<> persisted_stm<T>::wait_for_snapshot_hydrated() {
 
 template<supported_stm_snapshot T>
 ss::future<> persisted_stm<T>::do_write_local_snapshot() {
+    auto u = co_await _apply_lock.get_units();
     auto snapshot = co_await take_local_snapshot();
+    u.return_all();
     auto offset = snapshot.header.offset;
 
     co_await _snapshot_backend.persist_local_snapshot(std::move(snapshot));

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -212,7 +212,7 @@ public:
         return last_op;
     }
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply_with_lock(const model::record_batch& batch) override {
         auto last_op = apply_to_state(batch, state);
         if (last_op) {
             last_operation = std::move(*last_op);
@@ -292,7 +292,7 @@ public:
      * as it is going to be started without the full data in the snapshot, hence
      * the validation would fail.
      */
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply_with_lock(const model::record_batch& batch) override {
         if (batch.header().type != model::record_batch_type::raft_data) {
             co_return;
         }


### PR DESCRIPTION
When a local snapshot is taken by the `persisted_stm` it should not interleave with apply. Added a lock to make sure that both the apply and `take_local_snapshot` do not overlap.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none