### PR TITLE
rp_storage_tool: add docker build

### DIFF
--- a/tools/rp_storage_tool/Dockerfile
+++ b/tools/rp_storage_tool/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.79.0-slim-bullseye AS builder
+
+# If you are building on a workstation and copying the binary to a remote machine, and your
+# workstation doesn't happen to run the same linux distro as the remote machine, it is
+# useful to build a statically linked binary that will work on any distro.
+# That's what the next 2 lines are for
+RUN apt update && apt install -y musl-tools
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /src
+COPY . /src/
+RUN cargo build --release --target=x86_64-unknown-linux-musl
+
+FROM rust:1.79.0-slim-bullseye
+
+WORKDIR /usr/local/bin
+COPY --from=builder /src/target/release/rp-storage-tool .
+
+ENTRYPOINT ["rp-storage-tool"]
+CMD ["--help"]

--- a/tools/rp_storage_tool/README.md
+++ b/tools/rp_storage_tool/README.md
@@ -9,21 +9,11 @@ This tool is **not** for everyday use on live clusters.
 
 ## Quickstart
 
-    # Get a rust toolchain
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+You can build the tool as a docker image and run it as a container.
 
-    # Compile and run
-    cargo run --release -- --backend=<aws|gcp|azure> scan --source=<bucket name>
+    docker build -t rp-storage-tool ./tools/rp_storage_tool
 
-## Installation
-
-To run the tool outside a built tree, you may simply copy the statically linked binary.
-
-    # Compile
-    cargo build --release
-
-    # Grab the binary
-    cp target/release/rp-storage-tool /usr/local/bin
+    docker run -it --network=host rp-storage-tool
 
 ## Usage
 
@@ -81,7 +71,42 @@ For example, to use the tool with a bucket called `data` in a minio cluster at `
     AWS_ALLOW_HTTP=1 AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin AWS_REGION=us-east-1 \
       AWS_ENDPOINT=http://aplite:9000 cargo run --release -- --backend aws scan --source data
 
-### Building a portable binary
+### Taking the binary out of the docker image
+
+If you'd like to run the binary locally or copy it to a remote machine, you can take the built binary out of the docker image.
+
+    # Run the docker image and keep it alive while you're copying the binary out
+    docker run -it --entrypoint bash rp-storage-tool
+
+    # In another terminal, copy the binary out of the running container
+    docker cp rp-storage-tool:/usr/local/bin/rp-storage-tool ./
+
+
+## Building locally
+
+If you don't want to use docker to build and run the tool (see above for how to do that), you can build the tool directly
+using the rust toolchain and install it on your machine.
+
+#### Using cargo
+
+    # Get a rust toolchain
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+    # Compile and run
+    cargo run --release -- --backend=<aws|gcp|azure> scan --source=<bucket name>
+
+#### Installation
+
+To run the tool outside a built tree, you may simply copy the statically linked binary.
+
+    # Compile
+    cargo build --release
+
+    # Grab the binary
+    cp target/release/rp-storage-tool /usr/local/bin
+
+
+#### Building a portable binary
 
 If you are building on a workstation and copying the binary to a remote machine, and your
 workstation doesn't happen to run the same linux distro as the remote machine, it is


### PR DESCRIPTION
This adds a dockerized build to the rp_storage_tool to make the build more reproducible and stable.

This should also enable building it as a github action and publishing it so that we do not need to rebuild it on our machines while investigating.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
