### PR TITLE
datalake: iceberg to arrow schema translation

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Protobuf REQUIRED)
 v_cc_library(
   NAME datalake
   SRCS
+    arrow_schema_translator.cc
     protobuf_to_arrow_converter.cc
     proto_to_arrow_scalar.cc
     proto_to_arrow_struct.cc
@@ -17,6 +18,7 @@ v_cc_library(
     Arrow::arrow_shared
     Parquet::parquet_shared
     protobuf::libprotobuf
+    v::iceberg
 )
 
 add_subdirectory(tests)

--- a/src/v/datalake/arrow_schema_translator.cc
+++ b/src/v/datalake/arrow_schema_translator.cc
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/arrow_schema_translator.h"
+
+#include "iceberg/datatypes.h"
+
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+#include <arrow/type_traits.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace datalake {
+class schema_converter_interface {
+public:
+    virtual ~schema_converter_interface() noexcept = default;
+    // Return an Arrow field descriptor for this converter.
+    virtual std::shared_ptr<arrow::Field>
+    field(const std::string& name, iceberg::field_required required) = 0;
+};
+
+template<typename ArrowType>
+class scalar_schema_converter : public schema_converter_interface {
+public:
+    explicit scalar_schema_converter(
+      const std::shared_ptr<arrow::DataType>& data_type)
+      : _arrow_data_type{data_type} {
+        if (!_arrow_data_type) {
+            throw std::invalid_argument("Invalid arrow data type");
+        }
+    }
+
+    std::shared_ptr<arrow::Field>
+    field(const std::string& name, iceberg::field_required required) override {
+        if (!_arrow_data_type) {
+            throw std::runtime_error(
+              "Calling field() on uninitialized scalar converter");
+        }
+        return arrow::field(
+          name, _arrow_data_type, required == iceberg::field_required::no);
+    }
+
+private:
+    std::shared_ptr<arrow::DataType> _arrow_data_type;
+};
+
+class struct_schema_converter : public schema_converter_interface {
+public:
+    explicit struct_schema_converter(const iceberg::struct_type& schema);
+
+    std::shared_ptr<arrow::Field>
+    field(const std::string& name, iceberg::field_required required) override {
+        if (!_arrow_data_type) {
+            throw std::runtime_error(
+              "Calling field() on uninitialized struct converter");
+        }
+        return arrow::field(
+          name, _arrow_data_type, required == iceberg::field_required::no);
+    }
+
+    arrow::FieldVector get_field_vector() { return _fields; }
+
+private:
+    arrow::FieldVector _fields;
+    std::shared_ptr<arrow::DataType> _arrow_data_type;
+};
+
+class list_schema_converter : public schema_converter_interface {
+public:
+    explicit list_schema_converter(const iceberg::list_type& schema);
+
+    std::shared_ptr<arrow::Field>
+    field(const std::string& name, iceberg::field_required required) override {
+        if (!_arrow_data_type) {
+            throw std::runtime_error(
+              "Calling field() on uninitialized list converter");
+        }
+        return arrow::field(
+          name, _arrow_data_type, required == iceberg::field_required::no);
+    }
+
+private:
+    std::shared_ptr<arrow::DataType> _arrow_data_type;
+};
+
+class map_schema_converter : public schema_converter_interface {
+public:
+    explicit map_schema_converter(const iceberg::map_type& schema);
+
+    std::shared_ptr<arrow::Field>
+    field(const std::string& name, iceberg::field_required required) override {
+        if (!_arrow_data_type) {
+            throw std::runtime_error(
+              "Calling field() on uninitialized map converter");
+        }
+        return arrow::field(
+          name, _arrow_data_type, required == iceberg::field_required::no);
+    }
+
+private:
+    std::shared_ptr<arrow::DataType> _arrow_data_type;
+};
+
+struct schema_converter_builder_visitor {
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::struct_type& s) {
+        return std::make_unique<struct_schema_converter>(s);
+    }
+
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::list_type& s) {
+        return std::make_unique<list_schema_converter>(s);
+    }
+
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::map_type& m) {
+        return std::make_unique<map_schema_converter>(m);
+    }
+
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::primitive_type& p) {
+        return std::visit(*this, p);
+    }
+
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::boolean_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::BooleanType>>(
+          arrow::boolean());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::int_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::Int32Type>>(
+          arrow::int32());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::long_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::Int64Type>>(
+          arrow::int64());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::float_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::FloatType>>(
+          arrow::float32());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::double_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::DoubleType>>(
+          arrow::float64());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::decimal_type& t) {
+        if (t.precision == 0) {
+            return nullptr;
+        }
+        return std::make_unique<scalar_schema_converter<arrow::Decimal128Type>>(
+          arrow::decimal(t.precision, t.scale));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::date_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::Date32Type>>(
+          arrow::date32());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::time_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::Time64Type>>(
+          arrow::time64(arrow::TimeUnit::MICRO));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::timestamp_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::TimestampType>>(
+          arrow::timestamp(arrow::TimeUnit::MICRO));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::timestamptz_type& /*t*/) {
+        // Iceberg assumes timestampttz are in UTC.
+        return std::make_unique<scalar_schema_converter<arrow::TimestampType>>(
+          arrow::timestamp(arrow::TimeUnit::MICRO, "UTC"));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::string_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::StringType>>(
+          arrow::utf8());
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::uuid_type& /*t*/) {
+        // TODO: there's an arrow extension for a uuid logical type.
+        // Under-the-hood it's stored as a fixed(16). Do we want to use the
+        // logical type here?
+        return std::make_unique<
+          scalar_schema_converter<arrow::FixedSizeBinaryType>>(
+          arrow::fixed_size_binary(16));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::fixed_type& t) {
+        return std::make_unique<
+          scalar_schema_converter<arrow::FixedSizeBinaryType>>(
+          arrow::fixed_size_binary(static_cast<uint32_t>(t.length)));
+    }
+    std::unique_ptr<schema_converter_interface>
+    operator()(const iceberg::binary_type& /*t*/) {
+        return std::make_unique<scalar_schema_converter<arrow::BinaryType>>(
+          arrow::binary());
+    }
+};
+
+struct_schema_converter::struct_schema_converter(
+  const iceberg::struct_type& schema) {
+    _fields.reserve(schema.fields.size());
+    for (const auto& field : schema.fields) {
+        std::unique_ptr<schema_converter_interface> child = std::visit(
+          schema_converter_builder_visitor{}, field->type);
+        if (!child) {
+            // Don't have a valid data type.
+            _arrow_data_type = nullptr;
+            // We shouldn't get here. The child should throw if it can't be
+            // constructed correctly.
+            throw std::runtime_error("Unable to construct child converter");
+        }
+        _fields.push_back(child->field(field->name, field->required));
+    }
+    _arrow_data_type = arrow::struct_(_fields);
+}
+
+list_schema_converter::list_schema_converter(const iceberg::list_type& schema) {
+    std::unique_ptr<schema_converter_interface> child = std::visit(
+      schema_converter_builder_visitor{}, schema.element_field->type);
+    if (!child) {
+        // Don't have a valid data type.
+        _arrow_data_type = nullptr;
+        // We shouldn't get here. The child should throw if it can't be
+        // constructed correctly.
+        throw std::runtime_error("Unable to construct child converter");
+    }
+    std::shared_ptr<arrow::Field> child_field = child->field(
+      schema.element_field->name, schema.element_field->required);
+    if (child_field) {
+        _arrow_data_type = arrow::list(child_field);
+    } else {
+        throw std::runtime_error("Child converter has null field");
+    }
+}
+
+map_schema_converter::map_schema_converter(const iceberg::map_type& schema) {
+    std::unique_ptr<schema_converter_interface> key = std::visit(
+      schema_converter_builder_visitor{}, schema.key_field->type);
+    std::unique_ptr<schema_converter_interface> value = std::visit(
+      schema_converter_builder_visitor{}, schema.value_field->type);
+    if (!key || !value) {
+        _arrow_data_type = nullptr;
+        // We shouldn't get here. The child should throw if it can't be
+        // constructed correctly.
+        throw std::runtime_error("Unable to construct child converter");
+    }
+
+    std::shared_ptr<arrow::Field> key_field = key->field(
+      schema.key_field->name, schema.key_field->required);
+    std::shared_ptr<arrow::Field> value_field = value->field(
+      schema.value_field->name, schema.value_field->required);
+    if (!key_field || !value_field) {
+        _arrow_data_type = nullptr;
+        throw std::runtime_error("Child converter has null field");
+    }
+
+    _arrow_data_type = arrow::map(key_field->type(), value_field->type());
+}
+
+arrow_schema_translator::arrow_schema_translator(iceberg::struct_type&& schema)
+  : _schema(std::move(schema))
+  , _struct_converter(std::make_unique<struct_schema_converter>(_schema)) {}
+
+arrow_schema_translator::~arrow_schema_translator() = default;
+
+std::shared_ptr<arrow::Schema> arrow_schema_translator::build_arrow_schema() {
+    return arrow::schema(_struct_converter->get_field_vector());
+}
+} // namespace datalake

--- a/src/v/datalake/arrow_schema_translator.h
+++ b/src/v/datalake/arrow_schema_translator.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <arrow/type.h>
+
+#include <optional>
+
+namespace datalake {
+
+class struct_schema_converter;
+
+class arrow_schema_translator {
+public:
+    explicit arrow_schema_translator(iceberg::struct_type&& schema);
+
+    // Wrap constructor to return optional on failure.
+    static std::optional<arrow_schema_translator>
+    create(iceberg::struct_type&& schema) {
+        try {
+            return std::make_optional<arrow_schema_translator>(
+              std::move(schema));
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    ~arrow_schema_translator();
+
+    std::shared_ptr<arrow::Schema> build_arrow_schema();
+
+private:
+    iceberg::struct_type _schema;
+
+    // Top-level struct that represents the whole schema.
+    std::unique_ptr<struct_schema_converter> _struct_converter;
+};
+} // namespace datalake

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -16,7 +16,25 @@ rp_test(
   BINARY_NAME gtest_record_multiplexer
   SOURCES gtest_record_multiplexer_test.cc
   LIBRARIES
+    v::application
+    v::features
     v::gtest_main
+    v::kafka_test_utils
+    v::datalake
+    v::model_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)
+
+rp_test(
+  GTEST
+  BINARY_NAME gtest_arrow_writer
+  SOURCES arrow_writer_test.cc
+  LIBRARIES
+    v::application
+    v::features
+    v::gtest_main
+    v::kafka_test_utils
     v::datalake
     v::model_test_utils
   LABELS storage

--- a/src/v/datalake/tests/arrow_writer_test.cc
+++ b/src/v/datalake/tests/arrow_writer_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/arrow_schema_translator.h"
+#include "iceberg/datatypes.h"
+
+#include <gtest/gtest.h>
+
+iceberg::struct_type test_schema(iceberg::field_required required) {
+    using namespace iceberg;
+    struct_type schema;
+
+    schema.fields.emplace_back(
+      nested_field::create(1, "test_bool", required, boolean_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(2, "test_int", required, int_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(3, "test_long", required, long_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(4, "test_float", required, float_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(5, "test_double", required, double_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(6, "test_decimal", required, decimal_type{8, 16}));
+    schema.fields.emplace_back(
+      nested_field::create(7, "test_date", required, date_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(8, "test_time", required, time_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(9, "test_timestamp", required, timestamp_type{}));
+    schema.fields.emplace_back(nested_field::create(
+      10, "test_timestamptz", required, timestamptz_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(11, "test_string", required, string_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(12, "test_uuid", required, uuid_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(13, "test_fixed", required, fixed_type{100}));
+    schema.fields.emplace_back(
+      nested_field::create(14, "test_binary", required, binary_type{}));
+
+    struct_type nested_schema;
+    nested_schema.fields.emplace_back(
+      nested_field::create(1, "nested_bool", required, boolean_type{}));
+    nested_schema.fields.emplace_back(
+      nested_field::create(2, "nested_int", required, int_type{}));
+    nested_schema.fields.emplace_back(
+      nested_field::create(3, "nested_long", required, long_type{}));
+
+    schema.fields.emplace_back(nested_field::create(
+      15, "test_struct", required, std::move(nested_schema)));
+
+    schema.fields.emplace_back(nested_field::create(
+      16,
+      "test_list",
+      required,
+      list_type::create(1, required, string_type{})));
+
+    schema.fields.push_back(nested_field::create(
+      17,
+      "test_map",
+      required,
+      map_type::create(1, string_type{}, 2, required, long_type{})));
+    return schema;
+}
+
+TEST(ArrowWriterTest, TranslatesSchemas) {
+    datalake::arrow_schema_translator writer(
+      test_schema(iceberg::field_required::no));
+    auto schema = writer.build_arrow_schema();
+    ASSERT_NE(schema, nullptr);
+    std::string expected_schema = R"(test_bool: bool
+test_int: int32
+test_long: int64
+test_float: float
+test_double: double
+test_decimal: decimal128(8, 16)
+test_date: date32[day]
+test_time: time64[us]
+test_timestamp: timestamp[us]
+test_timestamptz: timestamp[us, tz=UTC]
+test_string: string
+test_uuid: fixed_size_binary[16]
+test_fixed: fixed_size_binary[100]
+test_binary: binary
+test_struct: struct<nested_bool: bool, nested_int: int32, nested_long: int64>
+test_list: list<element: string>
+test_map: map<string, int64>)";
+    EXPECT_EQ(schema->ToString(), expected_schema);
+}
+
+TEST(ArrowWriterTest, TranslatesSchemasWithRequired) {
+    datalake::arrow_schema_translator writer(
+      test_schema(iceberg::field_required::yes));
+    auto schema = writer.build_arrow_schema();
+    ASSERT_NE(schema, nullptr);
+    std::string expected_schema = R"(test_bool: bool not null
+test_int: int32 not null
+test_long: int64 not null
+test_float: float not null
+test_double: double not null
+test_decimal: decimal128(8, 16) not null
+test_date: date32[day] not null
+test_time: time64[us] not null
+test_timestamp: timestamp[us] not null
+test_timestamptz: timestamp[us, tz=UTC] not null
+test_string: string not null
+test_uuid: fixed_size_binary[16] not null
+test_fixed: fixed_size_binary[100] not null
+test_binary: binary not null
+test_struct: struct<nested_bool: bool not null, nested_int: int32 not null, nested_long: int64 not null> not null
+test_list: list<element: string not null> not null
+test_map: map<string, int64> not null)";
+    EXPECT_EQ(schema->ToString(), expected_schema);
+}
+
+TEST(ArrowWriterTest, BadSchema) {
+    using namespace iceberg;
+    struct_type input_schema;
+
+    // A decimal type with a precision of 0 will fail.
+    input_schema.fields.emplace_back(nested_field::create(
+      6, "test_decimal", field_required::yes, decimal_type{0, 16}));
+
+    EXPECT_ANY_THROW(
+      datalake::arrow_schema_translator(std::move(input_schema)));
+}

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -35,9 +35,8 @@ public:
 
 private:
     iceberg::struct_type _schema;
-    data_writer_result _result{};
+    data_writer_result _result;
 };
-
 class test_data_writer_factory : public data_writer_factory {
 public:
     std::unique_ptr<data_writer>


### PR DESCRIPTION
This is the first part of the Arrow writer that will translate abstract
    Iceberg types (iceberg::field_type and iceberg::value) to the Arrow and
    ultimately Parquet data. This PR adds schema translation that creates an
    Arrow schema from the Iceberg types.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
