### PR TITLE
bazel: mark clang-format as a manual target

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -61,4 +61,7 @@ sh_binary(
     data = [
         "@llvm_18_toolchain//:clang-format",
     ],
+    # Only build this target on demand, so we don't download
+    # this toolchain if we're using a different one for the build.
+    tags = ["manual"],
 )


### PR DESCRIPTION
See: https://bazel.build/reference/be/common-definitions#common-attributes

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
