### PR TITLE
tests/shard_placement_test: check total counts in rebalance_finished predicate

### DIFF
--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -604,10 +604,22 @@ class ShardPlacementTest(PreallocNodesTest):
                 node_id = self.redpanda.node_id(n)
                 shard_counts = self.get_shard_counts_by_topic(
                     shard_map, node_id)
+
+                total_counts = None
                 for topic in topics:
                     topic_counts = shard_counts[topic]
+
+                    if total_counts is None:
+                        total_counts = topic_counts
+                    else:
+                        for s, c in enumerate(topic_counts):
+                            total_counts[s] += c
+
                     if max(topic_counts) - min(topic_counts) > 1:
                         return False
+
+                if max(total_counts) - min(total_counts) > 1:
+                    return False
 
             return (True, shard_map)
 


### PR DESCRIPTION
Otherwise shard balancing may move some partitions even after we declare the rebalance finished in the test. This could lead to apparent inconsistency between shard maps taken at different points in time.

Fixes https://redpandadata.atlassian.net/browse/CORE-6851

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
