### PR TITLE
Dynamically adjust fetch debounce with PID controller

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -701,7 +701,44 @@ configuration::configuration()
         model::fetch_read_strategy::polling,
         model::fetch_read_strategy::non_polling,
         model::fetch_read_strategy::non_polling_with_debounce,
+        model::fetch_read_strategy::non_polling_with_pid,
       })
+  , fetch_pid_p_coeff(
+      *this,
+      "fetch_pid_p_coeff",
+      "Proportional coefficient for fetch PID controller.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100.0,
+      {.min = 0.0, .max = std::numeric_limits<double>::max()})
+  , fetch_pid_i_coeff(
+      *this,
+      "fetch_pid_i_coeff",
+      "Integral coefficient for fetch PID controller.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.01,
+      {.min = 0.0, .max = std::numeric_limits<double>::max()})
+  , fetch_pid_d_coeff(
+      *this,
+      "fetch_pid_d_coeff",
+      "Derivative coefficient for fetch PID controller.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.0,
+      {.min = 0.0, .max = std::numeric_limits<double>::max()})
+  , fetch_pid_target_utilization_fraction(
+      *this,
+      "fetch_pid_target_utilization_fraction",
+      "A fraction, between 0 and 1, for the target reactor utilization of the "
+      "fetch scheduling group.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.2,
+      {.min = 0.01, .max = 1.0})
+  , fetch_pid_max_debounce_ms(
+      *this,
+      "fetch_pid_max_debounce_ms",
+      "The maximum debounce time the fetch PID controller will apply, in "
+      "milliseconds.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100ms)
   , alter_topic_cfg_timeout_ms(
       *this,
       "alter_topic_cfg_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -213,6 +213,12 @@ struct configuration final : public config_store {
     deprecated_property rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     enum_property<model::fetch_read_strategy> fetch_read_strategy;
+    bounded_property<double, numeric_bounds> fetch_pid_p_coeff;
+    bounded_property<double, numeric_bounds> fetch_pid_i_coeff;
+    bounded_property<double, numeric_bounds> fetch_pid_d_coeff;
+    bounded_property<double, numeric_bounds>
+      fetch_pid_target_utilization_fraction;
+    property<std::chrono::milliseconds> fetch_pid_max_debounce_ms;
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -518,6 +518,7 @@ struct convert<model::fetch_read_strategy> {
       model::fetch_read_strategy_to_string(type::polling),
       model::fetch_read_strategy_to_string(type::non_polling),
       model::fetch_read_strategy_to_string(type::non_polling_with_debounce),
+      model::fetch_read_strategy_to_string(type::non_polling_with_pid),
     });
 
     static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
@@ -541,7 +542,11 @@ struct convert<model::fetch_read_strategy> {
                 .match(
                   model::fetch_read_strategy_to_string(
                     type::non_polling_with_debounce),
-                  type::non_polling_with_debounce);
+                  type::non_polling_with_debounce)
+                .match(
+                  model::fetch_read_strategy_to_string(
+                    type::non_polling_with_pid),
+                  type::non_polling_with_pid);
 
         return true;
     }

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -49,6 +49,7 @@ v_cc_library(
     server/quota_manager.cc
     server/client_quota_translator.cc
     server/snc_quota_manager.cc
+    server/fetch_pid_controller.cc
     server/fetch_session_cache.cc
     server/replicated_partition.cc
     server/partition_proxy.cc

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -5,6 +5,7 @@ redpanda_cc_library(
     srcs = [
         "client_quota_translator.cc",
         "connection_context.cc",
+        "fetch_pid_controller.cc",
         "fetch_session_cache.cc",
         "group.cc",
         "group_manager.cc",
@@ -60,6 +61,7 @@ redpanda_cc_library(
         "coordinator_ntp_mapper.h",
         "errors.h",
         "fetch_metadata_cache.h",
+        "fetch_pid_controller.h",
         "fetch_session.h",
         "fetch_session_cache.h",
         "fwd.h",

--- a/src/v/kafka/server/fetch_pid_controller.cc
+++ b/src/v/kafka/server/fetch_pid_controller.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/fetch_pid_controller.h"
+
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/reactor.hh>
+
+namespace kafka {
+
+fetch_pid_controller::fetch_pid_controller(const ss::scheduling_group& sg)
+  : _sg(sg)
+  , _p_coeff{config::shard_local_cfg().fetch_pid_p_coeff()}
+  , _i_coeff{config::shard_local_cfg().fetch_pid_i_coeff()}
+  , _d_coeff{config::shard_local_cfg().fetch_pid_d_coeff()}
+  , _target_fetch_sg_util{config::shard_local_cfg()
+                            .fetch_pid_target_utilization_fraction()}
+  , _max_delay{config::shard_local_cfg().fetch_pid_max_debounce_ms()}
+  , _p_coeff_binding{config::shard_local_cfg().fetch_pid_p_coeff.bind()}
+  , _i_coeff_binding{config::shard_local_cfg().fetch_pid_i_coeff.bind()}
+  , _d_coeff_binding{config::shard_local_cfg().fetch_pid_d_coeff.bind()}
+  , _target_fetch_sg_util_binding{config::shard_local_cfg()
+                                    .fetch_pid_target_utilization_fraction
+                                    .bind()}
+  , _max_delay_binding{
+      config::shard_local_cfg().fetch_pid_max_debounce_ms.bind()} {
+    _p_coeff_binding.watch([this] {
+        reset();
+        _p_coeff = config::shard_local_cfg().fetch_pid_p_coeff();
+    });
+    _i_coeff_binding.watch([this] {
+        reset();
+        _i_coeff = config::shard_local_cfg().fetch_pid_i_coeff();
+    });
+    _d_coeff_binding.watch([this] {
+        reset();
+        _d_coeff = config::shard_local_cfg().fetch_pid_d_coeff();
+    });
+    _target_fetch_sg_util_binding.watch([this] {
+        reset();
+        _target_fetch_sg_util
+          = config::shard_local_cfg().fetch_pid_target_utilization_fraction();
+    });
+    _max_delay_binding.watch([this] {
+        reset();
+        _max_delay = config::shard_local_cfg().fetch_pid_max_debounce_ms();
+    });
+    setup_metrics();
+}
+
+std::chrono::milliseconds fetch_pid_controller::current_delay() {
+    auto sampled_time = ss::sched_clock::now();
+    auto sample = _sg.get_stats().runtime;
+    auto total_busy_time = ss::engine().total_busy_time();
+
+    auto dt = sampled_time - _last_sampled_time;
+    if (dt < sample_rate) {
+        return _last_delay;
+    }
+
+    auto db = total_busy_time - _last_total_busy_time;
+    if (db < 0s) {
+        return _last_delay;
+    }
+    auto busy = (long double)(db / duration_unit) / (dt / duration_unit);
+    if (busy > 1.0) {
+        return _last_delay;
+    }
+
+    auto ds = sample - _last_sample;
+    if (ds < 0 * duration_unit) {
+        return _last_delay;
+    }
+    auto current_runtime = (long double)(ds / duration_unit)
+                           / (dt / duration_unit);
+    if (current_runtime > 1.0) {
+        return _last_delay;
+    }
+
+    // If reactor utilization ~ 100% then ensure the fetch runtime is
+    // less than or equal to _target_fetch_sg_util.
+    //
+    // Otherwise ensure that reactor utilization is 100% even if the
+    // fetch runtime is above _target_fetch_sg_util.
+    constexpr auto target_reactor_util = 0.999;
+    auto error = (busy < target_reactor_util)
+                   ? (busy - target_reactor_util)
+                   : (current_runtime - _target_fetch_sg_util);
+
+    // calculate the proportional
+    auto p = _p_coeff * error;
+
+    // calculate the integral
+    _error_int += error * (dt / duration_unit);
+    // Letting the integral fall below 0 only reduces the responsiveness
+    // in cases of sudden load spikes. Like-wise allowing the integral to go
+    // above the max delay in cases where the pid controller can't meet the
+    // utilization target will reduce responsiveness as well.
+    _error_int = std::clamp(
+      _error_int, 0.0L, (long double)(_max_delay / duration_unit) / _i_coeff);
+    auto i = _i_coeff * _error_int;
+
+    // calculate the derivative
+    auto d = (error - _last_error) / (dt / duration_unit);
+    d *= _d_coeff;
+
+    auto pid = p + i + d;
+    pid = std::max(0.0L, pid);
+
+    auto delay = std::chrono::duration_cast<std::chrono::milliseconds>(
+      duration_unit * pid);
+    delay = std::min(delay, _max_delay);
+
+    _total_delay += _last_delay * (dt / 1ms);
+    _last_delay = delay;
+    _last_error = error;
+    _last_sample = sample;
+    _last_total_busy_time = total_busy_time;
+    _last_sampled_time = sampled_time;
+
+    return delay;
+}
+
+void fetch_pid_controller::reset() {
+    _last_delay = 0ms;
+    _error_int = 0.0;
+    _last_error = 0.0;
+    _last_sample = _sg.get_stats().runtime;
+    _last_total_busy_time = ss::engine().total_busy_time();
+    _last_sampled_time = ss::sched_clock::now();
+}
+
+void fetch_pid_controller::setup_metrics() {
+    namespace sm = ss::metrics;
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka_fetch_pid"),
+      {
+        sm::make_counter(
+          "delay_seconds_total",
+          [this] { return (_total_delay / 1s) / 1000; },
+          sm::description(
+            "A running total of fetch delay set by the pid controller.")),
+        sm::make_counter(
+          "error_total",
+          [this] { return (_error_int * 1us) / 1s; },
+          sm::description(
+            "A running total of error in the fetch PID controller.")),
+      },
+      {},
+      {sm::shard_label});
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/fetch_pid_controller.h
+++ b/src/v/kafka/server/fetch_pid_controller.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+
+using namespace std::chrono_literals;
+
+namespace kafka {
+
+class fetch_pid_controller {
+    static constexpr auto duration_unit = 1us;
+    static constexpr auto sample_rate = 250us;
+
+public:
+    explicit fetch_pid_controller(const ss::scheduling_group& sg);
+
+    /*
+     * Returns the delay that should be applied to a given fetch in order to
+     * limit the fetch scheduling group to the target reactor utilization.
+     */
+    std::chrono::milliseconds current_delay();
+
+private:
+    void reset();
+    void setup_metrics();
+
+    ss::scheduling_group _sg;
+
+    std::chrono::milliseconds _total_delay{0ms};
+    std::chrono::milliseconds _last_delay{0ms};
+    long double _error_int{0.0};
+    long double _last_error{0.0};
+    ss::sched_clock::duration _last_sample{0ms};
+    ss::sched_clock::duration _last_total_busy_time{0ms};
+    ss::sched_clock::time_point _last_sampled_time{ss::sched_clock::now()};
+
+    double _p_coeff;
+    double _i_coeff;
+    double _d_coeff;
+    double _target_fetch_sg_util;
+    std::chrono::milliseconds _max_delay;
+
+    config::binding<double> _p_coeff_binding;
+    config::binding<double> _i_coeff_binding;
+    config::binding<double> _d_coeff_binding;
+    config::binding<double> _target_fetch_sg_util_binding;
+    config::binding<std::chrono::milliseconds> _max_delay_binding;
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -154,6 +154,7 @@ server::server(
   , _usage_manager(usage_manager)
   , _shard_table(tbl)
   , _partition_manager(pm)
+  , _fetch_pid_controller(fetch_sg)
   , _fetch_session_cache(
       config::shard_local_cfg().fetch_session_eviction_timeout_ms())
   , _id_allocator_frontend(id_allocator_frontend)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -17,6 +17,7 @@
 #include "kafka/protocol/types.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/fetch_metadata_cache.h"
+#include "kafka/server/fetch_pid_controller.h"
 #include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/handlers/fetch/replica_selector.h"
@@ -213,6 +214,10 @@ public:
         return _handler_probes.get_probe(key);
     }
 
+    fetch_pid_controller& pid_controller() noexcept {
+        return _fetch_pid_controller;
+    }
+
     ssx::semaphore& memory_fetch_sem() noexcept { return _memory_fetch_sem; }
 
     ss::future<> revoke_credentials(std::string_view name);
@@ -234,6 +239,7 @@ private:
     ss::sharded<kafka::usage_manager>& _usage_manager;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    kafka::fetch_pid_controller _fetch_pid_controller;
     kafka::fetch_session_cache _fetch_session_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
     bool _is_idempotence_enabled{false};

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -536,6 +536,7 @@ enum class fetch_read_strategy : uint8_t {
     polling = 0,
     non_polling = 1,
     non_polling_with_debounce = 2,
+    non_polling_with_pid = 3,
 };
 
 constexpr const char* fetch_read_strategy_to_string(fetch_read_strategy s) {
@@ -546,6 +547,8 @@ constexpr const char* fetch_read_strategy_to_string(fetch_read_strategy s) {
         return "non_polling";
     case fetch_read_strategy::non_polling_with_debounce:
         return "non_polling_with_debounce";
+    case fetch_read_strategy::non_polling_with_pid:
+        return "non_polling_with_pid";
     default:
         throw std::invalid_argument("unknown fetch_read_strategy");
     }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -522,7 +522,11 @@ std::istream& operator>>(std::istream& i, fetch_read_strategy& strat) {
               .match(
                 fetch_read_strategy_to_string(
                   fetch_read_strategy::non_polling_with_debounce),
-                fetch_read_strategy::non_polling_with_debounce);
+                fetch_read_strategy::non_polling_with_debounce)
+              .match(
+                fetch_read_strategy_to_string(
+                  fetch_read_strategy::non_polling_with_pid),
+                fetch_read_strategy::non_polling_with_pid);
     return i;
 }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Often when Redpanda is at CPU saturation the fetch scheduling group can
starve other operations. In these situations increasing the time a fetch
request waits on the server before starting allows for Redpanda to apply
backpressure to the clients and increase batching for fetch responses.
This increased batching frees up CPU resources for other operations to
use and tends to decrease end-to-end latency.

From testing its been found empirically that when Redpanda is at
saturation restricting the fetch scheduling group to only consume 20% of
overall reactor utilization will improve end-to-end latency for a
variety of workloads.

This commit implements a PID controller that will dynamically adjust
fetch debounce to ensure that the fetch scheduling group is only
consuming 20% of overall reactor utilization when Redpanda is at
saturation.

The test results for the controller can be found [here](https://redpandadata.atlassian.net/browse/CORE-5642?focusedCommentId=40979)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
