### PR TITLE
tests: wait for topic to be present before starting producer

### DIFF
--- a/tests/rptest/tests/mirror_maker_test.py
+++ b/tests/rptest/tests/mirror_maker_test.py
@@ -87,6 +87,18 @@ class MirrorMakerService(EndToEndTest):
         self.topic.partition_count = 1000 if self.redpanda.dedicated_nodes else 10
         self.source_client.create_topic(self.topic)
 
+        def topic_present():
+            td = self.source_client.describe_topic(self.topic.name)
+            return len(td.partitions) == self.topic.partition_count
+
+        wait_until(
+            topic_present,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=
+            f"Error waiting for topic {self.topic} to be present and ready",
+            retry_on_exc=True)
+
     def start_workload(self):
 
         self.consumer = VerifiableConsumer(


### PR DESCRIPTION
The `KgoVerifierProducer` expect topic to be present when starting. In Kafka that is used as a source cluster in the mirror maker setup test the topic information is propagated slowly. Added waiting for the topic to be discoverable before proceeding with the next steps in the test.

Fixes: CORE-1639

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none