### PR TITLE
`cluster`: don't apply invalid property change in `topic_table`

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -869,78 +869,87 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       != data_migrations::migrated_resource_state::non_restricted) {
         co_return errc::resource_is_being_migrated;
     }
-    auto& properties = tp->second.get_configuration().properties;
-    auto properties_snapshot = properties;
+    auto updated_properties = tp->second.get_configuration().properties;
     auto& overrides = cmd.value;
     /**
      * Update topic properties
      */
     incremental_update(
-      properties.cleanup_policy_bitflags, overrides.cleanup_policy_bitflags);
+      updated_properties.cleanup_policy_bitflags,
+      overrides.cleanup_policy_bitflags);
     incremental_update(
-      properties.compaction_strategy, overrides.compaction_strategy);
-    incremental_update(properties.compression, overrides.compression);
-    incremental_update(properties.retention_bytes, overrides.retention_bytes);
+      updated_properties.compaction_strategy, overrides.compaction_strategy);
+    incremental_update(updated_properties.compression, overrides.compression);
     incremental_update(
-      properties.retention_duration, overrides.retention_duration);
-    incremental_update(properties.segment_size, overrides.segment_size);
-    incremental_update(properties.timestamp_type, overrides.timestamp_type);
-
-    incremental_update(properties.shadow_indexing, overrides.shadow_indexing);
-    incremental_update(properties.batch_max_bytes, overrides.batch_max_bytes);
-
+      updated_properties.retention_bytes, overrides.retention_bytes);
     incremental_update(
-      properties.retention_local_target_bytes,
+      updated_properties.retention_duration, overrides.retention_duration);
+    incremental_update(updated_properties.segment_size, overrides.segment_size);
+    incremental_update(
+      updated_properties.timestamp_type, overrides.timestamp_type);
+    incremental_update(
+      updated_properties.shadow_indexing, overrides.shadow_indexing);
+    incremental_update(
+      updated_properties.batch_max_bytes, overrides.batch_max_bytes);
+    incremental_update(
+      updated_properties.retention_local_target_bytes,
       overrides.retention_local_target_bytes);
     incremental_update(
-      properties.retention_local_target_ms,
+      updated_properties.retention_local_target_ms,
       overrides.retention_local_target_ms);
     incremental_update(
-      properties.remote_delete,
+      updated_properties.remote_delete,
       overrides.remote_delete,
       storage::ntp_config::default_remote_delete);
-    incremental_update(properties.segment_ms, overrides.segment_ms);
+    incremental_update(updated_properties.segment_ms, overrides.segment_ms);
     incremental_update(
-      properties.record_key_schema_id_validation,
+      updated_properties.record_key_schema_id_validation,
       overrides.record_key_schema_id_validation);
     incremental_update(
-      properties.record_key_schema_id_validation_compat,
+      updated_properties.record_key_schema_id_validation_compat,
       overrides.record_key_schema_id_validation_compat);
     incremental_update(
-      properties.record_key_subject_name_strategy,
+      updated_properties.record_key_subject_name_strategy,
       overrides.record_key_subject_name_strategy);
     incremental_update(
-      properties.record_key_subject_name_strategy_compat,
+      updated_properties.record_key_subject_name_strategy_compat,
       overrides.record_key_subject_name_strategy_compat);
     incremental_update(
-      properties.record_value_schema_id_validation,
+      updated_properties.record_value_schema_id_validation,
       overrides.record_value_schema_id_validation);
     incremental_update(
-      properties.record_value_schema_id_validation_compat,
+      updated_properties.record_value_schema_id_validation_compat,
       overrides.record_value_schema_id_validation_compat);
     incremental_update(
-      properties.record_value_subject_name_strategy,
+      updated_properties.record_value_subject_name_strategy,
       overrides.record_value_subject_name_strategy);
     incremental_update(
-      properties.record_value_subject_name_strategy_compat,
+      updated_properties.record_value_subject_name_strategy_compat,
       overrides.record_value_subject_name_strategy_compat);
     incremental_update(
-      properties.initial_retention_local_target_bytes,
+      updated_properties.initial_retention_local_target_bytes,
       overrides.initial_retention_local_target_bytes);
     incremental_update(
-      properties.initial_retention_local_target_ms,
+      updated_properties.initial_retention_local_target_ms,
       overrides.initial_retention_local_target_ms);
-    incremental_update(properties.write_caching, overrides.write_caching);
-    incremental_update(properties.flush_ms, overrides.flush_ms);
-    incremental_update(properties.flush_bytes, overrides.flush_bytes);
+    incremental_update(
+      updated_properties.write_caching, overrides.write_caching);
+    incremental_update(updated_properties.flush_ms, overrides.flush_ms);
+    incremental_update(updated_properties.flush_bytes, overrides.flush_bytes);
+
+    auto& properties = tp->second.get_configuration().properties;
+
     // no configuration change, no need to generate delta
-    if (properties == properties_snapshot) {
+    if (updated_properties == properties) {
         co_return errc::success;
     }
 
-    if (!schema_id_validation_validator::is_valid(properties)) {
+    if (!schema_id_validation_validator::is_valid(updated_properties)) {
         co_return schema_id_validation_validator::ec;
     }
+
+    // Apply the changes
+    properties = std::move(updated_properties);
 
     // generate deltas for controller backend
     const auto& assignments = tp->second.get_assignments();


### PR DESCRIPTION
We check that the updated topic properties post `topic_table::apply(update_topic_properties_cmd)` is valid with the `schema_id_validation_validator`. However, this early `co_return` with an error code does not actually prevent the invalid configuration from being persisted in the `topic_table`.

Rework the logic in `topic_table::apply()` to prevent persisting of an invalid configuration.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug that resulted in persisting an invalid `topic_properties` configuration in the `topic_table`.

