### PR TITLE
mode/transform: serde_fields for several structs

### DIFF
--- a/src/v/model/tests/transform_test.cc
+++ b/src/v/model/tests/transform_test.cc
@@ -209,6 +209,7 @@ struct legacy_transform_offset_options_2
       : serde::
           envelope<latest_offset, serde::version<0>, serde::compat_version<0>> {
         bool operator==(const latest_offset&) const = default;
+        auto serde_fields() { return std::tie(); }
     };
     serde::variant<latest_offset, model::timestamp> position;
     bool operator==(const legacy_transform_offset_options_2&) const = default;

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -160,6 +160,7 @@ struct transform_offset_options
       : serde::
           envelope<latest_offset, serde::version<0>, serde::compat_version<0>> {
         bool operator==(const latest_offset&) const = default;
+        auto serde_fields() { return std::tie(); }
     };
     // A transform can either start at the latest offset, at a timestamp, or at
     // some delta from the start or end of an input partition.


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

In https://github.com/redpanda-data/redpanda/pull/22782, we aim to require explicit serde_fields for serde structs that would otherwise use aggregate field order. This is one in a series of pull requests that add serde_fields to existing structs, to be followed by a PR to remove the aggregate order fallback from serde itself.

The primary acceptance criterion for this PR should be "field order unchanged". Any functional change is a bug.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
