### PR TITLE
[v24.2.x] [CORE-2632] tiered_storage_model_test: relax requirements for SegmentRolledByTimeout TS_Read 

### DIFF
--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1391,6 +1391,7 @@ class SegmentRolledByTimeout(Expression):
         return [
             LogBasedValidator("SegmentRolledByTimeout_log",
                               "segment.ms applied, new segment start offset",
+                              confidence_threshold=4,
                               execution_stage=TestRunStage.Produce),
         ]
 

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -767,6 +767,7 @@ class TS_Read(Expression):
             MetricBasedValidator(
                 "TS_Read",
                 "vectorized_cloud_storage_successful_downloads_total",
+                confidence_threshold=4,
                 execution_stage=TestRunStage.Consume)
         ]
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22849
