### PR TITLE
[v24.1.x] `admin`: add `cloud_storage_cache_size` check to `config_multi_property_validation()` (manual backport)

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_probe.h"
 #include "cloud_storage/recursive_directory_walker.h"
+#include "config/configuration.h"
 #include "config/property.h"
 #include "resource_mgmt/io_priority.h"
 #include "resource_mgmt/storage.h"
@@ -196,6 +197,16 @@ public:
     get_local_path(const std::filesystem::path& key) const {
         return _cache_dir / key;
     }
+
+    // Checks if a cluster configuration is valid for the properties
+    // `cloud_storage_cache_size` and `cloud_storage_cache_size_percent`.
+    // Two cases are invalid: 1. the case in which both are 0, 2. the case in
+    // which `cache_size` is 0 while `cache_size_percent` is `std::nullopt`.
+    //
+    // Returns `std::nullopt` if the passed configuration is valid, or an
+    // `ss::sstring` explaining the misconfiguration otherwise.
+    static std::optional<ss::sstring>
+    validate_cache_config(const config::configuration& conf);
 
 private:
     /// Load access time tracker from file

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1634,6 +1634,14 @@ void config_multi_property_validation(
         errors[ss::sstring(name)] = ssx::sformat(
           "{} requires schema_registry to be enabled in redpanda.yaml", name);
     }
+
+    // cloud_storage_cache_size/size_percent validation
+    if (auto invalid_cache = cloud_storage::cache::validate_cache_config(
+          updated_config);
+        invalid_cache.has_value()) {
+        auto name = ss::sstring(updated_config.cloud_storage_cache_size.name());
+        errors[name] = invalid_cache.value();
+    }
 }
 } // namespace
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1491,6 +1491,41 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 if s['node_id'] == self.redpanda.idx(controller_node))
             assert local_status['config_version'] == config_version
 
+    # None for pct_value is std::nullopt, which defaults to 0.0 in the cloud cache.
+    @cluster(num_nodes=1)
+    def test_validate_cloud_storage_cache_size_config(self):
+        CloudCacheConf = namedtuple('CloudCacheConf',
+                                    ['size_value', 'pct_value', 'valid'])
+        test_cases = [
+            CloudCacheConf(size_value=0, pct_value=None, valid=False),
+            CloudCacheConf(size_value=0, pct_value=0.0, valid=False),
+            CloudCacheConf(size_value=0, pct_value=-1.0, valid=False),
+            CloudCacheConf(size_value=0, pct_value=101.0, valid=False),
+            CloudCacheConf(size_value=-1, pct_value=None, valid=False),
+            CloudCacheConf(size_value=1024, pct_value=None, valid=True),
+            CloudCacheConf(size_value=10, pct_value=50.0, valid=True),
+            CloudCacheConf(size_value=0, pct_value=0.1, valid=True)
+        ]
+
+        for size_value, pct_value, valid in test_cases:
+            upsert = {}
+            upsert["cloud_storage_cache_size"] = size_value
+            upsert["cloud_storage_cache_size_percent"] = pct_value
+
+            if valid:
+                patch_result = self.admin.patch_cluster_config(upsert=upsert)
+                new_version = patch_result['config_version']
+                wait_for_version_status_sync(self.admin, self.redpanda,
+                                             new_version)
+                updated_config = self.admin.get_cluster_config()
+                assert updated_config["cloud_storage_cache_size"] == size_value
+                assert updated_config[
+                    "cloud_storage_cache_size_percent"] == pct_value
+            else:
+                with expect_exception(requests.exceptions.HTTPError,
+                                      lambda e: e.response.status_code == 400):
+                    self.admin.patch_cluster_config(upsert=upsert)
+
 
 """
 PropertyAliasData:


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/23337.
Merge conflict due to unrelated changes in `cluster_config_test.py`.

Closes https://github.com/redpanda-data/redpanda/issues/23356

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
