### PR TITLE
[WIP] `storage`: support tombstone deletion from local storage

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -96,6 +96,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
       model::timestamp::min(),
       1,
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
@@ -516,6 +517,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       model::timestamp::min(),
       1, // max_bytes_in_log
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
@@ -809,6 +811,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
       model::timestamp::max(),
       0,
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -479,7 +479,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-    };
+      std::nullopt};
 
     auto random_initial_revision_id
       = tests::random_named_int<model::initial_revision_id>();

--- a/src/v/cluster/archival/tests/async_data_uploader_test.cc
+++ b/src/v/cluster/archival/tests/async_data_uploader_test.cc
@@ -167,6 +167,7 @@ public:
           model::timestamp::min(),
           std::nullopt,
           max_collect_offset,
+          std::nullopt,
           ss::default_priority_class(),
           as);
 

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -235,6 +235,7 @@ struct reupload_fixture : public archiver_fixture {
             model::timestamp::max(),
             std::nullopt,
             max_collectible,
+            std::nullopt,
             ss::default_priority_class(),
             abort_source})
           .get();

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -941,6 +941,7 @@ FIXTURE_TEST(
         model::timestamp::now(),
         std::nullopt,
         model::offset{999},
+        std::nullopt,
         ss::default_priority_class(),
         as))
       .get0();

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -22,6 +22,7 @@
 #include "model/namespace.h"
 #include "model/timestamp.h"
 #include "storage/types.h"
+#include "utils/tristate.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sharded.hh>
@@ -318,6 +319,11 @@ metadata_cache::get_default_record_value_subject_name_strategy() const {
     return pandaproxy::schema_registry::subject_name_strategy::topic_name;
 }
 
+std::optional<std::chrono::milliseconds>
+metadata_cache::get_default_tombstone_retention_ms() const {
+    return config::shard_local_cfg().tombstone_retention_ms();
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -335,6 +341,7 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_retention_local_target_bytes()};
     tp.retention_local_target_ms = tristate<std::chrono::milliseconds>{
       get_default_retention_local_target_ms()};
+    tp.tombstone_retention_ms = get_default_tombstone_retention_ms();
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -202,6 +202,8 @@ public:
     bool get_default_record_value_schema_id_validation() const;
     pandaproxy::schema_registry::subject_name_strategy
     get_default_record_value_subject_name_strategy() const;
+    std::optional<std::chrono::milliseconds>
+    get_default_tombstone_retention_ms() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -112,6 +112,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                       retention_timestamp,
                       100_MiB,
                       model::offset::max(),
+                      std::nullopt,
                       ss::default_priority_class(),
                       as,
                       storage::ntp_sanitizer_config{.sanitize_only = true}))

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -107,6 +107,7 @@ public:
                       model::timestamp::now().value() - ret_duration.count()),
                     std::nullopt,
                     log->stm_manager()->max_collectible_offset(),
+                    std::nullopt,
                     ss::default_priority_class(),
                     dummy_as,
                   })
@@ -228,6 +229,7 @@ public:
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         // Compacts until a single sealed segment remains, other than the

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -55,7 +55,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .write_caching = properties.write_caching,
             .flush_ms = properties.flush_ms,
             .flush_bytes = properties.flush_bytes,
-          });
+            .tombstone_retention_ms = properties.tombstone_retention_ms});
     }
     return {
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -39,7 +39,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "write_caching: {}, "
       "flush_ms: {}, "
       "flush_bytes: {}, "
-      "remote_label: {}}}",
+      "remote_label: {}, "
+      "tombstone_retention_ms: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -72,7 +73,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.write_caching,
       properties.flush_ms,
       properties.flush_bytes,
-      properties.remote_label);
+      properties.remote_label,
+      properties.tombstone_retention_ms);
 
     return o;
 }
@@ -108,7 +110,8 @@ bool topic_properties::has_overrides() const {
            || initial_retention_local_target_bytes.is_engaged()
            || initial_retention_local_target_ms.is_engaged()
            || write_caching.has_value() || flush_ms.has_value()
-           || flush_bytes.has_value() || remote_label.has_value();
+           || flush_bytes.has_value() || remote_label.has_value()
+           || tombstone_retention_ms.has_value();
 }
 
 bool topic_properties::requires_remote_erase() const {
@@ -141,6 +144,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.write_caching = write_caching;
     ret.flush_ms = flush_ms;
     ret.flush_bytes = flush_bytes;
+    ret.tombstone_retention_ms = tombstone_retention_ms;
     return ret;
 }
 
@@ -225,6 +229,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       tristate<size_t>{std::nullopt},
       tristate<std::chrono::milliseconds>{std::nullopt},
+      std::nullopt,
       std::nullopt,
       std::nullopt,
       std::nullopt,

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -33,7 +33,7 @@ namespace cluster {
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<9>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<10>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -71,7 +71,8 @@ struct topic_properties
       std::optional<model::vcluster_id> mpx_virtual_cluster_id,
       std::optional<model::write_caching_mode> write_caching,
       std::optional<std::chrono::milliseconds> flush_ms,
-      std::optional<size_t> flush_bytes)
+      std::optional<size_t> flush_bytes,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -108,7 +109,8 @@ struct topic_properties
       , mpx_virtual_cluster_id(mpx_virtual_cluster_id)
       , write_caching(write_caching)
       , flush_ms(flush_ms)
-      , flush_bytes(flush_bytes) {}
+      , flush_bytes(flush_bytes)
+      , tombstone_retention_ms(tombstone_retention_ms) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -162,6 +164,7 @@ struct topic_properties
     std::optional<model::write_caching_mode> write_caching;
     std::optional<std::chrono::milliseconds> flush_ms;
     std::optional<size_t> flush_bytes;
+    std::optional<std::chrono::milliseconds> tombstone_retention_ms;
 
     // Label to be used when generating paths of remote objects (manifests,
     // segments, etc) of this topic.
@@ -217,7 +220,8 @@ struct topic_properties
           flush_ms,
           flush_bytes,
           remote_label,
-          remote_topic_namespace_override);
+          remote_topic_namespace_override,
+          tombstone_retention_ms);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -962,9 +962,11 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       updated_properties.write_caching, overrides.write_caching);
     incremental_update(updated_properties.flush_ms, overrides.flush_ms);
     incremental_update(updated_properties.flush_bytes, overrides.flush_bytes);
+    incremental_update(
+      updated_properties.tombstone_retention_ms,
+      overrides.tombstone_retention_ms);
 
     auto& properties = tp->second.get_configuration().properties;
-
     // no configuration change, no need to generate delta
     if (updated_properties == properties) {
         co_return errc::success;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -656,6 +656,15 @@ private:
     std::error_code validate_force_reconfigurable_partition(
       const ntp_with_majority_loss&) const;
 
+    // Validation for the final property configuration from a
+    // update_topic_properties_cmd application. Allows user to perform
+    // validations that depend on more than one topic property.
+    //
+    // Returns true if the configured topic_properties is valid, and false
+    // otherwise.
+    bool
+    topic_multi_property_validation(const topic_properties& properties) const;
+
     underlying_t _topics;
     lifecycle_markers_t _lifecycle_markers;
     disabled_partitions_t _disabled_partitions;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1176,7 +1176,8 @@ void adl<cluster::incremental_topic_updates>::to(
       t.initial_retention_local_target_ms,
       t.write_caching,
       t.flush_ms,
-      t.flush_bytes);
+      t.flush_bytes,
+      t.tombstone_retention_ms);
 }
 
 cluster::incremental_topic_updates
@@ -1309,6 +1310,14 @@ adl<cluster::incremental_topic_updates>::from(iobuf_parser& in) {
                              .from(in);
         updates.flush_bytes
           = adl<cluster::property_update<std::optional<size_t>>>{}.from(in);
+    }
+
+    if (
+      version <= cluster::incremental_topic_updates::
+        version_with_tombstone_retention_ms) {
+        updates.tombstone_retention_ms = adl<cluster::property_update<
+          std::optional<std::chrono::milliseconds>>>{}
+                                           .from(in);
     }
 
     return updates;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -563,7 +563,7 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<6>,
+      serde::version<7>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
@@ -573,6 +573,7 @@ struct incremental_topic_updates
     static constexpr int8_t version_with_schema_id_validation = -6;
     static constexpr int8_t version_with_initial_retention = -7;
     static constexpr int8_t version_with_write_caching = -8;
+    static constexpr int8_t version_with_tombstone_retention_ms = -9;
     // negative version indicating different format:
     // -1 - topic_updates with data_policy
     // -2 - topic_updates without data_policy
@@ -581,7 +582,9 @@ struct incremental_topic_updates
     // -6 - topic updates with schema id validation
     // -7 - topic updates with initial retention
     // -8 - write caching properties
-    static constexpr int8_t version = version_with_write_caching;
+    // -9 - tombstone_retention_ms
+    static constexpr int8_t version = version_with_tombstone_retention_ms;
+
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -622,6 +625,8 @@ struct incremental_topic_updates
     property_update<std::optional<model::write_caching_mode>> write_caching;
     property_update<std::optional<std::chrono::milliseconds>> flush_ms;
     property_update<std::optional<size_t>> flush_bytes;
+    property_update<std::optional<std::chrono::milliseconds>>
+      tombstone_retention_ms;
 
     auto serde_fields() {
         return std::tie(
@@ -650,7 +655,8 @@ struct incremental_topic_updates
           initial_retention_local_target_ms,
           write_caching,
           flush_ms,
-          flush_bytes);
+          flush_bytes,
+          tombstone_retention_ms);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -358,6 +358,7 @@ struct compat_check<cluster::topic_properties> {
         json_write(flush_ms);
         json_write(flush_bytes);
         json_write(remote_topic_namespace_override);
+        json_write(tombstone_retention_ms);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -394,6 +395,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(flush_ms);
         json_read(flush_bytes);
         json_read(remote_topic_namespace_override);
+        json_read(tombstone_retention_ms);
         return obj;
     }
 
@@ -425,6 +427,7 @@ struct compat_check<cluster::topic_properties> {
         obj.flush_bytes = std::nullopt;
         obj.flush_ms = std::nullopt;
         obj.remote_topic_namespace_override = std::nullopt;
+        obj.tombstone_retention_ms = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -507,6 +510,7 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.write_caching = std::nullopt;
         obj.properties.flush_bytes = std::nullopt;
         obj.properties.flush_ms = std::nullopt;
+        obj.properties.tombstone_retention_ms = std::nullopt;
 
         obj.properties.mpx_virtual_cluster_id = std::nullopt;
 

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -649,7 +649,8 @@ struct instance_generator<cluster::topic_properties> {
           }),
           tests::random_optional([] { return tests::random_duration_ms(); }),
           tests::random_optional(
-            [] { return random_generators::get_int<size_t>(); })};
+            [] { return random_generators::get_int<size_t>(); }),
+          tests::random_optional([] { return tests::random_duration_ms(); })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -625,6 +625,7 @@ inline void rjson_serialize(
     write_exceptional_member_type(w, "write_caching", tps.write_caching);
     write_member(w, "flush_bytes", tps.flush_bytes);
     write_member(w, "flush_ms", tps.flush_ms);
+    write_member(w, "tombstone_retention_ms", tps.tombstone_retention_ms);
     w.EndObject();
 }
 
@@ -695,6 +696,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "write_caching", obj.write_caching);
     read_member(rd, "flush_bytes", obj.flush_bytes);
     read_member(rd, "flush_ms", obj.flush_ms);
+    read_member(rd, "tombstone_retention_ms", obj.tombstone_retention_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1631,7 +1631,7 @@ configuration::configuration()
       *this,
       "cloud_storage_enabled",
       "Enable archival storage",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , cloud_storage_enable_remote_read(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -783,7 +783,6 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
-
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",
@@ -844,6 +843,13 @@ configuration::configuration()
       "How often do we trigger background compaction",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10s)
+  , tombstone_retention_ms(
+      *this,
+      "tombstone_retention_ms",
+      "The retention time for tombstone records in a compacted topic",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_tombstone_retention_ms)
   , log_disable_housekeeping_for_tests(
       *this,
       "log_disable_housekeeping_for_tests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -178,6 +178,8 @@ struct configuration final : public config_store {
     // same as log.retention.ms in kafka
     retention_duration_property log_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
+    // same as delete.retention.ms in kafka
+    property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     // same as retention.size in kafka - TODO: size not implemented

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -247,4 +247,18 @@ validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring> validate_tombstone_retention_ms(
+  const std::optional<std::chrono::milliseconds>& ms) {
+    const auto& cloud_storage_enabled
+      = config::shard_local_cfg().cloud_storage_enabled;
+    if (cloud_storage_enabled() && ms.has_value()) {
+        return fmt::format(
+          "cannot set {} if {} is enabled at the cluster level",
+          config::shard_local_cfg().tombstone_retention_ms.name(),
+          cloud_storage_enabled.name());
+    }
+
+    return std::nullopt;
+}
+
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -56,4 +56,7 @@ validate_audit_excluded_topics(const std::vector<ss::sstring>&);
 std::optional<ss::sstring>
 validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os);
 
+std::optional<ss::sstring> validate_tombstone_retention_ms(
+  const std::optional<std::chrono::milliseconds>& ms);
+
 }; // namespace config

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -77,7 +77,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 26,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 27,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -274,6 +274,15 @@ create_topic_properties_update(alter_configs_resource& resource) {
                   cfg.value,
                   kafka::config_resource_operation::set,
                   flush_bytes_validator{});
+                continue;
+            }
+            if (cfg.name == topic_property_tombstone_retention_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.tombstone_retention_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  tombstone_retention_ms_validator{},
+                  true);
                 continue;
             }
 

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -315,7 +315,7 @@ alter_topic_configuration(
 }
 
 static ss::future<chunked_vector<alter_configs_resource_response>>
-alter_broker_configuartion(chunked_vector<alter_configs_resource> resources) {
+alter_broker_configuration(chunked_vector<alter_configs_resource> resources) {
     return unsupported_broker_configuration<
       alter_configs_resource,
       alter_configs_resource_response>(
@@ -357,7 +357,7 @@ ss::future<response_ptr> alter_configs_handler::handle(
     futures.push_back(alter_topic_configuration(
       ctx, std::move(groupped.topic_changes), request.data.validate_only));
     futures.push_back(
-      alter_broker_configuartion(std::move(groupped.broker_changes)));
+      alter_broker_configuration(std::move(groupped.broker_changes)));
 
     auto ret = co_await ss::when_all_succeed(futures.begin(), futures.end());
     // include authorization errors

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -377,7 +377,7 @@ static void add_topic_config(
     // Wrap overrides in an optional because add_topic_config expects
     // optional<S> where S = tristate<T>
     std::optional<tristate<T>> override_value;
-    if (overrides.is_disabled() || overrides.has_optional_value()) {
+    if (overrides.is_engaged()) {
         override_value = std::make_optional(overrides);
     }
 

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -634,6 +634,9 @@ config_response_container_t make_topic_configs(
       &describe_as_string<std::chrono::milliseconds>);
 
     // Shadow indexing properties
+    // These are "sticky" properties and do not use the cluster default after
+    // topic creation. The override should always govern the topic config's
+    // value.
     add_topic_config_if_requested(
       config_keys,
       result,
@@ -643,7 +646,7 @@ config_response_container_t make_topic_configs(
       topic_property_remote_read,
       topic_properties.shadow_indexing.has_value() ? std::make_optional(
         model::is_fetch_enabled(*topic_properties.shadow_indexing))
-                                                   : std::nullopt,
+                                                   : std::make_optional(false),
       include_synonyms,
       maybe_make_documentation(
         include_documentation,
@@ -660,7 +663,7 @@ config_response_container_t make_topic_configs(
       topic_property_remote_write,
       topic_properties.shadow_indexing.has_value() ? std::make_optional(
         model::is_archival_enabled(*topic_properties.shadow_indexing))
-                                                   : std::nullopt,
+                                                   : std::make_optional(false),
       include_synonyms,
       maybe_make_documentation(
         include_documentation,

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -448,6 +448,24 @@ struct flush_bytes_validator {
     }
 };
 
+struct tombstone_retention_ms_validator {
+    std::optional<ss::sstring> operator()(
+      const ss::sstring&,
+      const std::optional<std::chrono::milliseconds>& maybe_value) {
+        if (maybe_value.has_value()) {
+            const auto& value = maybe_value.value();
+            if (value < 1ms || value > serde::max_serializable_ms) {
+                return fmt::format(
+                  "tombstone.retention.ms value invalid, expected to be in "
+                  "range "
+                  "[1, {}]",
+                  serde::max_serializable_ms);
+            }
+        }
+        return std::nullopt;
+    }
+};
+
 template<typename T, typename... ValidatorTypes>
 requires requires(
   model::topic_namespace_view tns,
@@ -609,11 +627,18 @@ inline void parse_and_set_bool(
     }
 }
 
-template<typename T>
+template<typename T, typename Validator = noop_validator<tristate<T>>>
+requires requires(
+  const tristate<T>& value, const ss::sstring& str, Validator validator) {
+    {
+        validator(str, value)
+    } -> std::convertible_to<std::optional<ss::sstring>>;
+}
 void parse_and_set_tristate(
   cluster::property_update<tristate<T>>& property,
   const std::optional<ss::sstring>& value,
-  config_resource_operation op) {
+  config_resource_operation op,
+  Validator validator = noop_validator<tristate<T>>{}) {
     // remove property value
     if (op == config_resource_operation::remove) {
         property.op = cluster::incremental_update_operation::remove;
@@ -626,6 +651,11 @@ void parse_and_set_tristate(
             property.value = tristate<T>{};
         } else {
             property.value = tristate<T>(std::make_optional<T>(parsed));
+        }
+
+        auto v_error = validator(*value, property.value);
+        if (v_error) {
+            throw validation_error(*v_error);
         }
 
         property.op = cluster::incremental_update_operation::set;

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -67,7 +67,8 @@ static constexpr auto supported_configs = std::to_array(
    topic_property_initial_retention_local_target_ms,
    topic_property_write_caching,
    topic_property_flush_ms,
-   topic_property_flush_bytes});
+   topic_property_flush_bytes,
+   topic_property_tombstone_retention_ms});
 
 bool is_supported(std::string_view name) {
     return std::any_of(
@@ -92,7 +93,8 @@ using validators = make_validator_types<
   subject_name_strategy_validator,
   replication_factor_must_be_greater_or_equal_to_minimum,
   vcluster_id_validator,
-  write_caching_configs_validator>;
+  write_caching_configs_validator,
+  tombstone_retention_ms_validator>;
 
 static void
 append_topic_configs(request_context& ctx, create_topics_response& response) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -300,6 +300,15 @@ create_topic_properties_update(
                   flush_bytes_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_tombstone_retention_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.tombstone_retention_ms,
+                  cfg.value,
+                  op,
+                  tombstone_retention_ms_validator{},
+                  true);
+                continue;
+            }
 
         } catch (const validation_error& e) {
             vlog(
@@ -355,6 +364,7 @@ inline std::string_view map_config_name(std::string_view input) {
       .match("log.message.timestamp.type", "log_message_timestamp_type")
       .match("log.compression.type", "log_compression_type")
       .match("log.roll.ms", "log_segment_ms")
+      .match("delete.retention.ms", "tombstone_retention_ms")
       .default_match(input);
 }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -162,7 +162,7 @@ get_tristate_value(const config_map_t& config, std::string_view key) {
     }
     // disabled case
     if (v <= 0) {
-        return tristate<T>{};
+        return tristate<T>(disable_tristate);
     }
     return tristate<T>(std::make_optional<T>(*v));
 }

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -393,7 +393,8 @@ FIXTURE_TEST(
       "initial.retention.local.target.ms",
       "write.caching",
       "flush.ms",
-      "flush.bytes"};
+      "flush.bytes",
+      "tombstone.retention.ms"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);
@@ -481,6 +482,7 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     properties.emplace("write.caching", "true");
     properties.emplace("flush.ms", "225");
     properties.emplace("flush.bytes", "32468");
+    properties.emplace("tombstone.retention.ms", "5678");
 
     auto resp = alter_configs(
       make_alter_topic_config_resource_cv(test_tp, properties));
@@ -496,6 +498,8 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "cleanup.policy", "compact", describe_resp);
     assert_property_value(
       test_tp, "redpanda.remote.read", "true", describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "5678", describe_resp);
 }
 
 FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
@@ -512,6 +516,7 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     properties_1.emplace("write.caching", "true");
     properties_1.emplace("flush.ms", "225");
     properties_1.emplace("flush.bytes", "32468");
+    properties_1.emplace("tombstone.retention.ms", "5678");
 
     absl::flat_hash_map<ss::sstring, ss::sstring> properties_2;
     properties_2.emplace("retention.bytes", "4096");
@@ -519,6 +524,7 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     properties_2.emplace("write.caching", "false");
     properties_2.emplace("flush.ms", "100");
     properties_2.emplace("flush.bytes", "990");
+    properties_2.emplace("tombstone.retention.ms", "8765");
 
     auto cv = make_alter_topic_config_resource_cv(topic_1, properties_1);
     cv.push_back(make_alter_topic_config_resource(topic_2, properties_2));
@@ -540,12 +546,16 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     assert_property_value(topic_1, "write.caching", "true", describe_resp_1);
     assert_property_value(topic_1, "flush.ms", "225", describe_resp_1);
     assert_property_value(topic_1, "flush.bytes", "32468", describe_resp_1);
+    assert_property_value(
+      topic_1, "tombstone.retention.ms", "5678", describe_resp_1);
 
     auto describe_resp_2 = describe_configs(topic_2);
     assert_property_value(topic_2, "retention.bytes", "4096", describe_resp_2);
     assert_property_value(topic_2, "write.caching", "false", describe_resp_2);
     assert_property_value(topic_2, "flush.ms", "100", describe_resp_2);
     assert_property_value(topic_2, "flush.bytes", "990", describe_resp_2);
+    assert_property_value(
+      topic_2, "tombstone.retention.ms", "8765", describe_resp_2);
 }
 
 FIXTURE_TEST(
@@ -607,6 +617,7 @@ FIXTURE_TEST(
     properties.emplace("write.caching", "true");
     properties.emplace("flush.ms", "225");
     properties.emplace("flush.bytes", "32468");
+    properties.emplace("tombstone.retention.ms", "5678");
 
     auto resp = alter_configs(
       make_alter_topic_config_resource_cv(test_tp, properties));
@@ -622,6 +633,8 @@ FIXTURE_TEST(
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "225", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "32468", describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "5678", describe_resp);
 
     /**
      * Set custom properties again, previous settings should be overriden
@@ -632,6 +645,7 @@ FIXTURE_TEST(
     new_properties.emplace("write.caching", "false");
     new_properties.emplace("flush.ms", "9999");
     new_properties.emplace("flush.bytes", "8888");
+    new_properties.emplace("tombstone.retention.ms", "7777");
 
     alter_configs(make_alter_topic_config_resource_cv(test_tp, new_properties));
 
@@ -648,6 +662,8 @@ FIXTURE_TEST(
     assert_property_value(test_tp, "write.caching", "false", new_describe_resp);
     assert_property_value(test_tp, "flush.ms", "9999", new_describe_resp);
     assert_property_value(test_tp, "flush.bytes", "8888", new_describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "7777", new_describe_resp);
 }
 
 FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
@@ -671,6 +687,9 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     properties.emplace(
       "flush.bytes",
       std::make_pair("5678", kafka::config_resource_operation::set));
+    properties.emplace(
+      "tombstone.retention.ms",
+      std::make_pair("5678", kafka::config_resource_operation::set));
 
     auto resp = incremental_alter_configs(
       make_incremental_alter_topic_config_resource_cv(test_tp, properties));
@@ -686,6 +705,8 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "1234", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "5678", describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "5678", describe_resp);
 
     /**
      * Set only few properties, only they should be updated
@@ -713,6 +734,8 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "false", new_describe_resp);
     assert_property_value(test_tp, "flush.ms", "1234", new_describe_resp);
     assert_property_value(test_tp, "flush.bytes", "5678", new_describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "5678", new_describe_resp);
 }
 
 FIXTURE_TEST(
@@ -758,6 +781,9 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     properties.emplace(
       "flush.bytes",
       std::make_pair("8888", kafka::config_resource_operation::set));
+    properties.emplace(
+      "tombstone.retention.ms",
+      std::make_pair("7777", kafka::config_resource_operation::set));
 
     auto resp = incremental_alter_configs(
       make_incremental_alter_topic_config_resource_cv(test_tp, properties));
@@ -773,6 +799,8 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "9999", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "8888", describe_resp);
+    assert_property_value(
+      test_tp, "tombstone.retention.ms", "7777", describe_resp);
 
     /**
      * Remove custom properties
@@ -792,6 +820,9 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
       std::pair{std::nullopt, kafka::config_resource_operation::remove});
     new_properties.emplace(
       "flush.bytes",
+      std::pair{std::nullopt, kafka::config_resource_operation::remove});
+    new_properties.emplace(
+      "tombstone.retention.ms",
       std::pair{std::nullopt, kafka::config_resource_operation::remove});
 
     resp = incremental_alter_configs(
@@ -829,5 +860,12 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
         config::shard_local_cfg()
           .raft_replica_max_pending_flush_bytes()
           .value()),
+      new_describe_resp);
+    assert_property_value(
+      test_tp,
+      "tombstone.retention.ms",
+      fmt::format(
+        "{}",
+        config::shard_local_cfg().tombstone_retention_ms().value_or(-1ms)),
       new_describe_resp);
 }

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -305,6 +305,7 @@ ss::future<> run_workload(
                 model::timestamp::max(),
                 std::nullopt,
                 log->stm_manager()->max_collectible_offset(),
+                std::nullopt,
                 ss::default_priority_class(),
                 dummy_as,
               })

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -36,7 +36,8 @@ struct kv_t {
       size_t start,
       size_t num_records,
       std::optional<size_t> val_start = std::nullopt,
-      size_t key_cardinality = 0) {
+      size_t key_cardinality = 0,
+      bool produce_tombstones = false) {
         size_t vstart = val_start.value_or(start);
         std::vector<kv_t> records;
         records.reserve(num_records);
@@ -45,8 +46,10 @@ struct kv_t {
             if (key_cardinality > 0) {
                 key = key % key_cardinality;
             }
-            records.emplace_back(
-              ssx::sformat("key{}", key), ssx::sformat("val{}", vstart + i));
+            const auto value = produce_tombstones
+                                 ? ""
+                                 : ssx::sformat("val{}", vstart + i);
+            records.emplace_back(ssx::sformat("key{}", key), value);
         }
         return records;
     }

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -227,7 +227,8 @@ public:
     const iobuf& value() const { return _value; }
     iobuf release_value() { return std::exchange(_value, {}); }
     iobuf share_value() { return _value.share(0, _value.size_bytes()); }
-    bool has_value() const { return _val_size >= 0; }
+    bool has_value() const { return _val_size > 0; }
+    bool is_tombstone() const { return !has_value(); }
 
     const std::vector<record_header>& headers() const { return _headers; }
     std::vector<record_header>& headers() { return _headers; }
@@ -360,7 +361,7 @@ public:
     record_batch_attributes& operator|=(model::compression c) {
         // clang-format off
         _attributes |=
-        static_cast<std::underlying_type_t<model::compression>>(c) 
+        static_cast<std::underlying_type_t<model::compression>>(c)
             & record_batch_attributes::compression_mask;
         // clang-format on
         return *this;

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -544,6 +544,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
             first_ts,
             100_MiB,
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as,
             storage::ntp_sanitizer_config{.sanitize_only = true}))

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -74,10 +74,11 @@ private:
    1 byte  - non_data_timestamps
  */
 struct index_state
-  : serde::envelope<index_state, serde::version<7>, serde::compat_version<4>> {
+  : serde::envelope<index_state, serde::version<8>, serde::compat_version<4>> {
     static constexpr auto monotonic_timestamps_version = 5;
     static constexpr auto broker_timestamp_version = 6;
     static constexpr auto num_compactible_records_version = 7;
+    static constexpr auto clean_compact_timestamp_version = 8;
 
     static index_state make_empty_index(offset_delta_time with_offset);
 
@@ -130,6 +131,12 @@ struct index_state
     // Returns std::nullopt if this index was written in a version that didn't
     // support this field, and we can't conclude anything.
     std::optional<size_t> num_compactible_records_appended{0};
+
+    // If set, the timestamp at which every record up to and including
+    // those in this segment were first compacted via sliding window.
+    // If not yet set, sliding window compaction has not yet been applied to
+    // every previous record in the log.
+    std::optional<model::timestamp> clean_compact_timestamp{std::nullopt};
 
     size_t size() const;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -275,6 +275,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           collection_threshold,
           _config.retention_bytes(),
           current_log.handle->stm_manager()->max_collectible_offset(),
+          /*TODO: current_log.handle->config().tombstone_retention_ms()*/
+          std::nullopt,
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg),

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -275,8 +275,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           collection_threshold,
           _config.retention_bytes(),
           current_log.handle->stm_manager()->max_collectible_offset(),
-          /*TODO: current_log.handle->config().tombstone_retention_ms()*/
-          std::nullopt,
+          current_log.handle->config().tombstone_retention_ms(),
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg),

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -511,6 +511,7 @@ struct compact_op final : opfuzz::op {
           model::timestamp::max(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           *(ctx._as),
           storage::ntp_sanitizer_config{.sanitize_only = true});

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -897,7 +897,7 @@ bool segment::may_have_compactible_records() const {
         // that there were no data records, so err on the side of caution.
         return true;
     }
-    return num_compactible_records.value() > 1;
+    return num_compactible_records.value() > 0;
 }
 
 } // namespace storage

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -198,6 +198,7 @@ ss::future<index_state> deduplicate_segment(
     auto new_idx = co_await std::move(rdr).consume(
       std::move(copy_reducer), model::no_timeout);
     new_idx.broker_timestamp = seg->index().broker_timestamp();
+    new_idx.clean_compact_timestamp = seg->index().clean_compact_timestamp();
     co_return new_idx;
 }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -9,6 +9,7 @@
 
 #include "storage/segment_deduplication_utils.h"
 
+#include "model/timestamp.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
 #include "storage/index_state.h"
@@ -164,9 +165,13 @@ ss::future<index_state> deduplicate_segment(
       seg, cfg, probe, std::move(read_holder));
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
+
+    const std::optional<model::timestamp> tombstone_delete_horizon
+      = internal::get_tombstone_delete_horizon(seg, cfg);
     auto copy_reducer = internal::copy_data_segment_reducer(
       [&map,
        segment_last_offset = seg->offsets().get_committed_offset(),
+       tombstone_delete_horizon = tombstone_delete_horizon,
        compaction_placeholder_enabled](
         const model::record_batch& b,
         const model::record& r,
@@ -185,6 +190,12 @@ ss::future<index_state> deduplicate_segment(
                 b.header());
               return ss::make_ready_future<bool>(true);
           }
+          // Potentially deal with tombstone record removal
+          if (internal::should_remove_tombstone_record(
+                r, tombstone_delete_horizon)) {
+              return ss::make_ready_future<bool>(false);
+          }
+
           return should_keep(map, b, r);
       },
       &appender,

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -129,7 +129,8 @@ public:
       size_t step,
       ss::sharded<features::feature_table>& feature_table,
       std::optional<ntp_sanitizer_config> sanitizer_config,
-      std::optional<model::timestamp> broker_timestamp = std::nullopt);
+      std::optional<model::timestamp> broker_timestamp = std::nullopt,
+      std::optional<model::timestamp> clean_compact_timestamp = std::nullopt);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -197,6 +197,24 @@ public:
           _state.broker_timestamp, _state.max_timestamp, _retention_timestamp);
     }
 
+    // Check if compacted timestamp has a value.
+    bool has_clean_compact_timestamp() const {
+        return _state.clean_compact_timestamp.has_value();
+    }
+
+    // Set the compacted timestamp, if it doesn't already have a value.
+    void maybe_set_clean_compact_timestamp(model::timestamp t) {
+        if (!_state.clean_compact_timestamp.has_value()) {
+            _state.clean_compact_timestamp = t;
+            _needs_persistence = true;
+        }
+    }
+
+    // Get the compacted timestamp.
+    std::optional<model::timestamp> clean_compact_timestamp() const {
+        return _state.clean_compact_timestamp;
+    }
+
     ss::future<bool> materialize_index();
     ss::future<> flush();
     ss::future<> truncate(model::offset, model::timestamp);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1130,4 +1130,18 @@ void mark_segment_as_finished_window_compaction(
     }
 }
 
+bool should_remove_tombstone_record(
+  const model::record& r,
+  std::optional<model::timestamp> tombstone_delete_horizon) {
+    if (!r.is_tombstone()) {
+        return false;
+    }
+
+    if (!tombstone_delete_horizon.has_value()) {
+        return false;
+    }
+
+    return (model::timestamp::now() > tombstone_delete_horizon.value());
+}
+
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1122,4 +1122,12 @@ offset_delta_time should_apply_delta_time_offset(
       && feature_table.local().is_active(features::feature::node_isolation)};
 }
 
+void mark_segment_as_finished_window_compaction(
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp) {
+    seg->mark_as_finished_windowed_compaction();
+    if (set_clean_compact_timestamp) {
+        seg->index().maybe_set_clean_compact_timestamp(model::timestamp::now());
+    }
+}
+
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1130,6 +1130,20 @@ void mark_segment_as_finished_window_compaction(
     }
 }
 
+std::optional<model::timestamp> get_tombstone_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
+    std::optional<model::timestamp> tombstone_delete_horizon = {};
+    const auto& tombstone_retention_ms_opt = cfg.tombstone_retention_ms;
+    if (
+      seg->index().has_clean_compact_timestamp()
+      && tombstone_retention_ms_opt.has_value()) {
+        tombstone_delete_horizon = model::timestamp(
+          seg->index().clean_compact_timestamp()->value()
+          + cfg.tombstone_retention_ms->count());
+    }
+    return tombstone_delete_horizon;
+}
+
 bool should_remove_tombstone_record(
   const model::record& r,
   std::optional<model::timestamp> tombstone_delete_horizon) {

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,13 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Returns true iff the record `r` is a tombstone, and the timestamp returned by
+// `now()` is past the `tombstone_delete_horizon` timestamp (in the case it has
+// a value). Returns false in all other cases.
+bool should_remove_tombstone_record(
+  const model::record& r,
+  std::optional<model::timestamp> tombstone_delete_horizon);
+
 // Mark a segment as completed window compaction, and whether it is "clean" (in
 // which case the `clean_compact_timestamp` is set in the segment's index).
 void mark_segment_as_finished_window_compaction(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,26 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Mark a segment as completed window compaction, and whether it is "clean" (in
+// which case the `clean_compact_timestamp` is set in the segment's index).
+void mark_segment_as_finished_window_compaction(
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp);
+
+// Optionally returns the timestamp past which a tombstone may be removed.
+// This returns a value iff the segment `s` has been marked as cleanly
+// compacted, and the compaction_config has a value assigned for
+// `tombstone_retention_ms`. In all other cases, `std::nullopt` is returned,
+// indicating that tombstone records will not be removed if encountered.
+std::optional<model::timestamp> get_tombstone_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
+
+// Returns true iff the record `r` is a tombstone, and the timestamp returned by
+// `now()` is past the `tombstone_delete_horizon` timestamp (in the case it has
+// a value). Returns false in all other cases.
+bool should_remove_tombstone_record(
+  const model::record& r,
+  std::optional<model::timestamp> tombstone_delete_horizon);
+
 template<typename Func>
 auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
     static_assert(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,14 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Optionally returns the timestamp past which a tombstone may be removed.
+// This returns a value iff the segment `s` has been marked as cleanly
+// compacted, and the compaction_config has a value assigned for
+// `tombstone_retention_ms`. In all other cases, `std::nullopt` is returned,
+// indicating that tombstone records will not be removed if encountered.
+std::optional<model::timestamp> get_tombstone_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
+
 // Returns true iff the record `r` is a tombstone, and the timestamp returned by
 // `now()` is past the `tombstone_delete_horizon` timestamp (in the case it has
 // a value). Returns false in all other cases.

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -77,6 +77,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     first_log->housekeeping(conf).get();
@@ -125,6 +126,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       new_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     new_log->housekeeping(conf2).get();
@@ -197,6 +199,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     first_log->housekeeping(conf).get();
@@ -225,6 +228,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       new_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     new_log->housekeeping(conf2).get();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -174,6 +174,7 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -239,6 +240,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -281,6 +283,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -300,6 +303,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     generate_data(1, cardinality, records_per_segment).get();
     storage::compaction_config new_cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -348,6 +352,7 @@ TEST_F(CompactionFixtureTest, TestCompactWithNonDataBatches) {
       = disk_log.get_probe().get_segments_compacted();
     storage::compaction_config new_cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt);
@@ -435,6 +440,7 @@ TEST_P(CompactionFilledReaderTest, ReadFilledGaps) {
     // when reading.
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -493,6 +499,7 @@ TEST_F(CompactionFixtureTest, TestReadFilledGapsWithTerms) {
 
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -333,7 +333,7 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
 }
 
 FIXTURE_TEST(
-  test_truncate_whole_log_when_logs_are_garbadge_collected,
+  test_truncate_whole_log_when_logs_are_garbage_collected,
   storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     storage::log_manager mgr = make_log_manager(cfg);
@@ -364,6 +364,7 @@ FIXTURE_TEST(
         ts,
         std::nullopt,
         model::offset::max(),
+        std::nullopt,
         ss::default_priority_class(),
         as))
       .get0();
@@ -545,6 +546,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
       ts,
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as));
 
@@ -591,7 +593,7 @@ FIXTURE_TEST(test_concurrent_truncate_and_compaction, storage_test_fixture) {
     // leaving room for further windowed compaction.
     ss::abort_source as;
     compaction_config compaction_cfg(
-      model::offset::max(), ss::default_priority_class(), as);
+      model::offset::max(), std::nullopt, ss::default_priority_class(), as);
     auto& disk_log = *dynamic_cast<disk_log_impl*>(log.get());
     disk_log.adjacent_merge_compact(compaction_cfg).get();
     disk_log.adjacent_merge_compact(compaction_cfg).get();
@@ -608,7 +610,12 @@ FIXTURE_TEST(test_concurrent_truncate_and_compaction, storage_test_fixture) {
     auto ts = now();
     auto sleep_ms1 = random_generators::get_int(0, 100);
     housekeeping_config housekeeping_cfg(
-      ts, std::nullopt, model::offset::max(), ss::default_priority_class(), as);
+      ts,
+      std::nullopt,
+      model::offset::max(),
+      std::nullopt,
+      ss::default_priority_class(),
+      as);
     auto f1 = ss::sleep(sleep_ms1 * 1ms).then([&] {
         return log->housekeeping(housekeeping_cfg);
     });

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -76,7 +76,10 @@ TEST(FindSlidingRangeTest, TestCollectSegments) {
     for (int start = 0; start < 30; start += 5) {
         for (int end = start; end < 30; end += 5) {
             compaction_config cfg(
-              model::offset{end}, ss::default_priority_class(), never_abort);
+              model::offset{end},
+              std::nullopt,
+              ss::default_priority_class(),
+              never_abort);
             auto segs = disk_log.find_sliding_range(cfg, model::offset{start});
             if (end - start < 10) {
                 // If the compactible range isn't a full segment, we can't
@@ -98,7 +101,10 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(3, segs.size());
     ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
@@ -127,7 +133,10 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(5, segs.size());
 
@@ -158,7 +167,10 @@ TEST(BuildOffsetMap, TestBuildSimpleMap) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     probe pb;
 
     feature_table.start().get();
@@ -231,7 +243,10 @@ TEST(BuildOffsetMap, TestBuildMapWithMissingCompactedIndex) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     for (const auto& s : segs) {
         auto idx_path = s->path().to_compacted_index();
         ASSERT_FALSE(ss::file_exists(idx_path.string()).get());
@@ -273,7 +288,10 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
 
     // Build an offset map for our log.
     compaction_config cfg(
-      model::offset{0}, ss::default_priority_class(), never_abort);
+      model::offset{0},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     simple_key_offset_map all_segs_map(50);
     auto map_start_offset = build_offset_map(
                               cfg,

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -108,6 +108,7 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
       /*gc_upper=*/model::timestamp::max(),
       /*max_bytes_in_log=*/1,
       /*max_collect_offset=*/model::offset::min(),
+      /*tombstone_retention_ms=*/std::nullopt,
       ss::default_priority_class(),
       as);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -674,6 +674,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
       model::to_timestamp(broker_t0 - (2 * broker_ts_sep)),
       std::nullopt,
       model::offset::min(), // should prevent compaction
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto before = disk_log->offsets();
@@ -688,6 +689,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
             model::to_timestamp(timestamp),
             std::nullopt,
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as);
       };
@@ -761,6 +763,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       model::timestamp::min(),
       total_size + first_size,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     compact_and_prefix_truncate(*disk_log, ccfg_no_compact);
@@ -790,6 +793,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       model::timestamp::min(),
       max_size,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     compact_and_prefix_truncate(*disk_log, ccfg);
@@ -860,6 +864,7 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       gc_ts,
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -969,6 +974,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
           model::timestamp::min(),
           1000,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         return log->housekeeping(ccfg);
@@ -1150,6 +1156,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       model::timestamp::min(),
       1,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
@@ -1311,6 +1318,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         log->flush().get0();
@@ -1376,6 +1384,7 @@ FIXTURE_TEST(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->flush().get0();
@@ -1562,6 +1571,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       model::timestamp::min(),
       50_KiB,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1681,6 +1691,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1749,6 +1760,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1823,6 +1835,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -2020,6 +2033,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     /**
@@ -2354,6 +2368,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -2595,6 +2610,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto before_compaction = compact_in_memory(log);
@@ -2836,6 +2852,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                              model::timestamp::min(),
                              std::nullopt,
                              model::offset::max(),
+                             std::nullopt,
                              ss::default_priority_class(),
                              as))
                            .handle_exception_type(
@@ -2927,6 +2944,7 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
               model::timestamp::min(),
               std::nullopt,
               model::offset::max(),
+              std::nullopt,
               ss::default_priority_class(),
               as))
             .get();
@@ -3060,6 +3078,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       max_compact_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(ccfg).get0();
@@ -3124,6 +3143,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto& segment = *(disk_log->segments().begin());
@@ -3178,6 +3198,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -3274,6 +3295,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset(args.max_compact_offs),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(ccfg).get0();
@@ -3545,6 +3567,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
             model::timestamp::min(),
             cfg.retention_bytes(),
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as));
 
@@ -3729,6 +3752,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
       model::timestamp::max(),
       1,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       abs};
 
@@ -4184,6 +4208,7 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       log->offsets().committed_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(h_cfg).get();
@@ -4387,6 +4412,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       log->offsets().committed_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(h_cfg).get();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4346,10 +4346,10 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
 
 FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
 #ifdef NDEBUG
-    size_t num_test_cases = 5000;
+    size_t num_test_cases = 1000;
     size_t num_segments = 300;
 #else
-    size_t num_test_cases = 500;
+    size_t num_test_cases = 100;
     size_t num_segments = 30;
 #endif
     // This test generates 300 segments and creates a record batch map.

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3196,6 +3196,8 @@ struct compact_test_args {
     long msg_per_segment;
     long segments;
     long expected_compacted_segments;
+    long num_expected_gaps;
+    bool keys_use_segment_id;
 };
 
 static void
@@ -3218,36 +3220,42 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
     auto disk_log = log;
 
-    auto append_batch =
-      [](ss::shared_ptr<storage::log> log, model::term_id term) {
-          iobuf key = bytes_to_iobuf(bytes("key"));
-          iobuf value = random_generators::make_iobuf(100);
+    auto append_batch = [](
+                          ss::shared_ptr<storage::log> log,
+                          model::term_id term,
+                          std::optional<int> segment_id = std::nullopt) {
+        const auto key_str = ssx::sformat("key{}", segment_id.value_or(-1));
+        iobuf key = bytes_to_iobuf(bytes(key_str.data()));
+        iobuf value = random_generators::make_iobuf(100);
 
-          storage::record_batch_builder builder(
-            model::record_batch_type::raft_data, model::offset(0));
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
 
-          builder.add_raw_kv(key.copy(), value.copy());
+        builder.add_raw_kv(key.copy(), value.copy());
 
-          auto batch = std::move(builder).build();
+        auto batch = std::move(builder).build();
 
-          batch.set_term(term);
-          batch.header().first_timestamp = model::timestamp::now();
-          auto reader = model::make_memory_record_batch_reader(
-            {std::move(batch)});
-          storage::log_append_config cfg{
-            .should_fsync = storage::log_append_config::fsync::no,
-            .io_priority = ss::default_priority_class(),
-            .timeout = model::no_timeout,
-          };
+        batch.set_term(term);
+        batch.header().first_timestamp = model::timestamp::now();
+        auto reader = model::make_memory_record_batch_reader(
+          {std::move(batch)});
+        storage::log_append_config cfg{
+          .should_fsync = storage::log_append_config::fsync::no,
+          .io_priority = ss::default_priority_class(),
+          .timeout = model::no_timeout,
+        };
 
-          std::move(reader)
-            .for_each_ref(log->make_appender(cfg), cfg.timeout)
-            .get();
-      };
+        std::move(reader)
+          .for_each_ref(log->make_appender(cfg), cfg.timeout)
+          .get();
+    };
 
     for (int s = 0; s < args.segments; s++) {
+        std::optional<int> key = args.keys_use_segment_id
+                                   ? s
+                                   : std::optional<int>{};
         for (int i = 0; i < args.msg_per_segment; i++) {
-            append_batch(log, model::term_id(0));
+            append_batch(log, model::term_id(0), key);
         }
         disk_log->force_roll(ss::default_priority_class()).get0();
     }
@@ -3275,9 +3283,11 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     BOOST_REQUIRE_EQUAL(
       final_stats.committed_offset, args.segments * args.msg_per_segment);
 
-    // we used the same key for all messages, so we should have one huge gap at
-    // the beginning of each compacted segment
-    BOOST_REQUIRE_EQUAL(final_gaps.num_gaps, args.expected_compacted_segments);
+    // If we used keys with segment IDs for records in each segment, we
+    // should have one huge gap at the beginning of each compacted segment.
+    // If we used the same key for each record, we should only expect one gap
+    // after compaction runs across the entire window of segments.
+    BOOST_REQUIRE_EQUAL(final_gaps.num_gaps, args.num_expected_gaps);
     BOOST_REQUIRE_EQUAL(final_gaps.first_gap_start, model::offset(0));
 
     // If adjacent segment compaction worked in order from oldest to newest, we
@@ -3303,7 +3313,9 @@ FIXTURE_TEST(test_max_compact_offset_mid_segment, storage_test_fixture) {
        .num_compactable_msg = 100,
        .msg_per_segment = 100,
        .segments = 3,
-       .expected_compacted_segments = 1},
+       .expected_compacted_segments = 1,
+       .num_expected_gaps = 1,
+       .keys_use_segment_id = false},
       *this);
 }
 
@@ -3316,7 +3328,25 @@ FIXTURE_TEST(test_max_compact_offset_unset, storage_test_fixture) {
        .num_compactable_msg = 200,
        .msg_per_segment = 100,
        .segments = 3,
-       .expected_compacted_segments = 3},
+       .expected_compacted_segments = 3,
+       .num_expected_gaps = 1,
+       .keys_use_segment_id = false},
+      *this);
+}
+
+FIXTURE_TEST(
+  test_max_compact_offset_unset_use_segment_ids, storage_test_fixture) {
+    // Use segment IDs for keys, thereby preventing compaction from reducing
+    // down to just one record in the last segment (each segment will have 1,
+    // unique record)
+    do_compact_test(
+      {.max_compact_offs = model::offset::max(),
+       .num_compactable_msg = 200,
+       .msg_per_segment = 100,
+       .segments = 3,
+       .expected_compacted_segments = 3,
+       .num_expected_gaps = 3,
+       .keys_use_segment_id = true},
       *this);
 }
 

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -119,7 +119,8 @@ ss::future<> disk_log_builder::truncate(model::offset o) {
 
 ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
-  std::optional<size_t> max_partition_retention_size) {
+  std::optional<size_t> max_partition_retention_size,
+  std::optional<std::chrono::milliseconds> tombstone_retention_ms) {
     ss::abort_source as;
     auto eviction_future = get_log()->monitor_eviction(as);
 
@@ -128,6 +129,7 @@ ss::future<> disk_log_builder::gc(
         collection_upper_bound,
         max_partition_retention_size,
         model::offset::max(),
+        tombstone_retention_ms,
         ss::default_priority_class(),
         _abort_source))
       .get();

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -304,7 +304,9 @@ public:
     ss::future<> truncate(model::offset);
     ss::future<> gc(
       model::timestamp collection_upper_bound,
-      std::optional<size_t> max_partition_retention_size);
+      std::optional<size_t> max_partition_retention_size,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms
+      = std::nullopt);
     ss::future<usage_report> disk_usage(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -197,9 +197,11 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
       "{{max_collectible_offset:{}, "
-      "should_sanitize:{}}}",
+      "should_sanitize:{}, "
+      "tombstone_retention_ms:{}}}",
       c.max_collectible_offset,
-      c.sanitizer_config);
+      c.sanitizer_config,
+      c.tombstone_retention_ms);
     return o;
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -465,6 +465,7 @@ struct gc_config {
 struct compaction_config {
     compaction_config(
       model::offset max_collect_offset,
+      std::optional<std::chrono::milliseconds> tombstone_ret_ms,
       ss::io_priority_class p,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
@@ -472,6 +473,7 @@ struct compaction_config {
       hash_key_offset_map* key_map = nullptr,
       scoped_file_tracker::set_t* to_clean = nullptr)
       : max_collectible_offset(max_collect_offset)
+      , tombstone_retention_ms(tombstone_ret_ms)
       , iopc(p)
       , sanitizer_config(std::move(san_cfg))
       , key_offset_map_max_keys(max_keys)
@@ -482,6 +484,18 @@ struct compaction_config {
     // Cannot delete or compact past this offset (i.e. for unresolved txn
     // records): that is, only offsets <= this may be compacted.
     model::offset max_collectible_offset;
+
+    // The retention time for tombstones. Tombstone removal occurs only for
+    // "clean" compacted segments past the tombstone deletion horizon timestamp,
+    // which is a segment's clean_compact_timestamp + tombstone_retention_ms.
+    // This means tombstones are only removed after the second time they are
+    // "seen" by compaction.
+    //
+    // Tombstone removal is only supported for topics with remote writes
+    // disabled. As a result, this field will only have a value for compaction
+    // ran on non-archival topics.
+    std::optional<std::chrono::milliseconds> tombstone_retention_ms;
+
     // priority for all IO in compaction
     ss::io_priority_class iopc;
     // use proxy fileops with assertions and/or failure injection
@@ -514,12 +528,19 @@ struct housekeeping_config {
       model::timestamp upper,
       std::optional<size_t> max_bytes_in_log,
       model::offset max_collect_offset,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms,
       ss::io_priority_class p,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
       hash_key_offset_map* key_map = nullptr)
       : compact(
-        max_collect_offset, p, as, std::move(san_cfg), std::nullopt, key_map)
+        max_collect_offset,
+        tombstone_retention_ms,
+        p,
+        as,
+        std::move(san_cfg),
+        std::nullopt,
+        key_map)
       , gc(upper, max_bytes_in_log) {}
 
     compaction_config compact;

--- a/src/v/utils/tristate.h
+++ b/src/v/utils/tristate.h
@@ -121,7 +121,7 @@ public:
             fmt::print(o, "{{{}}}", t.value());
             return o;
         }
-        return o << "{}";
+        return o << "{{nullopt}}";
     };
 
     std::optional<T>& get_optional() {

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -242,7 +242,10 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         assert configs is not None, "didn't find Configs: section"
 
         def maybe_int(key: str, value: str):
-            if key in ["retention_ms", "retention_bytes", 'segment_bytes']:
+            if key in [
+                    "retention_ms", "retention_bytes", 'segment_bytes',
+                    'tombstone_retention_ms'
+            ]:
                 return int(value)
             return value
 

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -39,6 +39,7 @@ class TopicSpec:
     PROPERTY_WRITE_CACHING = "write.caching"
     PROPERTY_FLUSH_MS = "flush.ms"
     PROPERTY_FLUSH_BYTES = "flush.bytes"
+    PROPERTY_TOMBSTONE_RETENTION_MS = "tombstone.retention.ms"
 
     class CompressionTypes(str, Enum):
         """
@@ -120,7 +121,8 @@ class TopicSpec:
         | None = None,
             initial_retention_local_target_bytes: int | None = None,
             initial_retention_local_target_ms: int | None = None,
-            virtual_cluster_id: str | None = None):
+            virtual_cluster_id: str | None = None,
+            tombstone_retention_ms: int | None = None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -146,6 +148,7 @@ class TopicSpec:
         self.initial_retention_local_target_bytes = initial_retention_local_target_bytes
         self.initial_retention_local_target_ms = initial_retention_local_target_ms
         self.virtual_cluster_id = virtual_cluster_id
+        self.tombstone_retention_ms = tombstone_retention_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -46,6 +46,8 @@ class AlterTopicConfiguration(RedpandaTest):
     @parametrize(property=TopicSpec.PROPERTY_RETENTION_TIME, value=360000)
     @parametrize(property=TopicSpec.PROPERTY_TIMESTAMP_TYPE,
                  value="LogAppendTime")
+    @parametrize(property=TopicSpec.PROPERTY_TOMBSTONE_RETENTION_MS,
+                 value=123456789)
     def test_altering_topic_configuration(self, property, value):
         topic = self.topics[0].name
         self.client().alter_topic_configs(topic, {property: value})
@@ -66,7 +68,8 @@ class AlterTopicConfiguration(RedpandaTest):
         kcl.raw_alter_topic_config(
             1, topic, {
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
-                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
+                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime",
+                TopicSpec.PROPERTY_TOMBSTONE_RETENTION_MS: 1234567890
             })
         kafka_tools = KafkaCliTools(self.redpanda)
         spec = kafka_tools.describe_topic(topic)
@@ -74,6 +77,7 @@ class AlterTopicConfiguration(RedpandaTest):
         assert spec.replication_factor == 3
         assert spec.retention_ms == 360000
         assert spec.message_timestamp_type == "LogAppendTime"
+        assert spec.tombstone_retention_ms == 1234567890
 
     @cluster(num_nodes=3)
     def test_altering_multiple_topic_configurations(self):
@@ -83,13 +87,15 @@ class AlterTopicConfiguration(RedpandaTest):
             topic, {
                 TopicSpec.PROPERTY_SEGMENT_SIZE: 1024 * 1024,
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
-                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
+                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime",
+                TopicSpec.PROPERTY_TOMBSTONE_RETENTION_MS: 1234567890
             })
         spec = kafka_tools.describe_topic(topic)
 
         assert spec.segment_bytes == 1024 * 1024
         assert spec.retention_ms == 360000
         assert spec.message_timestamp_type == "LogAppendTime"
+        assert spec.tombstone_retention_ms == 1234567890
 
     def random_string(self, size):
         return ''.join(

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -247,6 +247,13 @@ class DescribeTopicsTest(RedpandaTest):
                 "Max not flushed bytes per partition. If configured threshold is reached "
                 "log will automatically be flushed even though it wasn't explicitly "
                 "requested"),
+            "tombstone.retention.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                doc_string=
+                "The retention time for tombstone records in a compacted topic",
+                source_type="DYNAMIC_TOPIC_CONFIG"),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/tombstone_retention_ms_test.py
+++ b/tests/rptest/tests/tombstone_retention_ms_test.py
@@ -1,0 +1,96 @@
+import typing
+
+from ducktape.mark import matrix, defaults
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kafka_cli_consumer import KafkaCliConsumer
+
+from rptest.services.verifiable_consumer import VerifiableConsumer
+from rptest.services.verifiable_producer import VerifiableProducer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_exception
+
+
+class TombstoneRetentionMsTest(RedpandaTest):
+    def __init__(self, ctx):
+        self.ctx = ctx
+        super().__init__(ctx)
+
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_get_cluster_config(self):
+        # Default value
+        cluster_default = self.rpk.cluster_config_get('tombstone_retention_ms')
+        assert cluster_default == 'null'
+
+    @cluster(num_nodes=1)
+    def test_set_cluster_config(self):
+        self.rpk.cluster_config_set('tombstone_retention_ms', 1234567890)
+        cluster_prop = self.rpk.cluster_config_get('tombstone_retention_ms')
+        assert cluster_prop == "1234567890"
+
+        topic_name = "tapioca"
+        topic = TopicSpec(name=topic_name)
+        self.rpk.create_topic(topic_name, partitions=1)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['tombstone.retention.ms'][0] == '1234567890'
+
+    @cluster(num_nodes=1)
+    def test_alter_topic_config(self):
+        topic_name = "tapioca"
+        topic = TopicSpec(name=topic_name)
+        self.rpk.create_topic(topic_name, partitions=1)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+
+        # Default value
+        assert topic_desc['tombstone.retention.ms'][0] == '-1'
+
+        self.rpk.alter_topic_config(topic_name, 'tombstone.retention.ms',
+                                    1234567890)
+
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['tombstone.retention.ms'][0] == '1234567890'
+
+    @cluster(num_nodes=1)
+    @matrix(tombstone_retention_ms=[None, 1000],
+            cloud_storage_remote_read=[False, True],
+            cloud_storage_remote_write=[False, True])
+    def test_create_topic_configurations(self, tombstone_retention_ms,
+                                         cloud_storage_remote_read,
+                                         cloud_storage_remote_write):
+        topic_name = "tapioca"
+        #We cannot enable tombstone_retention_ms if any cloud storage properties are also enabled.
+        is_valid = False if any([
+            cloud_storage_remote_read, cloud_storage_remote_write
+        ]) and tombstone_retention_ms is not None else True
+        self.rpk.cluster_config_set('cloud_storage_enable_remote_read',
+                                    cloud_storage_remote_read)
+        self.rpk.cluster_config_set('cloud_storage_enable_remote_write',
+                                    cloud_storage_remote_write)
+
+        topic = TopicSpec(name=topic_name)
+        config = {}
+        if tombstone_retention_ms is not None:
+            config = {'tombstone.retention.ms': tombstone_retention_ms}
+        else:
+            tombstone_retention_ms = -1
+
+        if is_valid:
+            # Expect a successful topic creation.
+            self.rpk.create_topic(topic_name, partitions=1, config=config)
+            topic_desc = self.rpk.describe_topic_configs(topic_name)
+            print(topic_desc['tombstone.retention.ms'])
+            assert topic_desc['tombstone.retention.ms'][0] == str(
+                tombstone_retention_ms)
+            assert is_valid == True
+        else:
+            # Expect a failure due to misconfiguration.
+            with expect_exception(
+                    RpkException, lambda e:
+                    'Unsupported tombstone_retention_ms configuration, cannot be enabled at the same time as repanda.remote.read or redpanda.remote.write.'
+                    in str(e)):
+                self.rpk.create_topic(topic_name, partitions=1, config=config)

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -127,6 +127,10 @@ def read_topic_properties_serde(rdr: Reader, version):
             'remote_label': rdr.read_optional(read_remote_label_serde),
             'topic_namespace_override': rdr.read_optional(read_topic_namespace)
         }
+    if version >= 10:
+        topic_properties |= {
+            'tombstone_retention_ms': rdr.read_optional(Reader.read_int64)
+        }
 
     return topic_properties
 
@@ -142,7 +146,7 @@ def read_topic_config(rdr: Reader, version):
         'replication_factor':
         rdr.read_int16(),
         'properties':
-        rdr.read_envelope(read_topic_properties_serde, max_version=9),
+        rdr.read_envelope(read_topic_properties_serde, max_version=10),
     }
     if version < 1:
         # see https://github.com/redpanda-data/redpanda/pull/6613


### PR DESCRIPTION
WIP of support for Kafka's `delete_retention_ms` (more aptly named in `redpanda` as `tombstone_retention_ms` :100:) and tombstone removal.

Likely to be split up into several PRs in the future for ease of review. Some of the first few commits are clean-up for the current compaction implementation.

Many, many more fixture and ducktape tests to come.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
