### PR TITLE
Revert `kafka`: deal with `truncation_offset < 0` cases in `prefix_truncate()`

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -485,12 +485,8 @@ replicated_partition::get_leader_epoch_last_offset_unbounded(
 ss::future<error_code> replicated_partition::prefix_truncate(
   model::offset kafka_truncation_offset,
   ss::lowres_clock::time_point deadline) {
-    if (kafka_truncation_offset() == -1) {
-        kafka_truncation_offset = high_watermark();
-    }
-    if (kafka_truncation_offset() < 0) {
-        co_return error_code::offset_out_of_range;
-    }
+    // truncation_offset < 0 cases have already been checked in
+    // `kafka::prefix_truncate()` handler.
     if (kafka_truncation_offset <= start_offset()) {
         // No-op, return early.
         co_return kafka::error_code::none;


### PR DESCRIPTION
And add a comment to remind developers that [these cases are already handled in `kafka::prefix_truncate()`](https://github.com/redpanda-data/redpanda/blob/ee0cb77ad1171a5f6d89cb16836896f3babb3c9a/src/v/kafka/server/handlers/delete_records.cc#L130-L136).

Reverts non-test changes made in https://github.com/redpanda-data/redpanda/pull/22968.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
