### PR TITLE
kafka: Fixed segfault issue with auditing and mTLS

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -203,7 +203,7 @@ ss::future<> connection_context::start() {
 }
 
 ss::future<> connection_context::stop() {
-    if (_hook) {
+    if (_hook && is_linked()) {
         _hook.value().get().erase(_hook.value().get().iterator_to(*this));
     }
     if (conn) {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -347,6 +347,10 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
 
     std::exception_ptr eptr;
     try {
+        co_await ctx->start();
+        // Must call start() to ensure `ctx` is inserted into the `_connections`
+        // list.  Otherwise if enqueing the audit message fails and `stop()` is
+        // called, this will result in a segfault.
         if (authn_method == config::broker_authn_method::mtls_identity) {
             auto authn_event = make_auth_event_options(mtls_state.value(), ctx);
             if (!ctx->server().audit_mgr().enqueue_authn_event(
@@ -356,7 +360,6 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
                   "system error");
             }
         }
-        co_await ctx->start();
         co_await ctx->process();
     } catch (...) {
         eptr = std::current_exception();

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -297,7 +297,9 @@ ss::future<> audit_client::update_status(kafka::error_code errc) {
         }
     } else if (_last_errc == kafka::error_code::illegal_sasl_state) {
         /// The status changed from erraneous to anything else
-        if (errc != kafka::error_code::illegal_sasl_state) {
+        if (
+          errc != kafka::error_code::illegal_sasl_state
+          && errc != kafka::error_code::broker_not_available) {
             co_await _sink->update_auth_status(
               audit_sink::auth_misconfigured_t::no);
         }


### PR DESCRIPTION
The connection_context::start method enqueues the connect_context instance into the list of connections.  If connection_context::stop is called before the item is inserted, then a segfault will happen.

Fixes: CORE-7245

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Fixed a segfault that will occur if mTLS is in use and the auditing client is not configured correctly

