### PR TITLE
Checking if deployment_args is a string or not before decoding

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -967,6 +967,10 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         ])
 
         self.logger.info('patching deployment to allow downscaling')
+        # Check if deployment_args is not a string, and if so, decode it
+        if not isinstance(deployment_args, str):
+            deployment_args = deployment_args.decode()
+
         deployment_args = deployment_args.decode().replace(
             '--allow-downscaling=false', '--allow-downscaling=true', 1)
         patch = [{


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

### Bug Fixes

* Checking if deployment_args is a string or not before decoding. This should avoid errors:

`deployment_args = deployment_args.decode().replace(
AttributeError: 'str' object has no attribute 'decode'`