### PR TITLE
iceberg: introduce partition keys

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -138,6 +138,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "partition_key_type",
+    srcs = [
+        "partition_key_type.cc",
+    ],
+    hdrs = [
+        "partition_key_type.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":datatypes",
+        ":partition",
+        ":schema",
+    ],
+)
+
+redpanda_cc_library(
     name = "logger",
     srcs = [
         "logger.cc",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -138,6 +138,23 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "partition_key",
+    srcs = [
+        "partition_key.cc",
+    ],
+    hdrs = [
+        "partition_key.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":partition",
+        ":struct_accessor",
+        ":transform_utils",
+        ":values",
+    ],
+)
+
+redpanda_cc_library(
     name = "partition_key_type",
     srcs = [
         "partition_key_type.cc",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -169,6 +169,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "struct_accessor",
+    srcs = [
+        "struct_accessor.cc",
+    ],
+    hdrs = [
+        "struct_accessor.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":datatypes",
+        ":values",
+        "//src/v/container:chunked_hash_map",
+    ],
+)
+
+redpanda_cc_library(
     name = "schema_json",
     srcs = [
         "schema_json.cc",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -124,15 +124,13 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "partition",
-    srcs = [
-        "partition.cc",
-    ],
     hdrs = [
         "partition.h",
     ],
     include_prefix = "iceberg",
     deps = [
         ":datatypes",
+        ":transform",
         "//src/v/container:fragmented_vector",
         "//src/v/utils:named_type",
         "@seastar",
@@ -183,6 +181,17 @@ redpanda_cc_library(
         ":schema",
         "//src/v/json",
     ],
+)
+
+redpanda_cc_library(
+    name = "transform",
+    srcs = [
+        "transform.cc",
+    ],
+    hdrs = [
+        "transform.h",
+    ],
+    include_prefix = "iceberg",
 )
 
 redpanda_cc_library(

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -219,6 +219,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "time_transform_visitor",
+    srcs = [
+        "time_transform_visitor.cc",
+    ],
+    hdrs = [
+        "time_transform_visitor.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":values",
+    ],
+)
+
+redpanda_cc_library(
     name = "transform",
     srcs = [
         "transform.cc",
@@ -227,6 +241,22 @@ redpanda_cc_library(
         "transform.h",
     ],
     include_prefix = "iceberg",
+)
+
+redpanda_cc_library(
+    name = "transform_utils",
+    srcs = [
+        "transform_utils.cc",
+    ],
+    hdrs = [
+        "transform_utils.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":time_transform_visitor",
+        ":transform",
+        ":values",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -154,6 +154,9 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "schema",
+    srcs = [
+        "schema.cc",
+    ],
     hdrs = [
         "schema.h",
     ],

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -33,6 +33,7 @@ v_cc_library(
     json_utils.cc
     logger.cc
     manifest_avro.cc
+    schema.cc
     schema_json.cc
     transform.cc
     values.cc

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -33,6 +33,7 @@ v_cc_library(
     json_utils.cc
     logger.cc
     manifest_avro.cc
+    partition_key.cc
     partition_key_type.cc
     schema.cc
     schema_json.cc

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -33,8 +33,8 @@ v_cc_library(
     json_utils.cc
     logger.cc
     manifest_avro.cc
-    partition.cc
     schema_json.cc
+    transform.cc
     values.cc
   DEPS
     Avro::avro

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -37,7 +37,9 @@ v_cc_library(
     schema.cc
     schema_json.cc
     struct_accessor.cc
+    time_transform_visitor.cc
     transform.cc
+    transform_utils.cc
     values.cc
   DEPS
     Avro::avro

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -35,6 +35,7 @@ v_cc_library(
     manifest_avro.cc
     schema.cc
     schema_json.cc
+    struct_accessor.cc
     transform.cc
     values.cc
   DEPS

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -33,6 +33,7 @@ v_cc_library(
     json_utils.cc
     logger.cc
     manifest_avro.cc
+    partition_key_type.cc
     schema.cc
     schema_json.cc
     struct_accessor.cc

--- a/src/v/iceberg/partition.h
+++ b/src/v/iceberg/partition.h
@@ -10,34 +10,12 @@
 
 #include "container/fragmented_vector.h"
 #include "iceberg/datatypes.h"
+#include "iceberg/transform.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
 
 namespace iceberg {
-
-struct identity_transform {};
-struct bucket_transform {
-    uint32_t n;
-};
-struct truncate_transform {
-    uint32_t length;
-};
-struct year_transform {};
-struct month_transform {};
-struct day_transform {};
-struct hour_transform {};
-struct void_transform {};
-
-using transform = std::variant<
-  identity_transform,
-  bucket_transform,
-  truncate_transform,
-  year_transform,
-  month_transform,
-  hour_transform,
-  void_transform>;
-bool operator==(const transform& lhs, const transform& rhs);
 
 struct partition_field {
     using id_t = named_type<int32_t, struct field_id_tag>;

--- a/src/v/iceberg/partition_key.cc
+++ b/src/v/iceberg/partition_key.cc
@@ -1,0 +1,45 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/partition_key.h"
+
+#include "iceberg/transform_utils.h"
+
+namespace iceberg {
+
+partition_key partition_key::create(
+  const struct_value& source_struct,
+  const struct_accessor::ids_accessor_map_t& accessors,
+  const partition_spec& spec) {
+    auto ret_val = std::make_unique<struct_value>();
+    for (const auto& partition_field : spec.fields) {
+        const auto& source_id = partition_field.source_id;
+        auto acc_iter = accessors.find(source_id);
+        if (acc_iter == accessors.end()) {
+            throw std::invalid_argument(
+              fmt::format("Expected accessor for field id {}", source_id));
+        }
+        const auto& field_accessor = acc_iter->second;
+        const auto& field_val_opt = field_accessor->get(source_struct);
+        if (!field_val_opt.has_value()) {
+            // All transforms must return null for a null input value.
+            ret_val->fields.emplace_back(std::nullopt);
+            continue;
+        }
+        const auto& field_val = *field_val_opt;
+        const auto& transform = partition_field.transform;
+        ret_val->fields.emplace_back(apply_transform(field_val, transform));
+    }
+    return partition_key{std::move(ret_val)};
+}
+
+bool operator==(const partition_key& lhs, const partition_key& rhs) {
+    return lhs.val == rhs.val;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/partition_key.h
+++ b/src/v/iceberg/partition_key.h
@@ -1,0 +1,54 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/partition.h"
+#include "iceberg/struct_accessor.h"
+#include "iceberg/values.h"
+
+namespace iceberg {
+
+// The struct value transformed from an original record by the transforms
+// defined in a given partition spec. The high level relationship between the
+// partition key and related abstractions is as follows:
+//
+//   schema   =>  struct_accessors
+//   (fields)     (value getters)
+//
+//   struct_accessors + struct_val + partition_spec  => partition_key
+//   (value getters)    (values)     (target fields)    (transformed values)
+//                                   ( + transforms)
+//
+// The partition_key is expected to be serialized as an Avro record for field
+// r102 of the manifest_entry.
+struct partition_key {
+    std::unique_ptr<struct_value> val;
+
+    static partition_key create(
+      const struct_value& source_struct,
+      const struct_accessor::ids_accessor_map_t& accessors,
+      const partition_spec& spec);
+};
+bool operator==(const partition_key&, const partition_key&);
+
+} // namespace iceberg
+
+namespace std {
+
+template<>
+struct hash<iceberg::partition_key> {
+    size_t operator()(const iceberg::partition_key& k) const {
+        if (!k.val) {
+            return 0;
+        }
+        return iceberg::value_hash(*k.val);
+    }
+};
+
+} // namespace std

--- a/src/v/iceberg/partition_key_type.cc
+++ b/src/v/iceberg/partition_key_type.cc
@@ -1,0 +1,86 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/partition_key_type.h"
+
+#include "iceberg/partition.h"
+#include "iceberg/schema.h"
+
+namespace iceberg {
+
+namespace {
+
+// TODO: at some point we should restrict the source types to what is defined
+// by the spec. For now, expect that the input types are allowed.
+struct transform_result_type_visitor {
+    explicit transform_result_type_visitor(const field_type& source)
+      : source_type_(source) {}
+
+    const field_type& source_type_;
+
+    field_type operator()(const identity_transform&) {
+        if (std::holds_alternative<primitive_type>(source_type_)) {
+            return std::get<primitive_type>(source_type_);
+        }
+        // TODO: requires a field copy method.
+        throw std::invalid_argument("Identity transform not supported");
+    }
+    field_type operator()(const bucket_transform&) { return int_type(); }
+    field_type operator()(const truncate_transform&) {
+        if (std::holds_alternative<primitive_type>(source_type_)) {
+            return std::get<primitive_type>(source_type_);
+        }
+        // TODO: requires a field copy method.
+        throw std::invalid_argument("Truncate transform not supported");
+    }
+    field_type operator()(const year_transform&) { return int_type(); }
+    field_type operator()(const month_transform&) { return int_type(); }
+    field_type operator()(const day_transform&) { return int_type(); }
+    field_type operator()(const hour_transform&) { return int_type(); }
+    field_type operator()(const void_transform&) {
+        // TODO: the spec also says the result may also be the source type.
+        return int_type();
+    }
+};
+
+field_type
+get_result_type(const field_type& source_type, const transform& transform) {
+    return std::visit(transform_result_type_visitor{source_type}, transform);
+}
+
+} // namespace
+
+partition_key_type partition_key_type::create(
+  const partition_spec& partition_spec, const schema& schema) {
+    struct_type schema_struct;
+    const auto& partition_fields = partition_spec.fields;
+    chunked_hash_set<nested_field::id_t> partition_field_ids;
+    for (const auto& field : partition_fields) {
+        partition_field_ids.emplace(field.source_id);
+    }
+    const auto ids_to_types = schema.ids_to_types(
+      std::move(partition_field_ids));
+    for (const auto& field : partition_fields) {
+        const auto& source_id = field.source_id;
+        const auto type_iter = ids_to_types.find(source_id);
+        if (type_iter == ids_to_types.end()) {
+            throw std::invalid_argument(fmt::format(
+              "Expected source field ID {} to be in schema", source_id()));
+        }
+        const auto& source_type = *type_iter->second;
+        auto result_field = nested_field::create(
+          field.field_id,
+          field.name,
+          field_required::no,
+          get_result_type(source_type, field.transform));
+        schema_struct.fields.emplace_back(std::move(result_field));
+    }
+    return {std::move(schema_struct)};
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/partition_key_type.h
+++ b/src/v/iceberg/partition_key_type.h
@@ -1,0 +1,38 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/datatypes.h"
+
+namespace iceberg {
+
+struct partition_spec;
+struct schema;
+
+// The struct type transformed from an original schema by the transforms
+// defined in a given partition spec. The high level relationship between the
+// partition key type and related abstractions is as follows:
+//
+//   partition_spec  +  schema   =>  partition_key_type
+//   (target fields)    (fields)     (transformed fields)
+//   ( + transforms)
+//
+// The partition_key_type is expected to be serialized as the Avro schema of
+// the r102 field of the manifest_entry.
+struct partition_key_type {
+    // NOTE: in accordance with the Iceberg spec, this type is not deeply
+    // nested and is comprised of a few primitive types.
+    struct_type type;
+
+    // Constructs the appropriate partition key type from the given partition
+    // spec and schema.
+    static partition_key_type create(const partition_spec&, const schema&);
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/schema.cc
+++ b/src/v/iceberg/schema.cc
@@ -1,0 +1,72 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/schema.h"
+
+namespace iceberg {
+
+namespace {
+struct nested_field_collecting_visitor {
+public:
+    explicit nested_field_collecting_visitor(
+      chunked_vector<const nested_field*>& to_visit)
+      : to_visit_(to_visit) {}
+    chunked_vector<const nested_field*>& to_visit_;
+
+    void operator()(const primitive_type&) {
+        // No-op, no additional fields to collect.
+    }
+    void operator()(const list_type& t) {
+        to_visit_.emplace_back(t.element_field.get());
+    }
+    void operator()(const struct_type& t) {
+        for (const auto& field : t.fields) {
+            to_visit_.emplace_back(field.get());
+        }
+    }
+    void operator()(const map_type& t) {
+        to_visit_.emplace_back(t.key_field.get());
+        to_visit_.emplace_back(t.value_field.get());
+    }
+};
+} // namespace
+
+schema::ids_types_map_t
+schema::ids_to_types(chunked_hash_set<nested_field::id_t> target_ids) const {
+    chunked_vector<const nested_field*> to_visit;
+    for (const auto& field : schema_struct.fields) {
+        to_visit.emplace_back(field.get());
+    }
+    bool has_filter = !target_ids.empty();
+    schema::ids_types_map_t ret;
+    while (!to_visit.empty()) {
+        if (has_filter && target_ids.empty()) {
+            // We've filtered everything.
+            break;
+        }
+        auto* field = to_visit.back();
+        to_visit.pop_back();
+        if (!field) {
+            continue;
+        }
+        const auto& type = field->type;
+        if (has_filter) {
+            const auto iter = target_ids.find(field->id);
+            if (iter != target_ids.end()) {
+                target_ids.erase(iter);
+                ret.emplace(field->id, &type);
+            }
+        } else {
+            ret.emplace(field->id, &type);
+        }
+        std::visit(nested_field_collecting_visitor{to_visit}, type);
+    }
+    return ret;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/schema.h
+++ b/src/v/iceberg/schema.h
@@ -12,16 +12,23 @@
 #include "iceberg/datatypes.h"
 #include "utils/named_type.h"
 
-#include <seastar/core/sstring.hh>
-
 namespace iceberg {
 
 struct schema {
     using id_t = named_type<int32_t, struct schema_id_tag>;
+    using ids_types_map_t
+      = chunked_hash_map<nested_field::id_t, const field_type*>;
+
     struct_type schema_struct;
     id_t schema_id;
     chunked_hash_set<nested_field::id_t> identifier_field_ids;
     friend bool operator==(const schema& lhs, const schema& rhs) = default;
+
+    // Returns a mapping from field id to the field type. If the given set of
+    // ids is non-empty, returns just the types of the given ids. Otherwise,
+    // returns types of all ids in the schema.
+    ids_types_map_t
+      ids_to_types(chunked_hash_set<nested_field::id_t> = {}) const;
 };
 
 } // namespace iceberg

--- a/src/v/iceberg/struct_accessor.cc
+++ b/src/v/iceberg/struct_accessor.cc
@@ -1,0 +1,140 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/struct_accessor.h"
+
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <variant>
+
+namespace iceberg {
+
+namespace {
+
+struct type_validating_visitor {
+    explicit type_validating_visitor(const primitive_type& t)
+      : type_(t) {}
+    const primitive_type& type_;
+
+    bool operator()(const boolean_value&) const {
+        return std::holds_alternative<boolean_type>(type_);
+    }
+    bool operator()(const int_value&) const {
+        return std::holds_alternative<int_type>(type_);
+    }
+    bool operator()(const long_value&) const {
+        return std::holds_alternative<long_type>(type_);
+    }
+    bool operator()(const float_value&) const {
+        return std::holds_alternative<float_type>(type_);
+    }
+    bool operator()(const double_value&) const {
+        return std::holds_alternative<double_type>(type_);
+    }
+    bool operator()(const decimal_value&) const {
+        return std::holds_alternative<decimal_type>(type_);
+    }
+    bool operator()(const date_value&) const {
+        return std::holds_alternative<date_type>(type_);
+    }
+    bool operator()(const time_value&) const {
+        return std::holds_alternative<time_type>(type_);
+    }
+    bool operator()(const timestamp_value&) const {
+        return std::holds_alternative<timestamp_type>(type_);
+    }
+    bool operator()(const timestamptz_value&) const {
+        return std::holds_alternative<timestamptz_type>(type_);
+    }
+    bool operator()(const string_value&) const {
+        return std::holds_alternative<string_type>(type_);
+    }
+    bool operator()(const uuid_value&) const {
+        return std::holds_alternative<uuid_type>(type_);
+    }
+    bool operator()(const fixed_value&) const {
+        return std::holds_alternative<fixed_type>(type_);
+    }
+    bool operator()(const binary_value&) const {
+        return std::holds_alternative<binary_type>(type_);
+    }
+};
+
+} // namespace
+
+bool value_matches_type(const primitive_value& v, const primitive_type& t) {
+    return std::visit(type_validating_visitor{t}, v);
+}
+
+struct_accessor::ids_accessor_map_t
+struct_accessor::from_struct_type(const struct_type& s) {
+    ids_accessor_map_t ret;
+    for (size_t i = 0; i < s.fields.size(); i++) {
+        const auto& field = s.fields[i];
+        if (!field) {
+            continue;
+        }
+        const auto& child = field->type;
+        if (std::holds_alternative<primitive_type>(child)) {
+            ret.emplace(
+              field->id,
+              std::make_unique<struct_accessor>(
+                i, std::get<primitive_type>(child)));
+        } else if (std::holds_alternative<struct_type>(child)) {
+            const auto& child_as_struct = std::get<struct_type>(child);
+            auto child_accessors = from_struct_type(child_as_struct);
+            for (auto& [id, child_accessor] : child_accessors) {
+                ret.emplace(
+                  id,
+                  std::make_unique<struct_accessor>(
+                    i, std::move(child_accessor)));
+            }
+        }
+        // Fallthrough in case of a list or map. It is valid for a top-level
+        // type to include a list or a map --  we will not return accessors for
+        // them or any descendants of them.
+    }
+    return ret;
+}
+
+const std::optional<value>&
+struct_accessor::get(const struct_value& parent_val) const {
+    if (position_ >= parent_val.fields.size()) {
+        throw std::invalid_argument(fmt::format(
+          "Invalid access to position {}, struct has {} fields",
+          position_,
+          parent_val.fields.size()));
+    }
+    const auto& child_val = parent_val.fields[position_];
+    if (!child_val) {
+        return child_val;
+    }
+    if (inner_) {
+        if (!std::holds_alternative<std::unique_ptr<struct_value>>(
+              *child_val)) {
+            throw std::invalid_argument("Unexpected non-struct value");
+        }
+        const auto& child_as_struct = std::get<std::unique_ptr<struct_value>>(
+          *child_val);
+        return inner_->get(*child_as_struct);
+    }
+    if (!std::holds_alternative<primitive_value>(*child_val)) {
+        throw std::invalid_argument(
+          fmt::format("Unexpected non-primitive value: {}", *child_val));
+    }
+    const primitive_value& prim_val = std::get<primitive_value>(*child_val);
+    if (!value_matches_type(prim_val, type_)) {
+        throw std::invalid_argument(
+          fmt::format("Expected value of {} type, got {}", type_, prim_val));
+    }
+    return child_val;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/struct_accessor.h
+++ b/src/v/iceberg/struct_accessor.h
@@ -1,0 +1,62 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+namespace iceberg {
+
+// Returns true if the given value is of the given type.
+bool value_matches_type(const primitive_value&, const primitive_type&);
+
+// Nested accessor to get child values from a struct value, e.g. to build a
+// partition key input for a struct value.
+//
+// Example usage, as pseudo-code:
+//
+//   ids_to_accessors = struct_accessor::from_struct_type(struct_type)
+//   field_value = ids_to_accessors[field_id(0)].get(struct_value)
+//
+// NOTE: intended use is just for building the partition key, and therefore no
+// support for searching lists or maps is done here -- just structs and
+// primitives. Other partitioning values are not supported by the Iceberg spec.
+class struct_accessor {
+public:
+    using ids_accessor_map_t
+      = chunked_hash_map<nested_field::id_t, std::unique_ptr<struct_accessor>>;
+
+    static ids_accessor_map_t from_struct_type(const struct_type&);
+
+    // Returns the child value from the given struct at `position_`.
+    const std::optional<value>& get(const struct_value& parent_val) const;
+
+    // Public for make_unique<> only.
+    struct_accessor(size_t position, const primitive_type& type)
+      : position_(position)
+      , type_(type) {}
+    struct_accessor(size_t position, std::unique_ptr<struct_accessor> inner)
+      : position_(position)
+      , type_(inner->type_)
+      , inner_(std::move(inner)) {}
+
+private:
+    // The position that this accessor will operate on when calling get().
+    const size_t position_;
+
+    // If `inner_` is set, `position_` is expected to refer to a struct field
+    // by callers of get() and the caller will be returned that struct value.
+    // Otherwise, the value referred to by `position_` is expected to be a
+    // value of type `type_`.
+    primitive_type type_;
+    std::unique_ptr<struct_accessor> inner_;
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -98,6 +98,23 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "partition_key_type_test",
+    timeout = "short",
+    srcs = [
+        "partition_key_type_test.cc",
+    ],
+    deps = [
+        ":test_schemas",
+        "//src/v/iceberg:partition",
+        "//src/v/iceberg:partition_key_type",
+        "//src/v/iceberg:schema",
+        "//src/v/iceberg:transform",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "schema_json_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -128,6 +128,21 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "struct_accessor_test",
+    timeout = "short",
+    srcs = [
+        "struct_accessor_test.cc",
+    ],
+    deps = [
+        ":test_schemas",
+        ":value_generator",
+        "//src/v/iceberg:struct_accessor",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "values_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -14,6 +14,21 @@ redpanda_test_cc_library(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "value_generator",
+    srcs = [
+        "value_generator.cc",
+    ],
+    hdrs = [
+        "value_generator.h",
+    ],
+    include_prefix = "iceberg/tests",
+    deps = [
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:values",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "datatypes_test",
     timeout = "short",

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -99,6 +99,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "schema_test",
+    timeout = "short",
+    srcs = [
+        "schema_test.cc",
+    ],
+    deps = [
+        ":test_schemas",
+        "//src/v/iceberg:schema",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "values_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -98,6 +98,25 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "partition_key_test",
+    timeout = "short",
+    srcs = [
+        "partition_key_test.cc",
+    ],
+    deps = [
+        ":test_schemas",
+        ":value_generator",
+        "//src/v/iceberg:partition",
+        "//src/v/iceberg:partition_key",
+        "//src/v/iceberg:struct_accessor",
+        "//src/v/iceberg:transform",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "partition_key_type_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -160,6 +160,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "transform_utils_test",
+    timeout = "short",
+    srcs = [
+        "transform_utils_test.cc",
+    ],
+    deps = [
+        "//src/v/iceberg:transform",
+        "//src/v/iceberg:transform_utils",
+        "//src/v/iceberg:values",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "values_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     datatypes_json_test.cc
     datatypes_test.cc
     manifest_serialization_test.cc
+    partition_key_type_test.cc
     partition_test.cc
     schema_json_test.cc
     schema_test.cc

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     datatypes_json_test.cc
     datatypes_test.cc
     manifest_serialization_test.cc
+    partition_key_test.cc
     partition_key_type_test.cc
     partition_test.cc
     schema_json_test.cc

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ rp_test(
     schema_test.cc
     struct_accessor_test.cc
     test_schemas.cc
+    transform_utils_test.cc
     values_test.cc
     value_generator.cc
   LIBRARIES

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     manifest_serialization_test.cc
     partition_test.cc
     schema_json_test.cc
+    schema_test.cc
     test_schemas.cc
     values_test.cc
   LIBRARIES

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ rp_test(
     partition_test.cc
     schema_json_test.cc
     schema_test.cc
+    struct_accessor_test.cc
     test_schemas.cc
     values_test.cc
     value_generator.cc

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ rp_test(
     schema_test.cc
     test_schemas.cc
     values_test.cc
+    value_generator.cc
   LIBRARIES
     Avro::avro
     Boost::iostreams

--- a/src/v/iceberg/tests/partition_key_test.cc
+++ b/src/v/iceberg/tests/partition_key_test.cc
@@ -1,0 +1,121 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/partition.h"
+#include "iceberg/partition_key.h"
+#include "iceberg/struct_accessor.h"
+#include "iceberg/tests/test_schemas.h"
+#include "iceberg/tests/value_generator.h"
+#include "iceberg/transform.h"
+#include "model/timestamp.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+field_type nested_type_with_timestamp(int field_id) {
+    struct_type type;
+    type.fields.emplace_back(nested_field::create(
+      field_id, "ts", field_required::yes, timestamp_type{}));
+    auto nested_type = test_nested_schema_type();
+    for (auto& f : std::get<struct_type>(nested_type).fields) {
+        type.fields.emplace_back(std::move(f));
+    }
+    return type;
+}
+
+partition_spec make_ts_partition_spec(int32_t source_field_id) {
+    partition_spec spec;
+    spec.spec_id = partition_spec::id_t{0};
+    spec.fields.emplace_back(partition_field{
+      .source_id = nested_field::id_t{source_field_id},
+      .field_id = partition_field::id_t{1000},
+      .name = "hour",
+      .transform = hour_transform{},
+    });
+    return spec;
+}
+
+struct_value
+val_with_timestamp(const field_type& type, model::timestamp timestamp_ms) {
+    static constexpr auto micros_per_ms = 1000;
+    auto timestamp_us = timestamp_ms.value() * micros_per_ms;
+    auto val = tests::make_value({.forced_num_val = timestamp_us}, type);
+    return std::move(*std::get<std::unique_ptr<struct_value>>(val));
+}
+
+TEST(PartitionKeyTest, TestHourlyGrouping) {
+    const auto ts_field_id = 0;
+    auto schema_type = nested_type_with_timestamp(ts_field_id);
+    auto partition_spec = make_ts_partition_spec(ts_field_id);
+    const auto accessors = struct_accessor::from_struct_type(
+      std::get<struct_type>(schema_type));
+
+    chunked_vector<struct_value> source_vals;
+    static constexpr auto ms_per_hr = 3600 * 1000;
+    static constexpr auto num_hrs = 10;
+    static constexpr auto records_per_hr = 5;
+    const auto start_time = model::timestamp::now();
+    for (int h = 0; h < num_hrs; h++) {
+        for (int i = 0; i < records_per_hr; i++) {
+            // Insert `records_per_hr` records in each hour.
+            source_vals.emplace_back(val_with_timestamp(
+              schema_type,
+              model::timestamp{start_time.value() + h * ms_per_hr + i}));
+        }
+    }
+
+    chunked_hash_map<partition_key, chunked_vector<struct_value>> vals_by_pk;
+    for (auto& v : source_vals) {
+        auto pk = partition_key::create(v, accessors, partition_spec);
+        auto [iter, _] = vals_by_pk.emplace(
+          std::move(pk), chunked_vector<struct_value>{});
+        iter->second.emplace_back(std::move(v));
+    }
+    size_t num_vals = 0;
+    for (const auto& [pk, vs] : vals_by_pk) {
+        num_vals += vs.size();
+    }
+    ASSERT_EQ(vals_by_pk.size(), 10);
+    ASSERT_EQ(num_vals, num_hrs * records_per_hr);
+}
+
+TEST(PartitionKeyTest, TestNullValuesKey) {
+    const auto ts_field_id = 0;
+    auto schema_type = nested_type_with_timestamp(ts_field_id);
+    struct_value v;
+    for (size_t i = 0; i < std::get<struct_type>(schema_type).fields.size();
+         i++) {
+        v.fields.emplace_back(std::nullopt);
+    }
+    const auto accessors = struct_accessor::from_struct_type(
+      std::get<struct_type>(schema_type));
+
+    auto partition_spec = make_ts_partition_spec(ts_field_id);
+    auto pk = partition_key::create(v, accessors, partition_spec);
+    ASSERT_EQ(1, pk.val->fields.size());
+    ASSERT_FALSE(pk.val->fields[0].has_value());
+}
+
+TEST(PartitionKeyTest, TestBogusPartitionSpec) {
+    const auto ts_field_id = 0;
+    auto schema_type = nested_type_with_timestamp(ts_field_id);
+    struct_value v;
+    for (size_t i = 0; i < std::get<struct_type>(schema_type).fields.size();
+         i++) {
+        v.fields.emplace_back(std::nullopt);
+    }
+    const auto accessors = struct_accessor::from_struct_type(
+      std::get<struct_type>(schema_type));
+
+    auto partition_spec = make_ts_partition_spec(ts_field_id + 1000);
+    ASSERT_THROW(
+      partition_key::create(v, accessors, partition_spec),
+      std::invalid_argument);
+}

--- a/src/v/iceberg/tests/partition_key_type_test.cc
+++ b/src/v/iceberg/tests/partition_key_type_test.cc
@@ -1,0 +1,167 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/partition.h"
+#include "iceberg/partition_key_type.h"
+#include "iceberg/schema.h"
+#include "iceberg/tests/test_schemas.h"
+#include "iceberg/transform.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+namespace {
+
+partition_spec make_spec(
+  int32_t spec_id,
+  int32_t source_id,
+  int32_t field_id,
+  const ss::sstring& name,
+  transform t) {
+    partition_spec spec{
+      .spec_id = partition_spec::id_t{spec_id},
+      .fields = {partition_field{
+        .source_id = nested_field::id_t{source_id},
+        .field_id = partition_field::id_t{field_id},
+        .name = name,
+        .transform = t,
+      }},
+    };
+    return spec;
+}
+
+schema nested_test_schema() {
+    return schema{
+      .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+}
+
+} // namespace
+
+class PartitionKeyTypeTest : public ::testing::Test {
+public:
+    void check_pk_type_field(
+      const nested_field_ptr& field,
+      int32_t expected_id,
+      const ss::sstring& expected_name,
+      const primitive_type& expected_type) {
+        ASSERT_FALSE(field->required);
+        ASSERT_EQ(expected_id, field->id());
+        ASSERT_STREQ(expected_name.c_str(), field->name.c_str());
+        ASSERT_TRUE(std::holds_alternative<primitive_type>(field->type));
+        ASSERT_EQ(std::get<primitive_type>(field->type), expected_type);
+    }
+};
+
+TEST_F(PartitionKeyTypeTest, TestMissingField) {
+    auto schema = nested_test_schema();
+    auto fake_id = 42;
+    auto spec = make_spec(0, fake_id, 1000, "ident", identity_transform{});
+    ASSERT_THROW(
+      partition_key_type::create(spec, schema), std::invalid_argument);
+}
+
+TEST_F(PartitionKeyTypeTest, TestMultipleFields) {
+    auto schema = nested_test_schema();
+    auto spec = make_spec(0, 1, 1000, "f1", identity_transform{});
+    spec.fields.emplace_back(partition_field{
+      .source_id = nested_field::id_t{2},
+      .field_id = partition_field::id_t{1001},
+      .name = "f2",
+      .transform = identity_transform{},
+    });
+    auto pk_type = partition_key_type::create(spec, schema);
+    const auto& pk_struct = pk_type.type;
+
+    ASSERT_EQ(2, pk_struct.fields.size());
+    ASSERT_NO_FATAL_FAILURE(
+      check_pk_type_field(pk_struct.fields[0], 1000, "f1", string_type{}));
+    ASSERT_NO_FATAL_FAILURE(
+      check_pk_type_field(pk_struct.fields[1], 1001, "f2", int_type{}));
+}
+
+struct transform_expectation {
+    int32_t source_field_id;
+    transform transform;
+    primitive_type expected_transformed_type;
+};
+
+class PartitionKeyTypeParamTest
+  : public PartitionKeyTypeTest
+  , public ::testing::WithParamInterface<transform_expectation> {};
+
+TEST_P(PartitionKeyTypeParamTest, TestSingleFieldCreate) {
+    const auto& expectation = GetParam();
+    auto schema = nested_test_schema();
+    auto spec = make_spec(
+      0, expectation.source_field_id, 1000, "tf", expectation.transform);
+    auto pk_type = partition_key_type::create(spec, schema);
+    const auto& pk_struct = pk_type.type;
+
+    ASSERT_EQ(1, pk_struct.fields.size());
+    ASSERT_NO_FATAL_FAILURE(check_pk_type_field(
+      pk_struct.fields[0], 1000, "tf", expectation.expected_transformed_type));
+}
+INSTANTIATE_TEST_SUITE_P(
+  Expectations,
+  PartitionKeyTypeParamTest,
+  ::testing::Values(
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = identity_transform{},
+      .expected_transformed_type = string_type{},
+    },
+    transform_expectation{
+      .source_field_id = 2,
+      .transform = identity_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = bucket_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = truncate_transform{},
+      .expected_transformed_type = string_type{},
+    },
+    transform_expectation{
+      .source_field_id = 2,
+      .transform = truncate_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = year_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = month_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = day_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = hour_transform{},
+      .expected_transformed_type = int_type{},
+    },
+    transform_expectation{
+      .source_field_id = 1,
+      .transform = void_transform{},
+      .expected_transformed_type = int_type{},
+    }));

--- a/src/v/iceberg/tests/schema_test.cc
+++ b/src/v/iceberg/tests/schema_test.cc
@@ -1,0 +1,127 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/schema.h"
+#include "iceberg/tests/test_schemas.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+TEST(SchemaTest, TestGetTypesNestedSchema) {
+    schema s{
+      .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    const auto ids_to_types = s.ids_to_types();
+    ASSERT_EQ(17, ids_to_types.size());
+    // First check all ids are accounted for.
+    for (int i = 1; i <= 17; i++) {
+        ASSERT_TRUE(ids_to_types.contains(nested_field::id_t{i}));
+    }
+    auto get_primitive_type = [&](int32_t id) {
+        auto* type = ids_to_types.at(nested_field::id_t{id});
+        EXPECT_TRUE(type);
+        EXPECT_TRUE(std::holds_alternative<primitive_type>(*type));
+        return std::get<primitive_type>(*type);
+    };
+    auto check_list_type = [&](int32_t id) {
+        auto* type = ids_to_types.at(nested_field::id_t{id});
+        EXPECT_TRUE(type);
+        ASSERT_TRUE(std::holds_alternative<list_type>(*type));
+    };
+    auto check_struct_type = [&](int32_t id) {
+        auto* type = ids_to_types.at(nested_field::id_t{id});
+        EXPECT_TRUE(type);
+        ASSERT_TRUE(std::holds_alternative<struct_type>(*type));
+    };
+    auto check_map_type = [&](int32_t id) {
+        auto* type = ids_to_types.at(nested_field::id_t{id});
+        EXPECT_TRUE(type);
+        ASSERT_TRUE(std::holds_alternative<map_type>(*type));
+    };
+    // Now check the types of each id.
+    ASSERT_TRUE(std::holds_alternative<string_type>(get_primitive_type(1)));
+    ASSERT_TRUE(std::holds_alternative<int_type>(get_primitive_type(2)));
+    ASSERT_TRUE(std::holds_alternative<boolean_type>(get_primitive_type(3)));
+    ASSERT_NO_FATAL_FAILURE(check_list_type(4));
+    ASSERT_TRUE(std::holds_alternative<string_type>(get_primitive_type(5)));
+    ASSERT_NO_FATAL_FAILURE(check_map_type(6));
+    ASSERT_TRUE(std::holds_alternative<string_type>(get_primitive_type(7)));
+    ASSERT_NO_FATAL_FAILURE(check_map_type(8));
+    ASSERT_TRUE(std::holds_alternative<string_type>(get_primitive_type(9)));
+    ASSERT_TRUE(std::holds_alternative<int_type>(get_primitive_type(10)));
+    ASSERT_NO_FATAL_FAILURE(check_list_type(11));
+    ASSERT_NO_FATAL_FAILURE(check_struct_type(12));
+    ASSERT_TRUE(std::holds_alternative<float_type>(get_primitive_type(13)));
+    ASSERT_TRUE(std::holds_alternative<float_type>(get_primitive_type(14)));
+    ASSERT_NO_FATAL_FAILURE(check_struct_type(15));
+    ASSERT_TRUE(std::holds_alternative<string_type>(get_primitive_type(16)));
+    ASSERT_TRUE(std::holds_alternative<int_type>(get_primitive_type(17)));
+}
+
+TEST(SchemaTest, TestGetFromNullSchema) {
+    struct_type type;
+    type.fields.emplace_back(nullptr);
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    const auto ids_to_types = s.ids_to_types();
+    ASSERT_TRUE(ids_to_types.empty());
+}
+
+TEST(SchemaTest, TestGetFromEmptySchema) {
+    struct_type type;
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    const auto ids_to_types = s.ids_to_types();
+    ASSERT_TRUE(ids_to_types.empty());
+}
+
+TEST(SchemaTest, TestGetTypesNestedSchemaNoneFilter) {
+    schema s{
+      .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    // Filter for a field that doesn't exist.
+    const auto ids_to_types = s.ids_to_types({nested_field::id_t{0}});
+    ASSERT_EQ(0, ids_to_types.size());
+}
+
+TEST(SchemaTest, TestGetTypesNestedSchemaNestedFilter) {
+    schema s{
+      .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    // Filter for a couple child fields.
+    const auto ids_to_types = s.ids_to_types(
+      {nested_field::id_t{14}, nested_field::id_t{17}});
+    ASSERT_EQ(2, ids_to_types.size());
+    {
+        auto* type = ids_to_types.at(nested_field::id_t{14});
+        ASSERT_TRUE(type);
+        EXPECT_TRUE(std::holds_alternative<primitive_type>(*type));
+        ASSERT_TRUE(
+          std::holds_alternative<float_type>(std::get<primitive_type>(*type)));
+    }
+    {
+        auto* type = ids_to_types.at(nested_field::id_t{17});
+        ASSERT_TRUE(type);
+        EXPECT_TRUE(std::holds_alternative<primitive_type>(*type));
+        ASSERT_TRUE(
+          std::holds_alternative<int_type>(std::get<primitive_type>(*type)));
+    }
+}

--- a/src/v/iceberg/tests/struct_accessor_test.cc
+++ b/src/v/iceberg/tests/struct_accessor_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/struct_accessor.h"
+#include "iceberg/tests/test_schemas.h"
+#include "iceberg/tests/value_generator.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+TEST(StructAccessorTest, TestGetAccessorsNestedSchema) {
+    auto schema_field_type = test_nested_schema_type();
+    const auto& schema_struct = std::get<struct_type>(schema_field_type);
+    auto accessors = struct_accessor::from_struct_type(schema_struct);
+    auto random_val = tests::make_value({}, schema_field_type);
+    const auto& random_struct = std::get<std::unique_ptr<struct_value>>(
+      random_val);
+    auto check_primitive_val = [&](int32_t id, const primitive_type& t) {
+        auto& acc = accessors.at(nested_field::id_t{id});
+        const auto& val = acc->get(*random_struct);
+        EXPECT_TRUE(val.has_value());
+        EXPECT_TRUE(std::holds_alternative<primitive_value>(*val));
+        EXPECT_TRUE(value_matches_type(std::get<primitive_value>(*val), t));
+    };
+    // In the test schema, only a few fields are not a part of a list or map.
+    // We should only have accessors for those fields.
+    ASSERT_EQ(5, accessors.size());
+    ASSERT_NO_FATAL_FAILURE(check_primitive_val(1, string_type{}));
+    ASSERT_NO_FATAL_FAILURE(check_primitive_val(2, int_type{}));
+    ASSERT_NO_FATAL_FAILURE(check_primitive_val(3, boolean_type{}));
+    ASSERT_NO_FATAL_FAILURE(check_primitive_val(16, string_type{}));
+    ASSERT_NO_FATAL_FAILURE(check_primitive_val(17, int_type{}));
+}

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -1,0 +1,59 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/transform.h"
+#include "iceberg/transform_utils.h"
+#include "iceberg/values.h"
+#include "model/timestamp.h"
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+using namespace iceberg;
+
+value make_timestamp_val(model::timestamp ts) {
+    static constexpr auto micros_per_millis = 1000;
+    auto ts_micros = ts.value() * micros_per_millis;
+    return timestamp_value{ts_micros};
+}
+
+TEST(TestTransforms, TestHourlyTransform) {
+    const auto start_time = model::timestamp::now();
+    auto start_transformed = apply_transform(
+      make_timestamp_val(start_time), hour_transform{});
+    static constexpr auto millis_per_hr = 60 * 60 * 1000;
+    ASSERT_TRUE(std::holds_alternative<primitive_value>(start_transformed));
+    ASSERT_TRUE(std::holds_alternative<int_value>(
+      std::get<primitive_value>(start_transformed)));
+    auto start_val = std::get<int_value>(
+      std::get<primitive_value>(start_transformed));
+
+    auto plus_1hr = model::timestamp(start_time.value() + millis_per_hr);
+    auto plus_1hr_transformed = apply_transform(
+      make_timestamp_val(plus_1hr), hour_transform{});
+    ASSERT_NE(start_transformed, plus_1hr_transformed);
+    ASSERT_TRUE(std::holds_alternative<primitive_value>(plus_1hr_transformed));
+    ASSERT_TRUE(std::holds_alternative<int_value>(
+      std::get<primitive_value>(plus_1hr_transformed)));
+    auto plus_1hr_val = std::get<int_value>(
+      std::get<primitive_value>(plus_1hr_transformed));
+    ASSERT_EQ(start_val.val + 1, plus_1hr_val.val);
+
+    auto minus_1hr = model::timestamp(start_time.value() - millis_per_hr);
+    auto minus_1hr_transformed = apply_transform(
+      make_timestamp_val(minus_1hr), hour_transform{});
+    ASSERT_NE(start_transformed, minus_1hr_transformed);
+    ASSERT_TRUE(std::holds_alternative<primitive_value>(minus_1hr_transformed));
+    ASSERT_TRUE(std::holds_alternative<int_value>(
+      std::get<primitive_value>(minus_1hr_transformed)));
+    auto minus_1hr_val = std::get<int_value>(
+      std::get<primitive_value>(minus_1hr_transformed));
+    ASSERT_EQ(start_val.val - 1, minus_1hr_val.val);
+}

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -1,0 +1,96 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/tests/value_generator.h"
+
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+namespace iceberg::tests {
+
+struct generating_primitive_value_visitor {
+    explicit generating_primitive_value_visitor(const value_spec& spec)
+      : spec_(spec) {}
+    const value_spec& spec_;
+
+    value operator()(const boolean_type&) { return boolean_value{false}; }
+    value operator()(const int_type&) {
+        return int_value{static_cast<int>(spec_.forced_num_val.value_or(0))};
+    }
+    value operator()(const long_type&) {
+        return long_value{spec_.forced_num_val.value_or(0)};
+    }
+    value operator()(const float_type&) {
+        return float_value{
+          static_cast<float>(spec_.forced_num_val.value_or(0))};
+    }
+    value operator()(const double_type&) {
+        return double_value{
+          static_cast<double>(spec_.forced_num_val.value_or(0))};
+    }
+    value operator()(const decimal_type&) {
+        return decimal_value{spec_.forced_num_val.value_or(0)};
+    }
+    value operator()(const date_type&) {
+        return date_value{static_cast<int>(spec_.forced_num_val.value_or(0))};
+    }
+    value operator()(const time_type&) {
+        return time_value{spec_.forced_num_val.value_or(0)};
+    }
+    value operator()(const timestamp_type&) {
+        return timestamp_value{spec_.forced_num_val.value_or(0)};
+    }
+    value operator()(const timestamptz_type&) {
+        return timestamptz_value{spec_.forced_num_val.value_or(0)};
+    }
+    value operator()(const string_type&) { return string_value{iobuf{}}; }
+    value operator()(const uuid_type&) { return uuid_value{uuid_t{}}; }
+    value operator()(const fixed_type&) { return fixed_value{iobuf{}}; }
+    value operator()(const binary_type&) { return binary_value{iobuf{}}; }
+};
+
+struct generating_value_visitor {
+    explicit generating_value_visitor(const value_spec& spec)
+      : spec_(spec) {}
+    const value_spec& spec_;
+
+    value operator()(const primitive_type& t) {
+        return std::visit(generating_primitive_value_visitor{spec_}, t);
+    }
+    value operator()(const struct_type& t) {
+        auto ret = std::make_unique<struct_value>();
+        for (const auto& f : t.fields) {
+            ret->fields.emplace_back(make_value(spec_, f->type));
+        }
+        return ret;
+    }
+    value operator()(const list_type& t) {
+        auto ret = std::make_unique<list_value>();
+        for (size_t i = 0; i < spec_.max_elements; i++) {
+            ret->elements.emplace_back(
+              make_value(spec_, t.element_field->type));
+        }
+        return ret;
+    }
+    value operator()(const map_type& t) {
+        auto ret = std::make_unique<map_value>();
+        for (size_t i = 0; i < spec_.max_elements; i++) {
+            kv_value kv{
+              make_value(spec_, t.key_field->type),
+              make_value(spec_, t.value_field->type)};
+            ret->kvs.emplace_back(std::move(kv));
+        }
+        return ret;
+    }
+};
+
+value make_value(const value_spec& spec, const field_type& type) {
+    return std::visit(generating_value_visitor{spec}, type);
+}
+
+} // namespace iceberg::tests

--- a/src/v/iceberg/tests/value_generator.h
+++ b/src/v/iceberg/tests/value_generator.h
@@ -1,0 +1,28 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+namespace iceberg::tests {
+
+// TODO: add random generation. For now, this just creates zero-values.
+struct value_spec {
+    // Number of elements to include in list and map fields.
+    size_t max_elements = 5;
+
+    // If set, numeric primitives will have values based on this value.
+    std::optional<int64_t> forced_num_val = std::nullopt;
+};
+
+// Creates an Iceberg value in accordance to the provided specification.
+value make_value(const value_spec&, const field_type&);
+
+} // namespace iceberg::tests

--- a/src/v/iceberg/time_transform_visitor.cc
+++ b/src/v/iceberg/time_transform_visitor.cc
@@ -1,0 +1,38 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/time_transform_visitor.h"
+
+#include "iceberg/values.h"
+
+namespace iceberg {
+
+namespace {
+int32_t micros_to_hr(int64_t micros) {
+    static constexpr int64_t s_per_hr = 3600;
+    static constexpr int64_t micros_per_s = 1000000;
+    static constexpr int64_t micros_per_hr = micros_per_s * s_per_hr;
+    return static_cast<int32_t>(micros / micros_per_hr);
+}
+} // namespace
+
+int32_t hour_transform_visitor::operator()(const primitive_value& v) {
+    if (std::holds_alternative<time_value>(v)) {
+        return micros_to_hr(std::get<time_value>(v).val);
+    }
+    if (std::holds_alternative<timestamp_value>(v)) {
+        return micros_to_hr(std::get<timestamp_value>(v).val);
+    }
+    if (std::holds_alternative<timestamptz_value>(v)) {
+        return micros_to_hr(std::get<timestamptz_value>(v).val);
+    }
+    throw std::invalid_argument(
+      fmt::format("hourly_visitor not implemented for primitive value {}", v));
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/time_transform_visitor.h
+++ b/src/v/iceberg/time_transform_visitor.h
@@ -1,0 +1,25 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/values.h"
+
+namespace iceberg {
+
+struct hour_transform_visitor {
+    int32_t operator()(const primitive_value& v);
+
+    template<typename T>
+    int32_t operator()(const T& t) {
+        throw std::invalid_argument(
+          fmt::format("hourly_visitor not implemented for value {}", t));
+    }
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/transform.cc
+++ b/src/v/iceberg/transform.cc
@@ -6,7 +6,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-#include "iceberg/partition.h"
+#include "iceberg/transform.h"
 
 namespace iceberg {
 

--- a/src/v/iceberg/transform.h
+++ b/src/v/iceberg/transform.h
@@ -1,0 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include <variant>
+
+namespace iceberg {
+
+struct identity_transform {};
+struct bucket_transform {
+    uint32_t n;
+};
+struct truncate_transform {
+    uint32_t length;
+};
+struct year_transform {};
+struct month_transform {};
+struct day_transform {};
+struct hour_transform {};
+struct void_transform {};
+
+using transform = std::variant<
+  identity_transform,
+  bucket_transform,
+  truncate_transform,
+  year_transform,
+  month_transform,
+  day_transform,
+  hour_transform,
+  void_transform>;
+bool operator==(const transform& lhs, const transform& rhs);
+
+} // namespace iceberg

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -1,0 +1,38 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/transform_utils.h"
+
+#include "iceberg/time_transform_visitor.h"
+#include "iceberg/transform.h"
+
+namespace iceberg {
+
+struct transform_applying_visitor {
+    explicit transform_applying_visitor(const value& source_val)
+      : source_val_(source_val) {}
+    const value& source_val_;
+
+    value operator()(const hour_transform&) {
+        int_value v{std::visit(hour_transform_visitor{}, source_val_)};
+        return v;
+    }
+
+    template<typename T>
+    value operator()(const T&) {
+        throw std::invalid_argument(
+          "transform_applying_visitor not implemented for transform");
+    }
+};
+
+value apply_transform(const value& source_val, const transform& transform) {
+    return std::visit(transform_applying_visitor{source_val}, transform);
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/transform_utils.h
+++ b/src/v/iceberg/transform_utils.h
@@ -1,0 +1,23 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "iceberg/transform.h"
+#include "iceberg/values.h"
+
+namespace iceberg {
+
+// Transforms the given value to its appropriate Iceberg value based on the
+// input transform.
+//
+// TODO: this is only implemented for the hourly transform on timestamp values!
+// This will throw if used for anything else!
+value apply_transform(const value&, const transform&);
+
+} // namespace iceberg


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds the capability to group together Iceberg values with a partition spec.

At a high level, the partition spec defines a set of fields and transforms to be applied to those fields that can be used to generate a "partition key" for a given record. The partition key needs to be serialized as Avro with each manifest, where each manifest file contains data that all have the same partition key.

To that end, this PR introduces a few things:
- utilities to get the types from a schema, so that the types can be transformed and a partition key schema can be constructed based on these types (also required by the Iceberg spec to be in the manifests)
- accessors to be able to get a specific field from a given value, so we can transform specific values
- types for the partition key and partition key type (simple wrappers around struct_value and struct_type)

Note, this PR does not include any kind of serialization into Avro. That will be required and will come in a follow-up change.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
