### PR TITLE
JavaScript Transforms SDK: Export SchemaFormat 

### DIFF
--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -386,6 +386,8 @@ public:
      */
     module_builder& add_function(std::string name, native_function);
 
+    module_builder& add_object(std::string name, object_builder obj);
+
     /** Build this module and make it available in this context. */
     std::expected<std::monostate, exception> build(JSContext* ctx);
 
@@ -393,6 +395,7 @@ private:
     std::string _name;
 
     std::unordered_map<std::string, native_function> _exports;
+    std::unordered_map<std::string, object_builder> _objects;
 };
 
 /**
@@ -474,8 +477,14 @@ private:
         native_function func;
     };
 
+    struct named_object_data {
+        std::unique_ptr<std::string> name;
+        object_export_data data;
+    };
+
     struct context_state {
         std::vector<named_native_function> named_functions;
+        std::vector<named_object_data> named_objects;
         // For each module, the functions that are defined for it.
         std::unordered_map<JSModuleDef*, std::vector<JSCFunctionListEntry>>
           module_functions;

--- a/src/transform-sdk/js/main.cc
+++ b/src/transform-sdk/js/main.cc
@@ -488,7 +488,7 @@ private:
             return std::unexpected(qjs::exception::make(
               ctx, "malformed schema def: expected int for 'format'"));
         }
-        std::vector<redpanda::sr::reference> native_refs;
+        redpanda::sr::schema::reference_container native_refs;
         auto refs = val.get_property("references");
         if (!refs.is_null() && !refs.is_undefined()) {
             if (!refs.is_array()) {
@@ -536,10 +536,25 @@ private:
             }
         }
 
-        return redpanda::sr::schema{
-          std::string{raw_schema.string_data().view()},
-          static_cast<redpanda::sr::schema_format>(format.as_integer()),
-          std::move(native_refs)};
+        switch (auto fmt = format.as_integer()) {
+        case static_cast<int32_t>(redpanda::sr::schema_format::avro):
+            return redpanda::sr::schema::new_avro(
+              std::string{raw_schema.string_data().view()},
+              std::make_optional(std::move(native_refs)));
+        case static_cast<int32_t>(redpanda::sr::schema_format::protobuf):
+            return redpanda::sr::schema::new_protobuf(
+              std::string{raw_schema.string_data().view()},
+              std::make_optional(std::move(native_refs)));
+        case static_cast<int32_t>(redpanda::sr::schema_format::json):
+            return redpanda::sr::schema::new_json(
+              std::string{raw_schema.string_data().view()},
+              std::make_optional(std::move(native_refs)));
+        default:
+            return std::unexpected(qjs::exception::make(
+              ctx,
+              std::format(
+                "malformed schema def: 'format' out of range, got {}", fmt)));
+        }
     }
 
     static std::expected<qjs::value, qjs::exception> make_subject_schema(

--- a/src/transform-sdk/js/main.cc
+++ b/src/transform-sdk/js/main.cc
@@ -807,6 +807,11 @@ std::expected<std::monostate, qjs::exception> initial_native_modules(
           }
           return encode_schema_id_impl(ctx, args[0], args[1]);
       });
+
+    qjs::object_builder schema_format;
+    schema_format.add_i32("Avro", 0).add_i32("Protobuf", 1).add_i32("JSON", 2);
+    sr_mod.add_object("SchemaFormat", std::move(schema_format));
+
     return runtime->add_module(std::move(mod))
       .and_then([runtime, &sr_mod](std::monostate) {
           return runtime->add_module(std::move(sr_mod));

--- a/src/transform-sdk/js/schema_registry_example/src/index.ts
+++ b/src/transform-sdk/js/schema_registry_example/src/index.ts
@@ -1,5 +1,5 @@
 import { onRecordWritten, OnRecordWrittenEvent, RecordWriter } from "@redpanda-data/transform-sdk"
-import { newClient, decodeSchemaID } from "@redpanda-data/transform-sdk-sr";
+import { newClient, decodeSchemaID, SchemaFormat } from "@redpanda-data/transform-sdk-sr";
 import { Type } from "avsc/lib/index.js"
 import { Buffer } from "buffer"
 
@@ -17,7 +17,7 @@ const subj_schema = sr_client.createSchema(
     "avro-value",
     {
         schema: JSON.stringify(schema),
-        format: 0,//SchemaFormat.Avro,
+        format: SchemaFormat.Avro,
         references: [],
     }
 );


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds a `SchemaFormat` "enum" (really a JS object with integer-valued fields) to the schema registry module. 

The enum previously appeared in our TypeScript typings but was left unimplemented by mistake. Usually, the TS compiler will emit a pure JS object corresponding to such an enum, but our setup doesn't do this because the SDK module(s) are all native code, mediated by `quickjs`.

This PR also includes an update to the SR example code (to use the enum rather than a bare int) and some quickjs-oriented helper structs related to constructing and exporting a singleton object into a native module.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* Implements `@redpanda-data/transform-sdk-sr.SchemaFormat` for the WASM Transforms JS module

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
