### PR TITLE
Made `raft_test_fixture` election timeout and `heartbeat_interval` runtime configurable

### DIFF
--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -13,7 +13,6 @@
 
 #include "bytes/iobuf_parser.h"
 #include "config/property.h"
-#include "config/throughput_control_group.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -28,11 +27,9 @@
 #include "raft/heartbeat_manager.h"
 #include "raft/heartbeats.h"
 #include "raft/state_machine_manager.h"
-#include "raft/tests/raft_group_fixture.h"
 #include "raft/timeout_jitter.h"
 #include "raft/types.h"
 #include "random/generators.h"
-#include "serde/serde.h"
 #include "ssx/future-util.h"
 #include "storage/api.h"
 #include "storage/kvstore.h"
@@ -42,30 +39,9 @@
 #include "test_utils/async.h"
 #include "utils/prefix_logger.h"
 
-#include <seastar/core/abort_source.hh>
-#include <seastar/core/circular_buffer.hh>
-#include <seastar/core/gate.hh>
-#include <seastar/core/io_priority_class.hh>
-#include <seastar/core/scheduling.hh>
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/core/timed_out_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/file.hh>
-#include <seastar/util/log.hh>
-#include <seastar/util/noncopyable_function.hh>
-
-#include <absl/container/flat_hash_set.h>
-#include <fmt/core.h>
-
-#include <algorithm>
-#include <chrono>
-#include <filesystem>
-#include <memory>
-#include <optional>
-#include <ranges>
-#include <stdexcept>
-#include <type_traits>
 
 namespace raft {
 

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -11,29 +11,21 @@
  */
 
 #pragma once
-
-#include "base/vassert.h"
-#include "bytes/iobuf.h"
 #include "bytes/random.h"
 #include "cluster/errc.h"
 #include "config/mock_property.h"
 #include "config/property.h"
 #include "features/feature_table.h"
 #include "model/fundamental.h"
-#include "model/metadata.h"
-#include "model/namespace.h"
 #include "model/timeout_clock.h"
-#include "raft/consensus.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/coordinated_recovery_throttle.h"
 #include "raft/errc.h"
 #include "raft/fwd.h"
-#include "raft/group_configuration.h"
 #include "raft/heartbeat_manager.h"
 #include "raft/recovery_memory_quota.h"
 #include "raft/state_machine_manager.h"
 #include "raft/types.h"
-#include "random/generators.h"
 #include "ssx/sformat.h"
 #include "storage/api.h"
 #include "test_utils/test.h"
@@ -46,11 +38,7 @@
 #include <absl/container/node_hash_map.h>
 #include <boost/range/irange.hpp>
 
-#include <optional>
 #include <ranges>
-#include <system_error>
-#include <type_traits>
-
 namespace raft {
 
 static constexpr raft::group_id test_group(123);


### PR DESCRIPTION
Added possibility co configure the election timeout and heartbeats in runtime when using `raft_test_fixture` 

<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none