### PR TITLE
[CORE-7010] ducktape: adapt segment parsing for partial batch headers

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -53,9 +53,9 @@ class SegmentReader:
             data = self.stream.read(records_size)
             if len(data) < records_size:
                 return None
-            assert len(
-                data
-            ) == records_size, f"data len is {len(data)} but the expected records size is {records_size}"
+            assert len(data) == records_size, (
+                f"data len is {len(data)} but the expected records size is {records_size}, "
+                f"parsed header: {header}")
             return header
         return None
 

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -113,7 +113,7 @@ def compute_size_for_file(file: Path, calc_md5: bool):
             return md5_for_bytes(calc_md5,
                                  data), sum(h.batch_size for h in reader)
         else:
-            # if the large page is not a null page this is a properly closed and
+            # if the last page is not a null page this is a properly closed and
             # truncated segment and hence we can just use filesize otherwise
             # compute the size of the segment
             with file.open('rb') as f:


### PR DESCRIPTION
There are cases where compute_storage.py reads a batch header with some fields > 0 (mostly CRC) while all other fields, especially the batch size is 0. In such cases the record size is computed to -61, which when passed to the python read function reads the entire file.

It is possible that this header is read in this way because it is being written to while the file is parsed. There are two supporting pieces of evidence:

* The same segment, parsed by the same script, after the test finishes, does not show any errors. The header where previously failure was seen has all non zero, consistent fields now including batch sizes.
* The CRC matches both when the rest of the fields are 0 and in the final version of the segment, in both cases it is non zero.

Header when the script fails:
```
Header(header_crc=2864585299, batch_size=0, base_offset=0, type=0, crc=0, attrs=0, delta=0, first_ts=0, max_ts=0, producer_id=0, producer_epoch=0, base_seq=0, record_count=0)
```

Header at same file offset, when running the script on the file after the test is finished:
```
Header(header_crc=2864585299, batch_size=89, base_offset=22225, type=1, crc=405058600, attrs=0, delta=1, first_ts=1724843533841, max_ts=1724843533841, producer_id=-1, producer_epoch=-1, base_seq=-1, record_count=2)
```

The change here makes the parser wait for a short period when not all fields are 0 but batch size is 0, and rewind and re-read the batch. This is done only a fixed number of times, so as to avoid infinite recursion. This should allow the segment appender to race ahead and write more batches for this script to consume. This should happen until the segment is rolled.

This makes the script slower. Another option would have been to just end the parse early in case we saw a header of batch size 0. However this will affect test logic because this script is primarily used in a size computation mode only where we are waiting for truncation of local storage. 

Under-reporting of sizes will lead us to believe that truncation happened earlier than it actually happens.

#FIXES https://github.com/redpanda-data/redpanda/issues/20298
FIXES CORE-6991
FIXES CORE-4584

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
