### PR TITLE
[v24.1.x] Revert `storage`: fix condition in `disk_log_impl::have_segments_to_evict()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -402,7 +402,7 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
       max_offset);
     // we only notify eviction monitor if there are segments to evict
     auto have_segments_to_evict
-      = !_segs.empty()
+      = (_segs.size() > 1)
         && _segs.front()->offsets().get_committed_offset() <= max_offset;
 
     if (_eviction_monitor && have_segments_to_evict) {

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -104,12 +104,12 @@ FIXTURE_TEST(retention_test_size_with_one_segment, gc_fixture) {
           builder.get_disk_log_impl().get_probe().partition_size()));
     BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
 
-    BOOST_TEST_MESSAGE("Should collect the segment");
+    BOOST_TEST_MESSAGE("Should not collect the segment");
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
+    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
 }
 
 /*


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22995
