### PR TITLE
crypto: upgrade to openssl 3.0.15

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -169,7 +169,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "7LKLCS0Lafr9yr6siqJGOOLGYr1Bp75aMy+sX6UKx64=",
+        "bzlTransitiveDigest": "90C95yN8vWXRgzI1sMx25AnVBZ8ET2Ih7+Ga8aXcjUY=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -340,9 +340,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "7375e6200ccd1540245a39c01bc8e37750d9aad5f747ad10a168a520e95dba43",
-              "strip_prefix": "openssl-9cff14fd97814baf8a9a07d8447960a64d616ada",
-              "url": "https://github.com/openssl/openssl/archive/9cff14fd97814baf8a9a07d8447960a64d616ada.tar.gz"
+              "sha256": "23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533",
+              "strip_prefix": "openssl-3.0.15",
+              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz"
             }
           },
           "c-ares": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -135,9 +135,9 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "7375e6200ccd1540245a39c01bc8e37750d9aad5f747ad10a168a520e95dba43",
-        strip_prefix = "openssl-9cff14fd97814baf8a9a07d8447960a64d616ada",
-        url = "https://github.com/openssl/openssl/archive/9cff14fd97814baf8a9a07d8447960a64d616ada.tar.gz",
+        sha256 = "23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533",
+        strip_prefix = "openssl-3.0.15",
+        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
crypto: upgrade to openssl 3.0.15

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
