### PR TITLE
CORE-7049 dt/rbac: wait for healthy cluster after restart

### DIFF
--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -885,6 +885,11 @@ class RolePersistenceTest(RBACTestBase):
 
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
+        # Wait for the cluster to elect a controller leader after the restart
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=30,
+                                 backoff_sec=1)
+
         admin = self.superuser_admin
 
         names = [


### PR DESCRIPTION
Deflake `RolePersistenceTest.test_role_survives_restart` by waiting for a healthy cluster after the nodes have been restarted. Otherwise, the later `create_role` request may fail. See the example failure in the attached ticket.

Fixes https://redpandadata.atlassian.net/browse/CORE-7049

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
