### PR TITLE
rpc/test: serde_fields for various rpc_gen_types

### DIFF
--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -45,18 +45,21 @@ struct echo_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
+    auto serde_fields() { return std::tie(str); }
 };
 
 struct echo_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
+    auto serde_fields() { return std::tie(str); }
 };
 
 struct cnt_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     uint64_t expected;
+    auto serde_fields() { return std::tie(expected); }
 };
 
 struct cnt_resp
@@ -64,18 +67,21 @@ struct cnt_resp
     using rpc_adl_exempt = std::true_type;
     uint64_t expected;
     uint64_t current;
+    auto serde_fields() { return std::tie(expected, current); }
 };
 
 struct sleep_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     uint64_t secs;
+    auto serde_fields() { return std::tie(secs); }
 };
 
 struct sleep_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring str;
+    auto serde_fields() { return std::tie(str); }
 };
 
 enum class failure_type { throw_exception, exceptional_future, none };
@@ -84,12 +90,15 @@ struct throw_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     failure_type type;
+    auto serde_fields() { return std::tie(type); }
 };
 
 struct throw_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     ss::sstring reply;
+
+    auto serde_fields() { return std::tie(reply); }
 };
 
 struct echo_req_serde_only


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

In https://github.com/redpanda-data/redpanda/pull/22782, we aim to require explicit serde_fields for serde structs that would otherwise use aggregate field order. This is one in a series of pull requests that add serde_fields to existing structs, to be followed by a PR to remove the aggregate order fallback from serde itself.

The primary acceptance criterion for this PR should be "field order unchanged". Any functional change is a bug.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
