### PR TITLE
bazel: exclude vtools

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 build
 vbuild
+vtools

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,9 @@ load("@gazelle//:def.bzl", "gazelle", "gazelle_test")
 # gazelle:prefix github.com/redpanda-data/redpanda
 # TODO(bazel): Build RPK with bazel
 # gazelle:exclude src/go/rpk
+# Exclude cmake based setup
+# gazelle:exclude vtools
+# gazelle:exclude vbuild
 # Exclude the golang we use in ducktape for now
 # gazelle:exclude tests
 # We don't yet use protobufs in our golang code


### PR DESCRIPTION
- **bazel: exclude vtools from gazelle**
- **bazel: ignore vtools**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
