### PR TITLE
Fixed reactor stalls occurring when clearing batch cache entries 

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -125,6 +125,7 @@ redpanda_cc_library(
         "//src/v/container:intrusive",
         "//src/v/model",
         "//src/v/resource_mgmt:available_memory",
+        "//src/v/ssx:async_algorithm",
         "//src/v/ssx:semaphore",
         "@abseil-cpp//absl/container:btree",
         "@seastar",

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -531,6 +531,7 @@ public:
     batch_cache_index(const batch_cache_index&) = delete;
     batch_cache_index& operator=(const batch_cache_index&) = delete;
 
+    ss::future<> clear_async();
     bool empty() const { return _index.empty(); }
 
     void

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -224,6 +224,9 @@ ss::future<> segment::do_close() {
     // after appender flushes to make sure we make things visible
     // only after appender flush
     f = f.then([this] { return _idx.flush(); });
+    if (_cache) {
+        f = f.then([this] { return _cache->clear_async(); });
+    }
     return f;
 }
 


### PR DESCRIPTION
Clearing a `batch_cache` asynchronously to prevent reactor stalls when
stopping partition or closing a segment with lots of active cache
entries.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none