### PR TITLE
[CORE-7039] schema_registry: Tolerate null metadata and ruleSet

### DIFF
--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -36,6 +36,8 @@ class post_subject_versions_request_handler
         schema,
         id,
         version,
+        metadata,
+        ruleset,
         schema_type,
         references,
         reference,
@@ -74,6 +76,8 @@ public:
                                      .match("schema", state::schema)
                                      .match("id", state::id)
                                      .match("version", state::version)
+                                     .match("metadata", state::metadata)
+                                     .match("ruleSet", state::ruleset)
                                      .match("schemaType", state::schema_type)
                                      .match("references", state::references)
                                      .default_match(std::nullopt)};
@@ -97,12 +101,36 @@ public:
         case state::schema:
         case state::id:
         case state::version:
+        case state::metadata:
+        case state::ruleset:
         case state::schema_type:
         case state::references:
         case state::reference_name:
         case state::reference_subject:
         case state::reference_version:
             return false;
+        }
+        return false;
+    }
+
+    bool Null() {
+        switch (_state) {
+        case state::metadata:
+        case state::ruleset:
+            _state = state::record;
+            return true;
+        case state::empty:
+        case state::record:
+        case state::schema:
+        case state::id:
+        case state::version:
+        case state::schema_type:
+        case state::references:
+        case state::reference:
+        case state::reference_name:
+        case state::reference_subject:
+        case state::reference_version:
+            break;
         }
         return false;
     }
@@ -127,6 +155,8 @@ public:
         case state::empty:
         case state::record:
         case state::schema:
+        case state::metadata:
+        case state::ruleset:
         case state::schema_type:
         case state::references:
         case state::reference:
@@ -170,6 +200,8 @@ public:
         case state::record:
         case state::id:
         case state::version:
+        case state::metadata:
+        case state::ruleset:
         case state::references:
         case state::reference:
         case state::reference_version:
@@ -193,6 +225,8 @@ public:
         case state::schema:
         case state::id:
         case state::version:
+        case state::metadata:
+        case state::ruleset:
         case state::schema_type:
         case state::reference:
         case state::reference_name:
@@ -222,6 +256,8 @@ public:
         case state::schema:
         case state::id:
         case state::version:
+        case state::metadata:
+        case state::ruleset:
         case state::schema_type:
         case state::references:
         case state::reference_name:

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1090,6 +1090,34 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_raw.json()["id"] == 1
 
     @cluster(num_nodes=3)
+    def test_post_subjects_subject_versions_metadata_ruleset(self):
+        """
+        Verify posting a schema with metatada and ruleSet
+        These are not supported, but if they're null, we let it pass.
+        """
+
+        topic = create_topic_names(1)[0]
+
+        self.logger.debug("Dump the schema with null metadata and ruleSet")
+        schema_1_data = json.dumps({
+            "schema": schema1_def,
+            "metadata": None,
+            "ruleSet": None
+        })
+
+        self.logger.debug("Posting schema as a subject key")
+        result_raw = self._post_subjects_subject_versions(
+            subject=f"{topic}-key", data=schema_1_data)
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Retrieving schema")
+        result_raw = self._post_subjects_subject(subject=f"{topic}-key",
+                                                 data=schema_1_data)
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+    @cluster(num_nodes=3)
     def test_post_subjects_subject(self):
         """
         Verify posting a schema


### PR DESCRIPTION
In the absence of supporting these features, it's friendly to tolerate clients that explicitly set them to `null`, such as the latest DotNet client.

Fixes #23038

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Improvements

* Schema Registry: Tolerate `null` `metadata` and `ruleSet` when registering or querying a schema
