### PR TITLE
[v24.2.x] [CORE-6970] `rptest`: mark `test_s3_oracle_self_config` as `ok_to_fail_fips`

### DIFF
--- a/tests/rptest/tests/cluster_self_config_test.py
+++ b/tests/rptest/tests/cluster_self_config_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 import re
 
-from ducktape.mark import parametrize, matrix
+from ducktape.mark import parametrize, matrix, ok_to_fail_fips
 
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -86,6 +86,8 @@ class ClusterSelfConfigTest(EndToEndTest):
 
             assert self_config_result and self_config_result in self_config_expected_results
 
+    # OCI only supports path-style requests, fips mode will always fail.
+    @ok_to_fail_fips
     @cluster(num_nodes=1)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23300
