### PR TITLE
`admin`: improve `cluster config get` UX for invalid requests

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1271,8 +1271,13 @@ void admin_server::register_config_routes() {
           auto key_str = req.get_query_param("key");
           if (!key_str.empty()) {
               // Write a single key to json.
-              config::shard_local_cfg().to_json_single_key(
-                writer, config::redact_secrets::yes, key_str);
+              try {
+                  config::shard_local_cfg().to_json_single_key(
+                    writer, config::redact_secrets::yes, key_str);
+              } catch (std::out_of_range&) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Unknown property {{{}}}", key_str));
+              }
           } else {
               // Write the entire config to json.
               config::shard_local_cfg().to_json(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1226,6 +1226,21 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                     f"Config setting {key}={strval} should have been rejected")
                 assert False
 
+        # Check that the `get` command hits proper validation paths
+        unknown_examples = [
+            "panda_size", "panda_retention_ms", "panda_mutation_rate"
+        ]
+
+        for key in unknown_examples:
+            with expect_exception(RpkException,
+                                  lambda e: "Unknown property" in str(e)):
+                self.rpk.cluster_config_get(key)
+
+        for key in unknown_examples:
+            with expect_exception(requests.exceptions.HTTPError,
+                                  lambda e: e.response.status_code == 400):
+                self.admin.get_cluster_config(key=key)
+
         # Check that resetting properties to their default via `set` works
         default_examples = [
             ("kafka_qdc_enable", False),


### PR DESCRIPTION
Requesting a key that does not exist in the `config_store::get()` function throws an `std::out_of_range` exception.

This would lead to retries on an invalid request made to `get_cluster_config` in the admin server, and what seems like a short hang to the user on the `rpk` side.

Improve the UX by wrapping this in a `try/catch` block, and throw a `ss::httpd::bad_param_exception` instead in case of an invalid key.

The admin request will not be retried, and the user on the `rpk` side will immediately get a proper `400` response.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
