### PR TITLE
bazel: improve krb5 build

### DIFF
--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -14,11 +14,22 @@ configure_make(
     configure_options = [
         "--srcdir=./src",
         "--disable-thread-support",
+        "--with-crypto-impl=openssl",
+        "--with-tls-impl=openssl",
+        # Normally, these libraries are auto detected,
+        # but we never want them so explicitly disable
+        # them.
         "--without-netlib",
+        "--without-keyutils",
+        "--without-lmdb",
+        "--without-libedit",
+        "--without-readline",
+        "--without-system-verto",
         # TODO(bazel) when building the static library the linker is exiting with a
         # duplicate symbol error
         "--enable-shared",
         "--disable-static",
+        # "--enable-asan=undefined,address",
     ],
     lib_source = ":srcs",
     out_shared_libs = [
@@ -26,6 +37,9 @@ configure_make(
         "libk5crypto.so.3",
         "libkrb5.so.3",
         "libkrb5support.so.0",
+    ],
+    deps = [
+        "@openssl",
     ],
     visibility = [
         "//visibility:public",

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -46,6 +46,7 @@ configure_make(
     },
     lib_source = ":srcs",
     out_shared_libs = [
+        "libcom_err.so.3",
         "libgssapi_krb5.so.2",
         "libk5crypto.so.3",
         "libkrb5.so.3",


### PR DESCRIPTION
- **bazel/krb5: disable extra libraries**
- **bazel/krb5: support parallel compilation via flag**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
