### PR TITLE
Minor cloud test fixes for tiers v3

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -436,7 +436,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                                         retention_local_bytes: int):
         self.rpk.alter_topic_config(self.topic,
                                     TopicSpec.PROPERTY_SEGMENT_SIZE,
-                                    segment_bytes)
+                                    max(self.min_segment_size, segment_bytes))
         self.rpk.alter_topic_config(
             self.topic, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
             retention_local_bytes)
@@ -789,7 +789,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # create default topics
         self._create_default_topics()
 
-        segment_size = 16 * MiB  # Min segment size across all tiers
+        segment_size = self.min_segment_size
         self.adjust_topic_segment_properties(
             segment_bytes=segment_size, retention_local_bytes=segment_size)
 
@@ -1289,7 +1289,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # create default topics
         self._create_default_topics()
 
-        segment_size = 16 * MiB  # Min segment size across all tiers
+        segment_size = self.min_segment_size
         self.adjust_topic_segment_properties(
             segment_bytes=segment_size, retention_local_bytes=segment_size)
 

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -425,7 +425,7 @@ class OMBValidationTest(RedpandaCloudTest):
             # did not connect to all brokers, so only require this fraction of the target connection count
             # in order to consider us ready to start. Since we already applied a 1.1x factor to the target
             # connection count above the advertised count, we are still well above the advertised limit.
-            SWARM_TARGET_CONNECTIONS_FUDGE = 0.98
+            SWARM_TARGET_CONNECTIONS_FUDGE = 0.96
             ccount = self._connection_count()
             self.logger.debug(
                 'Waiting for connections to reach target, current:'


### PR DESCRIPTION
Some minor fixes:

 - Change connection count fudge factor, it's like 1% off
 - Make the high throughput tests handle smaller segment sizes

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none


