### PR TITLE
test: increase rpk connect timeout

### DIFF
--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/spf13/afero"
@@ -203,6 +205,7 @@ func UserPaths() []string {
 	defaultPath, err := DefaultBinPath()
 	pathList := filepath.SplitList(os.Getenv("PATH"))
 	if err != nil {
+		zap.L().Sugar().Warnf("Unable to get default plugin path: %v; using $PATH only", err)
 		// If there is an error getting the default bin path we will only look
 		// for the binary in the $PATH.
 		return pathList

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1979,9 +1979,9 @@ class RpkTool:
         out = self._execute(cmd)
         return json.loads(out)
 
-    def _run_connect(self, cmd):
+    def _run_connect(self, cmd, timeout=None):
         cmd = [self._rpk_binary(), "connect"] + cmd
-        return self._execute(cmd)
+        return self._execute(cmd, timeout=timeout)
 
     def install_connect(self, version="", force=False):
         cmd = ["install"]
@@ -1991,7 +1991,10 @@ class RpkTool:
         if force:
             cmd += ["--force"]
 
-        return self._run_connect(cmd)
+        # This command has a higher timeout than normal rpk
+        # commands as it downloads and install the RP Connect
+        # binary.
+        return self._run_connect(cmd, timeout=2 * DEFAULT_TIMEOUT)
 
     def uninstall_connect(self):
         cmd = ["uninstall"]


### PR DESCRIPTION
Increased the timeout to 60, we still have room
to grow here since rpk's timeout is 240.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
