### PR TITLE
iceberg/tests: deflake TestSerializeManifestData

### DIFF
--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -258,10 +258,11 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
       std::get<struct_type>(test_nested_schema_type()));
 
     auto serialized_buf = serialize_avro(m);
-    auto m_roundtrip = parse_manifest(serialized_buf.copy());
-    ASSERT_EQ(m.metadata, m_roundtrip.metadata);
-    ASSERT_EQ(100, m_roundtrip.entries.size());
+    for (int i = 0; i < 10; i++) {
+        auto m_roundtrip = parse_manifest(std::move(serialized_buf));
+        ASSERT_EQ(m.metadata, m_roundtrip.metadata);
+        ASSERT_EQ(100, m_roundtrip.entries.size());
 
-    auto roundtrip_buf = serialize_avro(m_roundtrip);
-    ASSERT_EQ(serialized_buf, roundtrip_buf);
+        serialized_buf = serialize_avro(m_roundtrip);
+    }
 }


### PR DESCRIPTION
For reasons I don't fully understand (likely some flavor uninitialiezd data), the serialized Avro bytes have a bit of non-deterministic bytes in between the Avro header and records.

```
diff serialized_buf roundtrip_buf
255,256c255,256
<   00000fe0 | 22 3a 22 69 6e 74 22 7d  5d 7d 7d 5d 7d 00 23 ce  | ":"int"}]}}]}.#.
<   00000ff0 | dc 68 f6 a8 f1 4c ff 9b  6c fb 9e 11 8c 51 c8 01  | .h...L..l....Q..
---
>   00000fe0 | 22 3a 22 69 6e 74 22 7d  5d 7d 7d 5d 7d 00 2d 91  | ":"int"}]}}]}.-.
>   00000ff0 | 01 c3 65 57 53 38 21 39  28 ed cd a7 55 ab c8 01  | ..eWS8!9(...U...
```

Here, the ":"int"}]}}]}" is the end of the Avro header. I tried 0-initializing the buffers in avro_iobuf_ostream, but this didn't fix the issue.

Since the issue doesn't appear to affect serialization, I'm punting on getting byte-for-byte comparison to be stable. Instead, I've updated the test to just check that serialization works on the roundtrip buffer.

The test would previously fail some in 1000 times with CPU stress. The updated test passed 1000/1000 times.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
