### PR TITLE
cloud_io: put io_result in cloud_io namespace

### DIFF
--- a/src/v/cloud_io/io_result.cc
+++ b/src/v/cloud_io/io_result.cc
@@ -9,7 +9,7 @@
  */
 #include "cloud_io/io_result.h"
 
-namespace cloud_storage {
+namespace cloud_io {
 
 std::ostream& operator<<(std::ostream& o, const download_result& r) {
     switch (r) {
@@ -47,4 +47,4 @@ std::ostream& operator<<(std::ostream& o, const upload_result& r) {
     return o;
 }
 
-} // namespace cloud_storage
+} // namespace cloud_io

--- a/src/v/cloud_io/io_result.h
+++ b/src/v/cloud_io/io_result.h
@@ -12,8 +12,7 @@
 #include <cstdint>
 #include <iostream>
 
-// TODO: move into cloud_io namespace.
-namespace cloud_storage {
+namespace cloud_io {
 
 enum class [[nodiscard]] download_result : int32_t {
     success,
@@ -31,4 +30,4 @@ enum class [[nodiscard]] upload_result : int32_t {
 std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);
 
-} // namespace cloud_storage
+} // namespace cloud_io

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -113,10 +113,10 @@ public:
     /// \param download_request holds a reference to an iobuf in the `payload`
     /// field which will hold the downloaded object if the download was
     /// successful
-    ss::future<cloud_storage::download_result>
+    ss::future<download_result>
     download_object(download_request download_request);
 
-    ss::future<cloud_storage::download_result> object_exists(
+    ss::future<download_result> object_exists(
       const cloud_storage_clients::bucket_name& bucket,
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent,
@@ -128,7 +128,7 @@ public:
     ///
     /// \param path is a full S3 object path
     /// \param bucket is a name of the S3 bucket
-    ss::future<cloud_storage::upload_result> delete_object(transfer_details);
+    ss::future<upload_result> delete_object(transfer_details);
 
     /// \brief Delete multiple objects from S3
     ///
@@ -147,7 +147,7 @@ public:
              && std::same_as<
                std::ranges::range_value_t<R>,
                cloud_storage_clients::object_key>
-    ss::future<cloud_storage::upload_result> delete_objects(
+    ss::future<upload_result> delete_objects(
       const cloud_storage_clients::bucket_name& bucket,
       R keys,
       retry_chain_node& parent,
@@ -187,15 +187,14 @@ public:
     /// \brief Upload small objects to bucket. Suitable for uploading simple
     /// strings, does not check for leadership before upload like the segment
     /// upload function.
-    ss::future<cloud_storage::upload_result>
-    upload_object(upload_request upload_request);
+    ss::future<upload_result> upload_object(upload_request upload_request);
 
     // If you need to spawn a background task that relies on
     // this object staying alive, spawn it with this gate.
     seastar::gate& gate() { return _gate; };
     ss::abort_source& as() { return _as; }
 
-    ss::future<cloud_storage::upload_result> upload_stream(
+    ss::future<upload_result> upload_stream(
       transfer_details transfer_details,
       uint64_t content_length,
       const reset_input_stream& reset_str,
@@ -203,7 +202,7 @@ public:
       const std::string_view stream_label,
       std::optional<size_t> max_retries);
 
-    ss::future<cloud_storage::download_result> download_stream(
+    ss::future<download_result> download_stream(
       transfer_details transfer_details,
       const try_consume_stream& cons_str,
       const std::string_view stream_label,
@@ -217,7 +216,7 @@ public:
              && std::same_as<
                std::ranges::range_value_t<R>,
                cloud_storage_clients::object_key>
-    ss::future<cloud_storage::upload_result> delete_objects_sequentially(
+    ss::future<upload_result> delete_objects_sequentially(
       const cloud_storage_clients::bucket_name& bucket,
       R keys,
       retry_chain_node& parent,
@@ -227,7 +226,7 @@ public:
     /// backend limits.
     ///
     /// \pre the number of keys is <= delete_objects_max_keys
-    ss::future<cloud_storage::upload_result> delete_object_batch(
+    ss::future<upload_result> delete_object_batch(
       const cloud_storage_clients::bucket_name& bucket,
       std::vector<cloud_storage_clients::object_key> keys,
       retry_chain_node& parent,

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -23,7 +23,6 @@ class retry_chain_node;
 
 namespace cloud_storage {
 class cloud_storage_api;
-enum class upload_result;
 } // namespace cloud_storage
 
 namespace cloud_storage::inventory {

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -34,6 +34,9 @@
 
 namespace cloud_storage {
 
+using upload_result = cloud_io::upload_result;
+using download_result = cloud_io::download_result;
+
 using remote_metrics_disabled
   = ss::bool_class<struct remote_metrics_disabled_tag>;
 


### PR DESCRIPTION
Follow-up to https://github.com/redpanda-data/redpanda/pull/23194

I didn't do this originally because I didn't want to update a ton of code via s/cloud_storage::upload_result/cloud_io::upload_result. But instead this just adds a using declaration for cloud_storage, and moves the result types into the cloud_io namespace.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
