### PR TITLE
CORE-7338 license: add `enterprise_license_expiry_sec` metric

### DIFF
--- a/src/v/features/BUILD
+++ b/src/v/features/BUILD
@@ -14,6 +14,9 @@ redpanda_cc_library(
         "fwd.h",
         "logger.h",
     ],
+    implementation_deps = [
+        "//src/v/metrics",
+    ],
     include_prefix = "features",
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/features/CMakeLists.txt
+++ b/src/v/features/CMakeLists.txt
@@ -10,6 +10,8 @@ v_cc_library(
     v::model
     v::config
     v::version
+    v::security
+    v::metrics
   )
 
 add_dependencies(v_features kafka_codegen_headers)

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -17,6 +17,7 @@
 #include "utils/waiter_queue.h"
 
 #include <array>
+#include <memory>
 #include <string_view>
 #include <unordered_set>
 
@@ -497,6 +498,11 @@ public:
     static cluster::cluster_version get_earliest_logical_version();
 
     feature_table();
+    feature_table(const feature_table&) = delete;
+    feature_table& operator=(const feature_table&) = delete;
+    feature_table(feature_table&&) = delete;
+    feature_table& operator=(feature_table&&) = delete;
+    ~feature_table() noexcept;
 
     feature_state& get_state(feature f_id);
     const feature_state& get_state(feature f_id) const {
@@ -599,7 +605,15 @@ public:
     // Assert out on startup if we appear to have upgraded too far
     void assert_compatible_version(bool);
 
+    // Visible for testing
+    static long long calculate_expiry_metric(
+      const std::optional<security::license>& license,
+      security::license::clock::time_point now
+      = security::license::clock::now());
+
 private:
+    class probe;
+
     // Only for use by our friends feature backend & manager
     void set_active_version(
       cluster::cluster_version,
@@ -655,6 +669,7 @@ private:
 
     ss::gate _gate;
     ss::abort_source _as;
+    std::unique_ptr<probe> _probe;
 };
 
 } // namespace features

--- a/src/v/features/tests/BUILD
+++ b/src/v/features/tests/BUILD
@@ -1,0 +1,17 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "feature_table_test",
+    timeout = "short",
+    srcs = [
+        "feature_table_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster:features",
+        "//src/v/features",
+        "//src/v/security:license",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-#include "base/vlog.h"
 #include "cluster/feature_update_action.h"
 #include "features/feature_table.h"
 #include "features/feature_table_snapshot.h"

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -18,6 +18,11 @@
 #include "json/validator.h"
 #include "utils/base64.h"
 
+#include <algorithm>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace security {
 
 namespace crypto {
@@ -178,9 +183,11 @@ license make_license(const ss::sstring& raw_license) {
 }
 
 bool license::is_expired() const noexcept {
-    const auto now = std::chrono::duration_cast<std::chrono::seconds>(
-      std::chrono::system_clock::now().time_since_epoch());
-    return now > expiry;
+    return clock::now() > expiration();
+}
+
+license::clock::time_point license::expiration() const noexcept {
+    return clock::time_point{expiry};
 }
 
 } // namespace security

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -21,6 +21,7 @@
 
 #include <fmt/core.h>
 
+#include <chrono>
 #include <exception>
 #include <fstream>
 #include <vector>
@@ -67,6 +68,8 @@ inline std::ostream& operator<<(std::ostream& os, license_type lt) {
 
 struct license
   : serde::envelope<license, serde::version<1>, serde::compat_version<0>> {
+    using clock = std::chrono::system_clock;
+
     /// Expected encoded contents
     uint8_t format_version;
     license_type type;
@@ -83,6 +86,9 @@ struct license
 
     /// Seconds since epoch until license expiration
     std::chrono::seconds expires() const noexcept;
+
+    /// Expiration timepoint
+    clock::time_point expiration() const noexcept;
 
     auto operator<=>(const license&) const = delete;
 

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -13,6 +13,11 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace security {
 
 BOOST_AUTO_TEST_CASE(test_license_invalid_signature) {
@@ -76,7 +81,10 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content) {
     BOOST_CHECK_EQUAL(license.format_version, 0);
     BOOST_CHECK_EQUAL(license.type, license_type::enterprise);
     BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
+    BOOST_CHECK(!license.is_expired());
     BOOST_CHECK_EQUAL(license.expiry.count(), 4813252273);
+    BOOST_CHECK(
+      license.expiration() == license::clock::time_point{4813252273s});
     BOOST_CHECK_EQUAL(
       license.checksum,
       "2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf");

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -291,6 +291,7 @@ redpanda_cc_gtest(
     deps = [
         ":disk_log_builder",
         ":disk_log_builder_fixture",
+        "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/random:generators",

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -209,9 +209,14 @@ public:
           resources,
           feature_table) {
         configure_unit_test_logging();
-        // avoid double metric registrations
+        // avoid double metric registrations - disk_log_builder and other
+        // helpers also start a feature_table and other structs that register
+        // metrics
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
+            config::shard_local_cfg()
+              .get("disable_public_metrics")
+              .set_value(true);
             config::shard_local_cfg()
               .get("log_segment_size_min")
               .set_value(std::optional<uint64_t>{});
@@ -230,6 +235,7 @@ public:
         feature_table.stop().get();
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").reset();
+            config::shard_local_cfg().get("disable_public_metrics").reset();
             config::shard_local_cfg().get("log_segment_size_min").reset();
         }).get();
     }


### PR DESCRIPTION
This introduces a new metric for monitoring the expiry time of the enterprise license.

#### cluster_features_enterprise_license_expiry_sec
* Description: “Number of seconds remaining until the Enterprise License expires”
* Endpoints: both public and internal metrics
* Labels: none

Fixes https://redpandadata.atlassian.net/browse/CORE-7338

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes
### Features

* A new metric (*cluster_features_enterprise_license_expiry_sec*) is added for easier monitoring of the enterprise license's expiry time.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
