### PR TITLE
`admin`: add `cloud_storage_cache_size` check to `config_multi_property_validation()`

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1970,4 +1970,27 @@ ss::future<> cache::sync_access_time_tracker(
     }
 }
 
+std::optional<ss::sstring>
+cache::validate_cache_config(const config::configuration& conf) {
+    const auto& cloud_storage_cache_size = conf.cloud_storage_cache_size;
+    const auto& cloud_storage_cache_size_pct
+      = conf.cloud_storage_cache_size_percent;
+
+    // If not set, cloud cache uses default value of 0.0
+    auto cache_size_pct = cloud_storage_cache_size_pct().value_or(0.0);
+
+    using cache_size_pct_type = double;
+    static constexpr auto epsilon
+      = std::numeric_limits<cache_size_pct_type>::epsilon();
+
+    if ((cache_size_pct < epsilon) && (cloud_storage_cache_size() == 0)) {
+        return ss::format(
+          "Cannot set both {} and {} to 0.",
+          cloud_storage_cache_size.name(),
+          cloud_storage_cache_size_pct.name());
+    }
+
+    return std::nullopt;
+}
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_probe.h"
 #include "cloud_storage/recursive_directory_walker.h"
+#include "config/configuration.h"
 #include "config/property.h"
 #include "resource_mgmt/io_priority.h"
 #include "ssx/semaphore.h"
@@ -196,6 +197,16 @@ public:
     get_local_path(const std::filesystem::path& key) const {
         return _cache_dir / key;
     }
+
+    // Checks if a cluster configuration is valid for the properties
+    // `cloud_storage_cache_size` and `cloud_storage_cache_size_percent`.
+    // Two cases are invalid: 1. the case in which both are 0, 2. the case in
+    // which `cache_size` is 0 while `cache_size_percent` is `std::nullopt`.
+    //
+    // Returns `std::nullopt` if the passed configuration is valid, or an
+    // `ss::sstring` explaining the misconfiguration otherwise.
+    static std::optional<ss::sstring>
+    validate_cache_config(const config::configuration& conf);
 
 private:
     /// Load access time tracker from file

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1698,6 +1698,14 @@ void config_multi_property_validation(
         errors[ss::sstring(name)] = ssx::sformat(
           "{} requires schema_registry to be enabled in redpanda.yaml", name);
     }
+
+    // cloud_storage_cache_size/size_percent validation
+    if (auto invalid_cache = cloud_storage::cache::validate_cache_config(
+          updated_config);
+        invalid_cache.has_value()) {
+        auto name = ss::sstring(updated_config.cloud_storage_cache_size.name());
+        errors[name] = invalid_cache.value();
+    }
 }
 } // namespace
 


### PR DESCRIPTION
To prevent the invalid configuration of `cloud_storage_cache_size` and `cloud_storage_cache_size_percent` both being equal to `0`, add a new check to the `admin` server validation post `patch_cluster_config_handler()` call.

The following configurations are hereby invalid:

1. `cloud_storage_cache_size` and `cloud_storage_cache_size_percent` cannot both be 0
2. `cloud_storage_cache_size` cannot be `0` while `cloud_storage_cache_size_percent` is `nil` (`std::nullopt`)

Relevant slack thread: https://redpandadata.slack.com/archives/C02BDN76HUK/p1724373318548299

Relevant docs PR: https://github.com/redpanda-data/docs/pull/696#discussion_r1761590425

Backports to versions `v24.1.x` and `v24.2.x` are optional and left to the reviewers to decide if necessary.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

