### PR TITLE
r/persisted_stm: serialize apply and taking local snapshot with a mutex

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1015,7 +1015,7 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
     co_return errc::success;
 }
 
-ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
+ss::future<> archival_metadata_stm::do_apply(const model::record_batch& b) {
     if (
       b.header().type != model::record_batch_type::archival_metadata
       && b.header().type != model::record_batch_type::prefix_truncate) {
@@ -1288,7 +1288,8 @@ ss::future<> archival_metadata_stm::apply_local_snapshot(
     co_return;
 }
 
-ss::future<raft::stm_snapshot> archival_metadata_stm::take_local_snapshot() {
+ss::future<raft::stm_snapshot>
+archival_metadata_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     auto segments = segments_from_manifest(*_manifest);
     auto replaced = replaced_segments_from_manifest(*_manifest);
     auto spillover = spillover_from_manifest(*_manifest);
@@ -1310,17 +1311,19 @@ ss::future<raft::stm_snapshot> archival_metadata_stm::take_local_snapshot() {
       .last_scrubbed_offset = _manifest->last_scrubbed_offset(),
       .detected_anomalies = _manifest->detected_anomalies(),
       .highest_producer_id = _manifest->highest_producer_id()});
+    auto snapshot_offset = last_applied_offset();
+    apply_units.return_all();
 
     vlog(
       _logger.debug,
       "creating snapshot at offset: {}, remote start_offset: {}, "
       "last_offset: {}",
-      last_applied_offset(),
+      snapshot_offset,
       get_start_offset(),
       get_last_offset());
 
     co_return raft::stm_snapshot::create(
-      0, last_applied_offset(), std::move(snap_data));
+      0, snapshot_offset, std::move(snap_data));
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -302,12 +302,13 @@ private:
     ss::future<std::error_code>
     do_replicate_commands(model::record_batch, ss::abort_source&);
 
-    ss::future<> apply(const model::record_batch& batch) override;
+    ss::future<> do_apply(const model::record_batch& batch) override;
     ss::future<> apply_raft_snapshot(const iobuf&) override;
 
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
+    ss::future<raft::stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) override;
 
     struct segment;
     struct start_offset;

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -152,7 +152,7 @@ id_allocator_stm::do_allocate_id(model::timeout_clock::duration timeout) {
     co_return stm_allocation_result{id};
 }
 
-ss::future<> id_allocator_stm::apply(const model::record_batch& b) {
+ss::future<> id_allocator_stm::do_apply(const model::record_batch& b) {
     if (b.header().type != model::record_batch_type::id_allocator) {
         return ss::now();
     }
@@ -229,7 +229,8 @@ id_allocator_stm::apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) {
       std::logic_error("id_allocator_stm doesn't support snapshots"));
 }
 
-ss::future<raft::stm_snapshot> id_allocator_stm::take_local_snapshot() {
+ss::future<raft::stm_snapshot>
+id_allocator_stm::take_local_snapshot(ssx::semaphore_units) {
     return ss::make_exception_future<raft::stm_snapshot>(
       std::logic_error("id_allocator_stm doesn't support snapshots"));
 }

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -98,7 +98,7 @@ private:
       do_allocate_id(model::timeout_clock::duration);
     ss::future<bool> set_state(int64_t, model::timeout_clock::duration);
 
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> do_apply(const model::record_batch&) final;
 
     // Moves the state forward to the given value if the curent id is lower
     // than it.
@@ -108,7 +108,8 @@ private:
     ss::future<> write_snapshot();
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
+    ss::future<raft::stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) override;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
     ss::future<bool> sync(model::timeout_clock::duration);
 

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -379,7 +379,7 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
     co_return result.value().last_offset;
 }
 
-ss::future<> log_eviction_stm::apply(const model::record_batch& batch) {
+ss::future<> log_eviction_stm::do_apply(const model::record_batch& batch) {
     if (likely(
           batch.header().type != model::record_batch_type::prefix_truncate)) {
         co_return;
@@ -451,10 +451,12 @@ ss::future<> log_eviction_stm::apply_local_snapshot(
     return ss::now();
 }
 
-ss::future<raft::stm_snapshot> log_eviction_stm::take_local_snapshot() {
+ss::future<raft::stm_snapshot>
+log_eviction_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     vlog(_log.trace, "Taking snapshot at offset: {}", last_applied_offset());
     iobuf snap_data = serde::to_iobuf(
       snapshot_data{.effective_start_offset = _delete_records_eviction_offset});
+    apply_units.return_all();
     co_return raft::stm_snapshot::create(
       0, last_applied_offset(), std::move(snap_data));
 }

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -112,7 +112,8 @@ protected:
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
 
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
+    ss::future<raft::stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) override;
 
     virtual ss::future<model::offset> storage_eviction_event();
 
@@ -123,7 +124,7 @@ private:
     ss::future<> monitor_log_eviction();
     ss::future<> do_write_raft_snapshot(model::offset);
     ss::future<> handle_log_eviction_events();
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> do_apply(const model::record_batch&) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
     ss::future<offset_result> replicate_command(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -261,8 +261,10 @@ private:
       model::timeout_clock::duration);
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
-    ss::future<raft::stm_snapshot> do_take_local_snapshot(uint8_t version);
+    ss::future<raft::stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) override;
+    ss::future<raft::stm_snapshot>
+    do_take_local_snapshot(uint8_t version, ssx::semaphore_units apply_units);
     ss::future<std::optional<tx::abort_snapshot>>
       load_abort_snapshot(tx::abort_index);
     ss::future<> save_abort_snapshot(tx::abort_snapshot);
@@ -330,7 +332,7 @@ private:
 
     abort_origin get_abort_origin(tx::producer_ptr, model::tx_seq) const;
 
-    ss::future<> apply(const model::record_batch&) override;
+    ss::future<> do_apply(const model::record_batch&) override;
     void apply_fence(model::producer_identity, model::record_batch);
     void apply_control(model::producer_identity, model::control_record_type);
     void apply_data(model::batch_identity, const model::record_batch_header&);

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -59,7 +59,7 @@ struct rm_stm_test_fixture : simple_raft_fixture {
     }
 
     auto local_snapshot(uint8_t version) {
-        return _stm->do_take_local_snapshot(version);
+        return _stm->do_take_local_snapshot(version, {});
     }
 
     auto apply_snapshot(raft::stm_snapshot_header hdr, iobuf buf) {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -593,7 +593,8 @@ tm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tm_ss_buf) {
     return ss::now();
 }
 
-ss::future<raft::stm_snapshot> tm_stm::take_local_snapshot() {
+ss::future<raft::stm_snapshot>
+tm_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     // Update hash ranges to always have batch in log
     // So it cannot be deleted with cleanup policy
     if (_raft->is_leader()) {
@@ -604,31 +605,37 @@ ss::future<raft::stm_snapshot> tm_stm::take_local_snapshot() {
         }
     }
     co_return co_await ss::with_gate(
-      _gate, [this] { return do_take_snapshot(); });
+      _gate, [this, units = std::move(apply_units)]() mutable {
+          return do_take_snapshot(std::move(units));
+      });
 }
 
-ss::future<raft::stm_snapshot> tm_stm::do_take_snapshot() {
+ss::future<raft::stm_snapshot>
+tm_stm::do_take_snapshot(ssx::semaphore_units apply_units) {
     auto snapshot_version = active_snapshot_version();
+    auto snapshot_offset = last_applied_offset();
     if (snapshot_version == tm_snapshot_v0::version) {
         tm_snapshot_v0 tm_ss;
-        tm_ss.offset = last_applied_offset();
+        tm_ss.offset = snapshot_offset;
         tm_ss.transactions = get_transactions_list();
 
         iobuf tm_ss_buf;
         reflection::adl<tm_snapshot_v0>{}.to(tm_ss_buf, std::move(tm_ss));
 
+        apply_units.return_all();
         co_return raft::stm_snapshot::create(
-          tm_snapshot_v0::version, last_applied_offset(), std::move(tm_ss_buf));
+          tm_snapshot_v0::version, snapshot_offset, std::move(tm_ss_buf));
     } else {
         tm_snapshot tm_ss;
-        tm_ss.offset = last_applied_offset();
+        tm_ss.offset = snapshot_offset;
         tm_ss.transactions = get_transactions_list();
 
         iobuf tm_ss_buf;
         reflection::adl<tm_snapshot>{}.to(tm_ss_buf, std::move(tm_ss));
 
+        apply_units.return_all();
         co_return raft::stm_snapshot::create(
-          tm_snapshot::version, last_applied_offset(), std::move(tm_ss_buf));
+          tm_snapshot::version, snapshot_offset, std::move(tm_ss_buf));
     }
 }
 
@@ -713,7 +720,7 @@ tm_stm::apply_tm_update(model::record_batch_header hdr, model::record_batch b) {
     return ss::now();
 }
 
-ss::future<> tm_stm::apply(const model::record_batch& b) {
+ss::future<> tm_stm::do_apply(const model::record_batch& b) {
     const auto& hdr = b.header();
 
     if (hdr.type == model::record_batch_type::tm_update) {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -362,9 +362,10 @@ private:
     std::optional<tx_metadata> find_tx(const kafka::transactional_id&);
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
+    ss::future<raft::stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) override;
 
-    ss::future<> apply(const model::record_batch& b) final;
+    ss::future<> do_apply(const model::record_batch& b) final;
 
     ss::future<>
     apply_tm_update(model::record_batch_header hdr, model::record_batch b);
@@ -380,7 +381,8 @@ private:
       kafka::transactional_id,
       std::chrono::milliseconds,
       model::producer_identity);
-    ss::future<raft::stm_snapshot> do_take_snapshot();
+    ss::future<raft::stm_snapshot>
+    do_take_snapshot(ssx::semaphore_units apply_units);
     ss::future<result<raft::replicate_result>>
       quorum_write_empty_batch(model::timeout_clock::time_point);
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -381,8 +381,7 @@ private:
       kafka::transactional_id,
       std::chrono::milliseconds,
       model::producer_identity);
-    ss::future<raft::stm_snapshot>
-    do_take_snapshot(ssx::semaphore_units apply_units);
+
     ss::future<result<raft::replicate_result>>
       quorum_write_empty_batch(model::timeout_clock::time_point);
 

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -44,14 +44,15 @@ public:
         return ss::make_ready_future<fragmented_vector<model::tx_range>>();
     }
 
-    ss::future<> apply(const model::record_batch&) override;
+    ss::future<> do_apply(const model::record_batch&) override;
 
     model::offset max_collectible_offset() override;
 
     ss::future<>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;
 
-    ss::future<raft::stm_snapshot> take_local_snapshot() override;
+    ss::future<raft::stm_snapshot>
+      take_local_snapshot(ssx::semaphore_units) override;
 
     ss::future<> apply_raft_snapshot(const iobuf&) final;
     ss::future<iobuf> take_snapshot(model::offset) final;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -209,10 +209,16 @@ public:
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
+    ss::future<> apply(const model::record_batch& b) final {
+        return _apply_lock.with([this, &b] { return do_apply(b); });
+    }
+
 protected:
     ss::future<> start() override;
 
     ss::future<> stop() override;
+
+    virtual ss::future<> do_apply(const model::record_batch& b) = 0;
 
     /**
      * Called when local snapshot is applied to the state machine
@@ -220,9 +226,11 @@ protected:
     virtual ss::future<> apply_local_snapshot(stm_snapshot_header, iobuf&&) = 0;
 
     /**
-     * Called when a local snapshot is taken
+     * Called when a local snapshot is taken. Apply fiber is stalled until
+     * apply_units are alive for a consistent snapshot of the state machine.
      */
-    virtual ss::future<stm_snapshot> take_local_snapshot() = 0;
+    virtual ss::future<stm_snapshot>
+    take_local_snapshot(ssx::semaphore_units apply_units) = 0;
 
     /*
      * `sync` checks that current node is a leader and if `sync` wasn't
@@ -246,7 +254,7 @@ private:
     ss::future<> wait_for_snapshot_hydrated();
 
     ss::future<> do_write_local_snapshot();
-
+    mutex _apply_lock{"persisted_stm::apply_lock"};
     mutex _op_lock{"persisted_stm::op_lock"};
     std::vector<ss::lw_shared_ptr<expiring_promise<bool>>> _sync_waiters;
     ss::condition_variable _on_snapshot_hydrated;

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -454,6 +454,50 @@ struct persisted_stm_test_fixture : state_machine_fixture {
     absl::flat_hash_map<raft::vnode, ss::shared_ptr<persisted_kv>> node_stms;
 };
 
+class slow_persisted_stm : public persisted_stm<> {
+public:
+    static constexpr std::string_view name = "slow_persisted_stm";
+
+    explicit slow_persisted_stm(raft_node_instance& rn)
+      : persisted_stm<>("slow_persisted_stm", logger, rn.raft().get()) {}
+
+    ss::future<> do_apply(const model::record_batch& batch) override {
+        _last_stm_applied = batch.last_offset();
+        co_return;
+    }
+
+    ss::future<> apply_raft_snapshot(const iobuf& buffer) override {
+        co_return;
+    };
+
+    ss::future<iobuf>
+    take_snapshot(model::offset last_included_offset) override {
+        co_return iobuf{};
+    }
+
+    ss::future<>
+    apply_local_snapshot(stm_snapshot_header header, iobuf&& buffer) override {
+        _last_stm_applied = serde::from_iobuf<model::offset>(std::move(buffer));
+        co_return;
+    }
+
+    ss::future<> validate_applied_offsets(model::offset before) {
+        ASSERT_EQ_CORO(before, _last_stm_applied);
+    }
+
+    ss::future<stm_snapshot> take_local_snapshot(
+      [[maybe_unused]] ssx::semaphore_units apply_units) override {
+        auto applied_offset_before = _last_stm_applied;
+        co_await ss::sleep(2ms);
+        co_await validate_applied_offsets(applied_offset_before);
+        co_return stm_snapshot::create(
+          0, last_applied_offset(), serde::to_iobuf(_last_stm_applied));
+    }
+
+private:
+    model::offset _last_stm_applied{};
+};
+
 TEST_F_CORO(persisted_stm_test_fixture, test_basic_operations) {
     co_await initialize_state_machines();
     std::vector<kv_operation> ops;
@@ -651,4 +695,35 @@ TEST_F_CORO(persisted_stm_test_fixture, test_adding_state_machine) {
         ASSERT_EQ_CORO(stm->state, expected);
         ASSERT_EQ_CORO(stm->last_operation, other_stm->last_operation);
     }
+}
+
+// Test ensures that the snapshot is not interleaved with apply
+TEST_F_CORO(state_machine_fixture, test_concurrent_apply_and_snapshot) {
+    // Initialize raft group and stms
+    add_node(model::node_id(0), model::revision_id(0));
+    auto& raft_nodes = nodes();
+    ASSERT_EQ_CORO(raft_nodes.size(), 1);
+
+    auto& node = raft_nodes.begin()->second;
+    co_await node->initialise(all_vnodes());
+    raft::state_machine_manager_builder builder;
+    auto stm = builder.create_stm<slow_persisted_stm>(*node);
+    co_await node->start(std::move(builder));
+    co_await wait_for_leader(5s);
+
+    bool stop = false;
+    auto write_sleep_f = ss::do_until(
+      [&stop] { return stop; },
+      [&] {
+          return build_random_state(100).discard_result().then(
+            [] { return ss::sleep(3ms); });
+      });
+
+    auto local_snapshot_f = ss::do_until(
+      [&stop] { return stop; }, [&] { return stm->write_local_snapshot(); });
+
+    co_await ss::sleep(2s);
+    stop = true;
+    co_await std::move(write_sleep_f);
+    co_await std::move(local_snapshot_f);
 }


### PR DESCRIPTION
When a local snapshot is taken by the `persisted_stm` it should not
interleave with apply. Added a lock to make sure that both the apply and
`take_local_snapshot` do not overlap.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
