### PR TITLE
storage: build key offset map as separate bazel library

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -132,6 +132,37 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "compaction",
+    hdrs = [
+        "compaction.h",
+    ],
+    include_prefix = "storage",
+    deps = [
+        "//src/v/bytes",
+    ],
+)
+
+redpanda_cc_library(
+    name = "key_offset_map",
+    srcs = [
+        "key_offset_map.cc",
+    ],
+    hdrs = [
+        "key_offset_map.h",
+    ],
+    include_prefix = "storage",
+    deps = [
+        ":compaction",
+        "//src/v/container:fragmented_vector",
+        "//src/v/hashing:secure",
+        "//src/v/model",
+        "//src/v/utils:tracking_allocator",
+        "@abseil-cpp//absl/container:btree",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "storage",
     srcs = [
         "api.cc",
@@ -143,7 +174,6 @@ redpanda_cc_library(
         "disk_log_impl.cc",
         "file_sanitizer_types.cc",
         "fs_utils.cc",
-        "key_offset_map.cc",
         "kvstore.cc",
         "lock_manager.cc",
         "log_manager.cc",
@@ -191,7 +221,6 @@ redpanda_cc_library(
         "file_sanitizer_types.h",
         "fs_utils.h",
         "fwd.h",
-        "key_offset_map.h",
         "kvstore.h",
         "lock_manager.h",
         "log.h",
@@ -236,7 +265,9 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":batch_cache",
+        ":compaction",
         ":index_state",
+        ":key_offset_map",
         ":parser_utils",
         ":record_batch_builder",
         "//src/v/base",

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -13,6 +13,7 @@
 #include "bytes/bytes.h"
 #include "model/fundamental.h"
 #include "model/record_batch_types.h"
+#include "storage/compaction.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -20,14 +21,6 @@
 
 namespace storage {
 // simple types shared among readers and writers
-
-/**
- * Type representing a record key prefixed with batch_type
- */
-struct compaction_key : bytes {
-    explicit compaction_key(bytes b)
-      : bytes(std::move(b)) {}
-};
 
 inline compaction_key enhance_key(
   model::record_batch_type type, bool is_control_batch, bytes_view key) {

--- a/src/v/storage/compaction.h
+++ b/src/v/storage/compaction.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "bytes/bytes.h"
+
+namespace storage {
+
+/**
+ * Type representing a record key prefixed with batch_type
+ */
+struct compaction_key : bytes {
+    explicit compaction_key(bytes b)
+      : bytes(std::move(b)) {}
+};
+
+} // namespace storage

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -10,7 +10,8 @@
 
 #include "container/fragmented_vector.h"
 #include "hashing/secure.h"
-#include "storage/compacted_index.h"
+#include "model/fundamental.h"
+#include "storage/compaction.h"
 #include "utils/tracking_allocator.h"
 
 #include <seastar/core/future.hh>

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -110,3 +110,17 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "key_offset_map_test",
+    timeout = "short",
+    srcs = [
+        "key_offset_map_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/storage:key_offset_map",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/storage/tests/key_offset_map_test.cc
+++ b/src/v/storage/tests/key_offset_map_test.cc
@@ -224,14 +224,14 @@ TEST(HashKeyOffsetMapTest, Initialize) {
     const auto orig_size = map.size();
 
     // we'll try to overwrite with 99
-    for (int i = 0; i < orig_size; ++i) {
+    for (size_t i = 0; i < orig_size; ++i) {
         const auto key = fmt::format("key-{}", i);
         storage::compaction_key ck(bytes(key.begin(), key.end()));
         ASSERT_TRUE(map.put(ck, model::offset(99)).get());
     }
 
     // but it won't work cause they are still in the map
-    for (int i = 0; i < orig_size; ++i) {
+    for (size_t i = 0; i < orig_size; ++i) {
         const auto key = fmt::format("key-{}", i);
         storage::compaction_key ck(bytes(key.begin(), key.end()));
         const auto val = map.get(ck).get();
@@ -245,7 +245,7 @@ TEST(HashKeyOffsetMapTest, Initialize) {
     EXPECT_EQ(map.size(), 0);
 
     // now try to write the 99 offsets
-    for (int i = 0; i < orig_size; ++i) {
+    for (size_t i = 0; i < orig_size; ++i) {
         const auto key = fmt::format("key-{}", i);
         storage::compaction_key ck(bytes(key.begin(), key.end()));
         EXPECT_TRUE(map.put(ck, model::offset(99)).get());
@@ -253,7 +253,7 @@ TEST(HashKeyOffsetMapTest, Initialize) {
     EXPECT_EQ(map.size(), orig_size);
 
     // and we'll see the offset = 99 entries
-    for (int i = 0; i < orig_size; ++i) {
+    for (size_t i = 0; i < orig_size; ++i) {
         const auto key = fmt::format("key-{}", i);
         storage::compaction_key ck(bytes(key.begin(), key.end()));
         const auto val = map.get(ck).get();


### PR DESCRIPTION
* storage: build key offset map as separate bazel library
* adds the offset map test to bazel build

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

