### PR TITLE
archival_policy: skip if no data at desired start_offset

### DIFF
--- a/src/v/cluster/archival/archival_policy.cc
+++ b/src/v/cluster/archival/archival_policy.cc
@@ -208,6 +208,16 @@ archival_policy::lookup_result archival_policy::find_segment(
           start_offset);
         return {};
     }
+    if (start_offset > (*it)->offsets().get_committed_offset()) {
+        vlog(
+          archival_log.debug,
+          "Upload policy for {}: can't find candidate, found segment's "
+          "committed offset is less than start_offset {}: {}",
+          _ntp,
+          start_offset,
+          *it);
+        return {};
+    }
     // Invariant: it != set.end()
     bool closed = !(*it)->has_appender();
     bool below_flush_offset = flush_offset.has_value()


### PR DESCRIPTION
In searching for an upload candidate for offset N, we previously allow the archival_policy to return a segment that contained N, but whose committed offset was N-1, e.g. because the segment was the active segment and offset N is still dirty from a storage perspective.

This would previously result in an ERROR log when trying to find N in the segment.

Example:

```
DEBUG 2024-09-09 23:49:47,757 [shard 4:au  ] archival - archival_policy.cc:176 - Upload policy for {kafka/topic-mbxgxbewtz/18} invoked, start offset: 7042
DEBUG 2024-09-09 23:49:47,757 [shard 4:au  ] archival - archival_policy.cc:466 - Upload policy for {kafka/topic-mbxgxbewtz/18}, creating upload candidate: start_offset 7042, segment offsets {term:1, base_offset:4006, committed_offset:7041, dirty_offset:7042}, adjusted LSO 7041 ...
ERROR 2024-09-09 23:49:47,757 [shard 4:au  ] archival - archival_policy.cc:414 - Upload candidate not created, failed to get file range: Illegal seek
```

Updates the policy to check the committed offset of the found segment before returning.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
