### PR TITLE
Fix class instance check for raise_on_crash

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -17,7 +17,8 @@ from ducktape.mark._mark import Mark
 from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import RedpandaServiceBase, RedpandaServiceCloud
+from rptest.services.redpanda import RedpandaServiceBase, RedpandaService, \
+    RedpandaServiceCloud
 from rptest.services.redpanda_types import LogAllowList
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
 
@@ -124,7 +125,7 @@ def cluster(log_allow_list: LogAllowList | None = None,
                     if isinstance(redpanda, RedpandaServiceBase):
                         redpanda.cloud_storage_diagnostics()
                     if isinstance(redpanda,
-                                  RedpandaServiceCloud | RedpandaServiceCloud):
+                                  RedpandaService | RedpandaServiceCloud):
                         redpanda.raise_on_crash(log_allow_list=log_allow_list)
 
                 raise


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none