### PR TITLE
r/hb_mgr: check if current replica is a leader when collecting hbeats

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -82,6 +82,12 @@ heartbeat_manager::requests_for_range() {
           r->_fstats.end(),
           [this, r, last_heartbeat, &pending_beats, &reconnect_nodes](
             follower_stats::value_type& p) {
+              // we need to check again as the leadership might have been lost
+              // while we yield.
+              if (!r->is_elected_leader()) {
+                  return;
+              }
+
               auto& [id, follower_metadata] = p;
               if (
                 follower_metadata.last_received_reply_timestamp


### PR DESCRIPTION
Some time ago we made collecting heartbeats an asynchronous process (added yields in between creating hb requests for individual nodes). This made it possible for leadership to be already lost while the request for group is created as the yield happened and previously validated condition no longer holds. Trying to suppress the heartbeat while the replica is not leader lead to assertion.

Added a check to make sure the leadership is not lost when actually creating a heartbeat request for the follower.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes rare assertion that might have been triggered in the `raft::heartbeat_manager`