### PR TITLE
[v24.2.x] c/feature_table: bumped the cluster `earliest_version`

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -165,16 +165,8 @@ std::string_view to_string_view(feature_state::state s) {
 static constexpr cluster_version latest_version = cluster_version{13};
 
 // The earliest version we can upgrade from.  This is the version that
-// a freshly initialized node will start at: e.g. a 23.1 Redpanda joining
-// a cluster of 22.3.6 peers would do this:
-// - Start up blank, initialize feature table to version 7
-// - Send join request advertising version range 7-9
-// - 22.3.x peer accepts join request because version range 7-9 includes its
-//   active version (7).
-// - The new 23.1 node advances feature table to version 8 when it joins and
-//   sees controller log replay.
-// - Eventually once all nodes are 23.1, all nodes advance active version to 9
-static constexpr cluster_version earliest_version = cluster_version{7};
+// a freshly initialized node will start at.
+static constexpr cluster_version earliest_version = cluster_version{11};
 
 // Extra features that will be wired into the feature table if a special
 // environment variable is set


### PR DESCRIPTION
Cluster earliest version makes it possible for future Redpanda versions to safely assume that the feature is always active and retire it. Bumped the earliest version in v24.2.x to version `11` to open the possibility of retiring some of features.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none