### PR TITLE
redpanda: rename unsafe log monitor to be more general

### DIFF
--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -5,12 +5,12 @@ redpanda_cc_library(
     srcs = [
         "application.cc",
         "cli_parser.cc",
-        "monitor_unsafe_log_flag.cc",
+        "monitor_unsafe.cc",
     ],
     hdrs = [
         "application.h",
         "cli_parser.h",
-        "monitor_unsafe_log_flag.h",
+        "monitor_unsafe.h",
     ],
     include_prefix = "redpanda",
     visibility = ["//visibility:public"],

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -58,7 +58,7 @@ v_cc_library(
     admin/data_migration_utils.cc
     cli_parser.cc
     application.cc
-    monitor_unsafe_log_flag.cc
+    monitor_unsafe.cc
   DEPS
     Seastar::seastar
     v::crypto

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1429,7 +1429,7 @@ void application::wire_up_runtime_services(
           .get();
     }
 
-    construct_single_service(_monitor_unsafe_log_flag, std::ref(feature_table));
+    construct_single_service(_monitor_unsafe, std::ref(feature_table));
 
     construct_service(
       _debug_bundle_service, config::node().data_directory().path)
@@ -2794,7 +2794,7 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     construct_service(_aggregate_metrics_watcher).get();
 
     _admin.invoke_on_all([](admin_server& admin) { admin.set_ready(); }).get();
-    _monitor_unsafe_log_flag->start().get();
+    _monitor_unsafe->start().get();
 
     vlog(_log.info, "Successfully started Redpanda!");
     syschecks::systemd_notify_ready().get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -44,7 +44,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "raft/fwd.h"
-#include "redpanda/monitor_unsafe_log_flag.h"
+#include "redpanda/monitor_unsafe.h"
 #include "resource_mgmt/cpu_profiler.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
@@ -317,7 +317,7 @@ private:
     std::unique_ptr<pandaproxy::schema_registry::api> _schema_registry;
     ss::sharded<storage::compaction_controller> _compaction_controller;
     ss::sharded<archival::upload_controller> _archival_upload_controller;
-    std::unique_ptr<monitor_unsafe_log_flag> _monitor_unsafe_log_flag;
+    std::unique_ptr<monitor_unsafe> _monitor_unsafe;
     ss::sharded<archival::purger> _archival_purger;
 
     std::unique_ptr<wasm::caching_runtime> _wasm_runtime;

--- a/src/v/redpanda/monitor_unsafe.h
+++ b/src/v/redpanda/monitor_unsafe.h
@@ -16,13 +16,13 @@
 
 #include <seastar/core/sharded.hh>
 
-class monitor_unsafe_log_flag {
+class monitor_unsafe {
 public:
     static constexpr ss::shard_id backend_shard = 0;
     // Flag introduced in version v23.2.1 (cluster version 10)
     static constexpr cluster::cluster_version flag_introduction_version
       = cluster::cluster_version{10};
-    explicit monitor_unsafe_log_flag(
+    explicit monitor_unsafe(
       ss::sharded<features::feature_table>& feature_table);
 
     static void invoke_unsafe_log_update(
@@ -32,7 +32,7 @@ public:
 
 private:
     void unsafe_log_update();
-    ss::future<> maybe_log_flag_nag();
+    ss::future<> maybe_log_unsafe_nag();
 
     ss::sharded<features::feature_table>& _feature_table;
     config::binding<bool> _legacy_permit_unsafe_log_operation;


### PR DESCRIPTION
Going to reuse the unsafe log monitor to nag on other unsafe states, so rename it to be more general.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
