### PR TITLE
[v23.3.x] rpk connect as a managed plugin

### DIFF
--- a/src/go/rpk/pkg/cli/connect/client.go
+++ b/src/go/rpk/pkg/cli/connect/client.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+)
+
+const pluginBaseURL = "https://rpk-plugins.redpanda.com"
+
+type connectArtifact struct {
+	Path   string `json:"path"`
+	Sha256 string `json:"sha256"`
+}
+
+type archive struct {
+	Version   string                     `json:"version"`
+	IsLatest  bool                       `json:"is_latest"`
+	Artifacts map[string]connectArtifact `json:"artifacts"`
+}
+
+type connectManifest struct {
+	Archives []archive `json:"archives"`
+}
+
+func (c *connectManifest) LatestArtifact() (connectArtifact, string, error) {
+	osArch := runtime.GOOS + "-" + runtime.GOARCH
+	for _, a := range c.Archives {
+		if a.IsLatest {
+			if artifact, ok := a.Artifacts[osArch]; ok {
+				return artifact, a.Version, nil
+			} else {
+				return connectArtifact{}, "", fmt.Errorf("no artifact found for os-arch: %s in our latest release. Please report this issue with Redpanda Support", osArch)
+			}
+		}
+	}
+	return connectArtifact{}, "", errors.New("no latest artifact found. Please report this issue with Redpanda Support")
+}
+
+func (c *connectManifest) ArtifactVersion(version string) (connectArtifact, error) {
+	osArch := runtime.GOOS + "-" + runtime.GOARCH
+	for _, a := range c.Archives {
+		if a.Version == version {
+			if artifact, ok := a.Artifacts[osArch]; ok {
+				return artifact, nil
+			} else {
+				return connectArtifact{}, fmt.Errorf("no artifact found for os-arch: %s in Redpanda Connect version %q. Please report this issue with Redpanda Support", osArch, version)
+			}
+		}
+	}
+	return connectArtifact{}, fmt.Errorf("unable to find version %q", version)
+}
+
+// connectRepoClient is a client to connect against our repository containing
+// the Redpanda Connect packages.
+type connectRepoClient struct {
+	cl   *httpapi.Client
+	os   string
+	arch string
+}
+
+func newRepoClient() (*connectRepoClient, error) {
+	timeout := 240 * time.Second
+	if t := os.Getenv("RPK_PLUGIN_DOWNLOAD_TIMEOUT"); t != "" {
+		duration, err := time.ParseDuration(t)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse RPK_PLUGIN_DOWNLOAD_TIMEOUT: %v", err)
+		}
+		timeout = duration
+	}
+	return &connectRepoClient{
+		cl: httpapi.NewClient(
+			httpapi.HTTPClient(&http.Client{
+				Timeout: timeout,
+			}),
+		),
+		os:   runtime.GOOS,
+		arch: runtime.GOARCH,
+	}, nil
+}
+
+func (c *connectRepoClient) Manifest(ctx context.Context) (*connectManifest, error) {
+	var manifest connectManifest
+	err := c.cl.Get(ctx, fmt.Sprintf("%v/connect/manifest.json", getPluginURL()), nil, &manifest)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Redpanda Connect manifest: %v", err)
+	}
+	return &manifest, nil
+}
+
+func getPluginURL() string {
+	url := pluginBaseURL
+	if repoURL := os.Getenv("RPK_PLUGIN_REPOSITORY"); repoURL != "" {
+		url = repoURL
+	}
+	return url
+}

--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -1,0 +1,137 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func init() {
+	plugin.RegisterManaged("connect", []string{"connect"}, func(cmd *cobra.Command, _ afero.Fs, p *config.Params) *cobra.Command {
+		run := cmd.Run
+		cmd.Run = func(cmd *cobra.Command, args []string) {
+			pluginArgs, err := parseConnectFlags(p, cmd, args)
+			out.MaybeDie(err, "unable to parse flags: %v", err)
+			run(cmd, pluginArgs)
+		}
+		return cmd
+	})
+}
+
+func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "connect",
+		Short:              "A stream processor for mundane tasks - https://docs.redpanda.com/redpanda-connect",
+		DisableFlagParsing: true,                  // Required for managed plugins, we manually parse the flags.
+		Args:               cobra.MinimumNArgs(0), // Connect can be run without commands.
+		Run: func(cmd *cobra.Command, args []string) {
+			pluginArgs, err := parseConnectFlags(p, cmd, args)
+			out.MaybeDie(err, "unable to parse flags: %v", err)
+			connect, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("connect")
+			var pluginPath string
+			if !pluginExists {
+				// If it doesn't exist we only download when the user runs a
+				// subcommand.
+				var isSubcommand bool
+				for _, arg := range pluginArgs {
+					switch {
+					case arg == "-c":
+						out.Die("-c flag is not supported by this command; run 'rpk connect run' instead")
+					case arg == "--version":
+						fmt.Println("cannot get connect version: rpk connect is not installed; run 'rpk connect install'")
+						cmd.Help()
+						return
+					case strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-"):
+						continue
+					default:
+						isSubcommand = true
+					}
+				}
+				if !isSubcommand {
+					cmd.Help()
+					return
+				}
+				zap.L().Sugar().Debug("Redpanda Connect not found; downloading latest version")
+				path, err := installConnect(cmd.Context(), fs, "latest")
+				out.MaybeDie(err, "unable to install Redpanda Connect: %v; if running on an air-gapped environment you may install 'redpanda-connect' with your package manager.", err)
+				pluginPath = path
+			}
+			if pluginExists {
+				pluginPath = connect.Path
+				// Old plugin (unmanaged) might be installed, we rename it as
+				// a managed plugin from now on.
+				if !connect.Managed {
+					pluginPath = renameConnect(connect)
+				}
+			}
+			zap.L().Debug("executing connect plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
+			err = execFn(pluginPath, pluginArgs)
+			out.MaybeDie(err, "unable to execute redpanda connect plugin: %v", err)
+		},
+	}
+	cmd.AddCommand(
+		installCommand(fs),
+		uninstallCommand(fs),
+		upgradeCommand(fs),
+	)
+	return cmd
+}
+
+func parseConnectFlags(p *config.Params, cmd *cobra.Command, args []string) ([]string, error) {
+	f := cmd.Flags()
+
+	keepForPlugin, stripForRpk := cobraext.StripFlagset(args, f)
+	if err := f.Parse(stripForRpk); err != nil {
+		return nil, err
+	}
+	// Since we are manually parsing the flags, we need to force build the
+	// logger again.
+	zap.ReplaceGlobals(p.BuildLogger())
+	// We need to add back the Help and Version flags manually since we strip
+	// them for rpk.
+	if cobraext.LongFlagValue(args, f, "help", "h") == "true" && !slices.Contains(keepForPlugin, "--help") {
+		keepForPlugin = append(keepForPlugin, "--help")
+	}
+	// In rpk --verbose has a shorthand -v, in connect -v is used for version.
+	// This is _only_ valid for the 'connect' command:
+	isSubCommand := slices.ContainsFunc(keepForPlugin, func(s string) bool { return !strings.HasPrefix(s, "-") })
+	if cmd.Name() == "connect" && !isSubCommand {
+		if cobraext.LongFlagValue(args, f, "verbose", "v") == "true" && !slices.Contains(keepForPlugin, "--version") && !slices.Contains(keepForPlugin, "-v") {
+			keepForPlugin = append(keepForPlugin, "--version")
+		}
+	}
+	return keepForPlugin, nil
+}
+
+func renameConnect(connect *plugin.Plugin) string {
+	currentPath := connect.Path
+	newPath := strings.Replace(currentPath, ".rpk.ac-connect", ".rpk.managed-connect", -1)
+	err := os.Rename(currentPath, newPath)
+	if err != nil {
+		// If it fails, we just warn instead of failing as the
+		// user may have the plugin installed in a root-owned
+		// directory and be running rpk with another non-root
+		// user.
+		zap.L().Sugar().Warnf("Found unmanaged plugin, rpk was unable to rename %s as a managed connector: %v; please run 'rpk connect uninstall && rpk connect install' if you want rpk to manage Redpanda Connect", currentPath, err)
+		return currentPath
+	}
+	return newPath
+}

--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -69,7 +69,7 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 					return
 				}
 				fmt.Println("Downloading latest Redpanda Connect")
-				path, err := installConnect(cmd.Context(), fs, "latest")
+				path, _, err := installConnect(cmd.Context(), fs, "latest")
 				out.MaybeDie(err, "unable to install Redpanda Connect: %v; if running on an air-gapped environment you may install 'redpanda-connect' with your package manager.", err)
 				pluginPath = path
 			}

--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -69,7 +69,7 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 					cmd.Help()
 					return
 				}
-				zap.L().Sugar().Debug("Redpanda Connect not found; downloading latest version")
+				fmt.Println("Downloading latest Redpanda Connect")
 				path, err := installConnect(cmd.Context(), fs, "latest")
 				out.MaybeDie(err, "unable to install Redpanda Connect: %v; if running on an air-gapped environment you may install 'redpanda-connect' with your package manager.", err)
 				pluginPath = path

--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -11,7 +11,6 @@ package connect
 
 import (
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
@@ -76,10 +75,8 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 			}
 			if pluginExists {
 				pluginPath = connect.Path
-				// Old plugin (unmanaged) might be installed, we rename it as
-				// a managed plugin from now on.
 				if !connect.Managed {
-					pluginPath = renameConnect(connect)
+					zap.L().Sugar().Warn("rpk is using a self-managed version of Redpanda Connect. If you want rpk to manage connect, use rpk connect uninstall && rpk connect install. To continue managing Connect manually, use our redpanda-connect package.")
 				}
 			}
 			zap.L().Debug("executing connect plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
@@ -119,19 +116,4 @@ func parseConnectFlags(p *config.Params, cmd *cobra.Command, args []string) ([]s
 		}
 	}
 	return keepForPlugin, nil
-}
-
-func renameConnect(connect *plugin.Plugin) string {
-	currentPath := connect.Path
-	newPath := strings.Replace(currentPath, ".rpk.ac-connect", ".rpk.managed-connect", -1)
-	err := os.Rename(currentPath, newPath)
-	if err != nil {
-		// If it fails, we just warn instead of failing as the
-		// user may have the plugin installed in a root-owned
-		// directory and be running rpk with another non-root
-		// user.
-		zap.L().Sugar().Warnf("Found unmanaged plugin, rpk was unable to rename %s as a managed connector: %v; please run 'rpk connect uninstall && rpk connect install' if you want rpk to manage Redpanda Connect", currentPath, err)
-		return currentPath
-	}
-	return newPath
 }

--- a/src/go/rpk/pkg/cli/connect/install.go
+++ b/src/go/rpk/pkg/cli/connect/install.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func installCommand(fs afero.Fs) *cobra.Command {
+	var (
+		version string
+		force   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install Redpanda Connect",
+		Long: `Install Redpanda Connect
+
+This command install the latest version by default.
+
+Alternatively, you may specify a Redpanda Connect version using the 
+--connect-version flag.
+
+You may force the installation of Redpanda Connect using the --force flag.
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			version = strings.ToLower(version)
+			err := validateVersion(version)
+			out.MaybeDieErr(err)
+			_, installed := plugin.ListPlugins(fs, plugin.UserPaths()).Find("connect")
+			if installed && !force {
+				if version != "latest" {
+					out.Exit("Redpanda connect is already installed. Use --force to force installation, or delete current version with 'rpk connect uninstall' first")
+				}
+				out.Exit("Redpanda connect is already installed.\nIf you want to upgrade to the latest version, please run 'rpk connect upgrade'.")
+			}
+			_, err = installConnect(cmd.Context(), fs, version)
+			out.MaybeDie(err, "unable to install Redpanda Connect: %v; if running on an air-gapped environment you may install 'redpanda-connect' with your package manager.", err)
+
+			fmt.Println("Redpanda Connect successfully installed.")
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Force install of Redpanda Connect")
+	cmd.Flags().StringVar(&version, "connect-version", "latest", "Redpanda Connect version to install. (e.g. 4.32.0)")
+	return cmd
+}
+
+// installConnect installs Redpanda Connect plugin in the default location.
+// If the plugin is already installed, it will return early and won't download
+// the latest plugin. Version string let you select a specific version to
+// download, if "latest" or an empty string is passed, it will download the
+// latest version.
+func installConnect(ctx context.Context, fs afero.Fs, version string) (path string, err error) {
+	// We check this before calling the API, to avoid getting the binary
+	// and later fail due to a user setting.
+	pluginDir, err := plugin.DefaultBinPath()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine plugin default path: %v", err)
+	}
+
+	art, _, err := getConnectArtifact(ctx, version)
+	if err != nil {
+		return "", err
+	}
+
+	return downloadAndInstallConnect(ctx, fs, pluginDir, art.Path, art.Sha256)
+}
+
+func getConnectArtifact(ctx context.Context, version string) (connectArtifact, string, error) {
+	plCl, err := newRepoClient()
+	if err != nil {
+		return connectArtifact{}, "", err
+	}
+	manifest, err := plCl.Manifest(ctx)
+	if err != nil {
+		return connectArtifact{}, "", err
+	}
+	var (
+		art        connectArtifact
+		retVersion string
+	)
+	if version == "latest" || version == "" {
+		art, retVersion, err = manifest.LatestArtifact()
+		if err != nil {
+			return connectArtifact{}, "", err
+		}
+	} else {
+		art, err = manifest.ArtifactVersion(version)
+		if err != nil {
+			return connectArtifact{}, "", err
+		}
+		retVersion = version
+	}
+	return art, retVersion, nil
+}
+
+func downloadAndInstallConnect(ctx context.Context, fs afero.Fs, installPath, downloadURL, expShaPrefix string) (string, error) {
+	bin, err := plugin.Download(ctx, downloadURL, true, expShaPrefix)
+	if err != nil {
+		return "", fmt.Errorf("unable to download Redpanda Connect from %q: %v", downloadURL, err)
+	}
+
+	// Ensure the directory exists. We ignore errors here because any issues
+	// will be handled when we attempt to create the directory with os.MkdirAll.
+	if exists, _ := afero.DirExists(fs, installPath); !exists {
+		if rpkos.IsRunningSudo() {
+			return "", fmt.Errorf("detected rpk is running with sudo; please execute this command without sudo to avoid saving the plugin as a root owned binary in %s", installPath)
+		}
+		err = os.MkdirAll(installPath, 0o755)
+		if err != nil {
+			return "", fmt.Errorf("unable to create plugin directory %s: %v", installPath, err)
+		}
+	}
+	zap.L().Sugar().Debugf("writing Redpanda Connect plugin to %v", installPath)
+	path, err := plugin.WriteBinary(fs, "connect", installPath, bin, false, true)
+	if err != nil {
+		return "", fmt.Errorf("unable to write Redpanda Connect plugin: %v", err)
+	}
+	return path, nil
+}
+
+// validateVersion validates that the provided version in the flag is either
+// 'latest' or it's a full semantic version.
+func validateVersion(version string) error {
+	// This simple regexp just matches that a semver is in the string, it may
+	// be prefixed with 'v' and contain anything after. Nothing to capture.
+	if version == "latest" {
+		return nil
+	}
+	vMatch := regexp.MustCompile(`^v?\d{1,2}\.\d{1,2}\.\d{1,2}`).MatchString(version)
+	if !vMatch {
+		return fmt.Errorf("provided version %q is not valid. Ensure is either 'latest' or it follows the format MAJOR.MINOR.PATCH (e.g., 2.1.3)", version)
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/cli/connect/uninstall.go
+++ b/src/go/rpk/pkg/cli/connect/uninstall.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func uninstallCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the Redpanda Connect plugin",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			connect, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("connect")
+			if !pluginExists {
+				out.Exit("The Redpanda Connect managed plugin is not installed!")
+			}
+			ops, anyFailed := connect.Uninstall(true)
+			tw := out.NewTable("PATH", "MESSAGE")
+			defer func() {
+				tw.Flush()
+				if anyFailed {
+					os.Exit(1)
+				}
+			}()
+			for _, o := range ops {
+				tw.Print(o.Path, o.Message)
+			}
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/connect/upgrade.go
+++ b/src/go/rpk/pkg/cli/connect/upgrade.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package connect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func upgradeCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade to the latest Redpanda Connect version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			pluginDir, err := plugin.DefaultBinPath()
+			out.MaybeDie(err, "unable to determine managed plugin path: %w", err)
+			connect, pluginExists := plugin.ListPlugins(fs, plugin.UserPaths()).Find("connect")
+			if !pluginExists {
+				out.Die("Redpanda Connect plugin not found. You may install it running 'rpk connect install'")
+			}
+			// A user may have installed version of 'rpk connect' either
+			// manually or using a package manager (air-gapped). An attempt to
+			// upgrade can result in having multiple copies of connect. Instead,
+			// we kindly ask to re-install.
+			if !connect.Managed {
+				out.Die("Found an unmanaged Redpanda Connect plugin; unfortunately we cannot upgrade it with this install. Run 'rpk connect uninstall' first, and download a new one with 'rpk connect install' or use your package manager.")
+			}
+			art, version, err := getConnectArtifact(cmd.Context(), "latest")
+			out.MaybeDieErr(err)
+
+			currentSha, err := plugin.Sha256Path(fs, connect.Path)
+			out.MaybeDie(err, "unable to determine the sha256sum of current Redpanda Connect %q: %v", connect.Path, err)
+
+			if strings.HasPrefix(currentSha, art.Sha256) {
+				out.Exit("Redpanda Connect already up-to-date")
+			}
+			_, err = downloadAndInstallConnect(cmd.Context(), fs, pluginDir, art.Path, art.Sha256)
+			out.MaybeDieErr(err)
+
+			fmt.Printf("Redpanda Connect successfully upgraded to the latest version (%v).\n", version)
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/connect/upgrade.go
+++ b/src/go/rpk/pkg/cli/connect/upgrade.go
@@ -36,7 +36,7 @@ func upgradeCommand(fs afero.Fs) *cobra.Command {
 			// upgrade can result in having multiple copies of connect. Instead,
 			// we kindly ask to re-install.
 			if !connect.Managed {
-				out.Die("Found an unmanaged Redpanda Connect plugin; unfortunately we cannot upgrade it with this install. Run 'rpk connect uninstall' first, and download a new one with 'rpk connect install' or use your package manager.")
+				out.Die("Found a self-managed Redpanda Connect plugin; unfortunately, we cannot upgrade it with this installation. Run rpk connect uninstall && rpk connect install, or to continue managing Connect manually, use our redpanda-connect package.")
 			}
 			art, version, err := getConnectArtifact(cmd.Context(), "latest")
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/connect/upgrade.go
+++ b/src/go/rpk/pkg/cli/connect/upgrade.go
@@ -10,8 +10,12 @@
 package connect
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
 	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
@@ -20,7 +24,8 @@ import (
 )
 
 func upgradeCommand(fs afero.Fs) *cobra.Command {
-	return &cobra.Command{
+	var noConfirm bool
+	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade to the latest Redpanda Connect version",
 		Args:  cobra.NoArgs,
@@ -47,10 +52,54 @@ func upgradeCommand(fs afero.Fs) *cobra.Command {
 			if strings.HasPrefix(currentSha, art.Sha256) {
 				out.Exit("Redpanda Connect already up-to-date")
 			}
+			currentVersion, err := connectVersion(cmd.Context(), connect.Path)
+			out.MaybeDie(err, "unable to determine current version of Redpanda Connect: %v", err)
+
+			if !noConfirm {
+				latestVersion, err := redpanda.VersionFromString(version)
+				out.MaybeDie(err, "unable to parse latest version of Redpanda Connect: %v", err)
+				if latestVersion.Major > currentVersion.Major {
+					confirmed, err := out.Confirm("Confirm major version upgrade from %v to %v?", currentVersion.String(), latestVersion.String())
+					out.MaybeDie(err, "unable to confirm upgrade: %v", err)
+					if !confirmed {
+						out.Exit("Upgrade canceled.")
+					}
+				}
+			}
+
 			_, err = downloadAndInstallConnect(cmd.Context(), fs, pluginDir, art.Path, art.Sha256)
 			out.MaybeDieErr(err)
 
-			fmt.Printf("Redpanda Connect successfully upgraded to the latest version (%v).\n", version)
+			fmt.Printf("Redpanda Connect successfully upgraded from %v to the latest version (%v).\n", currentVersion.String(), version)
 		},
 	}
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt for major version upgrades")
+	return cmd
+}
+
+// connectVersion executes rpk connect --version and parses the current version
+// from the output.
+func connectVersion(ctx context.Context, connectPath string) (redpanda.Version, error) {
+	versionCmd := exec.CommandContext(ctx, connectPath, "--version")
+	var sb strings.Builder
+	versionCmd.Stdout = &sb
+	if err := versionCmd.Run(); err != nil {
+		return redpanda.Version{}, err
+	}
+	// Command output is:
+	//   Version: <Version>
+	//   Date: <Build date>
+	versionPrefix := "Version: "
+	var versionStr string
+	for _, l := range strings.Split(sb.String(), "\n") {
+		if strings.HasPrefix(l, versionPrefix) {
+			versionStr = strings.TrimPrefix(l, versionPrefix)
+			break
+		}
+	}
+	version, err := redpanda.VersionFromString(strings.TrimSpace(versionStr))
+	if err != nil {
+		return redpanda.Version{}, fmt.Errorf("unable to determine Redpanda version from %q: %v", versionStr, err)
+	}
+	return version, nil
 }

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
@@ -60,7 +60,7 @@ cluster is unreachable), use the hidden --force flag.
 						}
 						version, err := redpanda.VersionFromString(br.Version)
 						out.MaybeDie(err, "unable to get broker %d version: %v; to bypass the node version check re-run this with --force; see this command's help text for more details", br.NodeID, err)
-						isOld := version.Less(redpanda.Version{Year: 23, Feature: 1, Patch: 1})
+						isOld := version.Less(redpanda.Version{Major: 23, Feature: 1, Patch: 1})
 
 						anyOld = anyOld || isOld
 						b, found = br, true

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/acl"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/debug"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/generate"
@@ -109,6 +110,7 @@ func Execute() {
 		cloud.NewCommand(fs, p, osExec),
 		cluster.NewCommand(fs, p),
 		container.NewCommand(fs, p),
+		connect.NewCommand(fs, p, osExec),
 		profile.NewCommand(fs, p),
 		debug.NewCommand(fs, p),
 		generate.NewCommand(fs, p),

--- a/src/go/rpk/pkg/cobraext/cobraext.go
+++ b/src/go/rpk/pkg/cobraext/cobraext.go
@@ -191,13 +191,13 @@ func StripFlags(args []string, fs *pflag.FlagSet, long []string, short []string)
 // some flags in args. The flagset should be received from *inside* a cobra
 // command, where persistent and non-persistent flags from all parents are
 // merged. For repeated flags, only the last value is returned.
-func LongFlagValue(args []string, fs *pflag.FlagSet, flag string) string {
+func LongFlagValue(args []string, fs *pflag.FlagSet, flag, shorthand string) string {
 	nop := new(nopValue)
 	dup := pflag.NewFlagSet("dup", pflag.ContinueOnError)
 	dup.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 
 	var f string
-	dup.StringVar(&f, flag, "", "")
+	dup.StringVarP(&f, flag, shorthand, "", "")
 	added := dup.Lookup(flag)
 	fs.VisitAll(func(f *pflag.Flag) {
 		if f.Name != flag {

--- a/src/go/rpk/pkg/cobraext/cobraext.go
+++ b/src/go/rpk/pkg/cobraext/cobraext.go
@@ -105,7 +105,12 @@ func StripFlags(args []string, fs *pflag.FlagSet, long []string, short []string)
 			_, strip := stripLong[k]
 			if f == nil || !strip {
 				inFlag = len(kv) == 1
-				keep = append(keep, arg) // either we are keeping this flag, or it is not in our flag set so we cannot strip it
+				// either we are keeping this flag, or it is not in our flag
+				// set, so we cannot strip it.
+				keep = append(keep, arg)
+				// If we are at this point is because the flag does not exist,
+				// and it's part of the plugin. If the next arg starts with
+				// '-' we will assume this flag is a boolean flag.
 				if i+1 < len(args) && strings.HasPrefix(args[i+1], "-") {
 					inFlag = false
 				}

--- a/src/go/rpk/pkg/cobraext/cobraext.go
+++ b/src/go/rpk/pkg/cobraext/cobraext.go
@@ -106,6 +106,9 @@ func StripFlags(args []string, fs *pflag.FlagSet, long []string, short []string)
 			if f == nil || !strip {
 				inFlag = len(kv) == 1
 				keep = append(keep, arg) // either we are keeping this flag, or it is not in our flag set so we cannot strip it
+				if i+1 < len(args) && strings.HasPrefix(args[i+1], "-") {
+					inFlag = false
+				}
 				continue
 			}
 

--- a/src/go/rpk/pkg/cobraext/cobraext_test.go
+++ b/src/go/rpk/pkg/cobraext/cobraext_test.go
@@ -42,8 +42,8 @@ func TestStripFlagset(t *testing.T) {
 		expStripped []string
 	}{
 		{
-			args:        []string{"--config", "foo", "--config-opt", "bar", "--config-opt=biz", "-v", "-v=debug", "subcmd", "-f", "foo", "finalarg", "finalarg2"},
-			expKept:     []string{"-f", "foo", "finalarg", "finalarg2"},
+			args:        []string{"--config", "foo", "--config-opt", "bar", "--config-opt=biz", "--version", "-v", "-v=debug", "subcmd", "-f", "foo", "finalarg", "finalarg2", "-r", "--finalUnknown"},
+			expKept:     []string{"--version", "-f", "foo", "finalarg", "finalarg2", "-r", "--finalUnknown"},
 			expStripped: []string{"--config", "foo", "--config-opt", "bar", "--config-opt=biz", "-v", "-v=debug"},
 		},
 	} {

--- a/src/go/rpk/pkg/cobraext/cobraext_test.go
+++ b/src/go/rpk/pkg/cobraext/cobraext_test.go
@@ -137,34 +137,45 @@ func TestLongFlagValue(t *testing.T) {
 	fs.StringP("verbose", "v", "none", "Log level")
 	fs.Lookup("verbose").NoOptDefVal = "info"
 
-	args := []string{"--config", "foo", "--config-opt", "bar", "--config-opt=biz", "-v", "-v=debug", "subcmd", "-f", "foo", "finalarg", "finalarg2", "--unknown", "handled", "--unknown2=handled2"}
+	args := []string{"--config", "foo", "--config-opt", "bar", "--config-opt=biz", "-v", "-v=debug", "subcmd", "-f", "foo", "finalarg", "finalarg2", "--unknown", "handled", "--unknown2=handled2", "-h"}
 
 	for _, test := range []struct {
-		f   string
-		exp string
+		flag      string
+		shorthand string
+		exp       string
 	}{
 		{
-			f:   "config",
-			exp: "foo",
+			flag: "config",
+			exp:  "foo",
 		},
 		{
-			f:   "config-opt",
-			exp: "biz", // we take the last value
+			flag: "config-opt",
+			exp:  "biz", // we take the last value
 		},
 		{
-			f:   "noexist",
-			exp: "",
+			flag: "noexist",
+			exp:  "",
 		},
 		{
-			f:   "unknown",
-			exp: "handled",
+			flag: "unknown",
+			exp:  "handled",
 		},
 		{
-			f:   "unknown2",
-			exp: "handled2",
+			flag: "unknown2",
+			exp:  "handled2",
+		},
+		{
+			flag:      "verbose",
+			shorthand: "v",
+			exp:       "debug",
+		},
+		{
+			flag:      "help",
+			shorthand: "h",
+			exp:       "true",
 		},
 	} {
-		got := LongFlagValue(args, fs, test.f)
+		got := LongFlagValue(args, fs, test.flag, test.shorthand)
 		if got != test.exp {
 			t.Errorf("got %v != exp %v", got, test.exp)
 		}

--- a/src/go/rpk/pkg/httpapi/httpapi.go
+++ b/src/go/rpk/pkg/httpapi/httpapi.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 // BodyError is returned on non-2xx status codes. For 4xx, you can optionally
@@ -358,8 +359,10 @@ func maybeUnmarshalRespBodyInto(r io.Reader, into interface{}) error {
 		*t = string(body)
 	default:
 		if err := json.Unmarshal(body, into); err != nil {
-			if err := xml.Unmarshal(body, into); err != nil {
-				return fmt.Errorf("unable to decode response body: %w", err)
+			if err := yaml.Unmarshal(body, into); err != nil {
+				if err := xml.Unmarshal(body, into); err != nil {
+					return fmt.Errorf("unable to decode response body: %w", err)
+				}
 			}
 		}
 	}

--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/spf13/afero"
@@ -203,6 +205,7 @@ func UserPaths() []string {
 	defaultPath, err := DefaultBinPath()
 	pathList := filepath.SplitList(os.Getenv("PATH"))
 	if err != nil {
+		zap.L().Sugar().Warnf("Unable to get default plugin path: %v; using $PATH only", err)
 		// If there is an error getting the default bin path we will only look
 		// for the binary in the $PATH.
 		return pathList

--- a/src/go/rpk/pkg/redpanda/version.go
+++ b/src/go/rpk/pkg/redpanda/version.go
@@ -7,22 +7,20 @@ import (
 )
 
 type Version struct {
-	Year    int
+	Major   int
 	Feature int
 	Patch   int
 }
 
 // VersionFromString creates a Version struct based on a passed string that
-// contains the version with the AB.C.D convention where AB is the Year, C
-// is the feature, and D is the patch.
+// contains the semver version string.
 func VersionFromString(s string) (Version, error) {
-	// Match the version of redpanda following AB.C.D convention, where C and D
-	// can be either a single or double-digit and returns:
+	// Match the version of redpanda following semver convention, and returns:
 	//   - index 0: the full match
-	//   - index 1: the Year
+	//   - index 1: the Major
 	//   - index 2: the Feature
 	//   - index 3: the Patch
-	vMatch := regexp.MustCompile(`^v?(\d{2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|$)`).FindStringSubmatch(s)
+	vMatch := regexp.MustCompile(`^v?(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:\s|-rc\d{1,2}|-dev|$)`).FindStringSubmatch(s)
 
 	if len(vMatch) == 0 {
 		return Version{}, fmt.Errorf("unable to get the redpanda version from %q", s)
@@ -38,11 +36,15 @@ func VersionFromString(s string) (Version, error) {
 
 // Less returns true if the version is lower than the passed 'b' version.
 func (v Version) Less(b Version) bool {
-	if v.Year == b.Year {
+	if v.Major == b.Major {
 		if v.Feature == b.Feature {
 			return v.Patch < b.Patch
 		}
 		return v.Feature < b.Feature
 	}
-	return v.Year < b.Year
+	return v.Major < b.Major
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Feature, v.Patch)
 }

--- a/src/go/rpk/pkg/redpanda/version_test.go
+++ b/src/go/rpk/pkg/redpanda/version_test.go
@@ -14,12 +14,14 @@ func TestVersionFromString(t *testing.T) {
 		expErr bool
 	}{
 		{name: "with v", in: "v22.3.4", exp: Version{22, 3, 4}},
+		{name: "with v, single digit major", in: "4.36.1", exp: Version{4, 36, 1}},
 		{name: "with v and text", in: "v22.3.4 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{22, 3, 4}},
 		{name: "with v and rc", in: "v22.3.13-rc1", exp: Version{22, 3, 13}},
 		{name: "with v, with rc and text", in: "v22.3.13-rc1 - 29e2b111d1d94d6d1f6cc591457ed03119edf0e6-dirty", exp: Version{22, 3, 13}},
 		{name: "without v", in: "22.3.4", exp: Version{22, 3, 4}},
 		{name: "without v and text", in: "22.3.4 - 9eefb907c43bf1cfeb0783808c224385c857c0d4-dirty", exp: Version{22, 3, 4}},
 		{name: "without v and rc", in: "22.3.13-rc1", exp: Version{22, 3, 13}},
+		{name: "without v and rc - single major", in: "4.36.1-rc1", exp: Version{4, 36, 1}},
 		{name: "without v, with rc and text", in: "22.3.13-rc1 - 29e2b111d1d94d6d1f6cc591457ed03119edf0e6-dirty", exp: Version{22, 3, 13}},
 		{name: "incomplete", in: "22.3", expErr: true},
 		{name: "random string", in: "random", expErr: true},

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1782,7 +1782,7 @@ class RpkTool:
         return self._run_connect(cmd)
 
     def upgrade_connect(self):
-        cmd = ["upgrade"]
+        cmd = ["upgrade", "--no-confirm"]
         return self._run_connect(cmd)
 
     def connect_version(self):

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1759,9 +1759,9 @@ class RpkTool:
         out = self._execute(cmd)
         return json.loads(out)
 
-    def _run_connect(self, cmd):
+    def _run_connect(self, cmd, timeout=None):
         cmd = [self._rpk_binary(), "connect"] + cmd
-        return self._execute(cmd)
+        return self._execute(cmd, timeout=timeout)
 
     def install_connect(self, version="", force=False):
         cmd = ["install"]
@@ -1771,7 +1771,10 @@ class RpkTool:
         if force:
             cmd += ["--force"]
 
-        return self._run_connect(cmd)
+        # This command has a higher timeout than normal rpk
+        # commands as it downloads and install the RP Connect
+        # binary.
+        return self._run_connect(cmd, timeout=2 * DEFAULT_TIMEOUT)
 
     def uninstall_connect(self):
         cmd = ["uninstall"]

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1753,3 +1753,49 @@ class RpkTool:
         else:
             cmd += ["-X", "admin.hosts=" + self._admin_host()]
         return self._execute(cmd)
+
+    def run_mock_plugin(self, cmd):
+        cmd = [self._rpk_binary(), "pluginmock"] + cmd
+        out = self._execute(cmd)
+        return json.loads(out)
+
+    def _run_connect(self, cmd):
+        cmd = [self._rpk_binary(), "connect"] + cmd
+        return self._execute(cmd)
+
+    def install_connect(self, version="", force=False):
+        cmd = ["install"]
+        if version != "":
+            cmd += ["--connect-version", version]
+
+        if force:
+            cmd += ["--force"]
+
+        return self._run_connect(cmd)
+
+    def uninstall_connect(self):
+        cmd = ["uninstall"]
+
+        return self._run_connect(cmd)
+
+    def upgrade_connect(self):
+        cmd = ["upgrade"]
+        return self._run_connect(cmd)
+
+    def connect_version(self):
+        cmd = ["--version"]
+        out = self._run_connect(cmd)
+        """
+        Example output of rpk connect --version:
+        Version: 4.33.0
+        Date: 2024-08-13T21:40:38Z
+        """
+        pattern = r"Version:\s*([\d.]+)"
+        match = re.search(pattern, out)
+        if match:
+            return match.group(1)  # The version.
+        else:
+            raise RpkException(f"unable to parse connect version from {out}")
+
+    def run_connect_arbitrary(self, cmd):
+        return self._run_connect(cmd)

--- a/tests/rptest/tests/rpk_connect_test.py
+++ b/tests/rptest/tests/rpk_connect_test.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_exception
+from rptest.clients.rpk import RpkTool, RpkException
+
+
+class RpkConnectTest(RedpandaTest):
+    def __init__(self, ctx):
+        super(RpkConnectTest, self).__init__(test_context=ctx)
+        self._ctx = ctx
+        self._rpk = RpkTool(self.redpanda)
+
+    def cleanup_connect(self):
+        self._rpk.uninstall_connect()
+        assert "connect" not in self._rpk.plugin_list()
+
+    @cluster(num_nodes=1)
+    def test_manual_latest_install(self):
+        self.cleanup_connect()
+        self._rpk.install_connect()
+        assert "connect" in self._rpk.plugin_list()
+
+    @cluster(num_nodes=1)
+    def test_upgrade(self):
+        self.cleanup_connect()
+
+        initial_version = "4.35.1"
+        self._rpk.install_connect(initial_version)
+        assert "connect" in self._rpk.plugin_list()
+        assert self._rpk.connect_version() == initial_version
+
+        self._rpk.upgrade_connect()
+        # We assume here that is updated to latest.
+        assert self._rpk.connect_version() != initial_version
+
+    @cluster(num_nodes=1)
+    def test_automatic_install(self):
+        self.cleanup_connect()
+
+        # rpk will not install if the user runs just --help, instead
+        # it will display the help text and exit 0.
+        assert "Usage:" in self._rpk.run_connect_arbitrary(["--help"])
+
+        # rpk shouldn't install either if the user runs --version without
+        # connect being installed first.
+        with expect_exception(
+                RpkException,
+                lambda e: "rpk connect is not installed" in str(e)):
+            self._rpk.connect_version()
+
+        # Now, rpk should download and install on-the-fly Connect when
+        # executing a subcommand.
+        assert "connect" not in self._rpk.plugin_list()
+        self._rpk.run_connect_arbitrary(["run", "--help"])
+        assert "connect" in self._rpk.plugin_list()
+
+        # And executing --version now that is installed should return
+        # something and exit 0.
+        assert self._rpk.connect_version() != ""


### PR DESCRIPTION
This is a manual backport of all the PRs that makes the feature `rpk connect` as a managed plugin:

- https://github.com/redpanda-data/redpanda/pull/23117 - Main PR.
- https://github.com/redpanda-data/redpanda/pull/23305 - Ducktape Test timeout increase.
- https://github.com/redpanda-data/redpanda/pull/23336 - UX improvements after UAT.
- 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
### Improvements
- `rpk connect` now will be downloaded on the first run.
- rpk: introduce rpk connect install, rpk connect upgrade, and rpk connect uninstall, manual ways to manage rpk connect versioning.
