### PR TITLE
rpk: fix --no-profile and add cloud checks for `rpk security user` commands.

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -128,16 +128,6 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 				return
 			}
 
-			// The current profile was auth'd to the current organization.
-			// We tell the status of what org the user is talking to.
-			if p.FromCloud {
-				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q)\n", p.CloudCluster.FullName(), p.Name)
-				fmt.Println("Select a different cluster to talk to (or ctrl+c to keep the current cluster)?")
-				err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
-				profile.MaybeDieExistingName(err)
-				return
-			}
-
 			// Below here, the current profile is pointed to a
 			// local container cluster or a self hosted cluster.
 			// We want to create or swap to the cloud profile,
@@ -152,6 +142,16 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 				// The current profile is a self hosted cluster.
 				fmt.Printf("You are talking to a self hosted cluster (rpk profile name: %q)\n", p.Name)
 				fmt.Println("To talk to a cloud cluster, use 'rpk cloud cluster select'.")
+				return
+			}
+
+			// The current profile was auth'd to the current organization.
+			// We tell the status of what org the user is talking to.
+			if p.FromCloud {
+				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q)\n", p.CloudCluster.FullName(), p.Name)
+				fmt.Println("Select a different cluster to talk to (or ctrl+c to keep the current cluster)?")
+				err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
+				profile.MaybeDieExistingName(err)
 				return
 			}
 

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -57,6 +57,7 @@ acl help text for more info.
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -37,6 +37,7 @@ delete any ACLs that may exist for this user.
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -30,6 +30,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -29,6 +29,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			f := p.Formatter
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -89,10 +89,18 @@ func CheckExitCloudAdmin(p *RpkProfile) {
 }
 
 // CheckExitServerlessAdmin exits if the profile has FromCloud=true and the
-// cluster is a Serverless cluster
+// cluster is a Serverless cluster.
 func CheckExitServerlessAdmin(p *RpkProfile) {
 	if p.FromCloud && p.CloudCluster.IsServerless() {
 		out.Die("This admin API based command is not supported on Redpanda Cloud serverless clusters.")
+	}
+}
+
+// CheckExitNotServerlessAdmin exits if the profile has FromCloud=true and the
+// cluster is NOT a Serverless cluster.
+func CheckExitNotServerlessAdmin(p *RpkProfile) {
+	if p.FromCloud && !p.CloudCluster.IsServerless() {
+		out.Die("This admin API based command is not supported on Redpanda Cloud clusters.")
 	}
 }
 


### PR DESCRIPTION
- 572ad197a68ffdbc3b12ec6aaaabb83503bd981a Fixes a bug that prevented `--no-profile` from working with SSO.
- fe4768522c9fb954c5d4d42896452c722091a4ed Adds a cloud check (better error message) for `rpk security user` which is a command that cannot be used in cloud clusters (except for serverless)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* rpk: fix a bug in `rpk cloud login` that prevented `--no-profile` from working when used with SSO login.
