### PR TITLE
CORE-7327: Fix divergence in how desired segment size is computed across the system

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3231,13 +3231,8 @@ ss::future<bool> ntp_archiver::do_upload_remote(
 }
 
 size_t ntp_archiver::get_local_segment_size() const {
-    auto log_segment_size = config::shard_local_cfg().log_segment_size.value();
     const auto& cfg = _parent.raft()->log_config();
-    if (cfg.has_overrides()) {
-        log_segment_size = cfg.get_overrides().segment_size.value_or(
-          log_segment_size);
-    }
-    return log_segment_size;
+    return cfg.segment_bytes();
 }
 
 ss::future<bool>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -352,7 +352,6 @@ private:
     size_t get_log_truncation_counter() const noexcept override;
 
 private:
-    size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size
     // configuration. This takes into consideration any segment size
     // overrides since the last time it was called.

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -828,7 +828,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                 return internal::make_segment_appender(
                          path,
                          internal::number_of_chunks_from_config(ntpc),
-                         internal::segment_size_from_config(ntpc),
+                         ntpc.segment_bytes(),
                          pc,
                          resources,
                          std::move(ntp_sanitizer_config))

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -229,20 +229,6 @@ size_t number_of_chunks_from_config(const ntp_config& ntpc) {
     return def;
 }
 
-uint64_t segment_size_from_config(const ntp_config& ntpc) {
-    auto def = config::shard_local_cfg().log_segment_size();
-
-    if (!ntpc.has_overrides()) {
-        return def;
-    }
-    auto& o = ntpc.get_overrides();
-    if (o.segment_size) {
-        return o.segment_size.value();
-    } else {
-        return def;
-    }
-}
-
 ss::future<roaring::Roaring>
 natural_index_of_entries_to_keep(compacted_index_reader reader) {
     reader.reset();

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -147,7 +147,6 @@ ss::future<segment_appender_ptr> make_segment_appender(
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
 
 size_t number_of_chunks_from_config(const storage::ntp_config&);
-uint64_t segment_size_from_config(const storage::ntp_config&);
 
 /*
 1. if footer.flags == truncate write new .compacted_index file

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -129,3 +129,19 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+
+redpanda_cc_gtest(
+    name = "ntp_config_test",
+    timeout = "short",
+    srcs = [
+        "ntp_config_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -180,3 +180,17 @@ rp_test(
   ARGS "-- -c 1"
   LABELS storage
 )
+
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME ntp_config_test
+  SOURCES
+  ntp_config_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::storage
+  ARGS "-- -c 1"
+  LABELS storage
+)

--- a/src/v/storage/tests/ntp_config_test.cc
+++ b/src/v/storage/tests/ntp_config_test.cc
@@ -1,0 +1,134 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/ntp_config.h"
+#include "test_utils/scoped_config.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+struct segment_bytes_test_params {
+    std::optional<bool> cleanup_compact;
+    std::optional<uint64_t> override;
+
+    std::optional<uint64_t> log_segment_size;
+    std::optional<uint64_t> compacted_log_segment_size;
+
+    std::optional<uint64_t> min_limit;
+    std::optional<uint64_t> max_limit;
+
+    std::optional<uint64_t> expected;
+
+    friend void PrintTo(const segment_bytes_test_params& p, std::ostream* o) {
+        *o << "{override: " << p.override << ", "
+           << "log_segment_size: " << p.log_segment_size << ", "
+           << "compacted_log_segment_size: " << p.compacted_log_segment_size
+           << ", "
+           << "min_limit: " << p.min_limit << ", "
+           << "max_limit: " << p.max_limit << ", "
+           << "expected: " << p.expected << "}";
+    }
+};
+
+class segment_bytes_suite
+  : public ::testing::TestWithParam<segment_bytes_test_params> {};
+
+TEST_P(segment_bytes_suite, segment_bytes_test) {
+    auto c = storage::ntp_config(
+      model::ntp("test_ns", "test_tp", model::partition_id(0)),
+      "/tmp/foo/bar",
+      std::make_unique<storage::ntp_config::default_overrides>());
+
+    // Setup overrides.
+    c.get_overrides().segment_size = GetParam().override;
+    if (GetParam().cleanup_compact) {
+        c.get_overrides().cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags(
+            model::cleanup_policy_bitflags::compaction);
+    }
+
+    // Setup cluster settings.
+    scoped_config config;
+    if (GetParam().log_segment_size) {
+        config.get("log_segment_size").set_value(*GetParam().log_segment_size);
+    }
+    if (GetParam().compacted_log_segment_size) {
+        config.get("compacted_log_segment_size")
+          .set_value(*GetParam().compacted_log_segment_size);
+    }
+
+    if (GetParam().min_limit) {
+        config.get("log_segment_size_min").set_value(GetParam().min_limit);
+    }
+    if (GetParam().max_limit) {
+        config.get("log_segment_size_max").set_value(GetParam().max_limit);
+    }
+
+    // Verify expected segment bytes.
+    ASSERT_EQ(c.segment_bytes(), GetParam().expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  exhaustive,
+  segment_bytes_suite,
+  ::testing::Values(
+    // Cluster config is used by default.
+    segment_bytes_test_params{
+      .log_segment_size = 3_MiB,
+      .compacted_log_segment_size = 4_MiB,
+      .expected = 3_MiB},
+    segment_bytes_test_params{
+      .cleanup_compact = true,
+      .log_segment_size = 3_MiB,
+      .compacted_log_segment_size = 4_MiB,
+      .expected = 4_MiB},
+    // Cluster defaults are capped by min and max limits.
+    segment_bytes_test_params{
+      .log_segment_size = 0_MiB,
+      .compacted_log_segment_size = 4_MiB,
+      .min_limit = 1_MiB,
+      .max_limit = 2_MiB,
+      .expected = 1_MiB},
+    segment_bytes_test_params{
+      .log_segment_size = 3_MiB,
+      .compacted_log_segment_size = 4_MiB,
+      .min_limit = 1_MiB,
+      .max_limit = 2_MiB,
+      .expected = 2_MiB},
+    // cleanup.policy compact works the same.
+    segment_bytes_test_params{
+      .cleanup_compact = true,
+      .log_segment_size = 3_MiB,
+      .compacted_log_segment_size = 4_MiB,
+      .min_limit = 1_MiB,
+      .max_limit = 2_MiB,
+      .expected = 2_MiB},
+    // Overrides ignore log_segment_size and compacted_log_segment_size.
+    segment_bytes_test_params{
+      .override = 10_MiB,
+      .log_segment_size = 1_MiB,
+      .compacted_log_segment_size = 1_MiB,
+      .expected = 10_MiB},
+    segment_bytes_test_params{
+      .override = 10_MiB,
+      .log_segment_size = 100_MiB,
+      .compacted_log_segment_size = 100_MiB,
+      .expected = 10_MiB},
+    // Overrides are capped by min and max limits.
+    segment_bytes_test_params{
+      .override = 1_MiB,
+      .min_limit = 2_MiB,
+      .max_limit = 3_MiB,
+      .expected = 2_MiB},
+    segment_bytes_test_params{
+      .override = 10_MiB,
+      .min_limit = 1_MiB,
+      .max_limit = 2_MiB,
+      .expected = 2_MiB}));

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -80,3 +80,16 @@ redpanda_test_cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+
+redpanda_test_cc_library(
+    name = "scoped_config",
+    hdrs = [
+        "scoped_config.h",
+    ],
+    include_prefix = "test_utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/config",
+    ],
+)


### PR DESCRIPTION
CORE-7327

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* tbd

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
