### PR TITLE
bazel: bump configure_make default parallelism

### DIFF
--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -1,10 +1,11 @@
 load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
-# Make this build faster by setting `build --@krb5//:build_jobs=4` in user.bazelrc
+# Make this build faster by setting `build --@krb5//:build_jobs=8` in user.bazelrc
+# if you have the cores to spare
 int_flag(
     name = "build_jobs",
-    build_setting_default = 1,
+    build_setting_default = 4,
     make_variable = "BUILD_JOBS",
 )
 

--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -2,9 +2,10 @@ load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 # Make this build faster by setting `build --@openssl//:build_jobs=16` in user.bazelrc
+# if you have the cores to spare.
 int_flag(
     name = "build_jobs",
-    build_setting_default = 1,
+    build_setting_default = 8,
     make_variable = "BUILD_JOBS",
 )
 


### PR DESCRIPTION
Happy to bikeshed the values here.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
