### PR TITLE
`docker`: bump `rust` version

### DIFF
--- a/tests/docker/ducktape-deps/rust
+++ b/tests/docker/ducktape-deps/rust
@@ -2,4 +2,4 @@
 set -e
 set -x
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.70.0 -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.80.1 -y


### PR DESCRIPTION
After bumping dependencies in https://github.com/redpanda-data/redpanda/pull/23036, we must update the rust version from `1.70.0` to `1.80.1`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
