### PR TITLE
tests/shard_placement_test: increase node rebalance timeout

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5225,6 +5225,62 @@ class RedpandaService(RedpandaServiceBase):
         else:
             return None
 
+    def wait_node_add_rebalance_finished(self,
+                                         new_nodes,
+                                         admin=None,
+                                         min_partitions=5,
+                                         progress_timeout=30,
+                                         timeout=300,
+                                         backoff=2):
+        """Waits until the rebalance triggered by adding new nodes is finished."""
+
+        new_node_names = [n.name for n in new_nodes]
+
+        if admin is None:
+            admin = Admin(self)
+        started_at = time.monotonic()
+        last_reconfiguring = set()
+        last_bytes_moved = 0
+        last_update = started_at
+
+        while True:
+            time.sleep(backoff)
+
+            if time.monotonic() - last_update > progress_timeout:
+                raise TimeoutError(
+                    f"rebalance after adding nodes {new_node_names} "
+                    "stopped making progress")
+
+            if time.monotonic() - started_at > timeout:
+                raise TimeoutError(
+                    f"rebalance after adding nodes {new_node_names} "
+                    "timed out")
+
+            cur_reconfiguring = set()
+            cur_bytes_moved = 0
+            for p in admin.list_reconfigurations():
+                cur_reconfiguring.add(
+                    f"{p['ns']}/{p['topic']}/{p['partition']}")
+                cur_bytes_moved += p['bytes_moved']
+
+            if (cur_reconfiguring != last_reconfiguring
+                    or cur_bytes_moved != last_bytes_moved):
+                last_update = time.monotonic()
+
+            last_reconfiguring = cur_reconfiguring
+            last_bytes_moved = cur_bytes_moved
+
+            if len(cur_reconfiguring) > 0:
+                continue
+
+            partition_counts = [
+                len(admin.get_partitions(node=n)) for n in new_nodes
+            ]
+            if any(pc < min_partitions for pc in partition_counts):
+                continue
+
+            return
+
 
 def make_redpanda_service(context: TestContext,
                           num_brokers: int | None,

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -574,19 +574,8 @@ class ShardPlacementTest(PreallocNodesTest):
 
         self.redpanda.start(nodes=joiner_nodes)
 
-        def node_rebalance_finished():
-            in_progress = admin.list_reconfigurations(node=seed_nodes[0])
-            if len(in_progress) > 0:
-                return False
-
-            for n in joiner_nodes:
-                num_partitions = len(admin.get_partitions(node=n))
-                if num_partitions < 5:
-                    return False
-
-            return True
-
-        wait_until(node_rebalance_finished, timeout_sec=60, backoff_sec=2)
+        self.redpanda.wait_node_add_rebalance_finished(joiner_nodes,
+                                                       admin=admin)
         self.logger.info("node rebalance finished")
 
         def shard_rebalance_finished():


### PR DESCRIPTION
When the test is run on dedicated nodes, client workload can produce substantial amout of data and 60 seconds is not enough for the rebalance triggered by node addition to finish.

Increase the timeout if the test runs on dedicated nodes.

Fixes https://redpandadata.atlassian.net/browse/CORE-6779

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none