### PR TITLE
[v24.2.x] CORE-6845 cmake: update avro rebased to 1.12

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -117,7 +117,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "oKITe9nj2EdkBuBP+TT8pURFcRDI2cXavbOmpgbVdX4=",
+        "bzlTransitiveDigest": "qPEnE4QcGvcel5FaSnBKrtciazXJ4Kzk9ISA1sDvvHY=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -318,9 +318,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:avro.BUILD",
-              "sha256": "72919e8a512ed7c57ea77bbd2a47ceab0dab123a40767309b4d22350cf2ed960",
-              "strip_prefix": "avro-121d2a86cc43e5d4037d265f221aa3b64b9db0de",
-              "url": "https://github.com/redpanda-data/avro/archive/121d2a86cc43e5d4037d265f221aa3b64b9db0de.tar.gz"
+              "sha256": "a95c1b9517493d2e09d62a428ba7b4295c5cdb76eb07a0b2466f64a268486387",
+              "strip_prefix": "avro-b3d7efe3d8bc15e7a19ee349c51e14f8795b1515",
+              "url": "https://github.com/redpanda-data/avro/archive/b3d7efe3d8bc15e7a19ee349c51e14f8795b1515.tar.gz"
             }
           },
           "xxhash": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -19,9 +19,9 @@ def data_dependency():
     http_archive(
         name = "avro",
         build_file = "//bazel/thirdparty:avro.BUILD",
-        sha256 = "72919e8a512ed7c57ea77bbd2a47ceab0dab123a40767309b4d22350cf2ed960",
-        strip_prefix = "avro-121d2a86cc43e5d4037d265f221aa3b64b9db0de",
-        url = "https://github.com/redpanda-data/avro/archive/121d2a86cc43e5d4037d265f221aa3b64b9db0de.tar.gz",
+        sha256 = "a95c1b9517493d2e09d62a428ba7b4295c5cdb76eb07a0b2466f64a268486387",
+        strip_prefix = "avro-b3d7efe3d8bc15e7a19ee349c51e14f8795b1515",
+        url = "https://github.com/redpanda-data/avro/archive/b3d7efe3d8bc15e7a19ee349c51e14f8795b1515.tar.gz",
     )
 
     http_archive(

--- a/bazel/thirdparty/avro.BUILD
+++ b/bazel/thirdparty/avro.BUILD
@@ -2,8 +2,8 @@
 # This build is a translation from the cmake build. The second link below is a
 # cleaned up version of the first.
 #
-# https://github.com/redpanda-data/avro/blob/release-1.11.1-redpanda/lang/c%2B%2B/CMakeLists.txt
-# https://github.com/redpanda-data/avro/blob/release-1.11.1-redpanda/redpanda_build/CMakeLists.txt
+# https://github.com/redpanda-data/avro/blob/release-1.12.0-redpanda/lang/c%2B%2B/CMakeLists.txt
+# https://github.com/redpanda-data/avro/blob/release-1.12.0-redpanda/redpanda_build/CMakeLists.txt
 #
 # All of the header gymnastics below is to work around the problem of the C++
 # implementation files including the headers without the "avro/" prefix. It
@@ -141,6 +141,7 @@ cc_library(
         "@boost//:format",
         "@boost//:iostreams",
         "@boost//:lexical_cast",
+        "@fmt",
         "@snappy",
     ],
 )
@@ -157,5 +158,6 @@ cc_binary(
     deps = [
         ":avro",
         "@boost//:program_options",
+        "@fmt",
     ],
 )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -51,7 +51,7 @@ fetch_dep(seastar
 
 fetch_dep(avro
   REPO https://github.com/redpanda-data/avro
-  TAG release-1.11.1-redpanda
+  TAG release-1.12.0-redpanda
   SOURCE_SUBDIR redpanda_build)
 
 fetch_dep(rapidjson


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22848 

Fixes https://github.com/redpanda-data/redpanda/issues/22874
Fixes https://redpandadata.atlassian.net/browse/CORE-6902

The conflict was on the bazel lock file.