### PR TITLE
[v24.1.x] `kafka`: deal with `truncation_offset < 0` cases in `prefix_truncate()`

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -488,12 +488,8 @@ replicated_partition::get_leader_epoch_last_offset_unbounded(
 ss::future<error_code> replicated_partition::prefix_truncate(
   model::offset kafka_truncation_offset,
   ss::lowres_clock::time_point deadline) {
-    if (kafka_truncation_offset() == -1) {
-        kafka_truncation_offset = high_watermark();
-    }
-    if (kafka_truncation_offset() < 0) {
-        co_return error_code::offset_out_of_range;
-    }
+    // truncation_offset < 0 cases have already been checked in
+    // `kafka::prefix_truncate()` handler.
     if (kafka_truncation_offset <= start_offset()) {
         // No-op, return early.
         co_return kafka::error_code::none;

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -488,6 +488,12 @@ replicated_partition::get_leader_epoch_last_offset_unbounded(
 ss::future<error_code> replicated_partition::prefix_truncate(
   model::offset kafka_truncation_offset,
   ss::lowres_clock::time_point deadline) {
+    if (kafka_truncation_offset() == -1) {
+        kafka_truncation_offset = high_watermark();
+    }
+    if (kafka_truncation_offset() < 0) {
+        co_return error_code::offset_out_of_range;
+    }
     if (kafka_truncation_offset <= start_offset()) {
         // No-op, return early.
         co_return kafka::error_code::none;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22968
