### PR TITLE
`config`: mark `cloud_storage_enabled()` as `needs_restart::yes`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1631,7 +1631,7 @@ configuration::configuration()
       *this,
       "cloud_storage_enabled",
       "Enable archival storage",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , cloud_storage_enable_remote_read(
       *this,


### PR DESCRIPTION
This property should have been marked with needing a restart, since `redpanda` only attempts to construct archival/tiered storage related objects upon start-up, when it first checks this cluster property.

Correct the property by marking it as `needs_restart::yes`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes

* none
