### PR TITLE
kafka/protocol: use uint32_t for crc decoding in the header

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -158,9 +158,7 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
     auto trimmed_bytes = remainder.size_bytes();
     kbatch.trim_back(trimmed_bytes);
 
-    auto crcparser = iobuf_parser(kbatch.share(0, kbatch.size_bytes()));
-    auto parser = iobuf_parser(std::move(kbatch));
-
+    auto parser = iobuf_parser(kbatch.share(0, kbatch.size_bytes()));
     auto header = read_header(parser);
     if (unlikely(!v2_format)) {
         vlog(
@@ -169,6 +167,7 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
         return remainder;
     }
 
+    auto crcparser = iobuf_parser(std::move(kbatch));
     verify_crc(header, std::move(crcparser));
     if (unlikely(!valid_crc)) {
         if (trimmed_bytes > 0) {

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -70,7 +70,7 @@ public:
     void adapt_with_version(iobuf, api_version);
 
 private:
-    void verify_crc(uint32_t, iobuf_parser);
+    void verify_crc(const model::record_batch_header&, iobuf_parser);
     model::record_batch_header read_header(iobuf_parser&);
     void convert_message_set(storage::record_batch_builder&, iobuf, bool);
 };

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -26,15 +26,15 @@ constexpr size_t kafka_header_size = sizeof(int64_t) + // base offset
                                      sizeof(int32_t) + // batch length
                                      sizeof(int32_t) + // partition leader epoch
                                      sizeof(int8_t) +  // magic
-                                     sizeof(int32_t) + // crc
-                                     sizeof(int16_t) + // attributes
-                                     sizeof(int32_t) + // last offset delta
-                                     sizeof(int64_t) + // first timestamp
-                                     sizeof(int64_t) + // max timestamp
-                                     sizeof(int64_t) + // producer id
-                                     sizeof(int16_t) + // producer epoch
-                                     sizeof(int32_t) + // base sequence
-                                     sizeof(int32_t);  // num records
+                                     sizeof(uint32_t) + // crc
+                                     sizeof(int16_t) +  // attributes
+                                     sizeof(int32_t) +  // last offset delta
+                                     sizeof(int64_t) +  // first timestamp
+                                     sizeof(int64_t) +  // max timestamp
+                                     sizeof(int64_t) +  // producer id
+                                     sizeof(int16_t) +  // producer epoch
+                                     sizeof(int32_t) +  // base sequence
+                                     sizeof(int32_t);   // num records
 
 } // namespace internal
 
@@ -70,7 +70,7 @@ public:
     void adapt_with_version(iobuf, api_version);
 
 private:
-    void verify_crc(int32_t, iobuf_parser);
+    void verify_crc(uint32_t, iobuf_parser);
     model::record_batch_header read_header(iobuf_parser&);
     void convert_message_set(storage::record_batch_builder&, iobuf, bool);
 };

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -193,7 +193,7 @@ adl<model::record_batch_header>::parse_from(Parser& in) {
     auto sz = adl<int32_t>{}.from(in);
     auto off = adl<model::offset>{}.from(in);
     auto type = adl<model::record_batch_type>{}.from(in);
-    auto crc = adl<int32_t>{}.from(in);
+    auto crc = adl<uint32_t>{}.from(in);
     using attr_t = model::record_batch_attributes::type;
     auto attrs = model::record_batch_attributes(adl<attr_t>{}.from(in));
     auto delta = adl<int32_t>{}.from(in);

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -463,7 +463,7 @@ struct record_batch_header
     offset base_offset;
     /// \brief redpanda extension
     record_batch_type type;
-    int32_t crc{0};
+    uint32_t crc{0};
 
     // -- below the CRC are checksummed by the kafka crc. see @crc field
 

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -78,14 +78,15 @@ void crc_record_batch_header(
       header.record_count);
 }
 
-int32_t crc_record_batch(const record_batch_header& hdr, const iobuf& records) {
+uint32_t
+crc_record_batch(const record_batch_header& hdr, const iobuf& records) {
     auto crc = crc::crc32c();
     crc_record_batch_header(crc, hdr);
     crc_extend_iobuf(crc, records);
     return crc.value();
 }
 
-int32_t crc_record_batch(const record_batch& b) {
+uint32_t crc_record_batch(const record_batch& b) {
     return crc_record_batch(b.header(), b.data());
 }
 

--- a/src/v/model/record_utils.h
+++ b/src/v/model/record_utils.h
@@ -22,9 +22,8 @@ class record;
 
 void crc_record_batch_header(crc::crc32c&, const record_batch_header&);
 
-/// \brief int32_t because that's what kafka uses
-int32_t crc_record_batch(const record_batch& b);
-int32_t crc_record_batch(const record_batch_header&, const iobuf&);
+uint32_t crc_record_batch(const record_batch& b);
+uint32_t crc_record_batch(const record_batch_header&, const iobuf&);
 
 /// \brief uint32_t because that's what crc32c uses
 /// it is *only* record_batch_header.header_crc;

--- a/src/v/storage/record_batch_utils.cc
+++ b/src/v/storage/record_batch_utils.cc
@@ -46,7 +46,7 @@ model::record_batch_header batch_header_from_disk_iobuf(iobuf b) {
     using offset_t = model::offset::type;
     auto off = model::offset(reflection::adl<offset_t>{}.from(parser));
     auto type = reflection::adl<model::record_batch_type>{}.from(parser);
-    auto crc = reflection::adl<int32_t>{}.from(parser);
+    auto crc = reflection::adl<uint32_t>{}.from(parser);
     using attr_t = model::record_batch_attributes::type;
     auto attrs = model::record_batch_attributes(
       reflection::adl<attr_t>{}.from(parser));


### PR DESCRIPTION
Unlike what the code comments say Kafka protocol specifies using
uint32_t for crc in the header, this change avoids decoding it as
int32_t and then a later cast during comparison.

Java has no 32-bit unsigned int, so they use long to represent the
checksum value to avoid overflow (checksum > int32_max) but the actual
checksum is always a uint32_t (as per CRC32C definition).

There are no functional changes in the patch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
