### PR TITLE
`storage`: compaction utils cleanup

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -560,7 +560,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     vlog(gclog.debug, "[{}] running sliding window compaction", config().ntp());
     auto segs = find_sliding_range(cfg, new_start_offset);
     if (segs.empty()) {
-        vlog(gclog.debug, "[{}] no more segments to compact", config().ntp());
+        vlog(
+          gclog.debug, "[{}] no segments in range to compact", config().ntp());
         co_return false;
     }
     bool has_self_compacted = false;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -495,17 +495,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
         }
     }
 
-    if (auto range = find_compaction_range(cfg); range) {
-        auto r = co_await compact_adjacent_segments(std::move(*range), cfg);
-        vlog(
-          stlog.debug,
-          "Adjacent segments of {}, compaction result: {}",
-          config().ntp(),
-          r);
-        if (r.did_compact()) {
-            _compaction_ratio.update(r.compaction_ratio());
-        }
-    }
+    co_await compact_adjacent_segments(cfg);
 }
 
 segment_set disk_log_impl::find_sliding_range(
@@ -789,7 +779,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
 }
 
 std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
-disk_log_impl::find_compaction_range(const compaction_config& cfg) {
+disk_log_impl::find_adjacent_compaction_range(const compaction_config& cfg) {
     /*
      * adjacent segment compaction.
      *
@@ -865,7 +855,29 @@ disk_log_impl::find_compaction_range(const compaction_config& cfg) {
     return range;
 }
 
-ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
+ss::future<std::optional<compaction_result>>
+disk_log_impl::compact_adjacent_segments(storage::compaction_config cfg) {
+    std::optional<compaction_result> r;
+    if (auto range = find_adjacent_compaction_range(cfg); range) {
+        r = co_await do_compact_adjacent_segments(std::move(*range), cfg);
+        vlog(
+          gclog.debug,
+          "Adjacent segments of {}, compaction result: {}",
+          config().ntp(),
+          r);
+        if (r->did_compact()) {
+            _compaction_ratio.update(r->compaction_ratio());
+        }
+    } else {
+        vlog(
+          gclog.debug,
+          "Adjacent segments of {}, no adjacent pair",
+          config().ntp());
+    }
+    co_return r;
+}
+
+ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
   std::pair<segment_set::iterator, segment_set::iterator> range,
   storage::compaction_config cfg) {
     // lightweight copy of segments in range. once a scheduling event occurs in
@@ -1221,6 +1233,7 @@ ss::future<> disk_log_impl::do_compact(
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);
     }
+
     // TODO: unify error handling.
     compact_cfg.asrc = &_compaction_as;
     auto did_compact_fut = co_await ss::coroutine::as_future(
@@ -1238,23 +1251,10 @@ ss::future<> disk_log_impl::do_compact(
     }
     bool compacted = did_compact_fut.get();
     if (!compacted) {
-        if (auto range = find_compaction_range(compact_cfg); range) {
-            auto r = co_await compact_adjacent_segments(
-              std::move(*range), compact_cfg);
-            vlog(
-              gclog.debug,
-              "Adjacent segments of {}, compaction result: {}",
-              config().ntp(),
-              r);
-            if (r.did_compact()) {
-                _compaction_ratio.update(r.compaction_ratio());
-            }
-        } else {
-            vlog(
-              gclog.debug,
-              "Adjacent segments of {}, no adjacent pair",
-              config().ntp());
-        }
+        // If sliding window compaction did not occur, we fall back to adjacent
+        // segment compaction (as self compaction of segments occured in
+        // sliding_window_compact()).
+        co_await compact_adjacent_segments(compact_cfg);
     }
 }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -212,7 +212,7 @@ ss::future<index_state> deduplicate_segment(
             !compaction_placeholder_enabled
             && (is_last_batch && is_last_record_in_batch)) {
               vlog(
-                stlog.trace,
+                gclog.trace,
                 "retaining last record: {} of segment from batch: {}",
                 r,
                 b.header());

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -649,30 +649,24 @@ ss::future<> rebuild_compaction_index(
       gclog.info, "rebuilt index: {}, attempting compaction again", idx_path);
 }
 
-ss::future<compaction_result> self_compact_segment(
+ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
   ss::lw_shared_ptr<segment> s,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
-  compaction_config cfg,
-  storage::probe& pb,
-  storage::readers_cache& readers_cache,
+  const compaction_config& cfg,
+  ss::rwlock::holder& read_holder,
   storage_resources& resources,
-  ss::sharded<features::feature_table>& feature_table) {
-    if (s->has_appender()) {
-        throw std::runtime_error(fmt::format(
-          "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
-    }
-
-    if (s->finished_self_compaction() || !s->has_compactible_offsets(cfg)) {
-        co_return compaction_result{s->size_bytes()};
-    }
-
+  storage::probe& pb) {
     segment_full_path idx_path = s->path().to_compacted_index();
 
-    auto read_holder = co_await s->read_lock();
     compacted_index::recovery_state state;
     std::optional<scoped_file_tracker> to_clean;
     while (true) {
         if (s->is_closed()) {
+            // Temporary compaction index will be removed by file tracker.
+            vlog(
+              gclog.debug,
+              "Stopping in maybe_rebuild_compaction_index, segment closed: {}",
+              s->filename());
             throw segment_closed_exception();
         }
         // Check the index state while the read lock is held, preventing e.g.
@@ -696,22 +690,54 @@ ss::future<compaction_result> self_compact_segment(
 
         co_await rebuild_compaction_index(s, stm_manager, cfg, pb, resources);
 
-        // Take the lock again before proceeding so we're guaranteed the index
-        // will survive until it's used in self compaction below.
+        // Take the lock again before proceeding.
         read_holder = co_await s->read_lock();
     }
+
+    // Compaction index was successfully built, remove it from files to clean.
     if (to_clean.has_value()) {
         to_clean->clear();
     }
+
+    co_return state;
+}
+
+ss::future<compaction_result> self_compact_segment(
+  ss::lw_shared_ptr<segment> s,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  const compaction_config& cfg,
+  storage::probe& pb,
+  storage::readers_cache& readers_cache,
+  storage_resources& resources,
+  ss::sharded<features::feature_table>& feature_table) {
+    if (s->has_appender()) {
+        throw std::runtime_error(fmt::format(
+          "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
+    }
+
+    if (s->finished_self_compaction() || !s->has_compactible_offsets(cfg)) {
+        co_return compaction_result{s->size_bytes()};
+    }
+
+    auto read_holder = co_await s->read_lock();
+    compacted_index::recovery_state state
+      = co_await maybe_rebuild_compaction_index(
+        s, stm_manager, cfg, read_holder, resources, pb);
+
     if (state == compacted_index::recovery_state::already_compacted) {
-        vlog(gclog.debug, "detected {} is already compacted", idx_path);
+        vlog(
+          gclog.debug,
+          "detected {} is already compacted",
+          s->path().to_compacted_index());
         s->mark_as_finished_self_compaction();
         co_return compaction_result{s->size_bytes()};
     }
+
     vassert(
       state == compacted_index::recovery_state::index_recovered,
       "Unexpected state {}",
-      int(state));
+      state);
+
     auto sz_before = s->size_bytes();
     auto apply_offset = should_apply_delta_time_offset(feature_table);
     auto sz_after = co_await do_self_compact_segment(
@@ -723,10 +749,12 @@ ss::future<compaction_result> self_compact_segment(
       apply_offset,
       std::move(read_holder),
       feature_table);
+
     // compaction wasn't executed, return
     if (!sz_after) {
         co_return compaction_result(sz_before);
     }
+
     pb.segment_compacted();
     pb.add_compaction_removed_bytes(ssize_t(sz_before) - ssize_t(*sz_after));
     s->mark_as_finished_self_compaction();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -554,7 +554,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     auto write_lock_holder = co_await s->write_lock();
     if (segment_generation != s->get_generation_id()) {
         vlog(
-          stlog.debug,
+          gclog.debug,
           "segment generation mismatch current generation: {}, previous "
           "generation: {}, skipping compaction",
           s->get_generation_id(),

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -30,12 +30,28 @@
 
 namespace storage::internal {
 
+// Rebuilds the compaction index for a segment, if it is needed.
+// Requires a rwlock::holder to be passed in, which is likely to be the
+// segment's read_lock(). The lock owned by the holder will be held after this
+// function call completes, allowing the caller to proceed to self compaction or
+// other destructive operations.
+//
+// Returns the recovery_state, indicating status of the compaction index and
+// whether self-compaction should be executed or not.
+ss::future<compacted_index::recovery_state> maybe_rebuild_compaction_index(
+  ss::lw_shared_ptr<segment> s,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  const compaction_config& cfg,
+  ss::rwlock::holder& read_holder,
+  storage_resources& resources,
+  storage::probe& pb);
+
 /// \brief, this method will acquire it's own locks on the segment
 ///
 ss::future<compaction_result> self_compact_segment(
   ss::lw_shared_ptr<storage::segment>,
   ss::lw_shared_ptr<storage::stm_manager>,
-  storage::compaction_config,
+  const storage::compaction_config&,
   storage::probe&,
   storage::readers_cache&,
   storage::storage_resources&,


### PR DESCRIPTION
A small number of mostly non-functional changes to help clean-up compaction utilities ahead of improvements made with tombstone removal.

The changes are enumerated here:
1. Changes to log messages in compaction related functions.
2. Refactoring of repeated code into new function, `do_compact_adjacent_segments()`.
3. Improved code comments around various compaction related functions.
4. Refactoring of repeated code into new function, `maybe_rebuild_compaction_index()`.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
