### PR TITLE
schema_registry/json: Refactoring to add a context with schema version

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -226,7 +226,7 @@ jsoncons::jsonschema::json_schema<jsoncons::json> const& get_metaschema() {
     return meteschema_doc;
 }
 
-result<void> validate_json_schema(
+result<json_schema_dialect> validate_json_schema(
   json_schema_dialect dialect, const jsoncons::json& schema) {
     // validation pre-step: get metaschema for json draft
     auto const& metaschema_doc = [=]() -> const auto& {
@@ -261,10 +261,11 @@ result<void> validate_json_schema(
     // schema is a syntactically valid json schema, where $schema == Dialect.
     // TODO AB cross validate "$ref" fields, this is not done automatically
     // TODO validate that "pattern" and "patternProperties" are valid regex
-    return outcome::success();
+    return dialect;
 }
 
-result<void> try_validate_json_schema(const jsoncons::json& schema) {
+result<json_schema_dialect>
+try_validate_json_schema(const jsoncons::json& schema) {
     using enum json_schema_dialect;
 
     // no explicit $schema: try to validate from newest to oldest draft
@@ -272,7 +273,7 @@ result<void> try_validate_json_schema(const jsoncons::json& schema) {
     for (auto d : {draft202012, draft201909, draft7, draft6, draft4}) {
         auto res = validate_json_schema(d, schema);
         if (res.has_value()) {
-            return outcome::success();
+            return res;
         }
         // failed to validated with dialect d. save error for reporting
         if (!first_error.has_value()) {

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -63,12 +63,17 @@ struct json_schema_definition::impl {
         return std::move(buf).as_iobuf();
     }
 
-    explicit impl(json::Document doc, std::string_view name)
+    explicit impl(
+      json::Document doc,
+      std::string_view name,
+      canonical_schema_definition::references refs)
       : doc{std::move(doc)}
-      , name{name} {}
+      , name{name}
+      , refs(std::move(refs)) {}
 
     json::Document doc;
     ss::sstring name;
+    canonical_schema_definition::references refs;
 };
 
 bool operator==(
@@ -87,6 +92,11 @@ std::ostream& operator<<(std::ostream& os, const json_schema_definition& def) {
 
 canonical_schema_definition::raw_string json_schema_definition::raw() const {
     return canonical_schema_definition::raw_string{_impl->to_json()};
+}
+
+canonical_schema_definition::references const&
+json_schema_definition::refs() const {
+    return _impl->refs;
 }
 
 ss::sstring json_schema_definition::name() const { return {_impl->name}; };
@@ -1589,8 +1599,8 @@ make_json_schema_definition(sharded_store&, canonical_schema schema) {
     std::string_view name = schema.sub()();
     auto refs = std::move(schema).def().refs();
     co_return json_schema_definition{
-      ss::make_shared<json_schema_definition::impl>(std::move(doc), name),
-      std::move(refs)};
+      ss::make_shared<json_schema_definition::impl>(
+        std::move(doc), name, std::move(refs))};
 }
 
 ss::future<canonical_schema> make_canonical_json_schema(

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -103,6 +103,10 @@ ss::sstring json_schema_definition::name() const { return {_impl->name}; };
 
 namespace {
 
+std::string_view as_string_view(json::Value const& v) {
+    return {v.GetString(), v.GetStringLength()};
+}
+
 ss::future<> check_references(sharded_store& store, canonical_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         co_await store.is_subject_version_deleted(ref.sub, ref.version)
@@ -289,7 +293,7 @@ result<json::Document> parse_json(iobuf buf) {
         // schema is an actual object
         if (auto it = schema.FindMember("$schema"); it != schema.MemberEnd()) {
             if (it->value.IsString()) {
-                dialect = from_uri(it->value.GetString());
+                dialect = from_uri(as_string_view(it->value));
             }
 
             if (it->value.IsString() == false || dialect == std::nullopt) {
@@ -373,7 +377,7 @@ constexpr std::optional<json_type> from_string_view(std::string_view v) {
 }
 
 constexpr auto parse_json_type(json::Value const& v) {
-    std::string_view sv{v.GetString(), v.GetStringLength()};
+    auto sv = as_string_view(v);
     auto type = from_string_view(sv);
     if (!type) {
         throw as_exception(error_info{
@@ -717,11 +721,7 @@ bool is_string_superset(json::Value const& older, json::Value const& newer) {
 
     // both have "pattern". check if they are the same, the only
     // possible_value_accepted
-    auto older_pattern = std::string_view{
-      older_val_p->GetString(), older_val_p->GetStringLength()};
-    auto newer_pattern = std::string_view{
-      newer_val_p->GetString(), newer_val_p->GetStringLength()};
-    return older_pattern == newer_pattern;
+    return as_string_view(*older_val_p) == as_string_view(*newer_val_p);
 }
 
 bool is_numeric_superset(json::Value const& older, json::Value const& newer) {
@@ -999,13 +999,11 @@ bool is_object_properties_superset(
         // or it should be checked against every schema in
         // older["patternProperties"] that matches
         auto pattern_match_found = false;
-        for (auto pname
-             = std::string_view{prop.GetString(), prop.GetStringLength()};
+        for (auto pname = as_string_view(prop);
              auto const& [propPattern, schemaPattern] :
              older_pattern_properties) {
             // TODO this rebuilds the regex each time, could be cached
-            auto regex = re2::RE2(std::string_view{
-              propPattern.GetString(), propPattern.GetStringLength()});
+            auto regex = re2::RE2(as_string_view(propPattern));
             if (re2::RE2::PartialMatch(pname, regex)) {
                 pattern_match_found = true;
                 if (!is_superset(schemaPattern, schema)) {
@@ -1541,7 +1539,7 @@ bool check_compatible_dialects(
         if (it == v.MemberEnd()) {
             return std::nullopt;
         }
-        return from_uri(it->value.GetString());
+        return from_uri(as_string_view(it->value));
     };
 
     auto older_dialect = get_dialect(older);
@@ -1581,10 +1579,7 @@ void sort(json::Value& val) {
     case rapidjson::Type::kObjectType: {
         auto v = val.GetObject();
         std::sort(v.begin(), v.end(), [](auto& lhs, auto& rhs) {
-            return std::string_view{
-                     lhs.name.GetString(), lhs.name.GetStringLength()}
-                   < std::string_view{
-                     rhs.name.GetString(), rhs.name.GetStringLength()};
+            return as_string_view(lhs.name) < as_string_view(rhs.name);
         });
     }
     }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -281,15 +281,11 @@ public:
     struct impl;
     using pimpl = ss::shared_ptr<const impl>;
 
-    explicit json_schema_definition(
-      pimpl p, canonical_schema_definition::references refs)
-      : _impl{std::move(p)}
-      , _refs(std::move(refs)) {}
+    explicit json_schema_definition(pimpl p)
+      : _impl{std::move(p)} {}
 
     canonical_schema_definition::raw_string raw() const;
-    canonical_schema_definition::references const& refs() const {
-        return _refs;
-    };
+    canonical_schema_definition::references const& refs() const;
 
     const impl& operator()() const { return *_impl; }
 
@@ -309,7 +305,6 @@ public:
 
 private:
     pimpl _impl;
-    canonical_schema_definition::references _refs;
 };
 
 ///\brief A schema that has been validated.


### PR DESCRIPTION
No functional changes, just refactoring.

This is groundwork for references support in CORE-6836

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
