### PR TITLE
bump rust version

### DIFF
--- a/tests/docker/ducktape-deps/rust
+++ b/tests/docker/ducktape-deps/rust
@@ -2,4 +2,4 @@
 set -e
 set -x
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.70.0 -y
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.80.1 -y


### PR DESCRIPTION
[Similar to https://github.com/redpanda-data/vtools/pull/3098](https://github.com/redpanda-data/vtools/pull/3098)

## Backports Required
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
