### PR TITLE
Remove shard aggregation on consumer group metrics

### DIFF
--- a/src/v/kafka/server/group_probe.h
+++ b/src/v/kafka/server/group_probe.h
@@ -77,11 +77,10 @@ public:
         _public_metrics.add_group(
           prometheus_sanitize::metrics_name("kafka:consumer:group"),
           {sm::make_gauge(
-             "committed_offset",
-             [this] { return _offset; },
-             sm::description("Consumer group committed offset"),
-             labels)
-             .aggregate({sm::shard_label})});
+            "committed_offset",
+            [this] { return _offset; },
+            sm::description("Consumer group committed offset"),
+            labels)});
     }
 
 private:
@@ -129,15 +128,13 @@ public:
              "consumers",
              [this] { return _members.size(); },
              sm::description("Number of consumers in a group"),
-             labels)
-             .aggregate({sm::shard_label}),
+             labels),
 
            sm::make_gauge(
              "topics",
              [this] { return _offsets.size(); },
              sm::description("Number of topics in a group"),
-             labels)
-             .aggregate({sm::shard_label})});
+             labels)});
     }
 
 private:


### PR DESCRIPTION
Currently we only aggregate on the `shard` label in the consumer group metrics. This aggregation doesn't result in a reduced number of metric series. It does, however, cause seastar to use the `metric_aggregate_by_labels` class to aggregate the metrics.

This class uses a contiguous map type that isn't easily replaced and in cases where there are many consumer groups, kafka topics, and partitions there is enough unique label sets to cause an oversized allocation in the contiguous map.

By removing the `shard` label from aggregation though we avoid the code path where `metric_aggregate_by_labels` is used and hence avoid the oversized allocation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
### Improvements
* Adds a shard label to some consumer group metrics.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
