### PR TITLE
bazel: split out chunk cache into bazel library

### DIFF
--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/ssx:abort_source",
         "//src/v/ssx:thread_worker",
         "//src/v/storage",
+        "//src/v/storage:chunk_cache",
         "//src/v/strings:utf8",
         "//src/v/syschecks",
         "//src/v/transform",

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -165,11 +165,32 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "chunk_cache",
+    srcs = [
+        "chunk_cache.cc",
+    ],
     hdrs = [
         "chunk_cache.h",
         "segment_appender_chunk.h",
     ],
+    implementation_deps = [
+        "//src/v/config",
+        "//src/v/resource_mgmt:memory_groups",
+        "@boost//:iterator",
+    ],
     include_prefix = "storage",
+    visibility = [
+        "//src/v/storage/tests:__pkg__",
+        # TODO(bazel) chunk cache could probably be instantiated in
+        # log_manager.cc instead of in redpanda::application.
+        "//src/v/redpanda:__pkg__",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:intrusive",
+        "//src/v/ssx:semaphore",
+        "//src/v/utils:named_type",
+        "@seastar",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -164,6 +164,15 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "chunk_cache",
+    hdrs = [
+        "chunk_cache.h",
+        "segment_appender_chunk.h",
+    ],
+    include_prefix = "storage",
+)
+
+redpanda_cc_library(
     name = "storage",
     srcs = [
         "api.cc",
@@ -204,7 +213,6 @@ redpanda_cc_library(
         "api.h",
         "backlog_controller.h",
         "batch_consumer_utils.h",
-        "chunk_cache.h",
         "compacted_index.h",
         "compacted_index_chunk_reader.h",
         "compacted_index_reader.h",
@@ -245,7 +253,6 @@ redpanda_cc_library(
         "scoped_file_tracker.h",
         "segment.h",
         "segment_appender.h",
-        "segment_appender_chunk.h",
         "segment_deduplication_utils.h",
         "segment_index.h",
         "segment_reader.h",
@@ -266,6 +273,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":batch_cache",
+        ":chunk_cache",
         ":compaction",
         ":index_state",
         ":key_offset_map",

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -41,6 +41,7 @@ v_cc_library(
     api.cc
     node.cc
     key_offset_map.cc
+    chunk_cache.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/chunk_cache.cc
+++ b/src/v/storage/chunk_cache.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "storage/chunk_cache.h"
+
+#include "config/configuration.h"
+#include "resource_mgmt/memory_groups.h"
+
+#include <seastar/core/loop.hh>
+
+#include <boost/iterator/counting_iterator.hpp>
+
+namespace storage::internal {
+
+chunk_cache::chunk_cache() noexcept
+  : _size_target(memory_groups().chunk_cache_min_memory())
+  , _size_limit(memory_groups().chunk_cache_max_memory())
+  , _chunk_size(config::shard_local_cfg().append_chunk_size()) {}
+
+ss::future<> chunk_cache::start() {
+    const auto num_chunks = memory_groups().chunk_cache_min_memory()
+                            / _chunk_size;
+    return ss::do_for_each(
+      boost::counting_iterator<size_t>(0),
+      boost::counting_iterator<size_t>(num_chunks),
+      [this](size_t) {
+          auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
+          _size_total += _chunk_size;
+          add(c);
+      });
+}
+
+void chunk_cache::add(const chunk_ptr& chunk) {
+    if (_size_available >= _size_target) {
+        _size_total -= _chunk_size;
+        return;
+    }
+    _chunks.push_back(chunk);
+    _size_available += _chunk_size;
+    if (_sem.waiters()) {
+        _sem.signal();
+    }
+}
+
+ss::future<chunk_cache::chunk_ptr> chunk_cache::get() {
+    // don't steal if there are waiters
+    if (!_sem.waiters()) {
+        return do_get();
+    }
+    return ss::get_units(_sem, 1).then(
+      [this](ssx::semaphore_units) { return do_get(); });
+}
+
+ss::future<chunk_cache::chunk_ptr> chunk_cache::do_get() {
+    if (auto c = pop_or_allocate(); c) {
+        return ss::make_ready_future<chunk_ptr>(c);
+    }
+    return ss::get_units(_sem, 1).then(
+      [this](ssx::semaphore_units) { return do_get(); });
+}
+
+chunk_cache::chunk_ptr chunk_cache::pop_or_allocate() {
+    if (!_chunks.empty()) {
+        auto c = _chunks.front();
+        _chunks.pop_front();
+        _size_available -= _chunk_size;
+        c->reset();
+        return c;
+    }
+    if (_size_total < _size_limit) {
+        auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
+        _size_total += _chunk_size;
+        return c;
+    }
+    return nullptr;
+}
+
+chunk_cache& chunks() {
+    static thread_local chunk_cache cache;
+    return cache;
+}
+
+} // namespace storage::internal

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -9,18 +9,14 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+
 #include "base/seastarx.h"
-#include "base/vassert.h"
-#include "resource_mgmt/memory_groups.h"
 #include "ssx/semaphore.h"
 #include "storage/segment_appender_chunk.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/loop.hh>
-#include <seastar/util/later.hh>
-
-#include <boost/iterator/counting_iterator.hpp>
+#include <seastar/core/shared_ptr.hh>
 
 namespace storage::internal {
 
@@ -38,77 +34,25 @@ public:
      */
     static constexpr const alignment alignment{4_KiB};
 
-    chunk_cache() noexcept
-      : _size_target(memory_groups().chunk_cache_min_memory())
-      , _size_limit(memory_groups().chunk_cache_max_memory())
-      , _chunk_size(config::shard_local_cfg().append_chunk_size()) {}
-
+    chunk_cache() noexcept;
     chunk_cache(chunk_cache&&) = delete;
     chunk_cache& operator=(chunk_cache&&) = delete;
     chunk_cache(const chunk_cache&) = delete;
     chunk_cache& operator=(const chunk_cache&) = delete;
     ~chunk_cache() noexcept = default;
 
-    ss::future<> start() {
-        const auto num_chunks = memory_groups().chunk_cache_min_memory()
-                                / _chunk_size;
-        return ss::do_for_each(
-          boost::counting_iterator<size_t>(0),
-          boost::counting_iterator<size_t>(num_chunks),
-          [this](size_t) {
-              auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
-              _size_total += _chunk_size;
-              add(c);
-          });
-    }
+    ss::future<> start();
 
-    void add(const chunk_ptr& chunk) {
-        if (_size_available >= _size_target) {
-            _size_total -= _chunk_size;
-            return;
-        }
-        _chunks.push_back(chunk);
-        _size_available += _chunk_size;
-        if (_sem.waiters()) {
-            _sem.signal();
-        }
-    }
+    void add(const chunk_ptr& chunk);
 
-    ss::future<chunk_ptr> get() {
-        // don't steal if there are waiters
-        if (!_sem.waiters()) {
-            return do_get();
-        }
-        return ss::get_units(_sem, 1).then(
-          [this](ssx::semaphore_units) { return do_get(); });
-    }
+    ss::future<chunk_ptr> get();
 
     size_t chunk_size() const { return _chunk_size; }
 
 private:
-    ss::future<chunk_ptr> do_get() {
-        if (auto c = pop_or_allocate(); c) {
-            return ss::make_ready_future<chunk_ptr>(c);
-        }
-        return ss::get_units(_sem, 1).then(
-          [this](ssx::semaphore_units) { return do_get(); });
-    }
+    ss::future<chunk_ptr> do_get();
 
-    chunk_ptr pop_or_allocate() {
-        if (!_chunks.empty()) {
-            auto c = _chunks.front();
-            _chunks.pop_front();
-            _size_available -= _chunk_size;
-            c->reset();
-            return c;
-        }
-        if (_size_total < _size_limit) {
-            auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
-            _size_total += _chunk_size;
-            return c;
-        }
-        return nullptr;
-    }
+    chunk_ptr pop_or_allocate();
 
     ss::chunked_fifo<chunk_ptr> _chunks;
     ssx::semaphore _sem{0, "s/chunk-cache"};
@@ -120,9 +64,6 @@ private:
     const size_t _chunk_size{0};
 };
 
-inline chunk_cache& chunks() {
-    static thread_local chunk_cache cache;
-    return cache;
-}
+chunk_cache& chunks();
 
 } // namespace storage::internal

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
 #pragma once
 #include "base/seastarx.h"
 #include "base/vassert.h"

--- a/src/v/storage/segment_appender_chunk.h
+++ b/src/v/storage/segment_appender_chunk.h
@@ -12,8 +12,8 @@
 #pragma once
 #include "base/seastarx.h"
 #include "base/units.h"
-#include "config/configuration.h"
 #include "container/intrusive_list_helpers.h"
+#include "utils/named_type.h"
 
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_btest(
         "//src/v/config",
         "//src/v/random:generators",
         "//src/v/storage",
+        "//src/v/storage:chunk_cache",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@fmt",

--- a/src/v/storage/tests/appender_chunk_manipulations.cc
+++ b/src/v/storage/tests/appender_chunk_manipulations.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "config/configuration.h"
 #include "random/generators.h"
 #include "storage/segment_appender.h"
 


### PR DESCRIPTION
bazel: split out chunk cache into bazel library

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

