### PR TITLE
[v23.3.x] Fix cloud operator_v2 check

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -875,8 +875,14 @@ class HighThroughputTest(PreallocNodesTest):
 
         self.logger.info('verify operator-v2 is not activated')
         # kubectl get redpanda -n=redpanda
+        # Even when nothing is found, kubectl always exits 0.  Ref: https://github.com/kubernetes/kubectl/issues/821
+        # But when nothing is found, kubectl by default prints "No resources found in redpanda namespace." to stderr.
+        # Which gets merged into the result lines!
+        #
+        # So, we add --ignore-not-found.  This flag skips the human-readable "No resource" message.
+        # By the way, exit code is still 0, even with this flag :)
         get_redpanda = self.redpanda.kubectl.cmd(
-            ['get', 'redpanda', '-n=redpanda'])
+            ['get', 'redpanda', '-n=redpanda', '--ignore-not-found'])
         if len(get_redpanda) > 0:
             self.logger.warn('cannot run test with operator-v2')
             return


### PR DESCRIPTION
Fixes #23061

Backport of PR #23040

Note LOC is less than in #23040 because `v23.3.x` contains less instances of the bad opv2 check.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none