### PR TITLE
bazel: add clang-format command

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -51,3 +51,14 @@ py_binary(
         "@python_deps//pyyaml",
     ],
 )
+
+sh_binary(
+    name = "clang_format",
+    srcs = ["clang_format.sh"],
+    args = [
+        "$(rootpath @llvm_18_toolchain//:clang-format)",
+    ],
+    data = [
+        "@llvm_18_toolchain//:clang-format",
+    ],
+)

--- a/tools/clang_format.sh
+++ b/tools/clang_format.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+clang_format=$(readlink -f $1)
+# See: https://bazel.build/docs/user-manual#running-executables
+root_dir=$BUILD_WORKSPACE_DIRECTORY
+working_dir=$BUILD_WORKING_DIRECTORY
+
+pushd "$working_dir"
+git ls-files --full-name "*.cc" "*.java" "*.h" "*.proto" | xargs -n1 "$clang_format" -i -style=file -fallback-style=none
+popd


### PR DESCRIPTION
This adds a command to run clang-format using the version from our bazel
toolchain.

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
