### PR TITLE
utils: Added external_process library

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -119,8 +119,9 @@ def redpanda_cc_gtest(
         timeout,
         srcs = [],
         deps = [],
-        data = [],
-        args = []):
+        args = [],
+        env = {},
+        data = []):
     _redpanda_cc_unit_test(
         dash_dash_protocol = False,
         name = name,
@@ -128,6 +129,7 @@ def redpanda_cc_gtest(
         srcs = srcs,
         deps = deps,
         custom_args = args,
+        env = env,
         data = data,
     )
 

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -16,6 +16,7 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/model",
         "@fmt",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -61,7 +61,7 @@ private:
     private:                                                                   \
         void TestBody() override { TestBodyWrapped().get(); }                  \
         seastar::future<> TestBodyWrapped();                                   \
-        static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;  \
+        static ::testing::TestInfo* const test_info_ [[maybe_unused]];         \
     };                                                                         \
                                                                                \
     ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(                         \
@@ -121,7 +121,7 @@ private:
                 ::testing::internal::CodeLocation(__FILE__, __LINE__));        \
             return 0;                                                          \
         }                                                                      \
-        static int gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;           \
+        static int gtest_registering_dummy_ [[maybe_unused]];                  \
         GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
         (GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) const&) = delete;  \
         GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &                   \

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -1,0 +1,14 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "gtest_test",
+    timeout = "short",
+    srcs = [
+        "gtest_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -611,3 +611,19 @@ redpanda_cc_library(
     ],
     include_prefix = "utils",
 )
+
+redpanda_cc_library(
+    name = "external_process",
+    srcs = [
+        "external_process.cc",
+    ],
+    hdrs = [
+        "external_process.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "//src/v/base",
+        "//src/v/utils:mutex",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     bottomless_token_bucket.cc
     log_hist.cc
     xid.cc
+    external_process.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/external_process.cc
+++ b/src/v/utils/external_process.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "external_process.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/process.hh>
+
+#include <functional>
+#include <optional>
+
+namespace external_process {
+ss::future<std::unique_ptr<external_process>>
+external_process::create_external_process(
+  std::vector<ss::sstring> command,
+  std::optional<std::vector<ss::sstring>> env) {
+    vassert(
+      !command.empty(),
+      "Should not be passed an empty command list to "
+      "create_external_process");
+
+    auto path = std::filesystem::path(command[0]);
+    ss::experimental::spawn_parameters params{
+      .argv = std::move(command),
+      .env = env.has_value() ? std::move(env).value()
+                             : std::vector<ss::sstring>{}};
+
+    auto p = co_await ss::experimental::spawn_process(path, params);
+
+    co_return std::unique_ptr<external_process>(
+      new external_process(std::move(p), std::move(path), std::move(params)));
+}
+
+external_process::external_process(
+  ss::experimental::process p,
+  std::filesystem::path path,
+  ss::experimental::spawn_parameters params)
+  : _process(std::move(p))
+  , _path(std::move(path))
+  , _params(std::move(params))
+  , _terminate_mutex("external_process::terminate")
+  , _wait_mutex("external_process::wait") {}
+
+external_process::~external_process() {
+    vassert(_completed, "Process has not yet completed");
+    vassert(!_stdout_consumer.has_value(), "stdout consumer not cleaned up");
+    vassert(!_stderr_consumer.has_value(), "stderr consumer not cleaned up");
+}
+
+ss::future<ss::experimental::process::wait_status> external_process::wait() {
+    auto guard = _gate.hold();
+    if (_completed) {
+        throw std::system_error(
+          make_error_code(error_code::process_already_completed));
+    }
+
+    auto units = _wait_mutex.try_get_units();
+    if (!units) {
+        throw std::system_error(
+          make_error_code(error_code::process_already_being_waited_on));
+    }
+
+    auto resp = co_await _process.wait();
+
+    if (_stdout_consumer.has_value()) {
+        try {
+            co_await std::move(_stdout_consumer).value();
+        } catch (const std::exception& e) {
+            std::ignore = e;
+        }
+
+        _stdout_consumer.reset();
+    }
+
+    if (_stderr_consumer.has_value()) {
+        try {
+            co_await std::move(_stderr_consumer).value();
+        } catch (const std::exception& e) {
+            std::ignore = e;
+        }
+
+        _stderr_consumer.reset();
+    }
+
+    _completed = true;
+    term_as.request_abort();
+
+    co_return resp;
+}
+
+ss::future<> external_process::terminate(std::chrono::milliseconds timeout) {
+    auto guard = _gate.hold();
+
+    if (_completed) {
+        throw std::system_error(
+          make_error_code(error_code::process_already_completed));
+    }
+
+    auto units = _terminate_mutex.try_get_units();
+    if (!units) {
+        throw std::system_error(
+          make_error_code(error_code::process_already_being_terminated));
+    }
+
+    if (_wait_mutex.ready()) {
+        throw std::system_error(
+          make_error_code(error_code::terminate_called_before_wait));
+    }
+
+    try {
+        _process.terminate();
+    } catch (const std::exception& e) {
+        throw std::system_error(
+          make_error_code(error_code::failed_to_terminate_process), e.what());
+    }
+
+    try {
+        co_await ss::sleep_abortable(timeout, term_as);
+    } catch (const ss::sleep_aborted& e) {
+        std::ignore = e;
+    }
+
+    if (!_completed) {
+        try {
+            _process.kill();
+        } catch (const std::exception& e) {
+            throw std::system_error(
+              make_error_code(error_code::failed_to_terminate_process),
+              e.what());
+        }
+    }
+}
+} // namespace external_process

--- a/src/v/utils/external_process.h
+++ b/src/v/utils/external_process.h
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vassert.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/util/process.hh>
+
+#include <chrono>
+#include <optional>
+#include <system_error>
+
+namespace external_process {
+/**
+ * @brief Defines the error codes emited by this utility
+ */
+enum class error_code : int {
+    success = 0,
+    process_already_completed,
+    process_already_being_waited_on,
+    process_already_being_terminated,
+    failed_to_terminate_process,
+    terminate_called_before_wait
+};
+
+/**
+ * @brief Defines the external_process::error_category
+ */
+struct error_category final : public std::error_category {
+    /**
+     * @return const char* Name of the category
+     */
+    const char* name() const noexcept final {
+        return "external_process::error_category";
+    }
+
+    /**
+     * @param c Error code to stringify
+     * @return std::string Stringified version of @p c
+     */
+    std::string message(int c) const final {
+        switch (static_cast<error_code>(c)) {
+        case error_code::success:
+            return "success";
+        case error_code::process_already_completed:
+            return "process already completed";
+        case error_code::process_already_being_waited_on:
+            return "wait already called on process";
+        case error_code::process_already_being_terminated:
+            return "terminate already being called on the process";
+        case error_code::failed_to_terminate_process:
+            return "failed to terminate the process";
+        case error_code::terminate_called_before_wait:
+            return "termiate called before wait";
+        }
+
+        return "(unknown error code)";
+    }
+};
+
+/**
+ * @return const std::error_category& Returns static instance of
+ * external_process::error_category
+ */
+inline const std::error_category& error_category() noexcept {
+    static struct error_category e;
+    return e;
+}
+inline std::error_code make_error_code(error_code e) noexcept {
+    return {static_cast<int>(e), error_category()};
+}
+
+/**
+ * @brief This class wraps a Seastar experimental process instance
+ *
+ * The purpose of this class is to provide an easy way of controlling a spawned
+ * child process.
+ */
+class external_process final {
+public:
+    /**
+     * @brief Create a external process object
+     *
+     * This method will return a created external_process object with an already
+     * spawned process.  It will attach any provided consumer to the appropriate
+     * ss::input_stream<char>.
+     *
+     * @note You _must_ call `wait()` on the returned object before the object
+     * is destructed.
+     *
+     * @param command The command to run with its arguments, divided over the
+     * vector.  Will assert if empty.
+     * @param env Optionall provided a list of environmental variables as
+     * KEY=VALUE
+     * @return A std::unique_ptr containing the created external process
+     * @throw std::system_error If unable to launch the process
+     */
+    static ss::future<std::unique_ptr<external_process>>
+    create_external_process(
+      std::vector<ss::sstring> command,
+      std::optional<std::vector<ss::sstring>> env = std::nullopt);
+
+    external_process() = delete;
+    external_process(const external_process&) = delete;
+    external_process& operator=(const external_process&) = delete;
+    external_process(external_process&&) noexcept = delete;
+    external_process& operator=(external_process&&) noexcept = delete;
+
+    ~external_process();
+
+    /**
+     * @return true If process is still running, false otherwise
+     */
+    bool is_running() const { return !_completed; }
+
+    /**
+     * @return const std::filesystem::path& Path to the executable being
+     * executed
+     */
+    const std::filesystem::path& path() const noexcept { return _path; }
+    /**
+     * @return const ss::experimental::spawn_parameters& The spawn parameters
+     */
+    const ss::experimental::spawn_parameters& parameters() const noexcept {
+        return _params;
+    }
+
+    /**
+     * @brief Set the stdout consumer object
+     *
+     * @tparam Consumer The type of consumer, must satisfiy the requirements of
+     * ss::InputStreamConsumer
+     * @param consumer Instance of the consumer that will receive the output of
+     * stdout
+     * @note Will assert if called >1
+     */
+    template<typename Consumer>
+    requires ss::InputStreamConsumer<Consumer, char>
+    void set_stdout_consumer(Consumer consumer) {
+        vassert(!_stdout_consumer.has_value(), "Already set stdout consumer");
+        auto cout = _process.cout();
+        _stdout_consumer.emplace(ss::do_with(
+          std::move(cout),
+          [consumer = std::move(consumer)](
+            ss::input_stream<char>& cout) mutable {
+              return cout.consume(std::move(consumer));
+          }));
+    }
+
+    /**
+     * @brief Set the stderr consumer object
+     *
+     * @tparam Consumer The type of consumer, must satisfiy the requirements of
+     * ss::InputStreamConsumer
+     * @param consumer Instance of the consumer that will receive the output of
+     * stderr
+     * @note Will assert if called >1
+     */
+    template<typename Consumer>
+    requires ss::InputStreamConsumer<Consumer, char>
+    void set_stderr_consumer(Consumer consumer) {
+        vassert(!_stderr_consumer.has_value(), "Already set stdout consumer");
+        auto cerr = _process.cerr();
+        _stderr_consumer.emplace(ss::do_with(
+          std::move(cerr),
+          [consumer = std::move(consumer)](
+            ss::input_stream<char>& cerr) mutable {
+              return cerr.consume(std::move(consumer));
+          }));
+    }
+
+    /**
+     * @brief Waits for the process to finish executing
+     *
+     * This will in turn call wait(2) on the child process, awaiting for it
+     * to complete.  This function _must_ be called on all created
+     * `external_process` objects.  This can only be called once.
+     *
+     * @return ss::future<ss::experimental::process::wait_status> The result of
+     * the process
+     * @throw std::system_error Containing an `external_process::error_code`:
+     * * `external_process::process_already_completed` if process already
+     *    completed
+     * * `process_already_being_waited_on` if `wait()` has already been called
+     */
+    ss::future<ss::experimental::process::wait_status> wait();
+
+    /**
+     * @brief Attempts to call SIGTERM and then SIGKILL on the running process
+     *
+     * @note Must call this _after_ calling `wait()` and while awaiting for
+     * `wait()`'s future to complete.
+     *
+     * @param timeout How long to wait until calling SIGKILL if SIGTERM fails
+     * @throw std::system_error Containing an `external_process::errro_code`
+     * * `external_process::process_already_completed` if process already done
+     * * `external_process::process_already_being_terminated` if `terminate()`
+     *    already called
+     * * `external_process::failed_to_terminate_process` if unable to signal
+     *    process
+     * * `external_process::terminate_called_before_wait` if `terminate()`
+     *    called before `wait()`
+     */
+    ss::future<> terminate(std::chrono::milliseconds timeout);
+
+private:
+    external_process(
+      ss::experimental::process p,
+      std::filesystem::path path,
+      ss::experimental::spawn_parameters params);
+
+private:
+    // The external process
+    ss::experimental::process _process;
+    // Path to the executable that's being executed
+    std::filesystem::path _path;
+    // The parameters for the process
+    ss::experimental::spawn_parameters _params;
+    // Flag indicating that the external process has completed
+    bool _completed{false};
+    // Protects against multiple calls to `terminate()`
+    mutex _terminate_mutex;
+    // Protects against multiple calls to `wait()`
+    mutex _wait_mutex;
+    // Holds the future of the stdout consumer which will be cleaned up in
+    // wait()
+    std::optional<ss::future<>> _stdout_consumer{std::nullopt};
+    // Holds the future of the stderr consumer which will be cleaned up in
+    // wait()
+    std::optional<ss::future<>> _stderr_consumer{std::nullopt};
+    ss::abort_source term_as;
+    ss::gate _gate;
+};
+
+} // namespace external_process
+
+namespace std {
+template<>
+struct is_error_code_enum<external_process::error_code> : true_type {};
+} // namespace std

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -505,3 +505,21 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "external_process_test",
+    timeout = "short",
+    srcs = [
+        "external_process_test.cc",
+    ],
+    data = [":handle-sigterm.sh"],
+    env = {
+        "HANDLE_SIGTERM_SCRIPT": "$(location :handle-sigterm.sh)",
+    },
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:external_process",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+SET(HANDLE_SIGTERM_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/handle-sigterm.sh")
 
 rp_test(
   UNIT_TEST
@@ -22,6 +23,21 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::utils v::bytes v::version absl::flat_hash_set
   ARGS "-- -c 1"
   LABELS utils
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_utils_single_thread
+  SOURCES
+    external_process_test.cc
+  LIBRARIES
+    v::utils
+    v::gtest_main
+  LABELS utils
+  ARGS "-- -c 1"
+  ENV
+    "HANDLE_SIGTERM_SCRIPT=${HANDLE_SIGTERM_SCRIPT}"
 )
 
 rp_test(

--- a/src/v/utils/tests/external_process_test.cc
+++ b/src/v/utils/tests/external_process_test.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "test_utils/test.h"
+#include "utils/external_process.h"
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+
+#include <gtest/gtest.h>
+
+#include <system_error>
+
+TEST_CORO(external_process, bin_true) {
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/bin/true"});
+    auto res = co_await proc->wait();
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_exited>(res));
+    auto wait_exited = std::get<ss::experimental::process::wait_exited>(res);
+    EXPECT_EQ(wait_exited.exit_code, 0);
+}
+
+TEST_CORO(external_process, bin_false) {
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/bin/false"});
+    auto res = co_await proc->wait();
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_exited>(res));
+    auto wait_exited = std::get<ss::experimental::process::wait_exited>(res);
+    EXPECT_EQ(wait_exited.exit_code, 1);
+}
+
+using consumption_result_type =
+  typename ss::input_stream<char>::consumption_result_type;
+using stop_consuming_type =
+  typename consumption_result_type::stop_consuming_type;
+using tmp_buf = stop_consuming_type::tmp_buf;
+
+struct consumer {
+    consumer(std::string_view expected, bool& matched)
+      : _expected(expected)
+      , _matched(matched) {}
+
+    ss::future<consumption_result_type> operator()(tmp_buf buf) {
+        _matched = std::equal(buf.begin(), buf.end(), _expected.begin());
+        if (_matched) {
+            return ss::make_ready_future<consumption_result_type>(
+              stop_consuming_type({}));
+        }
+        _expected.remove_prefix(buf.size());
+        return ss::make_ready_future<consumption_result_type>(
+          ss::continue_consuming{});
+    }
+
+    std::string_view _expected;
+    bool& _matched;
+};
+
+TEST_CORO(external_process, echo_hi) {
+    bool matched = false;
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/bin/echo", "-n", "hi"});
+    proc->set_stdout_consumer(consumer{"hi", matched});
+    auto res = co_await proc->wait();
+
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_exited>(res));
+    auto wait_exited = std::get<ss::experimental::process::wait_exited>(res);
+    EXPECT_EQ(wait_exited.exit_code, 0);
+
+    EXPECT_TRUE(matched);
+}
+
+TEST_CORO(external_process, run_long_process) {
+    using namespace std::chrono_literals;
+
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/bin/sleep", "3"});
+    auto start_time = std::chrono::high_resolution_clock::now();
+    auto res = co_await proc->wait();
+    auto end_time = std::chrono::high_resolution_clock::now();
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_exited>(res));
+    auto wait_exited = std::get<ss::experimental::process::wait_exited>(res);
+    EXPECT_EQ(wait_exited.exit_code, 0);
+    EXPECT_GE(
+      std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time)
+        .count(),
+      3);
+}
+
+TEST_CORO(external_process, run_long_process_and_terminate) {
+    using namespace std::chrono_literals;
+
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/bin/sleep", "10"});
+    auto wait_fut = proc->wait();
+    co_await ss::sleep(1s);
+    EXPECT_TRUE(proc->is_running());
+    co_await proc->terminate(1s);
+    EXPECT_TRUE(!proc->is_running());
+    auto res = co_await std::move(wait_fut);
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_signaled>(res));
+    auto wait_signaled = std::get<ss::experimental::process::wait_signaled>(
+      res);
+    EXPECT_EQ(wait_signaled.terminating_signal, SIGTERM);
+}
+
+TEST_CORO(external_process, test_sigterm_ignored) {
+    using namespace std::chrono_literals;
+    const char* script_path = std::getenv("HANDLE_SIGTERM_SCRIPT");
+    ASSERT_TRUE_CORO(script_path != nullptr)
+      << "Missing 'HANDLE_SIGTERM_SCRIPT' env variable";
+    auto script_exists = co_await ss::file_exists(script_path);
+    ASSERT_TRUE_CORO(script_exists) << script_path << " does not exist";
+    bool matched = false;
+
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {script_path});
+    proc->set_stdout_consumer(consumer{"sigterm called", matched});
+    co_await ss::sleep(100ms);
+    ASSERT_TRUE_CORO(proc->is_running());
+    auto wait_fut = proc->wait();
+    auto term_fut = proc->terminate(5s);
+    co_await ss::sleep(1s);
+    // SIGTERM should be handled at this point and we're waiting 5 seconds
+    // until sending SIGKILL so the process should still be running
+    EXPECT_TRUE(proc->is_running());
+    EXPECT_TRUE(!term_fut.available());
+    EXPECT_TRUE(!wait_fut.available());
+    EXPECT_TRUE(!wait_fut.failed());
+    EXPECT_TRUE(matched);
+    co_await ss::sleep(5s);
+    EXPECT_TRUE(!proc->is_running());
+    EXPECT_TRUE(term_fut.available());
+    EXPECT_TRUE(wait_fut.available());
+    EXPECT_TRUE(!wait_fut.failed());
+    co_await std::move(term_fut);
+    auto res = co_await std::move(wait_fut);
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_signaled>(res));
+    auto wait_signaled = std::get<ss::experimental::process::wait_signaled>(
+      res);
+    EXPECT_EQ(wait_signaled.terminating_signal, SIGKILL);
+}
+
+TEST_CORO(external_process, no_such_bin) {
+    try {
+        co_await external_process::external_process::create_external_process(
+          {"/no/such/proc"});
+        ASSERT_TRUE_CORO(false) << "Should not have succeeded";
+    } catch (const std::system_error& e) {
+        EXPECT_EQ(e.code(), std::error_code(ENOENT, std::system_category()));
+    } catch (...) {
+        ASSERT_TRUE_CORO(false) << "Unexpected exception thrown";
+    }
+}
+
+TEST_CORO(external_process, test_bad_args) {
+    auto proc
+      = co_await external_process::external_process::create_external_process(
+        {"/usr/bin/ls", "--nope"});
+    auto res = co_await proc->wait();
+    ASSERT_TRUE_CORO(
+      std::holds_alternative<ss::experimental::process::wait_exited>(res));
+    auto wait_exited = std::get<ss::experimental::process::wait_exited>(res);
+    EXPECT_EQ(wait_exited.exit_code, 2);
+}

--- a/src/v/utils/tests/handle-sigterm.sh
+++ b/src/v/utils/tests/handle-sigterm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+## Simple bash script that traps SIGTERM
+
+function sigterm_cb() {
+  echo -n "sigterm called"
+}
+
+trap sigterm_cb SIGTERM
+
+while true; do
+  sleep 1
+done


### PR DESCRIPTION
Created an "external_process" class that wraps around Seastar's process utility.  It provides methods to assign stdout and stderr consumers as well as the ability to automate the termination of the child process.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
