### PR TITLE
[CORE-6665] schema registry - json schema get_record_name

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -156,6 +156,17 @@ json_schema_definition::refs() const {
 
 ss::sstring json_schema_definition::name() const { return {_impl->name}; };
 
+std::optional<ss::sstring> json_schema_definition::title() const {
+    if (!_impl->ctx.doc.IsObject()) {
+        return std::nullopt;
+    }
+    auto it = _impl->ctx.doc.FindMember("title");
+    if (it == _impl->ctx.doc.MemberEnd()) {
+        return std::nullopt;
+    }
+
+    return ss::sstring{it->value.GetString(), it->value.GetStringLength()};
+}
 namespace {
 
 std::string_view as_string_view(json::Value const& v) {

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -303,6 +303,9 @@ public:
 
     ss::sstring name() const;
 
+    // retrieve "title" property from the schema, used to form the record name
+    std::optional<ss::sstring> title() const;
+
 private:
     pimpl _impl;
 };

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -20,6 +20,7 @@
 #include "model/timeout_clock.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/avro.h"
+#include "pandaproxy/schema_registry/json.h"
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/schema_id_cache.h"
 #include "pandaproxy/schema_registry/schema_id_validation.h"
@@ -106,7 +107,7 @@ ss::future<std::optional<ss::sstring>> get_record_name(
   canonical_schema_definition schema,
   std::optional<std::vector<int32_t>>& offsets) {
     if (sns == subject_name_strategy::topic_name) {
-        // Result is succesfully nothing
+        // Result is successfully nothing
         co_return "";
     }
 
@@ -129,8 +130,11 @@ ss::future<std::optional<ss::sstring>> get_record_name(
         }
         co_return std::move(r).assume_value();
     } break;
-    case schema_type::json:
-        break;
+    case schema_type::json: {
+        auto s = co_await make_json_schema_definition(
+          store, {subject("r"), {std::move(schema).raw(), schema_type}});
+        co_return s.title();
+    } break;
     }
     co_return std::nullopt;
 }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2073,7 +2073,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert schema.json()["schemaType"] == protocol.name
 
     @cluster(num_nodes=4)
-    @matrix(protocol=[SchemaType.AVRO, SchemaType.PROTOBUF],
+    @matrix(protocol=[SchemaType.AVRO, SchemaType.PROTOBUF, SchemaType.JSON],
             client_type=[SerdeClientType.Python],
             validate_schema_id=[True],
             subject_name_strategy=list(TopicSpec.SubjectNameStrategyCompat),


### PR DESCRIPTION
Support JSON for Schema ID Validation by implementing `get_record_name` for json

Fixes https://redpandadata.atlassian.net/browse/CORE-6665

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none