### PR TITLE
cluster: remove allocation domains from the codebase

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -181,14 +181,6 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
     }
 }
 
-partition_allocation_domain
-get_allocation_domain(const model::topic_namespace_view tp_ns) {
-    if (tp_ns == model::kafka_consumer_offsets_nt) {
-        return partition_allocation_domains::consumer_offsets;
-    }
-    return partition_allocation_domains::common;
-}
-
 std::optional<model::revision_id> log_revision_on_node(
   const topic_table::partition_replicas_view& replicas_view,
   model::node_id node) {

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -331,12 +331,6 @@ inline bool moving_to_node(
 
 cluster::errc map_update_interruption_error_code(std::error_code);
 
-partition_allocation_domain get_allocation_domain(model::topic_namespace_view);
-inline partition_allocation_domain
-get_allocation_domain(const model::ntp& ntp) {
-    return get_allocation_domain(model::topic_namespace_view(ntp));
-}
-
 partition_state get_partition_state(ss::lw_shared_ptr<cluster::partition>);
 partition_raft_state get_partition_raft_state(consensus_ptr);
 std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr);

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -89,10 +89,7 @@ ss::shard_id allocation_node::allocate_shard() {
     return core;
 }
 
-void allocation_node::add_allocation(partition_allocation_domain domain) {
-    _allocated_partitions++;
-    ++_allocated_domain_partitions[domain];
-}
+void allocation_node::add_allocation() { _allocated_partitions++; }
 
 void allocation_node::add_allocation(ss::shard_id core) {
     vassert(
@@ -103,23 +100,13 @@ void allocation_node::add_allocation(ss::shard_id core) {
     _weights[core]++;
 }
 
-void allocation_node::remove_allocation(partition_allocation_domain domain) {
+void allocation_node::remove_allocation() {
     vassert(
       _allocated_partitions > allocation_capacity{0},
       "unable to deallocate partition at node {}",
       *this);
 
-    allocation_capacity& domain_partitions
-      = _allocated_domain_partitions[domain];
-    vassert(
-      domain_partitions > allocation_capacity{0}
-        && domain_partitions <= _allocated_partitions,
-      "Unable to deallocate partition in domain {} at node {}",
-      domain,
-      *this);
-
     _allocated_partitions--;
-    --domain_partitions;
 }
 
 void allocation_node::remove_allocation(ss::shard_id core) {
@@ -131,15 +118,9 @@ void allocation_node::remove_allocation(ss::shard_id core) {
     _weights[core]--;
 }
 
-void allocation_node::add_final_count(partition_allocation_domain domain) {
-    ++_final_partitions;
-    ++_final_domain_partitions[domain];
-}
+void allocation_node::add_final_count() { ++_final_partitions; }
 
-void allocation_node::remove_final_count(partition_allocation_domain domain) {
-    --_final_partitions;
-    --_final_domain_partitions[domain];
-}
+void allocation_node::remove_final_count() { --_final_partitions; }
 
 void allocation_node::update_core_count(uint32_t core_count) {
     auto old_count = _weights.size();
@@ -180,11 +161,7 @@ std::ostream& operator<<(std::ostream& o, const allocation_node& n) {
     for (auto w : n._weights) {
         fmt::print(o, "({})", w);
     }
-    fmt::print(
-      o,
-      "], allocated: {}({})}}",
-      n._allocated_partitions,
-      n._allocated_domain_partitions);
+    fmt::print(o, "], allocated: {}}}", n._allocated_partitions);
     return o;
 }
 

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -55,19 +55,6 @@ public:
         // state is being updated
         return _max_capacity - std::min(_allocated_partitions, _max_capacity);
     }
-    // Would-be free partition space in the node if only the partitions of the
-    // specified domain were allocated. Reserved partitions are considered
-    // allocated regardless of the specified domain
-    allocation_capacity
-    domain_partition_capacity(const partition_allocation_domain domain) const {
-        if (const auto domain_partitions_i = _allocated_domain_partitions.find(
-              domain);
-            domain_partitions_i != _allocated_domain_partitions.cend()) {
-            return _max_capacity
-                   - std::min(domain_partitions_i->second, _max_capacity);
-        }
-        return _max_capacity;
-    }
     // Overall partition space of the node, less reserved partitions
     allocation_capacity max_capacity() const { return _max_capacity; }
 
@@ -103,24 +90,6 @@ public:
     // number of partitions after all in-progress movements are finished
     allocation_capacity final_partitions() const { return _final_partitions; }
 
-    allocation_capacity
-    domain_allocated_partitions(partition_allocation_domain domain) const {
-        if (auto it = _allocated_domain_partitions.find(domain);
-            it != _allocated_domain_partitions.end()) {
-            return it->second;
-        }
-        return allocation_capacity{0};
-    }
-
-    allocation_capacity
-    domain_final_partitions(partition_allocation_domain domain) const {
-        if (auto it = _final_domain_partitions.find(domain);
-            it != _final_domain_partitions.end()) {
-            return it->second;
-        }
-        return allocation_capacity{0};
-    }
-
     bool empty() const {
         return _allocated_partitions == allocation_capacity{0};
     }
@@ -131,26 +100,21 @@ private:
 
     ss::shard_id allocate_shard();
 
-    void add_allocation(partition_allocation_domain);
+    void add_allocation();
     void add_allocation(ss::shard_id core);
-    void remove_allocation(partition_allocation_domain);
+    void remove_allocation();
     void remove_allocation(ss::shard_id core);
-    void add_final_count(partition_allocation_domain);
-    void remove_final_count(partition_allocation_domain);
+    void add_final_count();
+    void remove_final_count();
 
     model::node_id _id;
     /// each index is a CPU. A weight is roughly the number of assignments
     std::vector<uint32_t> _weights;
     allocation_capacity _max_capacity;
-    // number of partitions allocated in all domains
+    // number of partitions currently allocated on this node
     allocation_capacity _allocated_partitions{0};
-    // number of partitions allocated in a specific allocation domain
-    absl::flat_hash_map<partition_allocation_domain, allocation_capacity>
-      _allocated_domain_partitions;
     // number of partitions after all movements are finished
     allocation_capacity _final_partitions{0};
-    absl::flat_hash_map<partition_allocation_domain, allocation_capacity>
-      _final_domain_partitions;
 
     state _state = state::active;
 

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -159,12 +159,10 @@ bool allocation_state::node_local_core_assignment_enabled() const {
       features::feature::node_local_core_assignment);
 }
 
-void allocation_state::add_allocation(
-  const model::broker_shard& replica,
-  const partition_allocation_domain domain) {
+void allocation_state::add_allocation(const model::broker_shard& replica) {
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
-        it->second->add_allocation(domain);
+        it->second->add_allocation();
         if (!node_local_core_assignment_enabled()) {
             it->second->add_allocation(replica.shard);
         }
@@ -177,12 +175,10 @@ void allocation_state::add_allocation(
     }
 }
 
-void allocation_state::remove_allocation(
-  const model::broker_shard& replica,
-  const partition_allocation_domain domain) {
+void allocation_state::remove_allocation(const model::broker_shard& replica) {
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
-        it->second->remove_allocation(domain);
+        it->second->remove_allocation();
         if (!node_local_core_assignment_enabled()) {
             it->second->remove_allocation(replica.shard);
         }
@@ -195,15 +191,14 @@ void allocation_state::remove_allocation(
     }
 }
 
-uint32_t allocation_state::allocate(
-  model::node_id id, const partition_allocation_domain domain) {
+uint32_t allocation_state::allocate(model::node_id id) {
     verify_shard();
     auto it = _nodes.find(id);
     vassert(
       it != _nodes.end(), "allocated node with id {} have to be present", id);
 
-    it->second->add_allocation(domain);
-    it->second->add_final_count(domain);
+    it->second->add_allocation();
+    it->second->add_final_count();
     if (node_local_core_assignment_enabled()) {
 #ifndef NDEBUG
         // return invalid shard in debug mode so that we can spot places where
@@ -217,21 +212,17 @@ uint32_t allocation_state::allocate(
     }
 }
 
-void allocation_state::add_final_count(
-  const model::broker_shard& replica,
-  const partition_allocation_domain domain) {
+void allocation_state::add_final_count(const model::broker_shard& replica) {
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
-        it->second->add_final_count(domain);
+        it->second->add_final_count();
     }
 }
 
-void allocation_state::remove_final_count(
-  const model::broker_shard& replica,
-  const partition_allocation_domain domain) {
+void allocation_state::remove_final_count(const model::broker_shard& replica) {
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
-        it->second->remove_final_count(domain);
+        it->second->remove_final_count();
     }
 }
 

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -57,17 +57,13 @@ public:
 
     // Choose a shard for a replica and add the corresponding allocation.
     // node_id is required to belong to an existing node.
-    uint32_t allocate(model::node_id id, partition_allocation_domain);
+    uint32_t allocate(model::node_id id);
 
     // Operations on state
-    void
-    add_allocation(const model::broker_shard&, partition_allocation_domain);
-    void
-    remove_allocation(const model::broker_shard&, partition_allocation_domain);
-    void
-    add_final_count(const model::broker_shard&, partition_allocation_domain);
-    void
-    remove_final_count(const model::broker_shard&, partition_allocation_domain);
+    void add_allocation(const model::broker_shard&);
+    void remove_allocation(const model::broker_shard&);
+    void add_final_count(const model::broker_shard&);
+    void remove_final_count(const model::broker_shard&);
 
     bool validate_shard(model::node_id node, uint32_t shard) const;
 

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -234,18 +234,13 @@ hard_constraint disk_not_overflowed_by_partition(
       max_disk_usage_ratio, partition_size, node_disk_reports));
 }
 
-soft_constraint max_final_capacity(partition_allocation_domain domain) {
+soft_constraint max_final_capacity() {
     struct impl : soft_constraint::impl {
-        explicit impl(partition_allocation_domain domain_)
-          : domain(domain_) {}
-
         soft_constraint_evaluator make_evaluator(
           const allocated_partition&,
           std::optional<model::node_id> prev) const final {
-            return [domain = domain, prev](const allocation_node& node) {
-                auto count = domain == partition_allocation_domains::common
-                               ? node.final_partitions()
-                               : node.domain_final_partitions(domain);
+            return [prev](const allocation_node& node) {
+                auto count = node.final_partitions();
                 if (prev != node.id()) {
                     count += 1;
                 }
@@ -260,11 +255,9 @@ soft_constraint max_final_capacity(partition_allocation_domain domain) {
         }
 
         ss::sstring name() const final { return "max final capacity"; }
-
-        partition_allocation_domain domain;
     };
 
-    return soft_constraint(std::make_unique<impl>(domain));
+    return soft_constraint(std::make_unique<impl>());
 }
 
 soft_constraint least_disk_filled(

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -50,10 +50,8 @@ hard_constraint disk_not_overflowed_by_partition(
 /*
  * Scores nodes based on partition count after all moves have been finished
  * returning `0` for fully allocated nodes and `max_capacity` for empty nodes.
- * If partition_allocation_domain != common, takes into account only counts
- * in this domain.
  */
-soft_constraint max_final_capacity(partition_allocation_domain);
+soft_constraint max_final_capacity();
 
 /*
  * constraint scores nodes on free disk space

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -66,9 +66,7 @@ public:
     /// Create allocated_partition object from current replicas for use with the
     /// allocate_replica method.
     allocated_partition make_allocated_partition(
-      model::ntp ntp,
-      std::vector<model::broker_shard> replicas,
-      partition_allocation_domain) const;
+      model::ntp ntp, std::vector<model::broker_shard> replicas) const;
 
     /// try to substitute an existing replica with a newly allocated one and add
     /// it to the allocated_partition object. If the request fails,
@@ -116,21 +114,16 @@ public:
     // Partition state updates
 
     /// Best effort. Do not throw if we cannot find the replicas.
-    void add_allocations(
-      const std::vector<model::broker_shard>&, partition_allocation_domain);
-    void remove_allocations(
-      const std::vector<model::broker_shard>&, partition_allocation_domain);
-    void add_final_counts(
-      const std::vector<model::broker_shard>&, partition_allocation_domain);
-    void remove_final_counts(
-      const std::vector<model::broker_shard>&, partition_allocation_domain);
+    void add_allocations(const std::vector<model::broker_shard>&);
+    void remove_allocations(const std::vector<model::broker_shard>&);
+    void add_final_counts(const std::vector<model::broker_shard>&);
+    void remove_final_counts(const std::vector<model::broker_shard>&);
 
     void add_allocations_for_new_partition(
       const std::vector<model::broker_shard>& replicas,
-      raft::group_id group_id,
-      partition_allocation_domain domain) {
-        add_allocations(replicas, domain);
-        add_final_counts(replicas, domain);
+      raft::group_id group_id) {
+        add_allocations(replicas);
+        add_final_counts(replicas);
         _state->update_highest_group_id(group_id);
     }
 

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -219,14 +219,13 @@ struct allocation_units {
 
 private:
     friend class partition_allocator;
-    allocation_units(allocation_state&, partition_allocation_domain);
+    allocation_units(allocation_state&);
 
 private:
     ss::chunked_fifo<partition_assignment> _assignments;
     chunked_vector<model::broker_shard> _added_replicas;
     // keep the pointer to make this type movable
     ss::weak_ptr<allocation_state> _state;
-    partition_allocation_domain _domain;
     // oncore checker to ensure destruction happens on the same core
     [[no_unique_address]] oncore _oncore;
 };
@@ -278,10 +277,7 @@ private:
 
     // construct an object from an original assignment
     allocated_partition(
-      model::ntp,
-      std::vector<model::broker_shard>,
-      partition_allocation_domain,
-      allocation_state&);
+      model::ntp, std::vector<model::broker_shard>, allocation_state&);
 
     struct previous_replica {
         model::broker_shard bs;
@@ -301,7 +297,6 @@ private:
     replicas_t _replicas;
     std::optional<absl::flat_hash_map<model::node_id, uint32_t>>
       _original_node2shard;
-    partition_allocation_domain _domain;
     ss::weak_ptr<allocation_state> _state;
     // oncore checker to ensure destruction happens on the same core
     [[no_unique_address]] oncore _oncore;
@@ -348,10 +343,8 @@ using node2count_t = absl::flat_hash_map<model::node_id, size_t>;
 
 struct allocation_request {
     allocation_request() = delete;
-    explicit allocation_request(
-      model::topic_namespace nt, const partition_allocation_domain domain_)
-      : _nt(std::move(nt))
-      , domain(domain_) {}
+    explicit allocation_request(model::topic_namespace nt)
+      : _nt(std::move(nt)) {}
     allocation_request(const allocation_request&) = delete;
     allocation_request(allocation_request&&) = default;
     allocation_request& operator=(const allocation_request&) = delete;
@@ -360,7 +353,6 @@ struct allocation_request {
 
     model::topic_namespace _nt;
     ss::chunked_fifo<partition_constraints> partitions;
-    partition_allocation_domain domain;
     // if present, new partitions will be allocated using topic-aware counts
     // objective.
     std::optional<node2count_t> existing_replica_counts;

--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -55,13 +55,11 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
             replicas = units->get_assignments().front().replicas;
             allocator().add_allocations_for_new_partition(
               units->get_assignments().front().replicas,
-              units->get_assignments().front().group,
-              cluster::partition_allocation_domains::common);
+              units->get_assignments().front().group);
         }
         perf_tests::do_not_optimize(replicas);
         perf_tests::start_measuring_time();
-        allocator().remove_allocations(
-          replicas, cluster::partition_allocation_domains::common);
+        allocator().remove_allocations(replicas);
         perf_tests::stop_measuring_time();
     });
 }
@@ -85,8 +83,6 @@ PERF_TEST_F(partition_allocator_fixture, recovery) {
 
     perf_tests::start_measuring_time();
     allocator().add_allocations_for_new_partition(
-      replicas,
-      raft::group_id(replicas.size() / 3),
-      cluster::partition_allocation_domains::common);
+      replicas, raft::group_id(replicas.size() / 3));
     perf_tests::stop_measuring_time();
 }

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -79,9 +79,7 @@ struct partition_allocator_fixture {
 
         for (auto& pas : units.value()->get_assignments()) {
             allocator().add_allocations_for_new_partition(
-              pas.replicas,
-              pas.group,
-              cluster::partition_allocation_domains::common);
+              pas.replicas, pas.group);
         }
     }
 
@@ -120,8 +118,7 @@ struct partition_allocator_fixture {
 
     cluster::allocation_request make_allocation_request(
       model::topic_namespace tn, int partitions, uint16_t replication_factor) {
-        cluster::allocation_request req(
-          std::move(tn), cluster::partition_allocation_domains::common);
+        cluster::allocation_request req(std::move(tn));
         req.partitions.reserve(partitions);
         for (int i = 0; i < partitions; ++i) {
             req.partitions.emplace_back(

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -112,8 +112,7 @@ public:
         cluster::topic_configuration cfg(
           test_ns, model::topic(topic), partitions, replication_factor);
 
-        cluster::allocation_request req(
-          cfg.tp_ns, cluster::partition_allocation_domains::common);
+        cluster::allocation_request req(cfg.tp_ns);
         req.partitions.reserve(partitions);
         for (auto p = 0; p < partitions; ++p) {
             req.partitions.emplace_back(

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -110,8 +110,7 @@ struct topic_table_fixture {
         cluster::topic_configuration cfg(
           test_ns, model::topic(topic), partitions, replication_factor);
 
-        cluster::allocation_request req(
-          cfg.tp_ns, cluster::partition_allocation_domains::common);
+        cluster::allocation_request req(cfg.tp_ns);
         req.partitions.reserve(partitions);
         for (auto p = 0; p < partitions; ++p) {
             req.partitions.emplace_back(

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -116,19 +116,16 @@ private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
     template<typename T>
-    void
-    add_allocations_for_new_partitions(const T&, partition_allocation_domain);
+    void add_allocations_for_new_partitions(const T&);
 
     void update_allocations_for_reconfiguration(
       const std::vector<model::broker_shard>& previous,
-      const std::vector<model::broker_shard>& target,
-      partition_allocation_domain);
+      const std::vector<model::broker_shard>& target);
 
     void deallocate_topic(
       const model::topic_namespace&,
       const assignments_set&,
-      const in_progress_map&,
-      partition_allocation_domain);
+      const in_progress_map&);
 
     ss::future<std::error_code>
       do_topic_delete(topic_lifecycle_transition, model::offset);

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -371,7 +371,7 @@ static allocation_request make_allocation_request(
   const custom_assignable_topic_configuration& ca_cfg, bool topic_aware) {
     // no custom assignments, lets allocator decide based on partition count
     const auto& tp_ns = ca_cfg.cfg.tp_ns;
-    allocation_request req(tp_ns, get_allocation_domain(tp_ns));
+    allocation_request req(tp_ns);
     if (!ca_cfg.has_custom_assignment()) {
         req.partitions.reserve(ca_cfg.cfg.partition_count);
         for (auto p = 0; p < ca_cfg.cfg.partition_count; ++p) {
@@ -1409,7 +1409,7 @@ static allocation_request make_allocation_request(
   const create_partitions_configuration& cfg) {
     const auto new_partitions_cnt = cfg.new_total_partition_count
                                     - current_partitions_count;
-    allocation_request req(cfg.tp_ns, get_allocation_domain(cfg.tp_ns));
+    allocation_request req(cfg.tp_ns);
     req.existing_replica_counts = std::move(existing_replica_counts);
     req.partitions.reserve(new_partitions_cnt);
     for (auto p = 0; p < new_partitions_cnt; ++p) {
@@ -1694,7 +1694,7 @@ ss::future<result<allocation_units::pointer>> do_increase_replication_factor(
   double max_disk_usage_ratio,
   const topics_frontend::capacity_info& capacity_info,
   std::optional<node2count_t> existing_replica_counts) {
-    allocation_request req(ns_tp, get_allocation_domain(ns_tp));
+    allocation_request req(ns_tp);
     req.partitions.reserve(assignments.size());
     co_await ssx::async_for_each(
       assignments.begin(),
@@ -1866,7 +1866,7 @@ allocation_request make_allocation_request(
   replication_factor tp_replication_factor,
   const std::vector<model::node_id>& new_replicas) {
     auto nt = model::topic_namespace(ntp.ns, ntp.tp.topic);
-    allocation_request req(nt, get_allocation_domain(nt));
+    allocation_request req(nt);
     req.partitions.reserve(1);
     allocation_constraints constraints;
     constraints.add(on_nodes(new_replicas));

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3057,24 +3057,6 @@ struct node_decommission_progress {
     std::vector<partition_reconfiguration_state> current_reconfigurations;
 };
 
-/*
- * Partition Allocation Domains is the way to make certain partition replicas
- * distributed evenly across the nodes of the cluster. When partition allocation
- * is done within any domain but `common`, all existing allocations outside
- * of that domain will be ignored while assigning partition a node.
- * The `common` domain will consider allocations in all domains.
- * Negative values are used for hardcoded domains, positive values are reserved
- * for future use as user assigned domains, and may be used for a feature that
- * would allow users to designate certain topics to have their partition
- * replicas and leaders evenly distrbuted regardless of other topics.
- */
-using partition_allocation_domain
-  = named_type<int32_t, struct partition_allocation_domain_tag>;
-namespace partition_allocation_domains {
-constexpr auto common = partition_allocation_domain(0);
-constexpr auto consumer_offsets = partition_allocation_domain(-1);
-} // namespace partition_allocation_domains
-
 enum class cloud_storage_mode : uint8_t {
     disabled = 0,
     write_only = 1,


### PR DESCRIPTION
The original motivation for allocation domains was to ensure balanced distribution of __consumer_offsets partitions that doesn't depend on the distribution of user partitions. After topic-aware partition allocation and balancing got introduced, this is no longer relevant, as the same objective is achieved in a more general way.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none