### PR TITLE
`storage`: reduce `num_test_cases` in `test_offset_range_size2_compacted`

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4291,10 +4291,10 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
 
 FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
 #ifdef NDEBUG
-    size_t num_test_cases = 5000;
+    size_t num_test_cases = 1000;
     size_t num_segments = 300;
 #else
-    size_t num_test_cases = 500;
+    size_t num_test_cases = 100;
     size_t num_segments = 30;
 #endif
     // This test generates 300 segments and creates a record batch map.


### PR DESCRIPTION
This fixture test was timing out in both debug and release modes. Reduce the number of test cases to prevent timeouts.

Fixes https://github.com/redpanda-data/redpanda/issues/18563

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
