### PR TITLE
dt: skip license nag tests in fips mode

### DIFF
--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -10,7 +10,7 @@
 import threading
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, ok_to_fail_fips
 
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.python_librdkafka import PythonLibrdkafka
@@ -620,6 +620,7 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
         )
 
     @cluster(num_nodes=3)
+    @ok_to_fail_fips  # See NOTE below
     @parametrize(authn_config={"sasl_mechanisms": ["OAUTHBEARER", "SCRAM"]})
     @parametrize(authn_config={"http_authentication": ["OIDC", "BASIC"]})
     def test_license_nag(self, authn_config):
@@ -629,6 +630,8 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
 
         self.logger.debug("Ensuring no license nag")
         time.sleep(self.LICENSE_CHECK_INTERVAL_SEC * 2)
+        # NOTE: This assertion will FAIL if running in FIPS mode because
+        # being in FIPS mode will trigger the license nag
         assert not self._has_license_nag()
 
         self.logger.debug("Setting cluster config")

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -21,7 +21,7 @@ import socket
 
 from confluent_kafka.schema_registry import SchemaRegistryClient, topic_subject_name_strategy, record_subject_name_strategy, topic_record_subject_name_strategy, Schema, SchemaRegistryError, SchemaReference
 from confluent_kafka.serialization import (MessageField, SerializationContext)
-from ducktape.mark import parametrize, matrix
+from ducktape.mark import parametrize, matrix, ok_to_fail_fips
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.utils.util import wait_until
 
@@ -3835,6 +3835,7 @@ class SchemaRegistryLicenseTest(RedpandaTest):
         )
 
     @cluster(num_nodes=3)
+    @ok_to_fail_fips  # See NOTE below
     @parametrize(mode=SchemaIdValidationMode.REDPANDA)
     @parametrize(mode=SchemaIdValidationMode.COMPAT)
     def test_license_nag(self, mode):
@@ -3844,6 +3845,8 @@ class SchemaRegistryLicenseTest(RedpandaTest):
 
         self.logger.debug("Ensuring no license nag")
         time.sleep(self.LICENSE_CHECK_INTERVAL_SEC * 2)
+        # NOTE: This assertion will FAIL if running in FIPS mode because
+        # being in FIPS mode will trigger the license nag
         assert not self._has_license_nag()
 
         self.logger.debug("Setting cluster config")


### PR DESCRIPTION
Similar to https://github.com/redpanda-data/redpanda/pull/21350. Ignore all of the license nag tests in FIPS mode because the license nag always shows up due to running in FIPS mode.

Fixes https://redpandadata.atlassian.net/browse/CORE-6952
Fixes https://redpandadata.atlassian.net/browse/CORE-6953

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
