### PR TITLE
[CORE-7061] sr/store: Deep copy schema_def iobufs at the interface

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -89,7 +89,7 @@ public:
         if (it == _schemas.end()) {
             return not_found(id);
         }
-        return {it->second.definition.share()};
+        return {it->second.definition.copy()};
     }
 
     ///\brief Return the id of the schema, if it already exists.

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -14,6 +14,17 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  BINARY_NAME pandaproxy_schema_registry_multi_thread
+  SOURCES
+    mt_sharded_store.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v_pandaproxy_schema_registry
+  ARGS "-- -c 4"
+  LABELS pandaproxy
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME pandaproxy_schema_registry_single_thread
   SOURCES
     sharded_store.cc

--- a/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
@@ -1,0 +1,76 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/test/compatibility_protobuf.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/range/irange.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
+    constexpr size_t id_n = 1000;
+    pps::sharded_store store;
+    store.start(pps::is_mutable::yes, ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store] { store.stop().get(); });
+
+    const pps::schema_version ver1{1};
+
+    // Upsert a large(ish) number of schemas to the store, all with different
+    // subject names and IDs, so they should hash to different shards.
+    for (int i = 1; i <= id_n; ++i) {
+        auto referenced_schema = pps::canonical_schema{
+          pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()};
+        store
+          .upsert(
+            pps::seq_marker{
+              std::nullopt,
+              std::nullopt,
+              ver1,
+              pps::seq_marker_key_type::schema},
+            referenced_schema.copy(),
+            pps::schema_id{i},
+            ver1,
+            pps::is_deleted::no)
+          .get();
+    }
+
+    BOOST_REQUIRE(store.has_schema(pps::schema_id{id_n}).get());
+
+    // for each upserted schema, submit a number of concurrent
+    // get_schema_definition requests, spreading the requests across cores. the
+    // goal here is to have copies of a particular schema live on shards other
+    // than the "home" shard of that schema. previously, when
+    // 'store::get_schema_definition' was implemented with an iobuf share at the
+    // interface, this loop would reliably lead to a UAF segfault in
+    // '~ss::deleter()', the refcounted, non-thread-safe deleter for the
+    // temporary buffers underlying the shared iobuf.
+    for (int i = 1; i <= id_n; ++i) {
+        constexpr int num_parallel_requests = 20;
+        ss::parallel_for_each(
+          boost::irange(0, num_parallel_requests),
+          [&store, i](auto shrd) {
+              return ss::smp::submit_to(shrd % ss::smp::count, [&store, i]() {
+                  return store.get_schema_definition(pps::schema_id{i})
+                    .discard_result();
+              });
+          })
+          .get();
+    }
+}


### PR DESCRIPTION
sharded_store's main purpose is to supply a consistent interface to an underlying (sharded) in-memory store. So to process a given request, it must first work out the home shard for the desired schema ID or subject, dispatching requests to that shard.

Recently, schema registry was refactored to store schema definitions as iobufs (rather than contiguous strings) to avoid large allocations. To avoid semantically unnecessary _copies_, get_schema_definition was implemented to return a iobuf share across a shard boundary. This is an unsafe operation, as the reference counting and deletion machinery of the underlying temporary buffers is totally unsynchronized. This is UB in principle (data race) and leads to memory access faults (UAF, etc.) in practice.

So this commit changes 'store::get_schema_definition' to return a copy of the stored schema definition (iobuf), eliminating any cross-shard sharing of the underlying temp buffers. This approach is rather blunt and carries some cost at deallocation time (seastar allocator must work out the appropriate site for memory reclamation for each component temp buffer of a given schema def), but it should be safe since the component temp buffers are never live on multiple shards simultaneously.

Note that this path could be optimized somewhat by returning a shared iobuf managed by foreign_ptr and carrying out the necessary copy (a read-only operation) on the requesting shard.

This commit also includes a "unit test" that is more of a memory access canary, of sorts. Reverting the change in 'store::gets_schema_definition' will cause the test to fail reliably, producing memory faults in line with the reasoning above. With the change in place, this test reliably runs to completion without issue.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a regression in schema registry where concurrent requests could lead to memory faults

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
