### PR TITLE
Revert "Retire old membership updates based on Raft configuration"

### DIFF
--- a/src/v/cluster/archival/tests/service_fixture.cc
+++ b/src/v/cluster/archival/tests/service_fixture.cc
@@ -21,7 +21,6 @@
 #include "cluster/archival/types.h"
 #include "cluster/members_table.h"
 #include "config/configuration.h"
-#include "model/fundamental.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "storage/directories.h"
@@ -321,7 +320,7 @@ void archiver_fixture::initialize_shard(
             storage::ntp_config(
               ntp.first, data_dir.string(), std::move(defaults)),
             raft::group_id(1),
-            {raft::vnode(nm->broker.id(), model::revision_id(0))},
+            {nm->broker},
             raft::with_learner_recovery_throttle::yes,
             raft::keep_snapshotted_log::no,
             std::nullopt)

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -158,7 +158,7 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd, model::offset offset) {
 
     // Apply initial node UUID to ID map
     co_await _members_manager.local().set_initial_state(
-      cmd.value.initial_nodes, cmd.value.node_ids_by_uuid, offset);
+      cmd.value.initial_nodes, cmd.value.node_ids_by_uuid);
 
     // Apply cluster version to feature table: this activates features without
     // waiting for feature_manager to come up.

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -241,7 +241,7 @@ ss::future<> controller::start(
       _partition_manager,
       _shard_table,
       config::node().data_directory().as_sstring(),
-      seed_nodes);
+      initial_raft0_brokers);
 
     co_await _partition_leaders.start(std::ref(_tp_state));
     co_await _drain_manager.start(std::ref(_partition_manager));
@@ -448,6 +448,7 @@ ss::future<> controller::start(
       std::ref(_shard_placement),
       std::ref(_shard_table),
       std::ref(_partition_manager),
+      std::ref(_members_table),
       std::ref(_partition_leaders),
       std::ref(_tp_frontend),
       std::ref(_storage),

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -64,6 +64,60 @@
 namespace cluster {
 namespace {
 
+model::broker
+get_node_metadata(const members_table& members, model::node_id id) {
+    auto nm = members.get_node_metadata_ref(id);
+    if (!nm) {
+        nm = members.get_removed_node_metadata_ref(id);
+    }
+    if (!nm) {
+        throw std::logic_error(
+          fmt::format("Replica node {} is not available", id));
+    }
+    return nm->get().broker;
+}
+
+std::vector<model::broker> create_brokers_set(
+  const replicas_t& replicas, cluster::members_table& members) {
+    std::vector<model::broker> brokers;
+    brokers.reserve(replicas.size());
+    std::transform(
+      std::cbegin(replicas),
+      std::cend(replicas),
+      std::back_inserter(brokers),
+      [&members](const model::broker_shard& bs) {
+          return get_node_metadata(members, bs.node_id);
+      });
+    return brokers;
+}
+
+std::vector<raft::broker_revision> create_brokers_set(
+  const replicas_t& replicas,
+  const absl::flat_hash_map<model::node_id, model::revision_id>&
+    replica_revisions,
+  model::revision_id cmd_revision,
+  cluster::members_table& members) {
+    std::vector<raft::broker_revision> brokers;
+    brokers.reserve(replicas.size());
+
+    std::transform(
+      std::cbegin(replicas),
+      std::cend(replicas),
+      std::back_inserter(brokers),
+      [&](const model::broker_shard& bs) {
+          auto broker = get_node_metadata(members, bs.node_id);
+          model::revision_id rev;
+          auto rev_it = replica_revisions.find(bs.node_id);
+          if (rev_it != replica_revisions.end()) {
+              rev = rev_it->second;
+          } else {
+              rev = cmd_revision;
+          }
+          return raft::broker_revision{.broker = std::move(broker), .rev = rev};
+      });
+    return brokers;
+}
+
 static std::vector<raft::vnode> create_vnode_set(
   const replicas_t& replicas,
   const absl::flat_hash_map<model::node_id, model::revision_id>&
@@ -264,6 +318,7 @@ controller_backend::controller_backend(
   ss::sharded<shard_placement_table>& shard_placement,
   ss::sharded<shard_table>& st,
   ss::sharded<partition_manager>& pm,
+  ss::sharded<members_table>& members,
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<topics_frontend>& frontend,
   ss::sharded<storage::api>& storage,
@@ -280,6 +335,7 @@ controller_backend::controller_backend(
   , _shard_placement(shard_placement.local())
   , _shard_table(st)
   , _partition_manager(pm)
+  , _members_table(members)
   , _partition_leaders_table(leaders)
   , _topics_frontend(frontend)
   , _storage(storage)
@@ -305,6 +361,11 @@ controller_backend::controller_backend(
 }
 
 controller_backend::~controller_backend() = default;
+
+bool controller_backend::command_based_membership_active() const {
+    return _features.local().is_active(
+      features::feature::membership_change_controller_cmds);
+}
 
 ss::future<> controller_backend::stop() {
     vlog(clusterlog.info, "Stopping Controller Backend...");
@@ -438,26 +499,40 @@ ss::future<std::error_code> do_update_replica_set(
   const replicas_t& replicas,
   const replicas_revision_map& replica_revisions,
   model::revision_id cmd_revision,
+  members_table& members,
+  bool command_based_members_update,
   std::optional<model::offset> learner_initial_offset) {
     vlog(
       clusterlog.debug,
-      "[{}] updating partition replicas. revision: {}, replicas: {}, "
-      "learner initial offset: {}",
+      "[{}] updating partition replicas. revision: {}, replicas: {}, using "
+      "vnodes: {}, learner initial offset: {}",
       p->ntp(),
       cmd_revision,
       replicas,
+      command_based_members_update,
       learner_initial_offset);
 
-    auto nodes = create_vnode_set(replicas, replica_revisions, cmd_revision);
-    co_return co_await p->update_replica_set(
-      std::move(nodes), cmd_revision, learner_initial_offset);
+    // when cluster membership updates are driven by controller commands, use
+    // only vnodes to update raft replica set
+    if (likely(command_based_members_update)) {
+        auto nodes = create_vnode_set(
+          replicas, replica_revisions, cmd_revision);
+        co_return co_await p->update_replica_set(
+          std::move(nodes), cmd_revision, learner_initial_offset);
+    }
+
+    auto brokers = create_brokers_set(
+      replicas, replica_revisions, cmd_revision, members);
+    co_return co_await p->update_replica_set(std::move(brokers), cmd_revision);
 }
 
 ss::future<std::error_code> revert_configuration_update(
   ss::lw_shared_ptr<partition> p,
   const replicas_t& replicas,
   const replicas_revision_map& replica_revisions,
-  model::revision_id cmd_revision) {
+  model::revision_id cmd_revision,
+  members_table& members,
+  bool command_based_members_update) {
     vlog(
       clusterlog.debug,
       "[{}] reverting already finished reconfiguration. Revision: {}, replica "
@@ -466,7 +541,13 @@ ss::future<std::error_code> revert_configuration_update(
       cmd_revision,
       replicas);
     return do_update_replica_set(
-      std::move(p), replicas, replica_revisions, cmd_revision, std::nullopt);
+      std::move(p),
+      replicas,
+      replica_revisions,
+      cmd_revision,
+      members,
+      command_based_members_update,
+      std::nullopt);
 }
 
 /**
@@ -1083,8 +1164,7 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
           ntp,
           group_id,
           expected_log_revision.value(),
-          std::move(initial_replicas),
-          replicas_view.revisions());
+          std::move(initial_replicas));
         if (ec) {
             co_return ec;
         }
@@ -1279,9 +1359,7 @@ ss::future<std::error_code> controller_backend::create_partition(
   model::ntp ntp,
   raft::group_id group_id,
   model::revision_id log_revision,
-  replicas_t initial_replicas,
-  const absl::flat_hash_map<model::node_id, model::revision_id>&
-    replica_revision_map) {
+  replicas_t initial_replicas) {
     vlog(
       clusterlog.debug,
       "[{}] creating partition, log revision: {}, initial_replicas: {}",
@@ -1313,8 +1391,8 @@ ss::future<std::error_code> controller_backend::create_partition(
     }
     // no partition exists, create one
     if (likely(!partition)) {
-        std::vector<raft::vnode> initial_nodes = create_vnode_set(
-          initial_replicas, replica_revision_map, log_revision);
+        std::vector<model::broker> initial_brokers = create_brokers_set(
+          initial_replicas, _members_table.local());
 
         std::optional<cloud_storage_clients::bucket_name> read_replica_bucket;
         if (cfg->is_read_replica()) {
@@ -1337,7 +1415,7 @@ ss::future<std::error_code> controller_backend::create_partition(
                 log_revision,
                 initial_rev.value()),
               group_id,
-              std::move(initial_nodes),
+              std::move(initial_brokers),
               raft::with_learner_recovery_throttle::yes,
               raft::keep_snapshotted_log::no,
               std::move(xst_state),
@@ -1466,6 +1544,8 @@ controller_backend::cancel_replica_set_update(
                            replicas,
                            replicas_revisions,
                            cmd_revision,
+                           _members_table.local(),
+                           command_based_membership_active(),
                            std::nullopt)
                     .then([](std::error_code ec) {
                         return result<ss::stop_iteration>{ec};
@@ -1488,7 +1568,9 @@ controller_backend::cancel_replica_set_update(
                            std::move(p),
                            replicas,
                            replicas_revisions,
-                           cmd_revision)
+                           cmd_revision,
+                           _members_table.local(),
+                           command_based_membership_active())
                     .then([](std::error_code ec) {
                         return result<ss::stop_iteration>{ec};
                     });
@@ -1576,7 +1658,12 @@ controller_backend::force_abort_replica_set_update(
               cmd_revision,
               [&](ss::lw_shared_ptr<cluster::partition> p) {
                   return revert_configuration_update(
-                    std::move(p), replicas, replicas_revisions, cmd_revision);
+                    std::move(p),
+                    replicas,
+                    replicas_revisions,
+                    cmd_revision,
+                    _members_table.local(),
+                    command_based_membership_active());
               });
         }
         co_return errc::waiting_for_recovery;
@@ -1623,6 +1710,8 @@ controller_backend::update_partition_replica_set(
             replicas,
             replicas_revisions,
             cmd_revision,
+            _members_table.local(),
+            command_based_membership_active(),
             learner_initial_offset);
       });
 }

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -201,6 +201,7 @@ public:
       ss::sharded<shard_placement_table>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
+      ss::sharded<members_table>&,
       ss::sharded<cluster::partition_leaders_table>&,
       ss::sharded<topics_frontend>&,
       ss::sharded<storage::api>&,
@@ -291,8 +292,7 @@ private:
       model::ntp,
       raft::group_id,
       model::revision_id log_revision,
-      replicas_t initial_replicas,
-      const absl::flat_hash_map<model::node_id, model::revision_id>&);
+      replicas_t initial_replicas);
 
     ss::future<> add_to_shard_table(
       model::ntp,
@@ -373,6 +373,8 @@ private:
 
     void setup_metrics();
 
+    bool command_based_membership_active() const;
+
     bool should_skip(const model::ntp&) const;
 
     std::optional<model::offset> calculate_learner_initial_offset(
@@ -383,6 +385,7 @@ private:
     shard_placement_table& _shard_placement;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<members_table>& _members_table;
     ss::sharded<partition_leaders_table>& _partition_leaders_table;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<storage::api>& _storage;

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -443,6 +443,10 @@ ss::future<> members_backend::maybe_finish_decommissioning(update_meta& meta) {
 }
 
 ss::future<std::error_code> members_backend::do_remove_node(model::node_id id) {
+    if (!_features.local().is_active(
+          features::feature::membership_change_controller_cmds)) {
+        return _raft0->remove_member(id, model::revision_id{0});
+    }
     return _members_frontend.local().remove_node(id);
 }
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -841,18 +841,11 @@ model::node_id members_manager::get_node_id(const model::node_uuid& node_uuid) {
 }
 
 ss::future<> members_manager::set_initial_state(
-  std::vector<model::broker> initial_brokers,
-  uuid_map_t id_by_uuid,
-  model::offset update_offset) {
+  std::vector<model::broker> initial_brokers, uuid_map_t id_by_uuid) {
     vassert(_id_by_uuid.empty(), "will not overwrite existing data");
-
-    vlog(
-      clusterlog.info,
-      "initializing cluster state with initial brokers {}, and node UUID map: "
-      "{} at offset: {}",
-      initial_brokers,
-      id_by_uuid,
-      update_offset);
+    if (!id_by_uuid.empty()) {
+        vlog(clusterlog.info, "Initial node UUID map: {}", id_by_uuid);
+    }
     // Start the node ID assignment counter just past the highest node ID. This
     // helps ensure removed seed servers are accounted for when auto-assigning
     // node IDs, since seed servers don't call get_or_assign_node_id().
@@ -870,7 +863,7 @@ ss::future<> members_manager::set_initial_state(
           table.set_initial_brokers(initial_brokers);
       });
 
-    co_await persist_members_in_kvstore(update_offset);
+    co_await persist_members_in_kvstore(model::offset(0));
     // update partition allocator
     co_await _allocator.invoke_on(
       partition_allocator::shard,
@@ -881,7 +874,8 @@ ss::future<> members_manager::set_initial_state(
       });
 
     // update internode connections
-    if (_last_connection_update_offset < update_offset) {
+
+    if (_last_connection_update_offset < model::offset{0}) {
         for (auto& b : initial_brokers) {
             if (b.id() == _self.id()) {
                 continue;
@@ -894,7 +888,7 @@ ss::future<> members_manager::set_initial_state(
               _rpc_tls_config);
         }
 
-        _last_connection_update_offset = update_offset;
+        _last_connection_update_offset = model::offset{0};
     }
     for (auto& b : initial_brokers) {
         auto update = node_update{
@@ -1687,6 +1681,10 @@ members_manager::initialize_broker_connection(const model::broker& broker) {
 }
 
 ss::future<std::error_code> members_manager::add_node(model::broker broker) {
+    if (!command_based_membership_active()) {
+        return _raft0->add_group_member(
+          std::move(broker), model::revision_id(0));
+    }
     return replicate_and_wait(
       _controller_stm,
       _as,
@@ -1695,6 +1693,10 @@ ss::future<std::error_code> members_manager::add_node(model::broker broker) {
 }
 
 ss::future<std::error_code> members_manager::update_node(model::broker broker) {
+    if (!command_based_membership_active()) {
+        return _raft0->update_group_member(std::move(broker));
+    }
+
     return replicate_and_wait(
       _controller_stm,
       _as,
@@ -1705,16 +1707,6 @@ ss::future<std::error_code> members_manager::update_node(model::broker broker) {
 ss::future<>
 members_manager::persist_members_in_kvstore(model::offset update_offset) {
     static const bytes cluster_members_key("cluster_members");
-    auto current_members_snapshot = read_members_from_kvstore();
-    if (current_members_snapshot.update_offset >= update_offset) {
-        vlog(
-          clusterlog.trace,
-          "skipping persisting members, update offset {}, current snapshot "
-          "offset: {}",
-          update_offset,
-          current_members_snapshot.update_offset);
-        return ss::now();
-    }
     std::vector<model::broker> brokers;
     brokers.reserve(_members_table.local().node_count());
     for (auto& [_, node_metadata] : _members_table.local().nodes()) {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -176,8 +176,7 @@ public:
 
     // Initialize `_id_by_uuid` and brokers list. Should be called once only
     // when bootstrapping a cluster.
-    ss::future<>
-      set_initial_state(std::vector<model::broker>, uuid_map_t, model::offset);
+    ss::future<> set_initial_state(std::vector<model::broker>, uuid_map_t);
 
     // Returns a reference to a map containing mapping between node ids and node
     // uuids. Node UUID is node globally unique identifier which has an id
@@ -250,6 +249,11 @@ private:
     ss::future<std::error_code> update_node(model::broker);
 
     ss::future<join_node_reply> make_join_node_success_reply(model::node_id id);
+
+    bool command_based_membership_active() const {
+        return _feature_table.local().is_active(
+          features::feature::membership_change_controller_cmds);
+    }
 
     struct members_snapshot
       : serde::envelope<

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -17,10 +17,7 @@
 #include "cluster/types.h"
 #include "model/metadata.h"
 
-#include <fmt/format.h>
-
 #include <algorithm>
-#include <ranges>
 #include <vector>
 
 namespace cluster {
@@ -97,20 +94,7 @@ std::error_code members_table::apply(model::offset o, add_node_cmd cmd) {
 }
 
 void members_table::set_initial_brokers(std::vector<model::broker> brokers) {
-    /**
-     * With the new Redpanda clusters the set_initial brokers will be the first
-     * method updating the members table content. In previous versions where the
-     * configuration changes were driven by the controller Raft configuration
-     * the members table may already have some nodes when the set command is
-     * applied.
-     */
-    if (!_nodes.empty()) {
-        vlog(
-          clusterlog.info,
-          "resetting initial nodes from raft configuration: {}",
-          fmt::join(_nodes | std::views::values, ", "));
-        _nodes.clear();
-    }
+    vassert(!_nodes.empty(), "can not initialize not empty members table");
     vlog(clusterlog.info, "setting initial nodes {}", brokers);
     for (auto& b : brokers) {
         const auto id = b.id();

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -25,7 +25,6 @@
 #include "cluster/partition_recovery_manager.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
-#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
@@ -116,7 +115,7 @@ ss::future<> partition_manager::start() {
 ss::future<consensus_ptr> partition_manager::manage(
   storage::ntp_config ntp_cfg,
   raft::group_id group,
-  std::vector<raft::vnode> initial_nodes,
+  std::vector<model::broker> initial_nodes,
   raft::with_learner_recovery_throttle enable_learner_recovery_throttle,
   raft::keep_snapshotted_log keep_snapshotted_log,
   std::optional<xshard_transfer_state> xst_state,

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -90,7 +90,7 @@ public:
     ss::future<consensus_ptr> manage(
       storage::ntp_config,
       raft::group_id,
-      std::vector<raft::vnode>,
+      std::vector<model::broker>,
       raft::with_learner_recovery_throttle,
       raft::keep_snapshotted_log,
       std::optional<xshard_transfer_state>,

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -15,9 +15,8 @@
 #include "cluster/logger.h"
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
-#include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/namespace.h"
-#include "raft/fundamental.h"
 
 #include <vector>
 namespace cluster {
@@ -26,26 +25,20 @@ static ss::future<consensus_ptr> create_raft0(
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   const ss::sstring& data_directory,
-  const std::vector<model::node_id>& initial_nodes) {
-    if (!initial_nodes.empty()) {
+  std::vector<model::broker> initial_brokers) {
+    if (!initial_brokers.empty()) {
         vlog(clusterlog.info, "Current node is a cluster founder");
     }
     // controller log size is maintained with controller snapshots
     auto overrides = std::make_unique<storage::ntp_config::default_overrides>();
     overrides->cleanup_policy_bitflags = model::cleanup_policy_bitflags::none;
 
-    std::vector<raft::vnode> initial_vnodes;
-    initial_vnodes.reserve(initial_nodes.size());
-    for (auto& id : initial_nodes) {
-        initial_vnodes.emplace_back(id, model::revision_id(0));
-    }
-
     return pm.local()
       .manage(
         storage::ntp_config(
           model::controller_ntp, data_directory, std::move(overrides)),
         raft::group_id(0),
-        std::move(initial_vnodes),
+        std::move(initial_brokers),
         raft::with_learner_recovery_throttle::no,
         raft::keep_snapshotted_log::no,
         std::nullopt)

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -60,6 +60,8 @@ std::string_view to_string_view(feature f) {
         return "group_offset_retention";
     case feature::rpc_transport_unknown_errc:
         return "rpc_transport_unknown_errc";
+    case feature::membership_change_controller_cmds:
+        return "membership_change_controller_cmds";
     case feature::controller_snapshots:
         return "controller_snapshots";
     case feature::cloud_storage_manifest_format_v2:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -54,6 +54,7 @@ enum class feature : std::uint64_t {
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
     rpc_transport_unknown_errc = 1ULL << 21U,
+    membership_change_controller_cmds = 1ULL << 22U,
     controller_snapshots = 1ULL << 23U,
     cloud_storage_manifest_format_v2 = 1ULL << 24U,
     force_partition_reconfiguration = 1ULL << 26U,
@@ -104,7 +105,6 @@ inline const std::unordered_set<std::string_view> retired_features = {
   "idempotency_v2",
   "transaction_partitioning",
   "lightweight_heartbeats",
-  "membership_change_controller_cmds",
 };
 
 /**
@@ -258,6 +258,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{9},
     "rpc_transport_unknown_errc",
     feature::rpc_transport_unknown_errc,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{10},
+    "membership_change_controller_cmds",
+    feature::membership_change_controller_cmds,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -377,7 +377,7 @@ ss::future<> create_raft_state_for_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<raft::vnode> initial_nodes) {
+  std::vector<model::broker> initial_nodes) {
     // Prepare Raft state in kvstore
     vlog(
       raftlog.debug,
@@ -393,7 +393,7 @@ ss::future<> create_raft_state_for_pre_existing_partition(
 
     // Prepare Raft snapshot
     raft::group_configuration group_config(
-      std::move(initial_nodes), ntp_cfg.get_revision());
+      initial_nodes, ntp_cfg.get_revision());
     raft::snapshot_metadata meta = {
       // `last_included_index` should be the last offset included in
       // this fake snapshot. That's why we set it to be the first offest
@@ -445,7 +445,7 @@ ss::future<> bootstrap_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<raft::vnode> initial_nodes,
+  std::vector<model::broker> initial_nodes,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state) {
     co_await create_offset_translator_state_for_pre_existing_partition(
       api, ntp_cfg, group, min_rp_offset, max_rp_offset, ot_state);

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "base/likely.h"
-#include "group_configuration.h"
 #include "model/record.h"
 #include "raft/configuration_bootstrap_state.h"
 #include "raft/types.h"
@@ -212,6 +211,6 @@ ss::future<> bootstrap_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<raft::vnode> initial_nodes,
+  std::vector<model::broker> initial_nodes,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state);
 } // namespace raft::details

--- a/src/v/raft/fundamental.h
+++ b/src/v/raft/fundamental.h
@@ -12,8 +12,6 @@
 #pragma once
 
 #include "base/seastarx.h"
-#include "model/fundamental.h"
-#include "serde/envelope.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/lowres_clock.hh>
@@ -33,40 +31,6 @@ enum class reply_result : uint8_t {
     failure,
     group_unavailable,
     timeout
-};
-
-/**
- * Class representing single incarnation of a node being a member of Raft group.
- * This class allows Raft to recognize members with the same id coming from
- * different reconfiguration epochs.
- */
-class vnode
-  : public serde::envelope<vnode, serde::version<0>, serde::compat_version<0>> {
-public:
-    constexpr vnode() = default;
-
-    constexpr vnode(model::node_id nid, model::revision_id rev)
-      : _node_id(nid)
-      , _revision(rev) {}
-
-    bool operator==(const vnode& other) const = default;
-    bool operator!=(const vnode& other) const = default;
-
-    friend std::ostream& operator<<(std::ostream& o, const vnode& r);
-
-    template<typename H>
-    friend H AbslHashValue(H h, const vnode& node) {
-        return H::combine(std::move(h), node._node_id, node._revision);
-    }
-
-    constexpr model::node_id id() const { return _node_id; }
-    constexpr model::revision_id revision() const { return _revision; }
-
-    auto serde_fields() { return std::tie(_node_id, _revision); }
-
-private:
-    model::node_id _node_id;
-    model::revision_id _revision;
 };
 
 } // namespace raft

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -11,8 +11,8 @@
 
 #pragma once
 #include "model/metadata.h"
-#include "raft/fundamental.h"
 #include "reflection/adl.h"
+#include "serde/rw/envelope.h"
 #include "serde/rw/vector.h"
 
 #include <boost/range/join.hpp>
@@ -27,7 +27,34 @@ struct broker_revision {
 };
 
 static constexpr model::revision_id no_revision{};
+class vnode
+  : public serde::envelope<vnode, serde::version<0>, serde::compat_version<0>> {
+public:
+    constexpr vnode() = default;
 
+    constexpr vnode(model::node_id nid, model::revision_id rev)
+      : _node_id(nid)
+      , _revision(rev) {}
+
+    bool operator==(const vnode& other) const = default;
+    bool operator!=(const vnode& other) const = default;
+
+    friend std::ostream& operator<<(std::ostream& o, const vnode& r);
+
+    template<typename H>
+    friend H AbslHashValue(H h, const vnode& node) {
+        return H::combine(std::move(h), node._node_id, node._revision);
+    }
+
+    constexpr model::node_id id() const { return _node_id; }
+    constexpr model::revision_id revision() const { return _revision; }
+
+    auto serde_fields() { return std::tie(_node_id, _revision); }
+
+private:
+    model::node_id _node_id;
+    model::revision_id _revision;
+};
 /**
  * Enum describing configuration state.
  *

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -113,16 +113,17 @@ ss::future<> group_manager::stop_heartbeats() { return _heartbeats.stop(); }
 
 ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
   raft::group_id id,
-  const std::vector<raft::vnode>& nodes,
+  std::vector<model::broker> nodes,
   ss::shared_ptr<storage::log> log,
   with_learner_recovery_throttle enable_learner_recovery_throttle,
   keep_snapshotted_log keep_snapshotted_log) {
     auto revision = log->config().get_revision();
+    auto raft_cfg = create_initial_configuration(std::move(nodes), revision);
 
     auto raft = ss::make_lw_shared<raft::consensus>(
       _self,
       id,
-      raft::group_configuration(nodes, revision),
+      std::move(raft_cfg),
       raft::timeout_jitter(_configuration.election_timeout_ms),
       log,
       scheduling_config(_raft_sg, raft_priority()),
@@ -156,6 +157,35 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
             return raft;
         });
     });
+}
+
+raft::group_configuration group_manager::create_initial_configuration(
+  std::vector<model::broker> initial_brokers,
+  model::revision_id revision) const {
+    /**
+     * Decide which raft configuration to use for the partition, if all nodes
+     * are able to understand configuration without broker information the
+     * configuration will only use raft::vnode
+     */
+    if (likely(_feature_table.is_active(
+          features::feature::membership_change_controller_cmds))) {
+        std::vector<vnode> nodes;
+        nodes.reserve(initial_brokers.size());
+        for (auto& b : initial_brokers) {
+            nodes.emplace_back(b.id(), revision);
+        }
+
+        return {std::move(nodes), revision};
+    }
+
+    // old configuration with brokers
+    auto raft_cfg = raft::group_configuration(
+      std::move(initial_brokers), revision);
+    if (unlikely(!_feature_table.is_active(
+          features::feature::raft_improved_configuration))) {
+        raft_cfg.set_version(group_configuration::v_3);
+    }
+    return raft_cfg;
 }
 
 ss::future<> group_manager::remove(ss::lw_shared_ptr<raft::consensus> c) {

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -68,7 +68,7 @@ public:
 
     ss::future<ss::lw_shared_ptr<raft::consensus>> create_group(
       raft::group_id id,
-      const std::vector<raft::vnode>& nodes,
+      std::vector<model::broker> nodes,
       ss::shared_ptr<storage::log> log,
       with_learner_recovery_throttle enable_learner_recovery_throttle,
       keep_snapshotted_log = keep_snapshotted_log::no);
@@ -105,6 +105,8 @@ private:
     ss::future<xshard_transfer_state>
     do_shutdown(ss::lw_shared_ptr<consensus>, bool remove_persistent_state);
 
+    raft::group_configuration create_initial_configuration(
+      std::vector<model::broker>, model::revision_id) const;
     model::node_id _self;
     ss::scheduling_group _raft_sg;
     raft::consensus_client_protocol _client;

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -117,7 +117,7 @@ struct simple_raft_fixture {
                       auto group = raft::group_id(0);
                       return _group_mgr.local().create_group(
                         group,
-                        {self_vnode()},
+                        {self_broker()},
                         log,
                         raft::with_learner_recovery_throttle::yes);
                   })
@@ -169,7 +169,6 @@ struct simple_raft_fixture {
           std::nullopt,
           model::broker_properties{});
     }
-    raft::vnode self_vnode() { return {_self, model::revision_id{0}}; }
 
     void wait_for_becoming_leader() {
         using namespace std::chrono_literals;

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -622,7 +622,7 @@ def is_close_size(actual_size, expected_size):
     The actual size shouldn't be less than expected. Also, the difference
     between two values shouldn't be greater than the size of one segment.
     """
-    lower_bound = int(expected_size * 0.95)
+    lower_bound = expected_size
     upper_bound = expected_size + default_log_segment_size + \
                   int(default_log_segment_size * 0.2)
     return actual_size in range(lower_bound, upper_bound)


### PR DESCRIPTION
The PR has to be reverted as it is not possible to retire a `command_based_membership` feature without bumping the `earliest_version`
Reverts redpanda-data/redpanda#22701

## Release Notes
- none