### PR TITLE
`misc`: `std::rethrow_exception()` cleanup

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -23,6 +23,7 @@
 #include <seastar/util/noncopyable_function.hh>
 
 #include <chrono>
+#include <exception>
 #include <functional>
 #include <optional>
 
@@ -260,7 +261,7 @@ protected:
         }
 
         if (ex) {
-            rethrow_exception(ex);
+            std::rethrow_exception(ex);
         }
     }
 

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/net/tls.hh>
 
+#include <exception>
 #include <system_error>
 
 namespace net {
@@ -78,7 +79,7 @@ bool is_reconnect_error(const std::system_error& e) {
  */
 std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
     try {
-        rethrow_exception(e);
+        std::rethrow_exception(e);
     } catch (const std::system_error& e) {
         if (is_reconnect_error(e)) {
             return e.code().message();
@@ -119,7 +120,7 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
 
 bool is_auth_error(std::exception_ptr e) {
     try {
-        rethrow_exception(e);
+        std::rethrow_exception(e);
     } catch (const authentication_exception& e) {
         return true;
     } catch (...) {

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -30,6 +30,8 @@
 #include <seastar/net/api.hh>
 #include <seastar/util/later.hh>
 
+#include <exception>
+
 namespace net {
 
 server::server(server_configuration c, ss::logger& log)
@@ -113,7 +115,7 @@ void server::start() {
 bool is_gate_closed_exception(std::exception_ptr e) {
     try {
         if (e) {
-            rethrow_exception(e);
+            std::rethrow_exception(e);
         }
     } catch (const ss::gate_closed_exception&) {
         return true;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -55,6 +55,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <iterator>
 #include <optional>
 #include <ranges>
@@ -2331,7 +2332,7 @@ consensus::read_snapshot_metadata() {
     }
     co_await snapshot_reader->close();
     if (eptr) {
-        rethrow_exception(eptr);
+        std::rethrow_exception(eptr);
     }
     co_return metadata;
 }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -38,6 +38,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
 
+#include <exception>
 #include <optional>
 #include <stdexcept>
 #include <utility>
@@ -361,7 +362,7 @@ ss::future<> remove_compacted_index(const segment_full_path& reader_path) {
     return ss::remove_file(path.string())
       .handle_exception([path](const std::exception_ptr& e) {
           try {
-              rethrow_exception(e);
+              std::rethrow_exception(e);
           } catch (const std::filesystem::filesystem_error& e) {
               if (e.code() == std::errc::no_such_file_or_directory) {
                   // Do not log: ENOENT on removal is success


### PR DESCRIPTION
Due to [ADL](https://en.cppreference.com/w/cpp/language/adl) rules, there were some callsites to `std::rethrow_exception` with an unqualified namespace.

Cleanup these callsites with the proper `std::` qualifier and ensure `#include <exception>` is present.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
