### PR TITLE
Migrations infra part 6: cancelations, retries, blocking reads

### DIFF
--- a/src/v/cluster/data_migrated_resources.cc
+++ b/src/v/cluster/data_migrated_resources.cc
@@ -47,12 +47,12 @@ migrated_resource_state get_resource_state<inbound_migration>(state state) {
     case state::preparing:
     case state::prepared:
     case state::canceling:
-    case state::cancelled:
     case state::executing:
     case state::executed:
     case state::cut_over:
         return migrated_resource_state::fully_blocked;
     case state::finished:
+    case state::cancelled:
         return migrated_resource_state::non_restricted;
     }
 }
@@ -63,15 +63,15 @@ migrated_resource_state get_resource_state<outbound_migration>(state state) {
     case state::planned:
     case state::preparing:
     case state::prepared:
-    case state::canceling:
-    case state::cancelled:
         return migrated_resource_state::metadata_locked;
     case state::executing:
     case state::executed:
+    case state::canceling:
         return migrated_resource_state::read_only;
     case state::cut_over:
         return migrated_resource_state::fully_blocked;
     case state::finished:
+    case state::cancelled:
         return migrated_resource_state::non_restricted;
     }
 }

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -783,12 +783,13 @@ ss::future<> backend::handle_migration_update(id id) {
           "migration {} old sought state is {}",
           id,
           old_mrstate.scope.sought_state);
-        if (
-          !new_maybe_metadata || new_state >= old_mrstate.scope.sought_state) {
-            vlog(
-              dm_log.debug, "dropping migration {} reconciliation state", id);
-            drop_migration_reconciliation_rstate(old_it);
-        }
+        vassert(
+          !new_maybe_metadata || new_state >= old_mrstate.scope.sought_state,
+          "migration state went from seeking {} back to {}",
+          old_mrstate.scope.sought_state,
+          new_state);
+        vlog(dm_log.debug, "dropping migration {} reconciliation state", id);
+        drop_migration_reconciliation_rstate(old_it);
     }
     // create new state if needed
     if (new_maybe_metadata) {

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -523,7 +523,7 @@ ss::future<errc> backend::do_topic_work(
     vassert(
       sought_state == state::finished,
       "only ->finished state transition requires topic work");
-    // todo: unmount first
+    // unmount first
     auto unmount_res = co_await retry_loop(
       rcn, [this, &nt, &rcn] { return unmount_topic(nt, rcn); });
     if (unmount_res == errc::topic_not_exists) {
@@ -534,6 +534,7 @@ ss::future<errc> backend::do_topic_work(
         vlog(dm_log.warn, "failed to unmount topic {}: {}", nt, unmount_res);
         co_return unmount_res;
     }
+    // delete
     co_return co_await retry_loop(rcn, [this, &nt, &rcn] {
         return _topics_frontend.delete_topic_after_migration(
           nt, rcn.get_deadline());

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1437,6 +1437,9 @@ void backend::topic_reconciliation_state::clear() {
 
 backend::topic_scoped_work_state::topic_scoped_work_state()
   : _as()
-  , rcn(_as, ss::lowres_clock::time_point::max(), 2s) {}
+  , rcn(
+      _as,
+      ss::lowres_clock::now() + retry_chain_node::milliseconds_uint16_t::max(),
+      2s) {}
 
 } // namespace cluster::data_migrations

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -144,7 +144,11 @@ private:
     ss::future<errc> confirm_mount_topic(
       const model::topic_namespace& nt, retry_chain_node& rcn);
     ss::future<errc>
+    delete_topic(const model::topic_namespace& nt, retry_chain_node& rcn);
+    ss::future<errc>
     unmount_topic(const model::topic_namespace& nt, retry_chain_node& rcn);
+    ss::future<errc>
+    do_unmount_topic(const model::topic_namespace& nt, retry_chain_node& rcn);
 
     /* communication with partition workers */
     void start_partition_work(

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -268,18 +268,22 @@ private:
     };
     absl::flat_hash_map<id, advance_info> _advance_requests;
     chunked_vector<topic_table_delta> _unprocessed_deltas;
+    chunked_hash_map<model::node_id, check_ntp_states_reply> _rpc_responses;
 
-    /* Node-local data */
+    /* Node-local data for partition-scoped work */
     using topic_work_state_t
       = chunked_hash_map<model::partition_id, replica_work_state>;
     chunked_hash_map<model::topic_namespace, topic_work_state_t>
       _local_work_states;
-
-    chunked_hash_map<model::node_id, check_ntp_states_reply> _rpc_responses;
+    /*
+     * Topic-scoped work states for starting/stopping and disallowing concurrent
+     * work on the same topic: similar to data_migrations::worker
+     */
     chunked_vector<topic_work_result> _topic_work_results;
     chunked_hash_map<model::topic_namespace, tsws_lwptr_t>
       _active_topic_work_states; // no null pointers on scheduling points
 
+    /* Refs to services etc */
     model::node_id _self;
     migrations_table& _table;
     frontend& _frontend;

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -177,7 +177,7 @@ private:
       topic_reconciliation_state& tstate,
       id migration,
       work_scope scope,
-      bool schedule_local_work);
+      bool schedule_local_partition_work);
 
     std::optional<std::reference_wrapper<replica_work_state>>
     get_replica_work_state(const model::ntp& ntp);
@@ -260,7 +260,8 @@ private:
     /* Node-local data */
     using topic_work_state_t
       = chunked_hash_map<model::partition_id, replica_work_state>;
-    chunked_hash_map<model::topic_namespace, topic_work_state_t> _work_states;
+    chunked_hash_map<model::topic_namespace, topic_work_state_t>
+      _local_work_states;
 
     chunked_hash_map<model::node_id, check_ntp_states_reply> _rpc_responses;
     chunked_vector<topic_work_result> _topic_work_results;

--- a/src/v/cluster/data_migration_types.h
+++ b/src/v/cluster/data_migration_types.h
@@ -65,8 +65,6 @@ using consumer_group = named_type<ss::sstring, struct consumer_group_tag>;
  * ┌─────▼────┐
  * │ finished │
  * └──────────┘
- *
- *
  */
 enum class state {
     planned,

--- a/src/v/cluster/data_migration_worker.cc
+++ b/src/v/cluster/data_migration_worker.cc
@@ -32,7 +32,6 @@
 
 namespace cluster::data_migrations {
 
-// TODO: add configuration property
 worker::worker(
   model::node_id self,
   partition_leaders_table& leaders_table,

--- a/src/v/cluster/data_migration_worker.cc
+++ b/src/v/cluster/data_migration_worker.cc
@@ -22,7 +22,9 @@
 #include "rpc/connection_cache.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 
 #include <fmt/ostream.h>
@@ -78,6 +80,8 @@ worker::perform_partition_work(model::ntp&& ntp, partition_work&& work) {
         ntp_state.promise = ss::make_lw_shared<ss::promise<errc>>();
         ntp_state.is_running = false;
         ntp_state.work = std::move(work);
+        ntp_state.as->request_abort();
+        ntp_state.as = ss::make_lw_shared<ss::abort_source>();
     }
 
     spawn_work_if_leader(it);
@@ -100,7 +104,8 @@ worker::ntp_state::ntp_state(
   notification_id_type leadership_subscription)
   : is_leader(is_leader)
   , work(std::move(work))
-  , leadership_subscription(leadership_subscription) {}
+  , leadership_subscription(leadership_subscription)
+  , as(ss::make_lw_shared<ss::abort_source>()) {}
 
 ss::future<> worker::handle_operation_result(
   model::ntp ntp, id migration_id, state sought_state, errc ec) {
@@ -117,8 +122,24 @@ ss::future<> worker::handle_operation_result(
 
         // todo: configure sleep time, make it abortable from
         // worker::abort_partition_work
-        co_await ss::sleep_abortable(1s, _as);
+        auto it = _managed_ntps.find(ntp);
+        if (
+          it == _managed_ntps.end()
+          || it->second.work.migration_id != migration_id
+          || it->second.work.sought_state != sought_state) {
+            vlog(
+              dm_log.debug,
+              "as part of migration {}, partition work for moving ntp {} to "
+              "state {} is done with result {}, but not needed anymore",
+              migration_id,
+              std::move(ntp),
+              sought_state,
+              ec);
+            co_return;
+        }
+        co_await ss::sleep_abortable(1s, *it->second.as);
     }
+    bool should_retry = ec != errc::success && ec != errc::shutting_down;
     auto it = _managed_ntps.find(ntp);
     if (
       it == _managed_ntps.end() || it->second.work.migration_id != migration_id
@@ -126,15 +147,15 @@ ss::future<> worker::handle_operation_result(
         vlog(
           dm_log.debug,
           "as part of migration {}, partition work for moving ntp {} to state "
-          "{} is done with result {}, but not needed anymore",
+          "{} was about to {}, but not needed anymore",
           migration_id,
           std::move(ntp),
           sought_state,
-          ec);
+          ec,
+          should_retry ? "retry" : "complete");
         co_return;
     }
-    if (ec != errc::success && ec != errc::shutting_down) {
-        // any other errors deemed retryable
+    if (should_retry) {
         it->second.is_running = false;
         vlog(
           dm_log.info,
@@ -165,6 +186,7 @@ void worker::unmanage_ntp(managed_ntp_cit it, errc result) {
     _leaders_table.unregister_leadership_change_notification(
       it->second.leadership_subscription);
     it->second.promise->set_value(result);
+    it->second.as->request_abort();
     _managed_ntps.erase(it);
 }
 

--- a/src/v/cluster/data_migration_worker.cc
+++ b/src/v/cluster/data_migration_worker.cc
@@ -173,6 +173,11 @@ ss::future<> worker::handle_operation_result(
 
 void worker::handle_leadership_update(const model::ntp& ntp, bool is_leader) {
     auto it = _managed_ntps.find(ntp);
+    vlog(
+      dm_log.info,
+      "got leadership update regarding ntp={}, is_leader={}",
+      ntp,
+      is_leader);
     if (it == _managed_ntps.end() || it->second.is_leader == is_leader) {
         return;
     }
@@ -275,6 +280,11 @@ ss::future<errc> worker::do_work(
 
 void worker::spawn_work_if_leader(managed_ntp_it it) {
     vassert(!it->second.is_running, "work already running");
+    vlog(
+      dm_log.info,
+      "attempting to spawn work for ntp={}, is_leader={}",
+      it->first,
+      it->second.is_leader);
     if (!it->second.is_leader) {
         return;
     }

--- a/src/v/cluster/data_migration_worker.h
+++ b/src/v/cluster/data_migration_worker.h
@@ -18,6 +18,7 @@
 #include "errc.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -49,6 +50,7 @@ private:
         notification_id_type leadership_subscription;
         ss::lw_shared_ptr<ss::promise<errc>> promise
           = ss::make_lw_shared<ss::promise<errc>>();
+        ss::lw_shared_ptr<seastar::abort_source> as;
 
         ntp_state(const ntp_state&) = delete;
         ntp_state& operator=(const ntp_state&) = delete;

--- a/src/v/cluster/data_migration_worker.h
+++ b/src/v/cluster/data_migration_worker.h
@@ -70,6 +70,7 @@ private:
     void handle_leadership_update(const model::ntp& ntp, bool is_leader);
     void unmanage_ntp(managed_ntp_cit it, errc result);
     void spawn_work_if_leader(managed_ntp_it it);
+
     // also resulting future cannot throw when co_awaited
     ss::future<errc> do_work(managed_ntp_cit it) noexcept;
     ss::future<errc> do_work(

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -152,6 +152,11 @@ bool metadata_cache::should_reject_writes() const {
            == storage::disk_space_alert::degraded;
 }
 
+bool metadata_cache::should_reject_reads(model::topic_namespace_view tp) const {
+    return _migrated_resources.local().get_topic_state(tp)
+           >= data_migrations::migrated_resource_state::fully_blocked;
+}
+
 bool metadata_cache::should_reject_writes(
   model::topic_namespace_view tp) const {
     return _migrated_resources.local().get_topic_state(tp)

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -123,6 +123,9 @@ public:
     std::optional<model::rack_id> get_node_rack_id(model::node_id) const;
 
     bool should_reject_writes() const;
+
+    /// Check whether migrations block topic writes/reads
+    bool should_reject_reads(model::topic_namespace_view) const;
     bool should_reject_writes(model::topic_namespace_view) const;
 
     bool contains(model::topic_namespace_view, model::partition_id) const;


### PR DESCRIPTION
- abort/retry topic-scoped work where needed
- promptly abort when delaying partition-scoped work retry, and the work is not needed any more
- implement migration cancellation
- block topic reads where needed

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
* not sure TBH, this PR may be final apart from tests
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
