### PR TITLE
[CORE-7229] `storage`: add tombstone deletion implementation to local storage compaction

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -96,6 +96,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
       model::timestamp::min(),
       1,
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
@@ -516,6 +517,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       model::timestamp::min(),
       1, // max_bytes_in_log
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
@@ -809,6 +811,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
       model::timestamp::max(),
       0,
       log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     partition->log()->housekeeping(housekeeping_conf).get();

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -119,8 +119,8 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
                                     topic_name, model::partition_id(0), next)
                                   .get();
         BOOST_REQUIRE(!consumed_records.empty());
-        for (const auto& [k, v] : consumed_records) {
-            BOOST_REQUIRE_EQUAL(k, ssx::sformat("key{}", next()));
+        for (const auto& kv : consumed_records) {
+            BOOST_REQUIRE_EQUAL(kv.key, ssx::sformat("key{}", next()));
             next += model::offset(1);
         }
     }

--- a/src/v/cluster/archival/tests/async_data_uploader_test.cc
+++ b/src/v/cluster/archival/tests/async_data_uploader_test.cc
@@ -167,6 +167,7 @@ public:
           model::timestamp::min(),
           std::nullopt,
           max_collect_offset,
+          std::nullopt,
           ss::default_priority_class(),
           as);
 

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -235,6 +235,7 @@ struct reupload_fixture : public archiver_fixture {
             model::timestamp::max(),
             std::nullopt,
             max_collectible,
+            std::nullopt,
             ss::default_priority_class(),
             abort_source})
           .get();

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -941,6 +941,7 @@ FIXTURE_TEST(
         model::timestamp::now(),
         std::nullopt,
         model::offset{999},
+        std::nullopt,
         ss::default_priority_class(),
         as))
       .get0();

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -115,6 +115,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                       retention_timestamp,
                       100_MiB,
                       model::offset::max(),
+                      std::nullopt,
                       ss::default_priority_class(),
                       as,
                       storage::ntp_sanitizer_config{.sanitize_only = true}))

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -107,6 +107,7 @@ public:
                       model::timestamp::now().value() - ret_duration.count()),
                     std::nullopt,
                     log->stm_manager()->max_collectible_offset(),
+                    std::nullopt,
                     ss::default_priority_class(),
                     dummy_as,
                   })
@@ -228,6 +229,7 @@ public:
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         // Compacts until a single sealed segment remains, other than the

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -305,6 +305,7 @@ ss::future<> run_workload(
                 model::timestamp::max(),
                 std::nullopt,
                 log->stm_manager()->max_collectible_offset(),
+                std::nullopt,
                 ss::default_priority_class(),
                 dummy_as,
               })

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -228,6 +228,7 @@ public:
     iobuf release_value() { return std::exchange(_value, {}); }
     iobuf share_value() { return _value.share(0, _value.size_bytes()); }
     bool has_value() const { return _val_size >= 0; }
+    bool is_tombstone() const { return !has_value(); }
 
     const std::vector<record_header>& headers() const { return _headers; }
     std::vector<record_header>& headers() { return _headers; }
@@ -360,7 +361,7 @@ public:
     record_batch_attributes& operator|=(model::compression c) {
         // clang-format off
         _attributes |=
-        static_cast<std::underlying_type_t<model::compression>>(c) 
+        static_cast<std::underlying_type_t<model::compression>>(c)
             & record_batch_attributes::compression_mask;
         // clang-format on
         return *this;

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -544,6 +544,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
             first_ts,
             100_MiB,
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as,
             storage::ntp_sanitizer_config{.sanitize_only = true}))

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -579,15 +579,16 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           result);
         has_self_compacted = true;
     }
-    // Remove any of the beginning segments that may only have one or no
+    // Remove any of the beginning segments that don't have any
     // compactible records. They would be no-ops to compact.
     while (!segs.empty()) {
         if (segs.front()->may_have_compactible_records()) {
             break;
         }
-        // For all intents and purposes, these segments are already compacted.
+        // For all intents and purposes, these segments are already cleanly
+        // compacted.
         auto seg = segs.front();
-        seg->mark_as_finished_windowed_compaction();
+        internal::mark_segment_as_finished_window_compaction(seg, true);
         segs.pop_front();
     }
     if (segs.empty()) {
@@ -645,13 +646,18 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         if (cfg.asrc) {
             cfg.asrc->check();
         }
+        // A segment is considered "clean" if it has been fully indexed (all
+        // keys are de-duplicated)
+        const bool is_clean_compacted = seg->offsets().get_base_offset()
+                                        >= idx_start_offset;
         if (seg->offsets().get_base_offset() > map.max_offset()) {
             // The map was built from newest to oldest segments within this
             // sliding range. If we see a new segment whose offsets are all
             // higher than those indexed, it may be because the segment is
             // entirely comprised of non-data batches. Mark it as compacted so
             // we can progress through compactions.
-            seg->mark_as_finished_windowed_compaction();
+            internal::mark_segment_as_finished_window_compaction(
+              seg, is_clean_compacted);
             vlog(
               gclog.debug,
               "[{}] treating segment as compacted, offsets fall above highest "
@@ -663,8 +669,14 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         }
         if (!seg->may_have_compactible_records()) {
             // All data records are already compacted away. Skip to avoid a
-            // needless rewrite.
-            seg->mark_as_finished_windowed_compaction();
+            // needless rewrite. But, still flush index in case we are clean
+            // compacted to persist clean_compact_timestamp
+            internal::mark_segment_as_finished_window_compaction(
+              seg, is_clean_compacted);
+            if (is_clean_compacted) {
+                co_await seg->index().flush();
+            }
+
             vlog(
               gclog.trace,
               "[{}] treating segment as compacted, either all non-data "
@@ -673,6 +685,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               seg->filename());
             continue;
         }
+
         // TODO: implement a segment replacement strategy such that each term
         // tries to write only one segment (or more if the term had a large
         // amount of data), rather than replacing N segments with N segments.
@@ -758,11 +771,15 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         seg->index().swap_index_state(std::move(new_idx));
         seg->force_set_commit_offset_from_index();
         seg->release_batch_cache_index();
+
+        // Mark the segment as completed window compaction, and possibly set the
+        // clean_compact_timestamp in it's index.
+        internal::mark_segment_as_finished_window_compaction(
+          seg, is_clean_compacted);
+
         co_await seg->index().flush();
         co_await ss::rename_file(
           cmp_idx_tmpname.string(), cmp_idx_name.string());
-
-        seg->mark_as_finished_windowed_compaction();
         _probe->segment_compacted();
         _probe->add_compaction_removed_bytes(
           ssize_t(size_before) - ssize_t(size_after));
@@ -774,7 +791,9 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         vlog(
           gclog.debug, "[{}] Final compacted segment {}", config().ntp(), seg);
     }
+
     _last_compaction_window_start_offset = idx_start_offset;
+
     co_return true;
 }
 
@@ -940,6 +959,9 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     // size is already contained in the partition size probe
     replacement->mark_as_compacted_segment();
     if (all_window_compacted) {
+        // replacement's _clean_compact_timestamp will have been set in
+        // make_concatenated_segment if both segments were cleanly compacted
+        // already.
         replacement->mark_as_finished_windowed_compaction();
     }
     _probe->add_initial_segment(*replacement.get());

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -886,15 +886,10 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     auto segments = std::vector<ss::lw_shared_ptr<segment>>(
       range.first, range.second);
 
-    bool all_window_compacted = true;
-    for (const auto& seg : segments) {
-        if (!seg->finished_windowed_compaction()) {
-            all_window_compacted = false;
-            break;
-        }
-    }
+    const bool all_window_compacted = std::ranges::all_of(
+      segments, &segment::finished_windowed_compaction);
 
-    auto all_segments_self_compacted = std::ranges::all_of(
+    const bool all_segments_self_compacted = std::ranges::all_of(
       segments, &segment::finished_self_compaction);
 
     if (unlikely(!all_segments_self_compacted)) {

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -74,10 +74,11 @@ private:
    1 byte  - non_data_timestamps
  */
 struct index_state
-  : serde::envelope<index_state, serde::version<7>, serde::compat_version<4>> {
+  : serde::envelope<index_state, serde::version<8>, serde::compat_version<4>> {
     static constexpr auto monotonic_timestamps_version = 5;
     static constexpr auto broker_timestamp_version = 6;
     static constexpr auto num_compactible_records_version = 7;
+    static constexpr auto clean_compact_timestamp_version = 8;
 
     static index_state make_empty_index(offset_delta_time with_offset);
 
@@ -130,6 +131,12 @@ struct index_state
     // Returns std::nullopt if this index was written in a version that didn't
     // support this field, and we can't conclude anything.
     std::optional<size_t> num_compactible_records_appended{0};
+
+    // If set, the timestamp at which every record up to and including
+    // those in this segment were first compacted via sliding window.
+    // If not yet set, sliding window compaction has not yet been applied to
+    // every previous record in the log.
+    std::optional<model::timestamp> clean_compact_timestamp{std::nullopt};
 
     size_t size() const;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -275,6 +275,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           collection_threshold,
           _config.retention_bytes(),
           current_log.handle->stm_manager()->max_collectible_offset(),
+          /*TODO: current_log.handle->config().tombstone_retention_ms()*/
+          std::nullopt,
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg),

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -511,6 +511,7 @@ struct compact_op final : opfuzz::op {
           model::timestamp::max(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           *(ctx._as),
           storage::ntp_sanitizer_config{.sanitize_only = true});

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -897,7 +897,7 @@ bool segment::may_have_compactible_records() const {
         // that there were no data records, so err on the side of caution.
         return true;
     }
-    return num_compactible_records.value() > 1;
+    return num_compactible_records.value() > 0;
 }
 
 } // namespace storage

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -198,6 +198,7 @@ ss::future<index_state> deduplicate_segment(
     auto new_idx = co_await std::move(rdr).consume(
       std::move(copy_reducer), model::no_timeout);
     new_idx.broker_timestamp = seg->index().broker_timestamp();
+    new_idx.clean_compact_timestamp = seg->index().clean_compact_timestamp();
     co_return new_idx;
 }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -9,6 +9,7 @@
 
 #include "storage/segment_deduplication_utils.h"
 
+#include "model/timestamp.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
 #include "storage/index_state.h"
@@ -164,9 +165,13 @@ ss::future<index_state> deduplicate_segment(
       seg, cfg, probe, std::move(read_holder));
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
+
+    const std::optional<model::timestamp> tombstone_delete_horizon
+      = internal::get_tombstone_delete_horizon(seg, cfg);
     auto copy_reducer = internal::copy_data_segment_reducer(
       [&map,
        segment_last_offset = seg->offsets().get_committed_offset(),
+       tombstone_delete_horizon = tombstone_delete_horizon,
        compaction_placeholder_enabled](
         const model::record_batch& b,
         const model::record& r,
@@ -185,6 +190,12 @@ ss::future<index_state> deduplicate_segment(
                 b.header());
               return ss::make_ready_future<bool>(true);
           }
+          // Potentially deal with tombstone record removal
+          if (internal::should_remove_tombstone_record(
+                r, tombstone_delete_horizon)) {
+              return ss::make_ready_future<bool>(false);
+          }
+
           return should_keep(map, b, r);
       },
       &appender,

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -129,7 +129,8 @@ public:
       size_t step,
       ss::sharded<features::feature_table>& feature_table,
       std::optional<ntp_sanitizer_config> sanitizer_config,
-      std::optional<model::timestamp> broker_timestamp = std::nullopt);
+      std::optional<model::timestamp> broker_timestamp = std::nullopt,
+      std::optional<model::timestamp> clean_compact_timestamp = std::nullopt);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -197,6 +197,24 @@ public:
           _state.broker_timestamp, _state.max_timestamp, _retention_timestamp);
     }
 
+    // Check if compacted timestamp has a value.
+    bool has_clean_compact_timestamp() const {
+        return _state.clean_compact_timestamp.has_value();
+    }
+
+    // Set the compacted timestamp, if it doesn't already have a value.
+    void maybe_set_clean_compact_timestamp(model::timestamp t) {
+        if (!_state.clean_compact_timestamp.has_value()) {
+            _state.clean_compact_timestamp = t;
+            _needs_persistence = true;
+        }
+    }
+
+    // Get the compacted timestamp.
+    std::optional<model::timestamp> clean_compact_timestamp() const {
+        return _state.clean_compact_timestamp;
+    }
+
     ss::future<bool> materialize_index();
     ss::future<> flush();
     ss::future<> truncate(model::offset, model::timestamp);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1130,4 +1130,18 @@ void mark_segment_as_finished_window_compaction(
     }
 }
 
+bool should_remove_tombstone_record(
+  const model::record& r,
+  std::optional<model::timestamp> tombstone_delete_horizon) {
+    if (!r.is_tombstone()) {
+        return false;
+    }
+
+    if (!tombstone_delete_horizon.has_value()) {
+        return false;
+    }
+
+    return (model::timestamp::now() > tombstone_delete_horizon.value());
+}
+
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1122,4 +1122,12 @@ offset_delta_time should_apply_delta_time_offset(
       && feature_table.local().is_active(features::feature::node_isolation)};
 }
 
+void mark_segment_as_finished_window_compaction(
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp) {
+    seg->mark_as_finished_windowed_compaction();
+    if (set_clean_compact_timestamp) {
+        seg->index().maybe_set_clean_compact_timestamp(model::timestamp::now());
+    }
+}
+
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1130,6 +1130,20 @@ void mark_segment_as_finished_window_compaction(
     }
 }
 
+std::optional<model::timestamp> get_tombstone_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
+    std::optional<model::timestamp> tombstone_delete_horizon = {};
+    const auto& tombstone_retention_ms_opt = cfg.tombstone_retention_ms;
+    if (
+      seg->index().has_clean_compact_timestamp()
+      && tombstone_retention_ms_opt.has_value()) {
+        tombstone_delete_horizon = model::timestamp(
+          seg->index().clean_compact_timestamp()->value()
+          + cfg.tombstone_retention_ms->count());
+    }
+    return tombstone_delete_horizon;
+}
+
 bool should_remove_tombstone_record(
   const model::record& r,
   std::optional<model::timestamp> tombstone_delete_horizon) {

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,13 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Returns true iff the record `r` is a tombstone, and the timestamp returned by
+// `now()` is past the `tombstone_delete_horizon` timestamp (in the case it has
+// a value). Returns false in all other cases.
+bool should_remove_tombstone_record(
+  const model::record& r,
+  std::optional<model::timestamp> tombstone_delete_horizon);
+
 // Mark a segment as completed window compaction, and whether it is "clean" (in
 // which case the `clean_compact_timestamp` is set in the segment's index).
 void mark_segment_as_finished_window_compaction(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,11 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Mark a segment as completed window compaction, and whether it is "clean" (in
+// which case the `clean_compact_timestamp` is set in the segment's index).
+void mark_segment_as_finished_window_compaction(
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp);
+
 template<typename Func>
 auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
     static_assert(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -258,6 +258,14 @@ inline bool is_compactible(const model::record_batch& b) {
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table);
 
+// Optionally returns the timestamp past which a tombstone may be removed.
+// This returns a value iff the segment `s` has been marked as cleanly
+// compacted, and the compaction_config has a value assigned for
+// `tombstone_retention_ms`. In all other cases, `std::nullopt` is returned,
+// indicating that tombstone records will not be removed if encountered.
+std::optional<model::timestamp> get_tombstone_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
+
 // Returns true iff the record `r` is a tombstone, and the timestamp returned by
 // `now()` is past the `tombstone_delete_horizon` timestamp (in the case it has
 // a value). Returns false in all other cases.

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -77,6 +77,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     first_log->housekeeping(conf).get();
@@ -125,6 +126,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       new_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     new_log->housekeeping(conf2).get();
@@ -197,6 +199,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     first_log->housekeeping(conf).get();
@@ -225,6 +228,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       new_log->stm_manager()->max_collectible_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     new_log->housekeeping(conf2).get();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -174,6 +174,7 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -239,6 +240,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -281,6 +283,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -300,6 +303,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     generate_data(1, cardinality, records_per_segment).get();
     storage::compaction_config new_cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -348,6 +352,7 @@ TEST_F(CompactionFixtureTest, TestCompactWithNonDataBatches) {
       = disk_log.get_probe().get_segments_compacted();
     storage::compaction_config new_cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt);
@@ -435,6 +440,7 @@ TEST_P(CompactionFilledReaderTest, ReadFilledGaps) {
     // when reading.
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -493,6 +499,7 @@ TEST_F(CompactionFixtureTest, TestReadFilledGapsWithTerms) {
 
     storage::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      std::nullopt,
       ss::default_priority_class(),
       never_abort,
       std::nullopt,

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -333,7 +333,7 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
 }
 
 FIXTURE_TEST(
-  test_truncate_whole_log_when_logs_are_garbadge_collected,
+  test_truncate_whole_log_when_logs_are_garbage_collected,
   storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     storage::log_manager mgr = make_log_manager(cfg);
@@ -364,6 +364,7 @@ FIXTURE_TEST(
         ts,
         std::nullopt,
         model::offset::max(),
+        std::nullopt,
         ss::default_priority_class(),
         as))
       .get0();
@@ -545,6 +546,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
       ts,
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as));
 
@@ -591,7 +593,7 @@ FIXTURE_TEST(test_concurrent_truncate_and_compaction, storage_test_fixture) {
     // leaving room for further windowed compaction.
     ss::abort_source as;
     compaction_config compaction_cfg(
-      model::offset::max(), ss::default_priority_class(), as);
+      model::offset::max(), std::nullopt, ss::default_priority_class(), as);
     auto& disk_log = *dynamic_cast<disk_log_impl*>(log.get());
     disk_log.adjacent_merge_compact(compaction_cfg).get();
     disk_log.adjacent_merge_compact(compaction_cfg).get();
@@ -608,7 +610,12 @@ FIXTURE_TEST(test_concurrent_truncate_and_compaction, storage_test_fixture) {
     auto ts = now();
     auto sleep_ms1 = random_generators::get_int(0, 100);
     housekeeping_config housekeeping_cfg(
-      ts, std::nullopt, model::offset::max(), ss::default_priority_class(), as);
+      ts,
+      std::nullopt,
+      model::offset::max(),
+      std::nullopt,
+      ss::default_priority_class(),
+      as);
     auto f1 = ss::sleep(sleep_ms1 * 1ms).then([&] {
         return log->housekeeping(housekeeping_cfg);
     });

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0
 
 #include "gmock/gmock.h"
+#include "model/record_batch_types.h"
+#include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "storage/chunk_cache.h"
 #include "storage/disk_log_impl.h"
@@ -122,8 +124,6 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
     ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
 }
 
-// Even though segments with one record would be skipped over during
-// compaction, that shouldn't be reflected by the sliding range.
 TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     storage::disk_log_builder b;
     build_segments(
@@ -140,12 +140,11 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
       ss::default_priority_class(),
       never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
-    // Even though these segments don't have compactible records, they should
-    // be collected. E.g., they should still be self compacted to rebuild
-    // indexes if necessary, etc.
     ASSERT_EQ(5, segs.size());
+
+    // These segments are considered to have compactible records.
     for (const auto& seg : segs) {
-        ASSERT_FALSE(seg->may_have_compactible_records());
+        ASSERT_TRUE(seg->may_have_compactible_records());
     }
 
     // Add some segments with multiple records. They should be eligible for
@@ -158,11 +157,65 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
       /*mark_compacted=*/false);
     segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(8, segs.size());
-    int i = 0;
     for (const auto& seg : segs) {
-        bool should_have_records = i >= 5;
-        ASSERT_EQ(should_have_records, seg->may_have_compactible_records());
-        i++;
+        ASSERT_TRUE(seg->may_have_compactible_records());
+    }
+}
+
+TEST(FindSlidingRangeTest, TestPlaceholderBatchesNoCompactibleRecords) {
+    storage::disk_log_builder b;
+    b | start();
+    const int num_placeholder_batches = 3;
+    std::vector<int> offsets = {10, 17, 25};
+    ASSERT_EQ(offsets.size(), num_placeholder_batches);
+    for (int i = 0; i < num_placeholder_batches; ++i) {
+        auto placeholder_batch = model::test::make_random_batch(
+          model::offset{offsets[i]},
+          2,
+          false,
+          model::record_batch_type::compaction_placeholder);
+        b | add_segment(offsets[i]) | add_batch(std::move(placeholder_batch));
+    }
+    auto& disk_log = b.get_disk_log_impl();
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    compaction_config cfg(
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
+
+    ASSERT_EQ(disk_log.segment_count(), num_placeholder_batches);
+
+    // None of the segments should be included in the sliding range.
+    auto segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(0, segs.size());
+
+    for (const auto& seg : disk_log.segments()) {
+        ASSERT_FALSE(seg->may_have_compactible_records());
+    }
+}
+
+TEST(FindSlidingRangeTest, TestEmptySegmentNoCompactibleRecords) {
+    storage::disk_log_builder b;
+    b | start();
+    b | add_segment(0);
+    auto& disk_log = b.get_disk_log_impl();
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    compaction_config cfg(
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
+
+    ASSERT_EQ(disk_log.segment_count(), 1);
+
+    // The single closed, empty segment shouldn't be included in the sliding
+    // range.
+    auto segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(0, segs.size());
+
+    for (const auto& seg : disk_log.segments()) {
+        ASSERT_FALSE(seg->may_have_compactible_records());
     }
 }
 

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -76,7 +76,10 @@ TEST(FindSlidingRangeTest, TestCollectSegments) {
     for (int start = 0; start < 30; start += 5) {
         for (int end = start; end < 30; end += 5) {
             compaction_config cfg(
-              model::offset{end}, ss::default_priority_class(), never_abort);
+              model::offset{end},
+              std::nullopt,
+              ss::default_priority_class(),
+              never_abort);
             auto segs = disk_log.find_sliding_range(cfg, model::offset{start});
             if (end - start < 10) {
                 // If the compactible range isn't a full segment, we can't
@@ -98,7 +101,10 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(3, segs.size());
     ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
@@ -129,7 +135,10 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     // Even though these segments don't have compactible records, they should
     // be collected. E.g., they should still be self compacted to rebuild
@@ -164,7 +173,10 @@ TEST(BuildOffsetMap, TestBuildSimpleMap) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     probe pb;
 
     feature_table.start().get();
@@ -237,7 +249,10 @@ TEST(BuildOffsetMap, TestBuildMapWithMissingCompactedIndex) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction_config cfg(
-      model::offset{30}, ss::default_priority_class(), never_abort);
+      model::offset{30},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     for (const auto& s : segs) {
         auto idx_path = s->path().to_compacted_index();
         ASSERT_FALSE(ss::file_exists(idx_path.string()).get());
@@ -279,7 +294,10 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
 
     // Build an offset map for our log.
     compaction_config cfg(
-      model::offset{0}, ss::default_priority_class(), never_abort);
+      model::offset{0},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
     simple_key_offset_map all_segs_map(50);
     auto map_start_offset = build_offset_map(
                               cfg,

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -108,6 +108,7 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
       /*gc_upper=*/model::timestamp::max(),
       /*max_bytes_in_log=*/1,
       /*max_collect_offset=*/model::offset::min(),
+      /*tombstone_retention_ms=*/std::nullopt,
       ss::default_priority_class(),
       as);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -674,6 +674,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
       model::to_timestamp(broker_t0 - (2 * broker_ts_sep)),
       std::nullopt,
       model::offset::min(), // should prevent compaction
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto before = disk_log->offsets();
@@ -688,6 +689,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
             model::to_timestamp(timestamp),
             std::nullopt,
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as);
       };
@@ -761,6 +763,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       model::timestamp::min(),
       total_size + first_size,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     compact_and_prefix_truncate(*disk_log, ccfg_no_compact);
@@ -790,6 +793,7 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
       model::timestamp::min(),
       max_size,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     compact_and_prefix_truncate(*disk_log, ccfg);
@@ -860,6 +864,7 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       gc_ts,
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -969,6 +974,7 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
           model::timestamp::min(),
           1000,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         return log->housekeeping(ccfg);
@@ -1150,6 +1156,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       model::timestamp::min(),
       1,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto log = mgr.manage(std::move(ntp_cfg)).get0();
@@ -1311,6 +1318,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
+          std::nullopt,
           ss::default_priority_class(),
           as);
         log->flush().get0();
@@ -1376,6 +1384,7 @@ FIXTURE_TEST(
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->flush().get0();
@@ -1562,6 +1571,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
       model::timestamp::min(),
       50_KiB,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1681,6 +1691,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1749,6 +1760,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -1823,6 +1835,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -2020,6 +2033,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     /**
@@ -2354,6 +2368,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -2595,6 +2610,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto before_compaction = compact_in_memory(log);
@@ -2836,6 +2852,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                              model::timestamp::min(),
                              std::nullopt,
                              model::offset::max(),
+                             std::nullopt,
                              ss::default_priority_class(),
                              as))
                            .handle_exception_type(
@@ -2927,6 +2944,7 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
               model::timestamp::min(),
               std::nullopt,
               model::offset::max(),
+              std::nullopt,
               ss::default_priority_class(),
               as))
             .get();
@@ -3060,6 +3078,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       max_compact_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(ccfg).get0();
@@ -3124,6 +3143,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     auto& segment = *(disk_log->segments().begin());
@@ -3178,6 +3198,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       as);
 
@@ -3266,6 +3287,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset(args.max_compact_offs),
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(ccfg).get0();
@@ -3515,6 +3537,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
             model::timestamp::min(),
             cfg.retention_bytes(),
             model::offset::max(),
+            std::nullopt,
             ss::default_priority_class(),
             as));
 
@@ -3699,6 +3722,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
       model::timestamp::max(),
       1,
       model::offset::max(),
+      std::nullopt,
       ss::default_priority_class(),
       abs};
 
@@ -4154,6 +4178,7 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       log->offsets().committed_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(h_cfg).get();
@@ -4357,6 +4382,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
       model::timestamp::min(),
       std::nullopt,
       log->offsets().committed_offset,
+      std::nullopt,
       ss::default_priority_class(),
       as);
     log->housekeeping(h_cfg).get();

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -119,7 +119,8 @@ ss::future<> disk_log_builder::truncate(model::offset o) {
 
 ss::future<> disk_log_builder::gc(
   model::timestamp collection_upper_bound,
-  std::optional<size_t> max_partition_retention_size) {
+  std::optional<size_t> max_partition_retention_size,
+  std::optional<std::chrono::milliseconds> tombstone_retention_ms) {
     ss::abort_source as;
     auto eviction_future = get_log()->monitor_eviction(as);
 
@@ -128,6 +129,7 @@ ss::future<> disk_log_builder::gc(
         collection_upper_bound,
         max_partition_retention_size,
         model::offset::max(),
+        tombstone_retention_ms,
         ss::default_priority_class(),
         _abort_source))
       .get();

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -304,7 +304,9 @@ public:
     ss::future<> truncate(model::offset);
     ss::future<> gc(
       model::timestamp collection_upper_bound,
-      std::optional<size_t> max_partition_retention_size);
+      std::optional<size_t> max_partition_retention_size,
+      std::optional<std::chrono::milliseconds> tombstone_retention_ms
+      = std::nullopt);
     ss::future<usage_report> disk_usage(
       model::timestamp collection_upper_bound,
       std::optional<size_t> max_partition_retention_size);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -197,9 +197,11 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
       "{{max_collectible_offset:{}, "
-      "should_sanitize:{}}}",
+      "should_sanitize:{}, "
+      "tombstone_retention_ms:{}}}",
       c.max_collectible_offset,
-      c.sanitizer_config);
+      c.sanitizer_config,
+      c.tombstone_retention_ms);
     return o;
 }
 


### PR DESCRIPTION
This PR adds the underlying logic for tombstone removal to the local storage compaction subsystem.

`tombstone.retention.ms` is added as a field in `storage::compaction_config`, and can be used to remove tombstone records during or past the second time they are "seen" by the compaction subsystem.

A tombstone record is first considered "seen" when the owning segment is fully indexed during sliding window compaction (therefore, the owning segment is fully de-duplicated, and thus "clean"- i.e, no keys in that segment exist as potential duplicates in the log up to that point). This is the only time a segment can be considered "cleaned" by compaction.

A tombstone record can be considered "seen" for the second time either in self-compaction or again in sliding window compaction. At this point, it is safe to remove the tombstone record completely from the segment, if `timestamp::now() > clean_compact_timestamp + tombstone.retention.ms`.

This PR does NOT  add user facing configuration options for `tombstone.retention.ms` or any way to enable this feature yet, as this is coming in future PRs (along with more end to end testing of tombstone removal). [This parameter is intentionally left as `std::nullopt` to ensure the `log_manager` does not execute any tombstone deletion during housekeeping](https://github.com/redpanda-data/redpanda/commit/832a9969d30fef0df91c78492fd0b7e955eea613#diff-a1e1756fe2837364b78bb45aace32a6fafeb11e07d8ce0c20e8ec8f22cc5b6dcR278).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none