### PR TITLE
`kafka`: deal with `truncation_offset < 0` cases in `prefix_truncate()`

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -485,6 +485,12 @@ replicated_partition::get_leader_epoch_last_offset_unbounded(
 ss::future<error_code> replicated_partition::prefix_truncate(
   model::offset kafka_truncation_offset,
   ss::lowres_clock::time_point deadline) {
+    if (kafka_truncation_offset() == -1) {
+        kafka_truncation_offset = high_watermark();
+    }
+    if (kafka_truncation_offset() < 0) {
+        co_return error_code::offset_out_of_range;
+    }
     if (kafka_truncation_offset <= start_offset()) {
         // No-op, return early.
         co_return kafka::error_code::none;


### PR DESCRIPTION
As a follow-up to a previous commit which failed to consider the cases for a negative `truncation_offset`.

In Kafka, a `truncation_offset = -1` [indicates a `DeleteRecords` call up to the `high_watermark`](https://github.com/apache/kafka/blob/fb7e47f6e28cc325bbb354348d2abde4696d7915/core/src/main/scala/kafka/cluster/Partition.scala#L1683), [whereas all other negative values result in an `offset_out_of_range` error.](https://github.com/apache/kafka/blob/fb7e47f6e28cc325bbb354348d2abde4696d7915/core/src/main/scala/kafka/cluster/Partition.scala#L1688-L1689)

Correct the cases here, and add tests for both of them.

This will potentially require new messaging from docs, indicating the corner case for -1: https://docs.redpanda.com/current/reference/rpk/rpk-topic/rpk-topic-trim-prefix/.

Holding off on backports in light of the docs updates, unless they are deemed necessary.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug fixes

* Correct logic for `rpk topic trim-prefix` for negative values, where `-1` indicates a truncation up to the high-watermark, and all other negative values return an `offset_out_of_range` error code.
