### PR TITLE
cst/inv: Minor fixes for issues found during scrubber integration

### DIFF
--- a/src/v/cloud_storage/inventory/inv_consumer.cc
+++ b/src/v/cloud_storage/inventory/inv_consumer.cc
@@ -113,7 +113,7 @@ inventory_consumer::process_paths(fragmented_vector<ss::sstring> paths) {
 
 void inventory_consumer::process_path(ss::sstring path) {
     if (auto maybe_ntp = ntp_from_path(path);
-        _ntps.contains(maybe_ntp.value())) {
+        maybe_ntp.has_value() && _ntps.contains(maybe_ntp.value())) {
         const auto& ntp = maybe_ntp.value();
         auto hash = xxhash_64(path.data(), path.size());
 

--- a/src/v/cloud_storage/inventory/inv_consumer.cc
+++ b/src/v/cloud_storage/inventory/inv_consumer.cc
@@ -34,8 +34,9 @@ namespace ranges = std::ranges;
 namespace views = std::views;
 
 namespace {
-// hash-string/ns/tp/partition_rev/.*
-const RE2 path_expr{"^[[:xdigit:]]+/(.*?)/(.*?)/(\\d+)_\\d+/.*?"};
+// hash-string/ns/tp/partition_rev/.* OR
+// cluster-uuid/ns/tp/partition_rev/.*
+const RE2 path_expr{"^[[:xdigit:]-]+/(.*?)/(.*?)/(\\d+)_\\d+/.*?"};
 
 // Holds hashes for a given NTP in memory before they will be flushed to disk.
 // One of these structures is held per NTP in a map keyed by the NTP itself.

--- a/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
@@ -43,6 +43,8 @@ TEST(Consumer, ParseNTPFromPath) {
     std::vector<p> test_data{
       {"a0a6eeb8/kafka/topic-x/999_24/178-188-1574137-1-v1.log.1",
        std::make_optional(make_ntp("kafka", "topic-x", 999))},
+      {"d10492a6-2408-418e-9b6b-051697c5255b/k/t/1_24/---",
+       std::make_optional(make_ntp("k", "t", 1))},
       {"a/k/t/1_24/---", std::make_optional(make_ntp("k", "t", 1))},
       // Bad hex m
       {"m/k/t/1_24/---", std::nullopt},


### PR DESCRIPTION
This PR contains two minor fixes for issues found during scrubber integration:

1. fix  an unchecked optional access in inv. consumer
2. allow uuid prefixes to segment paths

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
