### PR TITLE
bazel: add missing shared library for krb5

### DIFF
--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -22,8 +22,10 @@ configure_make(
     ],
     lib_source = ":srcs",
     out_shared_libs = [
-        "libkrb5.so",
-        "libgssapi_krb5.so",
+        "libgssapi_krb5.so.2",
+        "libk5crypto.so.3",
+        "libkrb5.so.3",
+        "libkrb5support.so.0",
     ],
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
Looking at `ldd` of the bazel build, we were missing a library, so I'm
adding it here.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
