### PR TITLE
[v24.2.x] CORE-7049 dt/rbac: wait for healthy cluster after restart

### DIFF
--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -885,6 +885,11 @@ class RolePersistenceTest(RBACTestBase):
 
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
+        # Wait for the cluster to elect a controller leader after the restart
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=30,
+                                 backoff_sec=1)
+
         admin = self.superuser_admin
 
         names = [


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23217
