### PR TITLE
cmake: add serde/protobuf to cmake

### DIFF
--- a/src/v/serde/CMakeLists.txt
+++ b/src/v/serde/CMakeLists.txt
@@ -9,4 +9,5 @@ v_cc_library(
     absl::flat_hash_map
     v::compression
   )
+add_subdirectory(protobuf)
 add_subdirectory(test)

--- a/src/v/serde/protobuf/CMakeLists.txt
+++ b/src/v/serde/protobuf/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(Protobuf REQUIRED)
+
+v_cc_library(
+  NAME serde_protobuf
+  SRCS
+    parser.cc
+  DEPS
+    Seastar::seastar
+    v::bytes
+    v::container
+    v::utils
+    protobuf::libprotobuf
+  )


### PR DESCRIPTION
I initially built this in Bazel only and forgot to add a CMake build so
it's actually usable.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
