### PR TITLE
[rptest] unbreak Azure T4/T5 tests

### DIFF
--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -83,7 +83,7 @@ class CloudBroker():
         # Copy agent -> broker node
         remote_path = os.path.join("/tmp", script_name)
         _cp_cmd = self._kubeclient._ssh_prefix() + [
-            'kubectl', 'cp', script_name,
+            'kubectl', '-n', 'redpanda-node-setup', 'cp', script_name,
             f"{self.nodeshell.pod_name}:{remote_path}"
         ]
         self.logger.debug(_cp_cmd)


### PR DESCRIPTION
Azure tier-4 and tier-5 tests failed to launch successfully before these changes, and now (with this commit) the tests actually launch as expected.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none