### PR TITLE
rptest: reduce cache eviction throttling for tiny cache stress test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -64,6 +64,7 @@ class TieredStorageCacheStressTest(RedpandaTest):
             'cloud_storage_manifest_max_upload_interval_sec':
             self.manifest_upload_interval,
             'disable_public_metrics': False,
+            'cloud_storage_cache_check_interval': 500,
         }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
 


### PR DESCRIPTION
This is similar to the fix applied in
https://github.com/redpanda-data/redpanda/pull/22796/ commit 7763669 which is needed after carryover trim was disabled and we hit cache trimming throttling making the test slower than our threshold

Fixes #13648
CORE-1464

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
