### PR TITLE
[CORE-7095] debug_bundle: Admin API

### DIFF
--- a/src/v/debug_bundle/BUILD
+++ b/src/v/debug_bundle/BUILD
@@ -37,3 +37,18 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "json",
+    hdrs = [
+        "json.h",
+    ],
+    include_prefix = "debug_bundle",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":debug_bundle",
+        "//src/v/base",
+        "//src/v/json",
+        "//src/v/reflection:type_traits",
+    ],
+)

--- a/src/v/debug_bundle/BUILD
+++ b/src/v/debug_bundle/BUILD
@@ -31,7 +31,9 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
         "//src/v/utils:uuid",
         "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/strings",
         "@fmt",
+        "@re2",
         "@seastar",
     ],
 )

--- a/src/v/debug_bundle/json.h
+++ b/src/v/debug_bundle/json.h
@@ -199,6 +199,71 @@ debug_bundle::result<T> from_json(const json::Value& v) {
             return std::move(set);
         }
         return parse_error(": expected an array");
+    } else if constexpr (std::is_same_v<T, debug_bundle_parameters>) {
+        debug_bundle_parameters params;
+        if (v.IsObject()) {
+            const auto& obj = v.GetObject();
+            if (auto r = from_json<decltype(params.authn_options)>(
+                  obj, "authentication", false);
+                r.has_value()) {
+                params.authn_options = std::move(r).assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r
+                = from_json<decltype(params.controller_logs_size_limit_bytes)>(
+                  obj, "controller_logs_size_limit_bytes", false);
+                r.has_value()) {
+                params.controller_logs_size_limit_bytes = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.cpu_profiler_wait_seconds)>(
+                  obj, "cpu_profiler_wait_seconds", false);
+                r.has_value()) {
+                params.cpu_profiler_wait_seconds = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.logs_since)>(
+                  obj, "logs_since", false);
+                r.has_value()) {
+                params.logs_since = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.logs_size_limit_bytes)>(
+                  obj, "logs_size_limit_bytes", false);
+                r.has_value()) {
+                params.logs_size_limit_bytes = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.logs_until)>(
+                  obj, "logs_until", false);
+                r.has_value()) {
+                params.logs_until = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.metrics_interval_seconds)>(
+                  obj, "metrics_interval_seconds", false);
+                r.has_value()) {
+                params.metrics_interval_seconds = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+            if (auto r = from_json<decltype(params.partition)>(
+                  obj, "partition", false);
+                r.has_value()) {
+                params.partition = r.assume_value();
+            } else {
+                return std::move(r).assume_error();
+            }
+
+            return std::move(params);
+        }
+        return parse_error(": expected debug_bundle_parameters");
     } else {
         static_assert(always_false_v<T>, "Not implemented");
     }

--- a/src/v/debug_bundle/json.h
+++ b/src/v/debug_bundle/json.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "debug_bundle/error.h"
+#include "json/document.h"
+#include "utils/functional.h"
+
+#include <type_traits>
+
+namespace debug_bundle {
+
+template<typename T>
+debug_bundle::result<T> from_json(const json::Value& v) {
+    constexpr auto parse_error = []() {
+        return error_info{error_code::invalid_parameters, "Failed to parse"};
+    };
+
+    if constexpr (std::is_same_v<T, int>) {
+        if (v.IsInt()) {
+            return v.GetInt();
+        }
+    } else {
+        static_assert(always_false_v<T>, "Not implemented");
+    }
+    return parse_error();
+}
+
+} // namespace debug_bundle

--- a/src/v/debug_bundle/tests/BUILD
+++ b/src/v/debug_bundle/tests/BUILD
@@ -13,9 +13,12 @@ redpanda_cc_gtest(
         "//src/v/json",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "//src/v/utils:uuid",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@fmt",
         "@googletest//:gtest",
         "@rapidjson",
+        "@seastar",
     ],
 )
 

--- a/src/v/debug_bundle/tests/BUILD
+++ b/src/v/debug_bundle/tests/BUILD
@@ -4,14 +4,18 @@ redpanda_cc_gtest(
     name = "types_test",
     timeout = "short",
     srcs = [
+        "json_test.cc",
         "types_test.cc",
     ],
     deps = [
         "//src/v/debug_bundle",
+        "//src/v/debug_bundle:json",
+        "//src/v/json",
         "//src/v/model",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@googletest//:gtest",
+        "@rapidjson",
     ],
 )
 

--- a/src/v/debug_bundle/tests/BUILD
+++ b/src/v/debug_bundle/tests/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_gtest(
         "//src/v/debug_bundle:json",
         "//src/v/json",
         "//src/v/model",
+        "//src/v/security",
         "//src/v/test_utils:gtest",
         "//src/v/utils:uuid",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/debug_bundle/tests/CMakeLists.txt
+++ b/src/v/debug_bundle/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
     GTEST
     BINARY_NAME gtest_debug_bundle
     SOURCES
+      json_test.cc
       types_test.cc
     LIBRARIES
       v::debug_bundle

--- a/src/v/debug_bundle/tests/json_test.cc
+++ b/src/v/debug_bundle/tests/json_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "debug_bundle/json.h"
+#include "debug_bundle/types.h"
+#include "json/document.h"
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+#include <rapidjson/error/en.h>
+
+#include <type_traits>
+
+using namespace debug_bundle;
+
+template<typename T>
+class JsonTypeTest : public testing::Test {
+public:
+    ss::sstring json_input;
+    T expected;
+};
+
+using JsonTestTypes = ::testing::Types<int>;
+TYPED_TEST_SUITE(JsonTypeTest, JsonTestTypes);
+
+TYPED_TEST(JsonTypeTest, BasicType) {
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        this->json_input = R"(42)";
+        this->expected = 42;
+    } else {
+        static_assert(always_false_v<TypeParam>, "not implemented");
+    }
+
+    json::Document doc;
+    ASSERT_NO_THROW(doc.Parse(this->json_input));
+    ASSERT_FALSE(doc.HasParseError()) << fmt::format(
+      "Malformed json schema: {} at offset {}",
+      rapidjson::GetParseError_En(doc.GetParseError()),
+      doc.GetErrorOffset());
+
+    debug_bundle::result<TypeParam> res{outcome::success()};
+
+    ASSERT_NO_THROW(res = from_json<TypeParam>(doc));
+    ASSERT_TRUE(res.has_value()) << res.assume_error().message();
+    ASSERT_EQ(res.assume_value(), this->expected);
+}
+
+TYPED_TEST(JsonTypeTest, TypeIsInvalid) {
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        this->json_input = R"("42")";
+        this->expected = 42;
+    } else {
+        static_assert(always_false_v<TypeParam>, "not implemented");
+    }
+
+    json::Document doc;
+    ASSERT_NO_THROW(doc.Parse(this->json_input));
+    ASSERT_FALSE(doc.HasParseError()) << fmt::format(
+      "Malformed json schema: {} at offset {}",
+      rapidjson::GetParseError_En(doc.GetParseError()),
+      doc.GetErrorOffset());
+
+    debug_bundle::result<TypeParam> res{outcome::success()};
+
+    ASSERT_NO_THROW(res = from_json<TypeParam>(doc));
+    ASSERT_TRUE(res.has_error());
+    ASSERT_FALSE(res.has_exception());
+    EXPECT_EQ(res.assume_error().code(), error_code::invalid_parameters);
+    EXPECT_TRUE(res.assume_error().message().starts_with("Failed to parse"))
+      << res.assume_error().message();
+}

--- a/src/v/debug_bundle/types.h
+++ b/src/v/debug_bundle/types.h
@@ -74,6 +74,9 @@ struct partition_selection {
     model::topic_namespace tn;
     absl::btree_set<model::partition_id> partitions;
 
+    static std::optional<partition_selection>
+      from_string_view(std::string_view);
+
     friend bool
     operator==(const partition_selection&, const partition_selection&)
       = default;

--- a/src/v/debug_bundle/types.h
+++ b/src/v/debug_bundle/types.h
@@ -62,6 +62,8 @@ struct scram_creds {
     security::credential_user username;
     security::credential_password password;
     ss::sstring mechanism;
+
+    friend bool operator==(const scram_creds&, const scram_creds&) = default;
 };
 /// Variant so it can be expanded as new authn methods are added to rpk
 using debug_bundle_authn_options = std::variant<scram_creds>;
@@ -71,6 +73,10 @@ using debug_bundle_authn_options = std::variant<scram_creds>;
 struct partition_selection {
     model::topic_namespace tn;
     absl::btree_set<model::partition_id> partitions;
+
+    friend bool
+    operator==(const partition_selection&, const partition_selection&)
+      = default;
 };
 
 std::ostream& operator<<(std::ostream& o, const partition_selection& p);
@@ -85,6 +91,10 @@ struct debug_bundle_parameters {
     std::optional<time_variant> logs_until;
     std::optional<std::chrono::seconds> metrics_interval_seconds;
     std::optional<std::vector<partition_selection>> partition;
+
+    friend bool
+    operator==(const debug_bundle_parameters&, const debug_bundle_parameters&)
+      = default;
 };
 
 /// The state of the debug bundle process

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -57,6 +57,7 @@ v_cc_library(
     admin/migrations.cc
     admin/topics.cc
     admin/data_migration_utils.cc
+    admin/debug_bundle.cc
     cli_parser.cc
     application.cc
     monitor_unsafe_log_flag.cc

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -15,7 +15,8 @@ set(swags
   shadow_indexing
   transform 
   recovery 
-  migration)
+  migration
+  debug_bundle)
 
 set(swag_files)
 foreach(swag ${swags})

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -95,6 +95,14 @@ seastar_cc_swagger_library(
     ],
 )
 
+seastar_cc_swagger_library(
+    name = "debug_bundle",
+    src = "api-doc/debug_bundle.json",
+    definitions = [
+        "api-doc/debug_bundle.def.json",
+    ],
+)
+
 redpanda_cc_library(
     name = "cluster_config_schema_util",
     srcs = [
@@ -155,6 +163,7 @@ redpanda_cc_library(
         "api-doc/cluster_config.json.hh",
         "api-doc/config.json.hh",
         "api-doc/debug.json.hh",
+        "api-doc/debug_bundle.json.hh",
         "api-doc/features.json.hh",
         "api-doc/hbadger.json.hh",
         "api-doc/migration.json.hh",
@@ -180,6 +189,7 @@ redpanda_cc_library(
         ":config",
         ":data_migration_utils",
         ":debug",
+        ":debug_bundle",
         ":features",
         ":hbadger",
         ":migration",
@@ -200,6 +210,7 @@ redpanda_cc_library(
         "//src/v/container:fragmented_vector",
         "//src/v/container:lw_shared_container",
         "//src/v/debug_bundle",
+        "//src/v/debug_bundle:json",
         "//src/v/features",
         "//src/v/finjector",
         "//src/v/json",
@@ -210,6 +221,7 @@ redpanda_cc_library(
         "//src/v/pandaproxy",
         "//src/v/pandaproxy:config",
         "//src/v/raft",
+        "//src/v/reflection:type_traits",
         "//src/v/resource_mgmt:cpu_profiler",
         "//src/v/resource_mgmt:memory_sampling",
         "//src/v/rpc",
@@ -224,6 +236,7 @@ redpanda_cc_library(
         "//src/v/strings:string_switch",
         "//src/v/strings:utf8",
         "//src/v/transform",
+        "//src/v/utils:functional",
         "//src/v/utils:unresolved_address",
         "//src/v/wasm:api",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -199,6 +199,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:fragmented_vector",
         "//src/v/container:lw_shared_container",
+        "//src/v/debug_bundle",
         "//src/v/features",
         "//src/v/finjector",
         "//src/v/json",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -145,6 +145,7 @@ redpanda_cc_library(
     name = "admin",
     srcs = [
         "debug.cc",
+        "debug_bundle.cc",
         "kafka.cc",
         "migrations.cc",
         "partition.cc",
@@ -245,6 +246,7 @@ redpanda_cc_library(
         "@boost//:lexical_cast",
         "@boost//:range",
         "@fmt",
+        "@rapidjson",
         "@seastar",
     ],
 )

--- a/src/v/redpanda/admin/api-doc/debug_bundle.def.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.def.json
@@ -1,0 +1,87 @@
+"scram_authn": {
+  "type": "object",
+  "required": ["mechanism", "username", "password"],
+  "properties": {
+    "mechanism": {
+      "description": "SCRAM mechanism",
+      "type": "string"
+    },
+    "username": {
+      "description": "username used by RPK to authenticate against Kafka and Admin API",
+      "type": "string"
+    },
+    "password": {
+      "description": "password used by RPK to authenticate against Kafka and Admin API",
+      "type": "string"
+    }
+  }
+},
+"bundle_start_config_params": {
+  "type": "object",
+  "required": [],
+  "properties": {
+    "authentication": {
+      "description": "Authentication object",
+      "type": "scram_authn"
+    },
+    "controller_logs_size_limit_bytes": {
+      "type": "int"
+    },
+    "cpu_profiler_wait_seconds": {
+      "type": "int"
+    },
+    "logs_since": {
+      "description": "Include logs dated from specified date onward; (journalctl date format: YYYY-MM-DD, 'yesterday', or 'today'). Refer to journalctl documentation for more options.",
+      "type": "string"
+    },
+    "logs_size_limit_bytes": {
+      "type": "int"
+    },
+    "logs_until": {
+      "description": "Include logs older than the specified date; (journalctl date format: YYYY-MM-DD, 'yesterday', or 'today'). Refer to journalctl documentation for more options.",
+      "type": "string"
+    },
+    "metrics_interval_seconds": {
+      "type": "int"
+    },
+    "partition": {
+      "type": "string"
+    }
+  }
+},
+"bundle_start_config": {
+  "type": "object",
+  "required": ["job_id"],
+  "properties": {
+    "job_id": {
+      "description": "The Job UUID to use",
+      "type": "string"
+    },
+    "config": {
+      "description": "The parameters",
+      "type": "bundle_start_config_params"
+    }
+  }
+},
+"bundle_start_response": {
+  "type": "object",
+  "required": ["job_id"],
+  "properties": {
+    "job_id": {
+      "description": "The Job UUID associated with the debug bundle process",
+      "type": "string"
+    }
+  }
+},
+"error_body": {
+  "type": "object",
+  "required": ["code", "message"],
+  "properties": {
+    "code": {
+      "type": "int"
+    },
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/src/v/redpanda/admin/api-doc/debug_bundle.def.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.def.json
@@ -73,6 +73,42 @@
     }
   }
 },
+"get_bundle_status": {
+  "type": "object",
+  "required": ["job_id", "status", "created"],
+  "properties": {
+    "job_id": {
+      "description": "The Job UUID associated with the debug bundle process",
+      "type": "string"
+    },
+    "status": {
+      "description": "The status of the job",
+      "type": "string"
+    },
+    "created": {
+      "description": "When the job was started, in milliseconds since epoch",
+      "type": "int"
+    },
+    "filename": {
+      "description": "Path in API to get the file",
+      "type": "string"
+    },
+    "stdout": {
+      "description": "Only filled in once the process completes.  Content of stdout from rpk",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stderr": {
+      "description": "Only filled in once the process completes.  Content of stderr from rpk",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+},
 "error_body": {
   "type": "object",
   "required": ["code", "message"],

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -201,5 +201,56 @@
         }
       }
     }
+  },
+  "delete": {
+    "description": "Attempts to delete the generated debug bundle file",
+    "summary": "Attempts to delete the generated debug bundle file",
+    "operationId": "delete_debug_bundle_file",
+    "parameters": [
+      {
+        "name": "filename",
+        "in": "path",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "204": {
+        "description": "OK"
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "404": {
+        "description": "Not found",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "500": {
+        "description": "Internal error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
   }
 }

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -148,4 +148,58 @@
       }
     }
   }
+},
+"/v1/debug/bundle/file/{filename}": {
+  "get": {
+    "description": "Returns the generated debug bundle ZIP file",
+    "summary": "Returns the generated debug bundle ZIP file",
+    "operationId": "get_debug_bundle_file",
+    "parameters": [
+      {
+        "name": "filename",
+        "in": "path",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "produces": [
+      "application/json",
+      "application/zip"
+    ],
+    "responses": {
+      "200": {
+        "description": "OK"
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "404": {
+        "description": "Not found",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "500": {
+        "description": "Internal error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -1,0 +1,61 @@
+"/v1/debug/bundle": {
+  "post": {
+    "description": "Posting to this endpoint will trigger the start of an rpk debug bundle process.  If a process is already executing, this endpoint will return a 409 error.  If there is an issue with starting the process, this endpoint will return a 500 error.",
+    "summary": "Start an rpk debug bundle",
+    "operationId": "post_debug_bundle",
+    "consumes": [
+        "application/json"
+    ],
+    "parameters": [
+      {
+        "name": "config",
+        "in": "body",
+        "required": true,
+        "schema": {
+          "$ref": "#/definitions/bundle_start_config"
+        }
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "OK",
+        "schema": {
+          "$ref": "#/definitions/bundle_start_response"
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "422": {
+        "description": "Format error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "500": {
+        "description": "Internal server error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -57,5 +57,39 @@
         }
       }
     }
+  },
+  "get": {
+    "description": "Returns the status of a debug bundle process.  If one was never kicked off and bundle does not exist, this will return 409",
+    "summary": "Returns the status of a debug bundle process.",
+    "operationId": "get_debug_bundle",
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "200": {
+        "description": "OK",
+        "schema": {
+          "$ref": "#/definitions/get_bundle_status"
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
   }
 }

--- a/src/v/redpanda/admin/api-doc/debug_bundle.json
+++ b/src/v/redpanda/admin/api-doc/debug_bundle.json
@@ -92,4 +92,60 @@
       }
     }
   }
+},
+"/v1/debug/bundle/{jobid}": {
+  "delete": {
+    "description": "Attempts to kill a running bundle process.  Providing an incorrect `job_id` returns a 422.  If the process is not currently running, the request will return a 409 error.  Internal errors will return a 500 status.",
+    "summary": "Abort a running bundle process.",
+    "operationId": "delete_debug_bundle",
+    "consumes": [
+      "application/json"
+    ],
+    "parameters": [
+      {
+        "name": "jobid",
+        "in": "path",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "responses": {
+      "204": {
+        "description": "No content"
+      },
+      "401": {
+        "description": "Unauthorized",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "409": {
+        "description": "Conflict",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "422": {
+        "description": "Format Error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      },
+      "500": {
+        "description": "Internal error",
+        "schema": {
+          "$ref": "#/definitions/error_body"
+        }
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/type_traits.h"
+#include "debug_bundle/debug_bundle_service.h"
+#include "debug_bundle/error.h"
+#include "debug_bundle/json.h"
+#include "debug_bundle/types.h"
+#include "json/document.h"
+#include "json/types.h"
+#include "redpanda/admin/api-doc/debug_bundle.json.hh"
+#include "redpanda/admin/server.h"
+#include "reflection/type_traits.h"
+#include "ssx/sformat.h"
+#include "utils/functional.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/json/json_elements.hh>
+#include <seastar/util/short_streams.hh>
+
+#include <boost/lexical_cast/try_lexical_convert.hpp>
+#include <fmt/core.h>
+#include <rapidjson/error/en.h>
+
+#include <charconv>
+#include <chrono>
+#include <sstream>
+
+namespace {
+
+ss::future<debug_bundle::result<json::Document>>
+as_json_doc(ss::http::request* req) {
+    json::Document doc;
+    auto content = co_await ss::util::read_entire_stream_contiguous(
+      *req->content_stream);
+    doc.Parse(content);
+    if (doc.HasParseError()) {
+        co_return debug_bundle::error_info{
+          debug_bundle::error_code::invalid_parameters,
+          fmt::format(
+            "JSON parse error: {} at offset {}",
+            rapidjson::GetParseError_En(doc.GetParseError()),
+            doc.GetErrorOffset())};
+    } else {
+        co_return std::move(doc);
+    }
+}
+
+template<typename T>
+std::unique_ptr<ss::http::reply> make_json_body(
+  ss::http::reply::status_type status,
+  const T& t,
+  std::unique_ptr<ss::http::reply> rep) {
+    rep->set_status(status);
+    rep->write_body("json", ss::json::stream_object(t));
+    return rep;
+}
+
+std::unique_ptr<ss::http::reply> make_error_body(
+  debug_bundle::error_code ec,
+  const ss::sstring& msg,
+  std::unique_ptr<ss::http::reply> rep) {
+    ss::httpd::debug_bundle_json::error_body res;
+    res.code = static_cast<int>(ec);
+    res.message = msg;
+
+    ss::http::reply::status_type status{ss::http::reply::status_type::ok};
+    switch (ec) {
+    case debug_bundle::error_code::success:
+        status = ss::http::reply::status_type::ok;
+        break;
+    case debug_bundle::error_code::debug_bundle_process_running:
+    case debug_bundle::error_code::debug_bundle_process_never_started:
+    case debug_bundle::error_code::debug_bundle_process_not_running:
+        status = ss::http::reply::status_type::conflict;
+        break;
+    case debug_bundle::error_code::invalid_parameters:
+        status = ss::http::reply::status_type::unprocessable_entity;
+        break;
+    case debug_bundle::error_code::process_failed:
+    case debug_bundle::error_code::internal_error:
+    case debug_bundle::error_code::rpk_binary_not_present:
+        status = ss::http::reply::status_type::internal_server_error;
+        break;
+    case debug_bundle::error_code::job_id_not_recognized:
+        status = ss::http::reply::status_type::not_found;
+        break;
+    }
+    return make_json_body(status, res, std::move(rep));
+}
+
+std::unique_ptr<ss::http::reply> make_error_body(
+  const debug_bundle::error_info& err, std::unique_ptr<ss::http::reply> rep) {
+    return make_error_body(err.code(), err.message(), std::move(rep));
+}
+
+} // namespace
+
+void admin_server::register_debug_bundle_routes() {
+    register_route_raw_async<superuser>(
+      ss::httpd::debug_bundle_json::post_debug_bundle,
+      [this](
+        std::unique_ptr<ss::http::request> req,
+        std::unique_ptr<ss::http::reply> rep) {
+          return post_debug_bundle(std::move(req), std::move(rep));
+      });
+}
+
+ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
+  std::unique_ptr<ss::http::request> req,
+  std::unique_ptr<ss::http::reply> rep) {
+    using debug_bundle::from_json;
+
+    const auto json_doc = co_await as_json_doc(req.get());
+    if (json_doc.has_error()) {
+        co_return make_error_body(
+          std::move(json_doc).assume_error(), std::move(rep));
+    }
+    if (!json_doc.assume_value().IsObject()) {
+        co_return make_error_body(
+          debug_bundle::error_code::invalid_parameters,
+          "Request body is not a JSON object",
+          std::move(rep));
+    }
+    const auto& obj = json_doc.assume_value().GetObject();
+
+    auto job_id = from_json<debug_bundle::job_id_t>(obj, "job_id", true);
+    if (job_id.has_error()) {
+        co_return make_error_body(
+          std::move(job_id).assume_error(), std::move(rep));
+    }
+
+    auto params = from_json<debug_bundle::debug_bundle_parameters>(
+      obj, "config", false);
+    if (params.has_error()) {
+        co_return make_error_body(
+          std::move(params).assume_error(), std::move(rep));
+    }
+
+    auto res = co_await _debug_bundle_service.local()
+                 .initiate_rpk_debug_bundle_collection(
+                   job_id.assume_value(), std::move(params).assume_value());
+    if (res.has_error()) {
+        co_return make_error_body(res.assume_error(), std::move(rep));
+    }
+
+    ss::httpd::debug_bundle_json::bundle_start_response body;
+    body.job_id = ssx::sformat("{}", job_id.assume_value());
+    co_return make_json_body(
+      ss::http::reply::status_type::ok, body, std::move(rep));
+}

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -127,6 +127,13 @@ void admin_server::register_debug_bundle_routes() {
         std::unique_ptr<ss::http::reply> rep) {
           return delete_debug_bundle(std::move(req), std::move(rep));
       });
+    register_route_raw_async<superuser>(
+      ss::httpd::debug_bundle_json::get_debug_bundle_file,
+      [this](
+        std::unique_ptr<ss::http::request> req,
+        std::unique_ptr<ss::http::reply> rep) {
+          return get_debug_bundle_file(std::move(req), std::move(rep));
+      });
 }
 
 ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
@@ -218,6 +225,17 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::delete_debug_bundle(
 
     co_return make_json_body(
       ss::http::reply::status_type::no_content,
+      ss::json::json_void{},
+      std::move(rep));
+}
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::get_debug_bundle_file(
+  std::unique_ptr<ss::http::request> req,
+  std::unique_ptr<ss::http::reply> rep) {
+    auto job_id_str = req->get_path_param("filename");
+    co_return make_json_body(
+      ss::http::reply::status_type::not_implemented,
       ss::json::json_void{},
       std::move(rep));
 }

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -134,6 +134,13 @@ void admin_server::register_debug_bundle_routes() {
         std::unique_ptr<ss::http::reply> rep) {
           return get_debug_bundle_file(std::move(req), std::move(rep));
       });
+    register_route_raw_async<superuser>(
+      ss::httpd::debug_bundle_json::delete_debug_bundle_file,
+      [this](
+        std::unique_ptr<ss::http::request> req,
+        std::unique_ptr<ss::http::reply> rep) {
+          return delete_debug_bundle_file(std::move(req), std::move(rep));
+      });
 }
 
 ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
@@ -231,6 +238,17 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::delete_debug_bundle(
 
 ss::future<std::unique_ptr<ss::http::reply>>
 admin_server::get_debug_bundle_file(
+  std::unique_ptr<ss::http::request> req,
+  std::unique_ptr<ss::http::reply> rep) {
+    auto job_id_str = req->get_path_param("filename");
+    co_return make_json_body(
+      ss::http::reply::status_type::not_implemented,
+      ss::json::json_void{},
+      std::move(rep));
+}
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::delete_debug_bundle_file(
   std::unique_ptr<ss::http::request> req,
   std::unique_ptr<ss::http::reply> rep) {
     auto job_id_str = req->get_path_param("filename");

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -295,7 +295,8 @@ admin_server::admin_server(
   ss::sharded<security::audit::audit_log_manager>& audit_mgr,
   std::unique_ptr<cluster::tx_manager_migrator>& tx_manager_migrator,
   ss::sharded<kafka::server>& kafka_server,
-  ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend)
+  ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<debug_bundle::service>& debug_bundle_service)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -326,6 +327,7 @@ admin_server::admin_server(
   , _tx_manager_migrator(tx_manager_migrator)
   , _kafka_server(kafka_server)
   , _tx_gateway_frontend(tx_gateway_frontend)
+  , _debug_bundle_service(debug_bundle_service)
   , _default_blocked_reactor_notify(
       ss::engine().get_blocked_reactor_notify_ms()) {
     _server.set_content_streaming(true);

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -391,6 +391,8 @@ void admin_server::configure_admin_routes() {
     rb->register_api_file(_server._routes, "cluster");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "transform");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "debug_bundle");
     register_config_routes();
     register_cluster_config_routes();
     register_raft_routes();
@@ -410,6 +412,7 @@ void admin_server::configure_admin_routes() {
     register_wasm_transform_routes();
     register_data_migration_routes();
     register_topic_routes();
+    register_debug_bundle_routes();
     /**
      * Special REST apis active only in recovery mode
      */

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -671,6 +671,8 @@ private:
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>> get_debug_bundle(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>> delete_debug_bundle(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -669,6 +669,8 @@ private:
     // Debug Bundle routes
     ss::future<std::unique_ptr<ss::http::reply>> post_debug_bundle(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>> get_debug_bundle(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -434,6 +434,7 @@ private:
     void register_recovery_mode_routes();
     void register_data_migration_routes();
     void register_topic_routes();
+    void register_debug_bundle_routes();
 
     ss::future<ss::json::json_return_type> patch_cluster_config_handler(
       std::unique_ptr<ss::http::request>, const request_auth_result&);
@@ -664,6 +665,10 @@ private:
       mount_topics(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       unmount_topics(std::unique_ptr<ss::http::request>);
+
+    // Debug Bundle routes
+    ss::future<std::unique_ptr<ss::http::reply>> post_debug_bundle(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -18,6 +18,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "config/endpoint_tls_config.h"
+#include "debug_bundle/fwd.h"
 #include "finjector/stress_fiber.h"
 #include "kafka/server/fwd.h"
 #include "model/metadata.h"
@@ -93,7 +94,8 @@ public:
       ss::sharded<security::audit::audit_log_manager>&,
       std::unique_ptr<cluster::tx_manager_migrator>&,
       ss::sharded<kafka::server>&,
-      ss::sharded<cluster::tx_gateway_frontend>&);
+      ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<debug_bundle::service>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -721,6 +723,7 @@ private:
     std::unique_ptr<cluster::tx_manager_migrator>& _tx_manager_migrator;
     ss::sharded<kafka::server>& _kafka_server;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<debug_bundle::service>& _debug_bundle_service;
 
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -675,6 +675,8 @@ private:
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>> get_debug_bundle_file(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>> delete_debug_bundle_file(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -673,6 +673,8 @@ private:
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>> delete_debug_bundle(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>> get_debug_bundle_file(
+      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1147,7 +1147,8 @@ void application::configure_admin_server() {
       std::ref(audit_mgr),
       std::ref(_tx_manager_migrator),
       std::ref(_kafka_server),
-      std::ref(tx_gateway_frontend))
+      std::ref(tx_gateway_frontend),
+      std::ref(_debug_bundle_service))
       .get();
 }
 


### PR DESCRIPTION
Add support for:
1. `POST /v1/debug/bundle`
1. `GET /v1/debug/bundle`
1. `DELETE /v1/debug/bundle/{jobid}`
1. `GET /debug/bundle/file/{filename}` (returns `not_implemented`)
1. `DELETE /debug/bundle/file/{filename}` (returns `not_implemented`)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
