### PR TITLE
kafka: add proxy factory for partition in hand

### DIFF
--- a/src/v/kafka/server/partition_proxy.cc
+++ b/src/v/kafka/server/partition_proxy.cc
@@ -21,19 +21,25 @@ partition_proxy make_with_impl(Args&&... args) {
     return partition_proxy(std::make_unique<Impl>(std::forward<Args>(args)...));
 }
 
+partition_proxy
+make_partition_proxy(const ss::lw_shared_ptr<cluster::partition>& partition) {
+    return make_with_impl<replicated_partition>(partition);
+}
+
 std::optional<partition_proxy> make_partition_proxy(
   const model::ktp& ktp, cluster::partition_manager& cluster_pm) {
     auto partition = cluster_pm.get(ktp);
     if (partition) {
-        return make_with_impl<replicated_partition>(partition);
+        return make_partition_proxy(partition);
     }
     return std::nullopt;
 }
+
 std::optional<partition_proxy> make_partition_proxy(
   const model::ntp& ntp, cluster::partition_manager& cluster_pm) {
     auto partition = cluster_pm.get(ntp);
     if (partition) {
-        return make_with_impl<replicated_partition>(partition);
+        return make_partition_proxy(partition);
     }
     return std::nullopt;
 }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -176,8 +176,12 @@ private:
     std::unique_ptr<impl> _impl;
 };
 
+partition_proxy
+make_partition_proxy(const ss::lw_shared_ptr<cluster::partition>&);
+
 std::optional<partition_proxy>
 make_partition_proxy(const model::ktp&, cluster::partition_manager&);
+
 std::optional<partition_proxy>
 make_partition_proxy(const model::ntp&, cluster::partition_manager&);
 


### PR DESCRIPTION
I may have a non-null partition pointer that I want to wrap.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

