### PR TITLE
gha: reduce execution frequency (on cheap runner)

### DIFF
--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -2,19 +2,8 @@ name: Release rp-storage-tool
 
 on:
   push:
-    branches:
-      - dev
-      - 'v*'
     tags:
       - 'v*'
-  pull_request:
-    paths:
-      - 'tools/rp_storage_tool/**'
-      - 'tests/docker/Dockerfile'
-      - 'tests/docker/ducktape-deps/rust'
-      - 'tests/docker/ducktape-deps/rp-storage-tool'
-      - '.github/workflows/release-rp-storage-tool.yml'
-
 
 jobs:
   release-rp-storage-tool:
@@ -26,7 +15,7 @@ jobs:
           - release_for: linux-amd64
             os: ubuntu-latest
           - release_for: linux-arm64
-            os: ubuntu-latest-4-arm64
+            os: ubuntu-latest-2-arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: configure aws credentials


### PR DESCRIPTION
Since this runs on every push to the target branches, it is incurring excessive CI minutes usage. Only release on tagged commits to reduce consumption. Also, for the arm variant, use 2-core VMs.

fixes https://redpandadata.atlassian.net/browse/PESDLC-2053

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes


* none
