### PR TITLE
c/topic_config: Explicitly initialize non-class fields

### DIFF
--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -66,11 +66,11 @@ struct topic_configuration
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int
-    int32_t partition_count;
+    int32_t partition_count{0};
     // using signed integer because Kafka protocol defines it as signed int
-    int16_t replication_factor;
+    int16_t replication_factor{0};
     // bypass migration restrictions
-    bool is_migrated;
+    bool is_migrated{false};
 
     topic_properties properties;
 


### PR DESCRIPTION
Since we need a default constructor to keep serde happy.

This PR adds some default initializers to `cluster::topic_configuration` to avoid UB when the default constructor is used as in [this function](https://github.com/redpanda-data/redpanda/blob/f6958c8f59a37fc9f8503073779ae58634326caa/src/v/cluster/tests/serialization_rt_test.cc#L563-L570). We could/should adjust the test code to avoid this pattern, but precluding the invalid state at the struct definition is probably sufficient here.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
