### PR TITLE
storage: improve fallocate sizing

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -112,11 +112,8 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
 ss::future<> segment_appender::append(const model::record_batch& batch) {
     _batch_types_to_write |= 1LU << static_cast<uint8_t>(batch.header().type);
 
-    auto hdrbuf = std::make_unique<iobuf>(
-      storage::batch_header_to_disk_iobuf(batch.header()));
-    auto ptr = hdrbuf.get();
-    return append(*ptr).then(
-      [this, &batch, cpy = std::move(hdrbuf)] { return append(batch.data()); });
+    co_await append(storage::batch_header_to_disk_iobuf(batch.header()));
+    co_await append(batch.data());
 }
 
 ss::future<> segment_appender::append(bytes_view s) {

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -139,7 +139,7 @@ private:
     using chunk_ptr = ss::lw_shared_ptr<chunk>;
 
     void dispatch_background_head_write();
-    ss::future<> do_next_adaptive_fallocation();
+    ss::future<> do_next_adaptive_fallocation(size_t next_write_size);
     ss::future<> hydrate_last_half_page();
     ss::future<> do_truncation(size_t);
     ss::future<> do_append(const char* buf, size_t n);
@@ -156,6 +156,10 @@ private:
      */
     size_t next_committed_offset() const {
         return _committed_offset + (_head ? _head->bytes_pending() : 0);
+    }
+
+    bool need_fallocate_for_write(size_t write_size_bytes) {
+        return next_committed_offset() + write_size_bytes > _fallocation_offset;
     }
 
     // Reset the bit-map tracking unwritten batch types in the `_head` chunk.


### PR DESCRIPTION
* **storage: improve fallocate sizing**
When writing past segment size, fallocate just enough to support next
    write. After that segment should be rolled anyway.
    When very low on disk, still fallocate enough to support the next write.

    This does not reduce the number of fallocate syscalls. We just reduce
    the size we fallocate for the last batch appended to the segment in the
    general case. Hoping that file systems will appreciate this.

This is in addition to https://github.com/redpanda-data/redpanda/pull/23381/files

For 128 MiB segment size, this will briefly fallocate to 256 MiB then truncate it back to 128 MiB + 1 batch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
