### PR TITLE
ci/github: build and publish rp-storage-tool

### DIFF
--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -1,0 +1,80 @@
+name: Release rp-storage-tool
+
+on:
+  push:
+    branches:
+      - dev
+      - 'v*'
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'tools/rp_storage_tool/**'
+      - 'tests/docker/Dockerfile'
+      - 'tests/docker/ducktape-deps/rust'
+      - 'tests/docker/ducktape-deps/rp-storage-tool'
+      - '.github/workflows/release-rp-storage-tool.yml'
+
+
+jobs:
+  release-rp-storage-tool:
+    if: ${{ github.repository == 'redpanda-data/redpanda' || github.event_name == 'pull_request' }}
+    name: Release - ${{ matrix.platform.release_for }}
+    strategy:
+      matrix:
+        platform:
+          - release_for: linux-amd64
+            os: ubuntu-latest
+          - release_for: linux-arm64
+            os: ubuntu-latest-4-arm64
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: configure aws credentials
+        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/rp_storage_tool_uploader
+          parse-json-secrets: true
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build binary
+        run: |
+          export DOCKER_BUILDKIT=1
+          docker build -f tests/docker/Dockerfile \
+            -t rp-storage-tool \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from redpandadata/redpanda-test-node:cache-amd64 \
+            --cache-from redpandadata/redpanda-test-node:cache-arm64 \
+            --target rp-storage-tool . \
+            --load
+      - name: Get binary
+        run: |
+          id=$(docker create rp-storage-tool)
+          docker cp $id:/usr/local/bin/rp-storage-tool ./
+          ./rp-storage-tool --help
+      - name: Push to public bucket
+        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_RP_STORAGE_UPLOADER_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_RP_STORAGE_UPLOADER_SECRET }}
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          arch=$(uname -m)
+          os=$(uname | tr '[:upper:]' '[:lower:]')
+          if [[ $arch == "x86_64" || $arch == "amd64" ]]; then
+            arch="amd64"
+          elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
+            arch="arm64"
+          else
+            echo "unknown arch: $arch"
+            exit 1
+          fi
+          aws s3 cp ./rp-storage-tool s3://vectorized-public/releases/rp-storage-tool/${{ github.ref_name }}/$os/$arch/rp-storage-tool --acl public-read


### PR DESCRIPTION
Build and publish rp-storage-tool by using building the rp-storage-tool target of the test docker image; so that we don't duplicate things like the toolchain version, dependencies etc

builds:

* linux amd64
* linux arm64

Publishes on `push` to upstream `dev` and `v*` branches, and on tags

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none

