### PR TITLE
`kafka`: fix `alter-config --delete` for some "sticky" properties

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -801,9 +801,6 @@ void incremental_update(
         // It's guaranteed that the remove operation will only be
         // used with one of the 'drop_' flags.
         property = model::add_shadow_indexing_flag(*property, *override.value);
-        if (*property == model::shadow_indexing_mode::disabled) {
-            property = std::nullopt;
-        }
         return;
     case incremental_update_operation::set:
         // set new value

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -49,7 +49,22 @@ static void parse_and_set_shadow_indexing_mode(
     switch (op) {
     case config_resource_operation::remove:
         simode.op = cluster::incremental_update_operation::remove;
-        simode.value = model::negate_shadow_indexing_flag(enabled_value);
+        switch (enabled_value) {
+        case model::shadow_indexing_mode::archival:
+            simode.value
+              = config::shard_local_cfg().cloud_storage_enable_remote_write()
+                  ? model::shadow_indexing_mode::archival
+                  : model::shadow_indexing_mode::drop_archival;
+            break;
+        case model::shadow_indexing_mode::fetch:
+            simode.value
+              = config::shard_local_cfg().cloud_storage_enable_remote_read()
+                  ? model::shadow_indexing_mode::fetch
+                  : model::shadow_indexing_mode::drop_fetch;
+            break;
+        default:
+            break;
+        }
         break;
     case config_resource_operation::set:
         simode.op = cluster::incremental_update_operation::set;


### PR DESCRIPTION
There was buggy behavior for "sticky"[^1] properties and empty `std::optional<>`s created as a result of `rpk topic alter-config [TOPIC] --delete [PROPERTY]`.

Currently, `redpanda.remote.read` and `redpanda.remote.write` exhibit unique behavior in terms of not falling back to the configured cluster defaults for `cloud_storage_enable_remote_read` and `cloud_storage_enable_remote_write`.
    
We had a bug, triggered by this sequence of events:

1. `cloud_storage_enable_remote_read=false` at cluster level.
2. `rpk topic create t`
3. `rpk topic describe t` (correctly) describes `redpanda.remote.read=false`
4. `rpk cluster config set cloud_storage_enable_remote_read=true`
5. `rpk topic alter-config t --delete redpanda.remote.read`
6. `rpk topic describe t` describes `redpanda.remote.read=true`, but the underlying configuration option is actually `std::nullopt`

We now have `rpk topic describe` printing the cluster default and indicating topic `t` has remote read permissions, but this is not actually the case as far as the topic is concerned (topic property is `std::nullopt`, once again, we don't fall back on cluster default).

Fix the behaviour here by removing code in `incremental_update()` that set the shadow indexing optional to `std::nullopt` when the mode is `shadow_indexing_mode::disabled`. Also, when an `alter-config --delete` request is issued, fall back to the cluster default when setting the new `shadow_indexing_mode`.

This still results in somewhat unique behaviour for these topic properties as opposed to others in `redpanda`, as these properties will take on the value of the cluster default _**at time of call to**_ `alter-config --delete`, but future changes to the cluster default will not affect their values. This is by design, once again according to reference[^1]. 

[^1]: https://github.com/redpanda-data/redpanda/issues/7451

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug that would result in `rpk topic alter-config [TOPIC] --delete [PROPERTY]` causing `redpanda.remote.read` and `redpanda.remote.write` to become unset, instead of referring back to the cluster default.