### PR TITLE
bazel: fix build with GPU machines

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(name = "rules_go", version = "0.49.0")
 bazel_dep(name = "rules_proto", version = "6.0.2")
 bazel_dep(name = "rules_rust", version = "0.49.3")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
-bazel_dep(name = "zlib", version = "1.3")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 bazel_dep(name = "zstd", version = "1.5.6")
 
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -12,6 +12,14 @@ configure_make(
     configure_in_place = True,
     configure_options = [
         "--disable-libudev",
+
+        # Disable graphics and the many kinds of display driver discovery
+        "--disable-gl",
+        "--disable-opencl",
+        "--disable-cuda",
+        "--disable-rsmi",
+
+        # Build a static library
         "--disable-shared",
         "--enable-static",
     ],


### PR DESCRIPTION
I have a machine with GPUs and CUDA installs and the hwloc build
fails. Disable display device discovery, we don't care about GPU
placement.

Also avoid a warning by bumping zlib to the latest version.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
