### PR TITLE
bazel: port hdrhistogram to a native bazel build

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -168,7 +168,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "jjpzZNeglEOU9HDEnuA+Dy5U5wS39+0nBkIdi27GZgU=",
+        "bzlTransitiveDigest": "TMy4PlZ6gUhQm7zbM+I4lGWAfD2vbn9osHMiidDFBnA=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -219,9 +219,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:hdrhistogram.BUILD",
-              "sha256": "f81a192b62ae25bcebe63c9f3c74f371d04f88a74c1867532ec8a0012a9e482c",
-              "strip_prefix": "HdrHistogram_c-0.11.5",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/HdrHistogram_c-0.11.5.tar.gz"
+              "integrity": "sha256-u5U1GmqLJC3Jvh8oVidhqE1M8Kh0/8kKm2MHcKZGjpQ=",
+              "strip_prefix": "HdrHistogram_c-0.11.8",
+              "url": "https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.8.tar.gz"
             }
           },
           "base64": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -6,7 +6,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def data_dependency():
     """
-    Define third party dependency soruces.
+    Define third party dependency sources.
+
+    `integrity` can be generated using:
+
+    openssl dgst -sha256 -binary ARCHIVE.tar.gz | openssl base64 -A | sed 's/^/sha256-/'
     """
     http_archive(
         name = "ada",
@@ -45,9 +49,9 @@ def data_dependency():
     http_archive(
         name = "hdrhistogram",
         build_file = "//bazel/thirdparty:hdrhistogram.BUILD",
-        sha256 = "f81a192b62ae25bcebe63c9f3c74f371d04f88a74c1867532ec8a0012a9e482c",
-        strip_prefix = "HdrHistogram_c-0.11.5",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/HdrHistogram_c-0.11.5.tar.gz",
+        integrity = "sha256-u5U1GmqLJC3Jvh8oVidhqE1M8Kh0/8kKm2MHcKZGjpQ=",
+        strip_prefix = "HdrHistogram_c-0.11.8",
+        url = "https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.8.tar.gz",
     )
 
     http_archive(

--- a/bazel/thirdparty/hdrhistogram.BUILD
+++ b/bazel/thirdparty/hdrhistogram.BUILD
@@ -1,26 +1,34 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-)
-
-cmake(
+cc_library(
     name = "hdrhistogram",
-    cache_entries = {
-        "BUILD_SHARED_LIBS": "OFF",
-        "CMAKE_INSTALL_LIBDIR": "lib",
-        "HDR_HISTOGRAM_BUILD_PROGRAMS": "OFF",
-        "HDR_HISTOGRAM_BUILD_SHARED": "OFF",
-        "HDR_HISTOGRAM_BUILD_STATIC": "ON",
-    },
-    generate_args = ["-GNinja"],
-    lib_source = ":srcs",
-    out_static_libs = ["libhdr_histogram_static.a"],
-    visibility = [
-        "//visibility:public",
+    srcs = [
+        "src/hdr_atomic.h",
+        "src/hdr_encoding.c",
+        "src/hdr_encoding.h",
+        "src/hdr_endian.h",
+        "src/hdr_histogram.c",
+        "src/hdr_histogram_log.c",
+        "src/hdr_interval_recorder.c",
+        "src/hdr_malloc.h",
+        "src/hdr_tests.h",
+        "src/hdr_thread.c",
+        "src/hdr_time.c",
+        "src/hdr_writer_reader_phaser.c",
     ],
-    deps = [
-        "@zlib",
+    hdrs = [
+        "include/hdr/hdr_histogram.h",
+        "include/hdr/hdr_histogram_log.h",
+        "include/hdr/hdr_histogram_version.h",
+        "include/hdr/hdr_interval_recorder.h",
+        "include/hdr/hdr_thread.h",
+        "include/hdr/hdr_time.h",
+        "include/hdr/hdr_writer_reader_phaser.h",
     ],
+    copts = [
+        "-std=gnu99",
+        "-Wno-implicit-function-declaration",
+        "-Wno-error",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = ["@zlib"],
 )


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
