### PR TITLE
datalake: arrow_to_iobuf interface

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
   NAME datalake
   SRCS
     arrow_translator.cc
+    parquet_writer.cc
     protobuf_to_arrow_converter.cc
     proto_to_arrow_scalar.cc
     proto_to_arrow_struct.cc

--- a/src/v/datalake/parquet_writer.cc
+++ b/src/v/datalake/parquet_writer.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/parquet_writer.h"
+
+#include "bytes/iobuf.h"
+
+#include <arrow/array/array_base.h>
+#include <arrow/chunked_array.h>
+#include <arrow/io/file.h>
+#include <arrow/io/memory.h>
+#include <arrow/status.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/properties.h>
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+namespace datalake {
+
+class arrow_to_iobuf::iobuf_output_stream : public arrow::io::OutputStream {
+public:
+    iobuf_output_stream() = default;
+
+    ~iobuf_output_stream() override = default;
+
+    // Close the stream cleanly.
+    arrow::Status Close() override {
+        _closed = true;
+        return arrow::Status::OK();
+    }
+
+    // Return the position in this stream
+    arrow::Result<int64_t> Tell() const override { return _position; }
+
+    // Return whether the stream is closed
+    bool closed() const override { return _closed; }
+
+    arrow::Status Write(const void* data, int64_t nbytes) override {
+        _current_iobuf.append(reinterpret_cast<const uint8_t*>(data), nbytes);
+        _position += nbytes;
+        return arrow::Status::OK();
+    }
+
+    // TODO: implement this to avoid copying data multiple times
+    // virtual Status Write(const std::shared_ptr<Buffer>& data);
+
+    // Take the data from the iobuf and clear the internal state.
+    iobuf take_iobuf() { return std::exchange(_current_iobuf, {}); }
+
+private:
+    iobuf _current_iobuf;
+    bool _closed = false;
+    int64_t _position = 0;
+};
+
+arrow_to_iobuf::arrow_to_iobuf(const arrow::Schema& schema) {
+    // TODO: make the compression algorithm configurable.
+    std::shared_ptr<parquet::WriterProperties> writer_props
+      = parquet::WriterProperties::Builder()
+          .compression(arrow::Compression::SNAPPY)
+          ->build();
+
+    // Opt to store Arrow schema for easier reads back into Arrow
+    std::shared_ptr<parquet::ArrowWriterProperties> arrow_props
+      = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
+    _ostream = std::make_shared<iobuf_output_stream>();
+
+    auto writer_result = parquet::arrow::FileWriter::Open(
+      schema,
+      arrow::default_memory_pool(),
+      _ostream,
+      std::move(writer_props),
+      std::move(arrow_props));
+    if (!writer_result.ok()) {
+        throw std::runtime_error(fmt::format(
+          "Failed to create Arrow writer: {}", writer_result.status()));
+    }
+    _writer = std::move(writer_result.ValueUnsafe());
+}
+
+void arrow_to_iobuf::add_arrow_array(std::shared_ptr<arrow::Array> data) {
+    arrow::ArrayVector data_av = {std::move(data)};
+
+    std::shared_ptr<arrow::ChunkedArray> chunked_data
+      = std::make_shared<arrow::ChunkedArray>(std::move(data_av));
+    auto table_result = arrow::Table::FromChunkedStructArray(chunked_data);
+    if (!table_result.ok()) {
+        throw std::runtime_error(fmt::format(
+          "Failed to create arrow table: {}", table_result.status()));
+    }
+    auto table = table_result.ValueUnsafe();
+    auto write_result = _writer->WriteTable(*table);
+    if (!write_result.ok()) {
+        throw std::runtime_error(fmt::format(
+          "Failed to write arrow table: {}", write_result.ToString()));
+    }
+}
+
+iobuf arrow_to_iobuf::take_iobuf() { return _ostream->take_iobuf(); }
+
+iobuf arrow_to_iobuf::close_and_take_iobuf() {
+    auto status = _writer->Close();
+    if (!status.ok()) {
+        throw std::runtime_error(
+          fmt::format("Failed to close FileWriter: {}", status.ToString()));
+    }
+    return take_iobuf();
+}
+
+} // namespace datalake

--- a/src/v/datalake/parquet_writer.h
+++ b/src/v/datalake/parquet_writer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <arrow/type.h>
+#include <parquet/arrow/writer.h>
+
+namespace datalake {
+
+class arrow_to_iobuf {
+public:
+    explicit arrow_to_iobuf(const arrow::Schema& schema);
+
+    void add_arrow_array(std::shared_ptr<arrow::Array> data);
+
+    // Get the current pending data to be written and clear the internal state.
+    iobuf take_iobuf();
+
+    // Close the writer and get any remaining data that is pending.
+    iobuf close_and_take_iobuf();
+
+private:
+    class iobuf_output_stream;
+
+    std::shared_ptr<iobuf_output_stream> _ostream;
+    std::unique_ptr<parquet::arrow::FileWriter> _writer;
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ rp_test(
     v::kafka_test_utils
     v::datalake
     v::model_test_utils
-  LABELS storage
+  LABELS datalake
   ARGS "-- -c 1"
 )
 
@@ -38,6 +38,18 @@ rp_test(
     v::datalake
     v::model_test_utils
     v::iceberg_test_utils
-  LABELS storage
+  LABELS datalake
+  ARGS "-- -c 1"
+)
+
+rp_test(
+  GTEST
+  BINARY_NAME parquet_writer_test
+  SOURCES parquet_writer_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::datalake
+    v::iceberg_test_utils
+  LABELS datalake
   ARGS "-- -c 1"
 )

--- a/src/v/datalake/tests/arrow_writer_test.cc
+++ b/src/v/datalake/tests/arrow_writer_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 #include "datalake/arrow_translator.h"
+#include "datalake/tests/test_data.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/tests/value_generator.h"
 #include "iceberg/values.h"
@@ -18,64 +19,6 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
-
-iceberg::struct_type test_schema(iceberg::field_required required) {
-    using namespace iceberg;
-    struct_type schema;
-
-    schema.fields.emplace_back(
-      nested_field::create(1, "test_bool", required, boolean_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(2, "test_int", required, int_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(3, "test_long", required, long_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(4, "test_float", required, float_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(5, "test_double", required, double_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(6, "test_decimal", required, decimal_type{16, 8}));
-    schema.fields.emplace_back(
-      nested_field::create(7, "test_date", required, date_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(8, "test_time", required, time_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(9, "test_timestamp", required, timestamp_type{}));
-    schema.fields.emplace_back(nested_field::create(
-      10, "test_timestamptz", required, timestamptz_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(11, "test_string", required, string_type{}));
-    schema.fields.emplace_back(
-      nested_field::create(12, "test_uuid", required, uuid_type{}));
-    schema.fields.emplace_back(nested_field::create(
-      13, "test_fixed", required, fixed_type{11})); // length of "Hello world"
-    schema.fields.emplace_back(
-      nested_field::create(14, "test_binary", required, binary_type{}));
-
-    struct_type nested_schema;
-    nested_schema.fields.emplace_back(
-      nested_field::create(1, "nested_bool", required, boolean_type{}));
-    nested_schema.fields.emplace_back(
-      nested_field::create(2, "nested_int", required, int_type{}));
-    nested_schema.fields.emplace_back(
-      nested_field::create(3, "nested_long", required, long_type{}));
-
-    schema.fields.emplace_back(nested_field::create(
-      15, "test_struct", required, std::move(nested_schema)));
-
-    schema.fields.emplace_back(nested_field::create(
-      16,
-      "test_list",
-      required,
-      list_type::create(1, required, string_type{})));
-
-    schema.fields.push_back(nested_field::create(
-      17,
-      "test_map",
-      required,
-      map_type::create(1, string_type{}, 2, required, long_type{})));
-    return schema;
-}
 
 TEST(ArrowWriterTest, TranslatesSchemas) {
     datalake::arrow_translator writer(test_schema(iceberg::field_required::no));

--- a/src/v/datalake/tests/arrow_writer_test.cc
+++ b/src/v/datalake/tests/arrow_writer_test.cc
@@ -34,7 +34,7 @@ iceberg::struct_type test_schema(iceberg::field_required required) {
     schema.fields.emplace_back(
       nested_field::create(5, "test_double", required, double_type{}));
     schema.fields.emplace_back(
-      nested_field::create(6, "test_decimal", required, decimal_type{8, 16}));
+      nested_field::create(6, "test_decimal", required, decimal_type{16, 8}));
     schema.fields.emplace_back(
       nested_field::create(7, "test_date", required, date_type{}));
     schema.fields.emplace_back(
@@ -86,7 +86,7 @@ test_int: int32
 test_long: int64
 test_float: float
 test_double: double
-test_decimal: decimal128(8, 16)
+test_decimal: decimal128(16, 8)
 test_date: date32[day]
 test_time: time64[us]
 test_timestamp: timestamp[us]
@@ -111,7 +111,7 @@ test_int: int32 not null
 test_long: int64 not null
 test_float: float not null
 test_double: double not null
-test_decimal: decimal128(8, 16) not null
+test_decimal: decimal128(16, 8) not null
 test_date: date32[day] not null
 test_time: time64[us] not null
 test_timestamp: timestamp[us] not null
@@ -291,13 +291,13 @@ std::string get_expected_translation_output() {
     0,
     0
   ]
--- child 5 type: decimal128(8, 16)
+-- child 5 type: decimal128(16, 8)
   [
-    0.E-16,
-    0.E-16,
-    0.E-16,
-    0.E-16,
-    0.E-16
+    0.E-8,
+    0.E-8,
+    0.E-8,
+    0.E-8,
+    0.E-8
   ]
 -- child 6 type: date32[day]
   [

--- a/src/v/datalake/tests/parquet_writer_test.cc
+++ b/src/v/datalake/tests/parquet_writer_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/bytes.h"
+#include "datalake/arrow_translator.h"
+#include "datalake/parquet_writer.h"
+#include "datalake/tests/test_data.h"
+#include "iceberg/tests/value_generator.h"
+#include "utils/file_io.h"
+
+#include <arrow/array.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/io/memory.h>
+#include <arrow/table.h>
+#include <arrow/type_fwd.h>
+#include <gtest/gtest.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/type_fwd.h>
+
+TEST(ParquetWriter, CreatesValidParquetData) {
+    datalake::arrow_translator translator(
+      test_schema(iceberg::field_required::no));
+
+    iobuf full_result;
+
+    for (int i = 0; i < 5; i++) {
+        auto data = iceberg::tests::make_value(
+          iceberg::tests::value_spec{
+            .forced_fixed_val = iobuf::from("Hello world")},
+          test_schema(iceberg::field_required::no));
+        translator.add_data(std::move(data));
+    }
+
+    std::shared_ptr<arrow::Array> result = translator.take_chunk();
+    ASSERT_NE(result, nullptr);
+
+    datalake::arrow_to_iobuf writer(*translator.build_arrow_schema());
+
+    for (int i = 0; i < 10; i++) {
+        writer.add_arrow_array(result);
+        iobuf serialized = writer.take_iobuf();
+        // Sizes are not consistent between writes, but should be about right.
+        EXPECT_NEAR(serialized.size_bytes(), 3300, 200);
+        full_result.append_fragments(std::move(serialized));
+    }
+
+    // The last write is long. This is probably Parquet footer information.
+    auto serialized = writer.close_and_take_iobuf();
+    EXPECT_NEAR(serialized.size_bytes(), 21000, 1000);
+    full_result.append_fragments(std::move(serialized));
+
+    EXPECT_NEAR(full_result.size_bytes(), 55000, 1000);
+
+    // Check that the data is a valid parquet file. Convert the iobuf to a
+    // single buffer then import that into an arrow::io::BufferReader
+    auto full_result_bytes = iobuf_to_bytes(full_result);
+    auto reader = std::make_shared<arrow::io::BufferReader>(
+      full_result_bytes.data(), full_result_bytes.size());
+
+    // Open Parquet file reader
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+    ASSERT_TRUE(parquet::arrow::OpenFile(
+                  reader, arrow::default_memory_pool(), &arrow_reader)
+                  .ok());
+
+    // Read entire file as a single Arrow table
+    std::shared_ptr<arrow::Table> table;
+    ASSERT_TRUE(arrow_reader->ReadTable(&table).ok());
+
+    EXPECT_EQ(table->num_rows(), 10 * 5);
+    EXPECT_EQ(table->num_columns(), 17);
+}

--- a/src/v/datalake/tests/test_data.h
+++ b/src/v/datalake/tests/test_data.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/datatypes.h"
+
+inline iceberg::struct_type test_schema(iceberg::field_required required) {
+    using namespace iceberg;
+    struct_type schema;
+
+    schema.fields.emplace_back(
+      nested_field::create(1, "test_bool", required, boolean_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(2, "test_int", required, int_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(3, "test_long", required, long_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(4, "test_float", required, float_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(5, "test_double", required, double_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(6, "test_decimal", required, decimal_type{16, 8}));
+    schema.fields.emplace_back(
+      nested_field::create(7, "test_date", required, date_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(8, "test_time", required, time_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(9, "test_timestamp", required, timestamp_type{}));
+    schema.fields.emplace_back(nested_field::create(
+      10, "test_timestamptz", required, timestamptz_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(11, "test_string", required, string_type{}));
+    schema.fields.emplace_back(
+      nested_field::create(12, "test_uuid", required, uuid_type{}));
+    schema.fields.emplace_back(nested_field::create(
+      13, "test_fixed", required, fixed_type{11})); // length of "Hello world"
+    schema.fields.emplace_back(
+      nested_field::create(14, "test_binary", required, binary_type{}));
+
+    struct_type nested_schema;
+    nested_schema.fields.emplace_back(
+      nested_field::create(1, "nested_bool", required, boolean_type{}));
+    nested_schema.fields.emplace_back(
+      nested_field::create(2, "nested_int", required, int_type{}));
+    nested_schema.fields.emplace_back(
+      nested_field::create(3, "nested_long", required, long_type{}));
+
+    schema.fields.emplace_back(nested_field::create(
+      15, "test_struct", required, std::move(nested_schema)));
+
+    schema.fields.emplace_back(nested_field::create(
+      16,
+      "test_list",
+      required,
+      list_type::create(1, required, string_type{})));
+
+    schema.fields.push_back(nested_field::create(
+      17,
+      "test_map",
+      required,
+      map_type::create(1, string_type{}, 2, required, long_type{})));
+    return schema;
+}


### PR DESCRIPTION
This adds an arrow_to_iobuf interface that converts Arrow data to iobufs representing Parquet files that can be written to disk. There are two components:
1. An implementation of arrow::io::OutputStream that collects data in iobufs
2. A class that creates a parquet::io::FileWriter using that output stream and allows the caller to extract the generated iobufs.

This allows us to separate the compute side of generating parquet, which still occurs in the Arrow library, from the file io, which can now be made seastar-friednly.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
