### PR TITLE
[v24.1.x] storage/index_state: use chunked_vector

### DIFF
--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -119,9 +119,9 @@ struct index_state
     model::timestamp max_timestamp{0};
 
     /// breaking indexes into their own has a 6x latency reduction
-    fragmented_vector<uint32_t> relative_offset_index;
-    fragmented_vector<uint32_t> relative_time_index;
-    fragmented_vector<uint64_t> position_index;
+    chunked_vector<uint32_t> relative_offset_index;
+    chunked_vector<uint32_t> relative_time_index;
+    chunked_vector<uint64_t> position_index;
 
     // flag indicating whether the maximum timestamp on the batches
     // of this segment are monontonically increasing.

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -37,7 +37,7 @@ static storage::index_state make_random_index_state(
     }
 
     if (apply_offset == storage::offset_delta_time::no) {
-        fragmented_vector<uint32_t> time_index;
+        chunked_vector<uint32_t> time_index;
         for (auto i = 0; i < n; ++i) {
             time_index.push_back(random_generators::get_int<uint32_t>());
         }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22962
