### PR TITLE
[v24.2.x] CORE-6860 Schema Registry: add detailed verbose compatibility checks

### DIFF
--- a/src/v/pandaproxy/schema_registry/compatibility.cc
+++ b/src/v/pandaproxy/schema_registry/compatibility.cc
@@ -46,7 +46,7 @@ std::string_view description_for_type(avro_incompatibility_type t) {
     case avro_incompatibility_type::reader_field_missing_default_value:
         return "The field '{additional}' at path '{path}' in the {{reader}} "
                "schema has "
-               "no default value and is missing in the {{writer}}";
+               "no default value and is missing in the {{writer}} schema";
     case avro_incompatibility_type::type_mismatch:
         return "The type (path '{path}') of a field in the {{reader}} schema "
                "does not match with the {{writer}} schema";

--- a/src/v/pandaproxy/schema_registry/compatibility.cc
+++ b/src/v/pandaproxy/schema_registry/compatibility.cc
@@ -138,7 +138,7 @@ std::string_view description_for_type(proto_incompatibility_type t) {
 
 std::ostream& operator<<(std::ostream& os, const proto_incompatibility& v) {
     fmt::print(
-      os, "{{errorType:'{}', description:'{}'}}", v._type, v.describe());
+      os, R"({{errorType:"{}", description:"{}"}})", v._type, v.describe());
     return os;
 }
 

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -15,6 +15,7 @@
 #include "bytes/streambuf.h"
 #include "kafka/protocol/errors.h"
 #include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "ssx/sformat.h"
@@ -470,47 +471,59 @@ encoding get_encoding(pb::FieldDescriptor::Type type) {
     __builtin_unreachable();
 }
 
-struct compatibility_checker {
-    bool check_compatible() { return check_compatible(_writer.fd); }
+using proto_compatibility_result = raw_compatibility_result;
 
-    bool check_compatible(const pb::FileDescriptor* writer) {
+struct compatibility_checker {
+    proto_compatibility_result check_compatible(std::filesystem::path p) {
+        return check_compatible(_writer.fd, std::move(p));
+    }
+
+    proto_compatibility_result check_compatible(
+      const pb::FileDescriptor* writer, std::filesystem::path p) {
         // There must be a compatible reader message for every writer message
+        proto_compatibility_result compat_result;
         for (int i = 0; i < writer->message_type_count(); ++i) {
             auto w = writer->message_type(i);
             auto r = _reader._dp.FindMessageTypeByName(w->full_name());
-            if (!r || !check_compatible(r, w)) {
-                return false;
+
+            if (!r) {
+                compat_result.emplace<proto_incompatibility>(
+                  p / w->name(), proto_incompatibility::Type::message_removed);
+            } else {
+                compat_result.merge(check_compatible(r, w, p / w->name()));
             }
         }
-        return true;
+        return compat_result;
     }
 
-    bool check_compatible(
-      const pb::Descriptor* reader, const pb::Descriptor* writer) {
+    proto_compatibility_result check_compatible(
+      const pb::Descriptor* reader,
+      const pb::Descriptor* writer,
+      std::filesystem::path p) {
+        proto_compatibility_result compat_result;
         if (!_seen_descriptors.insert(reader).second) {
-            return true;
+            return compat_result;
         }
 
         for (int i = 0; i < writer->nested_type_count(); ++i) {
             auto w = writer->nested_type(i);
-            auto r = reader->FindNestedTypeByName(w->full_name());
-            if (!r || !check_compatible(r, w)) {
-                return false;
+            auto r = reader->FindNestedTypeByName(w->name());
+            if (!r) {
+                compat_result.emplace<proto_incompatibility>(
+                  p / w->name(), proto_incompatibility::Type::message_removed);
+            } else {
+                compat_result.merge(check_compatible(r, w, p / w->name()));
             }
         }
 
         for (int i = 0; i < writer->real_oneof_decl_count(); ++i) {
             auto w = writer->oneof_decl(i);
-            if (!check_compatible(reader, w)) {
-                return false;
-            }
+            compat_result.merge(check_compatible(reader, w, p / w->name()));
         }
 
         for (int i = 0; i < reader->real_oneof_decl_count(); ++i) {
             auto r = reader->oneof_decl(i);
-            if (!check_compatible(r, writer)) {
-                return false;
-            }
+            compat_result.merge(check_compatible(r, writer, p / r->name()));
         }
 
         // check writer fields
@@ -520,9 +533,16 @@ struct compatibility_checker {
             auto r = reader->FindFieldByNumber(number);
             // A reader may ignore a writer field iff it is not `required`
             if (!r && w->is_required()) {
-                return false;
-            } else if (r && !check_compatible(r, w)) {
-                return false;
+                compat_result.emplace<proto_incompatibility>(
+                  p / std::to_string(w->number()),
+                  proto_incompatibility::Type::required_field_removed);
+            } else if (r) {
+                auto oneof = r->containing_oneof();
+                compat_result.merge(check_compatible(
+                  r,
+                  w,
+                  p / (oneof ? oneof->name() : "")
+                    / std::to_string(w->number())));
             }
         }
 
@@ -533,18 +553,24 @@ struct compatibility_checker {
             auto w = writer->FindFieldByNumber(number);
             // A writer may ignore a reader field iff it is not `required`
             if ((!w || !w->is_required()) && r->is_required()) {
-                return false;
+                compat_result.emplace<proto_incompatibility>(
+                  p / std::to_string(number),
+                  proto_incompatibility::Type::required_field_added);
             }
         }
-        return true;
+        return compat_result;
     }
 
-    bool check_compatible(
-      const pb::Descriptor* reader, const pb::OneofDescriptor* writer) {
+    proto_compatibility_result check_compatible(
+      const pb::Descriptor* reader,
+      const pb::OneofDescriptor* writer,
+      std::filesystem::path p) {
+        proto_compatibility_result compat_result;
+
         // If the oneof in question doesn't appear in the reader descriptor,
         // then we don't need to account for any difference in fields.
         if (!reader->FindOneofByName(writer->name())) {
-            return true;
+            return compat_result;
         }
 
         for (int i = 0; i < writer->field_count(); ++i) {
@@ -552,14 +578,20 @@ struct compatibility_checker {
             auto r = reader->FindFieldByNumber(w->number());
 
             if (!r || !r->real_containing_oneof()) {
-                return false;
+                compat_result.emplace<proto_incompatibility>(
+                  p / std::to_string(w->number()),
+                  proto_incompatibility::Type::oneof_field_removed);
             }
         }
-        return true;
+        return compat_result;
     }
 
-    bool check_compatible(
-      const pb::OneofDescriptor* reader, const pb::Descriptor* writer) {
+    proto_compatibility_result check_compatible(
+      const pb::OneofDescriptor* reader,
+      const pb::Descriptor* writer,
+      std::filesystem::path p) {
+        proto_compatibility_result compat_result;
+
         size_t count = 0;
         for (int i = 0; i < reader->field_count(); ++i) {
             auto r = reader->field(i);
@@ -568,11 +600,19 @@ struct compatibility_checker {
                 ++count;
             }
         }
-        return count <= 1;
+        if (count > 1) {
+            compat_result.emplace<proto_incompatibility>(
+              std::move(p),
+              proto_incompatibility::Type::multiple_fields_moved_to_oneof);
+        }
+        return compat_result;
     }
 
-    bool check_compatible(
-      const pb::FieldDescriptor* reader, const pb::FieldDescriptor* writer) {
+    proto_compatibility_result check_compatible(
+      const pb::FieldDescriptor* reader,
+      const pb::FieldDescriptor* writer,
+      std::filesystem::path p) {
+        proto_compatibility_result compat_result;
         switch (writer->type()) {
         case pb::FieldDescriptor::Type::TYPE_MESSAGE:
         case pb::FieldDescriptor::Type::TYPE_GROUP: {
@@ -580,16 +620,23 @@ struct compatibility_checker {
                                     == pb::FieldDescriptor::Type::TYPE_MESSAGE
                                   || reader->type()
                                        == pb::FieldDescriptor::Type::TYPE_GROUP;
-
-            if (
-              !type_is_compat
-              || reader->message_type()->name()
-                   != writer->message_type()->name()) {
-                return false;
+            if (!type_is_compat) {
+                compat_result.emplace<proto_incompatibility>(
+                  std::move(p),
+                  proto_incompatibility::Type::field_kind_changed);
+            } else if (
+              reader->message_type()->name()
+              != writer->message_type()->name()) {
+                compat_result.emplace<proto_incompatibility>(
+                  std::move(p),
+                  proto_incompatibility::Type::field_named_type_changed);
             } else {
-                return check_compatible(
-                  reader->message_type(), writer->message_type());
+                compat_result.merge(check_compatible(
+                  reader->message_type(),
+                  writer->message_type(),
+                  std::move(p)));
             }
+            break;
         }
         case pb::FieldDescriptor::Type::TYPE_FLOAT:
         case pb::FieldDescriptor::Type::TYPE_DOUBLE:
@@ -607,14 +654,27 @@ struct compatibility_checker {
         case pb::FieldDescriptor::Type::TYPE_SFIXED32:
         case pb::FieldDescriptor::Type::TYPE_FIXED64:
         case pb::FieldDescriptor::Type::TYPE_SFIXED64:
-            return check_compatible(
-              get_encoding(reader->type()), get_encoding(writer->type()));
+            compat_result.merge(check_compatible(
+              get_encoding(reader->type()),
+              get_encoding(writer->type()),
+              std::move(p)));
         }
-        __builtin_unreachable();
+        return compat_result;
     }
 
-    bool check_compatible(encoding reader, encoding writer) {
-        return reader == writer && reader != encoding::struct_;
+    proto_compatibility_result check_compatible(
+      encoding reader, encoding writer, std::filesystem::path p) {
+        proto_compatibility_result compat_result;
+        // we know writer has scalar encoding because of the switch stmt above
+        if (reader == encoding::struct_) {
+            compat_result.emplace<proto_incompatibility>(
+              std::move(p), proto_incompatibility::Type::field_kind_changed);
+        } else if (reader != writer) {
+            compat_result.emplace<proto_incompatibility>(
+              std::move(p),
+              proto_incompatibility::Type::field_scalar_kind_changed);
+        }
+        return compat_result;
     }
 
     const protobuf_schema_definition::impl& _reader;
@@ -627,10 +687,9 @@ struct compatibility_checker {
 compatibility_result check_compatible(
   const protobuf_schema_definition& reader,
   const protobuf_schema_definition& writer,
-  verbose is_verbose [[maybe_unused]]) {
+  verbose is_verbose) {
     compatibility_checker checker{reader(), writer()};
-    // TODO(gellert.nagy): start using the is_verbose flag in a follow up PR
-    return compatibility_result{.is_compat = checker.check_compatible()};
+    return checker.check_compatible("#/")(is_verbose);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -201,14 +201,15 @@ sharded_store::get_schema_version(subject_schema schema) {
     // Check compatibility of the schema
     if (!v_id.has_value() && !versions.empty()) {
         auto compat = co_await is_compatible(
-          versions.back().version, schema.schema.share());
-        if (!compat) {
+          versions.back().version, schema.schema.share(), verbose::yes);
+        if (!compat.is_compat) {
             throw exception(
               error_code::schema_incompatible,
               fmt::format(
                 "Schema being registered is incompatible with an earlier "
-                "schema for subject \"{}\"",
-                sub));
+                "schema for subject \"{}\", details: [{}]",
+                sub,
+                fmt::join(compat.messages, ", ")));
         }
     }
     co_return has_schema_result{s_id, v_id};
@@ -826,7 +827,7 @@ ss::future<compatibility_result> sharded_store::do_is_compatible(
             version_messages.emplace_back(
               fmt::format("{{oldSchema: '{}'}}", to_string(old_valid.raw())));
             version_messages.emplace_back(
-              fmt::format("{{compatibility: {}}}", compat));
+              fmt::format("{{compatibility: '{}'}}", compat));
         }
 
         result.messages.reserve(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -11,12 +11,21 @@
 
 #include "pandaproxy/schema_registry/avro.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/test/compatibility_common.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_set.h>
+#include <avro/Compiler.hh>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <array>
+
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
+
+namespace {
 
 bool check_compatible(
   const pps::canonical_schema_definition& r,
@@ -31,6 +40,22 @@ bool check_compatible(
                .get())
       .is_compat;
 }
+
+pps::compatibility_result check_compatible_verbose(
+  const pps::canonical_schema_definition& r,
+  const pps::canonical_schema_definition& w) {
+    pps::sharded_store s;
+    return check_compatible(
+      pps::make_avro_schema_definition(
+        s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::avro}})
+        .get(),
+      pps::make_avro_schema_definition(
+        s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::avro}})
+        .get(),
+      pps::verbose::yes);
+}
+
+} // namespace
 
 SEASTAR_THREAD_TEST_CASE(test_avro_type_promotion) {
     BOOST_REQUIRE(check_compatible(schema_long, schema_int));
@@ -278,4 +303,268 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition_custom_attributes) {
       "schema2 is an avro_schema_definition");
     pps::canonical_schema_definition avro_conversion{valid};
     BOOST_CHECK_EQUAL(expected, avro_conversion);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_avro_alias_resolution_stopgap) {
+    auto writer = avro::compileJsonSchemaFromString(
+      R"({"type":"record","fields":[{"name":"bar","type":"float"}],"name":"foo"})");
+
+    auto reader = avro::compileJsonSchemaFromString(
+      R"({"type":"record","fields":[{"name":"bar","type":"float"}],"name":"foo_renamed","aliases":["foo"]})");
+
+    auto& writer_root = *writer.root();
+    auto& reader_root = *reader.root();
+
+    // This should resolve to true but it currently resolves to false because
+    // the Avro library doesn't fully support handling schema resolution with
+    // aliases yet. When the avro library supports alias resolution this test
+    // will fail and we should then update the compat check to don't report an
+    // incompatibility when the record names are properly aliased.
+    BOOST_CHECK(!writer_root.resolve(reader_root));
+}
+
+namespace {
+
+const auto schema_old = pps::sanitize_avro_schema_definition(
+                          {
+                            R"({
+    "type": "record",
+    "name": "myrecord",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "string"
+        },
+        {
+            "name": "f2",
+            "type": {
+                "name": "nestedRec",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "nestedF",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "uF",
+            "type": ["int", "string"]
+        },
+        {
+            "name": "enumF",
+            "type": {
+                "name": "ABorC",
+                "type": "enum",
+                "symbols": ["a", "b", "c"]
+            }
+        },
+        {
+            "name": "fixedF",
+            "type": {
+                "type": "fixed",
+                "name": "fixedT",
+                "size": 1
+            }
+        },
+	      {
+	          "name": "oldUnion",
+	          "type": ["int", "string"]
+	      },
+	      {
+	          "name": "newUnion",
+	          "type": "int"
+	      },
+        {
+            "name": "someList",
+            "type": {
+                "type": "array",
+                "items": "int"
+            }
+        },
+        {
+            "name": "otherEnumF",
+            "type": {
+                "type": "enum",
+                "name": "someEnum1",
+                "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+            }
+        }
+    ]
+})",
+                            pps::schema_type::avro})
+                          .value();
+
+const auto schema_new = pps::sanitize_avro_schema_definition(
+                          {
+                            R"({
+    "type": "record",
+    "name": "myrecord",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "int"
+        },
+        {
+            "name": "f2",
+            "type": {
+                "name": "nestedRec2",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "broken",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "uF",
+            "type": ["string"]
+        },
+        {
+            "name": "enumF",
+            "type": {
+                "name": "ABorC",
+                "type": "enum",
+                "symbols": ["a"]
+            }
+        },
+        {
+            "name": "fixedF",
+            "type": {
+                "type": "fixed",
+                "name": "fixedT",
+                "size": 2
+            }
+        },
+        {
+            "name": "oldUnion",
+	          "type": "boolean"
+	      },
+	      {
+	          "name": "newUnion",
+	          "type": ["boolean", "string"]
+	      },
+        {
+            "name": "someList",
+            "type": {
+                "type": "array",
+                "items": "long"
+            }
+        },
+        {
+            "name": "otherEnumF",
+            "type": {
+                "type": "enum",
+                "name": "someEnum2",
+                "aliases": ["someEnum1"],
+                "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+            }
+        }
+    ]
+})",
+                            pps::schema_type::avro})
+                          .value();
+
+using incompatibility = pps::avro_incompatibility;
+
+const absl::flat_hash_set<incompatibility> forward_expected{
+  {"/fields/0/type",
+   incompatibility::Type::type_mismatch,
+   "reader type: STRING not compatible with writer type: INT"},
+  {"/fields/1/type/name",
+   incompatibility::Type::name_mismatch,
+   "expected: nestedRec2"},
+  {"/fields/1/type/fields/0",
+   incompatibility::Type::reader_field_missing_default_value,
+   "nestedF"},
+  {"/fields/4/type/size",
+   incompatibility::Type::fixed_size_mismatch,
+   "expected: 2, found: 1"},
+  {"/fields/5/type",
+   incompatibility::Type::missing_union_branch,
+   "reader union lacking writer type: BOOLEAN"},
+  {"/fields/6/type", /* NOTE: this is more path info than the reference impl */
+   incompatibility::Type::type_mismatch,
+   "reader type: INT not compatible with writer type: BOOLEAN"},
+  {"/fields/6/type", /* NOTE: this is more path info than the reference impl */
+   incompatibility::Type::type_mismatch,
+   "reader type: INT not compatible with writer type: STRING"},
+  {"/fields/7/type/items",
+   incompatibility::Type::type_mismatch,
+   "reader type: INT not compatible with writer type: LONG"},
+  {"/fields/8/type/name",
+   incompatibility::Type::name_mismatch,
+   "expected: someEnum2"},
+};
+const absl::flat_hash_set<incompatibility> backward_expected{
+  {"/fields/0/type",
+   incompatibility::Type::type_mismatch,
+   "reader type: INT not compatible with writer type: STRING"},
+  {"/fields/1/type/name",
+   incompatibility::Type::name_mismatch,
+   "expected: nestedRec"},
+  {"/fields/1/type/fields/0",
+   incompatibility::Type::reader_field_missing_default_value,
+   "broken"},
+  {"/fields/2/type/0",
+   incompatibility::Type::missing_union_branch,
+   "reader union lacking writer type: INT"},
+  {"/fields/3/type/symbols",
+   incompatibility::Type::missing_enum_symbols,
+   "[b, c]"},
+  {"/fields/4/type/size",
+   incompatibility::Type::fixed_size_mismatch,
+   "expected: 1, found: 2"},
+  {"/fields/5/type", /* NOTE: this is more path info than the reference impl */
+   incompatibility::Type::type_mismatch,
+   "reader type: BOOLEAN not compatible with writer type: INT"},
+  {"/fields/5/type", /* NOTE: this is more path info than the reference impl */
+   incompatibility::Type::type_mismatch,
+   "reader type: BOOLEAN not compatible with writer type: STRING"},
+  {"/fields/6/type",
+   incompatibility::Type::missing_union_branch,
+   "reader union lacking writer type: INT"},
+  // Note: once Avro supports schema resolution with name aliases, the
+  // incompatibility below should go away
+  {"/fields/8/type/name",
+   incompatibility::Type::name_mismatch,
+   "expected: someEnum1 (alias resolution is not yet fully supported)"},
+};
+
+const auto compat_data = std::to_array<compat_test_data<incompatibility>>({
+  {
+    schema_old.share(),
+    schema_new.share(),
+    forward_expected,
+  },
+  {
+    schema_new.share(),
+    schema_old.share(),
+    backward_expected,
+  },
+});
+
+std::string format_set(const absl::flat_hash_set<ss::sstring>& d) {
+    return fmt::format("{}", fmt::join(d, "\n"));
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(test_avro_compat_messages) {
+    for (const auto& cd : compat_data) {
+        auto compat = check_compatible_verbose(cd.reader, cd.writer);
+        absl::flat_hash_set<ss::sstring> errs{
+          compat.messages.begin(), compat.messages.end()};
+        absl::flat_hash_set<ss::sstring> expected{
+          cd.expected.messages.begin(), cd.expected.messages.end()};
+
+        BOOST_CHECK(!compat.is_compat);
+        BOOST_CHECK_EQUAL(errs.size(), expected.size());
+        BOOST_REQUIRE_MESSAGE(
+          errs == expected,
+          fmt::format("{} != {}", format_set(errs), format_set(expected)));
+    }
 }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_common.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_common.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/compatibility.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <absl/container/flat_hash_set.h>
+
+namespace pps = pandaproxy::schema_registry;
+
+template<typename incompatibility>
+struct compat_test_data {
+    compat_test_data(
+      pps::canonical_schema_definition reader,
+      pps::canonical_schema_definition writer,
+      absl::flat_hash_set<incompatibility> exp)
+      : reader(std::move(reader))
+      , writer(std::move(writer))
+      , expected([&exp]() {
+          pps::raw_compatibility_result raw;
+          absl::c_for_each(std::move(exp), [&raw](auto e) {
+              raw.emplace<incompatibility>(std::move(e));
+          });
+          return std::move(raw)(pps::verbose::yes);
+      }()) {}
+
+    pps::canonical_schema_definition reader;
+    pps::canonical_schema_definition writer;
+    pps::compatibility_result expected;
+};

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -13,16 +13,22 @@
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/test/compatibility_common.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_set.h>
 #include <boost/test/unit_test.hpp>
+#include <fmt/core.h>
 
+#include <array>
 #include <utility>
 
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
+
+namespace {
 
 struct simple_sharded_store {
     simple_sharded_store() {
@@ -76,6 +82,22 @@ bool check_compatible(
           pps::canonical_schema_definition{reader, pps::schema_type::protobuf}})
       .get();
 }
+
+pps::compatibility_result check_compatible_verbose(
+  const pps::canonical_schema_definition& r,
+  const pps::canonical_schema_definition& w) {
+    pps::sharded_store s;
+    return check_compatible(
+      pps::make_protobuf_schema_definition(
+        s, {pps::subject("r"), {r.shared_raw(), pps::schema_type::protobuf}})
+        .get(),
+      pps::make_protobuf_schema_definition(
+        s, {pps::subject("w"), {w.shared_raw(), pps::schema_type::protobuf}})
+        .get(),
+      pps::verbose::yes);
+}
+
+} // namespace
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     simple_sharded_store store;
@@ -757,4 +779,223 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_oneof_fully_removed) {
       pps::compatibility_level::backward,
       R"(syntax = "proto3"; message Simple { int32 other = 3; })",
       R"(syntax = "proto3"; message Simple { oneof wrapper { int32 id = 1; int32 new_id = 2; } int32 other = 3; })"));
+}
+
+namespace {
+
+const pps::canonical_schema_definition proto2_old{
+  R"(syntax = "proto2";
+
+message someMessage {
+  required int32 a = 1;
+}
+
+message myrecord {
+  message Msg1 {
+    required int32 f1 = 1;
+  }
+  message Msg2 {
+     required int32 f1 = 1;
+  }
+  required Msg1 m1 = 1;
+  required Msg1 m2 = 2;
+  required int32 i1 = 3;
+
+  required int32 i2 = 4;
+
+  oneof union {
+    int32 u1 = 5;
+    string u2 = 6;
+    bool u3 = 23;
+    bool u4 = 40;
+  }
+
+  required int32 notu1 = 7;
+  required string notu2 = 8;
+
+})",
+  pps::schema_type::protobuf};
+
+const pps::canonical_schema_definition proto2_new{
+  R"(syntax = "proto2";
+
+message myrecord {
+  message Msg1d {
+    required int32 f1 = 1;
+  }
+  message Msg2 {
+     required string f1 = 1;
+  }
+  required Msg1d m1 = 1;
+  required int32 m2 = 2;
+  required string i1 = 3;
+  // required int32 i2 = 4;
+
+  oneof union {
+    int32 u1 = 5;
+    string u2 = 16;
+    string u3 = 23;
+  }
+  required bool u4 = 40;
+
+  oneof union2 {
+    int32 notu1 = 7;
+    string notu2 = 8;
+  }
+
+  required string whoops = 12;
+})",
+  pps::schema_type::protobuf};
+
+const pps::canonical_schema_definition proto3_old{
+  R"(syntax = "proto3";
+
+message someMessage {
+   int32 a = 1;
+}
+
+message myrecord {
+  message Msg1 {
+     int32 f1 = 1;
+  }
+  message Msg2 {
+     int32 f1 = 1;
+  }
+   Msg1 m1 = 1;
+   Msg1 m2 = 2;
+   int32 i1 = 3;
+
+   int32 i2 = 4;
+
+  oneof union {
+    int32 u1 = 5;
+    string u2 = 6;
+    bool u3 = 23;
+    bool u4 = 40;
+  }
+
+   int32 notu1 = 7;
+   string notu2 = 8;
+
+}
+)",
+  pps::schema_type::protobuf};
+
+const pps::canonical_schema_definition proto3_new{
+  R"(syntax = "proto3";
+
+message myrecord {
+  message Msg1d {
+     int32 f1 = 1;
+  }
+  message Msg2 {
+     string f1 = 1;
+  }
+   Msg1d m1 = 1;
+   int32 m2 = 2;
+   string i1 = 3;
+
+  oneof union {
+    int32 u1 = 5;
+    string u2 = 16;
+    string u3 = 23;
+  }
+
+  bool u4 = 40;
+
+  oneof union2 {
+    int32 notu1 = 7;
+    string notu2 = 8;
+  }
+
+   string whoops = 12;
+})",
+  pps::schema_type::protobuf};
+
+using incompatibility = pps::proto_incompatibility;
+
+const absl::flat_hash_set<incompatibility> forward_expected{
+  {"#/myrecord/union/16", incompatibility::Type::oneof_field_removed},
+  {"#/myrecord/union/23", incompatibility::Type::field_scalar_kind_changed},
+  {"#/myrecord/1", incompatibility::Type::field_named_type_changed},
+  {"#/myrecord/2", incompatibility::Type::field_kind_changed},
+  {"#/myrecord/3", incompatibility::Type::field_scalar_kind_changed},
+  {"#/myrecord/Msg1d", incompatibility::Type::message_removed},
+  {"#/myrecord/Msg2/1", incompatibility::Type::field_scalar_kind_changed},
+  // These are ignored for proto3 schemas
+  {"#/myrecord/4", incompatibility::Type::required_field_added},
+  {"#/myrecord/7", incompatibility::Type::required_field_added},
+  {"#/myrecord/8", incompatibility::Type::required_field_added},
+  {"#/myrecord/12", incompatibility::Type::required_field_removed},
+};
+
+const absl::flat_hash_set<incompatibility> backward_expected{
+  {"#/someMessage", incompatibility::Type::message_removed},
+  {"#/myrecord/union2", incompatibility::Type::multiple_fields_moved_to_oneof},
+  {"#/myrecord/union/6", incompatibility::Type::oneof_field_removed},
+  {"#/myrecord/union/23", incompatibility::Type::field_scalar_kind_changed},
+  {"#/myrecord/union/40", incompatibility::Type::oneof_field_removed},
+  {"#/myrecord/1", incompatibility::Type::field_named_type_changed},
+  {"#/myrecord/2", incompatibility::Type::field_kind_changed},
+  {"#/myrecord/3", incompatibility::Type::field_scalar_kind_changed},
+  {"#/myrecord/Msg1", incompatibility::Type::message_removed},
+  {"#/myrecord/Msg2/1", incompatibility::Type::field_scalar_kind_changed},
+  // These are ignored for proto3 schemas
+  {"#/myrecord/4", incompatibility::Type::required_field_removed},
+  {"#/myrecord/40", incompatibility::Type::required_field_added},
+  {"#/myrecord/12", incompatibility::Type::required_field_added},
+};
+
+absl::flat_hash_set<incompatibility>
+remove_proto2_incompatibilites(absl::flat_hash_set<incompatibility> exp) {
+    absl::erase_if(exp, [](const auto& e) {
+        return (
+          e.type() == incompatibility::Type::required_field_removed
+          || e.type() == incompatibility::Type::required_field_added);
+    });
+    return exp;
+}
+
+const auto compat_data = std::to_array<compat_test_data<incompatibility>>({
+  {
+    proto2_old.copy(),
+    proto2_new.copy(),
+    forward_expected,
+  },
+  {
+    proto2_new.copy(),
+    proto2_old.copy(),
+    backward_expected,
+  },
+  {
+    proto3_old.copy(),
+    proto3_new.copy(),
+    remove_proto2_incompatibilites(forward_expected),
+  },
+  {
+    proto3_new.copy(),
+    proto3_old.copy(),
+    remove_proto2_incompatibilites(backward_expected),
+  },
+});
+
+std::string format_set(const absl::flat_hash_set<ss::sstring>& d) {
+    return fmt::format("{}", fmt::join(d, "\n"));
+}
+
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compat_messages) {
+    for (const auto& cd : compat_data) {
+        auto compat = check_compatible_verbose(cd.reader, cd.writer);
+        absl::flat_hash_set<ss::sstring> errs{
+          compat.messages.begin(), compat.messages.end()};
+        absl::flat_hash_set<ss::sstring> expected{
+          cd.expected.messages.begin(), cd.expected.messages.end()};
+        BOOST_CHECK(!compat.is_compat);
+        BOOST_CHECK_EQUAL(errs.size(), expected.size());
+        BOOST_REQUIRE_MESSAGE(
+          errs == expected,
+          fmt::format("{} != {}", format_set(errs), format_set(expected)));
+    }
 }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1617,6 +1617,17 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 message in m for m in msgs
             ), f"Expected to find an instance of '{message}', got {msgs}"
 
+        self.logger.debug(
+            "Check post incompatible schema error message (expect verbose messages)"
+        )
+        result_raw = self._post_subjects_subject_versions(
+            subject=f"{topic}-key", data=incompatible_data)
+
+        assert result_raw.status_code == 409
+        msg = result_raw.json()["message"]
+        for message in ["oldSchemaVersion", "oldSchema", "compatibility"]:
+            assert message in msg, f"Expected to find an instance of '{message}', got {msgs}"
+
     @cluster(num_nodes=3)
     def test_delete_subject(self):
         """


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22958 

Fixes https://github.com/redpanda-data/redpanda/issues/23107
Fixes https://redpandadata.atlassian.net/browse/CORE-7073

Conflicts:
 * False conflict around `proto_compatibility_result check_compatible(std::filesystem::path)` in https://github.com/redpanda-data/redpanda/pull/23110/commits/4520d587095343d3fbe2c76920354c7fdfd76209. The commits should be identical to the one being cherry-picked.