### PR TITLE
`dotfiles`: add format commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,6 @@
 
 # upgraded to clang-format 18
 fc822009898f760092ba69ceac439de88d2ade90
+
+# applied clang-format changes
+0b64b2c3f7dd62a3770dbca42c11b3e92f71297e


### PR DESCRIPTION
Add commit https://github.com/redpanda-data/redpanda/pull/23073/commits/0b64b2c3f7dd62a3770dbca42c11b3e92f71297e from pull request https://github.com/redpanda-data/redpanda/pull/23073 to our `.git-blame-ignore-revs` file.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
