### PR TITLE
[backport] [v24.1.x] rm_stm: fix race during leadership transfer

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -313,7 +313,8 @@ private:
     ss::future<result<kafka_result>> transactional_replicate(
       model::batch_identity, model::record_batch_reader);
 
-    ss::future<result<kafka_result>> do_sync_and_transactional_replicate(
+    ss::future<result<kafka_result>> transactional_replicate(
+      model::term_id,
       producer_ptr,
       model::batch_identity,
       model::record_batch_reader,
@@ -331,6 +332,16 @@ private:
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>);
 
+    ss::future<result<kafka_result>> idempotent_replicate(
+      model::term_id,
+      producer_ptr,
+      model::batch_identity,
+      model::record_batch_reader,
+      raft::replicate_options,
+      ss::lw_shared_ptr<available_promise<>>,
+      ssx::semaphore_units,
+      producer_previously_known);
+
     ss::future<result<kafka_result>> do_idempotent_replicate(
       model::term_id,
       producer_ptr,
@@ -339,15 +350,6 @@ private:
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>,
       ssx::semaphore_units&,
-      producer_previously_known);
-
-    ss::future<result<kafka_result>> do_sync_and_idempotent_replicate(
-      producer_ptr,
-      model::batch_identity,
-      model::record_batch_reader,
-      raft::replicate_options,
-      ss::lw_shared_ptr<available_promise<>>,
-      ssx::semaphore_units,
       producer_previously_known);
 
     ss::future<result<kafka_result>> replicate_msg(


### PR DESCRIPTION
sync() before creating producers so the latter sees the latest state immediately after a leadership transfer. This was fixed during the rm_stm rewrite in `dev` branch but was not backported to 24.1.x

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
