### PR TITLE
kafka: clean up txn_reader dependencies

### DIFF
--- a/src/v/kafka/utils/BUILD
+++ b/src/v/kafka/utils/BUILD
@@ -8,16 +8,16 @@ redpanda_cc_library(
     hdrs = [
         "txn_reader.h",
     ],
-    include_prefix = "kafka/utils",
-    visibility = ["//visibility:public"],
-    deps = [
+    implementation_deps = [
         "//src/v/kafka/server",
-        "//src/v/model",
-        "//src/v/ssx:future_util",
-        "//src/v/ssx:sformat",
         "//src/v/storage",
         "@abseil-cpp//absl/container:btree",
         "@fmt",
+    ],
+    include_prefix = "kafka/utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/model",
         "@seastar",
     ],
 )

--- a/src/v/kafka/utils/tests/txn_reader_test.cc
+++ b/src/v/kafka/utils/tests/txn_reader_test.cc
@@ -28,7 +28,7 @@
 #include <seastar/util/variant_utils.hh>
 
 #include <absl/algorithm/container.h>
-#include <absl/container/btree_set.h>
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -16,7 +16,6 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
-#include "model/timestamp.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
@@ -25,13 +24,10 @@
 
 #include <absl/container/btree_set.h>
 
-#include <algorithm>
 #include <functional>
-#include <iterator>
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <ranges>
 #include <vector>
 
 namespace kafka {

--- a/src/v/kafka/utils/txn_reader.h
+++ b/src/v/kafka/utils/txn_reader.h
@@ -8,22 +8,23 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#pragma once
 
-#include "kafka/server/fwd.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
-#include "ssx/sformat.h"
-#include "storage/fwd.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/shared_ptr.hh>
 
-#include <absl/container/btree_map.h>
-#include <fmt/ostream.h>
-
 #include <memory>
 
+namespace storage {
+class offset_translator_state;
+}
+
 namespace kafka {
+
+class partition_proxy;
 
 // An interface for computing what transactions are aborted within a given range
 // of a partition.


### PR DESCRIPTION
kafka: clean up txn_reader dependencies

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
