### PR TITLE
iceberg: fix bazel test

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -119,6 +119,7 @@ def redpanda_cc_gtest(
         timeout,
         srcs = [],
         deps = [],
+        data = [],
         args = []):
     _redpanda_cc_unit_test(
         dash_dash_protocol = False,
@@ -127,6 +128,7 @@ def redpanda_cc_gtest(
         srcs = srcs,
         deps = deps,
         custom_args = args,
+        data = data,
     )
 
 def redpanda_cc_btest(

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -67,6 +67,9 @@ redpanda_cc_gtest(
     srcs = [
         "manifest_serialization_test.cc",
     ],
+    data = [
+        "testdata/nested_manifest.avro",
+    ],
     deps = [
         ":test_schemas",
         "//src/v/base",
@@ -81,6 +84,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:manifest_list_avro",
         "//src/v/iceberg:schema_json",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:runfiles",
         "//src/v/utils:file_io",
         "@avro",
         "@googletest//:gtest",

--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -19,6 +19,7 @@
 #include "iceberg/manifest_list_avro.h"
 #include "iceberg/schema_json.h"
 #include "iceberg/tests/test_schemas.h"
+#include "test_utils/runfiles.h"
 #include "utils/file_io.h"
 
 #include <seastar/core/temporary_buffer.hh>
@@ -273,8 +274,13 @@ TEST(ManifestSerializationTest, TestManifestAvroReaderWriter) {
 }
 
 TEST(ManifestSerializationTest, TestSerializeManifestData) {
+    auto manifest_path = test_utils::get_runfile_path(
+      "src/v/iceberg/tests/testdata/nested_manifest.avro");
+    if (!manifest_path.has_value()) {
+        manifest_path = "nested_manifest.avro";
+    }
     auto orig_buf = iobuf{
-      ss::util::read_entire_file("nested_manifest.avro").get0()};
+      ss::util::read_entire_file(manifest_path.value()).get0()};
     auto m = parse_manifest(orig_buf.copy());
     ASSERT_EQ(100, m.entries.size());
     ASSERT_EQ(m.metadata.manifest_content_type, manifest_content_type::data);

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -58,3 +58,24 @@ redpanda_test_cc_library(
         "@abseil-cpp//absl/container:node_hash_set",
     ],
 )
+
+redpanda_test_cc_library(
+    name = "runfiles",
+    srcs = [
+        "runfiles.cc",
+    ],
+    hdrs = [
+        "runfiles.h",
+    ],
+    implementation_deps = [
+        "@bazel_tools//tools/cpp/runfiles",
+        "@fmt",
+    ],
+    include_prefix = "test_utils",
+    # TODO(bazel) when cmake build is removed then this can be removed, and its
+    # associated used in runfiles.cc.
+    local_defines = [
+        "BAZEL_TEST=1",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/v/test_utils/CMakeLists.txt
+++ b/src/v/test_utils/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
   SRCS
     gtest_main.cc
     gtest_utils.cc
+    runfiles.cc
   DEPS Seastar::seastar Seastar::seastar_testing GTest::gtest GTest::gmock v::bytes_random)
 
 add_subdirectory(tests)

--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -1,0 +1,29 @@
+#include "test_utils/runfiles.h"
+
+#ifdef BAZEL_TEST
+#include "tools/cpp/runfiles/runfiles.h"
+#endif
+
+#include <fmt/format.h>
+
+#include <memory>
+
+namespace test_utils {
+
+std::optional<std::string>
+get_runfile_path([[maybe_unused]] std::string_view path) {
+#ifdef BAZEL_TEST
+    using bazel::tools::cpp::runfiles::Runfiles;
+    std::string error;
+    std::unique_ptr<Runfiles> runfiles(
+      Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+    if (runfiles == nullptr) {
+        throw std::runtime_error(error);
+    }
+    return runfiles->Rlocation(fmt::format("_main/{}", path));
+#else
+    return std::nullopt;
+#endif
+}
+
+} // namespace test_utils

--- a/src/v/test_utils/runfiles.h
+++ b/src/v/test_utils/runfiles.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace test_utils {
+
+/*
+ * Usage:
+ *  - Add a `data = [path/to/some.file]` to the test target
+ *  - Call get_runfile_path with "root/.../path/to/some.file"
+ *
+ * If the return value is std::nullopt then it means that the test is being
+ * compiled with CMake. Otherwise, it is compiled with Bazel and the return
+ * value contains the path to the data file.
+ */
+std::optional<std::string> get_runfile_path(std::string_view);
+
+} // namespace test_utils


### PR DESCRIPTION
Fixes bazel test for iceberg and adds helper for getting data into tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

