### PR TITLE
CORE-6861 Schema Registry: verbose compat checks for JSON

### DIFF
--- a/src/v/pandaproxy/schema_registry/compatibility.cc
+++ b/src/v/pandaproxy/schema_registry/compatibility.cc
@@ -148,6 +148,250 @@ ss::sstring proto_incompatibility::describe() const {
       fmt::arg("path", _path.string()));
 }
 
+std::ostream& operator<<(std::ostream& os, const json_incompatibility_type& t) {
+    switch (t) {
+    case json_incompatibility_type::type_narrowed:
+        return os << "TYPE_NARROWED";
+    case json_incompatibility_type::type_changed:
+        return os << "TYPE_CHANGED";
+    case json_incompatibility_type::max_length_added:
+        return os << "MAX_LENGTH_ADDED";
+    case json_incompatibility_type::max_length_decreased:
+        return os << "MAX_LENGTH_DECREASED";
+    case json_incompatibility_type::min_length_added:
+        return os << "MIN_LENGTH_ADDED";
+    case json_incompatibility_type::min_length_increased:
+        return os << "MIN_LENGTH_INCREASED";
+    case json_incompatibility_type::pattern_added:
+        return os << "PATTERN_ADDED";
+    case json_incompatibility_type::pattern_changed:
+        return os << "PATTERN_CHANGED";
+    case json_incompatibility_type::maximum_added:
+        return os << "MAXIMUM_ADDED";
+    case json_incompatibility_type::maximum_decreased:
+        return os << "MAXIMUM_DECREASED";
+    case json_incompatibility_type::minimum_added:
+        return os << "MINIMUM_ADDED";
+    case json_incompatibility_type::minimum_increased:
+        return os << "MINIMUM_INCREASED";
+    case json_incompatibility_type::exclusive_maximum_added:
+        return os << "EXCLUSIVE_MAXIMUM_ADDED";
+    case json_incompatibility_type::exclusive_maximum_decreased:
+        return os << "EXCLUSIVE_MAXIMUM_DECREASED";
+    case json_incompatibility_type::exclusive_minimum_added:
+        return os << "EXCLUSIVE_MINIMUM_ADDED";
+    case json_incompatibility_type::exclusive_minimum_increased:
+        return os << "EXCLUSIVE_MINIMUM_INCREASED";
+    case json_incompatibility_type::multiple_of_added:
+        return os << "MULTIPLE_OF_ADDED";
+    case json_incompatibility_type::multiple_of_expanded:
+        return os << "MULTIPLE_OF_EXPANDED";
+    case json_incompatibility_type::multiple_of_changed:
+        return os << "MULTIPLE_OF_CHANGED";
+    case json_incompatibility_type::required_attribute_added:
+        return os << "REQUIRED_ATTRIBUTE_ADDED";
+    case json_incompatibility_type::max_properties_added:
+        return os << "MAX_PROPERTIES_ADDED";
+    case json_incompatibility_type::max_properties_decreased:
+        return os << "MAX_PROPERTIES_DECREASED";
+    case json_incompatibility_type::min_properties_added:
+        return os << "MIN_PROPERTIES_ADDED";
+    case json_incompatibility_type::min_properties_increased:
+        return os << "MIN_PROPERTIES_INCREASED";
+    case json_incompatibility_type::additional_properties_removed:
+        return os << "ADDITIONAL_PROPERTIES_REMOVED";
+    case json_incompatibility_type::additional_properties_narrowed:
+        return os << "ADDITIONAL_PROPERTIES_NARROWED";
+    case json_incompatibility_type::dependency_array_added:
+        return os << "DEPENDENCY_ARRAY_ADDED";
+    case json_incompatibility_type::dependency_array_extended:
+        return os << "DEPENDENCY_ARRAY_EXTENDED";
+    case json_incompatibility_type::dependency_array_changed:
+        return os << "DEPENDENCY_ARRAY_CHANGED";
+    case json_incompatibility_type::dependency_schema_added:
+        return os << "DEPENDENCY_SCHEMA_ADDED";
+    case json_incompatibility_type::property_added_to_open_content_model:
+        return os << "PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL";
+    case json_incompatibility_type::
+      required_property_added_to_unopen_content_model:
+        return os << "REQUIRED_PROPERTY_ADDED_TO_UNOPEN_CONTENT_MODEL";
+    case json_incompatibility_type::property_removed_from_closed_content_model:
+        return os << "PROPERTY_REMOVED_FROM_CLOSED_CONTENT_MODEL";
+    case json_incompatibility_type::
+      property_removed_not_covered_by_partially_open_content_model:
+        return os << "PROPERTY_REMOVED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_"
+                     "MODEL";
+    case json_incompatibility_type::
+      property_added_not_covered_by_partially_open_content_model:
+        return os
+               << "PROPERTY_ADDED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL";
+    case json_incompatibility_type::reserved_property_removed:
+        return os << "RESERVED_PROPERTY_REMOVED";
+    case json_incompatibility_type::reserved_property_conflicts_with_property:
+        return os << "RESERVED_PROPERTY_CONFLICTS_WITH_PROPERTY";
+    case json_incompatibility_type::max_items_added:
+        return os << "MAX_ITEMS_ADDED";
+    case json_incompatibility_type::max_items_decreased:
+        return os << "MAX_ITEMS_DECREASED";
+    case json_incompatibility_type::min_items_added:
+        return os << "MIN_ITEMS_ADDED";
+    case json_incompatibility_type::min_items_increased:
+        return os << "MIN_ITEMS_INCREASED";
+    case json_incompatibility_type::unique_items_added:
+        return os << "UNIQUE_ITEMS_ADDED";
+    case json_incompatibility_type::additional_items_removed:
+        return os << "ADDITIONAL_ITEMS_REMOVED";
+    case json_incompatibility_type::additional_items_narrowed:
+        return os << "ADDITIONAL_ITEMS_NARROWED";
+    case json_incompatibility_type::item_added_to_open_content_model:
+        return os << "ITEM_ADDED_TO_OPEN_CONTENT_MODEL";
+    case json_incompatibility_type::item_removed_from_closed_content_model:
+        return os << "ITEM_REMOVED_FROM_CLOSED_CONTENT_MODEL";
+    case json_incompatibility_type::
+      item_removed_not_covered_by_partially_open_content_model:
+        return os << "ITEM_REMOVED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL";
+    case json_incompatibility_type::
+      item_added_not_covered_by_partially_open_content_model:
+        return os << "ITEM_ADDED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL";
+    case json_incompatibility_type::enum_array_narrowed:
+        return os << "ENUM_ARRAY_NARROWED";
+    case json_incompatibility_type::enum_array_changed:
+        return os << "ENUM_ARRAY_CHANGED";
+    case json_incompatibility_type::combined_type_changed:
+        return os << "COMBINED_TYPE_CHANGED";
+    case json_incompatibility_type::product_type_extended:
+        return os << "PRODUCT_TYPE_EXTENDED";
+    case json_incompatibility_type::sum_type_extended:
+        return os << "SUM_TYPE_EXTENDED";
+    case json_incompatibility_type::sum_type_narrowed:
+        return os << "SUM_TYPE_NARROWED";
+    case json_incompatibility_type::combined_type_subschemas_changed:
+        return os << "COMBINED_TYPE_SUBSCHEMAS_CHANGED";
+    case json_incompatibility_type::not_type_extended:
+        return os << "NOT_TYPE_EXTENDED";
+    case json_incompatibility_type::unknown:
+        return os << "UNKNOWN";
+    }
+    __builtin_unreachable();
+}
+
+std::string_view description_for_type(json_incompatibility_type t) {
+    switch (t) {
+    case json_incompatibility_type::maximum_added:
+    case json_incompatibility_type::minimum_added:
+    case json_incompatibility_type::exclusive_maximum_added:
+    case json_incompatibility_type::exclusive_minimum_added:
+    case json_incompatibility_type::multiple_of_added:
+    case json_incompatibility_type::max_length_added:
+    case json_incompatibility_type::min_length_added:
+    case json_incompatibility_type::pattern_added:
+    case json_incompatibility_type::required_attribute_added:
+    case json_incompatibility_type::max_properties_added:
+    case json_incompatibility_type::min_properties_added:
+    case json_incompatibility_type::dependency_array_added:
+    case json_incompatibility_type::dependency_schema_added:
+    case json_incompatibility_type::max_items_added:
+    case json_incompatibility_type::min_items_added:
+    case json_incompatibility_type::unique_items_added:
+    case json_incompatibility_type::additional_items_removed:
+    case json_incompatibility_type::additional_properties_removed:
+        return "The keyword at path '{path}' in the {{reader}} schema is not "
+               "present in the {{writer}} schema";
+    case json_incompatibility_type::min_length_increased:
+    case json_incompatibility_type::minimum_increased:
+    case json_incompatibility_type::exclusive_minimum_increased:
+    case json_incompatibility_type::min_properties_increased:
+    case json_incompatibility_type::multiple_of_expanded:
+    case json_incompatibility_type::min_items_increased:
+        return "The value at path '{path}' in the {{reader}} schema is more "
+               "than its value in the {{writer}} schema";
+    case json_incompatibility_type::max_length_decreased:
+    case json_incompatibility_type::maximum_decreased:
+    case json_incompatibility_type::max_items_decreased:
+    case json_incompatibility_type::exclusive_maximum_decreased:
+    case json_incompatibility_type::max_properties_decreased:
+        return "The value at path '{path}' in the {{reader}} schema is less "
+               "than its value in the {{writer}} schema";
+    case json_incompatibility_type::additional_items_narrowed:
+    case json_incompatibility_type::enum_array_narrowed:
+    case json_incompatibility_type::sum_type_narrowed:
+    case json_incompatibility_type::additional_properties_narrowed:
+        return "An array or combined type at path '{path}' has fewer elements "
+               "in the {{reader}} schema than the {{writer}} schema";
+    case json_incompatibility_type::pattern_changed:
+    case json_incompatibility_type::multiple_of_changed:
+    case json_incompatibility_type::dependency_array_changed:
+        return "The value at path '{path}' is different between the {{reader}} "
+               "and {{writer}} schema";
+    case json_incompatibility_type::type_changed:
+    case json_incompatibility_type::type_narrowed:
+    case json_incompatibility_type::combined_type_changed:
+    case json_incompatibility_type::combined_type_subschemas_changed:
+    case json_incompatibility_type::enum_array_changed:
+        return "A type at path '{path}' is different between the {{reader}} "
+               "schema and the {{writer}} schema";
+    case json_incompatibility_type::dependency_array_extended:
+    case json_incompatibility_type::product_type_extended:
+    case json_incompatibility_type::sum_type_extended:
+    case json_incompatibility_type::not_type_extended:
+        return "An array or combined type at path '{path}' has more elements "
+               "in the {{reader}} schema than the {{writer}} schema";
+    case json_incompatibility_type::property_added_to_open_content_model:
+    case json_incompatibility_type::item_added_to_open_content_model:
+        return "The {{reader}} schema has an open content model and has a "
+               "property or item at path '{path}' which is missing in the "
+               "{{writer}} schema";
+    case json_incompatibility_type::
+      required_property_added_to_unopen_content_model:
+        return "The {{reader}} schema has an unopen content model and has a "
+               "required property at path '{path}' which is missing in the "
+               "{{writer}} schema";
+    case json_incompatibility_type::property_removed_from_closed_content_model:
+    case json_incompatibility_type::item_removed_from_closed_content_model:
+        return "The {{reader}} has a closed content model and is missing a "
+               "property or item present at path '{path}' in the {{writer}} "
+               "schema";
+    case json_incompatibility_type::
+      property_removed_not_covered_by_partially_open_content_model:
+    case json_incompatibility_type::
+      item_removed_not_covered_by_partially_open_content_model:
+        return "A property or item is missing in the {{reader}} schema but "
+               "present at path '{path}' in the {{writer}} schema and is not "
+               "covered by its partially open content model";
+    case json_incompatibility_type::
+      property_added_not_covered_by_partially_open_content_model:
+    case json_incompatibility_type::
+      item_added_not_covered_by_partially_open_content_model:
+        return "The {{reader}} schema has a property or item at path '{path}' "
+               "which is missing in the {{writer}} schema and is not covered "
+               "by its partially open content model";
+    case json_incompatibility_type::reserved_property_removed:
+        return "The {{reader}} schema has reserved property '{path}' removed "
+               "from its metadata which is present in the {{writer}} schema.";
+    case json_incompatibility_type::reserved_property_conflicts_with_property:
+        return "The {{reader}} schema has property at path '{path}' that "
+               "conflicts with the reserved properties which is missing in the "
+               "{{writer}} schema.";
+
+    case json_incompatibility_type::unknown:
+        return "{{reader}} schema is not compatible with {{writer}} schema: "
+               "check '{path}'";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& os, const json_incompatibility& v) {
+    fmt::print(
+      os, R"({{errorType:"{}", description:"{}"}})", v._type, v.describe());
+    return os;
+}
+
+ss::sstring json_incompatibility::describe() const {
+    return fmt::format(
+      fmt::runtime(description_for_type(_type)),
+      fmt::arg("path", _path.string()));
+}
+
 compatibility_result
 raw_compatibility_result::operator()(verbose is_verbose) && {
     compatibility_result result = {.is_compat = !has_error()};

--- a/src/v/pandaproxy/schema_registry/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/compatibility.h
@@ -155,6 +155,15 @@ public:
     template<typename T, typename... Args>
     requires std::constructible_from<T, Args&&...>
              && std::convertible_to<T, schema_incompatibility>
+    static auto of(Args&&... args) {
+        raw_compatibility_result res;
+        res.emplace<T>(std::forward<Args>(args)...);
+        return res;
+    }
+
+    template<typename T, typename... Args>
+    requires std::constructible_from<T, Args&&...>
+             && std::convertible_to<T, schema_incompatibility>
     auto emplace(Args&&... args) {
         return _errors.emplace_back(
           std::in_place_type<T>, std::forward<Args>(args)...);

--- a/src/v/pandaproxy/schema_registry/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/compatibility.h
@@ -136,6 +136,105 @@ private:
     Type _type;
 };
 
+enum class json_incompatibility_type {
+    type_narrowed = 0,
+    type_changed,
+    max_length_added,
+    max_length_decreased,
+    min_length_added,
+    min_length_increased,
+    pattern_added,
+    pattern_changed,
+    maximum_added,
+    maximum_decreased,
+    minimum_added,
+    minimum_increased,
+    exclusive_maximum_added,
+    exclusive_maximum_decreased,
+    exclusive_minimum_added,
+    exclusive_minimum_increased,
+    multiple_of_added,
+    multiple_of_expanded,
+    multiple_of_changed,
+    required_attribute_added,
+    max_properties_added,
+    max_properties_decreased,
+    min_properties_added,
+    min_properties_increased,
+    additional_properties_removed,
+    additional_properties_narrowed,
+    dependency_array_added,
+    dependency_array_extended,
+    dependency_array_changed,
+    dependency_schema_added,
+    property_added_to_open_content_model,
+    required_property_added_to_unopen_content_model,
+    property_removed_from_closed_content_model,
+    property_removed_not_covered_by_partially_open_content_model,
+    property_added_not_covered_by_partially_open_content_model,
+    reserved_property_removed,
+    reserved_property_conflicts_with_property,
+    max_items_added,
+    max_items_decreased,
+    min_items_added,
+    min_items_increased,
+    unique_items_added,
+    additional_items_removed,
+    additional_items_narrowed,
+    item_added_to_open_content_model,
+    item_removed_from_closed_content_model,
+    item_removed_not_covered_by_partially_open_content_model,
+    item_added_not_covered_by_partially_open_content_model,
+    enum_array_narrowed,
+    enum_array_changed,
+    combined_type_changed,
+    product_type_extended,
+    sum_type_extended,
+    sum_type_narrowed,
+    combined_type_subschemas_changed,
+    not_type_extended,
+    unknown,
+};
+
+/**
+ * json_incompatibility - A single incompatibility between JSON schemas.
+ *
+ * Encapsulates:
+ *   - the path to the location of the incompatibility in the _writer_ schema
+ *   - the type of incompatibility
+ *
+ * Primary interface is `describe`, which combines the contained info into
+ * a format string which can then be interpolated with identifying info for
+ * the reader and writer schemas in the request handler.
+ */
+class json_incompatibility {
+public:
+    using Type = json_incompatibility_type;
+    json_incompatibility(std::filesystem::path path, Type type)
+      : _path(std::move(path))
+      , _type(type) {}
+
+    ss::sstring describe() const;
+    Type type() const { return _type; }
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const json_incompatibility& v);
+
+    friend bool
+    operator==(const json_incompatibility&, const json_incompatibility&)
+      = default;
+
+    // Helpful for unit testing
+    template<typename H>
+    friend H AbslHashValue(H h, const json_incompatibility& e) {
+        return H::combine(std::move(h), e._path.string(), e._type);
+    }
+
+private:
+    std::filesystem::path _path;
+    Type _type;
+};
+
 /**
  * raw_compatibility_result - A collection of unformatted proto or avro
  * incompatibilities. Its purpose is twofold:
@@ -146,8 +245,10 @@ private:
  *     incompatibilities into formatted error messages.
  */
 class raw_compatibility_result {
-    using schema_incompatibility
-      = std::variant<avro_incompatibility, proto_incompatibility>;
+    using schema_incompatibility = std::variant<
+      avro_incompatibility,
+      proto_incompatibility,
+      json_incompatibility>;
 
 public:
     raw_compatibility_result() = default;

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -18,6 +18,7 @@
 #include "json/schema.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
@@ -50,12 +51,15 @@
 #include <re2/re2.h>
 
 #include <exception>
+#include <filesystem>
 #include <ranges>
 #include <string_view>
 
 namespace pandaproxy::schema_registry {
 
 namespace {
+
+using json_compatibility_result = raw_compatibility_result;
 
 // this is the list of supported dialects
 enum class json_schema_dialect {
@@ -107,6 +111,10 @@ struct document_context {
     json::Document doc;
     json_schema_dialect dialect;
 };
+
+// Passed into is_superset_* methods where the path and the generated verbose
+// incompatibilities don't matter, only whether they are compatible or not
+const static std::filesystem::path ignored_path = "";
 
 } // namespace
 
@@ -365,8 +373,11 @@ result<document_context> parse_json(iobuf buf) {
 // a schema O is a superset of another schema N if every schema that is valid
 // for N is also valid for O. precondition: older and newer are both valid
 // schemas
-bool is_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer);
+json_compatibility_result is_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p);
 
 // close the implementation in a namespace to keep it contained
 namespace is_superset_impl {
@@ -614,11 +625,13 @@ extract_property_and_gate_check(
 //  value  |  value  | is_same or predicate
 template<typename VPred>
 requires std::is_invocable_r_v<bool, VPred, double, double>
-bool is_numeric_property_value_superset(
+json_compatibility_result is_numeric_property_value_superset(
   json::Value const& older,
   json::Value const& newer,
   std::string_view prop_name,
   VPred&& value_predicate,
+  json_incompatibility changed_err,
+  json_incompatibility added_err,
   std::optional<double> default_value = std::nullopt) {
     // get value or default_value
     auto get_value = [&](json::Value const& v) -> std::optional<double> {
@@ -655,26 +668,29 @@ bool is_numeric_property_value_superset(
               std::forward<VPred>(value_predicate),
               *older_value,
               *newer_value)) {
-            return false;
+            return json_compatibility_result::of<json_incompatibility>(
+              changed_err);
         }
     } else if (older_value.has_value()) {
         if (!default_value.has_value() || *older_value != *default_value) {
             // Non-default value was removed
-            return false;
+            return json_compatibility_result::of<json_incompatibility>(
+              added_err);
         }
     }
 
     // Value only in newer or neither
-    return true;
+    return json_compatibility_result{};
 }
 
 enum class additional_field_for { object, array };
 
-bool is_additional_superset(
+json_compatibility_result is_additional_superset(
   context const& ctx,
   json::Value const& older,
   json::Value const& newer,
-  additional_field_for field_type) {
+  additional_field_for field_type,
+  std::filesystem::path p) {
     // "additional___" can be either true (if omitted it's true), false
     // or a schema. The check is performed with this table.
     // older ap | newer ap | compatible
@@ -704,7 +720,22 @@ bool is_additional_superset(
             }
         }
     };
-
+    auto [additional_path, narrowed_errt, removed_errt] = [&] {
+        switch (field_type) {
+        case additional_field_for::object:
+            return std::make_tuple(
+              p / "additionalProperties",
+              json_incompatibility_type::additional_properties_narrowed,
+              json_incompatibility_type::additional_properties_removed);
+        case additional_field_for::array:
+            // Even for draft 202012 "additionalItems" is used in the path not
+            // "items"
+            return std::make_tuple(
+              p / "additionalItems",
+              json_incompatibility_type::additional_items_narrowed,
+              json_incompatibility_type::additional_items_removed);
+        }
+    }();
     // helper to parse additional__
     auto get_additional_props = [&](json_schema_dialect d, json::Value const& v)
       -> std::variant<bool, json::Value const*> {
@@ -722,64 +753,97 @@ bool is_additional_superset(
     // additionalProperties are boolean
     return std::visit(
       ss::make_visitor(
-        [](bool older, bool newer) {
-            if (older == newer) {
-                // same value is compatible
-                return true;
+        [&additional_path, removed_errt](bool older, bool newer) {
+            if (older || !newer) {
+                return json_compatibility_result{};
             }
-            // older=true  -> newer=false - compatible
             // older=false -> newer=true  - not compatible
-            return older;
+            return json_compatibility_result::of<json_incompatibility>(
+              std::move(additional_path), removed_errt);
         },
-        [&ctx](bool older, json::Value const* newer) {
+        [&ctx, &additional_path, removed_errt](
+          bool older, json::Value const* newer) {
             if (older) {
                 // true is compatible with any schema
-                return true;
+                return json_compatibility_result{};
             }
             // likely false, but need to check
-            return is_superset(ctx, get_false_schema(), *newer);
+            if (is_superset(ctx, get_false_schema(), *newer, ignored_path)
+                  .has_error()) {
+                return json_compatibility_result::of<json_incompatibility>(
+                  std::move(additional_path), removed_errt);
+            }
+            return json_compatibility_result{};
         },
-        [&ctx](json::Value const* older, bool newer) {
+        [&ctx, &additional_path, narrowed_errt](
+          json::Value const* older, bool newer) {
             if (!newer) {
                 // any schema is compatible with false
-                return true;
+                return json_compatibility_result{};
             }
             // convert newer to {} and check against that
-            return is_superset(ctx, *older, get_true_schema());
+            if (is_superset(ctx, *older, get_true_schema(), ignored_path)
+                  .has_error()) {
+                return json_compatibility_result::of<json_incompatibility>(
+                  std::move(additional_path), narrowed_errt);
+            }
+            return json_compatibility_result{};
         },
-        [&ctx](json::Value const* older, json::Value const* newer) {
+        [&ctx,
+         &additional_path](json::Value const* older, json::Value const* newer) {
             // check subschemas for compatibility
-            return is_superset(ctx, *older, *newer);
+            return is_superset(ctx, *older, *newer, std::move(additional_path));
         }),
       get_additional_props(ctx.older.dialect(), older),
       get_additional_props(ctx.newer.dialect(), newer));
 }
 
-bool is_string_superset(json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_string_superset(
+  json::Value const& older, json::Value const& newer, std::filesystem::path p) {
+    json_compatibility_result res;
+
     // note: "format" is not part of the checks
-    if (!is_numeric_property_value_superset(
-          older, newer, "minLength", std::less_equal<>{}, 0)) {
-        // older is less strict
-        return false;
-    }
-    if (!is_numeric_property_value_superset(
-          older, newer, "maxLength", std::greater_equal<>{})) {
-        // older is less strict
-        return false;
-    }
+
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "minLength",
+      std::less_equal<>{},
+      {p / "minLength", json_incompatibility_type::min_length_increased},
+      {p / "minLength", json_incompatibility_type::min_length_added},
+      0));
+
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "maxLength",
+      std::greater_equal<>{},
+      {p / "maxLength", json_incompatibility_type::max_length_decreased},
+      {p / "maxLength", json_incompatibility_type::max_length_added}));
 
     auto [maybe_gate_value, older_val_p, newer_val_p]
       = extract_property_and_gate_check(older, newer, "pattern");
     if (maybe_gate_value.has_value()) {
-        return maybe_gate_value.value();
+        if (!maybe_gate_value.value()) {
+            res.emplace<json_incompatibility>(
+              p / "pattern", json_incompatibility_type::pattern_added);
+        }
+        return res;
     }
 
     // both have "pattern". check if they are the same, the only
     // possible_value_accepted
-    return as_string_view(*older_val_p) == as_string_view(*newer_val_p);
+    if (as_string_view(*older_val_p) != as_string_view(*newer_val_p)) {
+        res.emplace<json_incompatibility>(
+          p / "pattern", json_incompatibility_type::pattern_changed);
+    }
+    return res;
 }
 
-bool is_numeric_superset(json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_numeric_superset(
+  json::Value const& older, json::Value const& newer, std::filesystem::path p) {
+    json_compatibility_result res;
+
     // preconditions:
     // newer["type"]=="number" implies older["type"]=="number"
     // older["type"]=="integer" implies newer["type"]=="integer"
@@ -793,41 +857,56 @@ bool is_numeric_superset(json::Value const& older, json::Value const& newer) {
     // "exclusiveMinimum" is always the exclusive range. in this check we
     // require for them to be the same datatype
 
-    if (!is_numeric_property_value_superset(
-          older, newer, "minimum", std::less_equal<>{})) {
-        // older["minimum"] is not superset of newer["minimum"] because newer is
-        // less strict
-        return false;
-    }
-    if (!is_numeric_property_value_superset(
-          older, newer, "maximum", std::greater_equal<>{})) {
-        // older["maximum"] is not superset of newer["maximum"] because newer
-        // is less strict
-        return false;
-    }
+    // older["minimum"] is not superset of newer["minimum"] because newer is
+    // less strict
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "minimum",
+      std::less_equal<>{},
+      {p / "minimum", json_incompatibility_type::minimum_increased},
+      {p / "minimum", json_incompatibility_type::minimum_added}));
 
-    if (!is_numeric_property_value_superset(
-          older, newer, "multipleOf", [](double older, double newer) {
-              // check that the reminder of newer/older is close enough to 0.
-              // close enough is defined as being close to the Unit in the Last
-              // Place of the bigger between the two.
-              // TODO: this is an approximate check, if a bigdecimal
-              // representation it would be possible to perform an exact
-              // reminder(newer, older)==0 check
-              constexpr auto max_ulp_error = 3;
-              return std::abs(std::remainder(newer, older))
-                     <= (max_ulp_error * boost::math::ulp(newer));
-          })) {
-        return false;
-    }
+    // older["maximum"] is not superset of newer["maximum"] because newer is
+    // less strict
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "maximum",
+      std::greater_equal<>{},
+      {p / "maximum", json_incompatibility_type::maximum_decreased},
+      {p / "maximum", json_incompatibility_type::maximum_added}));
+
+    // TODO: return multiple_of_expanded instead of multiple_of_changed if older
+    // is a multiple of newer
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "multipleOf",
+      [](double older, double newer) {
+          // check that the reminder of newer/older is close enough to 0.
+          // close enough is defined as being close to the Unit in the Last
+          // Place of the bigger between the two.
+          // TODO: this is an approximate check, if a bigdecimal
+          // representation it would be possible to perform an exact
+          // reminder(newer, older)==0 check
+          constexpr auto max_ulp_error = 3;
+          return std::abs(std::remainder(newer, older))
+                 <= (max_ulp_error * boost::math::ulp(newer));
+      },
+      {p / "multipleOf", json_incompatibility_type::multiple_of_changed},
+      {p / "multipleOf", json_incompatibility_type::multiple_of_added}));
 
     // exclusiveMinimum/exclusiveMaximum checks are mostly the same logic,
     // implemented in this helper
-    auto exclusive_limit_check = [](
-                                   json::Value const& older,
-                                   json::Value const& newer,
-                                   std::string_view prop_name,
-                                   std::invocable<double, double> auto pred) {
+    auto exclusive_limit_check =
+      [](
+        json::Value const& older,
+        json::Value const& newer,
+        std::string_view prop_name,
+        std::invocable<double, double> auto pred,
+        json_compatibility_result changed_err,
+        json_compatibility_result added_err) -> json_compatibility_result {
         auto get_value = [=](json::Value const& v)
           -> std::variant<std::monostate, bool, double> {
             auto it = v.FindMember(json::Value{
@@ -850,27 +929,36 @@ bool is_numeric_superset(json::Value const& older, json::Value const& newer) {
 
         return std::visit(
           ss::make_visitor(
-            [](bool older, bool newer) {
+            [&](bool older, bool newer) {
                 // compatible if no change or if older was not "exclusive"
-                return older == newer || older == false;
+                if (older != newer && older != false) {
+                    return changed_err;
+                }
+                return json_compatibility_result{};
             },
-            [](bool older, std::monostate) {
+            [&](bool older, std::monostate) {
                 // monostate defaults to false, compatible if older is false
-                return older == false;
+                if (older != false) {
+                    return added_err;
+                }
+                return json_compatibility_result{};
             },
             [&](double older, double newer) {
                 // delegate to pred
-                return std::invoke(pred, older, newer);
+                if (!std::invoke(pred, older, newer)) {
+                    return changed_err;
+                }
+                return json_compatibility_result{};
             },
-            [](double, std::monostate) {
+            [&](double, std::monostate) {
                 // newer is less strict than older
-                return false;
+                return added_err;
             },
             [](std::monostate, auto) {
                 // older has no rules, compatible with everything
-                return true;
+                return json_compatibility_result{};
             },
-            [&](auto, auto) -> bool {
+            [&](auto, auto) -> json_compatibility_result {
                 throw as_exception(invalid_schema(fmt::format(
                   R"(is_numeric_superset-{} not implemented for mixed types: older: '{}', newer: '{}')",
                   prop_name,
@@ -881,21 +969,42 @@ bool is_numeric_superset(json::Value const& older, json::Value const& newer) {
           get_value(newer));
     };
 
-    if (!exclusive_limit_check(
-          older, newer, "exclusiveMinimum", std::less_equal<>{})) {
-        return false;
-    }
+    auto p_exlusive_minimum = p / "exclusiveMinimum";
+    res.merge(exclusive_limit_check(
+      older,
+      newer,
+      "exclusiveMinimum",
+      std::less_equal<>{},
+      json_compatibility_result::of<json_incompatibility>(
+        p_exlusive_minimum,
+        json_incompatibility_type::exclusive_minimum_increased),
+      json_compatibility_result::of<json_incompatibility>(
+        p_exlusive_minimum,
+        json_incompatibility_type::exclusive_minimum_added)));
 
-    if (!exclusive_limit_check(
-          older, newer, "exclusiveMaximum", std::greater_equal<>{})) {
-        return false;
-    }
+    auto p_exlusive_maximum = p / "exclusiveMaximum";
+    res.merge(exclusive_limit_check(
+      older,
+      newer,
+      "exclusiveMaximum",
+      std::greater_equal<>{},
+      json_compatibility_result::of<json_incompatibility>(
+        p_exlusive_maximum,
+        json_incompatibility_type::exclusive_maximum_decreased),
+      json_compatibility_result::of<json_incompatibility>(
+        p_exlusive_maximum,
+        json_incompatibility_type::exclusive_maximum_added)));
 
-    return true;
+    return res;
 }
 
-bool is_array_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_array_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
+
     // "type": "array" is used to model an array or a tuple.
     // for array, "items" is a schema that validates all the elements.
     // for tuple in Draft4, "items" is an array of schemas to validate the
@@ -907,15 +1016,22 @@ bool is_array_superset(
     // then is split based on array/tuple.
 
     // size checks are common to both types
-    if (!is_numeric_property_value_superset(
-          older, newer, "minItems", std::less_equal<>{}, 0)) {
-        return false;
-    }
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "minItems",
+      std::less_equal<>{},
+      {p / "minItems", json_incompatibility_type::min_items_increased},
+      {p / "minItems", json_incompatibility_type::min_items_added},
+      0));
 
-    if (!is_numeric_property_value_superset(
-          older, newer, "maxItems", std::greater_equal<>{})) {
-        return false;
-    }
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "maxItems",
+      std::greater_equal<>{},
+      {p / "maxItems", json_incompatibility_type::max_items_decreased},
+      {p / "maxItems", json_incompatibility_type::max_items_added}));
 
     // uniqueItems makes sense mostly for arrays, but it's also allowed for
     // tuples, so the validation is done here
@@ -939,7 +1055,8 @@ bool is_array_superset(
 
     if (older_value == true && newer_value == false) {
         // removed unique items requirement
-        return false;
+        res.emplace<json_incompatibility>(
+          p / "uniqueItems", json_incompatibility_type::unique_items_added);
     }
 
     // in draft 2020, "prefixItems" is used to represent tuples instead of an
@@ -983,7 +1100,9 @@ bool is_array_superset(
 
     if (older_is_tuple != newer_is_tuple) {
         // one is a tuple and the other is not. not compatible
-        return false;
+        res.emplace<json_incompatibility>(
+          p / "items", json_incompatibility_type::unknown);
+        return res;
     }
     // both are tuples or both are arrays
 
@@ -992,10 +1111,12 @@ bool is_array_superset(
         // note that "additionalItems" can be defined, but it's
         // not used by validation because every element is validated against
         // "items"
-        return is_superset(
+        res.merge(is_superset(
           ctx,
           get_object_or_empty(ctx.older, older, "items"),
-          get_object_or_empty(ctx.newer, newer, "items"));
+          get_object_or_empty(ctx.newer, newer, "items"),
+          p / "items"));
+        return res;
     }
 
     // both are tuple schemas, validation is similar to object. one side
@@ -1003,9 +1124,11 @@ bool is_array_superset(
 
     // first check is for "additionalItems" compatibility, it's cheaper than the
     // rest
-    if (!is_additional_superset(
-          ctx, older, newer, additional_field_for::array)) {
-        return false;
+
+    res.merge(is_additional_superset(
+      ctx, older, newer, additional_field_for::array, p));
+    if (res.has_error()) {
+        return res;
     }
 
     auto older_tuple_schema
@@ -1014,11 +1137,14 @@ bool is_array_superset(
       = newer[get_tuple_items_kw(ctx.newer.dialect())].GetArray();
     auto older_it = older_tuple_schema.begin();
     auto newer_it = newer_tuple_schema.begin();
+    int index = 0;
     for (; older_it != older_tuple_schema.end()
            && newer_it != newer_tuple_schema.end();
-         ++older_it, ++newer_it) {
-        if (!is_superset(ctx, *older_it, *newer_it)) {
-            return false;
+         ++older_it, ++newer_it, ++index) {
+        res.merge(is_superset(
+          ctx, *older_it, *newer_it, p / "items" / std::to_string(index)));
+        if (res.has_error()) {
+            return res;
         }
     }
 
@@ -1036,15 +1162,35 @@ bool is_array_superset(
     auto excess_begin = newer_has_more ? newer_it : older_it;
     auto excess_end = newer_has_more ? newer_tuple_schema.end()
                                      : older_tuple_schema.end();
+    auto errt = newer_has_more
+                  ? json_incompatibility_type::
+                    item_removed_not_covered_by_partially_open_content_model
+                  : json_incompatibility_type::
+                    item_added_not_covered_by_partially_open_content_model;
 
-    return std::all_of(excess_begin, excess_end, [&](json::Value const& e) {
-        return newer_has_more ? is_superset(ctx, older_additional_schema, e)
-                              : is_superset(ctx, e, newer_additional_schema);
+    std::for_each(excess_begin, excess_end, [&](json::Value const& e) {
+        auto item_p = p / "items" / std::to_string(index);
+        auto sup_res = newer_has_more
+                         ? is_superset(ctx, older_additional_schema, e, item_p)
+                         : is_superset(ctx, e, newer_additional_schema, item_p);
+
+        if (sup_res.has_error()) {
+            res.merge(std::move(sup_res));
+            res.emplace<json_incompatibility>(std::move(item_p), errt);
+        }
+
+        ++index;
     });
+
+    return res;
 }
 
-bool is_object_properties_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_object_properties_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
     // check that every property in newer["properties"]
     // if it appears in older["properties"],
     //    then it has to be compatible with the schema
@@ -1056,7 +1202,7 @@ bool is_object_properties_superset(
     auto newer_properties = get_object_or_empty(ctx.newer, newer, "properties");
     if (newer_properties.ObjectEmpty()) {
         // no "properties" in newer, all good
-        return true;
+        return res;
     }
 
     // older["properties"] is a map of <prop, schema>
@@ -1069,14 +1215,15 @@ bool is_object_properties_superset(
       ctx.older, older, "additionalProperties");
     // scan every prop in newer["properties"]
     for (auto const& [prop, schema] : newer_properties) {
+        auto prop_path = [&p, &prop] {
+            return p / "properties" / prop.GetString();
+        };
+
         // it is either an evolution of a schema in older["properties"]
         if (auto older_it = older_properties.FindMember(prop);
             older_it != older_properties.MemberEnd()) {
             // prop exists in both
-            if (!is_superset(ctx, older_it->value, schema)) {
-                // not compatible
-                return false;
-            }
+            res.merge(is_superset(ctx, older_it->value, schema, prop_path()));
             // check next property
             continue;
         }
@@ -1091,28 +1238,60 @@ bool is_object_properties_superset(
             auto regex = re2::RE2(as_string_view(propPattern));
             if (re2::RE2::PartialMatch(pname, regex)) {
                 pattern_match_found = true;
-                if (!is_superset(ctx, schemaPattern, schema)) {
-                    // not compatible
-                    return false;
+
+                auto prop_res = is_superset(
+                  ctx, schemaPattern, schema, prop_path());
+
+                if (prop_res.has_error()) {
+                    res.merge(std::move(prop_res));
+                    res.emplace<json_incompatibility>(
+                      prop_path(),
+                      json_incompatibility_type::
+                        property_removed_not_covered_by_partially_open_content_model);
+                    break;
                 }
             }
+        }
+        if (pattern_match_found) {
+            // check next property
+            continue;
         }
 
         // or it should check against older["additionalProperties"], if no match
         // in patternProperties was found
-        if (
-          !pattern_match_found
-          && !is_superset(ctx, older_additional_properties, schema)) {
-            // not compatible
-            return false;
+        if (is_false_schema(older_additional_properties)) {
+            res.emplace<json_incompatibility>(
+              prop_path(),
+              json_incompatibility_type::
+                property_removed_from_closed_content_model);
+            continue;
         }
+
+        auto add_prop_res = is_superset(
+          ctx, older_additional_properties, schema, prop_path());
+
+        if (add_prop_res.has_error()) {
+            res.merge(std::move(add_prop_res));
+            res.emplace<json_incompatibility>(
+              prop_path(),
+              json_incompatibility_type::
+                property_removed_not_covered_by_partially_open_content_model);
+            continue;
+        }
+
+        // Additional properties matched. We can move on to the next property
+        // without any errors added to res.
     }
 
-    return true;
+    return res;
 }
 
-bool is_object_required_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_object_required_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
     // to pass the check, a required property from newer has to be present in
     // older, or if new it needs to have a default value.
     // note that:
@@ -1138,15 +1317,25 @@ bool is_object_required_superset(
     //       yes          |        yes         |  yes
     //       yes          |         no         |  if it has "default" in older
     //       no           |        yes         |  yes
-    return std::ranges::all_of(
+    std::ranges::for_each(
       older_req_in_both_properties, [&](json::Value const& o) {
-          return std::ranges::find(newer_req, o) != newer_req.End()
-                 || older_props[o].HasMember("default");
+          if (
+            std::ranges::find(newer_req, o) == newer_req.End()
+            && !older_props[o].HasMember("default")) {
+              res.emplace<json_incompatibility>(
+                p / "required" / as_string_view(o),
+                json_incompatibility_type::required_attribute_added);
+          }
       });
+    return res;
 }
 
-bool is_object_dependencies_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_object_dependencies_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
     // "dependencies", if present, is a dict of <property, string_array |
     // schema>. To be compatible, each key in older has to be in newer and the
     // values have to be of the same type and compatible.
@@ -1159,79 +1348,119 @@ bool is_object_dependencies_superset(
     // all dependencies in older need to carry over in newer, and need to be
     // compatible
     // TODO: n^2 search
-    return std::ranges::all_of(
-      older_p, [&](json::Value::Member const& older_dep) {
-          auto const& o = older_dep.value;
-          auto n_it = newer_p.FindMember(older_dep.name);
 
-          if (o.IsObject()) {
-              if (n_it == newer_p.MemberEnd()) {
-                  return false;
-              }
+    std::ranges::for_each(older_p, [&](json::Value::Member const& older_dep) {
+        auto path_dep = p / "dependencies" / as_string_view(older_dep.name);
+        auto const& o = older_dep.value;
+        auto n_it = newer_p.FindMember(older_dep.name);
 
-              auto const& n = n_it->value;
+        if (o.IsObject()) {
+            if (n_it == newer_p.MemberEnd()) {
+                res.emplace<json_incompatibility>(
+                  std::move(path_dep),
+                  json_incompatibility_type::dependency_schema_added);
+                return;
+            }
 
-              if (!n.IsObject()) {
-                  return false;
-              }
+            auto const& n = n_it->value;
 
-              // schemas: o and n needs to be compatible
-              return is_superset(ctx, o, n);
-          } else if (o.IsArray()) {
-              if (n_it == newer_p.MemberEnd()) {
-                  return false;
-              }
+            if (!n.IsObject()) {
+                res.emplace<json_incompatibility>(
+                  std::move(path_dep),
+                  json_incompatibility_type::dependency_schema_added);
+                return;
+            }
 
-              auto const& n = n_it->value;
+            // schemas: o and n needs to be compatible
+            res.merge(is_superset(ctx, o, n, std::move(path_dep)));
+        } else if (o.IsArray()) {
+            if (n_it == newer_p.MemberEnd()) {
+                res.emplace<json_incompatibility>(
+                  std::move(path_dep),
+                  json_incompatibility_type::dependency_array_added);
+                return;
+            }
 
-              if (!n.IsArray()) {
-                  return false;
-              }
-              // string array: n needs to be a a superset of o
-              // TODO: n^2 search
-              bool n_superset_of_o = std::ranges::all_of(
-                o.GetArray(), [n_array = n.GetArray()](json::Value const& p) {
-                    return std::ranges::find(n_array, p) != n_array.End();
-                });
-              if (!n_superset_of_o) {
-                  return false;
-              }
-              return true;
-          } else {
-              throw as_exception(invalid_schema(fmt::format(
-                "dependencies can only be an array or an object for valid "
-                "schemas but it was: {}",
-                pj{o})));
-          }
-      });
+            auto const& n = n_it->value;
+
+            if (!n.IsArray()) {
+                res.emplace<json_incompatibility>(
+                  std::move(path_dep),
+                  json_incompatibility_type::dependency_array_added);
+                return;
+            }
+            // string array: n needs to be a a superset of o
+            // TODO: n^2 search
+            bool n_superset_of_o = std::ranges::all_of(
+              o.GetArray(), [n_array = n.GetArray()](json::Value const& p) {
+                  return std::ranges::find(n_array, p) != n_array.End();
+              });
+            if (!n_superset_of_o) {
+                bool o_superset_of_n = std::ranges::all_of(
+                  n.GetArray(), [o_array = o.GetArray()](json::Value const& p) {
+                      return std::ranges::find(o_array, p) != o_array.End();
+                  });
+                if (o_superset_of_n) {
+                    res.emplace<json_incompatibility>(
+                      std::move(path_dep),
+                      json_incompatibility_type::dependency_array_extended);
+                } else {
+                    res.emplace<json_incompatibility>(
+                      std::move(path_dep),
+                      json_incompatibility_type::dependency_array_changed);
+                }
+            }
+            return;
+        } else {
+            throw as_exception(invalid_schema(fmt::format(
+              "dependencies can only be an array or an object for valid "
+              "schemas but it was: {}",
+              pj{o})));
+        }
+    });
+
+    return res;
 }
 
-bool is_object_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
-    if (!is_numeric_property_value_superset(
-          older, newer, "minProperties", std::less_equal<>{}, 0)) {
-        // newer requires less properties to be set
-        return false;
-    }
-    if (!is_numeric_property_value_superset(
-          older, newer, "maxProperties", std::greater_equal<>{})) {
-        // newer requires more properties to be set
-        return false;
-    }
-    if (!is_additional_superset(
-          ctx, older, newer, additional_field_for::object)) {
-        // additional properties are not compatible
-        return false;
-    }
-    if (!is_object_properties_superset(ctx, older, newer)) {
-        // "properties" in newer might not be compatible with
-        // older["properties"] (incompatible evolution) or
-        // older["patternProperties"] (it is not compatible with the pattern
-        // that matches the new name) or older["additionalProperties"] (older
-        // has partial open model that does not allow some new properties in
-        // newer)
-        return false;
-    }
+json_compatibility_result is_object_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
+
+    // newer requires less properties to be set
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "minProperties",
+      std::less_equal<>{},
+      {p / "minProperties",
+       json_incompatibility_type::min_properties_increased},
+      {p / "minProperties", json_incompatibility_type::min_properties_added},
+      0));
+
+    // newer requires more properties to be set
+    res.merge(is_numeric_property_value_superset(
+      older,
+      newer,
+      "maxProperties",
+      std::greater_equal<>{},
+      {p / "maxProperties",
+       json_incompatibility_type::max_properties_decreased},
+      {p / "maxProperties", json_incompatibility_type::max_properties_added}));
+
+    // Check if additional properties are compatible
+    res.merge(is_additional_superset(
+      ctx, older, newer, additional_field_for::object, p));
+
+    // "properties" in newer might not be compatible with
+    // older["properties"] (incompatible evolution) or
+    // older["patternProperties"] (it is not compatible with the pattern
+    // that matches the new name) or older["additionalProperties"] (older
+    // has partial open model that does not allow some new properties in
+    // newer)
+    res.merge(is_object_properties_superset(ctx, older, newer, p));
 
     // note: to match the behavior of the legacy software,
     // ```
@@ -1240,19 +1469,20 @@ bool is_object_superset(
     // ```
     // is omitted
 
-    if (!is_object_required_superset(ctx, older, newer)) {
-        // required properties are not compatible
-        return false;
-    }
-    if (!is_object_dependencies_superset(ctx, older, newer)) {
-        // dependencies are not compatible
-        return false;
-    }
+    // Check if required properties are compatible
+    res.merge(is_object_required_superset(ctx, older, newer, p));
 
-    return true;
+    // Check if dependencies are compatible
+    res.merge(is_object_dependencies_superset(ctx, older, newer, std::move(p)));
+
+    return res;
 }
 
-bool is_enum_superset(json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_enum_superset(
+  json::Value const& older, json::Value const& newer, std::filesystem::path p) {
+    json_compatibility_result res;
+    auto enum_p = p / "enum";
+
     auto older_it = older.FindMember("enum");
     auto newer_it = newer.FindMember("enum");
     auto older_is_enum = older_it != older.MemberEnd();
@@ -1260,12 +1490,14 @@ bool is_enum_superset(json::Value const& older, json::Value const& newer) {
 
     if (!older_is_enum && !newer_is_enum) {
         // both are not an "enum" schema, compatible
-        return true;
+        return res;
     }
 
     if (!(older_is_enum && newer_is_enum)) {
         // only one is an "enum" schema, not compatible
-        return false;
+        res.emplace<json_incompatibility>(
+          std::move(enum_p), json_incompatibility_type::enum_array_changed);
+        return res;
     }
 
     // both "enum"
@@ -1276,7 +1508,9 @@ bool is_enum_superset(json::Value const& older, json::Value const& newer) {
     if (newer_set.Size() > older_set.Size()) {
         // quick check:
         // newer has some value not in older
-        return false;
+        res.emplace<json_incompatibility>(
+          std::move(enum_p), json_incompatibility_type::enum_array_changed);
+        return res;
     }
 
     // TODO: current implementation is O(n^2), but could be O(n) with normalized
@@ -1286,15 +1520,22 @@ bool is_enum_superset(json::Value const& older, json::Value const& newer) {
         // also be improved with normalization of the input
         if (older_set.end() == std::ranges::find(older_set, v)) {
             // newer has an element not in older
-            return false;
+            res.emplace<json_incompatibility>(
+              std::move(enum_p), json_incompatibility_type::enum_array_changed);
+            return res;
         }
     }
 
-    return true;
+    return res;
 }
 
-bool is_not_combinator_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_not_combinator_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
+
     auto older_it = older.FindMember("not");
     auto newer_it = newer.FindMember("not");
     auto older_has_not = older_it != older.MemberEnd();
@@ -1302,19 +1543,29 @@ bool is_not_combinator_superset(
 
     if (older_has_not != newer_has_not) {
         // only one has a "not" schema, not compatible
-        return false;
+        res.emplace<json_incompatibility>(
+          p, json_incompatibility_type::type_changed);
+        return res;
     }
 
     if (older_has_not && newer_has_not) {
         // for not combinator, we want to check if the "not" newer subschema is
         // less strict than the older subschema, because this means that newer
         // validated less data than older
-        return is_superset(
-          {ctx.newer, ctx.older}, newer_it->value, older_it->value);
+        auto is_not_superset = is_superset(
+          {ctx.newer, ctx.older},
+          newer_it->value,
+          older_it->value,
+          ignored_path);
+
+        if (is_not_superset.has_error()) {
+            res.emplace<json_incompatibility>(
+              p / "not", json_incompatibility_type::not_type_extended);
+        }
     }
 
     // both do not have a "not" key, compatible
-    return true;
+    return res;
 }
 
 enum class p_combinator { oneOf, allOf, anyOf };
@@ -1329,8 +1580,13 @@ json::Value to_keyword(p_combinator c) {
     }
 }
 
-bool is_positive_combinator_superset(
-  context const& ctx, json::Value const& older, json::Value const& newer) {
+json_compatibility_result is_positive_combinator_superset(
+  context const& ctx,
+  json::Value const& older,
+  json::Value const& newer,
+  std::filesystem::path p) {
+    json_compatibility_result res;
+
     auto get_combinator = [](json::Value const& v) {
         auto res = std::optional<p_combinator>{};
         for (auto c :
@@ -1354,13 +1610,15 @@ bool is_positive_combinator_superset(
     auto maybe_newer_comb = get_combinator(newer);
     if (!maybe_older_comb.has_value()) {
         // older has not a combinator, maximum freedom for newer. compatible
-        return true;
+        return res;
     }
     // older has a combinator
 
     if (!maybe_newer_comb.has_value()) {
         // older has a combinator but newer does not. not compatible
-        return false;
+        res.emplace<json_incompatibility>(
+          std::move(p), json_incompatibility_type::combined_type_changed);
+        return res;
     }
     // newer has a combinator
 
@@ -1378,8 +1636,17 @@ bool is_positive_combinator_superset(
         if (older_schemas.Size() == 1 && newer_schemas.Size() == 1) {
             // both combinators have only one subschema, so the actual
             // combinator does not matter. compare subschemas directly
-            return is_superset(
-              ctx, *older_schemas.Begin(), *newer_schemas.Begin());
+            auto is_combinator_superset = is_superset(
+              ctx,
+              *older_schemas.Begin(),
+              *newer_schemas.Begin(),
+              ignored_path);
+            if (is_combinator_superset.has_error()) {
+                res.emplace<json_incompatibility>(
+                  std::move(p),
+                  json_incompatibility_type::combined_type_subschemas_changed);
+            }
+            return res;
         }
 
         // either older or newer - or both - has more than one subschema
@@ -1387,24 +1654,42 @@ bool is_positive_combinator_superset(
         if (older_schemas.Size() == 1 && newer_comb == p_combinator::allOf) {
             // older has only one subschema, newer is "allOf" so it can be
             // compatible if any one of the subschemas matches older
-            return std::ranges::any_of(
+            auto any_superset = std::ranges::any_of(
               newer_schemas, [&](json::Value const& s) {
-                  return is_superset(ctx, *older_schemas.Begin(), s);
+                  return !is_superset(
+                            ctx, *older_schemas.Begin(), s, ignored_path)
+                            .has_error();
               });
+            if (!any_superset) {
+                res.emplace<json_incompatibility>(
+                  std::move(p),
+                  json_incompatibility_type::combined_type_subschemas_changed);
+            }
+            return res;
         }
 
         if (older_comb == p_combinator::oneOf && newer_schemas.Size() == 1) {
             // older has multiple schemas but only one can be valid. it's
             // compatible if the only subschema in newer is compatible with one
             // in older
-            return std::ranges::any_of(
+            auto any_superset = std::ranges::any_of(
               older_schemas, [&](json::Value const& s) {
-                  return is_superset(ctx, s, *newer_schemas.Begin());
+                  return !is_superset(
+                            ctx, s, *newer_schemas.Begin(), ignored_path)
+                            .has_error();
               });
+            if (!any_superset) {
+                res.emplace<json_incompatibility>(
+                  std::move(p),
+                  json_incompatibility_type::combined_type_subschemas_changed);
+            }
+            return res;
         }
 
         // different combinators, not a special case. not compatible
-        return false;
+        res.emplace<json_incompatibility>(
+          std::move(p), json_incompatibility_type::combined_type_changed);
+        return res;
     }
 
     // same combinator for older and newer, or older is "anyOf"
@@ -1415,14 +1700,18 @@ bool is_positive_combinator_superset(
     if (older_schemas.Size() > newer_schemas.Size()) {
         if (older_comb == p_combinator::allOf) {
             // older has more restrictions than newer, not compatible
-            return false;
+            res.emplace<json_incompatibility>(
+              std::move(p), json_incompatibility_type::product_type_extended);
+            return res;
         }
     } else if (older_schemas.Size() < newer_schemas.Size()) {
         if (
           newer_comb == p_combinator::anyOf
           || newer_comb == p_combinator::oneOf) {
             // newer has more degrees of freedom than older, not compatible
-            return false;
+            res.emplace<json_incompatibility>(
+              std::move(p), json_incompatibility_type::sum_type_narrowed);
+            return res;
         }
     }
 
@@ -1444,7 +1733,9 @@ bool is_positive_combinator_superset(
     auto superset_graph = graph_t{older_schemas.Size() + newer_schemas.Size()};
     for (auto o = 0u; o < older_schemas.Size(); ++o) {
         for (auto n = 0u; n < newer_schemas.Size(); ++n) {
-            if (is_superset(ctx, older_schemas[o], newer_schemas[n])) {
+            if (!is_superset(
+                   ctx, older_schemas[o], newer_schemas[n], ignored_path)
+                   .has_error()) {
                 // translate n for the graph
                 auto n_index = n + older_schemas.Size();
                 add_edge(o, n_index, superset_graph);
@@ -1464,10 +1755,13 @@ bool is_positive_combinator_superset(
         // one of  sub schema was left out, meaning that it either had no valid
         // is_superset() relation with the other schema array, or that the
         // algorithm couldn't find a unique compatible pattern.
-        return false;
+        res.emplace<json_incompatibility>(
+          std::move(p),
+          json_incompatibility_type::combined_type_subschemas_changed);
+        return res;
     }
 
-    return true;
+    return res;
 }
 
 } // namespace is_superset_impl
@@ -1477,15 +1771,18 @@ using namespace is_superset_impl;
 // a schema O is a superset of another schema N if every schema that is valid
 // for N is also valid for O. precondition: older and newer are both valid
 // schemas
-bool is_superset(
+json_compatibility_result is_superset(
   context const& ctx,
   json::Value const& older_schema,
-  json::Value const& newer_schema) {
+  json::Value const& newer_schema,
+  std::filesystem::path p) {
+    json_compatibility_result res;
+
     // break recursion if parameters are atoms:
     if (is_true_schema(older_schema) || is_false_schema(newer_schema)) {
         // either older is the superset of every possible schema, or newer is
         // the subset of every possible schema
-        return true;
+        return res;
     }
 
     auto older = get_schema(ctx.older, older_schema);
@@ -1508,7 +1805,24 @@ bool is_superset(
         // newer_types_not_in_older accepts integer, and we can accept an
         // evolution from number -> integer. everything else is makes `newer`
         // less strict than older
-        return false;
+
+        auto older_minus_newer = json_type_list{};
+        std::ranges::set_difference(
+          older_types, newer_types, std::back_inserter(older_minus_newer));
+
+        if (
+          older_minus_newer.empty()
+          || (older_minus_newer == json_type_list{json_type::integer} && newer_minus_older == json_type_list{json_type::number})) {
+            // type_narrowed is reported when older has fewer elements or the
+            // same but with integer in older instead of number in newer
+            res.emplace<json_incompatibility>(
+              std::move(p), json_incompatibility_type::type_narrowed);
+        } else {
+            // Otherwise report the more general type_changed
+            res.emplace<json_incompatibility>(
+              std::move(p), json_incompatibility_type::type_changed);
+        }
+        return res;
     }
 
     // newer accepts less (or equal) types. for each type, try to find a less
@@ -1518,26 +1832,18 @@ bool is_superset(
         // to do a breadth first search to find a counterexample
         switch (t) {
         case json_type::string:
-            if (!is_string_superset(older, newer)) {
-                return false;
-            }
+            res.merge(is_string_superset(older, newer, p));
             break;
         case json_type::integer:
             [[fallthrough]];
         case json_type::number:
-            if (!is_numeric_superset(older, newer)) {
-                return false;
-            }
+            res.merge(is_numeric_superset(older, newer, p));
             break;
         case json_type::object:
-            if (!is_object_superset(ctx, older, newer)) {
-                return false;
-            }
+            res.merge(is_object_superset(ctx, older, newer, p));
             break;
         case json_type::array:
-            if (!is_array_superset(ctx, older, newer)) {
-                return false;
-            }
+            res.merge(is_array_superset(ctx, older, newer, p));
             break;
         case json_type::boolean:
             // no check needed for boolean;
@@ -1548,17 +1854,9 @@ bool is_superset(
         }
     }
 
-    if (!is_enum_superset(older, newer)) {
-        return false;
-    }
-
-    if (!is_not_combinator_superset(ctx, older, newer)) {
-        return false;
-    }
-
-    if (!is_positive_combinator_superset(ctx, older, newer)) {
-        return false;
-    }
+    res.merge(is_enum_superset(older, newer, p));
+    res.merge(is_not_combinator_superset(ctx, older, newer, p));
+    res.merge(is_positive_combinator_superset(ctx, older, newer, p));
 
     for (auto not_yet_handled_keyword : {
            // draft 6 unhandled keywords:
@@ -1580,7 +1878,7 @@ bool is_superset(
     }
 
     // no rule in newer is less strict than older, older is superset of newer
-    return true;
+    return res;
 }
 
 void sort(json::Value& val) {
@@ -1650,16 +1948,15 @@ ss::future<canonical_schema> make_canonical_json_schema(
 compatibility_result check_compatible(
   const json_schema_definition& reader,
   const json_schema_definition& writer,
-  verbose is_verbose [[maybe_unused]]) {
-    auto is_compatible = [&]() {
+  verbose is_verbose) {
+    auto raw_compat_result = [&]() {
         // reader is a superset of writer iff every schema that is valid for
         // writer is also valid for reader
         context ctx{.older{reader()}, .newer{writer()}};
-        return is_superset(ctx, reader().ctx.doc, writer().ctx.doc);
+        return is_superset(ctx, reader().ctx.doc, writer().ctx.doc, "#/");
     }();
 
-    // TODO(gellert.nagy): start using the is_verbose flag in a follow up PR
-    return compatibility_result{.is_compat = is_compatible};
+    return std::move(raw_compat_result)(is_verbose);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -510,6 +510,34 @@ static constexpr auto compatibility_test_cases = std::to_array<
 })",
     .reader_is_compatible_with_writer = false,
   },
+  // object checks: dependency "a" changed from array to object
+  {
+    .reader_schema = R"(
+{
+  "type": "object",
+  "dependencies": {"a": ["b"]}
+})",
+    .writer_schema = R"(
+{
+  "type": "object",
+  "dependencies": {"a": {"type": "number"}}
+})",
+    .reader_is_compatible_with_writer = false,
+  },
+  // object checks: dependency "a" changed from object to array
+  {
+    .reader_schema = R"(
+{
+  "type": "object",
+  "dependencies": {"a": {"type": "number"}}
+})",
+    .writer_schema = R"(
+{
+  "type": "object",
+  "dependencies": {"a": ["b"]}
+})",
+    .reader_is_compatible_with_writer = false,
+  },
   // array checks: size increase is not allowed
   {
     .reader_schema = R"({"type": "array", "minItems": 2, "maxItems": 10})",

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -88,4 +88,9 @@ std::ostream& operator<<(std::ostream& os, const canonical_schema& ref) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const compatibility_result& res) {
+    fmt::print(os, "is_compat: {}, messages: {}", res.is_compat, res.messages);
+    return os;
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -534,6 +534,11 @@ from_string_view<compatibility_level>(std::string_view sv) {
 }
 
 struct compatibility_result {
+    friend bool
+    operator==(const compatibility_result&, const compatibility_result&)
+      = default;
+    friend std::ostream& operator<<(std::ostream&, const compatibility_result&);
+
     bool is_compat;
     std::vector<ss::sstring> messages;
 };

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -199,6 +199,8 @@ message myrecord {
     ]
 }
 """,
+    json=r'{"type": "number"}',
+    json_incompat=r'{"type": "number", "multipleOf": 20}',
 )
 
 log_config = LoggingConfig('info',
@@ -1570,6 +1572,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
     @parametrize(schemas=("avro", "avro_incompat", "AVRO"))
     @parametrize(schemas=("proto3", "proto3_incompat", "PROTOBUF"))
     @parametrize(schemas=("proto2", "proto2_incompat", "PROTOBUF"))
+    @parametrize(schemas=("json", "json_incompat", "JSON"))
     def test_compatibility_messages(self, schemas):
         """
         Verify compatibility messages


### PR DESCRIPTION
This implements verbose compatibility reporting for json schema registry. This has already been implemented for Protobuf and Avro, and with this patch it is going to be supported for json as well.

This PR only changes what error message is being reported when there is an incompatibility but the logic of "what sets of schemas are considered compatible" is intended to be unchanged. The changes start with a few commits that introduce helpers and do non-logic-changing refactoring to make the main commit (https://github.com/redpanda-data/redpanda/commit/47d543b8427721118c84c72015dc837d112a2e69) easier to review. While the main commit is large, the changes in it are trivial, most of its complexity lies in verifying that the reported compatibility error type matches the reference implementation. The existing compatibility test suite is extended to capture not just the (non)compatibility of the schemas but also the reason for the incompatibility by checking the verbose error reported. This helps us achieve reasonable coverage of this patch.

Note that because our json compatibility checks are expressed as forward compatibility checks and not backward compatibility checks, the names of the error types are always the inverse of what the surrounding code and comments express. For example, we report the `additional_items_removed` error when `newer` has `additionalItems` but `older` does not.

#### Known discrepancies
There are some `Note`s and `TODO`s left in the unit tests where I noticed that the error type we report is different to what the reference implementation reports.
* The `Note`s highlight differences I don't intend to change because I consider them bugs in the reference implementation
* The `TODO`s I intend to make follow up tickets for

Fixes https://redpandadata.atlassian.net/browse/CORE-6861

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
### Features

* Schema Registry: verbose compatibility error reporting is now supported for JSON as well

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
