### PR TITLE
Refactored upgrades executed in random node operations test

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -268,11 +268,6 @@ class AddPartitionsOperation(Operation):
             n = ctx.redpanda.get_node_by_id(b['node_id'])
             if n not in ctx.redpanda.started_nodes():
                 continue
-            node_version = int_tuple(
-                VERSION_RE.findall(ctx.redpanda.get_version(n))[0])
-            # do not query nodes with redpanda version prior to v23.1.x
-            if node_version[0] < 23:
-                return None
             try:
                 partitions = ctx.admin().get_partitions(node=n,
                                                         topic=self.topic)

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import math
 import random
 import re
 import threading
@@ -58,6 +59,10 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             node_prealloc_count=3,
             *args,
             **kwargs)
+        self.nodes_with_prev_version = []
+        self.installer = self.redpanda._installer
+        self.previous_version = self.installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD)
 
     def min_producer_records(self):
         return 20 * self.producer_throughput
@@ -91,7 +96,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         # defer starting redpanda to test body
         pass
 
-    def _setup_test_scale(self, num_to_upgrade):
+    def _setup_test_scale(self):
         # test setup
         self.producer_timeout = 180
         self.consumer_timeout = 180
@@ -105,10 +110,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             self.rate_limit = 100 * 1024 * 1024  # 100 MBps
             self.total_data = 5 * 1024 * 1024 * 1024
         else:
-            # container test setup
-            if num_to_upgrade > 0:
-                self.should_skip = True
-
             self.max_partitions = 32
             self.producer_throughput = 1000 if self.debug_mode else 10000
             self.node_operations = 10
@@ -129,7 +130,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             f"running test with: [message_size {self.msg_size},  total_bytes: {self.total_data}, message_count: {self.msg_count}, rate_limit: {self.rate_limit}, cluster_operations: {self.node_operations}]"
         )
 
-    def _start_redpanda(self, number_nodes_to_upgrade, with_tiered_storage):
+    def _start_redpanda(self, mixed_versions, with_tiered_storage):
 
         if with_tiered_storage:
             si_settings = SISettings(self.test_context,
@@ -142,17 +143,21 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             self.redpanda.set_si_settings(si_settings)
 
         self.redpanda.set_seed_servers(self.redpanda.nodes)
-        if number_nodes_to_upgrade > 0:
-            installer = self.redpanda._installer
-            installer.install(
-                self.redpanda.nodes,
-                installer.highest_from_prior_feature_version(
-                    RedpandaInstaller.HEAD))
-            self.redpanda.start()
-            installer.install(self.redpanda.nodes[:number_nodes_to_upgrade],
-                              RedpandaInstaller.HEAD)
-            self.redpanda.restart_nodes(
-                self.redpanda.nodes[:number_nodes_to_upgrade])
+        if mixed_versions:
+            node_count = len(self.redpanda.nodes)
+            with_prev_version = math.ceil(node_count / 2.0)
+            self.logger.info(
+                f"Using cluster with mixed versions with {node_count - with_prev_version} nodes using current HEAD version {RedpandaInstaller.HEAD} and {with_prev_version} using previous version: {self.previous_version}"
+            )
+
+            self.nodes_with_prev_version = self.redpanda.nodes[:
+                                                               with_prev_version]
+            self.installer.install(self.nodes_with_prev_version,
+                                   self.previous_version)
+
+            self.redpanda.set_seed_servers(self.nodes_with_prev_version)
+            self.redpanda.start(auto_assign_node_id=True,
+                                omit_seeds_on_idx_one=False)
         else:
             self.redpanda.start(auto_assign_node_id=True,
                                 omit_seeds_on_idx_one=False)
@@ -272,9 +277,9 @@ class RandomNodeOperationsTest(PreallocNodesTest):
              log_allow_list=CHAOS_LOG_ALLOW_LIST +
              PREV_VERSION_LOG_ALLOW_LIST + TS_LOG_ALLOW_LIST)
     @matrix(enable_failures=[True, False],
-            num_to_upgrade=[0, 3],
+            mixed_versions=[True, False],
             with_tiered_storage=[True, False])
-    def test_node_operations(self, enable_failures, num_to_upgrade,
+    def test_node_operations(self, enable_failures, mixed_versions,
                              with_tiered_storage):
         # In order to reduce the number of parameters and at the same time cover
         # as many use cases as possible this test uses 3 topics which 3 separate
@@ -287,8 +292,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         def enable_fast_partition_movement():
             if not with_tiered_storage:
                 return False
-            if num_to_upgrade == 0:
-                return True
 
             initial_version = self.redpanda._installer.highest_from_prior_feature_version(
                 RedpandaInstaller.HEAD)
@@ -300,7 +303,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             return supported_by_prev
 
         def enable_write_caching_testing():
-            if num_to_upgrade == 0:
+            if not mixed_versions:
                 return True
             # Write caching feature is available 24.x and later.
             pre_upgrade_version = self.redpanda._installer.highest_from_prior_feature_version(
@@ -311,14 +314,14 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         default_segment_size = 1024 * 1024
 
         # setup test case scale parameters
-        self._setup_test_scale(num_to_upgrade)
+        self._setup_test_scale()
 
         if self.should_skip:
             cleanup_on_early_exit(self)
             return
 
         # start redpanda process
-        self._start_redpanda(num_to_upgrade,
+        self._start_redpanda(mixed_versions,
                              with_tiered_storage=with_tiered_storage)
 
         self.redpanda.set_cluster_config(
@@ -476,7 +479,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         self.admin_fuzz.wait(20, 180)
         self.admin_fuzz.stop()
 
-        if enable_failures:
+        if fi:
             fi.stop()
 
         # stop producer and consumer and verify results
@@ -489,6 +492,37 @@ class RandomNodeOperationsTest(PreallocNodesTest):
 
         if enable_fast_partition_movement():
             fast_producer_consumer.verify()
+
+        if mixed_versions:
+            self.logger.info("Upgrading cluster with current Redpanda version")
+            for n in self.nodes_with_prev_version:
+                self.redpanda.stop_node(n)
+            self.installer.install(self.nodes_with_prev_version,
+                                   RedpandaInstaller.HEAD)
+            for n in self.nodes_with_prev_version:
+                self.redpanda.start_node(n,
+                                         omit_seeds_on_idx_one=True,
+                                         auto_assign_node_id=True)
+
+            def cluster_version_updated():
+                admin = Admin(self.redpanda)
+                admin.get_brokers()
+                node_features = [
+                    admin.get_features(n)
+                    for n in self.redpanda.started_nodes()
+                ]
+                self.logger.info(
+                    f"Reported cluster versions: {[f['cluster_version']for f in node_features]}"
+                )
+                return all(f['cluster_version'] == f['node_latest_version']
+                           for f in node_features)
+
+            wait_until(
+                cluster_version_updated,
+                180,
+                backoff_sec=2,
+                err_msg="Error waiting for cluster to report consistent version"
+            )
 
         if with_tiered_storage:
             self.redpanda.stop_and_scrub_object_storage()


### PR DESCRIPTION
Change the `RandomNodeOperationsTest` upgrades handling. Previously, as
a result of membership changes during the test, it was perfectly possible
for the cluster to upgrade its cluster version while executing the test.
This might lead to a test failure as the node with previous version
wasn't able to rejoin the cluster.

Refactored the test to work with mixed versions in a way that the
majority of nodes is not upgraded throughout the test to prevent cluster
version from being updated. This way both new and old version Redpanda
nodes are able to join the cluster. Full upgrade is now executed at the
end of the test to validate if the cluster can be fully upgraded.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none