### PR TITLE
Fixed producer fencing when transaction is expired

### DIFF
--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -320,7 +320,7 @@ public:
     ss::future<txlock_unit> lock_tx(kafka::transactional_id, std::string_view);
 
     std::optional<txlock_unit>
-      try_lock_tx(kafka::transactional_id, std::string_view);
+    try_lock_tx(const kafka::transactional_id&, std::string_view);
 
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -255,7 +255,8 @@ public:
     ss::future<checked<tx_metadata, tm_stm::op_status>> finish_transaction(
       model::term_id expected_term,
       kafka::transactional_id tx_id,
-      tx_status completed_status);
+      tx_status completed_status,
+      bool bump_producer_epoch = false);
     ss::future<tm_stm::op_status> add_partitions(
       model::term_id,
       kafka::transactional_id,

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <utility>
 
 namespace cluster {
 using namespace std::chrono_literals;
@@ -47,11 +48,11 @@ using namespace std::chrono_literals;
 template<typename Func>
 static auto with(
   ss::shared_ptr<tm_stm> stm,
-  kafka::transactional_id tx_id,
+  const kafka::transactional_id& tx_id,
   const std::string_view name,
   Func&& func) noexcept {
     return stm->lock_tx(tx_id, name)
-      .then([stm, tx_id, func = std::forward<Func>(func)](auto units) mutable {
+      .then([stm, func = std::forward<Func>(func)](auto units) mutable {
           return ss::futurize_invoke(std::forward<Func>(func))
             .finally([units = std::move(units)] {});
       });
@@ -60,7 +61,7 @@ static auto with(
 template<typename Func>
 static auto with_free(
   ss::shared_ptr<tm_stm> stm,
-  kafka::transactional_id tx_id,
+  const kafka::transactional_id& tx_id,
   const std::string_view name,
   Func&& func) noexcept {
     auto units = stm->try_lock_tx(tx_id, name);
@@ -127,10 +128,10 @@ tx_gateway_frontend::do_route_globally(model::ntp tx_ntp, T&& request) {
     auto leader = leader_opt.value();
 
     if (leader == _self) {
-        co_return co_await do_route_locally(tx_ntp, std::move(request));
+        co_return co_await do_route_locally(tx_ntp, std::forward<T>(request));
     }
 
-    co_return co_await do_dispatch(leader, std::move(request));
+    co_return co_await do_dispatch(leader, std::forward<T>(request));
 }
 
 template<typename T>
@@ -150,7 +151,8 @@ tx_gateway_frontend::do_dispatch(model::node_id target, T&& request) {
         ss::this_shard_id(),
         target,
         timeout,
-        [request = std::move(request)](tx_gateway_client_protocol cp) mutable {
+        [request = std::forward<T>(request)](
+          tx_gateway_client_protocol cp) mutable {
             return send(cp, std::move(request));
         })
       .then(&rpc::get_ctx_data<typename T::reply>)
@@ -185,7 +187,7 @@ tx_gateway_frontend::do_route_locally(model::ntp tx_ntp, T&& request) {
     co_return co_await container().invoke_on(
       *shard,
       _ssg,
-      [tm = tx_ntp.tp.partition, request = std::move(request)](
+      [tm = tx_ntp.tp.partition, request = std::forward<T>(request)](
         tx_gateway_frontend& self) -> ss::future<typename T::reply> {
           if (self._gate.is_closed()) {
               return ss::make_ready_future<typename T::reply>(
@@ -265,7 +267,8 @@ tx_gateway_frontend::tx_gateway_frontend(
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.bind())
   , _transactions_enabled(config::shard_local_cfg().enable_transactions.value())
-  , _max_transactions_per_coordinator(max_transactions_per_coordinator) {
+  , _max_transactions_per_coordinator(
+      std::move(max_transactions_per_coordinator)) {
     /**
      * do not start expriry timer when transactions are disabled
      */
@@ -1188,12 +1191,12 @@ ss::future<add_partitions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
       -> ss::future<add_partitions_tx_reply> {
           return ss::with_gate(
             self._gate,
-            [request = std::move(request), timeout, tm, &self]()
-              -> ss::future<add_partitions_tx_reply> {
+            [request = std::move(request), timeout, tm, &self]() mutable
+            -> ss::future<add_partitions_tx_reply> {
                 return self.with_stm(
                   tm,
                   [request = std::move(request), timeout, &self](
-                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) {
+                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) mutable {
                       if (!r) {
                           return ss::make_ready_future<add_partitions_tx_reply>(
                             make_add_partitions_error_response(
@@ -1522,12 +1525,12 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
         tx_gateway_frontend& self) mutable -> ss::future<add_offsets_tx_reply> {
           return ss::with_gate(
             self._gate,
-            [request = std::move(request), timeout, tm, &self]()
-              -> ss::future<add_offsets_tx_reply> {
+            [request = std::move(request), timeout, tm, &self]() mutable
+            -> ss::future<add_offsets_tx_reply> {
                 return self.with_stm(
                   tm,
                   [request = std::move(request), timeout, &self](
-                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) {
+                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) mutable {
                       if (!r) {
                           return ss::make_ready_future<add_offsets_tx_reply>(
                             add_offsets_tx_reply{.error_code = r.error()});
@@ -1662,13 +1665,14 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
         tx_gateway_frontend& self) mutable -> ss::future<end_tx_reply> {
           return ss::with_gate(
             self._gate,
-            [request = std::move(request), timeout, tm, &self]()
-              -> ss::future<end_tx_reply> {
+            [request = std::move(request), timeout, tm, &self]() mutable
+            -> ss::future<end_tx_reply> {
                 return self.with_stm(
                   tm,
                   [request = std::move(request), timeout, &self](
-                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) {
-                      return self.do_end_txn(r, std::move(request), timeout);
+                    checked<ss::shared_ptr<tm_stm>, tx::errc> r) mutable {
+                      return self.do_end_txn(
+                        std::move(r), std::move(request), timeout);
                   });
             });
       });
@@ -2129,13 +2133,13 @@ ss::future<tx_gateway_frontend::op_result_t> tx_gateway_frontend::commit_data(
     while (0 < retries--) {
         std::vector<ss::future<commit_group_tx_reply>> gfs;
         gfs.reserve(tx.groups.size());
-        for (auto group : tx.groups) {
+        for (const auto& group : tx.groups) {
             gfs.push_back(_rm_group_proxy->commit_group_tx(
               group.group_id, tx.pid, tx.tx_seq, timeout));
         }
         std::vector<ss::future<commit_tx_reply>> cfs;
         cfs.reserve(tx.partitions.size());
-        for (auto rm : tx.partitions) {
+        for (const auto& rm : tx.partitions) {
             cfs.push_back(_rm_partition_frontend.local().commit_tx(
               rm.ntp, tx.pid, tx.tx_seq, timeout));
         }
@@ -2265,13 +2269,13 @@ ss::future<tx_gateway_frontend::op_result_t> tx_gateway_frontend::abort_data(
     while (0 < retries--) {
         std::vector<ss::future<abort_tx_reply>> pfs;
         pfs.reserve(tx.partitions.size());
-        for (auto rm : tx.partitions) {
+        for (const auto& rm : tx.partitions) {
             pfs.push_back(_rm_partition_frontend.local().abort_tx(
               rm.ntp, tx.pid, tx.tx_seq, timeout));
         }
         std::vector<ss::future<abort_group_tx_reply>> gfs;
         gfs.reserve(tx.groups.size());
-        for (auto group : tx.groups) {
+        for (const auto& group : tx.groups) {
             gfs.push_back(_rm_group_proxy->abort_group_tx(
               group.group_id, tx.pid, tx.tx_seq, timeout));
         }
@@ -2541,7 +2545,7 @@ void tx_gateway_frontend::expire_old_txs() {
     });
 }
 
-ss::future<> tx_gateway_frontend::expire_old_txs(model::ntp tx_ntp) {
+ss::future<> tx_gateway_frontend::expire_old_txs(const model::ntp& tx_ntp) {
     auto shard = _shard_table.local().shard_for(tx_ntp);
 
     if (!shard) {
@@ -2572,7 +2576,7 @@ ss::future<> tx_gateway_frontend::expire_old_txs(model::ntp tx_ntp) {
 
 ss::future<> tx_gateway_frontend::expire_old_txs(ss::shared_ptr<tm_stm> stm) {
     auto tx_ids = stm->get_expired_txs();
-    for (auto tx_id : tx_ids) {
+    for (const auto& tx_id : tx_ids) {
         co_await expire_old_tx(stm, tx_id);
     }
 }

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -269,7 +269,7 @@ private:
       process_locally(ss::shared_ptr<tm_stm>, try_abort_request);
 
     void expire_old_txs();
-    ss::future<> expire_old_txs(model::ntp);
+    ss::future<> expire_old_txs(const model::ntp&);
     ss::future<> expire_old_txs(ss::shared_ptr<tm_stm>);
     ss::future<> expire_old_tx(ss::shared_ptr<tm_stm>, kafka::transactional_id);
     ss::future<tx::errc> do_expire_old_tx(


### PR DESCRIPTION
If transaction expires all the subsequent requests from the producer
with the same producer id should fail with `FENCED` error forcing
producer to bump the producer epoch and retry the request.
During the transactional coordinator refactoring this critical behavior
was missed. This way a producer wasn't able to learn about the expired
transactions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes not fencing subsequent producer requests after its transaction has been expired
