### PR TITLE
cloud_storage: serde_fields for several structs

### DIFF
--- a/src/v/cloud_storage/lifecycle_marker.h
+++ b/src/v/cloud_storage/lifecycle_marker.h
@@ -94,6 +94,8 @@ struct remote_nt_lifecycle_marker
 
     lifecycle_status status;
 
+    auto serde_fields() { return std::tie(cluster_id, topic, status); }
+
     cloud_storage_clients::object_key
     get_key(const remote_path_provider& path_provider) {
         return cloud_storage_clients::object_key{

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2523,6 +2523,29 @@ struct partition_manifest_serde
     std::optional<model::offset> _last_scrubbed_offset;
     model::producer_id _highest_producer_id;
     model::offset _applied_offset;
+
+    auto serde_fields() {
+        return std::tie(
+          _ntp,
+          _rev,
+          _segments_serialized,
+          _replaced,
+          _last_offset,
+          _start_offset,
+          _last_uploaded_compacted_offset,
+          _insync_offset,
+          _cloud_log_size_bytes,
+          _archive_start_offset,
+          _archive_start_offset_delta,
+          _archive_clean_offset,
+          _start_kafka_offset,
+          archive_size_bytes,
+          _spillover_manifests_serialized,
+          _last_partition_scrub,
+          _last_scrubbed_offset,
+          _highest_producer_id,
+          _applied_offset);
+    }
 };
 
 static_assert(

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -90,6 +90,17 @@ public:
 
         segment_name_format sname_format{segment_name_format::v1};
 
+        auto serde_fields() {
+            return std::tie(
+              ntp_revision,
+              base_offset,
+              committed_offset,
+              archiver_term,
+              segment_term,
+              size_bytes,
+              sname_format);
+        }
+
         auto operator<=>(const lw_segment_meta&) const = default;
 
         static lw_segment_meta convert(const segment_meta& m);

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -321,6 +321,28 @@ struct offset_index_header
     int64_t last_time{model::timestamp::missing().value()};
     std::vector<int64_t> time_write_buf;
     iobuf time_index;
+
+    auto serde_fields() {
+        return std::tie(
+          min_file_pos_step,
+          num_elements,
+          base_rp,
+          last_rp,
+          base_kaf,
+          last_kaf,
+          base_file,
+          last_file,
+          rp_write_buf,
+          kaf_write_buf,
+          file_write_buf,
+          rp_index,
+          kaf_index,
+          file_index,
+          base_time,
+          last_time,
+          time_write_buf,
+          time_index);
+    }
 };
 
 iobuf offset_index::to_iobuf() {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

In https://github.com/redpanda-data/redpanda/pull/22782, we aim to require explicit `serde_fields` for serde structs that would otherwise use aggregate field order. This is one in a series of pull requests that add `serde_fields` to existing structs, to be followed by a PR to remove the aggregate order fallback from `serde` itself.

The primary acceptance criterion for this PR should be "field order unchanged". Any functional change is a bug.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
