### PR TITLE
bytes: replacement bytes implementation for libc++18

### DIFF
--- a/src/v/bytes/BUILD
+++ b/src/v/bytes/BUILD
@@ -37,7 +37,7 @@ redpanda_cc_library(
     deps = [
         ":iobuf",
         "//src/v/base",
-        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/container:inlined_vector",
         "@seastar",
     ],
 )

--- a/src/v/bytes/bytes.cc
+++ b/src/v/bytes/bytes.cc
@@ -28,9 +28,7 @@ std::ostream& operator<<(std::ostream& os, const bytes& b) {
     return os << bytes_view(b);
 }
 
-namespace std {
 std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
     fmt::print(os, "{{bytes:{}}}", b.size());
     return os;
 }
-} // namespace std

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -110,6 +110,8 @@ public:
         return a.data_ < b.data_;
     }
 
+    friend std::ostream& operator<<(std::ostream& os, const bytes& b);
+
 private:
     container_type data_;
 };
@@ -168,6 +170,8 @@ public:
           a.begin(), a.end(), b.begin(), b.end());
     }
 
+    friend std::ostream& operator<<(std::ostream& os, const bytes_view& b);
+
 private:
     explicit bytes_view(container_type data)
       : data_(data) {}
@@ -216,8 +220,6 @@ inline ss::sstring to_hex(const std::array<Char, Size>& data) {
     return to_hex(to_bytes_view(data));
 }
 
-std::ostream& operator<<(std::ostream& os, const bytes& b);
-
 inline bytes iobuf_to_bytes(const iobuf& in) {
     bytes out(bytes::initialized_later{}, in.size_bytes());
     {
@@ -257,12 +259,6 @@ struct hash<bytes> {
     size_t operator()(const bytes& v) const { return hash<bytes_view>()(v); }
 };
 } // namespace std
-
-// FIXME: remove overload from std::
-// NOLINTNEXTLINE(cert-dcl58-cpp)
-namespace std {
-std::ostream& operator<<(std::ostream& os, const bytes_view& b);
-}
 
 inline bool
 bytes_type_eq::operator()(const bytes& lhs, const bytes& rhs) const {

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -65,9 +65,6 @@ public:
     bytes(std::initializer_list<uint8_t> x)
       : data_(x) {}
 
-    bytes(const value_type* begin, const value_type* end)
-      : data_(begin, end) {}
-
     template<typename InputIterator>
     bytes(InputIterator begin, InputIterator end)
       : data_(begin, end) {}

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -40,6 +40,10 @@ public:
     using iterator = container_type::iterator;
     using const_iterator = container_type::const_iterator;
 
+    static bytes from_string(std::string_view s) {
+        return {s.begin(), s.end()};
+    }
+
     bytes() = default;
     bytes(const bytes&) = default;
     bytes& operator=(const bytes&) = default;
@@ -57,9 +61,6 @@ public:
 
     bytes(const value_type* data, size_t size)
       : data_(data, data + size) {}
-
-    bytes(const char* s)
-      : data_(s, s + strlen(s)) {}
 
     bytes(std::initializer_list<uint8_t> x)
       : data_(x) {}

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -16,22 +16,168 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <absl/hash/hash.h>
+#include <absl/container/inlined_vector.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <iosfwd>
 #include <span>
 
-// cannot be a `std::byte` because that's not sizeof(char)
-constexpr size_t bytes_inline_size = 31;
-using bytes = ss::basic_sstring<
-  uint8_t,  // Must be different from char to not leak to std::string_view
-  uint32_t, // size type - 4 bytes - 4GB max - don't use a size_t or any 64-bit
-  bytes_inline_size, // short string optimization size
-  false              // not null terminated
-  >;
+class bytes_view;
 
-using bytes_view = std::basic_string_view<uint8_t>;
+constexpr size_t bytes_inline_size = 31;
+
+class bytes {
+    using container_type = absl::InlinedVector<uint8_t, bytes_inline_size>;
+
+public:
+    using value_type = container_type::value_type;
+    using size_type = container_type::size_type;
+    using reference = container_type::reference;
+    using const_reference = container_type::const_reference;
+    using pointer = container_type::pointer;
+    using const_pointer = container_type::const_pointer;
+    using iterator = container_type::iterator;
+    using const_iterator = container_type::const_iterator;
+
+    bytes() = default;
+    bytes(const bytes&) = default;
+    bytes& operator=(const bytes&) = default;
+    bytes(bytes&&) noexcept = default;
+    bytes& operator=(bytes&&) noexcept = default;
+    ~bytes() = default;
+
+    struct initialized_later {};
+    bytes(initialized_later, size_t size)
+      : data_(size) {}
+
+    bytes(const value_type* data, size_t size)
+      : data_(data, data + size) {}
+
+    bytes(size_t size, value_type v)
+      : data_(size, v) {}
+
+    bytes(const char* s)
+      : data_(s, s + strlen(s)) {}
+
+    bytes(std::initializer_list<uint8_t> x)
+      : data_(x) {}
+
+    bytes(const value_type* begin, const value_type* end)
+      : data_(begin, end) {}
+
+    template<typename InputIterator>
+    bytes(InputIterator begin, InputIterator end)
+      : data_(begin, end) {}
+
+    explicit bytes(bytes_view);
+
+    reference operator[](size_type pos) noexcept { return data_[pos]; }
+    const_reference operator[](size_type pos) const noexcept {
+        return data_[pos];
+    }
+
+    pointer data() noexcept { return data_.data(); }
+    const_pointer data() const noexcept { return data_.data(); }
+
+    iterator begin() noexcept { return data_.begin(); }
+    const_iterator begin() const noexcept { return data_.begin(); }
+    const_iterator cbegin() const noexcept { return data_.cbegin(); }
+
+    iterator end() noexcept { return data_.end(); }
+    const_iterator end() const noexcept { return data_.end(); }
+    const_iterator cend() const noexcept { return data_.cend(); }
+
+    size_type size() const noexcept { return data_.size(); }
+    bool empty() const noexcept { return data_.empty(); }
+
+    void resize(size_type size) { data_.resize(size); }
+
+    void append(const_pointer p, size_t n) {
+        const auto prev_size = data_.size();
+        data_.resize(prev_size + n);
+        std::copy_n(p, n, data_.begin() + prev_size);
+    }
+
+    bytes& operator+=(const bytes& v) {
+        append(v.data(), v.size());
+        return *this;
+    }
+
+    friend bool operator==(const bytes&, const bytes&) = default;
+
+    friend bool operator<(const bytes& a, const bytes& b) {
+        return a.data_ < b.data_;
+    }
+
+private:
+    container_type data_;
+};
+
+class bytes_view {
+    using container_type = std::span<const uint8_t>;
+
+public:
+    using value_type = container_type::value_type;
+    using size_type = container_type::size_type;
+    using pointer = container_type::pointer;
+    using iterator = container_type::iterator;
+
+    bytes_view() = default;
+    bytes_view(const bytes_view&) = default;
+    bytes_view& operator=(const bytes_view&) = default;
+    bytes_view(bytes_view&&) noexcept = default;
+    bytes_view& operator=(bytes_view&&) noexcept = default;
+    ~bytes_view() = default;
+
+    bytes_view(const bytes& bytes)
+      : data_(bytes.begin(), bytes.end()) {}
+
+    bytes_view(const uint8_t* data, size_t size)
+      : data_(data, size) {}
+
+    pointer data() const noexcept { return data_.data(); }
+
+    iterator begin() const noexcept { return data_.begin(); }
+    iterator cbegin() const noexcept { return data_.begin(); }
+
+    iterator end() const noexcept { return data_.end(); }
+    iterator cend() const noexcept { return data_.end(); }
+
+    size_type size() const noexcept { return data_.size(); }
+    bool empty() const noexcept { return data_.empty(); }
+
+    const value_type& operator[](size_t pos) const noexcept {
+        return data_[pos];
+    }
+
+    bool starts_with(bytes_view v) const noexcept {
+        return size() >= v.size() && std::equal(v.begin(), v.end(), begin());
+    }
+
+    bytes_view substr(size_t offset) const {
+        return bytes_view(data_.subspan(offset));
+    }
+
+    friend bool operator==(const bytes_view& a, const bytes_view& b) {
+        return std::equal(a.begin(), a.end(), b.begin(), b.end());
+    }
+
+    friend bool operator<(const bytes_view& a, const bytes_view& b) {
+        return std::lexicographical_compare(
+          a.begin(), a.end(), b.begin(), b.end());
+    }
+
+private:
+    explicit bytes_view(container_type data)
+      : data_(data) {}
+
+    container_type data_;
+};
+
+inline bytes::bytes(bytes_view v)
+  : data_(v.begin(), v.end()) {}
+
 template<std::size_t Extent = std::dynamic_extent>
 using bytes_span = std::span<bytes::value_type, Extent>;
 
@@ -104,6 +250,11 @@ struct hash<bytes_view> {
           // NOLINTNEXTLINE
           {reinterpret_cast<const char*>(v.data()), v.size()});
     }
+};
+
+template<>
+struct hash<bytes> {
+    size_t operator()(const bytes& v) const { return hash<bytes_view>()(v); }
 };
 } // namespace std
 

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -98,6 +98,8 @@ public:
         std::copy_n(p, n, data_.begin() + prev_size);
     }
 
+    void push_back(value_type v) { data_.push_back(v); }
+
     friend bool operator==(const bytes&, const bytes&) = default;
 
     friend bool operator<(const bytes& a, const bytes& b) {

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -92,12 +92,6 @@ public:
 
     void resize(size_type size) { data_.resize(size); }
 
-    void append(const_pointer p, size_t n) {
-        const auto prev_size = data_.size();
-        data_.resize(prev_size + n);
-        std::copy_n(p, n, data_.begin() + prev_size);
-    }
-
     void push_back(value_type v) { data_.push_back(v); }
 
     friend bool operator==(const bytes&, const bytes&) = default;

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -101,11 +101,6 @@ public:
         std::copy_n(p, n, data_.begin() + prev_size);
     }
 
-    bytes& operator+=(const bytes& v) {
-        append(v.data(), v.size());
-        return *this;
-    }
-
     friend bool operator==(const bytes&, const bytes&) = default;
 
     friend bool operator<(const bytes& a, const bytes& b) {

--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -51,11 +51,12 @@ public:
     bytes(initialized_later, size_t size)
       : data_(size) {}
 
+    struct initialized_zero {};
+    bytes(initialized_zero, size_t size)
+      : data_(size, 0) {}
+
     bytes(const value_type* data, size_t size)
       : data_(data, data + size) {}
-
-    bytes(size_t size, value_type v)
-      : data_(size, v) {}
 
     bytes(const char* s)
       : data_(s, s + strlen(s)) {}

--- a/src/v/bytes/tests/bytes_tests.cc
+++ b/src/v/bytes/tests/bytes_tests.cc
@@ -29,3 +29,16 @@ SEASTAR_THREAD_TEST_CASE(test_xor) {
       data4,
       bytes(reinterpret_cast<const uint8_t*>(data3.data()), data3.size()));
 }
+
+SEASTAR_THREAD_TEST_CASE(bytes_lt) {
+    for (int a = 0; a <= 255; ++a) {
+        for (int b = 0; b <= 255; ++b) {
+            uint8_t real_a = a;
+            uint8_t real_b = b;
+            bytes bytes_a(&real_a, 1);
+            bytes bytes_b(&real_b, 1);
+            BOOST_REQUIRE_EQUAL(bytes_a < bytes_b, real_a < real_b);
+            BOOST_REQUIRE_EQUAL(bytes_a == bytes_b, real_a == real_b);
+        }
+    }
+}

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -45,7 +45,7 @@ FIXTURE_TEST(test_simple_token_request, fixture) {
     auto resp = cl.fetch_credentials().get0();
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
-      iobuf_to_bytes(std::get<iobuf>(resp)), cloud_role_tests::gcp_oauth_token);
+      iobuf_to_bytes(std::get<iobuf>(resp)), bytes::from_string(cloud_role_tests::gcp_oauth_token));
     BOOST_REQUIRE(has_call(cloud_role_tests::gcp_url));
 }
 
@@ -98,7 +98,7 @@ FIXTURE_TEST(test_aws_role_fetch_on_startup, fixture) {
 
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
-      iobuf_to_bytes(std::get<iobuf>(resp)), cloud_role_tests::aws_creds);
+      iobuf_to_bytes(std::get<iobuf>(resp)), bytes::from_string(cloud_role_tests::aws_creds));
 }
 
 FIXTURE_TEST(test_sts_credentials_fetch, fixture) {

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -45,7 +45,8 @@ FIXTURE_TEST(test_simple_token_request, fixture) {
     auto resp = cl.fetch_credentials().get0();
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
-      iobuf_to_bytes(std::get<iobuf>(resp)), bytes::from_string(cloud_role_tests::gcp_oauth_token));
+      iobuf_to_bytes(std::get<iobuf>(resp)),
+      bytes::from_string(cloud_role_tests::gcp_oauth_token));
     BOOST_REQUIRE(has_call(cloud_role_tests::gcp_url));
 }
 
@@ -98,7 +99,8 @@ FIXTURE_TEST(test_aws_role_fetch_on_startup, fixture) {
 
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
-      iobuf_to_bytes(std::get<iobuf>(resp)), bytes::from_string(cloud_role_tests::aws_creds));
+      iobuf_to_bytes(std::get<iobuf>(resp)),
+      bytes::from_string(cloud_role_tests::aws_creds));
 }
 
 FIXTURE_TEST(test_sts_credentials_fetch, fixture) {

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -1375,7 +1375,7 @@ TEST_P(all_types_remote_fixture, test_get_object) {
     ASSERT_EQ(last_request.url, "/" + url_base() + "p");
 
     ASSERT_TRUE(dl_res == download_result::success);
-    ASSERT_EQ(iobuf_to_bytes(buf), "p");
+    ASSERT_EQ(iobuf_to_bytes(buf), bytes::from_string("p"));
     ASSERT_TRUE(subscription.available());
     ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 }

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -234,7 +234,9 @@ ss::future<> bootstrap_backend::apply_cluster_uuid(model::cluster_uuid uuid) {
           storage.set_cluster_uuid(new_cluster_uuid);
       });
     co_await _storage.local().kvs().put(
-      cluster_uuid_key_space, bytes::from_string(cluster_uuid_key), serde::to_iobuf(uuid));
+      cluster_uuid_key_space,
+      bytes::from_string(cluster_uuid_key),
+      serde::to_iobuf(uuid));
     _cluster_uuid_applied = uuid;
     vlog(clusterlog.debug, "Cluster UUID initialized {}", uuid);
 }

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -234,7 +234,7 @@ ss::future<> bootstrap_backend::apply_cluster_uuid(model::cluster_uuid uuid) {
           storage.set_cluster_uuid(new_cluster_uuid);
       });
     co_await _storage.local().kvs().put(
-      cluster_uuid_key_space, cluster_uuid_key, serde::to_iobuf(uuid));
+      cluster_uuid_key_space, bytes::from_string(cluster_uuid_key), serde::to_iobuf(uuid));
     _cluster_uuid_applied = uuid;
     vlog(clusterlog.debug, "Cluster UUID initialized {}", uuid);
 }

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -93,7 +93,9 @@
 #include <optional>
 namespace cluster {
 
-const bytes controller::invariants_key{"configuration_invariants"};
+bytes controller::invariants_key() {
+    return bytes::from_string("configuration_invariants");
+}
 
 controller::controller(
   config_manager::preload_result&& config_preload,
@@ -582,7 +584,7 @@ ss::future<> controller::start(
           *config::node().node_id(), ss::smp::count);
         co_await _storage.local().kvs().put(
           storage::kvstore::key_space::controller,
-          invariants_key,
+          invariants_key(),
           reflection::to_iobuf(configuration_invariants{new_invariants}));
         conf_invariants = new_invariants;
         vlog(
@@ -1133,7 +1135,7 @@ controller::do_get_controller_partition_state(model::node_id target_node) {
 ss::future<configuration_invariants>
 controller::validate_configuration_invariants() {
     auto invariants_buf = _storage.local().kvs().get(
-      storage::kvstore::key_space::controller, invariants_key);
+      storage::kvstore::key_space::controller, invariants_key());
     vassert(
       config::node().node_id(),
       "Node id must be set before checking configuration invariants");
@@ -1145,7 +1147,7 @@ controller::validate_configuration_invariants() {
         // store configuration invariants
         co_await _storage.local().kvs().put(
           storage::kvstore::key_space::controller,
-          invariants_key,
+          invariants_key(),
           reflection::to_iobuf(configuration_invariants{current}));
         vlog(
           clusterlog.info,
@@ -1173,7 +1175,7 @@ controller::validate_configuration_invariants() {
         // the core count later decreases.
         co_await _storage.local().kvs().put(
           storage::kvstore::key_space::controller,
-          invariants_key,
+          invariants_key(),
           reflection::to_iobuf(configuration_invariants{current}));
         invariants = current;
         vlog(clusterlog.info, "updated configuration invariants: {}", current);

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -250,7 +250,7 @@ public:
     ss::future<result<partition_state_reply>>
     do_get_controller_partition_state(model::node_id id);
 
-    static const bytes invariants_key;
+    static bytes invariants_key();
 
 private:
     friend controller_probe;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1712,7 +1712,7 @@ ss::future<std::error_code> members_manager::update_node(model::broker broker) {
 
 ss::future<>
 members_manager::persist_members_in_kvstore(model::offset update_offset) {
-    static const bytes cluster_members_key("cluster_members");
+    static const auto cluster_members_key = bytes::from_string("cluster_members");
     auto current_members_snapshot = read_members_from_kvstore();
     if (current_members_snapshot.update_offset >= update_offset) {
         return ss::now();
@@ -1738,7 +1738,7 @@ members_manager::persist_members_in_kvstore(model::offset update_offset) {
 }
 
 members_manager::members_snapshot members_manager::read_members_from_kvstore() {
-    static const bytes cluster_members_key("cluster_members");
+    static const auto cluster_members_key = bytes::from_string("cluster_members");
     auto buffer = _storage.local().kvs().get(
       storage::kvstore::key_space::controller, cluster_members_key);
     if (buffer) {

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1712,7 +1712,8 @@ ss::future<std::error_code> members_manager::update_node(model::broker broker) {
 
 ss::future<>
 members_manager::persist_members_in_kvstore(model::offset update_offset) {
-    static const auto cluster_members_key = bytes::from_string("cluster_members");
+    static const auto cluster_members_key = bytes::from_string(
+      "cluster_members");
     auto current_members_snapshot = read_members_from_kvstore();
     if (current_members_snapshot.update_offset >= update_offset) {
         return ss::now();
@@ -1738,7 +1739,8 @@ members_manager::persist_members_in_kvstore(model::offset update_offset) {
 }
 
 members_manager::members_snapshot members_manager::read_members_from_kvstore() {
-    static const auto cluster_members_key = bytes::from_string("cluster_members");
+    static const auto cluster_members_key = bytes::from_string(
+      "cluster_members");
     auto buffer = _storage.local().kvs().get(
       storage::kvstore::key_space::controller, cluster_members_key);
     if (buffer) {

--- a/src/v/crypto/tests/hmac_tests.cc
+++ b/src/v/crypto/tests/hmac_tests.cc
@@ -27,7 +27,8 @@ static const absl::flat_hash_map<crypto::digest_type, size_t> expected_sizes = {
 
 TEST(crypto_hmac, length) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    bytes fake_key(16, 'k');
+    bytes fake_key(bytes::initialized_later{}, 16);
+    std::fill(fake_key.begin(), fake_key.end(), 'k');
     for (auto&& [k, v] : expected_sizes) {
         EXPECT_EQ(crypto::hmac_ctx::size(k), v)
           << "Mismatch on HMAC size for digest type " << k;

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -978,7 +978,7 @@ SEASTAR_THREAD_TEST_CASE(post_method) {
     auto response = client
                       ->post(
                         "/echo",
-                        bytes_to_iobuf(bytes(httpd_server_reply)),
+                        iobuf::from(httpd_server_reply),
                         http::content_type::json)
                       .get();
 

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -214,9 +214,8 @@ ss::future<> do_authenticate_scram512(
 ss::future<>
 do_authenticate_oauthbearer(shared_broker_t broker, ss::sstring token) {
     sasl_authenticate_request req;
-    req.data.auth_bytes = bytes::from_string("n,,\1auth=");
-    req.data.auth_bytes += bytes{token.cbegin(), token.cend()};
-    req.data.auth_bytes += bytes::from_string("\1\1");
+    req.data.auth_bytes = bytes::from_string(
+      fmt::format("n,,\1auth={}\1\1", token));
     auto res = co_await broker->dispatch(std::move(req));
     if (res.data.errored()) {
         throw broker_error{

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -164,7 +164,7 @@ static ss::future<> do_authenticate_scram(
      * send client final message
      */
     security::client_final_message client_final(
-      bytes("n,,"), server_first.nonce());
+      bytes::from_string("n,,"), server_first.nonce());
 
     auto salted_password = ScramAlgo::hi(
       bytes(password.cbegin(), password.cend()),
@@ -214,9 +214,9 @@ ss::future<> do_authenticate_scram512(
 ss::future<>
 do_authenticate_oauthbearer(shared_broker_t broker, ss::sstring token) {
     sasl_authenticate_request req;
-    req.data.auth_bytes = "n,,\1auth=";
+    req.data.auth_bytes = bytes::from_string("n,,\1auth=");
     req.data.auth_bytes += bytes{token.cbegin(), token.cend()};
-    req.data.auth_bytes += "\1\1";
+    req.data.auth_bytes += bytes::from_string("\1\1");
     auto res = co_await broker->dispatch(std::move(req));
     if (res.data.errored()) {
         throw broker_error{

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -64,7 +64,8 @@ static group get() {
 }
 
 static const std::vector<member_protocol> test_group_protos = {
-  {kafka::protocol_name("n0"), bytes::from_string("d0")}, {kafka::protocol_name("n1"), bytes::from_string("d1")}};
+  {kafka::protocol_name("n0"), bytes::from_string("d0")},
+  {kafka::protocol_name("n1"), bytes::from_string("d1")}};
 
 static member_ptr get_group_member(
   ss::sstring id = "m",
@@ -332,8 +333,10 @@ SEASTAR_THREAD_TEST_CASE(member_metadata) {
     for (auto& m : md) {
         conf[m.member_id] = m;
     }
-    BOOST_TEST(conf[kafka::member_id("m")].metadata == bytes::from_string("foo"));
-    BOOST_TEST(conf[kafka::member_id("n")].metadata == bytes::from_string("bar"));
+    BOOST_TEST(
+      conf[kafka::member_id("m")].metadata == bytes::from_string("foo"));
+    BOOST_TEST(
+      conf[kafka::member_id("n")].metadata == bytes::from_string("bar"));
 }
 
 SEASTAR_THREAD_TEST_CASE(select_protocol) {
@@ -430,7 +433,8 @@ SEASTAR_THREAD_TEST_CASE(supports_protocols) {
       std::chrono::seconds(1),
       std::chrono::seconds(3),
       kafka::protocol_type("p"),
-      chunked_vector<member_protocol>{{kafka::protocol_name("n2"), bytes::from_string("d0")}});
+      chunked_vector<member_protocol>{
+        {kafka::protocol_name("n2"), bytes::from_string("d0")}});
     (void)g.add_member(m2);
 
     // n2 is not supported bc the first member doesn't support it

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -64,7 +64,7 @@ static group get() {
 }
 
 static const std::vector<member_protocol> test_group_protos = {
-  {kafka::protocol_name("n0"), "d0"}, {kafka::protocol_name("n1"), "d1"}};
+  {kafka::protocol_name("n0"), bytes::from_string("d0")}, {kafka::protocol_name("n1"), bytes::from_string("d1")}};
 
 static member_ptr get_group_member(
   ss::sstring id = "m",
@@ -243,13 +243,13 @@ SEASTAR_THREAD_TEST_CASE(add_missing_assignments) {
     BOOST_TEST(a[kafka::member_id("n")] == bytes());
 
     a.clear();
-    a[kafka::member_id("m")] = bytes("d1");
-    a[kafka::member_id("o")] = bytes("d2");
+    a[kafka::member_id("m")] = bytes::from_string("d1");
+    a[kafka::member_id("o")] = bytes::from_string("d2");
     g.add_missing_assignments(a);
     BOOST_TEST(a.size() == 3);
-    BOOST_TEST(a[kafka::member_id("m")] == bytes("d1"));
+    BOOST_TEST(a[kafka::member_id("m")] == bytes::from_string("d1"));
     BOOST_TEST(a[kafka::member_id("n")] == bytes());
-    BOOST_TEST(a[kafka::member_id("o")] == bytes("d2"));
+    BOOST_TEST(a[kafka::member_id("o")] == bytes::from_string("d2"));
 }
 
 SEASTAR_THREAD_TEST_CASE(set_and_clear_assignments) {
@@ -264,12 +264,12 @@ SEASTAR_THREAD_TEST_CASE(set_and_clear_assignments) {
     BOOST_TEST(m2->assignment() == bytes());
 
     assignments_type a;
-    a[kafka::member_id("m")] = bytes("d1");
-    a[kafka::member_id("n")] = bytes("d2");
+    a[kafka::member_id("m")] = bytes::from_string("d1");
+    a[kafka::member_id("n")] = bytes::from_string("d2");
     g.set_assignments(a);
 
-    BOOST_TEST(m->assignment() == bytes("d1"));
-    BOOST_TEST(m2->assignment() == bytes("d2"));
+    BOOST_TEST(m->assignment() == bytes::from_string("d1"));
+    BOOST_TEST(m2->assignment() == bytes::from_string("d2"));
 
     g.clear_assignments();
     BOOST_TEST(m->assignment() == bytes());
@@ -311,12 +311,12 @@ SEASTAR_THREAD_TEST_CASE(member_metadata) {
 
     auto protos = std::vector<member_protocol>{
       {kafka::protocol_name("p0"), bytes()},
-      {kafka::protocol_name("p1"), bytes("foo")},
+      {kafka::protocol_name("p1"), bytes::from_string("foo")},
       {kafka::protocol_name("p2"), bytes()}};
     auto m0 = get_group_member("m", protos);
 
     protos = std::vector<member_protocol>{
-      {kafka::protocol_name("p1"), bytes("bar")},
+      {kafka::protocol_name("p1"), bytes::from_string("bar")},
       {kafka::protocol_name("p2"), bytes()},
       {kafka::protocol_name("p3"), bytes()}};
     auto m1 = get_group_member("n", protos);
@@ -332,8 +332,8 @@ SEASTAR_THREAD_TEST_CASE(member_metadata) {
     for (auto& m : md) {
         conf[m.member_id] = m;
     }
-    BOOST_TEST(conf[kafka::member_id("m")].metadata == bytes("foo"));
-    BOOST_TEST(conf[kafka::member_id("n")].metadata == bytes("bar"));
+    BOOST_TEST(conf[kafka::member_id("m")].metadata == bytes::from_string("foo"));
+    BOOST_TEST(conf[kafka::member_id("n")].metadata == bytes::from_string("bar"));
 }
 
 SEASTAR_THREAD_TEST_CASE(select_protocol) {
@@ -430,7 +430,7 @@ SEASTAR_THREAD_TEST_CASE(supports_protocols) {
       std::chrono::seconds(1),
       std::chrono::seconds(3),
       kafka::protocol_type("p"),
-      chunked_vector<member_protocol>{{kafka::protocol_name("n2"), "d0"}});
+      chunked_vector<member_protocol>{{kafka::protocol_name("n2"), bytes::from_string("d0")}});
     (void)g.add_member(m2);
 
     // n2 is not supported bc the first member doesn't support it

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -22,7 +22,7 @@
 namespace kafka {
 
 static const chunked_vector<member_protocol> test_protos = {
-  {kafka::protocol_name("n0"), "d0"}, {kafka::protocol_name("n1"), "d1"}};
+  {kafka::protocol_name("n0"), bytes::from_string("d0")}, {kafka::protocol_name("n1"), bytes::from_string("d1")}};
 
 static group_member get_member() {
     return group_member(
@@ -47,7 +47,7 @@ static join_group_response make_join_response() {
 }
 
 static sync_group_response make_sync_response() {
-    return sync_group_response(error_code::none, bytes("this is some bytes"));
+    return sync_group_response(error_code::none, bytes::from_string("this is some bytes"));
 }
 
 SEASTAR_THREAD_TEST_CASE(constructor) {
@@ -69,8 +69,8 @@ SEASTAR_THREAD_TEST_CASE(assignment) {
 
     BOOST_TEST(m.assignment() == bytes());
 
-    m.set_assignment(bytes("abc"));
-    BOOST_TEST(m.assignment() == bytes("abc"));
+    m.set_assignment(bytes::from_string("abc"));
+    BOOST_TEST(m.assignment() == bytes::from_string("abc"));
 
     m.clear_assignment();
     BOOST_TEST(m.assignment() == bytes());
@@ -166,7 +166,7 @@ SEASTAR_THREAD_TEST_CASE(output_stream) {
 SEASTAR_THREAD_TEST_CASE(member_serde) {
     // serialize a member's state to iobuf
     auto m0 = get_member();
-    m0.set_assignment(bytes("assignment"));
+    m0.set_assignment(bytes::from_string("assignment"));
     auto m0_state = m0.state().copy();
     iobuf m0_iobuf;
     auto writer = kafka::protocol::encoder(m0_iobuf);

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -22,7 +22,8 @@
 namespace kafka {
 
 static const chunked_vector<member_protocol> test_protos = {
-  {kafka::protocol_name("n0"), bytes::from_string("d0")}, {kafka::protocol_name("n1"), bytes::from_string("d1")}};
+  {kafka::protocol_name("n0"), bytes::from_string("d0")},
+  {kafka::protocol_name("n1"), bytes::from_string("d1")}};
 
 static group_member get_member() {
     return group_member(
@@ -47,7 +48,8 @@ static join_group_response make_join_response() {
 }
 
 static sync_group_response make_sync_response() {
-    return sync_group_response(error_code::none, bytes::from_string("this is some bytes"));
+    return sync_group_response(
+      error_code::none, bytes::from_string("this is some bytes"));
 }
 
 SEASTAR_THREAD_TEST_CASE(constructor) {

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -149,7 +149,7 @@ protected:
         BOOST_REQUIRE_GE(
           server_first.iterations(), security::scram_sha256::min_iterations);
         security::client_final_message client_final(
-          bytes("n,,"), server_first.nonce());
+          bytes::from_string("n,,"), server_first.nonce());
         auto salted_password = security::scram_sha256::hi(
           bytes(password.cbegin(), password.cend()),
           server_first.salt(),

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -23,12 +23,6 @@ static constexpr std::string_view period_key{"period"};
 static constexpr std::string_view max_duration_key{"max_duration"};
 static constexpr std::string_view buckets_key{"buckets"};
 
-static bytes key_to_bytes(std::string_view sv) {
-    bytes k;
-    k.append(reinterpret_cast<const uint8_t*>(sv.begin()), sv.size());
-    return k;
-}
-
 struct persisted_state {
     std::chrono::seconds configured_period;
     size_t configured_windows;
@@ -41,15 +35,15 @@ persist_to_disk(storage::kvstore& kvstore, persisted_state s) {
 
     co_await kvstore.put(
       kv_ks::usage,
-      key_to_bytes(period_key),
+      bytes::from_string(period_key),
       serde::to_iobuf(s.configured_period));
     co_await kvstore.put(
       kv_ks::usage,
-      key_to_bytes(max_duration_key),
+      bytes::from_string(max_duration_key),
       serde::to_iobuf(s.configured_windows));
     co_await kvstore.put(
       kv_ks::usage,
-      key_to_bytes(buckets_key),
+      bytes::from_string(buckets_key),
       serde::to_iobuf(std::move(s.current_state)));
 }
 
@@ -58,9 +52,9 @@ restore_from_disk(storage::kvstore& kvstore) {
     using kv_ks = storage::kvstore::key_space;
     std::optional<iobuf> period, windows, data;
     try {
-        period = kvstore.get(kv_ks::usage, key_to_bytes(period_key));
-        windows = kvstore.get(kv_ks::usage, key_to_bytes(max_duration_key));
-        data = kvstore.get(kv_ks::usage, key_to_bytes(buckets_key));
+        period = kvstore.get(kv_ks::usage, bytes::from_string(period_key));
+        windows = kvstore.get(kv_ks::usage, bytes::from_string(max_duration_key));
+        data = kvstore.get(kv_ks::usage, bytes::from_string(buckets_key));
     } catch (const std::exception& ex) {
         vlog(
           klog.debug,
@@ -89,9 +83,9 @@ restore_from_disk(storage::kvstore& kvstore) {
 static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
     using kv_ks = storage::kvstore::key_space;
     try {
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(period_key));
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(max_duration_key));
-        co_await kvstore.remove(kv_ks::usage, key_to_bytes(buckets_key));
+        co_await kvstore.remove(kv_ks::usage, bytes::from_string(period_key));
+        co_await kvstore.remove(kv_ks::usage, bytes::from_string(max_duration_key));
+        co_await kvstore.remove(kv_ks::usage, bytes::from_string(buckets_key));
     } catch (const std::exception& ex) {
         vlog(klog.debug, "Ignoring exception from storage layer: {}", ex);
     }

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -53,7 +53,8 @@ restore_from_disk(storage::kvstore& kvstore) {
     std::optional<iobuf> period, windows, data;
     try {
         period = kvstore.get(kv_ks::usage, bytes::from_string(period_key));
-        windows = kvstore.get(kv_ks::usage, bytes::from_string(max_duration_key));
+        windows = kvstore.get(
+          kv_ks::usage, bytes::from_string(max_duration_key));
         data = kvstore.get(kv_ks::usage, bytes::from_string(buckets_key));
     } catch (const std::exception& ex) {
         vlog(
@@ -84,7 +85,8 @@ static ss::future<> clear_persisted_state(storage::kvstore& kvstore) {
     using kv_ks = storage::kvstore::key_space;
     try {
         co_await kvstore.remove(kv_ks::usage, bytes::from_string(period_key));
-        co_await kvstore.remove(kv_ks::usage, bytes::from_string(max_duration_key));
+        co_await kvstore.remove(
+          kv_ks::usage, bytes::from_string(max_duration_key));
         co_await kvstore.remove(kv_ks::usage, bytes::from_string(buckets_key));
     } catch (const std::exception& ex) {
         vlog(klog.debug, "Ignoring exception from storage layer: {}", ex);

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -158,7 +158,7 @@ model::record_batch make_random_batch(record_batch_spec spec) {
         }
         if (spec.max_key_cardinality) {
             auto keystr = gen_alphanum_max_distinct(*spec.max_key_cardinality);
-            auto key = bytes_to_iobuf(keystr.c_str());
+            auto key = iobuf::from(keystr.c_str());
             rs.emplace_back(make_random_record(i, std::move(key)));
         } else {
             rs.emplace_back(make_random_record(i, sz));

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -216,11 +216,7 @@ kvstore_backed_stm_snapshot::kvstore_backed_stm_snapshot(
   , _kvstore(kvstore) {}
 
 bytes kvstore_backed_stm_snapshot::snapshot_key() const {
-    bytes k;
-    k.append(
-      reinterpret_cast<const uint8_t*>(_snapshot_key.begin()),
-      _snapshot_key.size());
-    return k;
+    return bytes::from_string(_snapshot_key);
 }
 
 const ss::sstring& kvstore_backed_stm_snapshot::name() { return _name; }
@@ -596,9 +592,7 @@ ss::future<> do_copy_persistent_stm_state(
   ss::sharded<storage::api>& api) {
     const auto key_as_str = raft::kvstore_backed_stm_snapshot::snapshot_key(
       snapshot_name, ntp);
-    bytes key;
-    key.append(
-      reinterpret_cast<const uint8_t*>(key_as_str.begin()), key_as_str.size());
+    auto key = bytes::from_string(key_as_str);
 
     auto snapshot = source_kvs.get(storage::kvstore::key_space::stms, key);
     if (snapshot) {
@@ -614,9 +608,7 @@ ss::future<> do_remove_persistent_stm_state(
   ss::sstring snapshot_name, model::ntp ntp, storage::kvstore& kvs) {
     const auto key_as_str = raft::kvstore_backed_stm_snapshot::snapshot_key(
       snapshot_name, ntp);
-    bytes key;
-    key.append(
-      reinterpret_cast<const uint8_t*>(key_as_str.begin()), key_as_str.size());
+    auto key = bytes::from_string(key_as_str);
     co_await kvs.remove(storage::kvstore::key_space::stms, key);
 }
 } // namespace raft

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -26,6 +26,8 @@
 #include "raft/recovery_memory_quota.h"
 #include "raft/state_machine_manager.h"
 #include "raft/types.h"
+#include "random/generators.h"
+#include "serde/rw/bytes.h"
 #include "ssx/sformat.h"
 #include "storage/api.h"
 #include "test_utils/test.h"

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -845,14 +845,14 @@ static json::validator make_broker_id_override_validator() {
 namespace {
 ss::future<> override_id_and_uuid(
   storage::kvstore& kvs, model::node_uuid uuid, model::node_id id) {
-    static const bytes node_uuid_key = "node_uuid";
+    static const auto node_uuid_key = bytes::from_string("node_uuid");
     co_await kvs.put(
       storage::kvstore::key_space::controller,
       node_uuid_key,
       serde::to_iobuf(uuid));
     auto invariants_iobuf = kvs.get(
       storage::kvstore::key_space::controller,
-      cluster::controller::invariants_key);
+      cluster::controller::invariants_key());
     if (invariants_iobuf) {
         auto invariants
           = reflection::from_iobuf<cluster::configuration_invariants>(
@@ -861,7 +861,7 @@ ss::future<> override_id_and_uuid(
 
         co_await kvs.put(
           storage::kvstore::key_space::controller,
-          cluster::controller::invariants_key,
+          cluster::controller::invariants_key(),
           reflection::to_iobuf(std::move(invariants)));
     }
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2507,7 +2507,7 @@ void application::start_bootstrap_services() {
     // Before we start up our bootstrapping RPC service, load any relevant
     // on-disk state we may need: existing cluster UUID, node ID, etc.
     if (std::optional<iobuf> cluster_uuid_buf = storage.local().kvs().get(
-          cluster::cluster_uuid_key_space, bytes(cluster::cluster_uuid_key));
+          cluster::cluster_uuid_key_space, bytes::from_string(cluster::cluster_uuid_key));
         cluster_uuid_buf) {
         const auto cluster_uuid = model::cluster_uuid{
           serde::from_iobuf<uuid_t>(std::move(*cluster_uuid_buf))};
@@ -2566,7 +2566,7 @@ void application::start_bootstrap_services() {
     auto configured_node_id = config::node().node_id();
     if (auto invariants_buf = storage.local().kvs().get(
           storage::kvstore::key_space::controller,
-          cluster::controller::invariants_key);
+          cluster::controller::invariants_key());
         invariants_buf) {
         auto invariants
           = reflection::from_iobuf<cluster::configuration_invariants>(
@@ -2589,7 +2589,7 @@ void application::start_bootstrap_services() {
 
     // Load the local node UUID, or create one if none exists.
     auto& kvs = storage.local().kvs();
-    static const bytes node_uuid_key = "node_uuid";
+    static const auto node_uuid_key = bytes::from_string("node_uuid");
     model::node_uuid node_uuid;
     auto node_uuid_buf = kvs.get(
       storage::kvstore::key_space::controller, node_uuid_key);
@@ -2674,7 +2674,7 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
                                  .kvs()
                                  .get(
                                    storage::kvstore::key_space::controller,
-                                   cluster::controller::invariants_key)
+                                   cluster::controller::invariants_key())
                                  .has_value();
 
     model::node_id node_id;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2507,7 +2507,8 @@ void application::start_bootstrap_services() {
     // Before we start up our bootstrapping RPC service, load any relevant
     // on-disk state we may need: existing cluster UUID, node ID, etc.
     if (std::optional<iobuf> cluster_uuid_buf = storage.local().kvs().get(
-          cluster::cluster_uuid_key_space, bytes::from_string(cluster::cluster_uuid_key));
+          cluster::cluster_uuid_key_space,
+          bytes::from_string(cluster::cluster_uuid_key));
         cluster_uuid_buf) {
         const auto cluster_uuid = model::cluster_uuid{
           serde::from_iobuf<uuid_t>(std::move(*cluster_uuid_buf))};

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -147,6 +147,7 @@ redpanda_cc_library(
         "//src/v/reflection:adl",
         "//src/v/security/audit:types",
         "//src/v/serde",
+        "//src/v/serde:bytes",
         "//src/v/serde:enum",
         "//src/v/serde:optional",
         "//src/v/ssx:future_util",

--- a/src/v/security/scram_credential.h
+++ b/src/v/security/scram_credential.h
@@ -13,6 +13,7 @@
 #include "reflection/adl.h"
 #include "security/acl.h"
 #include "serde/envelope.h"
+#include "serde/rw/bytes.h"
 
 #include <iosfwd>
 

--- a/src/v/security/tests/credential_store_test.cc
+++ b/src/v/security/tests/credential_store_test.cc
@@ -26,15 +26,15 @@ namespace security {
 
 BOOST_AUTO_TEST_CASE(credential_store_test) {
     const scram_credential cred0(
-      bytes("salty"),
-      bytes("i'm a server key"),
-      bytes("i'm the stored key"),
+      bytes::from_string("salty"),
+      bytes::from_string("i'm a server key"),
+      bytes::from_string("i'm the stored key"),
       123456);
 
     const scram_credential cred1(
-      bytes("salty2"),
-      bytes("i'm a server key2"),
-      bytes("i'm the stored key2"),
+      bytes::from_string("salty2"),
+      bytes::from_string("i'm a server key2"),
+      bytes::from_string("i'm the stored key2"),
       1234567);
 
     auto cred0_copy = cred0;
@@ -70,15 +70,15 @@ BOOST_AUTO_TEST_CASE(credential_store_test) {
 
 BOOST_AUTO_TEST_CASE(credential_store_test_principal) {
     const scram_credential cred0(
-      bytes("salty"),
-      bytes("i'm a server key"),
-      bytes("i'm the stored key"),
+      bytes::from_string("salty"),
+      bytes::from_string("i'm a server key"),
+      bytes::from_string("i'm the stored key"),
       123456);
 
     const scram_credential cred1(
-      bytes("salty2"),
-      bytes("i'm a server key2"),
-      bytes("i'm the stored key2"),
+      bytes::from_string("salty2"),
+      bytes::from_string("i'm a server key2"),
+      bytes::from_string("i'm the stored key2"),
       1234567,
       acl_principal{principal_type::ephemeral_user, "ephemeral"});
 

--- a/src/v/security/tests/scram_algorithm_test.cc
+++ b/src/v/security/tests/scram_algorithm_test.cc
@@ -65,8 +65,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Default format used by Kafka client: only user and nonce are
     // specified</kafka>
     {
-        client_first_message m(
-          bytes::from_string(ssx::sformat("n,,n=testuser,r={}", nonce).c_str()));
+        client_first_message m(bytes::from_string(
+          ssx::sformat("n,,n=testuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Username containing comma, encoded as =2C</kafka>
     {
-        client_first_message m(
-          bytes::from_string(ssx::sformat("n,,n=test=2Cuser,r={}", nonce).c_str()));
+        client_first_message m(bytes::from_string(
+          ssx::sformat("n,,n=test=2Cuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=2Cuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Username containing equals, encoded as =3D</kafka>
     {
-        client_first_message m(
-          bytes::from_string(ssx::sformat("n,,n=test=3Duser,r={}", nonce).c_str()));
+        client_first_message m(bytes::from_string(
+          ssx::sformat("n,,n=test=3Duser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=3Duser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -138,8 +138,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
 
     // <kafka>Invalid entry in gs2-header</kafka>
     BOOST_REQUIRE_EXCEPTION(
-      client_first_message(
-        bytes::from_string(ssx::sformat("n,x=something,n=testuser,r={}", nonce).c_str())),
+      client_first_message(bytes::from_string(
+        ssx::sformat("n,x=something,n=testuser,r={}", nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -204,9 +204,9 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
     // <kafka>Default format used by Kafka client: channel-binding, nonce and
     // proof are specified</kafka>
     {
-        client_final_message m(
-          bytes::from_string(ssx::sformat("c={},r={},p={}", channel_binding, nonce, proof)
-                  .c_str()));
+        client_final_message m(bytes::from_string(
+          ssx::sformat("c={},r={},p={}", channel_binding, nonce, proof)
+            .c_str()));
         BOOST_REQUIRE_EQUAL(
           base64_to_bytes(channel_binding), m.channel_binding());
         BOOST_REQUIRE_EQUAL(base64_to_bytes(proof), m.proof());
@@ -215,10 +215,10 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
 
     // <kafka>Optional extension specified</kafka>
     for (auto extension : valid_extensions()) {
-        client_final_message m(
-          bytes::from_string(ssx::sformat(
-                  "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
-                  .c_str()));
+        client_final_message m(bytes::from_string(
+          ssx::sformat(
+            "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
+            .c_str()));
         BOOST_REQUIRE_EQUAL(
           base64_to_bytes(channel_binding), m.channel_binding());
         BOOST_REQUIRE_EQUAL(base64_to_bytes(proof), m.proof());
@@ -238,8 +238,8 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
 
     // <kafka>Invalid channel binding</kafka>
     BOOST_REQUIRE_EXCEPTION(
-      client_final_message(
-        bytes::from_string(ssx::sformat("c=ab,r={},p={}", nonce, proof).c_str())),
+      client_final_message(bytes::from_string(
+        ssx::sformat("c=ab,r={},p={}", nonce, proof).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -249,8 +249,8 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
 
     // <kafka>Invalid proof</kafka>
     BOOST_REQUIRE_EXCEPTION(
-      client_final_message(
-        bytes::from_string(ssx::sformat("c={},r={},p=123", channel_binding, nonce).c_str())),
+      client_final_message(bytes::from_string(
+        ssx::sformat("c={},r={},p=123", channel_binding, nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(

--- a/src/v/security/tests/scram_algorithm_test.cc
+++ b/src/v/security/tests/scram_algorithm_test.cc
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // specified</kafka>
     {
         client_first_message m(
-          bytes(ssx::sformat("n,,n=testuser,r={}", nonce).c_str()));
+          bytes::from_string(ssx::sformat("n,,n=testuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Username containing comma, encoded as =2C</kafka>
     {
         client_first_message m(
-          bytes(ssx::sformat("n,,n=test=2Cuser,r={}", nonce).c_str()));
+          bytes::from_string(ssx::sformat("n,,n=test=2Cuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=2Cuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Username containing equals, encoded as =3D</kafka>
     {
         client_first_message m(
-          bytes(ssx::sformat("n,,n=test=3Duser,r={}", nonce).c_str()));
+          bytes::from_string(ssx::sformat("n,,n=test=3Duser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=3Duser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Optional authorization id specified</kafka>
     {
-        client_first_message m(bytes(
+        client_first_message m(bytes::from_string(
           ssx::sformat("n,a=testauthzid,n=testuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Optional reserved value specified</kafka>
     for (auto reserved : valid_reserved()) {
-        client_first_message m(bytes(
+        client_first_message m(bytes::from_string(
           ssx::sformat("n,,{},n=testuser,r={}", reserved, nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Optional extension specified</kafka>
     for (auto extension : valid_extensions()) {
-        client_first_message m(bytes(
+        client_first_message m(bytes::from_string(
           ssx::sformat("n,,n=testuser,r={},{}", nonce, extension).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>optional tokenauth specified as extensions</kafka>
     {
-        client_first_message m(bytes(
+        client_first_message m(bytes::from_string(
           ssx::sformat("n,,n=testuser,r={},tokenauth=true", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     // <kafka>Invalid entry in gs2-header</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_first_message(
-        bytes(ssx::sformat("n,x=something,n=testuser,r={}", nonce).c_str())),
+        bytes::from_string(ssx::sformat("n,x=something,n=testuser,r={}", nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     // <kafka>Invalid reserved entry</kafka>
     for (auto reserved : invalid_reserved()) {
         BOOST_REQUIRE_EXCEPTION(
-          client_first_message(bytes(
+          client_first_message(bytes::from_string(
             ssx::sformat("n,,{},n=testuser,r={}", reserved, nonce).c_str())),
           scram_exception,
           [](const scram_exception& e) {
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     // <kafka>Invalid extension</kafka>
     for (auto extension : invalid_extensions()) {
         BOOST_REQUIRE_EXCEPTION(
-          client_first_message(bytes(
+          client_first_message(bytes::from_string(
             ssx::sformat("n,,n=testuser,r={},{}", nonce, extension).c_str())),
           scram_exception,
           [](const scram_exception& e) {
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
     // proof are specified</kafka>
     {
         client_final_message m(
-          bytes(ssx::sformat("c={},r={},p={}", channel_binding, nonce, proof)
+          bytes::from_string(ssx::sformat("c={},r={},p={}", channel_binding, nonce, proof)
                   .c_str()));
         BOOST_REQUIRE_EQUAL(
           base64_to_bytes(channel_binding), m.channel_binding());
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
     // <kafka>Optional extension specified</kafka>
     for (auto extension : valid_extensions()) {
         client_final_message m(
-          bytes(ssx::sformat(
+          bytes::from_string(ssx::sformat(
                   "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
                   .c_str()));
         BOOST_REQUIRE_EQUAL(
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     // <kafka>Invalid channel binding</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_final_message(
-        bytes(ssx::sformat("c=ab,r={},p={}", nonce, proof).c_str())),
+        bytes::from_string(ssx::sformat("c=ab,r={},p={}", nonce, proof).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     // <kafka>Invalid proof</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_final_message(
-        bytes(ssx::sformat("c={},r={},p=123", channel_binding, nonce).c_str())),
+        bytes::from_string(ssx::sformat("c={},r={},p=123", channel_binding, nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     // <kafka>Invalid extensions</kafka>
     for (auto extension : invalid_extensions()) {
         BOOST_REQUIRE_EXCEPTION(
-          client_final_message(bytes(
+          client_final_message(bytes::from_string(
             ssx::sformat(
               "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
               .c_str())),

--- a/src/v/serde/BUILD
+++ b/src/v/serde/BUILD
@@ -216,3 +216,16 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "bytes",
+    hdrs = [
+        "rw/bytes.h",
+    ],
+    include_prefix = "serde",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":serde",
+        "//src/v/bytes",
+    ],
+)

--- a/src/v/serde/rw/bytes.h
+++ b/src/v/serde/rw/bytes.h
@@ -23,7 +23,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   bytes& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     bytes str(
       bytes::initialized_later{},
       read_nested<serde_size_t>(in, bytes_left_limit));

--- a/src/v/serde/rw/bytes.h
+++ b/src/v/serde/rw/bytes.h
@@ -1,0 +1,34 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "bytes/bytes.h"
+#include "serde/rw/rw.h"
+#include "serde/serde_size_t.h"
+
+namespace serde {
+
+inline void tag_invoke(tag_t<write_tag>, iobuf& out, bytes t) {
+    write<serde_size_t>(out, t.size());
+    out.append(t.data(), t.size());
+}
+
+inline void tag_invoke(
+  tag_t<read_tag>,
+  iobuf_parser& in,
+  bytes& t,
+  std::size_t const bytes_left_limit) {
+    bytes str(
+      bytes::initialized_later{},
+      read_nested<serde_size_t>(in, bytes_left_limit));
+    in.consume_to(str.size(), str.begin());
+    t = str;
+}
+
+} // namespace serde

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -13,6 +13,7 @@
 #include "serde/peek.h"
 #include "serde/rw/array.h"
 #include "serde/rw/bool_class.h"
+#include "serde/rw/bytes.h"
 #include "serde/rw/chrono.h"
 #include "serde/rw/enum.h"
 #include "serde/rw/envelope.h"

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -295,7 +295,7 @@ SEASTAR_THREAD_TEST_CASE(test_does_not_read_past_max_offset) {
 
 SEASTAR_THREAD_TEST_CASE(iobuf_is_zero_test) {
     const auto a = random_generators::gen_alphanum_string(1024);
-    const auto b = bytes("abc");
+    const auto b = bytes::from_string("abc");
     std::array<char, 1024> zeros{0};
     std::array<char, 1> one{1};
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1550,7 +1550,8 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     static constexpr size_t batch_size = 1_KiB; // Size visible to Kafka API
     static constexpr size_t input_batch_count = 100;
 
-    append_exactly(log, input_batch_count, batch_size, bytes::from_string("key"))
+    append_exactly(
+      log, input_batch_count, batch_size, bytes::from_string("key"))
       .get0(); // 100*1_KiB
 
     // Test becomes non-deterministic if we allow flush in background: flush

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1210,7 +1210,7 @@ void append_single_record_batch(
             val_bytes = random_generators::get_bytes(val_size);
         } else {
             ss::sstring v = ssx::sformat("v-{}", i);
-            val_bytes = bytes(v.c_str());
+            val_bytes = bytes::from_string(v.c_str());
         }
         iobuf value = bytes_to_iobuf(val_bytes);
         storage::record_batch_builder builder(
@@ -1550,7 +1550,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     static constexpr size_t batch_size = 1_KiB; // Size visible to Kafka API
     static constexpr size_t input_batch_count = 100;
 
-    append_exactly(log, input_batch_count, batch_size, "key")
+    append_exactly(log, input_batch_count, batch_size, bytes::from_string("key"))
       .get0(); // 100*1_KiB
 
     // Test becomes non-deterministic if we allow flush in background: flush

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -532,8 +532,8 @@ void append_custom_timestamp_batches(
   model::timestamp base_ts) {
     auto current_ts = base_ts;
     for (int i = 0; i < batch_count; ++i) {
-        iobuf key = bytes_to_iobuf(bytes("key"));
-        iobuf value = bytes_to_iobuf(bytes("v"));
+        iobuf key = iobuf::from("key");
+        iobuf value = iobuf::from("v");
 
         storage::record_batch_builder builder(
           model::record_batch_type::raft_data, model::offset(0));
@@ -568,8 +568,8 @@ FIXTURE_TEST(
                                          model::timestamp base_ts) {
         auto current_ts = base_ts;
 
-        iobuf key = bytes_to_iobuf(bytes("key"));
-        iobuf value = bytes_to_iobuf(bytes("v"));
+        iobuf key = iobuf::from("key");
+        iobuf value = iobuf::from("v");
 
         storage::record_batch_builder builder(
           model::record_batch_type::raft_data, model::offset(0));
@@ -1204,7 +1204,7 @@ void append_single_record_batch(
         } else {
             key_str = "key";
         }
-        iobuf key = bytes_to_iobuf(bytes(key_str.c_str()));
+        iobuf key = iobuf::from(key_str.c_str());
         bytes val_bytes;
         if (val_size > 0) {
             val_bytes = random_generators::get_bytes(val_size);
@@ -2331,7 +2331,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
                 } else {
                     key_str = "key";
                 }
-                iobuf key = bytes_to_iobuf(bytes(key_str.c_str()));
+                iobuf key = iobuf::from(key_str.c_str());
                 bytes val_bytes = random_generators::get_bytes(1024);
 
                 iobuf value = bytes_to_iobuf(val_bytes);
@@ -3246,7 +3246,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
                           model::term_id term,
                           std::optional<int> segment_id = std::nullopt) {
         const auto key_str = ssx::sformat("key{}", segment_id.value_or(-1));
-        iobuf key = bytes_to_iobuf(bytes(key_str.data()));
+        iobuf key = iobuf::from(key_str.data());
         iobuf value = random_generators::make_iobuf(100);
 
         storage::record_batch_builder builder(

--- a/src/v/utils/tests/base64_test.cc
+++ b/src/v/utils/tests/base64_test.cc
@@ -35,9 +35,9 @@ BOOST_AUTO_TEST_CASE(iobuf_type) {
         BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(input));
     };
 
-    encdec(bytes_to_iobuf(""), "");
-    encdec(bytes_to_iobuf("this is a string"), "dGhpcyBpcyBhIHN0cmluZw==");
-    encdec(bytes_to_iobuf("a"), "YQ==");
+    encdec(iobuf::from(""), "");
+    encdec(iobuf::from("this is a string"), "dGhpcyBpcyBhIHN0cmluZw==");
+    encdec(iobuf::from("a"), "YQ==");
 
     // test with multiple iobuf fragments
     iobuf buf;

--- a/src/v/utils/tests/base64_test.cc
+++ b/src/v/utils/tests/base64_test.cc
@@ -15,11 +15,11 @@
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE(bytes_type) {
-    auto encdec = [](const bytes& input, const auto expected) {
-        auto encoded = bytes_to_base64(input);
+    auto encdec = [](std::string_view input, std::string_view expected) {
+        auto encoded = bytes_to_base64(bytes::from_string(input));
         BOOST_REQUIRE_EQUAL(encoded, expected);
         auto decoded = base64_to_bytes(encoded);
-        BOOST_REQUIRE_EQUAL(decoded, input);
+        BOOST_REQUIRE_EQUAL(decoded, bytes::from_string(input));
     };
 
     encdec("", "");
@@ -66,9 +66,9 @@ BOOST_AUTO_TEST_CASE(test_base64_to_iobuf) {
 }
 
 BOOST_AUTO_TEST_CASE(base64_url_decode_test_basic) {
-    auto dec = [](std::string_view input, const bytes& expected) {
+    auto dec = [](std::string_view input, std::string_view expected) {
         auto decoded = base64url_to_bytes(input);
-        BOOST_REQUIRE_EQUAL(decoded, expected);
+        BOOST_REQUIRE_EQUAL(decoded, bytes::from_string(expected));
     };
 
     dec("UmVkcGFuZGEgUm9ja3M", "Redpanda Rocks");

--- a/src/v/wasm/ffi.cc
+++ b/src/v/wasm/ffi.cc
@@ -45,7 +45,7 @@ void sizer::append(int64_t v) { _offset += vint::vint_size(v); }
 void sizer::append_byte(uint8_t) { ++_offset; }
 
 writer::writer(array<uint8_t> buf)
-  : _tmp(vint::max_length, 0)
+  : _tmp(bytes::initialized_zero{}, vint::max_length)
   , _output(buf) {}
 
 void writer::append_with_length(const iobuf& b) {

--- a/src/v/wasm/parser/leb128.h
+++ b/src/v/wasm/parser/leb128.h
@@ -42,7 +42,7 @@ bytes encode(int_type value) {
             } else {
                 byte |= leading_bit_mask;
             }
-            output.append(&byte, 1);
+            output.push_back(byte);
         }
     } else {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
@@ -52,7 +52,7 @@ bytes encode(int_type value) {
             if (value != 0) {
                 byte |= leading_bit_mask;
             }
-            output.append(&byte, 1);
+            output.push_back(byte);
         } while (value != 0);
     }
 

--- a/src/v/wasm/parser/tests/leb128_test.cc
+++ b/src/v/wasm/parser/tests/leb128_test.cc
@@ -132,7 +132,8 @@ INSTANTIATE_TEST_SUITE_P(
   }));
 
 TEST(Overflow, Long) {
-    bytes encoded(size_t(11), 0xff);
+    bytes encoded(bytes::initialized_later{}, size_t(11));
+    std::fill(encoded.begin(), encoded.end(), 0xff);
     auto p = iobuf_parser(bytes_to_iobuf(encoded));
     EXPECT_THROW(decode<int64_t>(&p), decode_exception);
     p = iobuf_parser(bytes_to_iobuf(encoded));

--- a/src/v/wasm/parser/tests/parser_test.cc
+++ b/src/v/wasm/parser/tests/parser_test.cc
@@ -31,9 +31,7 @@ bytes wat2wasm(std::string_view wat) {
     wasm_byte_vec_new_empty(&wasm_bytes);
     wasmtime_error_t* error = wasmtime_wat2wasm(
       wat.data(), wat.size(), &wasm_bytes);
-    bytes b;
-    // NOLINTNEXTLINE(*-reinterpret-cast)
-    b.append(reinterpret_cast<uint8_t*>(wasm_bytes.data), wasm_bytes.size);
+    bytes b(reinterpret_cast<uint8_t*>(wasm_bytes.data), wasm_bytes.size);
     wasm_byte_vec_delete(&wasm_bytes);
     if (error != nullptr) {
         throw std::runtime_error("invalid wat");

--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -103,7 +103,8 @@ TEST_F(WasmTestFixture, SchemaRegistry) {
     auto records = transformed.copy_records();
     ASSERT_EQ(records.size(), 1);
     EXPECT_EQ(
-      iobuf_to_bytes(records[0].value()), bytes::from_string(R"JSON({"a":4,"b":"foo"})JSON"));
+      iobuf_to_bytes(records[0].value()),
+      bytes::from_string(R"JSON({"a":4,"b":"foo"})JSON"));
 }
 
 TEST_F(WasmTestFixture, MemoryIsLimited) {

--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -103,7 +103,7 @@ TEST_F(WasmTestFixture, SchemaRegistry) {
     auto records = transformed.copy_records();
     ASSERT_EQ(records.size(), 1);
     EXPECT_EQ(
-      iobuf_to_bytes(records[0].value()), R"JSON({"a":4,"b":"foo"})JSON");
+      iobuf_to_bytes(records[0].value()), bytes::from_string(R"JSON({"a":4,"b":"foo"})JSON"));
 }
 
 TEST_F(WasmTestFixture, MemoryIsLimited) {


### PR DESCRIPTION
libc++ >= v18 have deprecated (to be removed in v19) char_traits<T> for T other than char (and some other types, like wchar). our bytes implementation is uses T=uint8_t and because seastar::sstring interoperates with std::string/std::string_view, we encounter the deprecation.

this PR introduces a new bytes implementation that wraps a `seastar::sstring<char>`, and casts back and forth between pointers as needed at the interface level to provide the illusion of uint8_t storage.

after the conversion to sstring, we recognize that we now control the bytes interface, and use this to reduce the scope by, for example, removing the char* converting constructor, among a couple other interface clean-ups.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
