### PR TITLE
`rptest`: add `@skip_fips_mode` decorator

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -70,6 +70,7 @@ from rptest.services.storage_failure_injection import FailureInjectionConfig
 from rptest.services.utils import NodeCrash, LogSearchLocal, LogSearchCloud, Stopwatch
 from rptest.util import inject_remote_script, ssh_output_stderr, wait_until_result
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
+from rptest.utils.mode_checks import in_fips_environment
 import enum
 
 Partition = collections.namedtuple('Partition',
@@ -364,20 +365,6 @@ def is_redpanda_cloud(context: TestContext):
 def should_compile(allow_list_element: LogAllowListElem) -> bool:
     return not isinstance(allow_list_element, re.Pattern) and not isinstance(
         allow_list_element, AllowLogsOnPredicate)
-
-
-def in_fips_environment() -> bool:
-    """
-    Returns True if the file /proc/sys/crypto/fips_enabled is present and
-    contains '1', otherwise returns False.
-    """
-    fips_file = "/proc/sys/crypto/fips_enabled"
-    if os.path.exists(fips_file) and os.path.isfile(fips_file):
-        with open(fips_file, 'r') as f:
-            contents = f.read().strip()
-            return contents == '1'
-
-    return False
 
 
 class ResourceSettings:

--- a/tests/rptest/tests/cluster_self_config_test.py
+++ b/tests/rptest/tests/cluster_self_config_test.py
@@ -8,13 +8,14 @@
 # by the Apache License, Version 2.0
 import re
 
-from ducktape.mark import parametrize, matrix, ok_to_fail_fips
+from ducktape.mark import parametrize, matrix
 
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.utils import LogSearchLocal
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class ClusterSelfConfigTest(EndToEndTest):
@@ -86,7 +87,7 @@ class ClusterSelfConfigTest(EndToEndTest):
             assert self_config_result and self_config_result in self_config_expected_results
 
     # OCI only supports path-style requests, fips mode will always fail.
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=1)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -15,8 +15,9 @@ from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import in_fips_environment, MetricsEndpoint, MetricSamples, RedpandaServiceBase
+from rptest.services.redpanda import MetricsEndpoint, MetricSamples, RedpandaServiceBase
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.mode_checks import in_fips_environment
 
 
 class RedpandaStartupTest(RedpandaTest):

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -80,3 +80,33 @@ def in_fips_environment() -> bool:
             return contents == '1'
 
     return False
+
+
+def skip_fips_mode(*args, **kwargs):
+    """
+    Test method decorator which signals to the test runner to ignore a given test.
+
+    Example::
+
+        When no parameters are provided to the @ignore decorator, ignore all parametrizations of the test function
+
+        @skip_fips_mode  # Ignore all parametrizations
+        @parametrize(x=1, y=0)
+        @parametrize(x=2, y=3)
+        def the_test(...):
+            ...
+
+    Example::
+
+        If parameters are supplied to the @skip_fips_mode decorator, only skip the parametrization with matching parameter(s)
+
+        @skip_fips_mode(x=2, y=3)
+        @parametrize(x=1, y=0)  # This test will run as usual
+        @parametrize(x=2, y=3)  # This test will be ignored
+        def the_test(...):
+            ...
+    """
+    if in_fips_environment():
+        return ignore(args, kwargs)
+    else:
+        return args[0]

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -66,3 +66,17 @@ def skip_debug_mode(*args, **kwargs):
         return ignore(args, kwargs)
     else:
         return args[0]
+
+
+def in_fips_environment() -> bool:
+    """
+    Returns True if the file /proc/sys/crypto/fips_enabled is present and
+    contains '1', otherwise returns False.
+    """
+    fips_file = "/proc/sys/crypto/fips_enabled"
+    if os.path.exists(fips_file) and os.path.isfile(fips_file):
+        with open(fips_file, 'r') as f:
+            contents = f.read().strip()
+            return contents == '1'
+
+    return False


### PR DESCRIPTION
For use in ducktape tests that should not be ran in a FIPS-enabled environment (i.e, tests that are always expected to fail due to incompatibilities if FIPS mode is enabled).

Existing tests may still make use of `@ok_to_fail_fips`, but `@skip_fips_mode` offers the ability to not waste CI time on tests that will always fail with FIPS enabled (such as `test_s3_oracle_self_config`, which now makes use of the decorator).

Requested by https://github.com/redpanda-data/redpanda/pull/23300#discussion_r1761050385

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
