### PR TITLE
CORE-6896 dt/audit: enable oauth after keycloak is up

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -1743,8 +1743,9 @@ class AuditLogTestOauth(AuditLogTestBase):
         security = AuditLogTestSecurityConfig(
             user_creds=RedpandaServiceBase.SUPERUSER_CREDENTIALS)
         security.enable_sasl = True
-        security.sasl_mechanisms = ['SCRAM', 'OAUTHBEARER']
-        security.http_authentication = ['BASIC', 'OIDC']
+        security.sasl_mechanisms = ['SCRAM']
+        security.http_authentication = ['BASIC']
+        # We'll only enable Oath once keycloak is up and running
 
         self.keycloak = KeycloakService(test_context)
 
@@ -1771,11 +1772,18 @@ class AuditLogTestOauth(AuditLogTestBase):
             self.keycloak.clean_node(kc_node)
             assert False, f'Keycloak failed to start: {e}'
 
+        self.security.sasl_mechanisms += ['OAUTHBEARER']
+        self.security.http_authentication += ['OIDC']
+
         self._modify_cluster_config({
             'oidc_discovery_url':
             self.keycloak.get_discovery_url(kc_node),
             "oidc_token_audience":
-            self.token_audience
+            self.token_audience,
+            "sasl_mechanisms":
+            self.security.sasl_mechanisms,
+            "http_authentication":
+            self.security.http_authentication,
         })
 
         self.keycloak.admin.create_user('norma',


### PR DESCRIPTION
OAuth has a background loop that polls the OIDC discovery service (configured via the cluster config `oidc_discovery_url`) for updates. This background loop starts as soon as OAuth is enabled via the `sasl_mechanisms` and `http_authentication` cluster configs. `oidc_discovery_url` has a default value pointing to a Redpanda-hosted OIDC configuration. However, we should not rely on this Redpanda-hosted default OIDC endpoint in our tests and CI because it might be temporarily unavailable and cause the tests to be flaky.

To fix this test being flaky, we only enable OAuth once the local keycloak server is up and available to serve the OIDC discovery endpoint.

Without this fix, we might get the following error in the redpanda brokers' logs when the broker fails to poll the Redpanda-provided OIDC provider:
```
<BadLogLines nodes=docker-rp-14(1) example="ERROR 2024-07-21 06:42:40,090 [shard 0:main] security - oidc_service.cc:232 - Error updating jwks: security::exception (Invalid jwks: Invalid response from jwks_uri: https://auth.prd.cloud.redpanda.com:443/.well-known/jwks.json)">
```

Fixes https://redpandadata.atlassian.net/browse/CORE-6896
Ref https://ci-artifacts.dev.vectorized.cloud/redpanda/51827/0190d3fb-2bef-4848-b9e1-8cf3bed68363/vbuild/ducktape/results/final/report.html

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
