### PR TITLE
`kafka`: misc non-functional changes

### DIFF
--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -315,7 +315,7 @@ alter_topic_configuration(
 }
 
 static ss::future<chunked_vector<alter_configs_resource_response>>
-alter_broker_configuartion(chunked_vector<alter_configs_resource> resources) {
+alter_broker_configuration(chunked_vector<alter_configs_resource> resources) {
     return unsupported_broker_configuration<
       alter_configs_resource,
       alter_configs_resource_response>(
@@ -357,7 +357,7 @@ ss::future<response_ptr> alter_configs_handler::handle(
     futures.push_back(alter_topic_configuration(
       ctx, std::move(groupped.topic_changes), request.data.validate_only));
     futures.push_back(
-      alter_broker_configuartion(std::move(groupped.broker_changes)));
+      alter_broker_configuration(std::move(groupped.broker_changes)));
 
     auto ret = co_await ss::when_all_succeed(futures.begin(), futures.end());
     // include authorization errors

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -377,7 +377,7 @@ static void add_topic_config(
     // Wrap overrides in an optional because add_topic_config expects
     // optional<S> where S = tristate<T>
     std::optional<tristate<T>> override_value;
-    if (overrides.is_disabled() || overrides.has_optional_value()) {
+    if (overrides.is_engaged()) {
         override_value = std::make_optional(overrides);
     }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -162,7 +162,7 @@ get_tristate_value(const config_map_t& config, std::string_view key) {
     }
     // disabled case
     if (v <= 0) {
-        return tristate<T>{};
+        return tristate<T>(disable_tristate);
     }
     return tristate<T>(std::make_optional<T>(*v));
 }

--- a/src/v/utils/tristate.h
+++ b/src/v/utils/tristate.h
@@ -121,7 +121,7 @@ public:
             fmt::print(o, "{{{}}}", t.value());
             return o;
         }
-        return o << "{}";
+        return o << "{{nullopt}}";
     };
 
     std::optional<T>& get_optional() {


### PR DESCRIPTION
Some minor things I came across in the `kafka` and `tristate` subsystems that I thought could be improved for the reader.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
