### PR TITLE
gha: add build labels for bazel

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ k8s/tests:
 
 area/build:
 - changed-files:
-  - any-glob-to-any-file: ['cmake/**/*', '.github/**/*']
+  - any-glob-to-any-file: ['cmake/**/*', '.github/**/*', 'bazel/**/*', 'MODULE.bazel', '**/BUILD', '**/*.bzl']
 
 area/docs:
 - changed-files:


### PR DESCRIPTION
This will let folks concerned about the build quickly filter PRs that are modifying the build system in Bazel.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
