### PR TITLE
[v23.3.x] rpk: fix --no-profile and add cloud checks for rpk security user commands.

### DIFF
--- a/src/go/rpk/pkg/cli/acl/user/create.go
+++ b/src/go/rpk/pkg/cli/acl/user/create.go
@@ -57,6 +57,7 @@ acl help text for more info.
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/acl/user/delete.go
+++ b/src/go/rpk/pkg/cli/acl/user/delete.go
@@ -37,6 +37,7 @@ delete any ACLs that may exist for this user.
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/acl/user/list.go
+++ b/src/go/rpk/pkg/cli/acl/user/list.go
@@ -29,6 +29,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/acl/user/update.go
+++ b/src/go/rpk/pkg/cli/acl/user/update.go
@@ -29,6 +29,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			f := p.Formatter
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitNotServerlessAdmin(p)
 
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)

--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -128,16 +128,6 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 				return
 			}
 
-			// The current profile was auth'd to the current organization.
-			// We tell the status of what org the user is talking to.
-			if p.FromCloud {
-				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q)\n", p.CloudCluster.FullName(), p.Name)
-				fmt.Println("Select a different cluster to talk to (or ctrl+c to keep the current cluster)?")
-				err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
-				profile.MaybeDieExistingName(err)
-				return
-			}
-
 			// Below here, the current profile is pointed to a
 			// local container cluster or a self hosted cluster.
 			// We want to create or swap to the cloud profile,
@@ -152,6 +142,16 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 				// The current profile is a self hosted cluster.
 				fmt.Printf("You are talking to a self hosted cluster (rpk profile name: %q)\n", p.Name)
 				fmt.Println("To talk to a cloud cluster, use 'rpk cloud cluster select'.")
+				return
+			}
+
+			// The current profile was auth'd to the current organization.
+			// We tell the status of what org the user is talking to.
+			if p.FromCloud {
+				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q)\n", p.CloudCluster.FullName(), p.Name)
+				fmt.Println("Select a different cluster to talk to (or ctrl+c to keep the current cluster)?")
+				err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
+				profile.MaybeDieExistingName(err)
 				return
 			}
 

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -88,10 +88,18 @@ func CheckExitCloudAdmin(p *RpkProfile) {
 }
 
 // CheckExitServerlessAdmin exits if the profile has FromCloud=true and the
-// cluster is a Serverless cluster
+// cluster is a Serverless cluster.
 func CheckExitServerlessAdmin(p *RpkProfile) {
 	if p.FromCloud && p.CloudCluster.IsServerless() {
 		out.Die("This admin API based command is not supported on Redpanda Cloud serverless clusters.")
+	}
+}
+
+// CheckExitNotServerlessAdmin exits if the profile has FromCloud=true and the
+// cluster is NOT a Serverless cluster.
+func CheckExitNotServerlessAdmin(p *RpkProfile) {
+	if p.FromCloud && !p.CloudCluster.IsServerless() {
+		out.Die("This admin API based command is not supported on Redpanda Cloud clusters.")
 	}
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/23047

Had to be done manually as in v23.3.x we didn't have the `security` command and `user` was under `acl`.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
