### PR TITLE
tests: Increase warm msg count in cloud high throughput tests

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -216,7 +216,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
     min_segment_size = 16 * MiB
     unavailable_timeout = 60
     # default message count to check
-    msg_count = 10000
+    msg_count = 100000
     # Default value
     msg_timeout = 120
 


### PR DESCRIPTION
Only waiting for 10k messages isn't that much. It's only a few seconds
even on smaller tiers so not really enough time to warm up.

Increase the msg count to hopefully make this less flaky.

Ref CORE-7083

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes



* none

