### PR TITLE
raft: increase memory limit for gtest_raft_rpunit

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -61,6 +61,7 @@ def _redpanda_cc_test(
     """
     common_args = [
         "--blocked-reactor-notify-ms 2000000",
+        "--abort-on-seastar-bad-alloc",
     ]
 
     args = common_args + extra_args + custom_args

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -64,7 +64,7 @@ rp_test(
   SOURCES ${gsrcs}
   LIBRARIES  v::raft v::storage_test_utils v::model_test_utils v::features v::gtest_main
   LABELS raft
-  ARGS "-- -c 8"
+  ARGS "-- -c 8 -m 2G"
 )
 
 rp_test(

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -29,7 +29,10 @@ formatter = logging.Formatter(fmt_string)
 for h in logging.getLogger().handlers:
     h.setFormatter(formatter)
 
-COMMON_TEST_ARGS = ["--blocked-reactor-notify-ms 2000000"]
+COMMON_TEST_ARGS = [
+    "--blocked-reactor-notify-ms 2000000",
+    "--abort-on-seastar-bad-alloc",
+]
 
 
 def find_vbuild_path_from_binary(binary_path, num_subdirs=1):


### PR DESCRIPTION
Since this test uses 8 cores, by default each shard gets only 128M, which is barely enough and sometimes leads to bad allocs.

Also, turn `--abort-on-seastar-bad-alloc` on in tests, so that bad_allocs are more visible.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none