### PR TITLE
[v24.1.x] rptest: reduce cache eviction throttling for tiny cache stress test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -64,6 +64,7 @@ class TieredStorageCacheStressTest(RedpandaTest):
             'cloud_storage_manifest_max_upload_interval_sec':
             self.manifest_upload_interval,
             'disable_public_metrics': False,
+            'cloud_storage_cache_check_interval': 500,
         }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23006
Fixes: https://github.com/redpanda-data/redpanda/issues/23178,