### PR TITLE
[v23.3.x] `config`: mark `cloud_storage_enabled()` as `needs_restart::yes`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1553,7 +1553,7 @@ configuration::configuration()
       *this,
       "cloud_storage_enabled",
       "Enable archival storage",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , cloud_storage_enable_remote_read(
       *this,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23224
