### PR TITLE
bytes: simplify surface area of `bytes` api

### DIFF
--- a/src/v/bytes/bytes.cc
+++ b/src/v/bytes/bytes.cc
@@ -28,24 +28,9 @@ std::ostream& operator<<(std::ostream& os, const bytes& b) {
     return os << bytes_view(b);
 }
 
-std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
-    if (b) {
-        return os << *b;
-    }
-    return os << "empty";
-}
-
 namespace std {
 std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
     fmt::print(os, "{{bytes:{}}}", b.size());
     return os;
 }
 } // namespace std
-
-bool bytes_type_cmp::operator()(const bytes& lhs, const bytes_view& rhs) const {
-    return lhs < rhs;
-}
-
-bool bytes_type_cmp::operator()(const bytes& lhs, const bytes& rhs) const {
-    return lhs < rhs;
-}

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -89,7 +89,7 @@ std::ostream& operator<<(std::ostream& os, const bytes& b);
 std::ostream& operator<<(std::ostream& os, const bytes_opt& b);
 
 inline bytes iobuf_to_bytes(const iobuf& in) {
-    auto out = ss::uninitialized_string<bytes>(in.size_bytes());
+    bytes out(bytes::initialized_later{}, in.size_bytes());
     {
         iobuf::iterator_consumer it(in.cbegin(), in.cend());
         it.consume_to(in.size_bytes(), out.data());

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -32,23 +32,8 @@ using bytes = ss::basic_sstring<
   >;
 
 using bytes_view = std::basic_string_view<uint8_t>;
-using bytes_opt = std::optional<bytes>;
 template<std::size_t Extent = std::dynamic_extent>
 using bytes_span = std::span<bytes::value_type, Extent>;
-
-struct bytes_type_hash {
-    using is_transparent = std::true_type;
-    // NOTE: you hash a fragmented buffer with a linearized buffer
-    //       unless you make a copy and linearize first. Our fragmented buffer
-    //       correctly implements boost::hash_combine between fragments which
-    //       would be missing altogether from a linearize buffer which is simply
-    //       the std::hash<std::string_view>()
-    //
-    //   size_t operator()(const iobuf& k) const;
-    //
-    size_t operator()(const bytes& k) const;
-    size_t operator()(const bytes_view&) const;
-};
 
 template<typename R, R (*HashFunction)(bytes::const_pointer, size_t)>
 requires requires(bytes::const_pointer data, size_t len) {
@@ -86,7 +71,6 @@ inline ss::sstring to_hex(const std::array<Char, Size>& data) {
 }
 
 std::ostream& operator<<(std::ostream& os, const bytes& b);
-std::ostream& operator<<(std::ostream& os, const bytes_opt& b);
 
 inline bytes iobuf_to_bytes(const iobuf& in) {
     bytes out(bytes::initialized_later{}, in.size_bytes());
@@ -127,14 +111,6 @@ struct hash<bytes_view> {
 // NOLINTNEXTLINE(cert-dcl58-cpp)
 namespace std {
 std::ostream& operator<<(std::ostream& os, const bytes_view& b);
-}
-
-inline size_t bytes_type_hash::operator()(const bytes_view& k) const {
-    return absl::Hash<bytes_view>{}(k);
-}
-
-inline size_t bytes_type_hash::operator()(const bytes& k) const {
-    return absl::Hash<bytes>{}(k);
 }
 
 inline bool
@@ -187,9 +163,3 @@ operator^(const std::array<char, Size>& a, const std::array<char, Size>& b) {
       a.begin(), a.end(), b.begin(), out.begin(), std::bit_xor<>());
     return out;
 }
-
-struct bytes_type_cmp {
-    using is_transparent = std::true_type;
-    bool operator()(const bytes& lhs, const bytes_view& rhs) const;
-    bool operator()(const bytes& lhs, const bytes& rhs) const;
-};

--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -65,7 +65,7 @@ public:
     }
 
     bytes read_bytes(size_t n) {
-        auto b = ss::uninitialized_string<bytes>(n);
+        bytes b(bytes::initialized_later{}, n);
         _in.consume_to(n, b.begin());
         return b;
     }
@@ -106,7 +106,7 @@ public:
 
     bytes peek_bytes(size_t n) const {
         auto in = _in;
-        auto b = ss::uninitialized_string<bytes>(n);
+        bytes b(bytes::initialized_later{}, n);
         in.consume_to(n, b.begin());
         return b;
     }

--- a/src/v/bytes/random.cc
+++ b/src/v/bytes/random.cc
@@ -17,13 +17,13 @@
 namespace random_generators {
 
 bytes get_bytes(size_t n) {
-    auto b = ss::uninitialized_string<bytes>(n);
+    bytes b(bytes::initialized_later{}, n);
     std::generate_n(b.begin(), n, [] { return get_int<bytes::value_type>(); });
     return b;
 }
 
 bytes get_crypto_bytes(size_t n, bool use_private_rng) {
-    auto b = ss::uninitialized_string<bytes>(n);
+    bytes b(bytes::initialized_later{}, n);
     std::generate_n(b.begin(), n, [use_private_rng] {
         return get_int_secure<bytes::value_type>(use_private_rng);
     });

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -134,7 +134,7 @@ SEASTAR_THREAD_TEST_CASE(test_empty_istream) {
 
     BOOST_CHECK_THROW(in.consume_type<char>(), std::out_of_range);
 
-    bytes b = ss::uninitialized_string<bytes>(10);
+    bytes b(bytes::initialized_later{}, 10);
     BOOST_CHECK_THROW(in.consume_to(1, b.begin()), std::out_of_range);
     in.consume_to(0, b.begin());
 }

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -209,7 +209,7 @@ public:
         serde::write(buf, key);
         auto bytes = iobuf_to_bytes(buf);
         auto result = model::partition_id(
-          murmur2(bytes.c_str(), bytes.length()) % num_partitions.value());
+          murmur2(bytes.data(), bytes.size()) % num_partitions.value());
 
         auto res = co_await replicate_and_wait(
           make_coordinator_assignment_batch(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -932,12 +932,12 @@ struct adl<security::acl_host> {
             if (ipv4) {
                 ::in_addr addr{};
                 vassert(data.size() == sizeof(addr), "Unexpected ipv4 size");
-                std::memcpy(&addr, data.c_str(), sizeof(addr));
+                std::memcpy(&addr, data.data(), sizeof(addr));
                 return security::acl_host(ss::net::inet_address(addr));
             } else {
                 ::in6_addr addr{};
                 vassert(data.size() == sizeof(addr), "Unexpected ipv6 size");
-                std::memcpy(&addr, data.c_str(), sizeof(addr));
+                std::memcpy(&addr, data.data(), sizeof(addr));
                 return security::acl_host(ss::net::inet_address(addr));
             }
         }

--- a/src/v/crypto/tests/hmac_tests.cc
+++ b/src/v/crypto/tests/hmac_tests.cc
@@ -26,8 +26,8 @@ static const absl::flat_hash_map<crypto::digest_type, size_t> expected_sizes = {
 // NOLINTEND
 
 TEST(crypto_hmac, length) {
-    // NOLINTNEXTLINE
-    bytes fake_key('k', 16);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    bytes fake_key(16, 'k');
     for (auto&& [k, v] : expected_sizes) {
         EXPECT_EQ(crypto::hmac_ctx::size(k), v)
           << "Mismatch on HMAC size for digest type " << k;

--- a/src/v/iceberg/transform.h
+++ b/src/v/iceberg/transform.h
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include <cstdint>
 #include <variant>
 
 namespace iceberg {

--- a/src/v/kafka/protocol/flex_versions.cc
+++ b/src/v/kafka/protocol/flex_versions.cc
@@ -92,7 +92,7 @@ parse_tags(ss::input_stream<char>& src) {
         auto id = co_await read_unsigned_vint(total_bytes_read, src);
         auto next_len = co_await read_unsigned_vint(total_bytes_read, src);
         auto buf = co_await src.read_exactly(next_len);
-        auto data = ss::uninitialized_string<bytes>(buf.size());
+        bytes data(bytes::initialized_later{}, buf.size());
         std::copy_n(buf.begin(), buf.size(), data.begin());
         total_bytes_read += next_len;
         auto [_, succeded] = tags.emplace(tag_id(id), std::move(data));

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -122,7 +122,7 @@ bytes invoke_franz_harness(
           c.exit_code(),
           stdout);
     }
-    auto result = ss::uninitialized_string<bytes>(stdout.size());
+    bytes result(bytes::initialized_later{}, stdout.size());
     std::copy_n(stdout.begin(), stdout.size(), result.begin());
     return result;
 }

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -770,7 +770,7 @@ FIXTURE_TEST(corrupted_data_at_server, rpc_integration_fixture) {
     nb.set_correlation_id(10);
     nb.set_service_method(echo::echo_service::echo_method);
     auto bytes = random_generators::get_bytes();
-    nb.buffer().append(bytes.c_str(), bytes.size());
+    nb.buffer().append(bytes.data(), bytes.size());
 
     BOOST_TEST_MESSAGE("Request with invalid payload");
     // will fail all the futures as server close the connection

--- a/src/v/security/jwt.h
+++ b/src/v/security/jwt.h
@@ -48,7 +48,7 @@ concept string_viewable = detail::is_string_viewable<T>::value;
 
 template<typename ToCharT = char>
 std::basic_string_view<ToCharT> char_view_cast(string_viewable auto const& sv) {
-    return {reinterpret_cast<ToCharT const*>(sv.data()), sv.length()};
+    return {reinterpret_cast<ToCharT const*>(sv.data()), sv.size()};
 }
 
 struct string_viewable_compare {

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -77,7 +77,7 @@ scram_authenticator<T>::handle_client_final(bytes_view auth_bytes) {
 
     auto computed_stored_key = scram::computed_stored_key(
       client_signature,
-      bytes(client_final.proof().begin(), client_final.proof().end()));
+      bytes(client_final.proof().cbegin(), client_final.proof().cend()));
 
     if (computed_stored_key != _credential->stored_key()) {
         vlog(

--- a/src/v/serde/rw/inet_address.h
+++ b/src/v/serde/rw/inet_address.h
@@ -41,7 +41,7 @@ inline void tag_invoke(
               sizeof(addr)));
         }
 
-        std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+        std::memcpy(&addr, address_bytes.data(), sizeof(addr));
         t = ss::net::inet_address(addr);
     } else {
         ::in6_addr addr{};
@@ -56,7 +56,7 @@ inline void tag_invoke(
               address_bytes.size(),
               sizeof(addr)));
         }
-        std::memcpy(&addr, address_bytes.c_str(), sizeof(addr));
+        std::memcpy(&addr, address_bytes.data(), sizeof(addr));
         t = ss::net::inet_address(addr);
     }
 }

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -28,7 +28,7 @@ inline compaction_key enhance_key(
       static_cast<std::underlying_type<model::record_batch_type>::type>(type));
     auto ctrl_le = ss::cpu_to_le(static_cast<int8_t>(is_control_batch));
     auto total_size = sizeof(bt_le) + key.size() + sizeof(ctrl_le);
-    auto enriched_key = ss::uninitialized_string<bytes>(total_size);
+    bytes enriched_key(bytes::initialized_later{}, total_size);
     auto out = enriched_key.begin();
     out = std::copy_n(
       reinterpret_cast<const char*>(&bt_le), sizeof(bt_le), out);

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -216,7 +216,7 @@ ss::future<> kvstore::for_each(
           if (!spaced_key.starts_with(prefix)) {
               return;
           }
-          auto key = spaced_key.substr(prefix.length());
+          auto key = spaced_key.substr(prefix.size());
           visitor(key, kv.second);
       });
 }

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -155,8 +155,7 @@ static inline bytes make_spaced_key(kvstore::key_space ks, bytes_view key) {
     auto ks_native
       = static_cast<std::underlying_type<kvstore::key_space>::type>(ks);
     auto ks_le = ss::cpu_to_le(ks_native);
-    auto spaced_key = ss::uninitialized_string<bytes>(
-      sizeof(ks_le) + key.size());
+    bytes spaced_key(bytes::initialized_later{}, sizeof(ks_le) + key.size());
     auto out = spaced_key.begin();
     out = std::copy_n(
       reinterpret_cast<const char*>(&ks_le), sizeof(ks_le), out);

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -45,7 +45,7 @@ struct compacted_topic_fixture {
 
 bytes extract_record_key(bytes prefixed_key) {
     size_t sz = prefixed_key.size() - 2;
-    auto read_key = ss::uninitialized_string<bytes>(sz);
+    bytes read_key(bytes::initialized_later{}, sz);
 
     std::copy_n(prefixed_key.begin() + 2, sz, read_key.begin());
     return read_key;

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -62,7 +62,8 @@ static void set_version(iobuf& buf, int8_t version) {
     auto tmp = iobuf_to_bytes(buf);
     buf.clear();
     buf.append((const char*)&version, sizeof(version));
-    buf.append(bytes_to_iobuf(tmp.substr(1)));
+    vassert(tmp.size() > 1, "unexpected buffer size: {}", tmp.size());
+    buf.append(tmp.data() + 1, tmp.size() - 1);
 }
 
 // encode/decode using new serde framework

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -116,7 +116,7 @@ iobuf make_random_data(size_t len) {
 
 // fill an iobuf with len copies of char c
 iobuf make_iobuf_with_char(size_t len, unsigned char c) {
-    auto buf = ss::uninitialized_string<bytes>(len);
+    bytes buf(bytes::initialized_later{}, len);
     std::memset(buf.data(), c, len);
     iobuf ret;
     ret.append(buf.data(), buf.size());

--- a/src/v/utils/vint.h
+++ b/src/v/utils/vint.h
@@ -107,7 +107,7 @@ inline bytes to_bytes(uint32_t value) noexcept {
     // unsigned_vint::max_length bytes will be used to allocate the encoded size
     // at the start of the returned buffer
     auto sz = size(static_cast<uint64_t>(value));
-    auto out = ss::uninitialized_string<bytes>(sz);
+    bytes out(bytes::initialized_later{}, sz);
     serialize(value, out.begin());
     return out;
 }
@@ -162,7 +162,7 @@ inline bytes to_bytes(int64_t value) noexcept {
     // vint::max_length bytes will be used to allocate the encoded size at the
     // start of the returned buffer
     auto sz = vint_size(value);
-    auto out = ss::uninitialized_string<bytes>(sz);
+    bytes out(bytes::initialized_later{}, sz);
     serialize(value, out.begin());
     return out;
 }


### PR DESCRIPTION
clang-18 (well, more specifically libc++18) is going to deprecate char_traits<T> for T not equal to char and some other types. This makes it difficult to use a ss::sstring-based bytes implementation because ss::sstring tries to interoperate with std::string and std::string_view, causing deprecation warnings which will turn into errors in clang-19.

so we'll need to build a replacement (or at least a wrapper). this PR simplifies some of the surface area of the `bytes` api to make the resulting wrapper a bit simpler.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
