### PR TITLE
More iobuf cross-shard checks, better doc

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -152,10 +152,12 @@ public:
       , _verify_shard(x._verify_shard)
 #endif
     {
+        x.mutating_method_called();
         x._frags = container{};
         x._size = 0;
     }
     iobuf& operator=(iobuf&& x) noexcept {
+        mutating_method_called();
         if (this != &x) {
             this->~iobuf();
             new (this) iobuf(std::move(x));
@@ -339,6 +341,7 @@ private:
 };
 
 inline void iobuf::clear() {
+    mutating_method_called();
     _frags.clear_and_dispose(&details::dispose_io_fragment);
     _size = 0;
 }
@@ -382,6 +385,7 @@ inline void iobuf::mutating_method_called() const {
 }
 
 inline void iobuf::append(std::unique_ptr<fragment> f) {
+    mutating_method_called();
     if (!_frags.empty()) {
         _frags.back().trim();
     }
@@ -390,6 +394,7 @@ inline void iobuf::append(std::unique_ptr<fragment> f) {
     _frags.push_back(*f.release());
 }
 inline void iobuf::prepend(std::unique_ptr<fragment> f) {
+    mutating_method_called();
     _size += f->size();
     _frags.push_front(*f.release());
 }
@@ -414,6 +419,7 @@ inline void iobuf::reserve_memory(size_t reservation) {
 
 [[gnu::always_inline]] void inline iobuf::prepend(
   ss::temporary_buffer<char> b) {
+    mutating_method_called();
     if (unlikely(!b.size())) {
         return;
     }
@@ -431,6 +437,7 @@ inline void iobuf::reserve_memory(size_t reservation) {
 /// append src + len into storage
 [[gnu::always_inline]] void inline iobuf::append(
   const uint8_t* src, size_t len) {
+    mutating_method_called();
     // NOLINTNEXTLINE
     append(reinterpret_cast<const char*>(src), len);
 }
@@ -459,10 +466,10 @@ inline void iobuf::reserve_memory(size_t reservation) {
 
 /// appends the contents of buffer; might pack values into existing space
 [[gnu::always_inline]] inline void iobuf::append(ss::temporary_buffer<char> b) {
+    mutating_method_called();
     if (unlikely(!b.size())) {
         return;
     }
-    mutating_method_called();
     const size_t last_asz = last_allocation_size();
     // The following is a heuristic to decide between copying and zero-copy
     // append of the source buffer. The rule we apply is if the buffer we are

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -118,12 +118,9 @@ def cluster(log_allow_list: LogAllowList | None = None,
                         f"Test failed, doing failure checks on {redpanda.who_am_i()}..."
                     )
 
-                    # Disabled to avoid addr2line hangs
-                    # (https://github.com/redpanda-data/redpanda/issues/5004)
-                    # self.redpanda.decode_backtraces()
-
-                    if isinstance(redpanda, RedpandaServiceBase):
+                    if isinstance(redpanda, RedpandaService):
                         redpanda.cloud_storage_diagnostics()
+                        redpanda.decode_backtraces()
                     if isinstance(redpanda,
                                   RedpandaService | RedpandaServiceCloud):
                         redpanda.raise_on_crash(log_allow_list=log_allow_list)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -36,7 +36,11 @@ class RedpandaTestBase(ABC, Test):
         self.scale = Scale(test_context)
 
     def setUp(self):
-        self.__redpanda.start()
+        try:
+            self.__redpanda.start()
+        except:
+            self.__redpanda.decode_backtraces()
+            raise
         self._create_initial_topics()
 
     @abstractmethod


### PR DESCRIPTION
Increase the iobuf strictness in checking for "same shard" restrictions in debug mode.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

