### PR TITLE
bazel: remove test dep from seastar

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,6 @@ build:release --config=secure
 build:release --copt -mllvm --copt -inline-threshold=2500
 build:release --linkopt=-flto
 
-build --@seastar//:openssl=True
 build --keep_going
 
 # prevent actions and tests from using the network. anything that needs to

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -546,7 +546,9 @@ cc_library(
         "include/seastar/util/variant_utils.hh",
         "include/seastar/websocket/server.hh",
     ],
-    copts = select({
+    copts = [
+        "-Wno-unused-but-set-variable",
+    ] + select({
         ":use_stack_guards": ["-fstack-clash-protection"],
         "//conditions:default": [],
     }),

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -618,7 +618,6 @@ cc_library(
         "@boost//:filesystem",
         "@boost//:lockfree",
         "@boost//:program_options",
-        "@boost//:test.so",
         "@boost//:thread",
         "@c-ares",
         "@fmt",
@@ -668,6 +667,7 @@ cc_library(
     ],
     deps = [
         ":seastar",
+        "@boost//:test.so",
     ],
 )
 

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_btest(
     deps = [
         "//src/v/hashing:secure",
         "@boost//:test",
+        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -68,6 +68,7 @@ redpanda_cc_btest(
         "//src/v/serde",
         "//src/v/storage:index_state",
         "@boost//:test",
+        "@seastar//:testing",
     ],
 )
 


### PR DESCRIPTION
- **bazel: require openssl for seastar**
- **bazel: make boost test a test only dep**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
