### PR TITLE
cloud-tests: Fix incomplete kubectl command

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -880,16 +880,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             return
 
         self.logger.info('verify operator-v2 is not activated')
-        # kubectl get redpanda -n=redpanda
-        # Even when nothing is found, kubectl always exits 0.  Ref: https://github.com/kubernetes/kubectl/issues/821
-        # But when nothing is found, kubectl by default prints "No resources found in redpanda namespace." to stderr.
-        # Which gets merged into the result lines!
-        #
-        # So, we add --ignore-not-found.  This flag skips the human-readable "No resource" message.
-        # By the way, exit code is still 0, even with this flag :)
-        get_redpanda = self.redpanda.kubectl.cmd(
-            ['get', 'redpanda', '-n=redpanda', '--ignore-not-found'])
-        if len(get_redpanda) > 0:
+        if self.redpanda.is_operator_v2_cluster():
             self.logger.warn('cannot run test with operator-v2')
             return
 
@@ -1191,16 +1182,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         """
 
         self.logger.info('verify operator-v2 is not activated')
-        # kubectl get redpanda -n=redpanda
-        # Even when nothing is found, kubectl always exits 0.  Ref: https://github.com/kubernetes/kubectl/issues/821
-        # But when nothing is found, kubectl by default prints "No resources found in redpanda namespace." to stderr.
-        # Which gets merged into the result lines!
-        #
-        # So, we add --ignore-not-found.  This flag skips the human-readable "No resource" message.
-        # By the way, exit code is still 0, even with this flag :)
-        get_redpanda = self.redpanda.kubectl.cmd(
-            ['get', 'redpanda', '-n=redpanda', '--ignore-not-found'])
-        if len(get_redpanda) > 0:
+        if self.redpanda.is_operator_v2_cluster():
             self.logger.warn('cannot run test with operator-v2')
             return
 


### PR DESCRIPTION
We were not passing a resource type to get (`pod` missing) and hence the
command would fail.

Fix this and replace some usages with the existing helper function.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none


