### PR TITLE
omb_validation_test: Fix rejected metric count check

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -21,6 +21,7 @@ from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.machinetype import get_machine_info
+from rptest.services.metrics_check import ACTIVE_CONNECTIONS_METRIC, REJECTED_CONNECTIONS_METRIC
 from rptest.utils.type_utils import rcast
 
 # pyright: strict
@@ -35,9 +36,6 @@ minutes = 60
 hours = 60 * minutes
 
 T = TypeVar('T')
-
-REJECTED_METRIC = "vectorized_kafka_rpc_connections_rejected_total"
-ACTIVE_METRIC = "vectorized_kafka_rpc_active_connections"
 
 
 def not_none(value: T | None) -> T:
@@ -751,7 +749,7 @@ class OMBValidationTest(RedpandaCloudTest):
         self.redpanda.assert_cluster_is_reusable()
 
     def _connection_count(self):
-        return self.redpanda.metric_sum(ACTIVE_METRIC)
+        return self.redpanda.metric_sum(ACTIVE_CONNECTIONS_METRIC)
 
     def _rejected_count(self):
-        return self.redpanda.metric_sum(REJECTED_METRIC)
+        return self.redpanda.metric_sum(REJECTED_CONNECTIONS_METRIC)

--- a/tests/rptest/services/metrics_check.py
+++ b/tests/rptest/services/metrics_check.py
@@ -11,6 +11,9 @@ import re
 
 from rptest.services.redpanda import MetricsEndpoint
 
+REJECTED_CONNECTIONS_METRIC = "vectorized_kafka_rpc_connections_rejected"
+ACTIVE_CONNECTIONS_METRIC = "vectorized_kafka_rpc_active_connections"
+
 
 class MetricCheckFailed(Exception):
     def __init__(self, metric, old_value, new_value):


### PR DESCRIPTION
The actual metric name has no `_total` in the end so remove that.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none

