### PR TITLE
DNM: Debug compute storage failures

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -18,6 +18,7 @@ from typing import Iterator
 # NB: SegmentReader is duplicated in si_utils.py for deployment reasons. If
 # making changes please adapt both.
 class SegmentReader:
+    stream: io.BytesIO
     HDR_FMT_RP = "<IiqbIhiqqqhii"
     HEADER_SIZE = struct.calcsize(HDR_FMT_RP)
     Header = collections.namedtuple(
@@ -38,9 +39,14 @@ class SegmentReader:
             data = self.stream.read(records_size)
             if len(data) < records_size:
                 return None
-            assert len(
-                data
-            ) == records_size, f"data len is {len(data)} but the expected records size is {records_size}"
+
+            error_detail = {}
+            if len(data) != records_size:
+                error_detail["header"] = header
+                error_detail["current_pos"] = self.stream.tell()
+            assert len(data) == records_size, (
+                f"data len is {len(data)} but the expected records size is {records_size}, "
+                f"error detail={error_detail}")
             return header
         return None
 

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -28,7 +28,7 @@ class SegmentReader:
 
     def __init__(self, stream):
         self.stream = stream
-        self.tolerate_partial_reads = 10
+        self.tolerate_partial_reads = 5
         self.sleep_between_read_attempts = 0.5
         self.partial_reads = 0
 
@@ -129,7 +129,8 @@ def compute_size_for_file(file: Path, calc_md5: bool):
 
                 f.seek(0)
                 data = f.read()
-                reader = SegmentReader(io.BytesIO(data))
+                f.seek(0)
+                reader = SegmentReader(f)
                 return md5_for_bytes(calc_md5,
                                      data), sum(h.batch_size for h in reader)
     else:

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -144,6 +144,14 @@ def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
                             # It's valid to have a segment deleted
                             # at anytime
                             continue
+                        except AssertionError as e:
+                            if print_flat:
+                                raise e
+                            return {
+                                "parse_failed": True,
+                                "segment": str(segment),
+                                "error": str(e)
+                            }
                     part_output[segment.name] = seg_output
                 topic_output[partition.name] = part_output
             ns_output[topic.name] = topic_output


### PR DESCRIPTION
DNM

for help in debugging https://github.com/redpanda-data/redpanda/issues/20298

captures the segment with parse failure for further analysis

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
