### PR TITLE
bazel: add missing connect dep

### DIFF
--- a/src/go/rpk/pkg/cli/connect/BUILD
+++ b/src/go/rpk/pkg/cli/connect/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/plugin",
+        "//src/go/rpk/pkg/redpanda",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@org_uber_go_zap//:zap",


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
