### PR TITLE
Remove some warnings and ignored errors from ducktape log

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1165,7 +1165,6 @@ class RpkTool:
         self._redpanda.logger.debug(f'\n{output}')
 
         if p.returncode:
-            self._redpanda.logger.error(stderror)
             raise RpkException(
                 'command %s returned %d, output: %s' %
                 (' '.join(cmd) if log_cmd else '[redacted]', p.returncode,

--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -90,3 +90,6 @@ class RpkProducer(BackgroundThreadService):
     def stop_node(self, node):
         self._stopping.set()
         node.account.kill_process("rpk", clean_shutdown=False)
+
+    def clean_node(self, node):
+        pass


### PR DESCRIPTION
Remove some lines that pollute the log.

fixes https://redpandadata.atlassian.net/browse/PESDLC-2056

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none
