### PR TITLE
tests/shard_placement: fix waiting for shard map consistency

### DIFF
--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -207,16 +207,15 @@ class ShardPlacementTest(PreallocNodesTest):
         return shard_map
 
     def wait_shard_map_consistent_with_cluster_partitions(
-            self,
-            shard_map,
-            user_topics=[],
-            admin=None,
-            timeout_sec=30,
-            backoff_sec=3):
+            self, user_topics=[], admin=None, timeout_sec=30, backoff_sec=3):
         if admin is None:
             admin = Admin(self.redpanda)
 
         def is_consistent():
+            self.logger.debug("querying shard map directly from nodes...")
+            shard_map = self.get_replica_shard_map(
+                self.redpanda.started_nodes(), admin=None)
+
             self.logger.debug("querying shard map for all partitions...")
             all_partitions = admin.get_cluster_partitions(with_internal=True)
             if not self.shard_maps_equal(
@@ -284,7 +283,7 @@ class ShardPlacementTest(PreallocNodesTest):
         self.print_shard_stats(map_after_upgrade)
         assert map_after_upgrade == initial_map
         self.wait_shard_map_consistent_with_cluster_partitions(
-            map_after_upgrade, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         # Manually move replicas of one topic on one node to shard 0
 
@@ -308,7 +307,7 @@ class ShardPlacementTest(PreallocNodesTest):
         assert foo_shard_counts[0] == n_partitions
         assert sum(foo_shard_counts) == n_partitions
         self.wait_shard_map_consistent_with_cluster_partitions(
-            map_after_manual_move, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         # Add more nodes to the cluster and create another topic
 
@@ -372,7 +371,7 @@ class ShardPlacementTest(PreallocNodesTest):
         self.print_shard_stats(map_after_restart)
         assert map_after_restart == map_before_restart
         self.wait_shard_map_consistent_with_cluster_partitions(
-            map_after_restart, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         self.stop_client_load()
 
@@ -420,7 +419,7 @@ class ShardPlacementTest(PreallocNodesTest):
         assert counts_by_topic["bar"][core_count - 1] == n_partitions
         assert sum(counts_by_topic["bar"]) == n_partitions
         self.wait_shard_map_consistent_with_cluster_partitions(
-            shard_map, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         admin.trigger_cores_rebalance(node)
         self.logger.info(
@@ -433,7 +432,7 @@ class ShardPlacementTest(PreallocNodesTest):
         for topic, shard_counts in counts_by_topic.items():
             assert max(shard_counts) - min(shard_counts) <= 1
         self.wait_shard_map_consistent_with_cluster_partitions(
-            shard_map, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         self.stop_client_load()
 
@@ -606,6 +605,6 @@ class ShardPlacementTest(PreallocNodesTest):
         self.logger.info("shard rebalance finished")
         self.print_shard_stats(shard_map_after_balance)
         self.wait_shard_map_consistent_with_cluster_partitions(
-            shard_map_after_balance, user_topics=topics, admin=admin)
+            user_topics=topics, admin=admin)
 
         self.stop_client_load()

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -593,22 +593,10 @@ class ShardPlacementTest(PreallocNodesTest):
                 node_id = self.redpanda.node_id(n)
                 shard_counts = self.get_shard_counts_by_topic(
                     shard_map, node_id)
-
-                total_counts = None
                 for topic in topics:
                     topic_counts = shard_counts[topic]
-
-                    if total_counts is None:
-                        total_counts = topic_counts
-                    else:
-                        for s, c in enumerate(topic_counts):
-                            total_counts[s] += c
-
                     if max(topic_counts) - min(topic_counts) > 1:
                         return False
-
-                if max(total_counts) - min(total_counts) > 1:
-                    return False
 
             return (True, shard_map)
 


### PR DESCRIPTION
When we wait for consistency between shard maps queried using the /cluster/partitions admin API endpoint and the /partitions endpoint on nodes themselves, we need to query for both shard maps at approximately the same time (and not use the one queried in the beginning) because it may change in the process of waiting.

This is the second attempt at fixing https://redpandadata.atlassian.net/browse/CORE-6851

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none