### PR TITLE
utils: Add hybrid_clock

### DIFF
--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -651,3 +651,15 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "hybrid_clock",
+    hdrs = [
+        "hybrid_clock.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/hybrid_clock.h
+++ b/src/v/utils/hybrid_clock.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "base/likely.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+
+#include <chrono>
+
+/// The hybrid_clock is a thin wrapper around the seastar::lowres_clock
+/// that can be swapped from seastar::manual_clock in tests by flipping
+/// a runtime flag (per shard). The timestamps and durations are using
+/// last bit as a flag indicating the type of clock used to produce
+/// them.
+class hybrid_clock {
+    struct duration_with_flag {
+        uint64_t nanoseconds{0};
+        bool manual{false};
+    };
+
+public:
+    // Same as std::chrono::steady_clock::rep
+    //
+    using duration = std::chrono::nanoseconds;
+    using rep = duration::rep;
+    using period = duration::period;
+    using time_point = std::chrono::time_point<hybrid_clock, duration>;
+    static constexpr bool is_steady = true;
+
+    inline static time_point now() noexcept;
+
+    inline static void update() noexcept;
+
+    inline static void advance(duration d);
+
+    inline static void set_manual_mode(bool mode);
+
+    inline static bool is_manual(const time_point& t);
+
+    friend bool operator==(const time_point& lhs, const time_point& rhs);
+    friend auto operator<=>(const time_point& lhs, const time_point& rhs);
+    friend duration operator-(const time_point& lhs, const time_point& rhs);
+    friend time_point operator-(const time_point& lhs, const duration& rhs);
+    friend time_point operator+(const time_point& lhs, const duration& rhs);
+
+private:
+    inline static void throw_clock_mismatch() {
+        throw std::logic_error("clock mismatch");
+    }
+    // This will set zero bit of the duration to 0 if the lowres_clock  is used
+    // or to 1 if manual clock is used. That's totally fine given that the clock
+    // is lowres and the duration is expressed in nanoseconds. So the bit is
+    // normally set to zero and will only be flipped to 1 in case if manual
+    // clock is used.
+    inline static void duration_bit_hack(duration& target, bool manual);
+    // Extract the actual timestamp with the flag
+    inline static duration_with_flag decode(const duration& d);
+
+    inline static thread_local bool _manual{false}; // NOLINT
+    inline static constexpr uint64_t mask = uint64_t(0) - 2;
+};
+
+inline hybrid_clock::time_point hybrid_clock::now() noexcept {
+    auto dur = std::chrono::duration_cast<duration>(
+      seastar::lowres_clock::now().time_since_epoch());
+    if (unlikely(_manual)) {
+        auto now = seastar::manual_clock::now();
+        dur = std::chrono::duration_cast<duration>(now.time_since_epoch());
+    }
+    duration_bit_hack(dur, _manual);
+    return time_point(dur);
+}
+
+inline void hybrid_clock::update() noexcept { seastar::lowres_clock::update(); }
+
+inline void hybrid_clock::advance(hybrid_clock::duration d) {
+    seastar::manual_clock::advance(
+      std::chrono::duration_cast<seastar::manual_clock::duration>(d));
+}
+
+inline void hybrid_clock::set_manual_mode(bool mode) { _manual = mode; }
+
+inline bool hybrid_clock::is_manual(const time_point& t) {
+    const auto [nanos, flag] = decode(t.time_since_epoch());
+    return flag;
+}
+
+inline void
+hybrid_clock::duration_bit_hack(hybrid_clock::duration& target, bool manual) {
+    bool zero_bit = manual == true;
+    auto count = target.count();
+    uint64_t bits = 0;
+    static_assert(sizeof(bits) == sizeof(count));
+    std::memcpy(&bits, &count, sizeof(bits));
+    std::cout << "BH bits: " << bits << std::endl;
+    if (zero_bit) {
+        bits = bits | 1UL;
+    } else {
+        bits = bits & mask;
+    }
+    std::cout << "BH bits (after): " << bits << std::endl;
+    std::memcpy(&count, &bits, sizeof(bits));
+    target = duration(count);
+}
+
+// Extract the actual timestamp with the flag
+inline hybrid_clock::duration_with_flag
+hybrid_clock::decode(const hybrid_clock::duration& d) {
+    auto count = d.count();
+    uint64_t bits = count;
+    std::memcpy(&bits, &count, sizeof(bits));
+    std::cout << "Bits1: " << bits << std::endl;
+    bool flag = (bits & 1UL) != 0;
+    std::cout << "Flag: " << flag << std::endl;
+    bits = bits & mask;
+    std::cout << "Bits2: " << bits << std::endl;
+    return {
+      .nanoseconds = bits,
+      .manual = flag,
+    };
+}
+
+inline bool operator==(
+  const hybrid_clock::time_point& lhs, const hybrid_clock::time_point& rhs) {
+    auto [lhs_nanos, lhs_manual] = hybrid_clock::decode(lhs.time_since_epoch());
+    auto [rhs_nanos, rhs_manual] = hybrid_clock::decode(rhs.time_since_epoch());
+    if (lhs_manual != rhs_manual) {
+        hybrid_clock::throw_clock_mismatch();
+    }
+    return lhs_nanos == rhs_nanos;
+}
+
+inline auto operator<=>(
+  const hybrid_clock::time_point& lhs, const hybrid_clock::time_point& rhs) {
+    auto [lhs_nanos, lhs_manual] = hybrid_clock::decode(lhs.time_since_epoch());
+    auto [rhs_nanos, rhs_manual] = hybrid_clock::decode(rhs.time_since_epoch());
+    if (lhs_manual != rhs_manual) {
+        hybrid_clock::throw_clock_mismatch();
+    }
+    return lhs_nanos <=> rhs_nanos;
+}
+
+inline hybrid_clock::duration operator-(
+  const hybrid_clock::time_point& lhs, const hybrid_clock::time_point& rhs) {
+    std::cout << "NEEDLE1" << std::endl;
+    auto [lhs_nanos, lhs_manual] = hybrid_clock::decode(lhs.time_since_epoch());
+    auto [rhs_nanos, rhs_manual] = hybrid_clock::decode(rhs.time_since_epoch());
+    if (lhs_manual != rhs_manual) {
+        hybrid_clock::throw_clock_mismatch();
+    }
+    auto d = hybrid_clock::duration(lhs_nanos - rhs_nanos);
+    // The bitflag is always inherited from the operands
+    hybrid_clock::duration_bit_hack(d, lhs_manual);
+    return d;
+}
+
+inline hybrid_clock::time_point operator-(
+  const hybrid_clock::time_point& lhs, const hybrid_clock::duration& rhs) {
+    auto [lhs_nanos, lhs_manual] = hybrid_clock::decode(lhs.time_since_epoch());
+    auto d = std::chrono::nanoseconds(lhs_nanos) + rhs;
+    hybrid_clock::duration_bit_hack(d, lhs_manual);
+    return hybrid_clock::time_point(d);
+}
+
+inline hybrid_clock::time_point operator+(
+  const hybrid_clock::time_point& lhs, const hybrid_clock::duration& rhs) {
+    auto [lhs_nanos, lhs_manual] = hybrid_clock::decode(lhs.time_since_epoch());
+    auto d = std::chrono::nanoseconds(lhs_nanos) + rhs;
+    hybrid_clock::duration_bit_hack(d, lhs_manual);
+    return hybrid_clock::time_point(d);
+}
+
+class manual_clock_scope {
+public:
+    manual_clock_scope() { hybrid_clock::set_manual_mode(true); }
+    ~manual_clock_scope() { hybrid_clock::set_manual_mode(false); }
+};

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -523,3 +523,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "hybrid_clock_gtest",
+    timeout = "short",
+    srcs = [
+        "hybrid_clock_gtest.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:hybrid_clock",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/hybrid_clock_gtest.cc
+++ b/src/v/utils/tests/hybrid_clock_gtest.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "test_utils/test.h"
+#include "utils/hybrid_clock.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <system_error>
+
+TEST_CORO(hybrid_clock, lowres_clock_mode) {
+    auto h_now = hybrid_clock::now();
+    ASSERT_FALSE_CORO(hybrid_clock::is_manual(h_now));
+    auto l_now = seastar::lowres_clock::now();
+    // The clocks could be off by 1ns
+    ASSERT_EQ_CORO(
+      h_now.time_since_epoch().count() / 2,
+      l_now.time_since_epoch().count() / 2);
+    co_await seastar::sleep(std::chrono::milliseconds(100));
+    h_now = hybrid_clock::now();
+    l_now = seastar::lowres_clock::now();
+    ASSERT_EQ_CORO(
+      h_now.time_since_epoch().count() / 2,
+      l_now.time_since_epoch().count() / 2);
+    co_return;
+}
+
+TEST(hybrid_clock, manual_clock_mode) {
+    manual_clock_scope scope;
+    auto h_now = hybrid_clock::now();
+    ASSERT_TRUE(hybrid_clock::is_manual(h_now));
+    auto m_now = seastar::manual_clock::now();
+    ASSERT_EQ(
+      h_now.time_since_epoch().count() / 2,
+      m_now.time_since_epoch().count() / 2);
+    hybrid_clock::advance(std::chrono::seconds(10));
+    h_now = hybrid_clock::now();
+    m_now = seastar::manual_clock::now();
+    ASSERT_EQ(
+      h_now.time_since_epoch().count() / 2,
+      m_now.time_since_epoch().count() / 2);
+}
+
+TEST(hybrid_clock, operators_throw) {
+    // Check that manual and real clock timestamps can't be mixed in one
+    // expression
+    auto real = hybrid_clock::now();
+    manual_clock_scope scope;
+    auto manual = hybrid_clock::now();
+    ASSERT_THROW((void)(real < manual), std::logic_error);
+    ASSERT_THROW((void)(real > manual), std::logic_error);
+    ASSERT_THROW((void)(real <= manual), std::logic_error);
+    ASSERT_THROW((void)(real >= manual), std::logic_error);
+    ASSERT_THROW((void)(real == manual), std::logic_error);
+    ASSERT_THROW((void)(real != manual), std::logic_error);
+    ASSERT_THROW((void)(real - manual), std::logic_error);
+    // Time shifted hybrid clock shouldn't loose information about its origin
+    ASSERT_THROW(
+      (void)((manual + std::chrono::seconds(1)) < real), std::logic_error);
+    ASSERT_THROW(
+      (void)((manual + std::chrono::seconds(1)) < real), std::logic_error);
+}
+
+TEST(hybrid_clock, operators_correctness_manual) {
+    // Check that operators yield correct results
+    manual_clock_scope scope;
+    auto lhs = hybrid_clock::now();
+    auto lhe = seastar::manual_clock::now();
+    hybrid_clock::duration diff(std::chrono::seconds(10));
+    hybrid_clock::advance(diff);
+    auto rhs = hybrid_clock::now();
+    auto rhe = seastar::manual_clock::now();
+    ASSERT_TRUE(lhs < rhs);
+    ASSERT_TRUE(rhs > lhs);
+    ASSERT_EQ((rhs - lhs).count() / 2, (rhe - lhe).count() / 2);
+}
+
+TEST_CORO(hybrid_clock, operators_correctness_system) {
+    // Check that operators yield correct results
+    auto lhs = hybrid_clock::now();
+    auto lhe = seastar::lowres_clock::now();
+    hybrid_clock::duration diff(std::chrono::milliseconds(100));
+    co_await seastar::sleep(diff);
+    auto rhs = hybrid_clock::now();
+    auto rhe = seastar::lowres_clock::now();
+    ASSERT_TRUE_CORO(lhs < rhs);
+    ASSERT_TRUE_CORO(rhs > lhs);
+    ASSERT_EQ_CORO((rhs - lhs).count() / 2, (rhe - lhe).count() / 2);
+}


### PR DESCRIPTION
The hybrid_clock is a thin wrapper around the `seastar::lowres_clock`. Normally it works the same way as `lowres_clock` except that it can be off by 1ns compared to `lowres_clock`. The `hybrid_clock` can also act as a `seastar::manual_clock` wrapper if `hybrid_clock::set_manual_mode(true)` was called or the instance of `manual_clock_scope` is created.

The purpose of the hybrid_clock is to replace uses of the lowres_clock and allow us to easily use manual mode in tests.

The implementation uses thread local '_manual' flag which is set to false by default. The clock uses lowest bit of the timestamp to record the source clock which was used to generate the timestamp. The flag is checked if two timestamps are compared or subtracted from each other. If both timestamps are generated using different clocks the `std::logic_error` exception is thrown.

The runtime cost is minimal and prioritizes the normal mode (system clock).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none