### PR TITLE
serde/test: serde_fields for various structs

### DIFF
--- a/src/v/serde/test/bench.cc
+++ b/src/v/serde/test/bench.cc
@@ -26,6 +26,8 @@ struct small_t
     int16_t b = 2;
     int32_t c = 3;
     int64_t d = 4;
+
+    auto serde_fields() { return std::tie(a, b, c, d); }
 };
 static_assert(sizeof(small_t) == 16, "one more byte for padding");
 
@@ -47,6 +49,7 @@ struct big_t
   : public serde::envelope<big_t, serde::version<3>, serde::compat_version<2>> {
     small_t s;
     iobuf data;
+    auto serde_fields() { return std::tie(s, data); }
 };
 
 inline big_t gen_big(size_t data_size, size_t chunk_size) {

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -82,7 +82,10 @@ struct test_msg1
 };
 
 struct test_msg1_imcompatible
-  : serde::envelope<test_msg1, serde::version<5>, serde::compat_version<5>> {
+  : serde::envelope<
+      test_msg1_imcompatible,
+      serde::version<5>,
+      serde::compat_version<5>> {
     bool operator==(const test_msg1_imcompatible&) const = default;
 
     test_msg0 _m;
@@ -708,10 +711,8 @@ SEASTAR_THREAD_TEST_CASE(serde_checksum_update) {
 }
 
 struct old_cs
-  : public serde::checksum_envelope<
-      old_no_cs,
-      serde::version<3>,
-      serde::compat_version<2>> {
+  : public serde::
+      checksum_envelope<old_cs, serde::version<3>, serde::compat_version<2>> {
     bool operator==(const old_cs&) const = default;
 
     std::vector<test_msg1_new_manual> data_;
@@ -719,7 +720,7 @@ struct old_cs
 };
 struct new_no_cs
   : public serde::
-      envelope<new_cs, serde::version<4>, serde::compat_version<3>> {
+      envelope<new_no_cs, serde::version<4>, serde::compat_version<3>> {
     bool operator==(const new_no_cs& other) const {
         return data_ == other.data_;
     }
@@ -757,8 +758,10 @@ SEASTAR_THREAD_TEST_CASE(serde_checksum_update_1) {
 }
 
 struct serde_fields_test_struct
-  : serde::
-      envelope<test_msg1_new, serde::version<10>, serde::compat_version<5>> {
+  : serde::envelope<
+      serde_fields_test_struct,
+      serde::version<10>,
+      serde::compat_version<5>> {
     serde_fields_test_struct() = default;
     explicit serde_fields_test_struct(int a)
       : _a{a}

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -67,6 +67,7 @@ struct test_msg0
     bool operator==(const test_msg0&) const = default;
 
     char _i, _j;
+    auto serde_fields() { return std::tie(_i, _j); }
 };
 
 struct test_msg1
@@ -76,6 +77,8 @@ struct test_msg1
     int _a;
     test_msg0 _m;
     int _b, _c;
+
+    auto serde_fields() { return std::tie(_a, _m, _b, _c); }
 };
 
 struct test_msg1_imcompatible
@@ -83,6 +86,8 @@ struct test_msg1_imcompatible
     bool operator==(const test_msg1_imcompatible&) const = default;
 
     test_msg0 _m;
+
+    auto serde_fields() { return std::tie(_m); }
 };
 
 struct test_msg1_new
@@ -93,6 +98,7 @@ struct test_msg1_new
     int _a;
     test_msg0 _m;
     int _b, _c;
+    auto serde_fields() { return std::tie(_a, _m, _b, _c); }
 };
 
 struct test_msg1_new_manual {
@@ -157,6 +163,7 @@ SEASTAR_THREAD_TEST_CASE(envelope_too_big_test) {
         bool operator==(const big&) const = default;
 
         std::vector<char> data_;
+        auto serde_fields() { return std::tie(data_); }
     };
 
     auto too_big = std::make_unique<big>();
@@ -171,6 +178,8 @@ SEASTAR_THREAD_TEST_CASE(simple_envelope_test) {
         bool operator==(const msg&) const = default;
 
         int32_t _i, _j;
+
+        auto serde_fields() { return std::tie(_i, _j); }
     };
 
     auto b = iobuf();
@@ -264,6 +273,8 @@ struct inner_differing_sizes
     bool operator==(const inner_differing_sizes&) const = default;
 
     std::vector<int32_t> _ints;
+
+    auto serde_fields() { return std::tie(_ints); }
 };
 
 struct complex_msg
@@ -272,6 +283,8 @@ struct complex_msg
     bool operator==(const complex_msg&) const = default;
 
     int32_t _x;
+
+    auto serde_fields() { return std::tie(_vec, _x); }
 };
 
 static_assert(serde::is_envelope<complex_msg>);
@@ -508,6 +521,8 @@ struct small
     bool operator==(const small&) const = default;
 
     int a, b, c;
+
+    auto serde_fields() { return std::tie(a, b, c); }
 };
 
 struct big
@@ -515,6 +530,8 @@ struct big
     bool operator==(const big&) const = default;
 
     int a, b, c, d{0x1234};
+
+    auto serde_fields() { return std::tie(a, b, c, d); }
 };
 
 SEASTAR_THREAD_TEST_CASE(compat_test_added_field) {
@@ -573,6 +590,7 @@ SEASTAR_THREAD_TEST_CASE(compat_test_half_field_1) {
 
         int a, b;
         short c;
+        auto serde_fields() { return std::tie(a, b, c); }
     };
 
     auto b = serde::to_iobuf(half_field_1{.a = 1, .b = 2, .c = 3});
@@ -588,6 +606,7 @@ SEASTAR_THREAD_TEST_CASE(compat_test_half_field_2) {
 
         int a, b, c;
         short d;
+        auto serde_fields() { return std::tie(a, b, c, d); }
     };
 
     auto b = serde::to_iobuf(half_field_2{.a = 1, .b = 2, .c = 3, .d = 0x1234});
@@ -611,6 +630,7 @@ SEASTAR_THREAD_TEST_CASE(serde_checksum_envelope_test) {
         bool operator==(const checksummed&) const = default;
 
         std::vector<test_msg1_new_manual> data_;
+        auto serde_fields() { return std::tie(data_); }
     };
 
     auto const obj = checksummed{
@@ -632,6 +652,7 @@ struct old_no_cs
     bool operator==(const old_no_cs&) const = default;
 
     std::vector<test_msg1_new_manual> data_;
+    auto serde_fields() { return std::tie(data_); }
 };
 struct new_cs
   : public serde::
@@ -657,6 +678,7 @@ struct new_cs
     bool operator==(const new_cs&) const = default;
 
     std::vector<test_msg1_new_manual> data_;
+    auto serde_fields() { return std::tie(data_); }
 };
 
 SEASTAR_THREAD_TEST_CASE(serde_checksum_update) {
@@ -693,6 +715,7 @@ struct old_cs
     bool operator==(const old_cs&) const = default;
 
     std::vector<test_msg1_new_manual> data_;
+    auto serde_fields() { return std::tie(data_); }
 };
 struct new_no_cs
   : public serde::
@@ -703,6 +726,8 @@ struct new_no_cs
 
     serde::checksum_t unchecked_dummy_checksum_{0U};
     std::vector<test_msg1_new_manual> data_;
+
+    auto serde_fields() { return std::tie(unchecked_dummy_checksum_, data_); }
 };
 
 SEASTAR_THREAD_TEST_CASE(serde_checksum_update_1) {

--- a/src/v/serde/test/struct_gen.py
+++ b/src/v/serde/test/struct_gen.py
@@ -125,6 +125,17 @@ class Struct:
   {{ field }}
     {%- endfor %}
 {%- endfor %}
+
+    auto serde_fields() {
+        return std::tie(
+{% for generation in s._field_generations %}
+    {%- for field in generation %}
+        {{ field._name}}{{ ", " if not loop.last else "" }}
+    {%- endfor %}
+        {{ ", " if not loop.last else "" }}
+{%- endfor %}
+        );
+    }
 };
 """).render(s=self)
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

In https://github.com/redpanda-data/redpanda/pull/22782, we aim to require explicit serde_fields for serde structs that would otherwise use aggregate field order. This is one in a series of pull requests that add serde_fields to existing structs, to be followed by a PR to remove the aggregate order fallback from serde itself.

The primary acceptance criterion for this PR should be "field order unchanged". Any functional change is a bug.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
