### PR TITLE
Feat/core/6657/schema registry remove schemas requirement

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -191,6 +191,8 @@ public:
     explicit schema_context(json_schema_definition::impl const& schema)
       : _schema{schema} {}
 
+    json_schema_dialect dialect() const { return _schema.ctx.dialect; }
+
 private:
     json_schema_definition::impl const& _schema;
 };

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -1543,9 +1543,6 @@ bool is_superset(
     for (auto not_yet_handled_keyword : {
            // draft 6 unhandled keywords:
            "$ref",
-           // draft 2019-09 unhandled keywords:
-           "dependentRequired",
-           "dependentSchemas",
            // draft 2020-12 unhandled keywords:
            "prefixItems",
          }) {

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -847,6 +847,55 @@ static constexpr auto compatibility_test_cases = std::to_array<
   })",
     .reader_is_compatible_with_writer = true,
   },
+  // array checks: prefixItems/items are compatible across drafts
+  {
+    .reader_schema = R"({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "prefixItems": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "items": false
+        })",
+
+    .writer_schema = R"({
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "array",
+            "items": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "additionalItems": false
+        })",
+    .reader_is_compatible_with_writer = true,
+  },
+  {
+    .reader_schema = R"({
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "array",
+            "items": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "additionalItems": false
+        })",
+    .writer_schema = R"({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "prefixItems": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "items": false
+        })",
+
+    .reader_is_compatible_with_writer = true,
+  },
   // combinators: "not"
   {
     .reader_schema
@@ -1015,6 +1064,52 @@ static constexpr auto compatibility_test_cases = std::to_array<
   {
     .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
     .writer_schema = "true",
+    .reader_is_compatible_with_writer = true,
+  },
+  // array checks: prefixItems/items are compatible across drafts, unspecified
+  // schema
+  {
+    .reader_schema = R"({
+            "type": "array",
+            "prefixItems": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "items": false
+        })",
+
+    .writer_schema = R"({
+            "type": "array",
+            "items": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "additionalItems": false
+        })",
+    .reader_is_compatible_with_writer = true,
+  },
+  {
+    .reader_schema = R"({
+            "type": "array",
+            "items": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "additionalItems": false
+        })",
+    .writer_schema = R"({
+            "type": "array",
+            "prefixItems": [
+                {
+                    "type": "integer"
+                }
+            ],
+            "items": false
+        })",
+
     .reader_is_compatible_with_writer = true,
   },
 });

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -619,20 +619,6 @@ static constexpr auto compatibility_test_cases = std::to_array<
     = R"({"oneOf": [{"type":"number", "multipleOf": 10}, {"type": "number", "multipleOf": 1.1}]})",
     .reader_is_compatible_with_writer = false,
   },
-  // different dialects
-  {
-    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
-    .writer_schema
-    = R"({"$schema": "http://json-schema.org/draft-06/schema#"})",
-    .reader_is_compatible_with_writer = false,
-    .expected_exception = true,
-  },
-  {
-    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
-    .writer_schema = "true",
-    .reader_is_compatible_with_writer = false,
-    .expected_exception = true,
-  },
   //***** compatible section *****
   // atoms
   {
@@ -1017,6 +1003,18 @@ static constexpr auto compatibility_test_cases = std::to_array<
     .reader_schema = R"({"$schema": "http://json-schema.org/draft-06/schema"})",
     .writer_schema
     = R"({"$schema": "http://json-schema.org/draft-06/schema#"})",
+    .reader_is_compatible_with_writer = true,
+  },
+  // different dialects
+  {
+    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
+    .writer_schema
+    = R"({"$schema": "http://json-schema.org/draft-06/schema#"})",
+    .reader_is_compatible_with_writer = true,
+  },
+  {
+    .reader_schema = R"({"$schema": "http://json-schema.org/draft-04/schema"})",
+    .writer_schema = "true",
     .reader_is_compatible_with_writer = true,
   },
 });


### PR DESCRIPTION
* removes "dependedRequired" and "dependentSchema" from the list of unhandled keywords.
  - implementation can leverage the word done for "dependencies", but they are not implemented in the reference implementation 🤷‍♂️
* adds support for "prefixItems" for "type": "array" in draft2020. this keyword changes the semantics of "items", but the resulting schema should be comparable with a previous dialect
  - in practice this means that `{"type": "array", "prefixItems": [...]}` and `{"type": "array", "items": [...]}` are compatible
* removed the requirement that both schemas use the same dialect
  - the only potentially problematic keyword was items, and that is solved in this commit
  - exlusiveMinimum is another keyword that changed meaning from draft4 to draft6, but in this case the comparison against dialects should not be supported  

Fixes https://redpandadata.atlassian.net/browse/CORE-6657

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none