### PR TITLE
tests: Fix cloud tests provider selection

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1717,7 +1717,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         self._cc_config = context.globals[self.GLOBAL_CLOUD_CLUSTER_CONFIG]
 
         self._provider_config = {}
-        match get_cloud_provider():
+        match context.globals.get("cloud_provider"):
             case "aws" | "gcp":
                 self._provider_config.update({
                     'access_key':


### PR DESCRIPTION
`get_cloud_provider` relies on the environment variable `CLOUD_PROVIDER`
to be set. This doesn't get automatically set in a standard duck.py
setup.

Hence, rather rely on the cloud provider specified in the `global.json`
which does get correctly setup by duck.py/ansible.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
