### PR TITLE
`misc`: update `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,6 +40,10 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 PenaltyBreakAssignment: 80
 PenaltyBreakBeforeFirstCallParameter: 10
 PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: [static, inline, const, type]
+ReferenceAlignment: Left
 RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: OuterScope
 ---

--- a/src/v/bytes/details/io_iterator_consumer.h
+++ b/src/v/bytes/details/io_iterator_consumer.h
@@ -51,7 +51,7 @@ public:
         const_iterator;
 
     io_iterator_consumer(
-      io_const_iterator const& begin, io_const_iterator const& end) noexcept
+      const io_const_iterator& begin, const io_const_iterator& end) noexcept
       : _frag(begin)
       , _frag_end(end) {
         if (_frag != _frag_end) {

--- a/src/v/bytes/details/io_placeholder.h
+++ b/src/v/bytes/details/io_placeholder.h
@@ -24,7 +24,7 @@ public:
     io_placeholder() noexcept = default;
 
     io_placeholder(
-      iterator const& iter, size_t initial_index, size_t max_size_to_write)
+      const iterator& iter, size_t initial_index, size_t max_size_to_write)
       : _iter(iter)
       , _byte_index(initial_index)
       , _remaining_size(max_size_to_write) {}

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -327,14 +327,14 @@ inline void iobuf::reserve_memory(size_t reservation) {
     }
 }
 
-[[gnu::always_inline]] void inline iobuf::prepend(
-  ss::temporary_buffer<char> b) {
+[[gnu::always_inline]] inline void
+iobuf::prepend(ss::temporary_buffer<char> b) {
     if (unlikely(!b.size())) {
         return;
     }
     prepend(std::make_unique<fragment>(std::move(b)));
 }
-[[gnu::always_inline]] void inline iobuf::prepend(iobuf b) {
+[[gnu::always_inline]] inline void iobuf::prepend(iobuf b) {
     oncore_debug_verify(_verify_shard);
     while (!b._frags.empty()) {
         b._frags.pop_back_and_dispose([this](fragment* f) {
@@ -344,13 +344,13 @@ inline void iobuf::reserve_memory(size_t reservation) {
     }
 }
 /// append src + len into storage
-[[gnu::always_inline]] void inline iobuf::append(
-  const uint8_t* src, size_t len) {
+[[gnu::always_inline]] inline void
+iobuf::append(const uint8_t* src, size_t len) {
     // NOLINTNEXTLINE
     append(reinterpret_cast<const char*>(src), len);
 }
 
-[[gnu::always_inline]] void inline iobuf::append(const char* ptr, size_t size) {
+[[gnu::always_inline]] inline void iobuf::append(const char* ptr, size_t size) {
     oncore_debug_verify(_verify_shard);
     if (unlikely(size == 0)) {
         return;

--- a/src/v/cloud_io/auth_refresh_bg_op.cc
+++ b/src/v/cloud_io/auth_refresh_bg_op.cc
@@ -62,12 +62,12 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
         try {
             auto region_name = ss::visit(
               _client_conf,
-              [](cloud_storage_clients::s3_configuration const& cfg) {
+              [](const cloud_storage_clients::s3_configuration& cfg) {
                   // S3 needs a region name to compose requests, this extracts
                   // it from s3_configuration
                   return cloud_roles::aws_region_name{cfg.region};
               },
-              [](cloud_storage_clients::abs_configuration const&) {
+              [](const cloud_storage_clients::abs_configuration&) {
                   // Azure Blob Storage does not need a region name to compose
                   // the requests, so this value is defaulted since it's ignored
                   // downstream
@@ -103,7 +103,7 @@ bool auth_refresh_bg_op::is_static_config() const {
 cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
     return ss::visit(
       _client_conf,
-      [](cloud_storage_clients::s3_configuration const& cfg)
+      [](const cloud_storage_clients::s3_configuration& cfg)
         -> cloud_roles::credentials {
           return cloud_roles::aws_credentials{
             cfg.access_key.value(),
@@ -111,7 +111,7 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
             std::nullopt,
             cfg.region};
       },
-      [](cloud_storage_clients::abs_configuration const& cfg)
+      [](const cloud_storage_clients::abs_configuration& cfg)
         -> cloud_roles::credentials {
           return cloud_roles::abs_credentials{
             cfg.storage_account_name, cfg.shared_key.value()};

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -14,7 +14,7 @@
 
 namespace cloud_roles {
 apply_abs_oauth_credentials::apply_abs_oauth_credentials(
-  abs_oauth_credentials const& credentials)
+  const abs_oauth_credentials& credentials)
   : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())}
   , _timesource{} {}
 

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.h
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.h
@@ -19,7 +19,7 @@ namespace cloud_roles {
 class apply_abs_oauth_credentials final : public apply_credentials::impl {
 public:
     explicit apply_abs_oauth_credentials(
-      abs_oauth_credentials const& credentials);
+      const abs_oauth_credentials& credentials);
 
     std::error_code
     add_auth(http::client::request_header& header) const override;

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -28,7 +28,7 @@ apply_credentials make_credentials_applier(credentials creds) {
       [](abs_credentials abs) -> std::unique_ptr<apply_credentials::impl> {
           return std::make_unique<apply_abs_credentials>(std::move(abs));
       },
-      [](abs_oauth_credentials const& abs_oauth)
+      [](const abs_oauth_credentials& abs_oauth)
         -> std::unique_ptr<apply_credentials::impl> {
           return std::make_unique<apply_abs_oauth_credentials>(abs_oauth);
       })};

--- a/src/v/cloud_roles/azure_aks_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.cc
@@ -193,7 +193,7 @@ api_response_parse_result azure_aks_refresh_impl::parse_response(iobuf resp) {
       [](auto err_resp) -> api_response_parse_result {
           return std::move(err_resp);
       },
-      [&](json::Document const& jresp) -> api_response_parse_result {
+      [&](const json::Document& jresp) -> api_response_parse_result {
           next_sleep_duration(
             std::chrono::seconds{jresp["expires_in"].GetInt()});
           auto& access_token = jresp["access_token"];

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -138,7 +138,7 @@ FIXTURE_TEST(test_sts_credentials_fetch, fixture) {
 
 class cloud_roles::aks_test_helper {
 public:
-    static auto get_address(azure_aks_refresh_impl const& aks) {
+    static auto get_address(const azure_aks_refresh_impl& aks) {
         return aks.address();
     }
 };

--- a/src/v/cloud_roles/tests/schema_parsing_tests.cc
+++ b/src/v/cloud_roles/tests/schema_parsing_tests.cc
@@ -44,15 +44,15 @@ BOOST_AUTO_TEST_CASE(schema_parsing_error) {
       parse_schema_fail));
 }
 
-auto to_str(cloud_roles::validate_and_parse_res const& val) {
+auto to_str(const cloud_roles::validate_and_parse_res& val) {
     return ss::visit(
       val,
-      [](json::Document const&) -> ss::sstring { return "json::Document"; },
-      [](cloud_roles::malformed_api_response_error const& mal) {
+      [](const json::Document&) -> ss::sstring { return "json::Document"; },
+      [](const cloud_roles::malformed_api_response_error& mal) {
           return ssx::sformat(
             "malformed_api_response_error: {}", mal.missing_fields);
       },
-      [](cloud_roles::api_response_parse_error const& pe) {
+      [](const cloud_roles::api_response_parse_error& pe) {
           return ssx::sformat("api_response_parse_error: {}", pe.reason);
       });
 }

--- a/src/v/cloud_roles/tests/signature_test.cc
+++ b/src/v/cloud_roles/tests/signature_test.cc
@@ -22,7 +22,7 @@
 #include <sstream>
 
 std::chrono::time_point<std::chrono::system_clock>
-parse_time(std::string const& timestr) {
+parse_time(const std::string& timestr) {
     std::tm tm = {};
     std::stringstream ss(timestr + "0");
     ss >> std::get_time(&tm, "%Y%m%dT%H%M%SZ%Z");

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -85,12 +85,12 @@ operator<<(std::ostream& os, const api_response_parse_error& err) {
 // tmp trick to ensure that we are not calling into infinite recursion if
 // there is a new credential but no operator<<
 template<std::same_as<credentials> Cred>
-std::ostream& operator<<(std::ostream& os, Cred const& c) {
-    ss::visit(c, [&os](auto const& creds) { os << creds; });
+std::ostream& operator<<(std::ostream& os, const Cred& c) {
+    ss::visit(c, [&os](const auto& creds) { os << creds; });
     return os;
 }
 
-template std::ostream& operator<<(std::ostream& os, credentials const& c);
+template std::ostream& operator<<(std::ostream& os, const credentials& c);
 
 bool is_retryable(const std::system_error& ec) {
     auto code = ec.code();

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -123,7 +123,7 @@ using credentials = std::variant<
 // tmp trick to ensure that we are not calling into infinite recursion if
 // there is a new credential but no operator<<
 template<std::same_as<credentials> Cred>
-std::ostream& operator<<(std::ostream& os, Cred const& c);
+std::ostream& operator<<(std::ostream& os, const Cred& c);
 
 using api_response_parse_result = std::variant<
   malformed_api_response_error,

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -37,7 +37,7 @@ template<class Key, class Value>
 void read_nested(
   iobuf_parser& in,
   btree_map<Key, Value>& btree,
-  size_t const bytes_left_limit) {
+  const size_t bytes_left_limit) {
     using serde::read_nested;
     uint64_t sz;
     read_nested(in, sz, bytes_left_limit);

--- a/src/v/cloud_storage/anomalies_detector.cc
+++ b/src/v/cloud_storage/anomalies_detector.cc
@@ -100,7 +100,7 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
         first_seg_previous_manifest = *manifest.begin();
     }
 
-    for (auto const& spill_path : spill_manifest_paths) {
+    for (const auto& spill_path : spill_manifest_paths) {
         if (should_stop()) {
             _result.status = scrub_status::partial;
             co_return _result;

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -736,7 +736,7 @@ async_manifest_view::get_term_last_offset(model::term_id term) noexcept {
         } else {
             // look for first segment in next term, segments are sorted by
             // base_offset and term
-            for (auto const& p : stmm) {
+            for (const auto& p : stmm) {
                 if (p.segment_term > term) {
                     co_return p.base_kafka_offset() - kafka::offset(1);
                 }

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1082,7 +1082,7 @@ rehash_object_name(const std::filesystem::path& p) {
     uint64_t hash = 0;
     try {
         hash = std::stoull(prefix.c_str(), 0, 16);
-    } catch (std::invalid_argument const&) {
+    } catch (const std::invalid_argument&) {
         // The first component of the name is not a hex integer
         return std::nullopt;
     }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -70,7 +70,7 @@ struct fmt::formatter<cloud_storage::partition_manifest::segment_meta> {
     }
 
     template<typename FormatContext>
-    auto format(segment_meta const& m, FormatContext& ctx) {
+    auto format(const segment_meta& m, FormatContext& ctx) {
         return fmt::format_to(
           ctx.out(),
           "{{o={}-{} t={}-{}}}",
@@ -2546,7 +2546,7 @@ struct partition_manifest_serde
 
 static_assert(
   std::tuple_size_v<
-    decltype(std::declval<partition_manifest const&>().serde_fields())>
+    decltype(std::declval<const partition_manifest&>().serde_fields())>
     == std::tuple_size_v<
       decltype(std::declval<partition_manifest&>().serde_fields())>,
   "ensure that serde_fields() and serde_fields() const capture the same "
@@ -2562,14 +2562,14 @@ static_assert(
 // construct partition_manifest_serde while keeping
 // std::is_aggregate<partition_manifest_serde> true
 static auto partition_manifest_serde_from_partition_manifest(
-  partition_manifest const& m) -> partition_manifest_serde {
+  const partition_manifest& m) -> partition_manifest_serde {
     partition_manifest_serde tmp{};
     // copy every field that is not segment_meta_cstore in
     // partition_manifest_serde, and uses to_iobuf for segment_meta_cstore
 
     []<typename DT, typename ST, size_t... Is>(
       DT dest_tuple, ST src_tuple, std::index_sequence<Is...>) {
-        (([&]<typename Src>(auto& dest, Src const& src) {
+        (([&]<typename Src>(auto& dest, const Src& src) {
              if constexpr (std::is_same_v<Src, segment_meta_cstore>) {
                  dest = src.to_iobuf();
              } else if constexpr (reflection::is_fragmented_vector<Src>) {

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -40,7 +40,7 @@ struct walk_accumulator {
       , dirlist({std::move(start_dir)})
       , filter(std::move(collect_filter)) {}
 
-    ss::future<> visit(ss::sstring const& target, ss::directory_entry entry) {
+    ss::future<> visit(const ss::sstring& target, ss::directory_entry entry) {
         auto entry_path = fmt::format("{}/{}", target, entry.name);
         if (entry.type && entry.type == ss::directory_entry_type::regular) {
             size_t file_size{0};

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -615,7 +615,7 @@ private:
                       // Special case, it can happen when a timequery falls
                       // below the clean offset. Caused when the query races
                       // with retention/gc.
-                      auto const& spillovers = _partition->_manifest_view
+                      const auto& spillovers = _partition->_manifest_view
                                                  ->stm_manifest()
                                                  .get_spillover_map();
 

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -199,24 +199,24 @@ class column_store
     // projections from segment_meta to value_t used by the columns. the order
     // is the same of columns()
     constexpr static auto segment_meta_accessors = std::tuple{
-      [](segment_meta const& s) {
+      [](const segment_meta& s) {
           return static_cast<int64_t>(s.is_compacted);
       },
-      [](segment_meta const& s) { return static_cast<int64_t>(s.size_bytes); },
-      [](segment_meta const& s) { return s.base_offset(); },
-      [](segment_meta const& s) { return s.committed_offset(); },
-      [](segment_meta const& s) { return s.base_timestamp(); },
-      [](segment_meta const& s) { return s.max_timestamp(); },
-      [](segment_meta const& s) { return s.delta_offset(); },
-      [](segment_meta const& s) { return s.ntp_revision(); },
-      [](segment_meta const& s) { return s.archiver_term(); },
-      [](segment_meta const& s) { return s.segment_term(); },
-      [](segment_meta const& s) { return s.delta_offset_end(); },
-      [](segment_meta const& s) {
+      [](const segment_meta& s) { return static_cast<int64_t>(s.size_bytes); },
+      [](const segment_meta& s) { return s.base_offset(); },
+      [](const segment_meta& s) { return s.committed_offset(); },
+      [](const segment_meta& s) { return s.base_timestamp(); },
+      [](const segment_meta& s) { return s.max_timestamp(); },
+      [](const segment_meta& s) { return s.delta_offset(); },
+      [](const segment_meta& s) { return s.ntp_revision(); },
+      [](const segment_meta& s) { return s.archiver_term(); },
+      [](const segment_meta& s) { return s.segment_term(); },
+      [](const segment_meta& s) { return s.delta_offset_end(); },
+      [](const segment_meta& s) {
           return static_cast<std::underlying_type_t<segment_name_format>>(
             s.sname_format);
       },
-      [](segment_meta const& s) {
+      [](const segment_meta& s) {
           return static_cast<int64_t>(s.metadata_size_hint);
       },
     };
@@ -733,7 +733,7 @@ public:
           [&](auto&... field) { (field_writer(field), ...); }, member_fields());
     }
 
-    void serde_read(iobuf_parser& in, serde::header const& h) {
+    void serde_read(iobuf_parser& in, const serde::header& h) {
         // hint_map_t (absl::btree_map) is not serde-enabled, read it as
         // size,[(key,value)...]
         auto field_reader = [&]<typename FieldType>(FieldType& f) {
@@ -775,7 +775,7 @@ public:
     auto unsafe_alias() const -> column_store {
         auto tmp = column_store{};
         details::tuple_map(
-          [](auto& lhs, auto const& rhs) { lhs = rhs.unsafe_alias(); },
+          [](auto& lhs, const auto& rhs) { lhs = rhs.unsafe_alias(); },
           tmp.columns(),
           columns());
         tmp._hints = _hints;
@@ -1062,7 +1062,7 @@ public:
         flush_write_buffer();
         serde::write(out, std::exchange(_col, {}));
     }
-    void serde_read(iobuf_parser& in, serde::header const& h) {
+    void serde_read(iobuf_parser& in, const serde::header& h) {
         if (h._bytes_left_limit == in.bytes_left()) {
             return;
         }
@@ -1116,7 +1116,7 @@ segment_meta_cstore&
 segment_meta_cstore::operator=(segment_meta_cstore&&) noexcept
   = default;
 
-bool segment_meta_cstore::operator==(segment_meta_cstore const& oth) const {
+bool segment_meta_cstore::operator==(const segment_meta_cstore& oth) const {
     if (size() != oth.size()) {
         return false;
     }
@@ -1178,7 +1178,7 @@ segment_meta_cstore::at_index(size_t ix) const {
     return const_iterator(_impl->at_index(ix));
 }
 
-auto segment_meta_cstore::prev(const_iterator const& it) const
+auto segment_meta_cstore::prev(const const_iterator& it) const
   -> const_iterator {
 #ifndef NDEBUG
     vassert(it != begin(), "prev called on a begin() iterator");

--- a/src/v/cloud_storage/segment_meta_cstore.h
+++ b/src/v/cloud_storage/segment_meta_cstore.h
@@ -99,7 +99,7 @@ public:
     segment_meta_cstore& operator=(segment_meta_cstore&&) noexcept;
     ~segment_meta_cstore();
 
-    bool operator==(segment_meta_cstore const& oth) const;
+    bool operator==(const segment_meta_cstore& oth) const;
     /// Return iterator
     const_iterator begin() const;
     const_iterator end() const;
@@ -123,7 +123,7 @@ public:
     const_iterator upper_bound(model::offset) const;
     const_iterator lower_bound(model::offset) const;
     const_iterator at_index(size_t ix) const;
-    const_iterator prev(const_iterator const& it) const;
+    const_iterator prev(const const_iterator& it) const;
 
     void insert(const segment_meta&);
 

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1764,7 +1764,7 @@ void reference_check_timequery(
  * does its own linear scan of segments, as a reference implementation
  * of timequery.
  */
-void scan_ts_segments_general(partition_manifest const& m) {
+void scan_ts_segments_general(const partition_manifest& m) {
     // Before range: should get first segment
     reference_check_timequery(
       m, model::timestamp{m.begin()->base_timestamp() - 100});
@@ -1785,7 +1785,7 @@ void scan_ts_segments_general(partition_manifest const& m) {
  * offset
  */
 void expect_ts_segment(
-  std::optional<partition_manifest::segment_meta> const& s, int base_offset) {
+  const std::optional<partition_manifest::segment_meta>& s, int base_offset) {
     BOOST_REQUIRE(s);
     BOOST_REQUIRE_EQUAL(s->base_offset, model::offset{base_offset});
 }
@@ -1794,7 +1794,7 @@ void expect_ts_segment(
  * For non-overlapping time ranges on segments, verify that each timestamp
  * maps to the expected segment.
  */
-void scan_ts_segments(partition_manifest const& m) {
+void scan_ts_segments(const partition_manifest& m) {
     // Before range: should get first segment
     expect_ts_segment(
       m.timequery(model::timestamp{m.begin()->base_timestamp() - 100}),

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -150,7 +150,7 @@ public:
     }
 
 private:
-    static void serialize(iobuf& buf, auto const& v) {
+    static void serialize(iobuf& buf, const auto& v) {
         auto tmp = std::bit_cast<std::array<uint8_t, sizeof(v)>>(v);
         buf.append(tmp.data(), tmp.size());
     }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
@@ -424,7 +424,7 @@ using cstore_operation = std::variant<
 // SIN SECTION
 // this is a sections of ODR sins to appease the daemons of the linker
 
-auto cloud_storage::operator<<(std::ostream& os, segment_meta const& s)
+auto cloud_storage::operator<<(std::ostream& os, const segment_meta& s)
   -> std::ostream& {
     return os << fmt::format(
              "{{is_compacted: {}, size_bytes: {}, base_offset: {}, "
@@ -447,7 +447,7 @@ auto cloud_storage::operator<<(std::ostream& os, segment_meta const& s)
              s.metadata_size_hint);
 }
 
-auto cloud_storage::operator<<(std::ostream& os, segment_name_format const& sn)
+auto cloud_storage::operator<<(std::ostream& os, const segment_name_format& sn)
   -> std::ostream& {
     return os << fmt::format("{}", unsigned(sn));
 }
@@ -457,7 +457,7 @@ auto cloud_storage::operator<<(std::ostream& os, segment_name_format const& sn)
 template<>
 struct fmt::formatter<cstore_operation>
   : public fmt::formatter<std::string_view> {
-    auto format(cstore_operation const& op, auto& ctx) const {
+    auto format(const cstore_operation& op, auto& ctx) const {
         auto f = [&] {
             return std::visit<std::string>(
               []<typename OP>(OP const& op) {

--- a/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_test.cc
@@ -326,14 +326,14 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_full) {
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_complete) {
     segment_meta_cstore store;
     auto manifest = generate_metadata(short_test_size);
-    for (auto const& sm : manifest) {
+    for (const auto& sm : manifest) {
         store.insert(sm);
     }
 
     store.prefix_truncate(model::offset::max());
     BOOST_REQUIRE(store.empty());
 
-    for (auto const& sm : manifest) {
+    for (const auto& sm : manifest) {
         store.insert(sm);
     }
     store.prefix_truncate(manifest.back().committed_offset + model::offset{1});
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_prefix_truncate_complete) {
 BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_serde_roundtrip) {
     segment_meta_cstore store{};
     auto manifest = generate_metadata(10007);
-    for (auto const& sm : manifest) {
+    for (const auto& sm : manifest) {
         store.insert(sm);
     }
     {
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(test_segment_meta_cstore_insert_replacements) {
       manifest.begin(),
       manifest.end(),
       false,
-      [&](bool generating_replacement, auto const& in) {
+      [&](bool generating_replacement, const auto& in) {
           if (generating_replacement) {
               if (random_generators::get_int(1) == 1) {
                   // absorb "in" and keep generating

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -58,7 +58,7 @@ struct topic_manifest_state
 
     auto serde_fields() { return std::tie(cfg, initial_revision); }
 
-    bool operator==(topic_manifest_state const&) const = default;
+    bool operator==(const topic_manifest_state&) const = default;
 };
 
 } // namespace

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -69,7 +69,7 @@ public:
     /// Change topic-manifest revision
     void set_revision(model::initial_revision_id id) noexcept { _rev = id; }
 
-    std::optional<cluster::topic_configuration> const&
+    const std::optional<cluster::topic_configuration>&
     get_topic_config() const noexcept {
         return _topic_config;
     }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -264,7 +264,7 @@ struct spillover_manifest_path_components
         return std::tie(base, last, base_kafka, next_kafka, base_ts, last_ts);
     }
 
-    bool operator==(spillover_manifest_path_components const&) const = default;
+    bool operator==(const spillover_manifest_path_components&) const = default;
 
     template<typename H>
     friend H AbslHashValue(H h, const spillover_manifest_path_components& c) {
@@ -303,7 +303,7 @@ struct anomaly_meta
     segment_meta at;
     std::optional<segment_meta> previous;
 
-    bool operator==(anomaly_meta const&) const = default;
+    bool operator==(const anomaly_meta&) const = default;
 
     auto serde_fields() { return std::tie(type, at, previous); }
 

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -178,8 +178,8 @@ abs_request_creator::abs_request_creator(
   , _apply_credentials{std::move(apply_credentials)} {}
 
 result<http::client::request_header> abs_request_creator::make_get_blob_request(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   std::optional<http_byte_range> byte_range) {
     // GET /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
@@ -210,7 +210,7 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
 }
 
 result<http::client::request_header> abs_request_creator::make_put_blob_request(
-  bucket_name const& name, object_key const& key, size_t payload_size_bytes) {
+  const bucket_name& name, const object_key& key, size_t payload_size_bytes) {
     // PUT /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -241,7 +241,7 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
 
 result<http::client::request_header>
 abs_request_creator::make_get_blob_metadata_request(
-  bucket_name const& name, object_key const& key) {
+  const bucket_name& name, const object_key& key) {
     // HEAD /{container-id}/{blob-id}?comp=metadata HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -266,7 +266,7 @@ abs_request_creator::make_get_blob_metadata_request(
 
 result<http::client::request_header>
 abs_request_creator::make_delete_blob_request(
-  bucket_name const& name, object_key const& key) {
+  const bucket_name& name, const object_key& key) {
     // DELETE /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -361,8 +361,8 @@ abs_request_creator::make_get_account_info_request() {
 
 result<http::client::request_header>
 abs_request_creator::make_set_expiry_to_blob_request(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   ss::lowres_clock::duration expires_in) const {
     // https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry?tabs=microsoft-entra-id
     // available only if HNS are enabled for the bucket
@@ -394,8 +394,8 @@ abs_request_creator::make_set_expiry_to_blob_request(
 result<http::client::request_header>
 abs_request_creator::make_delete_file_request(
   const access_point_uri& adls_ap,
-  bucket_name const& name,
-  object_key const& path) {
+  const bucket_name& name,
+  const object_key& path) {
     // DELETE /{container-id}/{path} HTTP/1.1
     // Host: {storage-account-id}.dfs.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
@@ -571,8 +571,8 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
 
 ss::future<result<http::client::response_stream_ref, error_outcome>>
 abs_client::get_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
   std::optional<http_byte_range> byte_range) {
@@ -584,8 +584,8 @@ abs_client::get_object(
 }
 
 ss::future<http::client::response_stream_ref> abs_client::do_get_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   ss::lowres_clock::duration timeout,
   bool expect_no_such_key,
   std::optional<http_byte_range> byte_range) {
@@ -638,8 +638,8 @@ ss::future<http::client::response_stream_ref> abs_client::do_get_object(
 
 ss::future<result<abs_client::no_response, error_outcome>>
 abs_client::put_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
@@ -654,8 +654,8 @@ abs_client::put_object(
 }
 
 ss::future<> abs_client::do_put_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   size_t payload_size,
   ss::input_stream<char> body,
   ss::lowres_clock::duration timeout,
@@ -694,15 +694,15 @@ ss::future<> abs_client::do_put_object(
 
 ss::future<result<abs_client::head_object_result, error_outcome>>
 abs_client::head_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   ss::lowres_clock::duration timeout) {
     return send_request(do_head_object(name, key, timeout), key);
 }
 
 ss::future<abs_client::head_object_result> abs_client::do_head_object(
-  bucket_name const& name,
-  object_key const& key,
+  const bucket_name& name,
+  const object_key& key,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_get_blob_metadata_request(name, key);
     if (!header) {
@@ -955,7 +955,7 @@ abs_client::do_test_set_expiry_on_dummy_file(
 
     co_await response_stream->prefetch_headers();
     vassert(response_stream->is_header_done(), "Header is not received");
-    auto const& headers = response_stream->get_headers();
+    const auto& headers = response_stream->get_headers();
 
     if (headers.result() == boost::beast::http::status::bad_request) {
         if (auto error_code_it = headers.find(error_code_name);

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -35,8 +35,8 @@ public:
     /// \param payload_size_bytes is a size of the object in bytes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_put_blob_request(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size_bytes);
 
     /// \brief Create a 'Get Blob' request header
@@ -45,8 +45,8 @@ public:
     /// \param key is the blob identifier
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_blob_request(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     /// \brief Create a 'Get Blob Metadata' request header
@@ -55,7 +55,7 @@ public:
     /// \param key is a blob name
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_blob_metadata_request(
-      bucket_name const& name, object_key const& key);
+      const bucket_name& name, const object_key& key);
 
     /// \brief Create a 'Delete Blob' request header
     ///
@@ -63,7 +63,7 @@ public:
     /// \param key is an blob name
     /// \return initialized and signed http header or error
     result<http::client::request_header>
-    make_delete_blob_request(bucket_name const& name, object_key const& key);
+    make_delete_blob_request(const bucket_name& name, const object_key& key);
 
     // clang-format off
     /// \brief Initialize http header for 'List Blobs' request
@@ -90,8 +90,8 @@ public:
     /// \brief Init http header for 'Set Expiry' request. the object will be
     /// expired in `expires_in` ms after the request is received
     result<http::client::request_header> make_set_expiry_to_blob_request(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration expires_in) const;
 
     /// \brief Create a 'Filesystem Delete' request header
@@ -103,8 +103,8 @@ public:
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_delete_file_request(
       const access_point_uri& adls_ap,
-      bucket_name const& name,
-      object_key const& path);
+      const bucket_name& name,
+      const object_key& path);
 
 private:
     access_point_uri _ap;
@@ -146,8 +146,8 @@ public:
     /// \return future that becomes ready after request was sent
     ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt) override;
@@ -158,8 +158,8 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     ss::future<result<head_object_result, error_outcome>> head_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
     /// Put blob to ABS container.
@@ -170,8 +170,8 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the upload is completed
     ss::future<result<no_response, error_outcome>> put_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
@@ -240,7 +240,7 @@ public:
     /// \param key is the path to be deleted
     /// \param timeout is a timeout of the operation
     ss::future<result<no_response, error_outcome>> delete_path(
-      bucket_name const& name,
+      const bucket_name& name,
       object_key path,
       ss::lowres_clock::duration timeout);
 
@@ -252,23 +252,23 @@ private:
       std::optional<op_type_tag> op_type = std::nullopt);
 
     ss::future<http::client::response_stream_ref> do_get_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
       bool accept_no_content = false);
 
     ss::future<head_object_result> do_head_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<> do_delete_object(
@@ -296,7 +296,7 @@ private:
     do_test_set_expiry_on_dummy_file(ss::lowres_clock::duration timeout);
 
     ss::future<> do_delete_path(
-      bucket_name const& name,
+      const bucket_name& name,
       object_key path,
       ss::lowres_clock::duration timeout);
 

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -49,8 +49,8 @@ public:
     /// \return future that becomes ready after request was sent
     virtual ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt)
@@ -68,8 +68,8 @@ public:
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the request is completed
     virtual ss::future<result<head_object_result, error_outcome>> head_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout)
       = 0;
 
@@ -83,8 +83,8 @@ public:
     /// \param accept_no_content accepts a 204 response as valid
     /// \return future that becomes ready when the upload is completed
     virtual ss::future<result<no_response, error_outcome>> put_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -49,8 +49,8 @@ public:
     /// \param payload_size_bytes is a size of the object in bytes
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_unsigned_put_object_request(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size_bytes);
 
     /// \brief Create a 'GetObject' request header
@@ -60,8 +60,8 @@ public:
     /// \param key is an object name
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_object_request(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     /// \brief Create a 'HeadObject' request header
@@ -70,7 +70,7 @@ public:
     /// \param key is an object name
     /// \return initialized and signed http header or error
     result<http::client::request_header>
-    make_head_object_request(bucket_name const& name, object_key const& key);
+    make_head_object_request(const bucket_name& name, const object_key& key);
 
     /// \brief Create a 'DeleteObject' request header
     ///
@@ -78,7 +78,7 @@ public:
     /// \param key is an object name
     /// \return initialized and signed http header or error
     result<http::client::request_header>
-    make_delete_object_request(bucket_name const& name, object_key const& key);
+    make_delete_object_request(const bucket_name& name, const object_key& key);
 
     /// \brief Create a 'DeleteObjects' request header and body
     ///
@@ -87,7 +87,7 @@ public:
     /// \return the header and an the body as an input_stream
     result<std::tuple<http::client::request_header, ss::input_stream<char>>>
     make_delete_objects_request(
-      bucket_name const& name, std::span<const object_key> keys);
+      const bucket_name& name, std::span<const object_key> keys);
 
     /// \brief Initialize http header for 'ListObjectsV2' request
     ///
@@ -152,8 +152,8 @@ public:
     /// \return future that gets ready after request was sent
     ss::future<result<http::client::response_stream_ref, error_outcome>>
     get_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt) override;
@@ -163,8 +163,8 @@ public:
     /// \param key is an id of the object
     /// \return future that becomes ready when the request is completed
     ss::future<result<head_object_result, error_outcome>> head_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout) override;
 
     /// Put object to S3 bucket.
@@ -174,8 +174,8 @@ public:
     /// \param body is an input_stream that can be used to read body
     /// \return future that becomes ready when the upload is completed
     ss::future<result<no_response, error_outcome>> put_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
@@ -203,20 +203,20 @@ public:
 
 private:
     ss::future<head_object_result> do_head_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout);
 
     ss::future<http::client::response_stream_ref> do_get_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
       std::optional<http_byte_range> byte_range = std::nullopt);
 
     ss::future<> do_put_object(
-      bucket_name const& name,
-      object_key const& key,
+      const bucket_name& name,
+      const object_key& key,
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -195,7 +195,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
               keys.begin(),
               keys.end(),
               std::back_inserter(out),
-              [](auto const& ks) {
+              [](const auto& ks) {
                   return cloud_storage_clients::object_key(ks);
               });
             return out;

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -137,7 +137,7 @@ template<>
 struct fmt::formatter<
   cloud_storage_clients::client::delete_objects_result::key_reason>
   : public fmt::formatter<std::string_view> {
-    auto format(auto const& kr, auto& ctx) const {
+    auto format(const auto& kr, auto& ctx) const {
         return formatter<std::string_view>::format(
           fmt::format(R"kr(key:"{}" reason:"{}")kr", kr.key, kr.reason), ctx);
     }
@@ -200,7 +200,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
               keys.begin(),
               keys.end(),
               std::back_inserter(out),
-              [](auto const& ks) {
+              [](const auto& ks) {
                   return cloud_storage_clients::object_key(ks);
               });
             return out;

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -246,7 +246,7 @@ void set_routes(ss::httpd::routes& r) {
 
               // partially validate the request xml and construct the response
               // with the provided keys
-              for (auto const& [tag, value] : req_root.get_child("Delete")) {
+              for (const auto& [tag, value] : req_root.get_child("Delete")) {
                   if (tag == "Quiet") {
                       continue;
                   }
@@ -711,7 +711,7 @@ SEASTAR_TEST_CASE(test_delete_objects_errors) {
           result.value().undeleted_keys.begin(),
           result.value().undeleted_keys.end(),
           std::back_inserter(u_keys),
-          [](auto const& kr) { return kr.key; });
+          [](const auto& kr) { return kr.key; });
         std::sort(u_keys.begin(), u_keys.end());
         BOOST_REQUIRE(
           std::equal(keys.begin(), keys.end(), u_keys.begin(), u_keys.end()));

--- a/src/v/cluster/archival/purger.cc
+++ b/src/v/cluster/archival/purger.cc
@@ -323,7 +323,7 @@ purger::global_position purger::get_global_position() {
     uint32_t total = 0;
 
     // Iterate over node IDs earlier than ours, sum their core counts
-    for (auto const& [id, node] : nodes) {
+    for (const auto& [id, node] : nodes) {
         const auto cores = node.broker.properties().cores;
         if (id < self) {
             result += cores;

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -353,7 +353,7 @@ FIXTURE_TEST(
 
     auto upload_in_term
       = uploader.upload_until_term_change().handle_exception_type(
-        [](seastar::abort_requested_exception const& e) { std::ignore = e; });
+        [](const seastar::abort_requested_exception& e) { std::ignore = e; });
     // Wait for some valid metadata to show up.
     cluster::cloud_metadata::cluster_metadata_manifest manifest;
     RPTEST_REQUIRE_EVENTUALLY(5s, [this, &manifest] {

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -59,7 +59,7 @@ public:
       ss::sharded<ss::abort_source>&);
 
     // Preload early in startup, from bootstrap file or config cache
-    static ss::future<preload_result> preload(YAML::Node const&);
+    static ss::future<preload_result> preload(const YAML::Node&);
 
     // Preload while joining the cluster, from a controller snapshot sent
     // in response to a join request.
@@ -82,7 +82,7 @@ public:
         std::vector<ss::sstring> invalid;
     };
 
-    status_map const& get_status() const { return status; }
+    const status_map& get_status() const { return status; }
 
     status_map get_projected_status() const;
 
@@ -102,13 +102,13 @@ public:
 private:
     void merge_apply_result(
       config_status&,
-      cluster_config_delta_cmd_data const&,
-      apply_result const&);
+      const cluster_config_delta_cmd_data&,
+      const apply_result&);
 
     bool should_send_status();
     ss::future<> reconcile_status();
     ss::future<std::error_code> apply_delta(cluster_config_delta_cmd&&);
-    ss::future<> store_delta(cluster_config_delta_cmd_data const& data);
+    ss::future<> store_delta(const cluster_config_delta_cmd_data& data);
 
     bool _bootstrap_complete{false};
     void start_bootstrap();
@@ -116,7 +116,7 @@ private:
 
     static ss::future<preload_result> load_cache();
     static ss::future<bool> load_bootstrap();
-    static ss::future<> load_legacy(YAML::Node const&);
+    static ss::future<> load_legacy(const YAML::Node&);
 
     ss::future<std::error_code> apply_status(cluster_config_status_cmd&& cmd);
 

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -671,7 +671,7 @@ controller_backend::calculate_learner_initial_offset(
         return std::nullopt;
     }
 
-    auto const cloud_storage_safe_offset
+    const auto cloud_storage_safe_offset
       = p->archival_meta_stm()->max_collectible_offset();
     /**
      * Last offset uploaded to the cloud is target learner retention upper
@@ -896,9 +896,9 @@ ss::future<> controller_backend::try_reconcile_ntp(
                     last_error = errc::partition_operation_failed;
                 }
             }
-        } catch (ss::gate_closed_exception const&) {
+        } catch (const ss::gate_closed_exception&) {
             break;
-        } catch (ss::abort_requested_exception const&) {
+        } catch (const ss::abort_requested_exception&) {
             break;
         } catch (...) {
             vlog(

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -139,7 +139,7 @@ void controller_probe::setup_metrics() {
                       return int64_t{0};
                   }
 
-                  auto const& manifest = maybe_manifest_ref.value().get();
+                  const auto& manifest = maybe_manifest_ref.value().get();
                   if (manifest.upload_time_since_epoch == 0ms) {
                       // we never uploaded, so let's return a value that is not
                       // problematic to the aggregation of this metric

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -54,7 +54,7 @@ concept Reservable = requires(T t) { t.reserve(0U); };
 
 template<typename Vec>
 ss::future<Vec>
-read_vector_async_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
+read_vector_async_nested(iobuf_parser& in, const std::size_t bytes_left_limit) {
     using value_type = typename Vec::value_type;
     const auto size = serde::read_nested<serde::serde_size_t>(
       in, bytes_left_limit);
@@ -78,7 +78,7 @@ read_vector_async_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
 
 template<typename Map>
 ss::future<Map>
-read_map_async_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
+read_map_async_nested(iobuf_parser& in, const std::size_t bytes_left_limit) {
     using key_type = typename Map::key_type;
     using mapped_type = typename Map::mapped_type;
     const auto size = serde::read_nested<serde::serde_size_t>(
@@ -113,7 +113,7 @@ ss::future<> topics_t::topic_t::serde_async_write(iobuf& out) {
 }
 
 ss::future<>
-topics_t::topic_t::serde_async_read(iobuf_parser& in, serde::header const h) {
+topics_t::topic_t::serde_async_read(iobuf_parser& in, const serde::header h) {
     metadata = serde::read_nested<decltype(metadata)>(in, h._bytes_left_limit);
     partitions = co_await read_map_async_nested<decltype(partitions)>(
       in, h._bytes_left_limit);
@@ -137,7 +137,7 @@ ss::future<> topics_t::serde_async_write(iobuf& out) {
 }
 
 ss::future<>
-topics_t::serde_async_read(iobuf_parser& in, serde::header const h) {
+topics_t::serde_async_read(iobuf_parser& in, const serde::header h) {
     topics = co_await read_map_async_nested<decltype(topics)>(
       in, h._bytes_left_limit);
     highest_group_id = serde::read_nested<decltype(highest_group_id)>(
@@ -164,7 +164,7 @@ ss::future<> security_t::serde_async_write(iobuf& out) {
 }
 
 ss::future<>
-security_t::serde_async_read(iobuf_parser& in, serde::header const h) {
+security_t::serde_async_read(iobuf_parser& in, const serde::header h) {
     user_credentials
       = co_await read_vector_async_nested<decltype(user_credentials)>(
         in, h._bytes_left_limit);
@@ -197,7 +197,7 @@ ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
 }
 
 ss::future<>
-controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
+controller_snapshot::serde_async_read(iobuf_parser& in, const serde::header h) {
     bootstrap = co_await serde::read_async_nested<decltype(bootstrap)>(
       in, h._bytes_left_limit);
     features = co_await serde::read_async_nested<decltype(features)>(

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -178,7 +178,7 @@ struct topics_t
         friend bool operator==(const topic_t&, const topic_t&) = default;
 
         ss::future<> serde_async_write(iobuf&);
-        ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+        ss::future<> serde_async_read(iobuf_parser&, const serde::header);
     };
 
     chunked_hash_map<model::topic_namespace, topic_t> topics;
@@ -196,7 +196,7 @@ struct topics_t
     friend bool operator==(const topics_t&, const topics_t&) = default;
 
     ss::future<> serde_async_write(iobuf&);
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 };
 
 struct named_role_t
@@ -224,7 +224,7 @@ struct security_t
     friend bool operator==(const security_t&, const security_t&) = default;
 
     ss::future<> serde_async_write(iobuf&);
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 };
 
 struct metrics_reporter_t
@@ -313,7 +313,7 @@ struct controller_snapshot
       = default;
 
     ss::future<> serde_async_write(iobuf&);
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 };
 
 /// A subset of the controller snapshot used to initialize nodes joining

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -247,8 +247,8 @@ migrations_table::validate_migrated_resources(
 
 ss::future<std::error_code>
 migrations_table::apply(update_data_migration_state_cmd cmd) {
-    auto const id = cmd.value.id;
-    auto const requested_state = cmd.value.requested_state;
+    const auto id = cmd.value.id;
+    const auto requested_state = cmd.value.requested_state;
     vlog(
       dm_log.debug,
       "applying update data migration {} state to {}",

--- a/src/v/cluster/ephemeral_credential_frontend.cc
+++ b/src/v/cluster/ephemeral_credential_frontend.cc
@@ -40,7 +40,7 @@ constexpr auto timeout = 5s;
 using scram = security::scram_sha512_authenticator::auth::scram;
 
 security::ephemeral_credential
-make_ephemeral_credential(security::acl_principal const& principal) {
+make_ephemeral_credential(const security::acl_principal& principal) {
     constexpr auto gen = []() {
         return random_generators::gen_alphanum_string(credential_length);
     };
@@ -52,7 +52,7 @@ make_ephemeral_credential(security::acl_principal const& principal) {
 }
 
 security::scram_credential
-make_scram_credential(security::ephemeral_credential const& cred) {
+make_scram_credential(const security::ephemeral_credential& cred) {
     return scram::make_credentials(
       cred.principal(), cred.password(), scram::min_iterations);
 }
@@ -75,7 +75,7 @@ ephemeral_credential_frontend::ephemeral_credential_frontend(
   , _gate{} {}
 
 ss::future<ephemeral_credential_frontend::get_return>
-ephemeral_credential_frontend::get(security::acl_principal const& principal) {
+ephemeral_credential_frontend::get(const security::acl_principal& principal) {
     auto guard = _gate.hold();
     get_return res;
 
@@ -124,7 +124,7 @@ ephemeral_credential_frontend::put(security::ephemeral_credential cred) {
 }
 
 ss::future<std::error_code> ephemeral_credential_frontend::inform(
-  model::node_id node_id, security::acl_principal const& principal) {
+  model::node_id node_id, const security::acl_principal& principal) {
     auto guard = _gate.hold();
 
     auto e_cred_res = co_await get(principal);

--- a/src/v/cluster/ephemeral_credential_frontend.h
+++ b/src/v/cluster/ephemeral_credential_frontend.h
@@ -47,7 +47,7 @@ public:
         security::ephemeral_credential credential;
         std::error_code err{errc::success};
     };
-    ss::future<get_return> get(security::acl_principal const&);
+    ss::future<get_return> get(const security::acl_principal&);
 
     // Insert or update a scram_credential
     ss::future<> put(
@@ -60,7 +60,7 @@ public:
 
     // Inform a node of the credential for the given principal
     ss::future<std::error_code>
-    inform(model::node_id, security::acl_principal const&);
+    inform(model::node_id, const security::acl_principal&);
 
 private:
     model::node_id _self;

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -168,7 +168,7 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
                           return ss::do_until(
                             [this] { return _as.local().abort_requested(); },
                             [this] { return maybe_update_feature_table(); });
-                      }).handle_exception([](std::exception_ptr const& e) {
+                      }).handle_exception([](const std::exception_ptr& e) {
         vlog(clusterlog.warn, "Exception from updater: {}", e);
     });
 

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -314,7 +314,7 @@ health_monitor_backend::get_cluster_disk_health(
 ss::future<std::error_code>
 health_monitor_backend::maybe_refresh_cluster_health(
   force_refresh refresh, model::timeout_clock::time_point deadline) {
-    auto const need_refresh = refresh
+    const auto need_refresh = refresh
                               || _last_refresh + max_metadata_age()
                                    < ss::lowres_clock::now();
 

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1090,7 +1090,7 @@ members_manager::get_or_assign_node_id(const model::node_uuid& node_uuid) {
 
 ss::future<result<join_node_reply>>
 members_manager::dispatch_join_to_seed_server(
-  seed_iterator it, join_node_request const& req) {
+  seed_iterator it, const join_node_request& req) {
     using ret_t = result<join_node_reply>;
     auto f = ss::make_ready_future<ret_t>(errc::seed_servers_exhausted);
     if (it == std::cend(_seed_servers)) {
@@ -1237,7 +1237,7 @@ static bool contains_address(
 }
 
 ss::future<result<join_node_reply>>
-members_manager::handle_join_request(join_node_request const req) {
+members_manager::handle_join_request(const join_node_request req) {
     using ret_t = result<join_node_reply>;
     using status_t = join_node_reply::status_code;
 

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -149,7 +149,7 @@ public:
     // controller command to register the requested node UUID, responding with
     // a newly assigned node ID.
     ss::future<result<join_node_reply>>
-    handle_join_request(join_node_request const r);
+    handle_join_request(const join_node_request r);
 
     // Applies a committed record batch, specializing handling based on the
     // batch type.
@@ -214,7 +214,7 @@ private:
     bool try_register_node_id(const model::node_id&, const model::node_uuid&);
 
     ss::future<result<join_node_reply>> dispatch_join_to_seed_server(
-      seed_iterator it, join_node_request const& req);
+      seed_iterator it, const join_node_request& req);
     ss::future<result<join_node_reply>> dispatch_join_to_remote(
       const config::seed_server&, join_node_request&& req);
 

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -242,7 +242,7 @@ metrics_reporter::build_metrics_snapshot() {
 
     snapshot.has_kafka_gssapi = absl::c_any_of(
       config::shard_local_cfg().sasl_mechanisms(),
-      [](auto const& mech) { return mech == "GSSAPI"; });
+      [](const auto& mech) { return mech == "GSSAPI"; });
 
     snapshot.has_oidc = config::oidc_is_enabled_kafka()
                         || config::oidc_is_enabled_http();

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -38,7 +38,7 @@ public:
     local_monitor(const local_monitor&) = delete;
     local_monitor(local_monitor&&) = default;
     ~local_monitor() = default;
-    local_monitor& operator=(local_monitor const&) = delete;
+    local_monitor& operator=(const local_monitor&) = delete;
     local_monitor& operator=(local_monitor&&) = delete;
 
     ss::future<> start();

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -747,7 +747,7 @@ uint64_t partition::non_log_disk_size_bytes() const {
     _raft->stm_manager()->for_each_stm(
       [this, &stm_local_size](
         const ss::sstring& name, const raft::state_machine_base& stm) {
-          auto const sz = stm.get_local_state_size();
+          const auto sz = stm.get_local_state_size();
           vlog(
             clusterlog.trace,
             "local non-log disk size of {} stm {} = {} bytes",

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -238,7 +238,7 @@ void partition_balancer_backend::on_topic_table_update() {
 }
 
 void partition_balancer_backend::on_health_monitor_update(
-  node_health_report const& report,
+  const node_health_report& report,
   std::optional<ss::lw_shared_ptr<const node_health_report>> old_report) {
     if (!old_report) {
         vlog(
@@ -356,7 +356,7 @@ ss::future<> partition_balancer_backend::do_tick() {
       = (100 - _storage_space_alert_free_threshold_percent()) / 100.0;
     // claim node unresponsive it doesn't responded to at least 7
     // status requests by default 700ms
-    auto const node_responsiveness_timeout = _node_status_interval() * 7;
+    const auto node_responsiveness_timeout = _node_status_interval() * 7;
 
     partition_balancer_planner planner(
       planner_config{

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -82,7 +82,7 @@ private:
     void on_members_update(model::node_id, model::membership_state);
     void on_topic_table_update();
     void on_health_monitor_update(
-      node_health_report const&,
+      const node_health_report&,
       std::optional<ss::lw_shared_ptr<const node_health_report>>);
     size_t get_min_partition_size_threshold() const;
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -295,7 +295,7 @@ void partition_balancer_planner::init_per_node_state(
   const cluster_health_report& health_report,
   request_context& ctx,
   plan_data& result) {
-    auto const now = rpc::clock_type::now();
+    const auto now = rpc::clock_type::now();
     for (const auto& [id, broker] : _state.members().nodes()) {
         if (
           broker.state.get_membership_state()

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1824,7 +1824,7 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
         model::offset last = model::offset::min();
         fragmented_vector<tx::tx_range> aborted_ranges;
 
-        for (auto const& entry : _aborted_tx_state.aborted) {
+        for (const auto& entry : _aborted_tx_state.aborted) {
             first = std::min(first, entry.first);
             last = std::max(last, entry.last);
             aborted_ranges.push_back(entry);

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -94,7 +94,7 @@ distinct_labels_preferred(const char* label_name, Mapper&& mapper) {
             std::optional<T> prev_label;
 
             for (auto& r : partition.replicas()) {
-                auto const l = _mapper(r.node_id);
+                const auto l = _mapper(r.node_id);
                 if (!l) {
                     continue;
                 }

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -108,7 +108,7 @@ allocation_constraints partition_allocator::default_constraints() {
  * with partitions that cannot be re-accommodated on smaller peers).
  */
 std::error_code partition_allocator::check_cluster_limits(
-  allocation_request const& request) const {
+  const allocation_request& request) const {
     if (_members.local().nodes().empty()) {
         // Empty members table, we're probably running in a unit test
         return errc::success;

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -138,7 +138,7 @@ public:
 
 private:
     std::error_code
-    check_cluster_limits(allocation_request const& request) const;
+    check_cluster_limits(const allocation_request& request) const;
 
     result<reallocation_step> do_allocate_replica(
       allocated_partition&,

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -388,7 +388,7 @@ security_frontend::get_bootstrap_user_creds_from_env() {
     return std::optional<user_and_credential>(
       std::in_place,
       security::credential_user{parts[0]},
-      ss::visit(scram, [&](auto const& scram) {
+      ss::visit(scram, [&](const auto& scram) {
           using scram_t = std::decay_t<decltype(scram)>;
           return scram_t::make_credentials(
             ss::sstring{parts[1]}, scram_t::min_iterations);

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -80,7 +80,7 @@ private:
     do_start_test(start_test_request r);
 
     struct previous_netcheck_entity {
-        static const inline model::node_id unassigned{-1};
+        static inline const model::node_id unassigned{-1};
         model::node_id source{unassigned};
         ss::lowres_clock::time_point last_request{ss::lowres_clock::now()};
     };

--- a/src/v/cluster/tests/plugin_table_test.cc
+++ b/src/v/cluster/tests/plugin_table_test.cc
@@ -161,8 +161,8 @@ TEST(PluginTable, Notifications) {
 }
 
 TEST(PluginTable, TopicIndexes) {
-    const static std::optional<meta> missing = std::nullopt;
-    const static std::optional<id> missing_id = std::nullopt;
+    static const std::optional<meta> missing = std::nullopt;
+    static const std::optional<id> missing_id = std::nullopt;
     cluster::plugin_table table;
 
     auto millwheel = make_meta(

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -224,8 +224,8 @@ private:
                       ntp,
                       res.error());
                 }
-            } catch (ss::gate_closed_exception const&) {
-            } catch (ss::abort_requested_exception const&) {
+            } catch (const ss::gate_closed_exception&) {
+            } catch (const ss::abort_requested_exception&) {
             } catch (...) {
                 vlog(
                   _logger.warn,

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -863,7 +863,7 @@ tm_stm_factory::tm_stm_factory(
   : _feature_table(feature_table) {}
 
 bool tm_stm_factory::is_applicable_for(const storage::ntp_config& cfg) const {
-    auto const& ntp = cfg.ntp();
+    const auto& ntp = cfg.ntp();
     return ntp.ns == model::kafka_internal_namespace
            && ntp.tp.topic == model::tx_manager_topic;
 }

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -27,7 +27,7 @@ namespace cluster {
 // From this a common retry_chain_logger is created
 partition_validator::partition_validator(
   cloud_storage::remote& remote,
-  cloud_storage_clients::bucket_name const& bucket,
+  const cloud_storage_clients::bucket_name& bucket,
   ss::abort_source& as,
   model::ntp ntp,
   model::initial_revision_id rev_id,
@@ -153,7 +153,7 @@ partition_validator::do_validate_manifest_metadata() {
     // this unpack is to trigger a compilation error if a new field is added
     // to cloud_storage::anomalies. If a new anomalies is added, it should
     // be also handled here
-    auto const& [no_partition_manifest, missing_spillovers, missing_segments, segment_anomalies, ignore1, ignore2, ignore3, ignore4]
+    const auto& [no_partition_manifest, missing_spillovers, missing_segments, segment_anomalies, ignore1, ignore2, ignore3, ignore4]
       = anomalies.detected;
 
     if (no_partition_manifest) {
@@ -184,7 +184,7 @@ partition_validator::do_validate_manifest_metadata() {
     // sev-low classify anomaly_meta as failure or ok (not problematic for the
     // recovery use case) true: failure, false: passed
     constexpr static auto is_fatal_anomaly =
-      [](cloud_storage::anomaly_meta const& am) {
+      [](const cloud_storage::anomaly_meta& am) {
           using enum cloud_storage::anomaly_type;
           switch (am.type) {
           case offset_gap:
@@ -217,7 +217,7 @@ cloud_storage::remote_manifest_path partition_validator::get_path() {
 // wrap allocation and execution of partition_validation,
 ss::future<validation_result> do_validate_recovery_partition(
   cloud_storage::remote& remote,
-  cloud_storage_clients::bucket_name const& bucket,
+  const cloud_storage_clients::bucket_name& bucket,
   ss::abort_source& as,
   model::ntp ntp,
   model::initial_revision_id rev_id,
@@ -239,7 +239,7 @@ ss::future<validation_result> do_validate_recovery_partition(
 /// its partition manifest. perform checks based on recovery_checks.mode
 ss::future<absl::flat_hash_map<model::partition_id, validation_result>>
 maybe_validate_recovery_topic(
-  custom_assignable_topic_configuration const& assignable_config,
+  const custom_assignable_topic_configuration& assignable_config,
   cloud_storage_clients::bucket_name bucket,
   cloud_storage::remote& remote,
   ss::abort_source& as) {

--- a/src/v/cluster/topic_recovery_validator.h
+++ b/src/v/cluster/topic_recovery_validator.h
@@ -44,7 +44,7 @@ enum class validation_result {
 /// if the map is empty, it has to be interpreted as "validation ok"
 ss::future<absl::flat_hash_map<model::partition_id, validation_result>>
 maybe_validate_recovery_topic(
-  custom_assignable_topic_configuration const& assignable_config,
+  const custom_assignable_topic_configuration& assignable_config,
   cloud_storage_clients::bucket_name bucket,
   cloud_storage::remote& remote,
   ss::abort_source& as);
@@ -60,7 +60,7 @@ public:
 
     partition_validator(
       cloud_storage::remote& remote,
-      cloud_storage_clients::bucket_name const& bucket,
+      const cloud_storage_clients::bucket_name& bucket,
       ss::abort_source& as,
       model::ntp ntp,
       model::initial_revision_id rev_id,
@@ -86,7 +86,7 @@ private:
     cloud_storage::remote_manifest_path get_path();
 
     cloud_storage::remote* remote_;
-    cloud_storage_clients::bucket_name const* bucket_;
+    const cloud_storage_clients::bucket_name* bucket_;
     ss::abort_source* as_;
     model::ntp ntp_;
     model::initial_revision_id rev_id_;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -48,7 +48,7 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
           errc::topic_already_exists);
     }
 
-    auto const migration_state = _migrated_resources.get_topic_state(cmd.key);
+    const auto migration_state = _migrated_resources.get_topic_state(cmd.key);
     if (
       !cmd.value.cfg.is_migrated
       && migration_state
@@ -115,7 +115,7 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
 
 std::error_code topic_table::do_local_delete(
   model::topic_namespace nt, model::offset offset, bool ignore_migration) {
-    auto const migration_state = _migrated_resources.get_topic_state(nt);
+    const auto migration_state = _migrated_resources.get_topic_state(nt);
     if (
       !ignore_migration
       && migration_state
@@ -204,7 +204,7 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
 
 ss::future<std::error_code>
 topic_table::apply(create_partition_cmd cmd, model::offset offset) {
-    auto const migration_state = _migrated_resources.get_topic_state(
+    const auto migration_state = _migrated_resources.get_topic_state(
       cmd.value.cfg.tp_ns);
     vlog(
       clusterlog.trace,
@@ -874,7 +874,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     if (tp == _topics.end()) {
         co_return make_error_code(errc::topic_not_exists);
     }
-    auto const migration_state = _migrated_resources.get_topic_state(cmd.key);
+    const auto migration_state = _migrated_resources.get_topic_state(cmd.key);
     if (
       migration_state
       != data_migrations::migrated_resource_state::non_restricted) {

--- a/src/v/cluster/topic_validators.h
+++ b/src/v/cluster/topic_validators.h
@@ -22,7 +22,7 @@ struct schema_id_validation_validator {
 
     template<typename T>
     static bool
-    compatible(std::optional<T> const& lhs, std::optional<T> const& rhs) {
+    compatible(const std::optional<T>& lhs, const std::optional<T>& rhs) {
         // If both are specified, they must match
         return !lhs || !rhs || lhs == rhs;
     }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -536,7 +536,7 @@ ss::future<topic_result> topics_frontend::do_create_topic(
           assignable_config, bucket, _cloud_storage_api.local(), _as.local());
         if (std::ranges::any_of(
               validation_map,
-              [](std::pair<model::partition_id, validation_result> const& vp) {
+              [](const std::pair<model::partition_id, validation_result>& vp) {
                   using enum validation_result;
                   switch (vp.second) {
                   case passed:

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -18,7 +18,7 @@
 
 namespace json {
 
-inline void read_value(json::Value const& rd, cluster::errc& e) {
+inline void read_value(const json::Value& rd, cluster::errc& e) {
     /// TODO: Make giant switch to confirm value is a proper cluster::errc
     auto err = rd.GetInt();
     e = static_cast<cluster::errc>(err);
@@ -47,7 +47,7 @@ void rjson_serialize(
 }
 
 template<typename T>
-void read_value(json::Value const& rd, cluster::property_update<T>& pu) {
+void read_value(const json::Value& rd, cluster::property_update<T>& pu) {
     read_member(rd, "value", pu.value);
     auto op = read_enum_ut(rd, "op", pu.op);
     switch (op) {
@@ -69,7 +69,7 @@ void read_value(json::Value const& rd, cluster::property_update<T>& pu) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::cluster_property_kv& obj) {
+read_value(const json::Value& rd, cluster::cluster_property_kv& obj) {
     read_member(rd, "key", obj.key);
     read_member(rd, "value", obj.value);
 }
@@ -83,7 +83,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::remote_topic_properties& rtp) {
+read_value(const json::Value& rd, cluster::remote_topic_properties& rtp) {
     read_member(rd, "remote_revision", rtp.remote_revision);
     read_member(rd, "remote_partition_count", rtp.remote_partition_count);
 }
@@ -108,7 +108,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::config_status& s) {
+inline void read_value(const json::Value& rd, cluster::config_status& s) {
     read_member(rd, "node", s.node);
     read_member(rd, "version", s.version);
     read_member(rd, "restart", s.restart);
@@ -117,7 +117,7 @@ inline void read_value(json::Value const& rd, cluster::config_status& s) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::partition_move_direction& e) {
+read_value(const json::Value& rd, cluster::partition_move_direction& e) {
     auto direction = rd.GetInt();
     switch (direction) {
     case 0:
@@ -138,7 +138,7 @@ read_value(json::Value const& rd, cluster::partition_move_direction& e) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::feature_update_action::action_t& e) {
+read_value(const json::Value& rd, cluster::feature_update_action::action_t& e) {
     auto action = rd.GetInt();
     switch (action) {
     case 1:
@@ -160,7 +160,7 @@ read_value(json::Value const& rd, cluster::feature_update_action::action_t& e) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::feature_update_action& obj) {
+read_value(const json::Value& rd, cluster::feature_update_action& obj) {
     read_member(rd, "feature_name", obj.feature_name);
     read_member(rd, "action", obj.action);
 }
@@ -174,7 +174,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& v, cluster::tx::errc& obj) {
+inline void read_value(const json::Value& v, cluster::tx::errc& obj) {
     obj = {v.GetInt()};
 }
 
@@ -188,7 +188,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::topic_result& obj) {
+inline void read_value(const json::Value& rd, cluster::topic_result& obj) {
     model::topic_namespace tp_ns;
     cluster::errc ec;
     read_member(rd, "tp_ns", tp_ns);
@@ -342,14 +342,14 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::partitions_filter& obj) {
+inline void read_value(const json::Value& rd, cluster::partitions_filter& obj) {
     cluster::partitions_filter::ns_map_t namespaces;
     read_member(rd, "namespaces", namespaces);
     obj = cluster::partitions_filter{{}, namespaces};
 }
 
 inline void
-read_value(json::Value const& rd, cluster::node_report_filter& obj) {
+read_value(const json::Value& rd, cluster::node_report_filter& obj) {
     cluster::include_partitions_info include_partitions;
     cluster::partitions_filter ntp_filters;
     read_member(rd, "include_partitions", include_partitions);
@@ -359,7 +359,7 @@ read_value(json::Value const& rd, cluster::node_report_filter& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::cluster_report_filter& obj) {
+read_value(const json::Value& rd, cluster::cluster_report_filter& obj) {
     cluster::node_report_filter node_report_filter;
     std::vector<model::node_id> nodes;
 
@@ -370,7 +370,7 @@ read_value(json::Value const& rd, cluster::cluster_report_filter& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::drain_manager::drain_status& obj) {
+read_value(const json::Value& rd, cluster::drain_manager::drain_status& obj) {
     bool finished;
     bool errors;
     std::optional<size_t> partitions;
@@ -388,7 +388,7 @@ read_value(json::Value const& rd, cluster::drain_manager::drain_status& obj) {
       {}, finished, errors, partitions, eligible, transferring, failed};
 }
 
-inline void read_value(json::Value const& rd, cluster::partition_status& obj) {
+inline void read_value(const json::Value& rd, cluster::partition_status& obj) {
     model::partition_id id;
     model::term_id term;
     std::optional<model::node_id> leader_id;
@@ -404,7 +404,7 @@ inline void read_value(json::Value const& rd, cluster::partition_status& obj) {
       {}, id, term, leader_id, revision_id, size_bytes};
 }
 
-inline void read_value(json::Value const& rd, cluster::topic_status& obj) {
+inline void read_value(const json::Value& rd, cluster::topic_status& obj) {
     model::topic_namespace tp_ns;
     cluster::partition_statuses_t partitions;
 
@@ -413,7 +413,7 @@ inline void read_value(json::Value const& rd, cluster::topic_status& obj) {
     obj = cluster::topic_status(tp_ns, std::move(partitions));
 }
 
-inline void read_value(json::Value const& rd, cluster::node::local_state& obj) {
+inline void read_value(const json::Value& rd, cluster::node::local_state& obj) {
     cluster::node::application_version redpanda_version;
     cluster::cluster_version logical_version;
     std::chrono::milliseconds uptime;
@@ -430,7 +430,7 @@ inline void read_value(json::Value const& rd, cluster::node::local_state& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::node_health_report_serde& obj) {
+read_value(const json::Value& rd, cluster::node_health_report_serde& obj) {
     model::node_id id;
     cluster::node::local_state local_state;
     chunked_vector<cluster::topic_status> topics;
@@ -444,7 +444,7 @@ read_value(json::Value const& rd, cluster::node_health_report_serde& obj) {
       id, local_state, std::move(topics), drain_status);
 }
 
-inline void read_value(json::Value const& rd, cluster::node_state& obj) {
+inline void read_value(const json::Value& rd, cluster::node_state& obj) {
     model::node_id id;
     model::membership_state membership_state;
     cluster::alive is_alive;
@@ -457,7 +457,7 @@ inline void read_value(json::Value const& rd, cluster::node_state& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::cluster_health_report& obj) {
+read_value(const json::Value& rd, cluster::cluster_health_report& obj) {
     std::optional<model::node_id> raft0_leader;
     std::vector<cluster::node_state> node_states;
     std::vector<cluster::node_health_report_ptr> node_reports;
@@ -466,7 +466,7 @@ read_value(json::Value const& rd, cluster::cluster_health_report& obj) {
     read_member(rd, "node_states", node_states);
     auto reports_v = rd.FindMember("node_reports");
     if (reports_v != rd.MemberEnd()) {
-        for (auto const& e : reports_v->value.GetArray()) {
+        for (const auto& e : reports_v->value.GetArray()) {
             cluster::node_health_report_serde report;
             read_value(e, report);
             node_reports.emplace_back(
@@ -479,7 +479,7 @@ read_value(json::Value const& rd, cluster::cluster_health_report& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, cluster::move_cancellation_result& obj) {
+read_value(const json::Value& rd, cluster::move_cancellation_result& obj) {
     model::ntp ntp;
     cluster::errc result;
     read_member(rd, "ntp", ntp);
@@ -500,7 +500,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::partition_assignment& obj) {
+read_value(const json::Value& rd, cluster::partition_assignment& obj) {
     json_read(group);
     json_read(id);
     json_read(replicas);
@@ -518,7 +518,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::backend_operation& obj) {
+inline void read_value(const json::Value& rd, cluster::backend_operation& obj) {
     json_read(source_shard);
     read_member(rd, "partition_assignment", obj.p_as);
     read_member(rd, "op_type", obj.type);
@@ -540,7 +540,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::ntp_reconciliation_state& obj) {
+read_value(const json::Value& rd, cluster::ntp_reconciliation_state& obj) {
     model::ntp ntp;
     ss::chunked_fifo<cluster::backend_operation> operations;
     cluster::reconciliation_status status;
@@ -628,7 +628,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
+inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
     read_member(rd, "compression", obj.compression);
     read_member(rd, "cleanup_policy_bitflags", obj.cleanup_policy_bitflags);
     read_member(rd, "compaction_strategy", obj.compaction_strategy);
@@ -710,7 +710,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::topic_configuration& cfg) {
+read_value(const json::Value& rd, cluster::topic_configuration& cfg) {
     read_member(rd, "tp_ns", cfg.tp_ns);
     read_member(rd, "partition_count", cfg.partition_count);
     read_member(rd, "replication_factor", cfg.replication_factor);
@@ -726,7 +726,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, v8_engine::data_policy& dp) {
+inline void read_value(const json::Value& rd, v8_engine::data_policy& dp) {
     read_member(rd, "fn_name", dp.fn_name);
     read_member(rd, "sct_name", dp.sct_name);
 }
@@ -740,7 +740,7 @@ inline void rjson_serialize(
 }
 
 inline void read_value(
-  json::Value const& rd, cluster::incremental_topic_custom_updates& itc) {
+  const json::Value& rd, cluster::incremental_topic_custom_updates& itc) {
     read_member(rd, "data_policy", itc.data_policy);
 }
 
@@ -762,7 +762,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::incremental_topic_updates& itu) {
+read_value(const json::Value& rd, cluster::incremental_topic_updates& itu) {
     read_member(rd, "compression", itu.compression);
     read_member(rd, "cleanup_policy_bitflags", itu.cleanup_policy_bitflags);
     read_member(rd, "compaction_strategy", itu.compaction_strategy);
@@ -786,7 +786,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::topic_properties_update& tpu) {
+read_value(const json::Value& rd, cluster::topic_properties_update& tpu) {
     read_member(rd, "tp_ns", tpu.tp_ns);
     read_member(rd, "properties", tpu.properties);
     read_member(rd, "custom_properties", tpu.custom_properties);

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -29,53 +29,53 @@
 
 namespace json {
 
-inline char const* to_str(rapidjson::Type const t) {
-    static char const* str[] = {
+inline const char* to_str(const rapidjson::Type t) {
+    static const char* str[] = {
       "Null", "False", "True", "Object", "Array", "String", "Number"};
     return str[t];
 }
 
-inline void read_value(json::Value const& v, int64_t& target) {
+inline void read_value(const json::Value& v, int64_t& target) {
     target = v.GetInt64();
 }
 
-inline void read_value(json::Value const& v, uint64_t& target) {
+inline void read_value(const json::Value& v, uint64_t& target) {
     target = v.GetUint64();
 }
 
-inline void read_value(json::Value const& v, uint32_t& target) {
+inline void read_value(const json::Value& v, uint32_t& target) {
     target = v.GetUint();
 }
 
-inline void read_value(json::Value const& v, int32_t& target) {
+inline void read_value(const json::Value& v, int32_t& target) {
     target = v.GetInt();
 }
 
-inline void read_value(json::Value const& v, int16_t& target) {
+inline void read_value(const json::Value& v, int16_t& target) {
     target = v.GetInt();
 }
 
-inline void read_value(json::Value const& v, uint16_t& target) {
+inline void read_value(const json::Value& v, uint16_t& target) {
     target = v.GetUint();
 }
 
-inline void read_value(json::Value const& v, int8_t& target) {
+inline void read_value(const json::Value& v, int8_t& target) {
     target = v.GetInt();
 }
 
-inline void read_value(json::Value const& v, uint8_t& target) {
+inline void read_value(const json::Value& v, uint8_t& target) {
     target = v.GetUint();
 }
 
-inline void read_value(json::Value const& v, bool& target) {
+inline void read_value(const json::Value& v, bool& target) {
     target = v.GetBool();
 }
 
-inline void read_value(json::Value const& v, ss::sstring& target) {
+inline void read_value(const json::Value& v, ss::sstring& target) {
     target = v.GetString();
 }
 
-inline void read_value(json::Value const& v, iobuf& target) {
+inline void read_value(const json::Value& v, iobuf& target) {
     target = bytes_to_iobuf(base64_to_bytes(v.GetString()));
 }
 
@@ -84,26 +84,26 @@ inline void rjson_serialize(
     rjson_serialize(w, v.count());
 }
 
-inline void read_value(json::Value const& v, std::chrono::nanoseconds& target) {
+inline void read_value(const json::Value& v, std::chrono::nanoseconds& target) {
     target = std::chrono::nanoseconds(v.GetInt64());
 }
 
 template<typename T, typename Tag, typename IsConstexpr>
 void read_value(
-  json::Value const& v, detail::base_named_type<T, Tag, IsConstexpr>& target) {
+  const json::Value& v, detail::base_named_type<T, Tag, IsConstexpr>& target) {
     auto t = T{};
     read_value(v, t);
     target = detail::base_named_type<T, Tag, IsConstexpr>{std::move(t)};
 }
 
 inline void
-read_value(json::Value const& v, std::chrono::milliseconds& target) {
+read_value(const json::Value& v, std::chrono::milliseconds& target) {
     target = std::chrono::milliseconds(v.GetUint64());
 }
 
 template<typename T>
-void read_value(json::Value const& v, std::vector<T>& target) {
-    for (auto const& e : v.GetArray()) {
+void read_value(const json::Value& v, std::vector<T>& target) {
+    for (const auto& e : v.GetArray()) {
         auto t = T{};
         read_value(e, t);
         target.push_back(std::move(t));
@@ -111,8 +111,8 @@ void read_value(json::Value const& v, std::vector<T>& target) {
 }
 
 template<typename T, size_t chunk_size = 128>
-void read_value(json::Value const& v, ss::chunked_fifo<T, chunk_size>& target) {
-    for (auto const& e : v.GetArray()) {
+void read_value(const json::Value& v, ss::chunked_fifo<T, chunk_size>& target) {
+    for (const auto& e : v.GetArray()) {
         auto t = T{};
         read_value(e, t);
         target.push_back(std::move(t));
@@ -121,8 +121,8 @@ void read_value(json::Value const& v, ss::chunked_fifo<T, chunk_size>& target) {
 
 template<typename T, size_t fragment_size_bytes>
 void read_value(
-  json::Value const& v, fragmented_vector<T, fragment_size_bytes>& target) {
-    for (auto const& e : v.GetArray()) {
+  const json::Value& v, fragmented_vector<T, fragment_size_bytes>& target) {
+    for (const auto& e : v.GetArray()) {
         auto t = T{};
         read_value(e, t);
         target.push_back(std::move(t));
@@ -130,7 +130,7 @@ void read_value(
 }
 
 template<typename T>
-void read_value(json::Value const& v, std::optional<T>& target) {
+void read_value(const json::Value& v, std::optional<T>& target) {
     if (v.IsNull()) {
         target = std::nullopt;
     } else {
@@ -146,14 +146,14 @@ rjson_serialize(json::Writer<json::StringBuffer>& w, const iobuf& buf) {
 }
 
 template<typename Writer, typename T>
-void write_member(Writer& w, char const* key, T const& value) {
+void write_member(Writer& w, const char* key, const T& value) {
     w.String(key);
     rjson_serialize(w, value);
 }
 
 // Reads the enum's underlying type directly.
 template<typename Enum>
-inline auto read_enum_ut(json::Value const& v, char const* key, Enum)
+inline auto read_enum_ut(const json::Value& v, const char* key, Enum)
   -> std::underlying_type_t<Enum> {
     std::underlying_type_t<Enum> value;
     read_member(v, key, value);
@@ -162,7 +162,7 @@ inline auto read_enum_ut(json::Value const& v, char const* key, Enum)
 
 template<typename Enum>
 requires(std::is_enum_v<Enum>)
-inline void read_value(json::Value const& v, Enum& e) {
+inline void read_value(const json::Value& v, Enum& e) {
     std::underlying_type_t<Enum> value;
     read_value(v, value);
     e = Enum(value);
@@ -170,7 +170,7 @@ inline void read_value(json::Value const& v, Enum& e) {
 
 template<typename Enum>
 requires(std::is_enum_v<Enum>)
-inline void read_member(json::Value const& v, char const* key, Enum& e) {
+inline void read_member(const json::Value& v, const char* key, Enum& e) {
     std::underlying_type_t<Enum> value;
     read_member(v, key, value);
     e = Enum(value);
@@ -178,8 +178,8 @@ inline void read_member(json::Value const& v, char const* key, Enum& e) {
 
 template<typename T>
 requires(!std::is_enum_v<T>)
-void read_member(json::Value const& v, char const* key, T& target) {
-    auto const it = v.FindMember(key);
+void read_member(const json::Value& v, const char* key, T& target) {
+    const auto it = v.FindMember(key);
     if (it != v.MemberEnd()) {
         read_value(it->value, target);
     } else {
@@ -201,14 +201,14 @@ rjson_serialize(json::Writer<json::StringBuffer>& w, const model::ntp& ntp) {
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::ntp& obj) {
+inline void read_value(const json::Value& rd, model::ntp& obj) {
     read_member(rd, "ns", obj.ns);
     read_member(rd, "topic", obj.tp.topic);
     read_member(rd, "partition", obj.tp.partition);
 }
 
 template<typename T>
-void read_value(json::Value const& v, ss::bool_class<T>& target) {
+void read_value(const json::Value& v, ss::bool_class<T>& target) {
     target = ss::bool_class<T>(v.GetBool());
 }
 
@@ -278,7 +278,7 @@ inline void rjson_serialize(
 }
 
 template<typename T, typename V>
-inline void read_value(json::Value const& rd, std::unordered_map<T, V>& obj) {
+inline void read_value(const json::Value& rd, std::unordered_map<T, V>& obj) {
     for (const auto& e : rd.GetArray()) {
         T key;
         read_member(e, "key", key);
@@ -289,7 +289,7 @@ inline void read_value(json::Value const& rd, std::unordered_map<T, V>& obj) {
 }
 
 template<typename T, typename V>
-inline void read_value(json::Value const& rd, absl::node_hash_map<T, V>& obj) {
+inline void read_value(const json::Value& rd, absl::node_hash_map<T, V>& obj) {
     for (const auto& e : rd.GetArray()) {
         T key;
         read_member(e, "key", key);
@@ -300,7 +300,7 @@ inline void read_value(json::Value const& rd, absl::node_hash_map<T, V>& obj) {
 }
 
 template<typename T, typename V>
-inline void read_value(json::Value const& rd, absl::flat_hash_map<T, V>& obj) {
+inline void read_value(const json::Value& rd, absl::flat_hash_map<T, V>& obj) {
     for (const auto& e : rd.GetArray()) {
         T key;
         read_member(e, "key", key);
@@ -311,7 +311,7 @@ inline void read_value(json::Value const& rd, absl::flat_hash_map<T, V>& obj) {
 }
 
 template<typename V>
-inline void read_value(json::Value const& rd, absl::node_hash_set<V>& obj) {
+inline void read_value(const json::Value& rd, absl::node_hash_set<V>& obj) {
     for (const auto& e : rd.GetArray()) {
         auto v = V{};
         read_value(e, v);
@@ -320,7 +320,7 @@ inline void read_value(json::Value const& rd, absl::node_hash_set<V>& obj) {
 }
 
 template<typename V>
-inline void read_value(json::Value const& rd, absl::btree_set<V>& obj) {
+inline void read_value(const json::Value& rd, absl::btree_set<V>& obj) {
     for (const auto& e : rd.GetArray()) {
         auto v = V{};
         read_value(e, v);
@@ -354,7 +354,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::broker_properties& obj) {
+inline void read_value(const json::Value& rd, model::broker_properties& obj) {
     read_member(rd, "cores", obj.cores);
     read_member(rd, "available_memory_gb", obj.available_memory_gb);
     read_member(rd, "available_disk_gb", obj.available_disk_gb);
@@ -365,7 +365,7 @@ inline void read_value(json::Value const& rd, model::broker_properties& obj) {
 }
 
 inline void
-read_value(json::Value const& rd, ss::net::inet_address::family& obj) {
+read_value(const json::Value& rd, ss::net::inet_address::family& obj) {
     obj = static_cast<ss::net::inet_address::family>(rd.GetInt());
 }
 
@@ -374,7 +374,7 @@ inline void rjson_serialize(
     w.Int(static_cast<int>(b));
 }
 
-inline void read_value(json::Value const& rd, net::unresolved_address& obj) {
+inline void read_value(const json::Value& rd, net::unresolved_address& obj) {
     ss::sstring host;
     uint16_t port{0};
     read_member(rd, "address", host);
@@ -382,7 +382,7 @@ inline void read_value(json::Value const& rd, net::unresolved_address& obj) {
     obj = net::unresolved_address(std::move(host), port);
 }
 
-inline void read_value(json::Value const& rd, model::broker_endpoint& obj) {
+inline void read_value(const json::Value& rd, model::broker_endpoint& obj) {
     ss::sstring host;
     uint16_t port{0};
 
@@ -409,7 +409,7 @@ rjson_serialize(json::Writer<json::StringBuffer>& w, const model::broker& b) {
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::broker& obj) {
+inline void read_value(const json::Value& rd, model::broker& obj) {
     model::node_id id;
     std::vector<model::broker_endpoint> kafka_advertised_listeners;
     net::unresolved_address rpc_address;
@@ -440,7 +440,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::topic_namespace& obj) {
+inline void read_value(const json::Value& rd, model::topic_namespace& obj) {
     model::ns ns;
     model::topic tp;
     read_member(rd, "ns", ns);
@@ -460,7 +460,7 @@ inline void rjson_serialize(
 }
 
 inline void read_value(
-  json::Value const& rd,
+  const json::Value& rd,
   cluster::partition_balancer_violations::unavailable_node& un) {
     read_member(rd, "id", un.id);
     read_member(rd, "unavailable_since", un.unavailable_since);
@@ -478,7 +478,7 @@ inline void rjson_serialize(
 }
 
 inline void read_value(
-  json::Value const& rd,
+  const json::Value& rd,
   cluster::partition_balancer_violations::full_node& fn) {
     read_member(rd, "id", fn.id);
     read_member(rd, "disk_used_percent", fn.disk_used_percent);
@@ -496,18 +496,18 @@ inline void rjson_serialize(
 }
 
 inline void read_value(
-  json::Value const& rd, cluster::partition_balancer_violations& violations) {
+  const json::Value& rd, cluster::partition_balancer_violations& violations) {
     read_member(rd, "unavailable_nodes", violations.unavailable_nodes);
     read_member(rd, "full_nodes", violations.full_nodes);
 }
 
-inline void read_value(json::Value const& rd, security::acl_host& host) {
+inline void read_value(const json::Value& rd, security::acl_host& host) {
     ss::sstring address;
     read_member(rd, "address", address);
     host = security::acl_host(address);
 }
 
-inline void read_value(json::Value const& rd, model::vcluster_id& v) {
+inline void read_value(const json::Value& rd, model::vcluster_id& v) {
     ss::sstring xid_str;
     read_value(rd, xid_str);
     v = model::vcluster_id(xid::from_string(xid_str));
@@ -531,7 +531,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, security::acl_principal& principal) {
+read_value(const json::Value& rd, security::acl_principal& principal) {
     security::principal_type type{};
     read_member(rd, "type", type);
     ss::sstring name;
@@ -550,7 +550,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, security::acl_entry& entry) {
+inline void read_value(const json::Value& rd, security::acl_entry& entry) {
     security::acl_principal principal;
     security::acl_host host;
     security::acl_operation operation{};
@@ -578,7 +578,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, security::resource_pattern& pattern) {
+read_value(const json::Value& rd, security::resource_pattern& pattern) {
     ss::sstring name;
     security::resource_type resource{};
     security::pattern_type pattern_type{};
@@ -602,7 +602,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, security::acl_binding& binding) {
+inline void read_value(const json::Value& rd, security::acl_binding& binding) {
     security::resource_pattern pattern;
     security::acl_entry entry;
     read_member(rd, "pattern", pattern);
@@ -621,7 +621,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::create_acls_cmd_data& data) {
+read_value(const json::Value& rd, cluster::create_acls_cmd_data& data) {
     read_member(rd, "bindings", data.bindings);
 }
 
@@ -635,13 +635,13 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::delete_acls_result& data) {
+read_value(const json::Value& rd, cluster::delete_acls_result& data) {
     read_member(rd, "error", data.error);
     read_member(rd, "bindings", data.bindings);
 }
 
 inline void read_value(
-  json::Value const& rd,
+  const json::Value& rd,
   security::resource_pattern_filter::pattern_filter_type& pattern_filter) {
     using type = security::resource_pattern_filter::serialized_pattern_type;
     type ser_filter{};
@@ -681,7 +681,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, security::resource_pattern_filter& pattern) {
+read_value(const json::Value& rd, security::resource_pattern_filter& pattern) {
     std::optional<security::resource_type> resource;
     std::optional<ss::sstring> name;
     std::optional<security::resource_pattern_filter::pattern_filter_type>
@@ -707,7 +707,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, security::acl_entry_filter& filter) {
+read_value(const json::Value& rd, security::acl_entry_filter& filter) {
     std::optional<security::acl_principal> principal;
     std::optional<security::acl_host> host;
     std::optional<security::acl_operation> operation;
@@ -747,7 +747,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, security::acl_binding_filter& binding) {
+read_value(const json::Value& rd, security::acl_binding_filter& binding) {
     security::resource_pattern_filter pattern_filter;
     security::acl_entry_filter entry_filter;
     read_member(rd, "pattern", pattern_filter);
@@ -767,7 +767,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::delete_acls_cmd_data& data) {
+read_value(const json::Value& rd, cluster::delete_acls_cmd_data& data) {
     read_member(rd, "filters", data.filters);
 }
 
@@ -783,7 +783,7 @@ inline void rjson_serialize(
 enum class tristate_status : uint8_t { disabled = 0, not_set, set };
 
 template<typename T>
-void read_value(json::Value const& rd, tristate<T>& target) {
+void read_value(const json::Value& rd, tristate<T>& target) {
     tristate_status ts{tristate_status::disabled};
     auto ts_val = read_enum_ut(rd, "status", ts);
     switch (ts_val) {

--- a/src/v/compat/metadata_dissemination_json.h
+++ b/src/v/compat/metadata_dissemination_json.h
@@ -28,7 +28,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, cluster::ntp_leader& obj) {
+inline void read_value(const json::Value& rd, cluster::ntp_leader& obj) {
     read_member(rd, "ntp", obj.ntp);
     read_member(rd, "term", obj.term);
     read_member(rd, "leader_id", obj.leader_id);
@@ -49,7 +49,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, cluster::ntp_leader_revision& obj) {
+read_value(const json::Value& rd, cluster::ntp_leader_revision& obj) {
     read_member(rd, "ntp", obj.ntp);
     read_member(rd, "term", obj.term);
     read_member(rd, "leader_id", obj.leader_id);

--- a/src/v/compat/model_json.h
+++ b/src/v/compat/model_json.h
@@ -15,7 +15,7 @@
 
 namespace json {
 
-inline void read_value(json::Value const& rd, model::compression& e) {
+inline void read_value(const json::Value& rd, model::compression& e) {
     std::underlying_type_t<model::compression> value;
     read_value(rd, value);
     switch (value) {
@@ -42,7 +42,7 @@ inline void read_value(json::Value const& rd, model::compression& e) {
     }
 }
 
-inline void read_value(json::Value const& rd, model::timestamp_type& e) {
+inline void read_value(const json::Value& rd, model::timestamp_type& e) {
     std::underlying_type_t<model::timestamp_type> value;
     read_value(rd, value);
     switch (value) {
@@ -58,7 +58,7 @@ inline void read_value(json::Value const& rd, model::timestamp_type& e) {
 }
 
 inline void
-read_value(json::Value const& rd, model::cleanup_policy_bitflags& e) {
+read_value(const json::Value& rd, model::cleanup_policy_bitflags& e) {
     std::underlying_type_t<model::cleanup_policy_bitflags> value;
     read_value(rd, value);
     switch (value) {
@@ -79,7 +79,7 @@ read_value(json::Value const& rd, model::cleanup_policy_bitflags& e) {
     }
 }
 
-inline void read_value(json::Value const& rd, model::compaction_strategy& e) {
+inline void read_value(const json::Value& rd, model::compaction_strategy& e) {
     std::underlying_type_t<model::compaction_strategy> value;
     read_value(rd, value);
     switch (value) {
@@ -98,7 +98,7 @@ inline void read_value(json::Value const& rd, model::compaction_strategy& e) {
     }
 }
 
-inline void read_value(json::Value const& rd, model::shadow_indexing_mode& e) {
+inline void read_value(const json::Value& rd, model::shadow_indexing_mode& e) {
     std::underlying_type_t<model::shadow_indexing_mode> value;
     read_value(rd, value);
     switch (value) {
@@ -141,7 +141,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::producer_identity& obj) {
+inline void read_value(const json::Value& rd, model::producer_identity& obj) {
     read_member(rd, "id", obj.id);
     read_member(rd, "epoch", obj.epoch);
 }
@@ -156,7 +156,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::broker_shard& obj) {
+inline void read_value(const json::Value& rd, model::broker_shard& obj) {
     read_member(rd, "node_id", obj.node_id);
     read_member(rd, "shard", obj.shard);
 }
@@ -173,7 +173,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::partition_metadata& obj) {
+inline void read_value(const json::Value& rd, model::partition_metadata& obj) {
     read_member(rd, "id", obj.id);
     read_member(rd, "replicas", obj.replicas);
     read_member(rd, "leader_node", obj.leader_node);
@@ -187,7 +187,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::topic_metadata& tm) {
+inline void read_value(const json::Value& rd, model::topic_metadata& tm) {
     read_member(rd, "tp_ns", tm.tp_ns);
     read_member(rd, "partitions", tm.partitions);
 }
@@ -236,7 +236,7 @@ void rjson_serialize_exceptional_type(
 }
 
 template<typename Writer, typename T>
-void write_exceptional_member_type(Writer& w, char const* key, T const& value) {
+void write_exceptional_member_type(Writer& w, const char* key, const T& value) {
     w.String(key);
     rjson_serialize_exceptional_type(w, value);
 }

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -25,7 +25,7 @@ rjson_serialize(json::Writer<json::StringBuffer>& w, const raft::vnode& v) {
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, raft::vnode& obj) {
+inline void read_value(const json::Value& rd, raft::vnode& obj) {
     model::node_id node_id;
     model::revision_id revision;
     read_member(rd, "id", node_id);
@@ -53,7 +53,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, raft::protocol_metadata& obj) {
+inline void read_value(const json::Value& rd, raft::protocol_metadata& obj) {
     raft::protocol_metadata tmp;
     read_member(rd, "group", tmp.group);
     read_member(rd, "commit_index", tmp.commit_index);
@@ -65,7 +65,7 @@ inline void read_value(json::Value const& rd, raft::protocol_metadata& obj) {
     obj = tmp;
 }
 
-inline void read_value(json::Value const& rd, raft::heartbeat_metadata& obj) {
+inline void read_value(const json::Value& rd, raft::heartbeat_metadata& obj) {
     raft::heartbeat_metadata tmp;
     read_member(rd, "meta", tmp.meta);
     read_member(rd, "node_id", tmp.node_id);
@@ -85,7 +85,7 @@ inline void rjson_serialize(
     w.EndObject();
 }
 
-inline void read_value(json::Value const& rd, raft::append_entries_reply& out) {
+inline void read_value(const json::Value& rd, raft::append_entries_reply& out) {
     raft::append_entries_reply obj;
     json_read(target_node_id);
     json_read(node_id);
@@ -120,7 +120,7 @@ inline void rjson_serialize(
     rjson_serialize(wr, v.value());
 }
 
-inline void read_value(json::Value const& rd, model::timestamp& out) {
+inline void read_value(const json::Value& rd, model::timestamp& out) {
     out = model::timestamp(rd.GetInt64());
 }
 
@@ -144,7 +144,7 @@ inline void rjson_serialize(
 }
 
 inline void
-read_value(json::Value const& rd, model::record_batch_attributes& out) {
+read_value(const json::Value& rd, model::record_batch_attributes& out) {
     out = model::record_batch_attributes(rd.GetInt());
 }
 
@@ -153,7 +153,7 @@ inline void rjson_serialize(
     rjson_serialize(wr, b.value());
 }
 
-inline void read_value(json::Value const& rd, model::record_attributes& out) {
+inline void read_value(const json::Value& rd, model::record_attributes& out) {
     out = model::record_attributes(rd.GetInt());
 }
 
@@ -211,7 +211,7 @@ inline void rjson_serialize(
     wr.EndObject();
 }
 
-inline void read_value(json::Value const& rd, model::record_batch_header& out) {
+inline void read_value(const json::Value& rd, model::record_batch_header& out) {
     model::record_batch_header obj;
     json_read(header_crc);
     json_read(size_bytes);
@@ -238,8 +238,8 @@ inline void read_value(json::Value const& rd, model::record_batch_header& out) {
  * circumvent the normal api to which requires default ctor is available.
  */
 inline void read_value(
-  json::Value const& v, ss::circular_buffer<model::record_batch>& target) {
-    for (auto const& e : v.GetArray()) {
+  const json::Value& v, ss::circular_buffer<model::record_batch>& target) {
+    for (const auto& e : v.GetArray()) {
         model::record_batch_header header;
         std::vector<model::record> records;
 
@@ -254,7 +254,7 @@ inline void read_value(
         vassert(
           e.HasMember("records") && e["records"].IsArray(),
           "invalid records field");
-        for (auto const& r : e["records"].GetArray()) {
+        for (const auto& r : e["records"].GetArray()) {
             vassert(r.IsObject(), "record is not an object");
 
             int32_t size_bytes{};

--- a/src/v/compat/storage_json.h
+++ b/src/v/compat/storage_json.h
@@ -15,7 +15,7 @@
 
 namespace json {
 
-inline void read_value(json::Value const& rd, storage::disk& obj) {
+inline void read_value(const json::Value& rd, storage::disk& obj) {
     read_member(rd, "path", obj.path);
     read_member(rd, "free", obj.free);
     read_member(rd, "total", obj.total);

--- a/src/v/compression/internal/lz4_frame_compressor.cc
+++ b/src/v/compression/internal/lz4_frame_compressor.cc
@@ -176,7 +176,7 @@ iobuf lz4_frame_compressor::compress_with_block_size(
     return ret;
 }
 
-inline static constexpr size_t
+static inline constexpr size_t
 compute_frame_uncompressed_size(size_t frame_size, size_t original) {
     if (frame_size == 0 || frame_size > original * 255) {
         return original * 4;
@@ -184,7 +184,7 @@ compute_frame_uncompressed_size(size_t frame_size, size_t original) {
     return frame_size;
 }
 
-iobuf lz4_frame_compressor::uncompress(iobuf const& input) {
+iobuf lz4_frame_compressor::uncompress(const iobuf& input) {
     size_t src_size = input.size_bytes();
 
     const size_t max_chunk = details::io_allocation_size::max_chunk_size;

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -116,7 +116,7 @@ public:
      * redacted if secret.
      */
     template<typename U>
-    std::string_view format_raw(U const& in) {
+    std::string_view format_raw(const U& in) {
         if (is_secret() && !in.empty()) {
             return secret_placeholder;
         } else {

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -57,7 +57,7 @@ public:
       const std::set<std::string_view> ignore_missing = {}) {
         error_map_t errors;
 
-        for (auto const& [name, property] : _properties) {
+        for (const auto& [name, property] : _properties) {
             if (property->is_required() == required::no) {
                 continue;
             }
@@ -68,7 +68,7 @@ public:
             }
         }
 
-        for (auto const& node : root_node) {
+        for (const auto& node : root_node) {
             auto name = node.first.as<ss::sstring>();
             auto* prop = [&]() -> base_property* {
                 auto found = _properties.find(name);
@@ -100,11 +100,11 @@ public:
                 }
                 prop->set_value(node.second);
                 ok = true;
-            } catch (YAML::InvalidNode const& e) {
+            } catch (const YAML::InvalidNode& e) {
                 errors[name] = fmt::format("Invalid syntax: {}", e);
-            } catch (YAML::ParserException const& e) {
+            } catch (const YAML::ParserException& e) {
                 errors[name] = fmt::format("Invalid syntax: {}", e);
-            } catch (YAML::BadConversion const& e) {
+            } catch (const YAML::BadConversion& e) {
                 errors[name] = fmt::format("Invalid value: {}", e);
             }
 
@@ -122,7 +122,7 @@ public:
 
     template<typename Func>
     void for_each(Func&& f) const {
-        for (auto const& [_, property] : _properties) {
+        for (const auto& [_, property] : _properties) {
             f(*property);
         }
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -418,7 +418,7 @@ configuration::configuration()
       "the log will be automatically force flushed.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms,
-      [](auto const& v) -> std::optional<ss::sstring> {
+      [](const auto& v) -> std::optional<ss::sstring> {
           // maximum duration imposed by serde serialization.
           if (v < 1ms || v > serde::max_serializable_ms) {
               return fmt::format(
@@ -3280,7 +3280,7 @@ configuration::configuration()
       "provider.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       "https://auth.prd.cloud.redpanda.com/.well-known/openid-configuration",
-      [](auto const& v) -> std::optional<ss::sstring> {
+      [](const auto& v) -> std::optional<ss::sstring> {
           auto res = security::oidc::parse_url(v);
           if (res.has_error()) {
               return res.error().message();

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -570,11 +570,11 @@ struct convert<model::recovery_validation_mode> {
       {"check_manifest_existence",
        "check_manifest_and_segment_metadata",
        "no_check"});
-    static Node encode(type const& rhs) {
+    static Node encode(const type& rhs) {
         Node node;
         return Node{boost::lexical_cast<std::string>(rhs)};
     }
-    static bool decode(Node const& node, type& rhs) {
+    static bool decode(const Node& node, type& rhs) {
         auto node_str = node.as<std::string>();
         if (
           std::ranges::find(acceptable_values, node_str)

--- a/src/v/config/endpoint_tls_config.h
+++ b/src/v/config/endpoint_tls_config.h
@@ -28,7 +28,7 @@ struct endpoint_tls_config {
         return o;
     }
 
-    bool operator==(endpoint_tls_config const& rhs) const = default;
+    bool operator==(const endpoint_tls_config& rhs) const = default;
 
     static std::optional<ss::sstring> validate(const endpoint_tls_config& ec) {
         return tls_config::validate(ec.config);

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -249,9 +249,9 @@ node_config::node_config() noexcept
 
 void validate_multi_node_property_config(
   std::map<ss::sstring, ss::sstring>& errors) {
-    auto const& cfg = config::node();
+    const auto& cfg = config::node();
     const auto& kafka_api = cfg.kafka_api.value();
-    for (auto const& ep : kafka_api) {
+    for (const auto& ep : kafka_api) {
         const auto& n = ep.name;
         auto authn_method = ep.authn_method;
         if (authn_method.has_value()) {
@@ -279,7 +279,7 @@ void validate_multi_node_property_config(
         }
     }
 
-    for (auto const& ep : cfg.advertised_kafka_api()) {
+    for (const auto& ep : cfg.advertised_kafka_api()) {
         auto err = model::broker_endpoint::validate_not_is_addr_any(ep);
         if (err) {
             errors.emplace("advertised_kafka_api", ssx::sformat("{}", *err));

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -166,12 +166,12 @@ public:
     node_config() noexcept;
     error_map_t load(const YAML::Node& root_node);
     error_map_t load(
-      std::filesystem::path const& loaded_from, const YAML::Node& root_node) {
+      const std::filesystem::path& loaded_from, const YAML::Node& root_node) {
         _cfg_file_path = loaded_from;
         return load(root_node);
     }
 
-    std::filesystem::path const& get_cfg_file_path() const {
+    const std::filesystem::path& get_cfg_file_path() const {
         return _cfg_file_path;
     }
 

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -170,7 +170,7 @@ public:
         return update_value(std::move(n.as<T>()));
     }
 
-    std::optional<validation_error> validate(T const& v) const {
+    std::optional<validation_error> validate(const T& v) const {
         if (auto err = _validator(v); err) {
             return std::make_optional<validation_error>(name().data(), *err);
         }
@@ -459,7 +459,7 @@ public:
     template<typename U>
     friend inline binding<U> mock_binding(U&&);
     template<typename U>
-    friend inline binding<U> mock_binding(U const&);
+    friend inline binding<U> mock_binding(const U&);
 };
 
 /**
@@ -477,7 +477,7 @@ inline binding<T> mock_binding(T&& value) {
 }
 
 template<typename T>
-inline binding<T> mock_binding(T const& value) {
+inline binding<T> mock_binding(const T& value) {
     return binding<T>(T(value));
 }
 /**
@@ -834,7 +834,7 @@ public:
           def,
           [this](T new_value) -> std::optional<ss::sstring> {
               auto found = std::find_if(
-                _values.begin(), _values.end(), [&new_value](T const& v) {
+                _values.begin(), _values.end(), [&new_value](const T& v) {
                     return v == new_value;
                 });
               if (found == _values.end()) {

--- a/src/v/config/tests/advertised_kafka_api_test.cc
+++ b/src/v/config/tests/advertised_kafka_api_test.cc
@@ -11,7 +11,7 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-static auto const no_advertised_kafka_api_conf
+static const auto no_advertised_kafka_api_conf
   = "redpanda:\n"
     "  data_directory: /var/lib/redpanda/data\n"
     "  node_id: 1\n"
@@ -30,11 +30,11 @@ static auto const no_advertised_kafka_api_conf
     "    address: 127.0.0.1\n"
     "    port: 9644\n";
 
-static auto const advertised_kafka_api_conf = "  advertised_kafka_api:\n"
+static const auto advertised_kafka_api_conf = "  advertised_kafka_api:\n"
                                               "    address: 10.48.0.2\n"
                                               "    port: 1234\n";
 
-static auto const kafka_endpoints_conf_v2
+static const auto kafka_endpoints_conf_v2
   = "redpanda:\n"
     "  data_directory: /var/lib/redpanda/data\n"
     "  node_id: 1\n"

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -536,7 +536,7 @@ SEASTAR_THREAD_TEST_CASE(property_bind_with_multiple_config_stores) {
         // admin/server.cc::patch_cluster_config)
         auto cfg_tmp = test_config();
         // Populate the temporary config object with existing values
-        cfg.for_each([&](auto const& p) {
+        cfg.for_each([&](const auto& p) {
             auto& tmp_p = cfg_tmp.get(p.name());
             tmp_p = p;
         });

--- a/src/v/config/tests/seed_server_property_test.cc
+++ b/src/v/config/tests/seed_server_property_test.cc
@@ -13,7 +13,7 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-static auto const old_seed_server_format = R"(
+static const auto old_seed_server_format = R"(
 redpanda:
   data_directory: /var/lib/redpanda/data
   node_id: 1
@@ -36,7 +36,7 @@ redpanda:
     address: 127.0.0.1
     port: 9644)";
 
-static auto const old_seed_server_format_no_id = R"(
+static const auto old_seed_server_format_no_id = R"(
 redpanda:
   data_directory: /var/lib/redpanda/data
   node_id: 1
@@ -57,7 +57,7 @@ redpanda:
     address: 127.0.0.1
     port: 9644)";
 
-static auto const new_seed_server_format = R"(
+static const auto new_seed_server_format = R"(
 redpanda:
   data_directory: /var/lib/redpanda/data"
   node_id: 1

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -119,7 +119,7 @@ validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms) {
     // Validate results
     for (const auto& m : mechanisms) {
         if (absl::c_none_of(
-              supported, [&m](auto const& s) { return s == m; })) {
+              supported, [&m](const auto& s) { return s == m; })) {
             return ssx::sformat("'{}' is not a supported SASL mechanism", m);
         }
     }
@@ -134,7 +134,7 @@ validate_http_authn_mechanisms(const std::vector<ss::sstring>& mechanisms) {
     // Validate results
     for (const auto& m : mechanisms) {
         if (absl::c_none_of(
-              supported, [&m](auto const& s) { return s == m; })) {
+              supported, [&m](const auto& s) { return s == m; })) {
             return ssx::sformat(
               "'{}' is not a supported HTTP authentication mechanism", m);
         }

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -279,7 +279,7 @@ TEST(Vector, IteratorTypes) {
 
 struct foo {
     int a;
-    friend std::ostream& operator<<(std::ostream& os, foo const& f) {
+    friend std::ostream& operator<<(std::ostream& os, const foo& f) {
         return os << f.a;
     }
     bool operator==(const foo&) const = default;

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -49,7 +49,7 @@ void feature_table_snapshot::apply(feature_table& ft) const {
         auto snap_state_iter = std::find_if(
           states.begin(),
           states.end(),
-          [&spec](feature_state_snapshot const& s) {
+          [&spec](const feature_state_snapshot& s) {
               return s.name == spec.name;
           });
         if (snap_state_iter == states.end()) {

--- a/src/v/hashing/combine.h
+++ b/src/v/hashing/combine.h
@@ -24,22 +24,22 @@ template<typename>
 inline constexpr bool always_false_v = false;
 
 template<typename T>
-concept is_absl_hashable = requires(T const& t) {
+concept is_absl_hashable = requires(const T& t) {
     { absl::Hash<T>{}(t) } -> std::convertible_to<std::size_t>;
 };
 
 template<typename T>
-concept is_std_hashable = requires(T const& t) {
+concept is_std_hashable = requires(const T& t) {
     { std::hash<T>{}(t) } -> std::convertible_to<std::size_t>;
 };
 
 template<typename T>
-concept is_boost_hashable = requires(T const& t) {
+concept is_boost_hashable = requires(const T& t) {
     { boost::hash<T>{}(t) } -> std::convertible_to<std::size_t>;
 };
 
 template<typename T>
-size_t combine(size_t& seed, T const& t) {
+size_t combine(size_t& seed, const T& t) {
     if constexpr (is_std_hashable<T>) {
         boost::hash_combine(seed, std::hash<T>{}(t));
     } else if constexpr (is_absl_hashable<T>) {

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -198,7 +198,7 @@ struct old_ntp_hash<model::ntp> {
 } // namespace
 
 size_t get_ktp_hash(const ktp& k) { return std::hash<ktp>{}(k); }
-size_t get_kaf_hash0(model::ktp const&) {
+size_t get_kaf_hash0(const model::ktp&) {
     return std::hash<std::string_view>{}("kafka");
 }
 size_t get_kaf_hash1() {

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -280,7 +280,7 @@ const client::response_header& client::response_stream::get_headers() const {
 static std::vector<boost::asio::const_buffer>
 iobuf_to_constbufseq(const iobuf& iobuf) {
     std::vector<boost::asio::const_buffer> seq;
-    for (auto const& fragm : iobuf) {
+    for (const auto& fragm : iobuf) {
         boost::asio::const_buffer cbuf{fragm.get(), fragm.size()};
         seq.push_back(cbuf);
     }

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -105,8 +105,8 @@ public:
         explicit response_stream(client* client, verb v, ss::sstring target);
 
         response_stream(response_stream&&) = delete;
-        response_stream(response_stream const&) = delete;
-        response_stream& operator=(response_stream const&) = delete;
+        response_stream(const response_stream&) = delete;
+        response_stream& operator=(const response_stream&) = delete;
         response_stream operator=(response_stream&&) = delete;
 
         /// Return true if the whole http payload is received and parsed
@@ -117,7 +117,7 @@ public:
 
         /// Access response headers (should only be called if is_headers_done()
         /// == true)
-        response_header const& get_headers() const;
+        const response_header& get_headers() const;
 
         /// Prefetch HTTP headers. Read data from the socket until the header is
         /// received and parsed (is_headers_done = true).
@@ -158,8 +158,8 @@ public:
         explicit request_stream(client* client, request_header&& hdr);
 
         request_stream(request_stream&&) = delete;
-        request_stream(request_stream const&) = delete;
-        request_stream& operator=(request_stream const&) = delete;
+        request_stream(const request_stream&) = delete;
+        request_stream& operator=(const request_stream&) = delete;
         request_stream operator=(request_stream&&) = delete;
         ~request_stream() override = default;
 

--- a/src/v/http/iobuf_body.cc
+++ b/src/v/http/iobuf_body.cc
@@ -73,7 +73,7 @@ void iobuf_body::value_type::finish() { _done = true; }
 // iobuf_body::reader implementation
 
 void iobuf_body::reader::init(
-  boost::optional<std::uint64_t> const&, boost::beast::error_code& ec) {
+  const boost::optional<std::uint64_t>&, boost::beast::error_code& ec) {
     ec = {};
 }
 
@@ -83,7 +83,7 @@ void iobuf_body::reader::finish(boost::beast::error_code& ec) {
     _body.finish();
 }
 
-std::uint64_t iobuf_body::size(value_type const& body) { return body.size(); }
+std::uint64_t iobuf_body::size(const value_type& body) { return body.size(); }
 
 static_assert(
   boost::beast::http::is_body<iobuf_body>::value,

--- a/src/v/http/iobuf_body.h
+++ b/src/v/http/iobuf_body.h
@@ -73,8 +73,8 @@ struct iobuf_body {
         ~value_type() = default;
         value_type(value_type&&) = default;
         value_type& operator=(value_type&&) = default;
-        value_type(value_type const&) = delete;
-        const value_type& operator=(value_type const&) = delete;
+        value_type(const value_type&) = delete;
+        const value_type& operator=(const value_type&) = delete;
 
         size_t size() const;
 
@@ -118,7 +118,7 @@ struct iobuf_body {
           boost::beast::http::header<isRequest, Fields>&, value_type& b);
 
         void init(
-          boost::optional<std::uint64_t> const&, boost::beast::error_code& ec);
+          const boost::optional<std::uint64_t>&, boost::beast::error_code& ec);
 
         /// Generic 'put' implementation that work with any ConstBufferSequence
         template<class ConstBufferSequence>
@@ -132,7 +132,7 @@ struct iobuf_body {
     };
 
     /// Returns the body's payload size
-    static std::uint64_t size(value_type const& body);
+    static std::uint64_t size(const value_type& body);
 };
 
 template<bool isRequest, class Fields>

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -214,7 +214,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_POST_roundtrip) {
       config,
       std::move(header),
       ss::sstring(httpd_server_reply),
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
           iobuf_parser parser(std::move(body));
@@ -279,7 +279,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_GET_streaming_roundtrip) {
       std::move(header),
       std::nullopt,
       skip_bytes,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
           iobuf_parser parser(std::move(body));
@@ -308,7 +308,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_POST_streaming_roundtrip) {
       std::move(header),
       ss::sstring(httpd_server_reply),
       0,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
           iobuf_parser parser(std::move(body));
@@ -331,7 +331,7 @@ SEASTAR_THREAD_TEST_CASE(test_error_500) {
       config,
       std::move(header),
       std::nullopt,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(
             header.result(), boost::beast::http::status::internal_server_error);
           iobuf_parser parser(std::move(body));
@@ -352,7 +352,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_GET_roundtrip) {
       config,
       std::move(header),
       std::nullopt,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
           iobuf_parser parser(std::move(body));
           std::string actual = parser.read_string(parser.bytes_left());
@@ -376,7 +376,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_PUT_roundtrip) {
       config,
       std::move(header),
       ss::sstring(httpd_server_reply),
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
           iobuf_parser parser(std::move(body));
           std::string actual = parser.read_string(parser.bytes_left());
@@ -401,7 +401,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_PUT_empty_roundtrip) {
       config,
       std::move(header),
       std::move(stream),
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
           iobuf_parser parser(std::move(body));
           std::string actual = parser.read_string(parser.bytes_left());
@@ -601,7 +601,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor) {
       ss::sstring(httpd_server_reply),
       {full_response},
       false,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
           iobuf_parser parser(std::move(body));
           std::string actual = parser.read_string(parser.bytes_left());
@@ -634,13 +634,13 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_incorrect_reply) {
       ss::sstring(httpd_server_reply),
       {full_response},
       false,
-      [](http::client::response_header const&, iobuf&&) {
+      [](const http::client::response_header&, iobuf&&) {
           BOOST_FAIL("Exception expected");
       },
-      [](std::exception_ptr const& eptr) {
+      [](const std::exception_ptr& eptr) {
           try {
               std::rethrow_exception(eptr);
-          } catch (boost::system::system_error const& e) {
+          } catch (const boost::system::system_error& e) {
               BOOST_REQUIRE(e.code() == boost::beast::http::error::bad_version);
           }
       });
@@ -683,7 +683,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_chunked_encoding) {
       ss::sstring(httpd_server_reply),
       {bufparser.read_string(bufparser.bytes_left())},
       false,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
           iobuf_parser parser(std::move(body));
           std::string actual = parser.read_string(parser.bytes_left());
@@ -774,7 +774,7 @@ void run_framing_test_using_impostor(
           ss::sstring(httpd_server_reply),
           chunks,
           prefetch_headers,
-          [](http::client::response_header const& header, iobuf&& body) {
+          [](const http::client::response_header& header, iobuf&& body) {
               BOOST_REQUIRE_EQUAL(
                 header.result(), boost::beast::http::status::ok);
               iobuf_parser parser(std::move(body));
@@ -831,7 +831,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_no_content_length) {
       ss::sstring(httpd_server_reply),
       {full_response},
       false,
-      [](http::client::response_header const& header, iobuf&& body) {
+      [](const http::client::response_header& header, iobuf&& body) {
           // Expect normal reply despite the absence of content-length
           // header
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -63,7 +63,7 @@ std::optional<std::reference_wrapper<const http_test_utils::request_info>>
 http_imposter_fixture::get_latest_request(
   const ss::sstring& url, bool ignore_url_params) const {
     auto i = std::ranges::upper_bound(
-      _targets, url, std::less<>{}, [=](auto const& url_ri) {
+      _targets, url, std::less<>{}, [=](const auto& url_ri) {
           return ignore_url_params ? remove_query_params(url_ri.first)
                                    : url_ri.first;
       });
@@ -175,7 +175,7 @@ bool http_imposter_fixture::has_call(
   std::string_view url, bool ignore_params) const {
     return std::ranges::find_if(
              _requests,
-             [&](http_test_utils::request_info const& ri) {
+             [&](const http_test_utils::request_info& ri) {
                  return url
                         == (ignore_params ? remove_query_params(ri.url) : ri.url);
              })

--- a/src/v/kafka/client/assignment_plans.cc
+++ b/src/v/kafka/client/assignment_plans.cc
@@ -61,7 +61,7 @@ assignments assignment_range::plan(
   const chunked_vector<member_id>& members,
   const chunked_vector<metadata_response::topic>& topics) {
     assignments assignments;
-    for (auto const& t : topics) {
+    for (const auto& t : topics) {
         auto [len, rem] = std::ldiv(t.partitions.size(), members.size());
         auto iterations = std::min(t.partitions.size(), members.size());
         auto p_begin = t.partitions.begin();

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -105,7 +105,7 @@ public:
 
 private:
     /// \brief Log the client ID if it exists, otherwise don't log
-    friend std::ostream& operator<<(std::ostream& os, broker const& b) {
+    friend std::ostream& operator<<(std::ostream& os, const broker& b) {
         if (b._client.client_id().has_value()) {
             fmt::print(os, "{}: ", b._client.client_id().value());
         }

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -37,7 +37,7 @@ public:
       : _config(config) {};
     brokers(const brokers&) = delete;
     brokers(brokers&&) = default;
-    brokers& operator=(brokers const&) = delete;
+    brokers& operator=(const brokers&) = delete;
     brokers& operator=(brokers&&) = delete;
     ~brokers() noexcept = default;
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -88,7 +88,7 @@ ss::future<> client::connect() {
 
 namespace {
 template<typename Func>
-ss::future<> catch_and_log(client const& c, Func&& f) noexcept {
+ss::future<> catch_and_log(const client& c, Func&& f) noexcept {
     return ss::futurize_invoke(std::forward<Func>(f))
       .discard_result()
       .handle_exception([&c](std::exception_ptr e) {
@@ -562,7 +562,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
               bool has_error = std::any_of(
                 res.data.topics.begin(),
                 res.data.topics.end(),
-                [](auto const& topics) {
+                [](const auto& topics) {
                     return std::any_of(
                       topics.partitions.begin(),
                       topics.partitions.end(),

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -77,7 +77,7 @@ public:
     using external_mitigate
       = ss::noncopyable_function<ss::future<>(std::exception_ptr)>;
     explicit client(
-      YAML::Node const& cfg,
+      const YAML::Node& cfg,
       external_mitigate mitigater = impl::default_external_mitigate);
 
     /// \brief Connect to all brokers.
@@ -193,7 +193,7 @@ private:
     ss::future<> apply(metadata_response res);
 
     /// \brief Log the client ID if it exists, otherwise don't log
-    friend std::ostream& operator<<(std::ostream& os, client const& c) {
+    friend std::ostream& operator<<(std::ostream& os, const client& c) {
         if (c._config.client_identifier().has_value()) {
             fmt::print(os, "{}: ", c._config.client_identifier().value());
         }

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -30,8 +30,8 @@ namespace kafka::client {
 ss::future<std::unique_ptr<kafka::client::configuration>>
 create_client_credentials(
   cluster::controller& controller,
-  config::configuration const& cluster_cfg,
-  kafka::client::configuration const& client_cfg,
+  const config::configuration& cluster_cfg,
+  const kafka::client::configuration& client_cfg,
   security::acl_principal principal) {
     auto new_cfg = std::make_unique<kafka::client::configuration>(
       to_yaml(client_cfg, config::redact_secrets::no));
@@ -68,7 +68,7 @@ create_client_credentials(
 }
 
 void set_client_credentials(
-  kafka::client::configuration const& client_cfg,
+  const kafka::client::configuration& client_cfg,
   kafka::client::client& client) {
     client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());
     client.config().scram_username.set_value(client_cfg.scram_username());
@@ -76,7 +76,7 @@ void set_client_credentials(
 }
 
 ss::future<> set_client_credentials(
-  kafka::client::configuration const& client_cfg,
+  const kafka::client::configuration& client_cfg,
   ss::sharded<kafka::client::client>& client) {
     co_await client.invoke_on_all([&client_cfg](kafka::client::client& client) {
         client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -28,16 +28,16 @@ namespace kafka::client {
 ss::future<std::unique_ptr<kafka::client::configuration>>
 create_client_credentials(
   cluster::controller& controller,
-  config::configuration const& cluster_cfg,
-  kafka::client::configuration const& client_cfg,
+  const config::configuration& cluster_cfg,
+  const kafka::client::configuration& client_cfg,
   security::acl_principal principal);
 
 void set_client_credentials(
-  kafka::client::configuration const& client_cfg,
+  const kafka::client::configuration& client_cfg,
   kafka::client::client& client);
 
 ss::future<> set_client_credentials(
-  kafka::client::configuration const& client_cfg,
+  const kafka::client::configuration& client_cfg,
   ss::sharded<kafka::client::client>& client);
 
 model::compression compression_from_str(std::string_view v);

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -214,14 +214,14 @@ ss::future<> consumer::subscribe(chunked_vector<model::topic> topics) {
 void consumer::on_leader_join(const join_group_response& res) {
     _members.clear();
     _members.reserve(res.data.members.size());
-    for (auto const& m : res.data.members) {
+    for (const auto& m : res.data.members) {
         _members.push_back(m.member_id);
     }
     std::sort(_members.begin(), _members.end());
     _members.erase_to_end(std::unique(_members.begin(), _members.end()));
 
     _subscribed_topics.clear();
-    for (auto const& m : res.data.members) {
+    for (const auto& m : res.data.members) {
         protocol::decoder r(bytes_to_iobuf(m.metadata));
         auto topics = r.read_array([](protocol::decoder& reader) {
             return model::topic(reader.read_string());
@@ -420,7 +420,7 @@ ss::future<fetch_response> consumer::fetch(
     refresh_inactivity_timer();
     // Split requests by broker
     broker_reqs_t broker_reqs;
-    for (auto const& [t, ps] : _assignment) {
+    for (const auto& [t, ps] : _assignment) {
         for (const auto& p : ps) {
             auto tp = model::topic_partition{t, p};
             auto leader = co_await _topic_cache.leader(tp);

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -79,7 +79,7 @@ fetch_session::make_offset_commit_request() const {
     return res;
 }
 
-std::ostream& operator<<(std::ostream& os, fetch_session const& fs) {
+std::ostream& operator<<(std::ostream& os, const fetch_session& fs) {
     fmt::print(os, "{{id={}, epoch={}}}", fs.id(), fs.epoch());
     return os;
 }

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -43,7 +43,7 @@ public:
     std::vector<kafka::offset_commit_request_topic>
     make_offset_commit_request() const;
 
-    friend std::ostream& operator<<(std::ostream& os, fetch_session const&);
+    friend std::ostream& operator<<(std::ostream& os, const fetch_session&);
 
 private:
     kafka::fetch_session_id _id{kafka::invalid_fetch_session_id};

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -260,7 +260,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
         auto m_id = sorted_members[i];
         auto assignment = client.consumer_assignment(group_id, m_id).get();
         BOOST_REQUIRE_EQUAL(assignment.size(), 3);
-        for (auto const& [topic, partitions] : assignment) {
+        for (const auto& [topic, partitions] : assignment) {
             BOOST_REQUIRE_EQUAL(partitions.size(), 1);
             BOOST_REQUIRE_EQUAL(partitions[0](), i);
         }
@@ -271,9 +271,9 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
               .get();
         BOOST_REQUIRE_EQUAL(offsets.data.error_code, kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(offsets.data.topics.size(), 3);
-        for (auto const& t : offsets.data.topics) {
+        for (const auto& t : offsets.data.topics) {
             BOOST_REQUIRE_EQUAL(t.partitions.size(), 1);
-            for (auto const& p : t.partitions) {
+            for (const auto& p : t.partitions) {
                 BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
                 BOOST_REQUIRE_EQUAL(p.partition_index(), i);
                 BOOST_REQUIRE_EQUAL(p.committed_offset(), -1);
@@ -335,7 +335,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
         auto m_id = sorted_members[i];
         auto assignment = client.consumer_assignment(group_id, m_id).get();
         BOOST_REQUIRE_EQUAL(assignment.size(), 3);
-        for (auto const& [topic, partitions] : assignment) {
+        for (const auto& [topic, partitions] : assignment) {
             BOOST_REQUIRE_EQUAL(partitions.size(), 1);
             BOOST_REQUIRE_EQUAL(partitions[0](), i);
         }
@@ -346,9 +346,9 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
               .get();
         BOOST_REQUIRE_EQUAL(offsets.data.error_code, kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(offsets.data.topics.size(), 3);
-        for (auto const& t : offsets.data.topics) {
+        for (const auto& t : offsets.data.topics) {
             BOOST_REQUIRE_EQUAL(t.partitions.size(), 1);
-            for (auto const& p : t.partitions) {
+            for (const auto& p : t.partitions) {
                 BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
                 BOOST_REQUIRE_EQUAL(p.partition_index(), i);
                 BOOST_REQUIRE_EQUAL(p.committed_offset(), 5);
@@ -385,9 +385,9 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
               .get();
         BOOST_REQUIRE_EQUAL(offsets.data.error_code, kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(offsets.data.topics.size(), 3);
-        for (auto const& t : offsets.data.topics) {
+        for (const auto& t : offsets.data.topics) {
             BOOST_REQUIRE_EQUAL(t.partitions.size(), 1);
-            for (auto const& p : t.partitions) {
+            for (const auto& p : t.partitions) {
                 BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
                 BOOST_REQUIRE_EQUAL(p.partition_index(), i);
                 auto part_it = std::find_if(

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -69,7 +69,7 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
         const auto& p = res.data.topics[0];
         BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
-        auto const& r = p.partitions[0];
+        const auto& r = p.partitions[0];
         BOOST_REQUIRE_EQUAL(r.partition_index, ntp.tp.partition);
         BOOST_REQUIRE_EQUAL(r.error_code, kafka::error_code::none);
     }

--- a/src/v/kafka/client/test/test_config_utils.cc
+++ b/src/v/kafka/client/test/test_config_utils.cc
@@ -33,13 +33,13 @@
 
 namespace kafka::client {
 // BOOST_REQURE_EQUAL fails to find this if it's in the global namespace
-bool operator==(configuration const& lhs, configuration const& rhs) {
+bool operator==(const configuration& lhs, const configuration& rhs) {
     return fmt::format("{}", config::to_yaml(lhs, config::redact_secrets::no))
            == fmt::format(
              "{}", config::to_yaml(rhs, config::redact_secrets::no));
 }
 
-std::ostream& operator<<(std::ostream& os, configuration const& c) {
+std::ostream& operator<<(std::ostream& os, const configuration& c) {
     YAML::Emitter e{os};
     auto n = config::to_yaml(c, config::redact_secrets::no);
     n.SetStyle(YAML::EmitterStyle::value::Block);
@@ -53,7 +53,7 @@ std::ostream& operator<<(std::ostream& os, configuration const& c) {
 namespace {
 
 template<typename T>
-std::unique_ptr<T> clone_config(T const& t) {
+std::unique_ptr<T> clone_config(const T& t) {
     return T{config::to_yaml(t), config::redact_secrets::no};
 }
 
@@ -65,7 +65,7 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
 
-    auto const& ec_store
+    const auto& ec_store
       = app.controller->get_ephemeral_credential_store().local();
 
     // Default configuration doesn't have a SASL listener

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -33,7 +33,7 @@ topic_cache::apply(small_fragment_vector<metadata_response::topic>&& topics) {
         auto& cache_t
           = cache.emplace(t.name, std::move(topic_data)).first->second;
         cache_t.partitions.reserve(t.partitions.size());
-        for (auto const& p : t.partitions) {
+        for (const auto& p : t.partitions) {
             cache_t.partitions.emplace(
               p.partition_index, partition_data{.leader = p.leader_id});
         }

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -42,7 +42,7 @@ public:
     topic_cache() = default;
     topic_cache(const topic_cache&) = delete;
     topic_cache(topic_cache&&) = default;
-    topic_cache& operator=(topic_cache const&) = delete;
+    topic_cache& operator=(const topic_cache&) = delete;
     topic_cache& operator=(topic_cache&&) = delete;
     ~topic_cache() noexcept = default;
 

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -219,7 +219,7 @@ public:
         }
     }
 
-    std::optional<ss::sstring> const& client_id() const { return _client_id; }
+    const std::optional<ss::sstring>& client_id() const { return _client_id; }
 
 private:
     void write_header(protocol::encoder& wr, api_key key, api_version version) {

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -149,7 +149,7 @@ client_quota_value client_quota_translator::get_client_quota_value(
                 client_quota_rule::kafka_client_id};
           }
 
-          const static auto default_client_key = entity_key{
+          static const auto default_client_key = entity_key{
             entity_key::client_id_default_match{}};
           auto default_quota = _quota_store.local().get_quota(
             default_client_key);

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -291,7 +291,7 @@ ss::future<chunked_vector<R>> do_alter_topics_configuration(
 
 template<typename T, typename R>
 ss::future<chunked_vector<R>> unsupported_broker_configuration(
-  chunked_vector<T> resources, std::string_view const msg) {
+  chunked_vector<T> resources, const std::string_view msg) {
     chunked_vector<R> responses;
     responses.reserve(resources.size());
     std::transform(
@@ -504,7 +504,7 @@ void parse_and_set_optional(
                 throw validation_error(*v_error);
             }
             property.value = std::move(v);
-        } catch (std::runtime_error const&) {
+        } catch (const std::runtime_error&) {
             throw boost::bad_lexical_cast();
         }
         return;
@@ -549,7 +549,7 @@ inline void parse_and_set_optional_duration(
                 throw validation_error(*v_error);
             }
             property.value = std::move(v);
-        } catch (std::runtime_error const&) {
+        } catch (const std::runtime_error&) {
             throw boost::bad_lexical_cast();
         }
         return;
@@ -571,7 +571,7 @@ inline void parse_and_set_optional_bool_alpha(
             property.value = string_switch<bool>(*value)
                                .match("true", true)
                                .match("false", false);
-        } catch (std::runtime_error const&) {
+        } catch (const std::runtime_error&) {
             // Our callers expect this exception type on malformed values
             throw boost::bad_lexical_cast();
         }
@@ -677,7 +677,7 @@ public:
 
     ///\brief Parse a topic property from the supplied cfg.
     template<typename C>
-    bool operator()(C const& cfg, kafka::config_resource_operation op) {
+    bool operator()(const C& cfg, kafka::config_resource_operation op) {
         using property_t = std::variant<
           decltype(&props.record_key_schema_id_validation),
           decltype(&props.record_key_subject_name_strategy)>;
@@ -729,7 +729,7 @@ private:
     ///\brief Parse and set a boolean from 'true' or 'false'.
     static void apply(
       cluster::property_update<std::optional<bool>>& prop,
-      std::optional<ss::sstring> const& value,
+      const std::optional<ss::sstring>& value,
       kafka::config_resource_operation op) {
         kafka::parse_and_set_optional_bool_alpha(prop, value, op);
     }
@@ -737,7 +737,7 @@ private:
     static void apply(
       cluster::property_update<std::optional<
         pandaproxy::schema_registry::subject_name_strategy>>& prop,
-      std::optional<ss::sstring> const& value,
+      const std::optional<ss::sstring>& value,
       kafka::config_resource_operation op) {
         kafka::parse_and_set_optional(prop, value, op);
     }

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -53,7 +53,7 @@ request_iterator validate_range_duplicates(
     absl::node_hash_map<model::topic_view, uint32_t> freq;
 
     freq.reserve(std::distance(begin, end));
-    for (auto const& r : boost::make_iterator_range(begin, end)) {
+    for (const auto& r : boost::make_iterator_range(begin, end)) {
         freq[r.name]++;
     }
     auto valid_range_end = std::partition(

--- a/src/v/kafka/server/handlers/details/leader_epoch.h
+++ b/src/v/kafka/server/handlers/details/leader_epoch.h
@@ -25,7 +25,7 @@ inline kafka::error_code check_leader_epoch(
     if (request_epoch < 0) {
         return error_code::none;
     }
-    auto const partition_epoch = p.leader_epoch();
+    const auto partition_epoch = p.leader_epoch();
 
     if (request_epoch > partition_epoch) {
         return error_code::unknown_leader_epoch;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1821,7 +1821,7 @@ std::optional<model::node_id> rack_aware_replica_selector::select_replica(
             continue;
         }
 
-        auto const node_it = _md_cache.nodes().find(replica.id);
+        const auto node_it = _md_cache.nodes().find(replica.id);
         /**
          * Skip nodes which are in maintenance mode or we do not have
          * information about them

--- a/src/v/kafka/server/handlers/handler_interface.cc
+++ b/src/v/kafka/server/handlers/handler_interface.cc
@@ -103,7 +103,7 @@ private:
  */
 template<KafkaApiHandlerAny H>
 struct handler_holder {
-    static const inline handler_base<KafkaApiTwoPhaseHandler<H>> instance{
+    static inline const handler_base<KafkaApiTwoPhaseHandler<H>> instance{
       handler_info{
         H::api::key,
         H::api::name,

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -233,8 +233,8 @@ ss::future<produce_response::partition> finalize_request_with_error_code(
  * the batch, if present
  */
 static auto validate_batch_timestamps(
-  model::ntp const& ntp,
-  model::record_batch_header const& header,
+  const model::ntp& ntp,
+  const model::record_batch_header& header,
   model::timestamp_type timestamp_type,
   net::server_probe& probe) -> std::optional<model::timestamp> {
     // we compute in std::chrono::timepoints, we print in model::timestamps

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -148,7 +148,7 @@ Iter validate_range_duplicates(Iter begin, Iter end, ErrIter out_it) {
     using type = typename Iter::value_type;
     boost::container::flat_map<model::topic_view, uint32_t> freq;
     freq.reserve(std::distance(begin, end));
-    for (auto const& r : boost::make_iterator_range(begin, end)) {
+    for (const auto& r : boost::make_iterator_range(begin, end)) {
         freq[r.name]++;
     }
     auto valid_range_end = std::partition(

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -238,21 +238,21 @@ struct subject_name_strategy_validator {
         return std::all_of(
           c.configs.begin(),
           c.configs.end(),
-          [](createable_topic_config const& v) {
+          [](const createable_topic_config& v) {
               return !is_sns_config(v) || !v.value.has_value()
                      || is_valid_sns(v.value.value());
           });
     }
 
 private:
-    static bool is_sns_config(createable_topic_config const& c) {
+    static bool is_sns_config(const createable_topic_config& c) {
         static constexpr const auto config_names = {
           topic_property_record_key_subject_name_strategy,
           topic_property_record_key_subject_name_strategy_compat,
           topic_property_record_value_subject_name_strategy,
           topic_property_record_value_subject_name_strategy_compat};
         return std::any_of(
-          config_names.begin(), config_names.end(), [&c](auto const& v) {
+          config_names.begin(), config_names.end(), [&c](const auto& v) {
               return c.name == v;
           });
     }

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -40,7 +40,7 @@
 
 using namespace std::chrono_literals;
 
-const static unsigned quotas_shard = 0;
+static const unsigned quotas_shard = 0;
 
 namespace kafka {
 

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -142,7 +142,7 @@ quota_t node_to_shard_quota(const std::optional<quota_t> node_quota) {
 
 auto update_node_bucket(
   ssx::sharded_ptr<kafka::snc_quota_manager::bucket_t>& b,
-  config::binding<std::optional<int64_t>> const& cfg) {
+  const config::binding<std::optional<int64_t>>& cfg) {
     if (!cfg().has_value()) {
         return b.reset();
     }

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -710,7 +710,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
             << "%");
 
         constexpr auto get_throttle_percentile =
-          [](ss::metrics::histogram const& h, int p) {
+          [](const ss::metrics::histogram& h, int p) {
               auto count_p = double(h.sample_count) * p / 100;
               auto lb = std::ranges::lower_bound(
                 h.buckets,

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -25,9 +25,9 @@
 #include <optional>
 #include <vector>
 
-const static auto fixed_client_id = "shared-client-id";
-const static size_t total_requests{10 << 20};
-const static size_t unique_client_id_count = 1000;
+static const auto fixed_client_id = "shared-client-id";
+static const size_t total_requests{10 << 20};
+static const size_t unique_client_id_count = 1000;
 
 std::vector<ss::sstring> initialize_client_ids() {
     std::vector<ss::sstring> client_ids;
@@ -146,7 +146,7 @@ struct latency_test_case {
     bool no_quotas;
 };
 
-const static size_t n_repeats = 100;
+static const size_t n_repeats = 100;
 
 future<size_t> run_latency_test(latency_test_case tc) {
     ss::sharded<cluster::client_quota::store> quota_store;

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -27,7 +27,7 @@
 using namespace std::chrono_literals;
 using kafka::scale_to_smp_count;
 
-const static auto client_id = "franz-go";
+static const auto client_id = "franz-go";
 
 struct fixture {
     ss::sharded<cluster::client_quota::store> quota_store;

--- a/src/v/kafka/server/tests/topic_utils_test.cc
+++ b/src/v/kafka/server/tests/topic_utils_test.cc
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(
       partitions_validator::error_message,
       partitions_validator::is_valid);
     BOOST_REQUIRE_EQUAL(errs.size(), 2);
-    for (auto const& e : errs) {
+    for (const auto& e : errs) {
         BOOST_TEST(
           (int8_t)e.error_code
           == (int8_t)kafka::error_code::invalid_partitions);

--- a/src/v/kafka/server/tests/validator_tests.cc
+++ b/src/v/kafka/server/tests/validator_tests.cc
@@ -25,7 +25,7 @@ struct test_validator_data {
     std::vector<createable_topic_config> configs;
     bool is_valid;
     friend std::ostream&
-    operator<<(std::ostream& os, test_validator_data const& d) {
+    operator<<(std::ostream& os, const test_validator_data& d) {
         fmt::print(os, "configs: {}, expect valid: {}", d.configs, d.is_valid);
         return os;
     }

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -192,7 +192,7 @@ public:
       : named_type<ss::sstring, struct model_topic_type>(ss::sstring(view())) {}
 
     friend void
-    read_nested(iobuf_parser& in, topic& t, size_t const bytes_left_limit) {
+    read_nested(iobuf_parser& in, topic& t, const size_t bytes_left_limit) {
         using serde::read_nested;
         return read_nested(in, t._value, bytes_left_limit);
     }
@@ -342,7 +342,7 @@ struct topic_partition {
     friend std::ostream& operator<<(std::ostream&, const topic_partition&);
 
     friend void read_nested(
-      iobuf_parser& in, topic_partition& tp, size_t const bytes_left_limit) {
+      iobuf_parser& in, topic_partition& tp, const size_t bytes_left_limit) {
         using serde::read_nested;
 
         read_nested(in, tp.topic, bytes_left_limit);
@@ -386,7 +386,7 @@ struct ntp {
     }
 
     friend void
-    read_nested(iobuf_parser& in, ntp& ntp, size_t const bytes_left_limit) {
+    read_nested(iobuf_parser& in, ntp& ntp, const size_t bytes_left_limit) {
         using serde::read_nested;
 
         read_nested(in, ntp.ns, bytes_left_limit);

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -275,7 +275,7 @@ struct broker_shard {
     }
 
     friend void read_nested(
-      iobuf_parser& in, broker_shard& bs, std::size_t const bytes_left_limit) {
+      iobuf_parser& in, broker_shard& bs, const std::size_t bytes_left_limit) {
         using serde::read_nested;
         read_nested(in, bs.node_id, bytes_left_limit);
         read_nested(in, bs.shard, bytes_left_limit);
@@ -374,7 +374,7 @@ struct topic_namespace {
     friend void read_nested(
       iobuf_parser& in,
       topic_namespace& t,
-      std::size_t const bytes_left_limit) {
+      const std::size_t bytes_left_limit) {
         using serde::read_nested;
         read_nested(in, t.ns, bytes_left_limit);
         read_nested(in, t.tp, bytes_left_limit);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, timestamp ts) {
 }
 
 void read_nested(
-  iobuf_parser& in, timestamp& ts, size_t const bytes_left_limit) {
+  iobuf_parser& in, timestamp& ts, const size_t bytes_left_limit) {
     serde::read_nested(in, ts._v, bytes_left_limit);
 }
 
@@ -582,7 +582,7 @@ std::istream& operator>>(std::istream& is, recovery_validation_mode& vm) {
                  "check_manifest_and_segment_metadata",
                  check_manifest_and_segment_metadata)
                .match("no_check", no_check);
-    } catch (std::runtime_error const&) {
+    } catch (const std::runtime_error&) {
         is.setstate(std::ios::failbit);
     }
     return is;

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -377,7 +377,7 @@ public:
     friend inline void read_nested(
       iobuf_parser& in,
       record_batch_attributes& attrs,
-      size_t const bytes_left_limit) {
+      const size_t bytes_left_limit) {
         attrs._attributes = serde::read_nested<uint64_t>(in, bytes_left_limit);
     }
 

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -81,7 +81,7 @@ public:
     // ADL helpers for interfacing with the serde library.
     friend void write(iobuf& out, timestamp ts);
     friend void
-    read_nested(iobuf_parser& in, timestamp& ts, size_t const bytes_left_limit);
+    read_nested(iobuf_parser& in, timestamp& ts, const size_t bytes_left_limit);
 
     static timestamp now();
 

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -437,7 +437,7 @@ void tag_invoke(
   serde::tag_t<serde::read_tag>,
   iobuf_parser& in,
   wasm_binary_iobuf& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     auto size = serde::read_nested<serde::serde_size_t>(in, bytes_left_limit);
     t = wasm_binary_iobuf(std::make_unique<iobuf>(in.share(size)));
 }

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -55,7 +55,7 @@ void tag_invoke(
   serde::tag_t<serde::read_tag>,
   iobuf_parser& in,
   wasm_binary_iobuf& t,
-  std::size_t const bytes_left_limit);
+  const std::size_t bytes_left_limit);
 
 /** Serde support for wasm_binary_iobuf - it has the same format as iobuf. */
 void tag_invoke(

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -54,12 +54,12 @@ public:
     public:
         units() = default;
 
-        units(conn_quota& quotas, ss::net::inet_address const& addr)
+        units(conn_quota& quotas, const ss::net::inet_address& addr)
           : _quotas(std::ref(quotas))
           , _addr(addr) {}
 
-        units(units const&) = delete;
-        units& operator=(units const&) = delete;
+        units(const units&) = delete;
+        units& operator=(const units&) = delete;
         units(units&& rhs) noexcept
           : _addr(rhs._addr)
           , _verify_shard(rhs._verify_shard) {
@@ -169,7 +169,7 @@ private:
     ss::shard_id addr_to_shard(ss::net::inet_address) const;
 
     void
-    assert_on_home([[maybe_unused]] ss::net::inet_address const& addr) const {
+    assert_on_home([[maybe_unused]] const ss::net::inet_address& addr) const {
 #ifndef NDEBUG
         vassert(
           conn_quota::addr_to_shard(addr) == ss::this_shard_id(),

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -287,7 +287,7 @@ void rjson_serialize(
     w.StartObject();
     w.Key("offsets");
     w.StartArray();
-    for (auto const& p : v.partitions) {
+    for (const auto& p : v.partitions) {
         rjson_serialize(w, p);
     }
     w.EndArray();

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -139,7 +139,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_records_name) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 25");
       });
 }
@@ -158,7 +158,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_name) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 99");
       });
 }
@@ -177,7 +177,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_partition_type) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 112");
       });
 }
@@ -197,7 +197,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_before_records) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 28");
       });
 }
@@ -217,7 +217,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_after_records) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 152");
       });
 }
@@ -237,7 +237,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_between_records) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 144");
       });
 }
@@ -252,7 +252,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request_error_no_records) {
     BOOST_CHECK_EXCEPTION(
       ppj::impl::rjson_parse(input, make_binary_v2_handler()),
       ppj::parse_error,
-      [](ppj::parse_error const& e) {
+      [](const ppj::parse_error& e) {
           return e.what() == std::string_view("parse error at offset 24");
       });
 }

--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -25,7 +25,7 @@ namespace pandaproxy {
 static constexpr auto gc_timer_period = 10s;
 
 kafka_client_cache::kafka_client_cache(
-  YAML::Node const& cfg, size_t max_size, std::chrono::milliseconds keep_alive)
+  const YAML::Node& cfg, size_t max_size, std::chrono::milliseconds keep_alive)
   : _config{cfg}
   , _cache_max_size{max_size}
   , _keep_alive{keep_alive} {

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -37,16 +37,16 @@ namespace pandaproxy {
 class kafka_client_cache {
 public:
     kafka_client_cache(
-      YAML::Node const& cfg,
+      const YAML::Node& cfg,
       size_t max_size,
       std::chrono::milliseconds keep_alive);
 
     ~kafka_client_cache() = default;
 
     kafka_client_cache(kafka_client_cache&&) = default;
-    kafka_client_cache(kafka_client_cache const&) = delete;
+    kafka_client_cache(const kafka_client_cache&) = delete;
     kafka_client_cache& operator=(kafka_client_cache&&) = delete;
-    kafka_client_cache& operator=(kafka_client_cache const&) = delete;
+    kafka_client_cache& operator=(const kafka_client_cache&) = delete;
 
     ss::future<> start();
     ss::future<> stop();

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -176,7 +176,7 @@ ss::future<> proxy::configure() {
       principal);
     co_await kafka::client::set_client_credentials(*config, _client);
 
-    auto const& store = _controller->get_ephemeral_credential_store().local();
+    const auto& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));
     co_await container().invoke_on_all(
       _ctx.smp_sg, [has_ephemeral_credentials](proxy& p) {
@@ -212,7 +212,7 @@ ss::future<> proxy::mitigate_error(std::exception_ptr eptr) {
     }
     vlog(plog.debug, "mitigate_error: {}", eptr);
     return ss::make_exception_future<>(eptr).handle_exception_type(
-      [this, eptr](kafka::client::broker_error const& ex) {
+      [this, eptr](const kafka::client::broker_error& ex) {
           if (
             ex.error == kafka::error_code::sasl_authentication_failed
             && _has_ephemeral_credentials) {

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -230,7 +230,7 @@ enum class object_type { complex, field };
 template<object_type type>
 struct member_sorter {
     bool operator()(
-      json::Document::Member const& lhs, json::Document::Member const& rhs) {
+      const json::Document::Member& lhs, const json::Document::Member& rhs) {
         constexpr auto order = [](std::string_view name) {
             auto val = string_switch<char>(name)
                          .match("type", type == object_type::complex ? 0 : 1)
@@ -248,7 +248,7 @@ struct member_sorter {
                          .default_match(std::numeric_limits<char>::max());
             return val;
         };
-        constexpr auto as_string_view = [](json::Value const& v) {
+        constexpr auto as_string_view = [](const json::Value& v) {
             return std::string_view{v.GetString(), v.GetStringLength()};
         };
         return order(as_string_view(lhs.name))
@@ -548,7 +548,7 @@ ss::future<collected_schema> collect_schema(
   collected_schema collected,
   ss::sstring name,
   canonical_schema schema) {
-    for (auto const& ref : schema.def().refs()) {
+    for (const auto& ref : schema.def().refs()) {
         if (!collected.contains(ref.name)) {
             auto ss = co_await store.get_subject_schema(
               ref.sub, ref.version, include_deleted::no);

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -142,10 +142,10 @@ std::error_code make_error_code(error_code e) {
 }
 
 error_info no_reference_found_for(
-  canonical_schema const& schema, const subject& sub, schema_version ver) {
+  const canonical_schema& schema, const subject& sub, schema_version ver) {
     // fmt v8 doesn't support formatting for elements in a range
     auto fmt_refs = schema.def().refs()
-                    | std::views::transform([](auto const& ref) {
+                    | std::views::transform([](const auto& ref) {
                           return fmt::format("{{{:e}}}", ref);
                       });
     return {

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -165,7 +165,7 @@ inline error_info has_references(const subject& sub, schema_version ver) {
 }
 
 error_info no_reference_found_for(
-  canonical_schema const& schema, const subject& sub, schema_version ver);
+  const canonical_schema& schema, const subject& sub, schema_version ver);
 
 inline error_info compatibility_not_found(const subject& sub) {
     return error_info{

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -432,7 +432,7 @@ protobuf_schema_definition::raw() const {
 }
 
 ::result<ss::sstring, kafka::error_code>
-protobuf_schema_definition::name(std::vector<int> const& fields) const {
+protobuf_schema_definition::name(const std::vector<int>& fields) const {
     if (fields.empty()) {
         return kafka::error_code::invalid_record;
     }

--- a/src/v/pandaproxy/schema_registry/schema_id_cache.h
+++ b/src/v/pandaproxy/schema_registry/schema_id_cache.h
@@ -44,7 +44,7 @@ public:
       field field,
       subject_name_strategy sns,
       schema_id s_id,
-      offsets_t const& offsets) {
+      const offsets_t& offsets) {
         auto& map = _cache.get<underlying_map>();
         auto it = map.find(entry::view_t(topic, field, sns, s_id, offsets));
         bool has = it != map.end();
@@ -111,19 +111,19 @@ private:
           field,
           subject_name_strategy,
           schema_id,
-          offsets_t const&>;
+          const offsets_t&>;
         view_t view() const { return {topic, f, sns, s_id, offsets}; }
 
         // Full comparison of entry
         struct less {
             using is_transparent = void;
-            bool operator()(entry const& lhs, entry const& rhs) const {
+            bool operator()(const entry& lhs, const entry& rhs) const {
                 return lhs.view() < rhs.view();
             }
-            bool operator()(view_t lhs, entry const& rhs) const {
+            bool operator()(view_t lhs, const entry& rhs) const {
                 return lhs < rhs.view();
             }
-            bool operator()(entry const& lhs, view_t rhs) const {
+            bool operator()(const entry& lhs, view_t rhs) const {
                 return lhs.view() < rhs;
             }
         };
@@ -131,10 +131,10 @@ private:
         // Compare only the topic
         struct topic_less {
             using is_transparent = void;
-            bool operator()(model::topic_view lhs, entry const& rhs) const {
+            bool operator()(model::topic_view lhs, const entry& rhs) const {
                 return lhs < model::topic_view(rhs.topic);
             }
-            bool operator()(entry const& lhs, model::topic_view rhs) const {
+            bool operator()(const entry& lhs, model::topic_view rhs) const {
                 return model::topic_view(lhs.topic) < rhs;
             }
         };

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -116,7 +116,7 @@ ss::future<> seq_writer::read_sync() {
     co_await wait_for(max_offset - model::offset{1});
 }
 
-ss::future<> seq_writer::check_mutable(std::optional<subject> const& sub) {
+ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
     auto mode = sub ? co_await _store.get_mode(*sub, default_to_global::yes)
                     : co_await _store.get_mode();
     if (mode == mode::read_only) {
@@ -485,7 +485,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     }
 
     auto is_referenced = co_await ssx::parallel_transform(
-      versions.begin(), versions.end(), [this, &sub](auto const& ver) {
+      versions.begin(), versions.end(), [this, &sub](const auto& ver) {
           return _store.is_referenced(sub, ver);
       });
     if (std::any_of(is_referenced.begin(), is_referenced.end(), [](auto v) {
@@ -502,7 +502,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
 
     try {
         rb(co_await _store.get_subject_mode_written_at(sub));
-    } catch (exception const& e) {
+    } catch (const exception& e) {
         if (e.code() != error_code::subject_not_found) {
             throw;
         }
@@ -510,7 +510,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
 
     try {
         rb(co_await _store.get_subject_config_written_at(sub));
-    } catch (exception const& e) {
+    } catch (const exception& e) {
         if (e.code() != error_code::subject_not_found) {
             throw;
         }

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -41,7 +41,7 @@ public:
     ss::future<> read_sync();
 
     // Throws 42205 if the subject cannot be modified
-    ss::future<> check_mutable(std::optional<subject> const& sub);
+    ss::future<> check_mutable(const std::optional<subject>& sub);
 
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -79,7 +79,7 @@ public:
         auto guard = _g.hold();
         try {
             co_return co_await _h(std::move(rq), std::move(rp));
-        } catch (kafka::client::partition_error const& ex) {
+        } catch (const kafka::client::partition_error& ex) {
             if (
               ex.error == kafka::error_code::unknown_topic_or_partition
               && ex.tp.topic == model::schema_registry_internal_tp.topic) {
@@ -454,7 +454,7 @@ ss::future<> service::configure() {
       principal);
     co_await kafka::client::set_client_credentials(*config, _client);
 
-    auto const& store = _controller->get_ephemeral_credential_store().local();
+    const auto& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));
     co_await container().invoke_on_all(
       _ctx.smp_sg, [has_ephemeral_credentials](service& s) {
@@ -470,7 +470,7 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
     vlog(plog.warn, "mitigate_error: {}", eptr);
     return ss::make_exception_future<>(eptr)
       .handle_exception_type(
-        [this, eptr](kafka::client::broker_error const& ex) {
+        [this, eptr](const kafka::client::broker_error& ex) {
             if (
               ex.error == kafka::error_code::sasl_authentication_failed
               && _has_ephemeral_credentials) {
@@ -484,7 +484,7 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
             return ss::make_exception_future<>(eptr);
         })
       .handle_exception_type([this,
-                              eptr](kafka::client::topic_error const& ex) {
+                              eptr](const kafka::client::topic_error& ex) {
           if (
             ex.error == kafka::error_code::topic_authorization_failed
             && _has_ephemeral_credentials) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -190,7 +190,7 @@ sharded_store::get_schema_version(subject_schema schema) {
 
     std::optional<schema_version> v_id;
     if (s_id.has_value()) {
-        auto v_it = absl::c_find_if(versions, [id = *s_id](auto const& s_id_v) {
+        auto v_it = absl::c_find_if(versions, [id = *s_id](const auto& s_id_v) {
             return s_id_v.id == id;
         });
         if (v_it != versions.end()) {
@@ -217,7 +217,7 @@ sharded_store::get_schema_version(subject_schema schema) {
 
 ss::future<sharded_store::insert_result>
 sharded_store::project_ids(subject_schema schema) {
-    auto const& sub = schema.schema.sub();
+    const auto& sub = schema.schema.sub();
     auto s_id = schema.id;
     if (s_id == invalid_schema_id) {
         // New schema, project an ID for it.
@@ -423,7 +423,7 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
     if (opt_ver.has_value()) {
         ver = *opt_ver;
         auto version_not_found = std::none_of(
-          versions.begin(), versions.end(), [ver](auto const& v) {
+          versions.begin(), versions.end(), [ver](const auto& v) {
               return ver == v;
           });
         if (version_not_found) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -140,7 +140,7 @@ public:
         auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
 
         if (!version.has_value()) {
-            auto const& versions = sub_it->second.versions;
+            const auto& versions = sub_it->second.versions;
             auto it = std::find_if(
               versions.rbegin(), versions.rend(), [inc_del](const auto& ver) {
                   return inc_del || !ver.deleted;
@@ -183,7 +183,7 @@ public:
             if (inc_del || !sub.second.deleted) {
                 auto has_version = absl::c_any_of(
                   sub.second.versions,
-                  [inc_del](auto const& v) { return inc_del || !v.deleted; });
+                  [inc_del](const auto& v) { return inc_del || !v.deleted; });
                 if (
                   has_version
                   && sub.first().starts_with(subject_prefix.value_or(""))) {
@@ -196,10 +196,10 @@ public:
 
     ///\brief Return if there are subjects.
     bool has_subjects(include_deleted inc_del) const {
-        return absl::c_any_of(_subjects, [inc_del](auto const& sub) {
+        return absl::c_any_of(_subjects, [inc_del](const auto& sub) {
             return absl::c_any_of(
               sub.second.versions,
-              [inc_del](auto const& v) { return inc_del || !v.deleted; });
+              [inc_del](const auto& v) { return inc_del || !v.deleted; });
         });
     }
 

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -65,7 +65,7 @@ struct error_test_case {
     ss::sstring def;
     pps::error_info err;
     friend std::ostream&
-    operator<<(std::ostream& os, error_test_case const& e) {
+    operator<<(std::ostream& os, const error_test_case& e) {
         fmt::print(
           os,
           "def: {}, error_code: {}, error_message: {}",
@@ -126,7 +126,7 @@ SEASTAR_THREAD_TEST_CASE(test_make_invalid_json_schema) {
                   .get();
                 BOOST_CHECK_MESSAGE(
                   false, "terminated without an exception for invalid schema");
-            } catch (pps::exception const& e) {
+            } catch (const pps::exception& e) {
                 BOOST_CHECK_EQUAL(e.code(), data.err.code());
                 BOOST_WARN_MESSAGE(
                   e.message() == data.err.message(),

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -213,7 +213,7 @@ public:
       avro::ValidSchema vs, canonical_schema_definition::references refs);
 
     canonical_schema_definition::raw_string raw() const;
-    canonical_schema_definition::references const& refs() const {
+    const canonical_schema_definition::references& refs() const {
         return _refs;
     };
 
@@ -249,7 +249,7 @@ public:
       , _refs(std::move(refs)) {}
 
     canonical_schema_definition::raw_string raw() const;
-    canonical_schema_definition::references const& refs() const {
+    const canonical_schema_definition::references& refs() const {
         return _refs;
     };
 
@@ -269,7 +269,7 @@ public:
     }
 
     ::result<ss::sstring, kafka::error_code>
-    name(std::vector<int> const& fields) const;
+    name(const std::vector<int>& fields) const;
 
 private:
     pimpl _impl;
@@ -285,7 +285,7 @@ public:
       : _impl{std::move(p)} {}
 
     canonical_schema_definition::raw_string raw() const;
-    canonical_schema_definition::references const& refs() const;
+    const canonical_schema_definition::references& refs() const;
 
     const impl& operator()() const { return *_impl; }
 

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -142,8 +142,8 @@ ss::future<std::optional<ss::sstring>> get_record_name(
 template<typename T>
 T combine(
   pandaproxy::schema_registry::schema_id_validation_mode mode,
-  std::optional<T> const& redpanda,
-  std::optional<T> const& compat,
+  const std::optional<T>& redpanda,
+  const std::optional<T>& compat,
   T dflt) {
     switch (mode) {
     case pandaproxy::schema_registry::schema_id_validation_mode::none:

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -55,7 +55,7 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
   const model::topic& topic,
   const cluster::topic_properties& props);
 
-ss::future<schema_id_validator::result> inline maybe_validate_schema_id(
+inline ss::future<schema_id_validator::result> maybe_validate_schema_id(
   std::optional<schema_id_validator> validator,
   model::record_batch_reader rbr,
   cluster::partition_probe* probe) {

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -53,7 +53,7 @@ concept KafkaRequestType = std::same_as<T, typename T::api_type::request_type>;
 template<typename F>
 concept KafkaRequestFactory = KafkaRequestType<std::invoke_result_t<F>>;
 
-ss::shard_id inline consumer_shard(const kafka::group_id& g_id) {
+inline ss::shard_id consumer_shard(const kafka::group_id& g_id) {
     auto hash = xxhash_64(g_id().data(), g_id().length());
     return jump_consistent_hash(hash, ss::smp::count);
 }
@@ -223,7 +223,7 @@ public:
         }
 
         template<std::invocable<kafka::client::client&> Func>
-        auto dispatch(kafka::group_id const& group_id, Func&& func) {
+        auto dispatch(const kafka::group_id& group_id, Func&& func) {
             switch (authn_method) {
             case config::rest_authn_method::none: {
                 return service().client().invoke_on(

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -24,9 +24,9 @@ public:
     pandaproxy_test_fixture()
       : redpanda_thread_fixture() {}
 
-    pandaproxy_test_fixture(pandaproxy_test_fixture const&) = delete;
+    pandaproxy_test_fixture(const pandaproxy_test_fixture&) = delete;
     pandaproxy_test_fixture(pandaproxy_test_fixture&&) = delete;
-    pandaproxy_test_fixture operator=(pandaproxy_test_fixture const&) = delete;
+    pandaproxy_test_fixture operator=(const pandaproxy_test_fixture&) = delete;
     pandaproxy_test_fixture operator=(pandaproxy_test_fixture&&) = delete;
     ~pandaproxy_test_fixture() = default;
 

--- a/src/v/pandaproxy/test/utils.h
+++ b/src/v/pandaproxy/test/utils.h
@@ -43,7 +43,7 @@ inline boost::beast::string_view to_header_value(serialization_format fmt) {
 inline http::client::request_header make_header(
   boost::beast::http::verb method,
   boost::beast::string_view target,
-  iobuf const& body,
+  const iobuf& body,
   serialization_format content,
   serialization_format accept) {
     http::client::request_header hdr;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1540,7 +1540,7 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
             }
         }
 
-        auto const last_applied = read_last_applied();
+        const auto last_applied = read_last_applied();
         if (last_applied > lstats.dirty_offset) {
             vlog(
               _ctxlog.error,
@@ -1598,7 +1598,7 @@ ss::future<> consensus::write_last_applied(model::offset o) {
      * In order to keep an invariant that: 'last applied offset MUST be
      * readable' we limit it here to committed (leader flushed) offset.
      */
-    auto const limited_offset = std::min(o, _flushed_offset);
+    const auto limited_offset = std::min(o, _flushed_offset);
     auto key = last_applied_key();
     iobuf val = reflection::to_iobuf(limited_offset);
     return _storage.kvs().put(

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -602,7 +602,7 @@ group_configuration::find_by_node_id(model::node_id id) const {
 std::vector<vnode> group_configuration::all_nodes() const {
     std::vector<vnode> ret;
 
-    auto const copy_unique = [&ret](const std::vector<vnode>& source) {
+    const auto copy_unique = [&ret](const std::vector<vnode>& source) {
         std::copy_if(
           source.begin(),
           source.end(),

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -131,7 +131,7 @@ heartbeat_manager::requests_for_range() {
               }
               vlog(r->_ctxlog.trace, "[{}] full heartbeat", id);
               r->_probe->full_heartbeat();
-              auto const seq_id = follower_metadata.next_follower_sequence();
+              const auto seq_id = follower_metadata.next_follower_sequence();
 
               follower_metadata.last_sent_protocol_meta = raft_metadata;
               group_beat.data = heartbeat_request_data{

--- a/src/v/raft/heartbeats.cc
+++ b/src/v/raft/heartbeats.cc
@@ -56,7 +56,7 @@ ss::future<> heartbeat_request_v2::serde_async_write(iobuf& out) {
 }
 
 ss::future<> heartbeat_request_v2::serde_async_read(
-  iobuf_parser& in, serde::header const hdr) {
+  iobuf_parser& in, const serde::header hdr) {
     using serde::read_async_nested;
     using serde::read_nested;
     _source_node = serde::read_nested<model::node_id>(
@@ -117,7 +117,7 @@ ss::future<> heartbeat_reply_v2::serde_async_write(iobuf& out) {
 }
 
 ss::future<> heartbeat_reply_v2::serde_async_read(
-  iobuf_parser& in, serde::header const hdr) {
+  iobuf_parser& in, const serde::header hdr) {
     using serde::read_async_nested;
     using serde::read_nested;
     _source_node = read_nested<model::node_id>(in, hdr._bytes_left_limit);

--- a/src/v/raft/heartbeats.h
+++ b/src/v/raft/heartbeats.h
@@ -154,7 +154,7 @@ public:
     friend inline void read_nested(
       iobuf_parser& in,
       deltafor_column<ValueT, DeltaT, FieldT>& c,
-      size_t const bytes_left_limit) {
+      const size_t bytes_left_limit) {
         using serde::read_async_nested;
         using serde::read_nested;
         c._remainder_buffer = read_nested<row_t>(in, bytes_left_limit);
@@ -274,7 +274,7 @@ struct full_heartbeat_reply {
     friend inline void read_nested(
       iobuf_parser& in,
       full_heartbeat_reply& req,
-      size_t const bytes_left_limit) {
+      const size_t bytes_left_limit) {
         using serde::read_nested;
         read_nested(in, req.group, bytes_left_limit);
         read_nested(in, req.result, bytes_left_limit);
@@ -301,7 +301,7 @@ struct full_heartbeat {
       = default;
 
     friend inline void read_nested(
-      iobuf_parser& in, full_heartbeat& fh, size_t const bytes_left_limit) {
+      iobuf_parser& in, full_heartbeat& fh, const size_t bytes_left_limit) {
         using serde::read_nested;
         read_nested(in, fh.group, bytes_left_limit);
         read_nested(in, fh.data, bytes_left_limit);
@@ -348,7 +348,7 @@ public:
     };
 
     ss::future<> serde_async_write(iobuf& out);
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 
     heartbeat_request_v2 copy() const;
 
@@ -432,7 +432,7 @@ public:
     };
 
     ss::future<> serde_async_write(iobuf& out);
-    ss::future<> serde_async_read(iobuf_parser&, serde::header const);
+    ss::future<> serde_async_read(iobuf_parser&, const serde::header);
 
     heartbeat_reply_v2 copy() const;
 

--- a/src/v/raft/recovery_scheduler.h
+++ b/src/v/raft/recovery_scheduler.h
@@ -36,7 +36,7 @@ struct recovery_status {
     uint64_t partitions_active{0};
     uint64_t offsets_pending{0};
 
-    void merge(recovery_status const& rhs) {
+    void merge(const recovery_status& rhs) {
         partitions_to_recover += rhs.partitions_to_recover;
         partitions_active += rhs.partitions_active;
         offsets_pending += rhs.offsets_pending;

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -175,7 +175,7 @@ replicate_batcher::do_cache_with_backpressure(
 }
 
 ss::future<> replicate_batcher::flush(
-  ssx::semaphore_units batcher_units, bool const transfer_flush) {
+  ssx::semaphore_units batcher_units, const bool transfer_flush) {
     auto item_cache = std::exchange(_item_cache, {});
     // this function should not throw, nor return exceptional futures,
     // since it is usually invoked in the background and there is
@@ -211,7 +211,7 @@ ss::future<> replicate_batcher::flush(
         }
 
         auto meta = _ptr->meta();
-        auto const term = model::term_id(meta.term);
+        const auto term = model::term_id(meta.term);
         ss::circular_buffer<model::record_batch> data;
         std::vector<item_ptr> notifications;
         ssx::semaphore_units item_memory_units(_max_batch_size_sem, 0);

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -128,7 +128,7 @@ public:
       model::record_batch_reader,
       replicate_options);
 
-    ss::future<> flush(ssx::semaphore_units u, bool const transfer_flush);
+    ss::future<> flush(ssx::semaphore_units u, const bool transfer_flush);
 
     ss::future<> stop();
 

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -71,7 +71,7 @@ public:
     [[gnu::always_inline]] ss::future<heartbeat_reply>
     heartbeat(heartbeat_request r, rpc::streaming_context&) final {
         using ret_t = std::vector<append_entries_reply>;
-        auto const req_sz = r.heartbeats.size();
+        const auto req_sz = r.heartbeats.size();
         auto grouped = group_hbeats_by_shard(std::move(r.heartbeats));
 
         std::vector<ss::future<std::vector<append_entries_reply>>> futures;
@@ -469,7 +469,7 @@ private:
         shard_groupped_hbeat_requests ret;
 
         for (auto& r : reqs) {
-            auto const shard = _shard_table.shard_for(r.meta.group);
+            const auto shard = _shard_table.shard_for(r.meta.group);
             if (unlikely(!shard)) {
                 ret.group_missing_requests.push_back(r);
                 continue;
@@ -487,7 +487,7 @@ private:
         shard_groupped_hbeat_requests_v2 ret;
 
         for (const auto& full_beat : hb_request.full_heartbeats()) {
-            auto const shard = _shard_table.shard_for(full_beat.group);
+            const auto shard = _shard_table.shard_for(full_beat.group);
             if (unlikely(!shard)) {
                 ret.group_missing_requests.push_back(group_heartbeat{
                   .group = full_beat.group, .data = full_beat.data});
@@ -499,8 +499,8 @@ private:
               full_heartbeat{.group = full_beat.group, .data = full_beat.data});
         }
         hb_request.for_each_lw_heartbeat([this, &ret](int64_t group_id) {
-            auto const lw_beat = raft::group_id(group_id);
-            auto const shard = _shard_table.shard_for(lw_beat);
+            const auto lw_beat = raft::group_id(group_id);
+            const auto shard = _shard_table.shard_for(lw_beat);
             if (unlikely(!shard)) {
                 ret.group_missing_requests.push_back(
                   group_heartbeat{.group = lw_beat});

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -241,7 +241,7 @@ ss::future<> state_machine_manager::do_apply_raft_snapshot(
 
     auto snapshot_content = co_await read_iobuf_exactly(
       reader.input(), snapshot_file_sz);
-    auto const snapshot_content_sz = snapshot_content.size_bytes();
+    const auto snapshot_content_sz = snapshot_content.size_bytes();
 
     vlog(
       _log.debug,

--- a/src/v/raft/tests/jitter_tests.cc
+++ b/src/v/raft/tests/jitter_tests.cc
@@ -24,8 +24,8 @@ using namespace std::chrono_literals; // NOLINT
 SEASTAR_THREAD_TEST_CASE(base_jitter_gurantees) {
     raft::timeout_jitter jit(
       config::mock_binding<std::chrono::milliseconds>(100ms));
-    auto const low = jit.base_duration();
-    auto const high = jit.base_duration() + 50ms;
+    const auto low = jit.base_duration();
+    const auto high = jit.base_duration() + 50ms;
     BOOST_CHECK_EQUAL(
       std::chrono::duration_cast<std::chrono::milliseconds>(low).count(),
       (100ms).count());

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -56,8 +56,8 @@ inline ss::logger tstlog("raft_test");
 
 using namespace std::chrono_literals; // NOLINT
 
-inline static std::chrono::milliseconds heartbeat_interval = 40ms;
-inline static const raft::replicate_options
+static inline std::chrono::milliseconds heartbeat_interval = 40ms;
+static inline const raft::replicate_options
   default_replicate_opts(raft::consistency_level::quorum_ack);
 
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -107,7 +107,7 @@ struct reconfiguration_test
               /**
                * Use archival metadata batches to populate offset translator
                */
-              auto const batch_type = random_generators::random_choice(
+              const auto batch_type = random_generators::random_choice(
                 {model::record_batch_type::raft_data,
                  model::record_batch_type::archival_metadata});
               storage::record_batch_builder builder(

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -420,7 +420,7 @@ TEST_F_CORO(
     auto batches = co_await model::consume_reader_to_memory(
       std::move(rdr), model::no_timeout);
 
-    for (auto const& b : batches) {
+    for (const auto& b : batches) {
         simple_kv::apply_to_state(b, partial_expected_state);
     }
 

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -211,7 +211,7 @@ admin_server::get_reconfigurations_handler(std::unique_ptr<ss::http::request>) {
         ntps.push_back(ntp);
     }
 
-    auto const deadline = model::timeout_clock::now() + 5s;
+    const auto deadline = model::timeout_clock::now() + 5s;
 
     auto [reconfiguration_states, reconciliations]
       = co_await ss::when_all_succeed(
@@ -699,7 +699,7 @@ void admin_server::register_partition_routes() {
                 return ss::json::json_return_type(
                   ss::json::stream_range_as_array(
                     lw_shared_container{std::move(partitions)},
-                    [](summary const& i) -> summary const& { return i; }));
+                    [](const summary& i) -> const summary& { return i; }));
             });
       });
 

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -361,7 +361,7 @@ void admin_server::register_security_routes() {
           bool include_ephemeral = req->get_query_param("include_ephemeral")
                                    == "true";
 
-          auto pred = [include_ephemeral](auto const& c) {
+          auto pred = [include_ephemeral](const auto& c) {
               return include_ephemeral
                      || security::credential_store::is_not_ephemeral(c);
           };

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -671,7 +671,7 @@ void admin_server::rearm_log_level_timer() {
 
     auto reset_values = _log_level_resets | std::views::values;
     auto& lvl_rst = *std::ranges::min_element(
-      reset_values, std::less<>{}, [](level_reset const& l) {
+      reset_values, std::less<>{}, [](const level_reset& l) {
           return l.expires.value_or(ss::timer<>::clock::time_point::max());
       });
     if (lvl_rst.expires.has_value()) {
@@ -698,7 +698,7 @@ void admin_server::log_level_timer_handler() {
 }
 
 ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
-  ss::http::request& req, model::ntp const& ntp) const {
+  ss::http::request& req, const model::ntp& ntp) const {
     auto leader_id_opt = _metadata_cache.local().get_leader_id(ntp);
 
     if (!leader_id_opt.has_value()) {
@@ -782,7 +782,7 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
         auto match_i = std::find_if(
           kafka_endpoints.begin(),
           kafka_endpoints.end(),
-          [req_hostname](model::broker_endpoint const& be) {
+          [req_hostname](const model::broker_endpoint& be) {
               return be.address.host() == req_hostname;
           });
         if (match_i != kafka_endpoints.end()) {
@@ -1025,7 +1025,7 @@ get_brokers(cluster::controller* const controller) {
 ss::future<> admin_server::throw_on_error(
   ss::http::request& req,
   std::error_code ec,
-  model::ntp const& ntp,
+  const model::ntp& ntp,
   model::node_id id) const {
     if (!ec) {
         co_return;
@@ -1552,10 +1552,10 @@ join_properties(const std::vector<std::reference_wrapper<
  * checks, so for the moment we just do the checks here by hand.
  */
 void config_multi_property_validation(
-  ss::sstring const& username,
+  const ss::sstring& username,
   pandaproxy::schema_registry::api* schema_registry,
-  cluster::config_update_request const& req,
-  config::configuration const& updated_config,
+  const cluster::config_update_request& req,
+  const config::configuration& updated_config,
   std::map<ss::sstring, ss::sstring>& errors) {
     absl::flat_hash_set<ss::sstring> modified_keys;
     for (const auto& i : req.upsert) {
@@ -1750,7 +1750,7 @@ void admin_server::register_cluster_config_routes() {
       ss::httpd::cluster_config_json::patch_cluster_config,
       [this](
         std::unique_ptr<ss::http::request> req,
-        request_auth_result const& auth_state) {
+        const request_auth_result& auth_state) {
           return patch_cluster_config_handler(std::move(req), auth_state);
       });
 }
@@ -1758,7 +1758,7 @@ void admin_server::register_cluster_config_routes() {
 ss::future<ss::json::json_return_type>
 admin_server::patch_cluster_config_handler(
   std::unique_ptr<ss::http::request> req,
-  request_auth_result const& auth_state) {
+  const request_auth_result& auth_state) {
     static thread_local auto cluster_config_validator(
       make_cluster_config_validator());
     auto doc = co_await parse_json_body(req.get());
@@ -1844,7 +1844,7 @@ admin_server::patch_cluster_config_handler(
                         upsert_no_op_names.insert(yaml_name);
                     }
                 }
-            } catch (YAML::BadConversion const& e) {
+            } catch (const YAML::BadConversion& e) {
                 // Be helpful, and give the user an example of what
                 // the setting should look like, if we have one.
                 ss::sstring example;

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -221,7 +221,7 @@ private:
      * with an extra request_auth_state argument if peek_auth is true.
      */
     template<auth_level required_auth, bool peek_auth = false, typename F>
-    void register_route(ss::httpd::path_description const& path, F handler) {
+    void register_route(const ss::httpd::path_description& path, F handler) {
         path.set(
           _server._routes,
           [this, handler](std::unique_ptr<ss::http::request> req)
@@ -263,7 +263,7 @@ private:
      */
     template<auth_level required_auth, bool peek_auth = false, typename F>
     void
-    register_route_sync(ss::httpd::path_description const& path, F handler) {
+    register_route_sync(const ss::httpd::path_description& path, F handler) {
         path.set(
           _server._routes,
           [this,
@@ -293,7 +293,7 @@ private:
      */
     template<auth_level required_auth, bool peek_auth = false, typename F>
     void register_route_raw_async(
-      ss::httpd::path_description const& path, F handler) {
+      const ss::httpd::path_description& path, F handler) {
         auto wrapped_handler = [this, handler](
                                  std::unique_ptr<ss::http::request> req,
                                  std::unique_ptr<ss::http::reply> rep)
@@ -333,7 +333,7 @@ private:
 
     template<auth_level required_auth>
     void register_route_raw_sync(
-      ss::httpd::path_description const& path,
+      const ss::httpd::path_description& path,
       ss::httpd::handle_function handler) {
         auto handler_f = new ss::httpd::function_handler{
           [this, handler](ss::httpd::const_req req, ss::http::reply& reply) {
@@ -392,7 +392,7 @@ private:
 
     template<auth_level required_auth>
     void register_route(
-      ss::httpd::path_description const& path, request_handler_fn handler) {
+      const ss::httpd::path_description& path, request_handler_fn handler) {
         path.set(
           _server._routes,
           new handler_impl<required_auth>{*this, std::move(handler)});
@@ -666,10 +666,10 @@ private:
     ss::future<> throw_on_error(
       ss::http::request& req,
       std::error_code ec,
-      model::ntp const& ntp,
+      const model::ntp& ntp,
       model::node_id id = model::node_id{-1}) const;
     ss::future<ss::httpd::redirect_exception>
-    redirect_to_leader(ss::http::request& req, model::ntp const& ntp) const;
+    redirect_to_leader(ss::http::request& req, const model::ntp& ntp) const;
 
     ss::future<ss::json::json_return_type> cancel_node_partition_moves(
       ss::http::request& req, cluster::partition_move_direction direction);

--- a/src/v/redpanda/admin/util.cc
+++ b/src/v/redpanda/admin/util.cc
@@ -15,7 +15,7 @@
 
 namespace admin {
 void apply_validator(
-  json::validator& validator, json::Document::ValueType const& doc) {
+  json::validator& validator, const json::Document::ValueType& doc) {
     try {
         json::validate(validator, doc);
     } catch (const json::json_validation_error& err) {

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -68,7 +68,7 @@ struct timeout_spec {
      * timeout_at() will return time_point::max(), i.e., the furthest possible
      * point in the future.
      */
-    const static timeout_spec none;
+    static const timeout_spec none;
 
     constexpr timeout_spec(
       clock_type::time_point timeout_point, clock_type::duration timeout_period)

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -529,7 +529,7 @@ bool resource_pattern_filter::matches(const resource_pattern& pattern) const {
 void read_nested(
   iobuf_parser& in,
   resource_pattern_filter& filter,
-  size_t const bytes_left_limit) {
+  const size_t bytes_left_limit) {
     using serde::read_nested;
 
     read_nested(in, filter._resource, bytes_left_limit);

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -477,7 +477,7 @@ public:
     friend void read_nested(
       iobuf_parser& in,
       resource_pattern_filter& filter,
-      size_t const bytes_left_limit);
+      const size_t bytes_left_limit);
 
     friend void write(iobuf& out, resource_pattern_filter filter);
 

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -335,7 +335,7 @@ ss::future<> audit_client::mitigate_error(std::exception_ptr eptr) {
     auto f = ss::now();
     try {
         std::rethrow_exception(eptr);
-    } catch (kafka::client::broker_error const& ex) {
+    } catch (const kafka::client::broker_error& ex) {
         f = update_status(ex.error);
         if (ex.error == kafka::error_code::sasl_authentication_failed) {
             f = f.then([this, ex]() {

--- a/src/v/security/config.h
+++ b/src/v/security/config.h
@@ -34,6 +34,6 @@ validate_rules(const std::optional<std::vector<ss::sstring>>& r) noexcept;
 namespace security::oidc {
 
 std::optional<ss::sstring>
-validate_principal_mapping_rule(ss::sstring const& rule);
+validate_principal_mapping_rule(const ss::sstring& rule);
 
 }

--- a/src/v/security/config_bsl.cc
+++ b/src/v/security/config_bsl.cc
@@ -30,7 +30,7 @@ std::regex make_regex(std::string_view sv) {
 }
 
 bool regex_search(
-  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+  std::string_view msg, std::cmatch& match, const std::regex& regex) {
     return std::regex_search(
       msg.begin(),
       msg.end(),
@@ -40,7 +40,7 @@ bool regex_search(
 }
 
 bool regex_match(
-  std::string_view msg, std::cmatch& match, std::regex const& regex) {
+  std::string_view msg, std::cmatch& match, const std::regex& regex) {
     return std::regex_match(
       msg.begin(),
       msg.end(),

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -129,7 +129,7 @@ validate_kerberos_mapping_rules(const std::vector<ss::sstring>& r) noexcept {
 }
 
 namespace oidc {
-std::ostream& operator<<(std::ostream& os, parsed_url const& url) {
+std::ostream& operator<<(std::ostream& os, const parsed_url& url) {
     fmt::print(os, "{}://{}:{}{}", url.scheme, url.host, url.port, url.target);
     return os;
 }
@@ -229,7 +229,7 @@ parse_principal_mapping_rule(std::string_view mapping) {
 }
 
 std::optional<ss::sstring>
-validate_principal_mapping_rule(ss::sstring const& rule) {
+validate_principal_mapping_rule(const ss::sstring& rule) {
     auto rule_res = parse_principal_mapping_rule(rule);
     if (rule_res.has_error()) {
         return rule_res.assume_error().message();

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -51,7 +51,7 @@ public:
     }
 
     template<typename T>
-    auto get(const credential_user& name) const -> std::optional<T> const {
+    auto get(const credential_user& name) const -> const std::optional<T> {
         if (auto it = _credentials.find(name); it != _credentials.end()) {
             return std::get<T>(it->second);
         }
@@ -70,8 +70,8 @@ public:
     // be serialized to disk, and in the general case, should not be displayed
     // to users.
     static constexpr auto is_not_ephemeral =
-      [](security::credential_store::container_type::value_type const& t) {
-          return ss::visit(t.second, [](security::scram_credential const& c) {
+      [](const security::credential_store::container_type::value_type& t) {
+          return ss::visit(t.second, [](const security::scram_credential& c) {
               return !c.principal().has_value()
                      || c.principal().value().type()
                           != security::principal_type::ephemeral_user;

--- a/src/v/security/ephemeral_credential_store.h
+++ b/src/v/security/ephemeral_credential_store.h
@@ -26,8 +26,8 @@ class ephemeral_credential_store {
     using value_type = ephemeral_credential;
 
     struct get_principal_ref {
-        acl_principal const& operator()(acl_principal const& p) { return p; }
-        acl_principal const& operator()(value_type const& v) {
+        const acl_principal& operator()(const acl_principal& p) { return p; }
+        const acl_principal& operator()(const value_type& v) {
             return v.principal();
         }
     };
@@ -35,7 +35,7 @@ class ephemeral_credential_store {
     struct hasher {
         using is_transparent = void;
         template<typename T>
-        size_t operator()(T const& t) const {
+        size_t operator()(const T& t) const {
             return absl::Hash<acl_principal>()(get_principal_ref{}(t));
         };
     };
@@ -43,7 +43,7 @@ class ephemeral_credential_store {
     struct hash_comp {
         using is_transparent = void;
         template<typename L, typename R>
-        bool operator()(L const& l, R const& r) const {
+        bool operator()(const L& l, const R& r) const {
             return std::equal_to<>()(
               get_principal_ref{}(l), get_principal_ref{}(r));
         }
@@ -55,7 +55,7 @@ class ephemeral_credential_store {
 public:
     ephemeral_credential_store() = default;
 
-    const_iterator find(acl_principal const& p) const {
+    const_iterator find(const acl_principal& p) const {
         assert_principal(p);
         return _credentials.find(p);
     }
@@ -74,7 +74,7 @@ public:
     }
 
 private:
-    static void assert_principal(acl_principal const& p) {
+    static void assert_principal(const acl_principal& p) {
         vassert(
           p.type() == principal_type::ephemeral_user,
           "principal_type expected to be ephemeral: {}",

--- a/src/v/security/gssapi.h
+++ b/src/v/security/gssapi.h
@@ -55,7 +55,7 @@ public:
     }
     buffer(const buffer&) = delete;
     buffer operator=(buffer&&) = delete;
-    buffer operator=(buffer const&) = delete;
+    buffer operator=(const buffer&) = delete;
 
     ~buffer() {
         if (value() != nullptr) {
@@ -71,7 +71,7 @@ public:
     buffer_set(buffer_set&&) = delete;
     buffer_set(const buffer_set&) = delete;
     buffer_set operator=(buffer_set&&) = delete;
-    buffer_set operator=(buffer_set const&) = delete;
+    buffer_set operator=(const buffer_set&) = delete;
 
     ~buffer_set() {
         if (_impl != nullptr) {
@@ -98,7 +98,7 @@ public:
     name(name&&) = delete;
     name(const name&) = delete;
     name operator=(name&&) = delete;
-    name operator=(name const&) = delete;
+    name operator=(const name&) = delete;
 
     ~name() {
         if (_impl != nullptr) {
@@ -122,7 +122,7 @@ public:
         return display_name;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, name const& name) {
+    friend std::ostream& operator<<(std::ostream& os, const name& name) {
         fmt::print(os, "{}", std::string_view(name.display_name_buffer()));
         return os;
     }
@@ -137,7 +137,7 @@ public:
     cred_id(cred_id&&) = delete;
     cred_id(const cred_id&) = delete;
     cred_id operator=(cred_id&&) = delete;
-    cred_id operator=(cred_id const&) = delete;
+    cred_id operator=(const cred_id&) = delete;
     ~cred_id() { reset(); }
 
     void reset() {
@@ -160,7 +160,7 @@ public:
     ctx_id(ctx_id&&) = delete;
     ctx_id(const ctx_id&) = delete;
     ctx_id operator=(ctx_id&&) = delete;
-    ctx_id operator=(ctx_id const&) = delete;
+    ctx_id operator=(const ctx_id&) = delete;
     ~ctx_id() { reset(); }
 
     void reset() {

--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -35,7 +35,7 @@
 namespace security {
 
 std::ostream&
-operator<<(std::ostream& os, gssapi_authenticator::state const s) {
+operator<<(std::ostream& os, const gssapi_authenticator::state s) {
     using state = gssapi_authenticator::state;
     switch (s) {
     case state::init:

--- a/src/v/security/gssapi_authenticator.h
+++ b/src/v/security/gssapi_authenticator.h
@@ -58,7 +58,7 @@ public:
 
 private:
     friend std::ostream&
-    operator<<(std::ostream& os, gssapi_authenticator::state const s);
+    operator<<(std::ostream& os, const gssapi_authenticator::state s);
 
     ssx::singleton_thread_worker& _worker;
     security::acl_principal _principal;

--- a/src/v/security/gssapi_principal_mapper.cc
+++ b/src/v/security/gssapi_principal_mapper.cc
@@ -147,7 +147,7 @@ template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::gssapi_name, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>>(
-  security::gssapi_name const& r,
+  const security::gssapi_name& r,
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     fmt::format_to(ctx.out(), "{}", r._primary);
     if (!r._host_name.empty()) {
@@ -164,7 +164,7 @@ template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::gssapi_principal_mapper, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>>(
-  security::gssapi_principal_mapper const& r,
+  const security::gssapi_principal_mapper& r,
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     return fmt::format_to(ctx.out(), "[{}]", fmt::join(r._rules, ", "));
 }

--- a/src/v/security/gssapi_rule.cc
+++ b/src/v/security/gssapi_rule.cc
@@ -233,7 +233,7 @@ ss::sstring gssapi_rule::replace_substitution(
   repeat repeat_) {
     ss::sstring replace_value;
 
-    std::regex_constants::match_flag_type const flags
+    const std::regex_constants::match_flag_type flags
       = std::regex_constants::format_default
         | (repeat_ ? std::regex_constants::match_default : std::regex_constants::format_first_only);
 
@@ -253,7 +253,7 @@ template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::gssapi_rule, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>>(
-  security::gssapi_rule const& r,
+  const security::gssapi_rule& r,
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     if (r._is_default) {
         return fmt::format_to(ctx.out(), "DEFAULT");

--- a/src/v/security/jwt.cc
+++ b/src/v/security/jwt.cc
@@ -13,7 +13,7 @@ namespace security::oidc::detail {
 bytes base64_url_decode(std::string_view sv) { return base64url_to_bytes(sv); };
 
 std::optional<bytes>
-base64_url_decode(json::Value const& v, std::string_view field) {
+base64_url_decode(const json::Value& v, std::string_view field) {
     auto b64 = string_view<>(v, field);
     if (!b64.has_value()) {
         return std::nullopt;

--- a/src/v/security/krb5.cc
+++ b/src/v/security/krb5.cc
@@ -41,7 +41,7 @@ struct realm_deleter {
 
 result<context> context::create() noexcept {
     ::krb5_context krb5_ctx{nullptr};
-    int const krb5_rv = ::krb5_init_context(&krb5_ctx);
+    const int krb5_rv = ::krb5_init_context(&krb5_ctx);
     if (krb5_rv != 0) {
         impl::error_message msg{
           ::krb5_get_error_message(nullptr, krb5_rv), nullptr};
@@ -55,7 +55,7 @@ result<context> context::create() noexcept {
 
 result<ss::sstring> context::get_default_realm() const noexcept {
     char* default_realm_ptr = nullptr;
-    int const krb5_rv = ::krb5_get_default_realm(
+    const int krb5_rv = ::krb5_get_default_realm(
       _ctx.get(), &default_realm_ptr);
     if (krb5_rv != 0) {
         impl::error_message msg{
@@ -65,7 +65,7 @@ result<ss::sstring> context::get_default_realm() const noexcept {
         return err;
     }
 
-    std::unique_ptr<char, realm_deleter> const default_realm(
+    const std::unique_ptr<char, realm_deleter> default_realm(
       default_realm_ptr, realm_deleter{_ctx.get()});
     return ss::sstring{std::string_view{default_realm.get()}};
 }

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -56,7 +56,7 @@ template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::tls::principal_mapper, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>>(
-  security::tls::principal_mapper const& r,
+  const security::tls::principal_mapper& r,
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     return fmt::format_to(ctx.out(), "[{}]", fmt::join(r._rules, ", "));
 }

--- a/src/v/security/mtls_rule.cc
+++ b/src/v/security/mtls_rule.cc
@@ -49,7 +49,7 @@ template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::tls::rule, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>>(
-  security::tls::rule const& r,
+  const security::tls::rule& r,
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     if (r._is_default) {
         return fmt::format_to(ctx.out(), "DEFAULT");

--- a/src/v/security/oidc_authenticator.cc
+++ b/src/v/security/oidc_authenticator.cc
@@ -31,8 +31,8 @@
 namespace security::oidc {
 
 result<authentication_data> authenticate(
-  jwt const& jwt,
-  principal_mapping_rule const& mapping,
+  const jwt& jwt,
+  const principal_mapping_rule& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,
@@ -73,9 +73,9 @@ result<authentication_data> authenticate(
 }
 
 result<authentication_data> authenticate(
-  jws const& jws,
-  verifier const& verifier,
-  principal_mapping_rule const& mapping,
+  const jws& jws,
+  const verifier& verifier,
+  const principal_mapping_rule& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,
@@ -147,7 +147,7 @@ authenticator::authenticate(std::string_view bearer_token) {
     return _impl->authenticate(bearer_token);
 }
 
-std::ostream& operator<<(std::ostream& os, sasl_authenticator::state const s) {
+std::ostream& operator<<(std::ostream& os, const sasl_authenticator::state s) {
     using state = sasl_authenticator::state;
     switch (s) {
     case state::init:

--- a/src/v/security/oidc_authenticator.h
+++ b/src/v/security/oidc_authenticator.h
@@ -25,17 +25,17 @@ struct authentication_data {
     ss::lowres_system_clock::time_point expiry;
 };
 result<authentication_data> authenticate(
-  jws const& jws,
-  verifier const& verifier,
-  principal_mapping_rule const& mapping,
+  const jws& jws,
+  const verifier& verifier,
+  const principal_mapping_rule& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,
   ss::lowres_system_clock::time_point now);
 
 result<authentication_data> authenticate(
-  jwt const& jwt,
-  principal_mapping_rule const& mapping,
+  const jwt& jwt,
+  const principal_mapping_rule& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,
@@ -45,9 +45,9 @@ class authenticator {
 public:
     explicit authenticator(service& service);
     authenticator(authenticator&&) = default;
-    authenticator(authenticator const&) = delete;
+    authenticator(const authenticator&) = delete;
     authenticator& operator=(authenticator&&) = delete;
-    authenticator& operator=(authenticator const&) = delete;
+    authenticator& operator=(const authenticator&) = delete;
     ~authenticator();
 
     result<authentication_data> authenticate(std::string_view bearer_token);
@@ -64,9 +64,9 @@ public:
 
     explicit sasl_authenticator(oidc::service& service);
     sasl_authenticator(sasl_authenticator&&) = default;
-    sasl_authenticator(sasl_authenticator const&) = delete;
+    sasl_authenticator(const sasl_authenticator&) = delete;
     sasl_authenticator& operator=(sasl_authenticator&&) = delete;
-    sasl_authenticator& operator=(sasl_authenticator const&) = delete;
+    sasl_authenticator& operator=(const sasl_authenticator&) = delete;
     ~sasl_authenticator() override;
 
     ss::future<result<bytes>> authenticate(bytes) override;
@@ -89,7 +89,7 @@ public:
 
 private:
     friend std::ostream&
-    operator<<(std::ostream& os, sasl_authenticator::state const s);
+    operator<<(std::ostream& os, const sasl_authenticator::state s);
 
     authenticator _authenticator;
     authentication_data _auth_data;

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -17,7 +17,7 @@
 namespace security::oidc {
 
 result<acl_principal> principal_mapping_rule_apply(
-  const principal_mapping_rule& mapping, jwt const& jwt) {
+  const principal_mapping_rule& mapping, const jwt& jwt) {
     auto claim = jwt.claim(mapping.claim());
     if (claim.value_or("").empty()) {
         return errc::jwt_invalid_principal;

--- a/src/v/security/oidc_principal_mapping_applicator.h
+++ b/src/v/security/oidc_principal_mapping_applicator.h
@@ -17,6 +17,6 @@
 namespace security::oidc {
 
 result<acl_principal>
-principal_mapping_rule_apply(const principal_mapping_rule&, jwt const& jwt);
+principal_mapping_rule_apply(const principal_mapping_rule&, const jwt& jwt);
 
 }

--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -191,7 +191,7 @@ struct service::impl {
         return _gate.close();
     }
 
-    probe& get_probe_for(parsed_url const& url) {
+    probe& get_probe_for(const parsed_url& url) {
         auto& p = _probes[url.host];
         if (!p) {
             p = std::make_unique<probe>();
@@ -219,10 +219,10 @@ struct service::impl {
     ss::future<> update() {
         auto enabled = absl::c_any_of(
                          _sasl_mechanisms(),
-                         [](auto const& m) { return m == "OAUTHBEARER"; })
+                         [](const auto& m) { return m == "OAUTHBEARER"; })
                        || absl::c_any_of(
                          _http_authentication(),
-                         [](auto const& m) { return m == "OIDC"; });
+                         [](const auto& m) { return m == "OIDC"; });
         if (!enabled) {
             co_return;
         }
@@ -444,9 +444,9 @@ std::chrono::seconds service::clock_skew_tolerance() const {
     return _impl->_clock_skew_tolerance();
 }
 
-verifier const& service::get_verifier() const { return _impl->_verifier; }
+const verifier& service::get_verifier() const { return _impl->_verifier; }
 
-principal_mapping_rule const& service::get_principal_mapping_rule() const {
+const principal_mapping_rule& service::get_principal_mapping_rule() const {
     return _impl->_rule;
 }
 

--- a/src/v/security/oidc_service.h
+++ b/src/v/security/oidc_service.h
@@ -33,15 +33,15 @@ public:
       config::binding<std::chrono::seconds> jwks_refresh_interval);
     service(service&&) = delete;
     service& operator=(service&&) = delete;
-    service(service const&) = delete;
-    service& operator=(service const&) = delete;
+    service(const service&) = delete;
+    service& operator=(const service&) = delete;
     ~service() noexcept;
 
     ss::future<> start();
     ss::future<> stop();
 
-    verifier const& get_verifier() const;
-    principal_mapping_rule const& get_principal_mapping_rule() const;
+    const verifier& get_verifier() const;
+    const principal_mapping_rule& get_principal_mapping_rule() const;
     std::string_view audience() const;
     result<std::string_view> issuer() const;
     std::chrono::seconds clock_skew_tolerance() const;

--- a/src/v/security/oidc_url_parser.h
+++ b/src/v/security/oidc_url_parser.h
@@ -23,8 +23,8 @@ struct parsed_url {
     ss::sstring host;
     uint16_t port;
     ss::sstring target;
-    friend bool operator==(parsed_url const&, parsed_url const&) = default;
-    friend std::ostream& operator<<(std::ostream&, parsed_url const&);
+    friend bool operator==(const parsed_url&, const parsed_url&) = default;
+    friend std::ostream& operator<<(std::ostream&, const parsed_url&);
 };
 result<parsed_url> parse_url(std::string_view);
 

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -57,7 +57,7 @@ request_authenticator::authenticate(const ss::http::request& req) {
     const auto& cred_store = _controller->get_credential_store().local();
     try {
         return do_authenticate(req, cred_store, _require_auth());
-    } catch (ss::httpd::base_exception const& e) {
+    } catch (const ss::httpd::base_exception& e) {
         if (e.status() == ss::http::reply::status_type::unauthorized) {
             if (_require_auth()) {
                 throw;
@@ -76,13 +76,13 @@ request_authenticator::authenticate(const ss::http::request& req) {
 }
 
 request_auth_result request_authenticator::do_authenticate(
-  ss::http::request const& req,
-  security::credential_store const& cred_store,
+  const ss::http::request& req,
+  const security::credential_store& cred_store,
   bool require_auth) {
     constexpr auto supports = [](std::string_view m) {
         return absl::c_any_of(
           config::shard_local_cfg().http_authentication(),
-          [m](auto const& mech) { return m == mech; });
+          [m](const auto& mech) { return m == mech; });
     };
 
     auto auth_hdr = req.get_header("authorization");
@@ -98,7 +98,7 @@ request_auth_result request_authenticator::do_authenticate(
         ss::sstring decoded_bytes;
         try {
             decoded_bytes = base64_to_string(base64);
-        } catch (base64_decoder_exception const&) {
+        } catch (const base64_decoder_exception&) {
             vlog(logger.info, "Client auth failure: bad BASE64 encoding");
             throw ss::httpd::bad_request_exception(
               "Malformed Authorization header");

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -97,9 +97,9 @@ public:
      */
     void pass();
 
-    ss::sstring const& get_username() const { return _username; }
-    ss::sstring const& get_password() const { return _password; }
-    ss::sstring const& get_sasl_mechanism() const { return _sasl_mechanism; }
+    const ss::sstring& get_username() const { return _username; }
+    const ss::sstring& get_password() const { return _password; }
+    const ss::sstring& get_sasl_mechanism() const { return _sasl_mechanism; }
 
     bool is_authenticated() const { return _authenticated; };
     bool is_superuser() const { return _superuser; }
@@ -126,8 +126,8 @@ public:
 
 private:
     request_auth_result do_authenticate(
-      ss::http::request const& req,
-      security::credential_store const& cred_store,
+      const ss::http::request& req,
+      const security::credential_store& cred_store,
       bool require_auth);
 
     cluster::controller* _controller{nullptr};

--- a/src/v/security/tests/jwt_test.cc
+++ b/src/v/security/tests/jwt_test.cc
@@ -29,7 +29,7 @@ struct parse_test_data {
     std::string_view data;
     oidc::errc err;
     friend std::ostream&
-    operator<<(std::ostream& os, parse_test_data const& r) {
+    operator<<(std::ostream& os, const parse_test_data& r) {
         fmt::print(os, "data: {}, errc: {}", r.data, r.err);
         return os;
     }
@@ -200,7 +200,7 @@ struct verify_test_data {
     oidc::errc update_err;
     oidc::errc verify_err;
     friend std::ostream&
-    operator<<(std::ostream& os, verify_test_data const& r) {
+    operator<<(std::ostream& os, const verify_test_data& r) {
         fmt::print(
           os,
           "jwks: {}, jwks_err: {}, jws: {}, jws_err: {}, update_err: {}, "
@@ -301,7 +301,7 @@ struct auth_test_data {
     oidc::errc auth_err;
     security::acl_principal principal;
     security::oidc::principal_mapping_rule mapping{};
-    friend std::ostream& operator<<(std::ostream& os, auth_test_data const& r) {
+    friend std::ostream& operator<<(std::ostream& os, const auth_test_data& r) {
         fmt::print(
           os,
           "jwks: {}, jws: {}, issuer: {}, audience: {}, clock_skew_tolerance: "
@@ -432,7 +432,7 @@ struct auth_error_test_data {
     oidc::errc auth_err;
     security::acl_principal principal;
     friend std::ostream&
-    operator<<(std::ostream& os, auth_error_test_data const& r) {
+    operator<<(std::ostream& os, const auth_error_test_data& r) {
         fmt::print(
           os,
           "token_payload: {}, issuer: {}, audience: {}, clock_skew_tolerance: "

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -26,7 +26,7 @@ struct principal_mapping_test_data {
     result<security::acl_principal> principal;
 
     friend std::ostream&
-    operator<<(std::ostream& os, principal_mapping_test_data const& d) {
+    operator<<(std::ostream& os, const principal_mapping_test_data& d) {
         fmt::print(
           os,
           "payload: {}, mapping: {}, principal: {}",

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -21,12 +21,12 @@ using version_t = std::uint8_t;
 
 template<version_t V>
 struct version {
-    static constexpr auto const v = V;
+    static constexpr const auto v = V;
 };
 
 template<version_t V>
 struct compat_version {
-    static constexpr auto const v = V;
+    static constexpr const auto v = V;
 };
 
 /**
@@ -58,7 +58,7 @@ struct envelope {
     requires(std::is_same_v<
              std::remove_cvref_t<O>,
              envelope<T, Version, CompatVersion>>)
-    bool operator==(O const&) const {
+    bool operator==(const O&) const {
         return true;
     }
 
@@ -66,7 +66,7 @@ struct envelope {
     requires(std::is_same_v<
              std::remove_cvref_t<O>,
              envelope<T, Version, CompatVersion>>)
-    std::strong_ordering operator<=>(O const&) const {
+    std::strong_ordering operator<=>(const O&) const {
         return std::strong_ordering::equal;
     }
 };
@@ -84,7 +84,7 @@ static constexpr std::size_t envelope_header_size = 6;
  */
 template<typename T, typename Version, typename CompatVersion>
 struct checksum_envelope {
-    bool operator==(checksum_envelope const&) const = default;
+    bool operator==(const checksum_envelope&) const = default;
     using value_t = T;
     static constexpr auto redpanda_serde_version = Version::v;
     static constexpr auto redpanda_serde_compat_version = CompatVersion::v;

--- a/src/v/serde/protobuf/tests/parser_test.cc
+++ b/src/v/serde/protobuf/tests/parser_test.cc
@@ -64,7 +64,7 @@ class IgnoreUnknownFields
 class ProtobufParserFixture : public testing::Test {
 public:
     std::unique_ptr<pb::Message> construct_message(std::string_view txtpb) {
-        const static std::unordered_map<std::string, const pb::FileDescriptor*>
+        static const std::unordered_map<std::string, const pb::FileDescriptor*>
           global_protos = {
             {"two.proto", pbtwo::SearchRequest::descriptor()->file()},
             {"three.proto", pbthree::SearchRequest::descriptor()->file()},

--- a/src/v/serde/read_header.h
+++ b/src/v/serde/read_header.h
@@ -28,7 +28,7 @@ struct header {
 };
 
 template<typename T>
-header read_header(iobuf_parser& in, std::size_t const bytes_left_limit) {
+header read_header(iobuf_parser& in, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
 
     version_t version;

--- a/src/v/serde/rw/array.h
+++ b/src/v/serde/rw/array.h
@@ -35,7 +35,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   std::array<T, Size>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
     using value_type = typename Type::value_type;
     const auto size = read_nested<serde_size_t>(in, bytes_left_limit);

--- a/src/v/serde/rw/bool_class.h
+++ b/src/v/serde/rw/bool_class.h
@@ -25,7 +25,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   ss::bool_class<Tag>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     t = ss::bool_class<Tag>{
       read_nested<std::int8_t>(in, bytes_left_limit) != 0};
 }

--- a/src/v/serde/rw/chrono.h
+++ b/src/v/serde/rw/chrono.h
@@ -102,7 +102,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   std::chrono::duration<R, P>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::chrono::duration<R, P>;
 
     static_assert(
@@ -125,7 +125,7 @@ template<typename Clock, typename Duration>
 void read(
   iobuf_parser&,
   std::chrono::time_point<Clock, Duration>& t,
-  std::size_t const /* bytes_left_limit */) {
+  const std::size_t /* bytes_left_limit */) {
     static_assert(
       base::unsupported_type<decltype(t)>::value,
       "Time point serialization is risky and can have unintended "

--- a/src/v/serde/rw/enum.h
+++ b/src/v/serde/rw/enum.h
@@ -25,7 +25,7 @@ template<typename T>
 requires(serde_is_enum_v<std::decay_t<T>>)
 void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
     using Type = std::decay_t<T>;
-    auto const val = static_cast<std::underlying_type_t<Type>>(t);
+    const auto val = static_cast<std::underlying_type_t<Type>>(t);
     if (unlikely(
           val > std::numeric_limits<serde_enum_serialized_t>::max()
           || val < std::numeric_limits<serde_enum_serialized_t>::min())) {
@@ -42,10 +42,10 @@ void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
 template<typename T>
 requires serde_is_enum_v<std::decay_t<T>>
 void tag_invoke(
-  tag_t<read_tag>, iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+  tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
 
-    auto const val = read_nested<serde_enum_serialized_t>(in, bytes_left_limit);
+    const auto val = read_nested<serde_enum_serialized_t>(in, bytes_left_limit);
     if (unlikely(
           val > std::numeric_limits<std::underlying_type_t<Type>>::max())) {
         throw serde_exception(fmt_with_ctx(

--- a/src/v/serde/rw/inet_address.h
+++ b/src/v/serde/rw/inet_address.h
@@ -23,7 +23,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   ss::net::inet_address& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     bool is_ipv4 = read_nested<bool>(in, bytes_left_limit);
     auto address_buf = read_nested<iobuf>(in, bytes_left_limit);
     auto address_bytes = iobuf_to_bytes(address_buf);

--- a/src/v/serde/rw/iobuf.h
+++ b/src/v/serde/rw/iobuf.h
@@ -19,7 +19,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   iobuf& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
 }
 

--- a/src/v/serde/rw/map.h
+++ b/src/v/serde/rw/map.h
@@ -37,9 +37,9 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   Map auto& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
-    auto const size = read_nested<serde_size_t>(in, bytes_left_limit);
+    const auto size = read_nested<serde_size_t>(in, bytes_left_limit);
     if constexpr (Reservable<Type>) {
         t.reserve(size);
     }

--- a/src/v/serde/rw/named_type.h
+++ b/src/v/serde/rw/named_type.h
@@ -19,7 +19,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   ::detail::base_named_type<T, Tag, IsConstexpr>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
     t = Type{read_nested<typename Type::type>(in, bytes_left_limit)};
 }

--- a/src/v/serde/rw/optional.h
+++ b/src/v/serde/rw/optional.h
@@ -30,7 +30,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   std::optional<T>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     t = read_nested<bool>(in, bytes_left_limit)
           ? std::optional{read_nested<T>(in, bytes_left_limit)}
           : std::nullopt;

--- a/src/v/serde/rw/rw.h
+++ b/src/v/serde/rw/rw.h
@@ -24,16 +24,16 @@ concept DirectReadable = requires(iobuf_parser& in, const header& h) {
 };
 
 template<typename T>
-void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+void read_nested(iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     read_tag(in, t, bytes_left_limit);
 }
 
 template<typename T>
-T read_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
+T read_nested(iobuf_parser& in, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(std::is_default_constructible_v<T> || DirectReadable<T>);
     if constexpr (DirectReadable<T>) {
-        auto const h = read_header<Type>(in, bytes_left_limit);
+        const auto h = read_header<Type>(in, bytes_left_limit);
         return Type::serde_direct_read(in, h);
     } else {
         auto t = Type();

--- a/src/v/serde/rw/scalar.h
+++ b/src/v/serde/rw/scalar.h
@@ -26,7 +26,7 @@ namespace serde {
 template<typename T>
 requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>)
 void tag_invoke(
-  tag_t<read_tag>, iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
+  tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
     using Type = std::decay_t<T>;
 
     if (unlikely(in.bytes_left() - bytes_left_limit < sizeof(Type))) {
@@ -54,19 +54,19 @@ requires(std::is_scalar_v<std::decay_t<T>> && !serde_is_enum_v<std::decay_t<T>>)
 void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
     using Type = std::decay_t<T>;
     if constexpr (sizeof(Type) == 1) {
-        out.append(reinterpret_cast<char const*>(&t), sizeof(t));
+        out.append(reinterpret_cast<const char*>(&t), sizeof(t));
     } else if constexpr (std::is_same_v<float, Type>) {
-        auto const le_t = htole32(std::bit_cast<std::uint32_t>(t));
+        const auto le_t = htole32(std::bit_cast<std::uint32_t>(t));
         static_assert(sizeof(le_t) == sizeof(Type));
-        out.append(reinterpret_cast<char const*>(&le_t), sizeof(le_t));
+        out.append(reinterpret_cast<const char*>(&le_t), sizeof(le_t));
     } else if constexpr (std::is_same_v<double, Type>) {
-        auto const le_t = htole64(std::bit_cast<std::uint64_t>(t));
+        const auto le_t = htole64(std::bit_cast<std::uint64_t>(t));
         static_assert(sizeof(le_t) == sizeof(Type));
-        out.append(reinterpret_cast<char const*>(&le_t), sizeof(le_t));
+        out.append(reinterpret_cast<const char*>(&le_t), sizeof(le_t));
     } else {
-        auto const le_t = ss::cpu_to_le(t);
+        const auto le_t = ss::cpu_to_le(t);
         static_assert(sizeof(le_t) == sizeof(Type));
-        out.append(reinterpret_cast<char const*>(&le_t), sizeof(le_t));
+        out.append(reinterpret_cast<const char*>(&le_t), sizeof(le_t));
     }
 }
 
@@ -78,7 +78,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   bool& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     int8_t byte;
     read_tag(in, byte, bytes_left_limit);
     t = (byte != 0);

--- a/src/v/serde/rw/set.h
+++ b/src/v/serde/rw/set.h
@@ -38,7 +38,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   SetNotMap auto& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
 
     const auto size = read_nested<serde_size_t>(in, bytes_left_limit);

--- a/src/v/serde/rw/sstring.h
+++ b/src/v/serde/rw/sstring.h
@@ -30,7 +30,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   ss::basic_sstring<char_type, Size, max_size, NulTerminate>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     auto str = ss::uninitialized_string<
       ss::basic_sstring<char_type, Size, max_size, NulTerminate>>(
       read_nested<serde_size_t>(in, bytes_left_limit));

--- a/src/v/serde/rw/tags.h
+++ b/src/v/serde/rw/tags.h
@@ -43,7 +43,7 @@ inline constexpr struct write_fn {
 inline constexpr struct read_fn {
     template<typename T>
     void operator()(
-      iobuf_parser& in, T& t, std::size_t const bytes_left_limit) const {
+      iobuf_parser& in, T& t, const std::size_t bytes_left_limit) const {
         return tag_invoke(*this, in, t, bytes_left_limit);
     }
 } read_tag{};

--- a/src/v/serde/rw/tristate_rw.h
+++ b/src/v/serde/rw/tristate_rw.h
@@ -31,7 +31,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   tristate<T>& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
 
     int8_t flag = read_nested<int8_t>(in, bytes_left_limit);

--- a/src/v/serde/rw/uuid.h
+++ b/src/v/serde/rw/uuid.h
@@ -24,7 +24,7 @@ inline void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   uuid_t& t,
-  std::size_t const /* bytes_left_limit */) {
+  const std::size_t /* bytes_left_limit */) {
     in.consume_to(uuid_t::length, t.mutable_uuid().begin());
 }
 

--- a/src/v/serde/rw/vector.h
+++ b/src/v/serde/rw/vector.h
@@ -41,7 +41,7 @@ void tag_invoke(
   tag_t<read_tag>,
   iobuf_parser& in,
   Vector auto& t,
-  std::size_t const bytes_left_limit) {
+  const std::size_t bytes_left_limit) {
     using Type = std::decay_t<decltype(t)>;
     using value_type = typename Type::value_type;
 

--- a/src/v/ssx/abort_source.h
+++ b/src/v/ssx/abort_source.h
@@ -27,7 +27,7 @@ public:
             auto dex = parent.get_default_exception();
             auto sub = parent.subscribe(
               [this, dex](
-                std::optional<std::exception_ptr> const& ex) mutable noexcept {
+                const std::optional<std::exception_ptr>& ex) mutable noexcept {
                   dex = ex.value_or(dex);
                   return _as.invoke_on_all(
                     [dex](auto& as) { return as.request_abort_ex(dex); });
@@ -44,7 +44,7 @@ public:
     }
 
     auto& local() noexcept { return _as.local(); }
-    auto const& local() const noexcept { return _as.local(); }
+    const auto& local() const noexcept { return _as.local(); }
 
     template<typename Func>
     [[nodiscard]] auto subscribe(Func&& func) {

--- a/src/v/ssx/sharded_ptr.h
+++ b/src/v/ssx/sharded_ptr.h
@@ -40,8 +40,8 @@ public:
     sharded_ptr(sharded_ptr&& other) noexcept = default;
     sharded_ptr& operator=(sharded_ptr&&) noexcept = default;
 
-    sharded_ptr(sharded_ptr const&) = delete;
-    sharded_ptr& operator=(sharded_ptr const&) = delete;
+    sharded_ptr(const sharded_ptr&) = delete;
+    sharded_ptr& operator=(const sharded_ptr&) = delete;
 
     /// dereferences pointer to the managed object for the local shard.
     ///
@@ -135,7 +135,7 @@ public:
     ///
     /// reset must have been called at least once.
     /// stop must not have been called.
-    std::shared_ptr<T> const& local() const {
+    const std::shared_ptr<T>& local() const {
         return _state[ss::this_shard_id()];
     }
 

--- a/src/v/ssx/sharded_value.h
+++ b/src/v/ssx/sharded_value.h
@@ -35,11 +35,11 @@ public:
     sharded_value(sharded_value&& other) noexcept = default;
     sharded_value& operator=(sharded_value&&) noexcept = default;
 
-    sharded_value(sharded_value const&) = delete;
-    sharded_value& operator=(sharded_value const&) = delete;
+    sharded_value(const sharded_value&) = delete;
+    sharded_value& operator=(const sharded_value&) = delete;
 
     /// get a reference to the local instance
-    T const& local() const { return _state[ss::this_shard_id()]; }
+    const T& local() const { return _state[ss::this_shard_id()]; }
 
     /// get a reference to the local instance
     T& local() { return _state[ss::this_shard_id()]; }

--- a/src/v/ssx/tests/abort_source_test.cc
+++ b/src/v/ssx/tests/abort_source_test.cc
@@ -25,7 +25,7 @@ struct derived_error final : std::runtime_error {
 };
 
 struct fixture {
-    using sub_arg_t = std::optional<std::exception_ptr> const&;
+    using sub_arg_t = const std::optional<std::exception_ptr>&;
 
     auto make_incrementor() {
         ++expected_count;
@@ -78,7 +78,7 @@ SEASTAR_THREAD_TEST_CASE(ssx_sharded_abort_source_test_abort_parent) {
     // Ensure parent exception is propated
     BOOST_REQUIRE(f.sas.abort_requested());
     BOOST_REQUIRE_EXCEPTION(
-      f.sas.check(), derived_error, [](derived_error const& e) {
+      f.sas.check(), derived_error, [](const derived_error& e) {
           return e.what() == expected_msg;
       });
 

--- a/src/v/ssx/tests/sharded_ptr_test.cc
+++ b/src/v/ssx/tests/sharded_ptr_test.cc
@@ -48,7 +48,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_ptr_basic_ops) {
     try {
         p0.reset().get();
         BOOST_FAIL("Expected exception");
-    } catch (ss::broken_semaphore const&) {
+    } catch (const ss::broken_semaphore&) {
         // Success
     } catch (...) {
         BOOST_FAIL("Unexpected exception");
@@ -58,7 +58,7 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_ptr_basic_ops) {
     try {
         p0.stop().get();
         BOOST_FAIL("Expected exception");
-    } catch (ss::broken_semaphore const&) {
+    } catch (const ss::broken_semaphore&) {
         // Success
     } catch (...) {
         BOOST_FAIL("Unexpected exception");

--- a/src/v/ssx/tests/thread_worker.cc
+++ b/src/v/ssx/tests/thread_worker.cc
@@ -24,9 +24,9 @@ struct move_only {
       : value(v) {}
     ~move_only() = default;
     move_only(move_only&&) = default;
-    move_only(move_only const&) = delete;
+    move_only(const move_only&) = delete;
     move_only& operator=(move_only&&) = default;
-    move_only& operator=(move_only const&) = delete;
+    move_only& operator=(const move_only&) = delete;
     size_t value;
 };
 

--- a/src/v/ssx/thread_worker.h
+++ b/src/v/ssx/thread_worker.h
@@ -45,9 +45,9 @@ class task_base {
 public:
     task_base() = default;
     task_base(task_base&&) = delete;
-    task_base(task_base const&) = delete;
+    task_base(const task_base&) = delete;
     task_base& operator=(task_base&&) = delete;
-    task_base& operator=(task_base const&) = delete;
+    task_base& operator=(const task_base&) = delete;
 
     virtual ss::stop_iteration process(ss::alien::instance&, ss::shard_id) = 0;
     virtual void

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -49,8 +49,8 @@ compaction_key_reducer::operator()(compacted_index::entry&& e) {
         }
     } else {
         // not found - insert
-        auto const key_size = e.key.size();
-        auto const expected_size = [this, key_size] {
+        const auto key_size = e.key.size();
+        const auto expected_size = [this, key_size] {
             return idx_mem_usage() + _keys_mem_usage + key_size;
         };
 
@@ -296,8 +296,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
           });
     }
     auto batch = co_await compress_batch(original, std::move(to_copy.value()));
-    auto const start_pos = _appender->file_byte_offset();
-    auto const header_size = batch.header().size_bytes;
+    const auto start_pos = _appender->file_byte_offset();
+    const auto header_size = batch.header().size_bytes;
     _acc += header_size;
     // do not set broker_timestamp in this index, leave the operation to the
     // caller who has more context

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -310,7 +310,7 @@ disk_log_impl::time_based_gc_max_offset(gc_config cfg) const {
     // this will retrive cluster configs, to reused them during the scan since
     // there are no scheduling points
 
-    auto const retention_cfg = time_based_retention_cfg::make(
+    const auto retention_cfg = time_based_retention_cfg::make(
       _feature_table.local());
 
     // if the segment max timestamp is bigger than now plus threshold we

--- a/src/v/storage/fs_utils.cc
+++ b/src/v/storage/fs_utils.cc
@@ -57,7 +57,7 @@ partition_path::partition_path(const ntp_config& ntpc)
 }
 
 std::optional<segment_full_path> segment_full_path::parse(
-  partition_path const& dir_part, const ss::sstring& filename) noexcept {
+  const partition_path& dir_part, const ss::sstring& filename) noexcept {
     std::optional<segment_path::metadata> file_part_opt;
     try {
         file_part_opt = segment_path::parse_segment_filename(filename);

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -221,7 +221,7 @@ ss::future<> kvstore::for_each(
 }
 
 void kvstore::apply_op(
-  bytes key, std::optional<iobuf> value, ssx::semaphore_units const&) {
+  bytes key, std::optional<iobuf> value, const ssx::semaphore_units&) {
     auto it = _db.find(key);
     bool found = it != _db.end();
     if (value) {

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -179,7 +179,7 @@ private:
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);
     void apply_op(
-      bytes key, std::optional<iobuf> value, ssx::semaphore_units const&);
+      bytes key, std::optional<iobuf> value, const ssx::semaphore_units&);
     ss::future<> flush_and_apply_ops();
     ss::future<> roll();
     ss::future<> save_snapshot();

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -656,8 +656,8 @@ ss::future<> remove_orphan_partition_files(
               vlog(stlog.info, "Cleaning up ntp directory {} ", ntp_directory);
               return ss::recursive_remove_directory(ntp_directory)
                 .handle_exception_type([ntp_directory](
-                                         std::filesystem::
-                                           filesystem_error const& err) {
+                                         const std::filesystem::
+                                           filesystem_error& err) {
                     vlog(
                       stlog.error,
                       "Exception while cleaning orphan files for {} Error: {}",
@@ -713,7 +713,7 @@ ss::future<> log_manager::remove_orphan_files(
                       topic_directory.string());
                 })
                 .handle_exception_type(
-                  [](std::filesystem::filesystem_error const& err) {
+                  [](const std::filesystem::filesystem_error& err) {
                       auto lvl = err.code()
                                      == std::errc::no_such_file_or_directory
                                    ? ss::log_level::trace
@@ -726,7 +726,7 @@ ss::future<> log_manager::remove_orphan_files(
                   });
           })
           .handle_exception_type(
-            [](std::filesystem::filesystem_error const& err) {
+            [](const std::filesystem::filesystem_error& err) {
                 vlog(
                   stlog.error, "Exception while cleaning orphan files {}", err);
             });

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -444,7 +444,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
                       recs.error().message());
                 }
 
-                auto const batch_parse_err
+                const auto batch_parse_err
                   = recs.error() == parser_errc::header_only_crc_missmatch
                     || recs.error()
                          == parser_errc::input_stream_not_enough_bytes;

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -336,7 +336,7 @@ struct persisted_batch {
     int32_t length;
 
     friend inline void read_nested(
-      iobuf_parser& in, persisted_batch& b, size_t const bytes_left_limit) {
+      iobuf_parser& in, persisted_batch& b, const size_t bytes_left_limit) {
         serde::read_nested(in, b.base_offset, bytes_left_limit);
         serde::read_nested(in, b.length, bytes_left_limit);
     }

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -65,7 +65,7 @@ struct time_based_retention_cfg {
     bool use_escape_hatch_for_timestamps_in_the_future;
 
     static auto
-    make(features::feature_table const& ft) -> time_based_retention_cfg {
+    make(const features::feature_table& ft) -> time_based_retention_cfg {
         return {
           .use_broker_time = ft.is_active(
             features::feature::broker_time_based_retention),
@@ -273,7 +273,7 @@ operator<<(std::ostream&, const std::optional<segment_index::entry>&);
 template<>
 struct fmt::formatter<storage::time_based_retention_cfg>
   : public fmt::formatter<std::string_view> {
-    auto format(storage::time_based_retention_cfg const& cfg, auto& ctx) const {
+    auto format(const storage::time_based_retention_cfg& cfg, auto& ctx) const {
         auto str = ssx::sformat(
           "[.use_broker_time={}, "
           ".use_escape_hatch_for_timestamps_in_the_future={}]",

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -90,8 +90,8 @@ ss::future<> spill_key_index::index(
 
 ss::future<> spill_key_index::add_key(compaction_key b, value_type v) {
     auto f = ss::now();
-    auto const entry_size = entry_mem_usage(b);
-    auto const expected_size = idx_mem_usage() + _keys_mem_usage + entry_size;
+    const auto entry_size = entry_mem_usage(b);
+    const auto expected_size = idx_mem_usage() + _keys_mem_usage + entry_size;
 
     auto take_result = _resources.compaction_index_take_bytes(entry_size);
     if (_mem_units.count() == 0) {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -65,7 +65,7 @@ void validate_offsets(
     BOOST_REQUIRE_EQUAL(write_headers.size(), read_batches.size());
     auto it = read_batches.begin();
     model::offset next_base = base;
-    for (auto const& h : write_headers) {
+    for (const auto& h : write_headers) {
         BOOST_REQUIRE_EQUAL(it->base_offset(), next_base);
         // last offset delta is inclusive (record with this offset belongs to
         // previous batch)

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -32,12 +32,12 @@
 #include <vector>
 namespace storage {
 
-inline static ss::sstring random_dir() {
+static inline ss::sstring random_dir() {
     return ssx::sformat(
       "test.dir_{}", random_generators::gen_alphanum_string(7));
 }
 
-inline static log_config log_builder_config() {
+static inline log_config log_builder_config() {
     return log_config(
       random_dir(),
       100_MiB,
@@ -45,21 +45,21 @@ inline static log_config log_builder_config() {
       storage::make_sanitized_file_config());
 }
 
-inline static log_reader_config reader_config() {
+static inline log_reader_config reader_config() {
     return log_reader_config{
       model::offset(0),
       model::model_limits<model::offset>::max(),
       ss::default_priority_class()};
 }
 
-inline static log_append_config append_config() {
+static inline log_append_config append_config() {
     return log_append_config{
       .should_fsync = storage::log_append_config::fsync::yes,
       .io_priority = ss::default_priority_class(),
       .timeout = model::no_timeout};
 }
 
-inline static model::ntp log_builder_ntp() {
+static inline model::ntp log_builder_ntp() {
     return model::ntp(
       model::ns("test.log_builder"),
       model::topic(random_generators::gen_alphanum_string(8)),

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -81,7 +81,7 @@ private:
 
 // The lexicographically smallest ntp
 // NOLINTNEXTLINE(cert-err58-cpp)
-const static model::ntp min_ntp = model::ntp(
+static const model::ntp min_ntp = model::ntp(
   model::ns(""), model::topic(""), model::partition_id::min());
 
 } // namespace

--- a/src/v/utils/auto_fmt.h
+++ b/src/v/utils/auto_fmt.h
@@ -33,7 +33,7 @@ struct auto_fmt {};
 template<class Derived, char delimiter>
 std::ostream&
 operator<<(std::ostream& o, const auto_fmt<Derived, delimiter>& e) {
-    constexpr auto const a = reflection::arity<Derived>() - 1;
+    constexpr const auto a = reflection::arity<Derived>() - 1;
     static_assert(a <= 16, "Too many fields");
     constexpr char d = delimiter;
     if constexpr (a == 0) {

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -72,7 +72,7 @@ struct delta_xor {
         return p;
     }
 
-    bool operator==(delta_xor const&) const = default;
+    bool operator==(const delta_xor&) const = default;
 };
 
 /*
@@ -130,7 +130,7 @@ struct delta_delta {
 
     ValueT _step_size;
 
-    bool operator==(delta_delta const&) const = default;
+    bool operator==(const delta_delta&) const = default;
 };
 
 namespace decomp {
@@ -237,7 +237,7 @@ auto serialize_little_endian(unsigned_serializable auto bits, uint8_t* output) {
 
 template<size_t bytes_to_read>
 auto deserialize_little_endian(
-  uint8_t const* input, unsigned_serializable auto& output) {
+  const uint8_t* input, unsigned_serializable auto& output) {
     if constexpr (bytes_to_read > 0) {
         static_assert(
           std::endian::native == std::endian::little,
@@ -686,7 +686,7 @@ template<class value_t, class decoder_t>
 class deltafor_frame_const_iterator
   : public boost::iterator_facade<
       deltafor_frame_const_iterator<value_t, decoder_t>,
-      value_t const,
+      const value_t,
       boost::iterators::forward_traversal_tag> {
     constexpr static uint32_t buffer_depth = details::FOR_buffer_depth;
     constexpr static uint32_t index_mask = buffer_depth - 1;
@@ -1032,7 +1032,7 @@ template<class value_t, auto delta_alg>
 class deltafor_column_const_iterator
   : public boost::iterator_facade<
       deltafor_column_const_iterator<value_t, delta_alg>,
-      value_t const,
+      const value_t,
       boost::iterators::forward_traversal_tag> {
     friend class boost::iterator_core_access;
 
@@ -1216,7 +1216,7 @@ class deltafor_column_impl
 
     // crtp helper
     auto to_underlying() const -> decltype(auto) {
-        return *static_cast<Derived const*>(this);
+        return *static_cast<const Derived*>(this);
     }
 
 public:
@@ -1418,7 +1418,7 @@ public:
     void serde_write(iobuf& out) {
         // std::list is not part of the serde-enabled types, save is as
         // size,elements
-        auto const frames_size = _frames.size();
+        const auto frames_size = _frames.size();
         if (unlikely(
               frames_size > std::numeric_limits<serde::serde_size_t>::max())) {
             throw serde::serde_exception(fmt_with_ctx(
@@ -1433,7 +1433,7 @@ public:
         }
     }
 
-    void serde_read(iobuf_parser& in, serde::header const& h) {
+    void serde_read(iobuf_parser& in, const serde::header& h) {
         // std::list is not part of the serde-enabled types, retrieve size and
         // push_back the elements
         if (unlikely(in.bytes_left() < h._bytes_left_limit)) {
@@ -1446,7 +1446,7 @@ public:
               h._bytes_left_limit,
               in.bytes_left()));
         }
-        auto const frames_size = serde::read_nested<serde::serde_size_t>(
+        const auto frames_size = serde::read_nested<serde::serde_size_t>(
           in, h._bytes_left_limit);
         for (auto i = 0U; i < frames_size; ++i) {
             _frames.push_back(
@@ -1468,7 +1468,7 @@ public:
 protected:
     auto get_frame_iterator_by_element_index(size_t ix) const {
         return std::find_if(
-          _frames.begin(), _frames.end(), [ix](frame_t const& f) mutable {
+          _frames.begin(), _frames.end(), [ix](const frame_t& f) mutable {
               if (f.size() > ix) {
                   return true;
               }

--- a/src/v/utils/xid.cc
+++ b/src/v/utils/xid.cc
@@ -113,7 +113,7 @@ fmt::formatter<xid>::format(const xid& id, format_context& ctx) const {
     return ctx.out();
 }
 
-void read_nested(iobuf_parser& in, xid& id, size_t const bytes_left_limit) {
+void read_nested(iobuf_parser& in, xid& id, const size_t bytes_left_limit) {
     serde::read_nested(in, id._data, bytes_left_limit);
 }
 

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -79,7 +79,7 @@ public:
     friend std::istream& operator>>(std::istream&, xid&);
 
     friend void
-    read_nested(iobuf_parser& in, xid& id, size_t const bytes_left_limit);
+    read_nested(iobuf_parser& in, xid& id, const size_t bytes_left_limit);
 
     friend void write(iobuf& out, xid id);
 


### PR DESCRIPTION
Makes the following changes to `.clang-format` to ensure consistent formatting in the codebase:

```diff
+ PointerAlignment: Left
+ QualifierAlignment: Custom
+ QualifierOrder: [static, inline, const, type]
+ ReferenceAlignment: Left
```

Thereby enforcing west const, pointer/reference alignment to the type, and a consistent qualifier order for all `.cc/.h` files.

As noted by https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifieralignment, extra care should be taken when reviewing formatting performed with this option.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
