### PR TITLE
[v24.1.x] feature_table: bumped earliest logical version

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -158,17 +158,9 @@ std::string_view to_string_view(feature_state::state s) {
 // imply that new data formats may be written.
 static constexpr cluster_version latest_version = cluster_version{12};
 
-// The earliest version we can upgrade from.  This is the version that
-// a freshly initialized node will start at: e.g. a 23.1 Redpanda joining
-// a cluster of 22.3.6 peers would do this:
-// - Start up blank, initialize feature table to version 7
-// - Send join request advertising version range 7-9
-// - 22.3.x peer accepts join request because version range 7-9 includes its
-//   active version (7).
-// - The new 23.1 node advances feature table to version 8 when it joins and
-//   sees controller log replay.
-// - Eventually once all nodes are 23.1, all nodes advance active version to 9
-static constexpr cluster_version earliest_version = cluster_version{7};
+// The earliest version we can upgrade from.
+// This is the version that a freshly initialized node will start at.
+static constexpr cluster_version earliest_version = cluster_version{10};
 
 // Extra features that will be wired into the feature table if a special
 // environment variable is set


### PR DESCRIPTION
The earliest logical version is the version that the node starts with. The earliest logical version of the previous release must be greater than or equal to all the features that were deprecated in the future releases. If a feature was deprecated a node assumes that it is immediately active hence the newly formed cluster of nodes with previous Redpanda version must bootstrap with correct earliest version.

## Release Notes
- none

