### PR TITLE
Jcipar/batching parquet writer

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
   SRCS
     arrow_translator.cc
     datalake_manager.cc
+    batching_parquet_writer.cc
     parquet_writer.cc
     record_multiplexer.cc
     schema_registry.cc

--- a/src/v/datalake/arrow_translator.cc
+++ b/src/v/datalake/arrow_translator.cc
@@ -11,6 +11,7 @@
 
 #include "container/fragmented_vector.h"
 #include "iceberg/datatypes.h"
+#include "iceberg/values.h"
 
 #include <arrow/api.h>
 #include <arrow/array/array_primitive.h>
@@ -93,6 +94,8 @@ public:
       const std::optional<iceberg::value>& maybe_value) override;
 
     void add_data(const iceberg::value& value) override;
+
+    void add_struct_data(const iceberg::struct_value value);
 
     arrow::FieldVector get_field_vector();
 
@@ -524,25 +527,19 @@ void struct_converter::add_optional_data(
     }
 }
 
-void struct_converter::add_data(const iceberg::value& value) {
-    // 1. Call add_data on all children
-    // 2. Call append on our builder
-    const auto& struct_val
-      = get_or_throw<std::unique_ptr<iceberg::struct_value>>(
-        value, "Scalar converter expected a binary field");
-
-    if (struct_val->fields.size() != _child_converters.size()) {
+void struct_converter::add_struct_data(const iceberg::struct_value struct_val) {
+    if (struct_val.fields.size() != _child_converters.size()) {
         throw std::invalid_argument(fmt::format(
           "Got incorrect number of fields in struct converter. Expected {} "
           "got {}",
           _child_converters.size(),
-          struct_val->fields.size()));
+          struct_val.fields.size()));
     }
     for (size_t i = 0; i < _child_converters.size(); i++) {
-        if (_field_required[i] && !struct_val->fields[i].has_value()) {
+        if (_field_required[i] && !struct_val.fields[i].has_value()) {
             throw std::invalid_argument("Missing required field");
         }
-        _child_converters[i]->add_optional_data(struct_val->fields[i]);
+        _child_converters[i]->add_optional_data(struct_val.fields[i]);
     }
     auto status = _builder->Append();
     if (!status.ok()) {
@@ -551,6 +548,16 @@ void struct_converter::add_data(const iceberg::value& value) {
         throw std::runtime_error(fmt::format(
           "Unable to append to struct builder: {}", status.ToString()));
     }
+}
+
+void struct_converter::add_data(const iceberg::value& value) {
+    // 1. Call add_data on all children
+    // 2. Call append on our builder
+    const auto& struct_val
+      = get_or_throw<std::unique_ptr<iceberg::struct_value>>(
+        value, "Scalar converter expected a binary field");
+
+    add_struct_data(std::move(*struct_val));
 }
 
 arrow::FieldVector struct_converter::get_field_vector() { return _fields; }
@@ -717,8 +724,8 @@ std::shared_ptr<arrow::Schema> arrow_translator::build_arrow_schema() {
     return arrow::schema(_struct_converter->get_field_vector());
 }
 
-void arrow_translator::add_data(iceberg::value value) {
-    _struct_converter->add_data(value);
+void arrow_translator::add_data(iceberg::struct_value value) {
+    _struct_converter->add_struct_data(std::move(value));
 }
 
 std::shared_ptr<arrow::Array> arrow_translator::take_chunk() {

--- a/src/v/datalake/arrow_translator.cc
+++ b/src/v/datalake/arrow_translator.cc
@@ -708,9 +708,8 @@ void map_converter::add_data(const iceberg::value& value) {
     }
 }
 
-arrow_translator::arrow_translator(iceberg::struct_type&& schema)
-  : _schema(std::move(schema))
-  , _struct_converter(std::make_unique<struct_converter>(_schema)) {}
+arrow_translator::arrow_translator(iceberg::struct_type schema)
+  : _struct_converter(std::make_unique<struct_converter>(std::move(schema))) {}
 
 arrow_translator::~arrow_translator() = default;
 

--- a/src/v/datalake/arrow_translator.h
+++ b/src/v/datalake/arrow_translator.h
@@ -14,6 +14,7 @@
 #include "iceberg/values.h"
 
 #include <arrow/type.h>
+#include <parquet/arrow/writer.h>
 
 #include <optional>
 
@@ -23,17 +24,7 @@ class struct_converter;
 
 class arrow_translator {
 public:
-    explicit arrow_translator(iceberg::struct_type&& schema);
-
-    // Wrap constructor to return optional on failure.
-    static std::optional<arrow_translator>
-    create(iceberg::struct_type&& schema) {
-        try {
-            return std::make_optional<arrow_translator>(std::move(schema));
-        } catch (...) {
-            return std::nullopt;
-        }
-    }
+    explicit arrow_translator(iceberg::struct_type schema);
 
     ~arrow_translator();
 
@@ -46,8 +37,6 @@ public:
     std::shared_ptr<arrow::Array> take_chunk();
 
 private:
-    iceberg::struct_type _schema;
-
     // Top-level struct that represents the whole schema.
     std::unique_ptr<struct_converter> _struct_converter;
 };

--- a/src/v/datalake/arrow_translator.h
+++ b/src/v/datalake/arrow_translator.h
@@ -29,7 +29,7 @@ public:
     ~arrow_translator();
 
     std::shared_ptr<arrow::Schema> build_arrow_schema();
-    void add_data(iceberg::value value);
+    void add_data(iceberg::struct_value value);
 
     // Returns an arrow:Array for all of the data that has been added since the
     // translator was created or the last take_chunk call. It then clears the

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -43,8 +43,8 @@ batching_parquet_writer::initialize(std::filesystem::path output_file_path) {
     _output_stream = co_await ss::make_file_output_stream(_output_file);
 }
 
-ss::future<void> batching_parquet_writer::add_data_struct(
-  iceberg::value data, int64_t approx_size) {
+ss::future<data_writer_error> batching_parquet_writer::add_data_struct(
+  iceberg::struct_value data, int64_t approx_size) {
     _iceberg_to_arrow.add_data(std::move(data));
     _row_count++;
     _byte_count += approx_size;
@@ -54,6 +54,7 @@ ss::future<void> batching_parquet_writer::add_data_struct(
       || _byte_count > _byte_count_threshold) {
         co_await write_row_group();
     }
+    co_return data_writer_error::ok;
 }
 
 ss::future<data_writer_result> batching_parquet_writer::finish() {

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -34,53 +34,129 @@ batching_parquet_writer::batching_parquet_writer(
   , _row_count_threshold{row_count_threshold}
   , _byte_count_threshold{byte_count_threshold} {}
 
-ss::future<>
+ss::future<data_writer_error>
 batching_parquet_writer::initialize(std::filesystem::path output_file_path) {
-    _output_file = co_await ss::open_file_dma(
-      output_file_path.string(),
-      ss::open_flags::create | ss::open_flags::truncate | ss::open_flags::wo);
+    _output_file_path = std::move(output_file_path);
+    try {
+        _output_file = co_await ss::open_file_dma(
+          _output_file_path.string(),
+          ss::open_flags::create | ss::open_flags::truncate
+            | ss::open_flags::wo);
+    } catch (...) {
+        co_return data_writer_error::file_io_error;
+    }
+    bool error = false;
+    try {
+        _output_stream = co_await ss::make_file_output_stream(_output_file);
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await _output_file.close();
+        co_return data_writer_error::file_io_error;
+    }
 
-    _output_stream = co_await ss::make_file_output_stream(_output_file);
+    _result.file_path = _output_file_path.string();
+    co_return data_writer_error::ok;
 }
 
 ss::future<data_writer_error> batching_parquet_writer::add_data_struct(
   iceberg::struct_value data, int64_t approx_size) {
-    _iceberg_to_arrow.add_data(std::move(data));
+    bool error = false;
+    try {
+        _iceberg_to_arrow.add_data(std::move(data));
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await abort();
+        co_return data_writer_error::parquet_conversion_error;
+    }
     _row_count++;
     _byte_count += approx_size;
 
     if (
       _row_count >= _row_count_threshold
       || _byte_count > _byte_count_threshold) {
-        co_await write_row_group();
+        co_return co_await write_row_group();
     }
     co_return data_writer_error::ok;
 }
 
-ss::future<data_writer_result> batching_parquet_writer::finish() {
-    // TODO: fill in result structure
-    return write_row_group()
-      .then([this] {
-          data_writer_result res;
-          iobuf out = _arrow_to_iobuf.close_and_take_iobuf();
+ss::future<result<data_writer_result, data_writer_error>>
+batching_parquet_writer::finish() {
+    auto write_result = co_await write_row_group();
+    if (write_result != data_writer_error::ok) {
+        co_await abort();
+        co_return write_result;
+    }
+    bool error = false;
+    iobuf out;
+    try {
+        out = _arrow_to_iobuf.close_and_take_iobuf();
+        _result.file_size_bytes += out.size_bytes();
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await abort();
+        co_return data_writer_error::parquet_conversion_error;
+    }
 
-          return write_iobuf_to_output_stream(std::move(out), _output_stream)
-            .then([res] { return res; });
-      })
-      .finally([this] { return _output_stream.close(); });
+    try {
+        co_await write_iobuf_to_output_stream(std::move(out), _output_stream);
+        co_await _output_stream.close();
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await abort();
+        co_return data_writer_error::file_io_error;
+    }
+
+    co_return _result;
 }
 
-ss::future<> batching_parquet_writer::write_row_group() {
+ss::future<data_writer_error> batching_parquet_writer::write_row_group() {
     if (_row_count == 0) {
         // This can happen if finish() is called when there is no new data.
-        co_return;
+        co_return data_writer_error::ok;
     }
-    auto chunk = _iceberg_to_arrow.take_chunk();
-    _row_count = 0;
-    _byte_count = 0;
-    _arrow_to_iobuf.add_arrow_array(chunk);
-    iobuf out = _arrow_to_iobuf.take_iobuf();
-    co_await write_iobuf_to_output_stream(std::move(out), _output_stream);
+    bool error = false;
+    iobuf out;
+    try {
+        auto chunk = _iceberg_to_arrow.take_chunk();
+        _result.record_count += _row_count;
+        _row_count = 0;
+        _byte_count = 0;
+        _arrow_to_iobuf.add_arrow_array(chunk);
+        out = _arrow_to_iobuf.take_iobuf();
+        _result.file_size_bytes += out.size_bytes();
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await abort();
+        co_return data_writer_error::parquet_conversion_error;
+    }
+    try {
+        co_await write_iobuf_to_output_stream(std::move(out), _output_stream);
+    } catch (...) {
+        error = true;
+    }
+    if (error) {
+        co_await abort();
+        co_return data_writer_error::file_io_error;
+    }
+    co_return data_writer_error::ok;
+}
+
+ss::future<> batching_parquet_writer::abort() {
+    co_await _output_stream.close();
+    auto exists = co_await ss::file_exists(_output_file_path.c_str());
+    if (exists) {
+        co_await ss::remove_file(_output_file_path.c_str());
+    }
 }
 
 } // namespace datalake

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/batching_parquet_writer.h"
+
+#include "bytes/iostream.h"
+#include "datalake/arrow_translator.h"
+#include "datalake/data_writer_interface.h"
+
+#include <seastar/core/file-types.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <cstdint>
+
+namespace datalake {
+
+batching_parquet_writer::batching_parquet_writer(
+  iceberg::struct_type schema,
+  size_t row_count_threshold,
+  size_t byte_count_threshold)
+  : _iceberg_to_arrow(std::move(schema))
+  , _arrow_to_iobuf(_iceberg_to_arrow.build_arrow_schema())
+  , _row_count_threshold{row_count_threshold}
+  , _byte_count_threshold{byte_count_threshold} {}
+
+ss::future<>
+batching_parquet_writer::initialize(std::filesystem::path output_file_path) {
+    _output_file = co_await ss::open_file_dma(
+      output_file_path.string(),
+      ss::open_flags::create | ss::open_flags::truncate | ss::open_flags::wo);
+
+    _output_stream = co_await ss::make_file_output_stream(_output_file);
+}
+
+ss::future<void> batching_parquet_writer::add_data_struct(
+  iceberg::value data, int64_t approx_size) {
+    _iceberg_to_arrow.add_data(std::move(data));
+    _row_count++;
+    _byte_count += approx_size;
+
+    if (
+      _row_count >= _row_count_threshold
+      || _byte_count > _byte_count_threshold) {
+        co_await write_row_group();
+    }
+}
+
+ss::future<data_writer_result> batching_parquet_writer::finish() {
+    // TODO: fill in result structure
+    return write_row_group()
+      .then([this] {
+          data_writer_result res;
+          iobuf out = _arrow_to_iobuf.close_and_take_iobuf();
+
+          return write_iobuf_to_output_stream(std::move(out), _output_stream)
+            .then([res] { return res; });
+      })
+      .finally([this] { return _output_stream.close(); });
+}
+
+ss::future<> batching_parquet_writer::write_row_group() {
+    if (_row_count == 0) {
+        // This can happen if finish() is called when there is no new data.
+        co_return;
+    }
+    auto chunk = _iceberg_to_arrow.take_chunk();
+    _row_count = 0;
+    _byte_count = 0;
+    _arrow_to_iobuf.add_arrow_array(chunk);
+    iobuf out = _arrow_to_iobuf.take_iobuf();
+    co_await write_iobuf_to_output_stream(std::move(out), _output_stream);
+}
+
+} // namespace datalake

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -16,6 +16,7 @@
 
 #include <seastar/core/file.hh>
 #include <seastar/core/iostream.hh>
+
 #include <base/seastarx.h>
 
 #include <filesystem>

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -35,7 +35,7 @@ namespace datalake {
 //    4. Writes them to the open file
 // 4. When finish() is called it flushes all remaining data and closes the
 // files.
-class batching_parquet_writer {
+class batching_parquet_writer : public data_writer {
 public:
     batching_parquet_writer(
       iceberg::struct_type schema,
@@ -44,10 +44,10 @@ public:
 
     ss::future<> initialize(std::filesystem::path output_file_path);
 
-    // TODO: error type?
-    ss::future<> add_data_struct(iceberg::value data, int64_t approx_size);
+    ss::future<data_writer_error>
+    add_data_struct(iceberg::struct_value data, int64_t approx_size) override;
 
-    ss::future<data_writer_result> finish();
+    ss::future<data_writer_result> finish() override;
 
 private:
     ss::future<> write_row_group();

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+#include "datalake/arrow_translator.h"
+#include "datalake/data_writer_interface.h"
+#include "datalake/parquet_writer.h"
+#include "iceberg/datatypes.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/iostream.hh>
+#include <base/seastarx.h>
+
+#include <filesystem>
+
+namespace datalake {
+// batching_parquet_writer ties together the low-level components for iceberg to
+// parquet translation to provide a high-level interface for creating parquet
+// files from iceberg::value. It:
+// 1. Opens a ss::file to store the results
+// 2. Accepts iceberg::value and collects them in an arrow_translator
+// 3. Once the row count or size threshold is reached it writes data to the
+//    file:
+//    1. takes a chunk from the arrow_translator
+//    2. Adds the chunk to the parquet_writer
+//    3. Extracts iobufs from the parquet_writer
+//    4. Writes them to the open file
+// 4. When finish() is called it flushes all remaining data and closes the
+// files.
+class batching_parquet_writer {
+public:
+    batching_parquet_writer(
+      iceberg::struct_type schema,
+      size_t row_count_threshold,
+      size_t byte_count_threshold);
+
+    ss::future<> initialize(std::filesystem::path output_file_path);
+
+    // TODO: error type?
+    ss::future<> add_data_struct(iceberg::value data, int64_t approx_size);
+
+    ss::future<data_writer_result> finish();
+
+private:
+    ss::future<> write_row_group();
+
+    // translating
+    arrow_translator _iceberg_to_arrow;
+    arrow_to_iobuf _arrow_to_iobuf;
+
+    // batching
+    size_t _row_count_threshold;
+    size_t _byte_count_threshold;
+    size_t _row_count = 0;
+    size_t _byte_count = 0;
+
+    // Output
+    ss::file _output_file;
+    ss::output_stream<char> _output_stream;
+};
+
+} // namespace datalake

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -7,6 +7,9 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+#pragma once
+
+#include "base/outcome.h"
 #include "datalake/schemaless_translator.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
@@ -15,12 +18,12 @@
 #include <cstddef>
 #include <memory>
 
-#pragma once
-
 namespace datalake {
 enum class data_writer_error {
     ok = 0,
-    uh_oh,
+    parquet_conversion_error,
+    file_io_error,
+
 };
 
 struct data_writer_result
@@ -28,28 +31,11 @@ struct data_writer_result
       data_writer_result,
       serde::version<0>,
       serde::compat_version<0>> {
-    size_t row_count = 0;
+    ss::sstring file_path = "";
+    size_t record_count = 0;
+    size_t file_size_bytes = 0;
 
-    auto serde_fields() { return std::tie(row_count); }
-};
-
-class data_writer {
-public:
-    virtual ~data_writer() = default;
-
-    virtual ss::future<data_writer_error> add_data_struct(
-      iceberg::struct_value /* data */, int64_t /* approx_size */)
-      = 0;
-
-    virtual ss::future<data_writer_result> finish() = 0;
-};
-
-class data_writer_factory {
-public:
-    virtual ~data_writer_factory() = default;
-
-    virtual std::unique_ptr<data_writer>
-      create_writer(iceberg::struct_type /* schema */) = 0;
+    auto serde_fields() { return std::tie(record_count); }
 };
 
 struct data_writer_error_category : std::error_category {
@@ -59,8 +45,10 @@ struct data_writer_error_category : std::error_category {
         switch (static_cast<data_writer_error>(ev)) {
         case data_writer_error::ok:
             return "Ok";
-        case data_writer_error::uh_oh:
-            return "Uh oh!";
+        case data_writer_error::parquet_conversion_error:
+            return "Parquet Conversion Error";
+        case data_writer_error::file_io_error:
+            return "File IO Error";
         }
     }
 
@@ -73,6 +61,26 @@ struct data_writer_error_category : std::error_category {
 inline std::error_code make_error_code(data_writer_error e) noexcept {
     return {static_cast<int>(e), data_writer_error_category::error_category()};
 }
+
+class data_writer {
+public:
+    virtual ~data_writer() = default;
+
+    virtual ss::future<data_writer_error> add_data_struct(
+      iceberg::struct_value /* data */, int64_t /* approx_size */)
+      = 0;
+
+    virtual ss::future<result<data_writer_result, data_writer_error>>
+    finish() = 0;
+};
+
+class data_writer_factory {
+public:
+    virtual ~data_writer_factory() = default;
+
+    virtual std::unique_ptr<data_writer>
+      create_writer(iceberg::struct_type /* schema */) = 0;
+};
 
 } // namespace datalake
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -33,11 +33,11 @@ public:
     virtual ~data_writer() = default;
 
     // TODO: error type?
-    virtual bool add_data_struct(
+    virtual ss::future<bool> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
 
-    virtual data_writer_result finish() = 0;
+    virtual ss::future<data_writer_result> finish() = 0;
 };
 
 class data_writer_factory {

--- a/src/v/datalake/parquet_writer.cc
+++ b/src/v/datalake/parquet_writer.cc
@@ -10,6 +10,7 @@
 #include "datalake/parquet_writer.h"
 
 #include "bytes/iobuf.h"
+#include "datalake/data_writer_interface.h"
 
 #include <arrow/array/array_base.h>
 #include <arrow/chunked_array.h>
@@ -63,7 +64,7 @@ private:
     int64_t _position = 0;
 };
 
-arrow_to_iobuf::arrow_to_iobuf(const arrow::Schema& schema) {
+arrow_to_iobuf::arrow_to_iobuf(std::shared_ptr<arrow::Schema> schema) {
     // TODO: make the compression algorithm configurable.
     std::shared_ptr<parquet::WriterProperties> writer_props
       = parquet::WriterProperties::Builder()
@@ -77,7 +78,7 @@ arrow_to_iobuf::arrow_to_iobuf(const arrow::Schema& schema) {
     _ostream = std::make_shared<iobuf_output_stream>();
 
     auto writer_result = parquet::arrow::FileWriter::Open(
-      schema,
+      *schema,
       arrow::default_memory_pool(),
       _ostream,
       std::move(writer_props),
@@ -117,5 +118,4 @@ iobuf arrow_to_iobuf::close_and_take_iobuf() {
     }
     return take_iobuf();
 }
-
 } // namespace datalake

--- a/src/v/datalake/parquet_writer.h
+++ b/src/v/datalake/parquet_writer.h
@@ -18,7 +18,7 @@ namespace datalake {
 
 class arrow_to_iobuf {
 public:
-    explicit arrow_to_iobuf(const arrow::Schema& schema);
+    explicit arrow_to_iobuf(std::shared_ptr<arrow::Schema> schema);
 
     void add_arrow_array(std::shared_ptr<arrow::Array> data);
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -70,9 +70,13 @@ record_multiplexer::end_of_stream() {
     // TODO: once we have multiple _writers this should be a loop
     if (_writer) {
         chunked_vector<data_writer_result> ret;
-        data_writer_result res = co_await _writer->finish();
-        ret.push_back(res);
-        co_return ret;
+        auto res = co_await _writer->finish();
+        if (res.has_value()) {
+            ret.push_back(res.value());
+            co_return ret;
+        } else {
+            co_return res.error();
+        }
     } else {
         co_return chunked_vector<data_writer_result>{};
     }

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -15,6 +15,10 @@
 #include "model/record.h"
 #include "storage/parser_utils.h"
 
+#include <ios>
+#include <stdexcept>
+#include <system_error>
+
 namespace datalake {
 record_multiplexer::record_multiplexer(
   std::unique_ptr<data_writer_factory> writer_factory)
@@ -28,32 +32,41 @@ record_multiplexer::operator()(model::record_batch batch) {
     }
     auto first_timestamp = batch.header().first_timestamp.value();
     auto base_offset = static_cast<int64_t>(batch.base_offset());
-    co_await batch.for_each_record_async(
-      [first_timestamp, base_offset, this](
-        model::record record) -> ss::future<> {
-          iobuf key = record.release_key();
-          iobuf val = record.release_value();
-          // *1000: Redpanda timestamps are milliseconds. Iceberg uses
-          // microseconds.
-          int64_t timestamp = (first_timestamp + record.timestamp_delta())
-                              * 1000;
-          int64_t offset = static_cast<int64_t>(base_offset)
-                           + record.offset_delta();
-          int64_t estimated_size = key.size_bytes() + val.size_bytes() + 16;
+    auto it = model::record_batch_iterator::create(batch);
+    while (it.has_next()) {
+        auto record = it.next();
+        iobuf key = record.release_key();
+        iobuf val = record.release_value();
+        // *1000: Redpanda timestamps are milliseconds. Iceberg uses
+        // microseconds.
+        int64_t timestamp = (first_timestamp + record.timestamp_delta()) * 1000;
+        int64_t offset = static_cast<int64_t>(base_offset)
+                         + record.offset_delta();
+        int64_t estimated_size = key.size_bytes() + val.size_bytes() + 16;
 
-          // Translate the record
-          auto& translator = get_translator();
-          iceberg::struct_value data = translator.translate_event(
-            std::move(key), std::move(val), timestamp, offset);
-          // Send it to the writer
-          auto& writer = get_writer();
-          co_await writer.add_data_struct(std::move(data), estimated_size);
-      });
+        // Translate the record
+        auto& translator = get_translator();
+        iceberg::struct_value data = translator.translate_event(
+          std::move(key), std::move(val), timestamp, offset);
+        // Send it to the writer
+        auto& writer = get_writer();
+        data_writer_error writer_status = co_await writer.add_data_struct(
+          std::move(data), estimated_size);
+        if (writer_status != data_writer_error::ok) {
+            // If a write fails, the writer is left in an indeterminate state,
+            // we cannot continue in this case.
+            _writer_status = writer_status;
+            co_return ss::stop_iteration::yes;
+        }
+    }
     co_return ss::stop_iteration::no;
 }
 
-ss::future<chunked_vector<data_writer_result>>
+ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
 record_multiplexer::end_of_stream() {
+    if (_writer_status != data_writer_error::ok) {
+        co_return _writer_status;
+    }
     // TODO: once we have multiple _writers this should be a loop
     if (_writer) {
         chunked_vector<data_writer_result> ret;

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "base/outcome.h"
+#include "container/fragmented_vector.h"
 #include "datalake/data_writer_interface.h"
 #include "datalake/schemaless_translator.h"
 #include "model/record.h"
@@ -40,7 +42,8 @@ public:
     explicit record_multiplexer(
       std::unique_ptr<data_writer_factory> writer_factory);
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
-    ss::future<chunked_vector<data_writer_result>> end_of_stream();
+    ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
+    end_of_stream();
 
 private:
     schemaless_translator& get_translator();
@@ -52,6 +55,8 @@ private:
 
     // TODO: similarly this will be a map keyed by schema_id
     std::unique_ptr<data_writer> _writer;
+
+    data_writer_error _writer_status = data_writer_error::ok;
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -43,13 +43,11 @@ public:
     ss::future<chunked_vector<data_writer_result>> end_of_stream();
 
 private:
-    using translator = std::variant<schemaless_translator>;
-
-    translator& get_translator();
+    schemaless_translator& get_translator();
     data_writer& get_writer();
 
     // TODO: in a future PR this will be a map of translators keyed by schema_id
-    translator _translator;
+    schemaless_translator _translator;
     std::unique_ptr<data_writer_factory> _writer_factory;
 
     // TODO: similarly this will be a map keyed by schema_id

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -97,3 +97,15 @@ target_include_directories(v_datalake_test_proto_cc_files
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+rp_test(
+  GTEST
+  BINARY_NAME batching_parquet_writer_test
+  SOURCES batching_parquet_writer_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::datalake
+    v::iceberg_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)
+

--- a/src/v/datalake/tests/arrow_writer_test.cc
+++ b/src/v/datalake/tests/arrow_writer_test.cc
@@ -77,7 +77,7 @@ TEST(ArrowWriterTest, TranslatesData) {
       test_schema(iceberg::field_required::no));
 
     for (int i = 0; i < 5; i++) {
-        auto data = iceberg::tests::make_value(
+        auto data = iceberg::tests::make_struct_value(
           iceberg::tests::value_spec{
             .forced_fixed_val = iobuf::from("Hello world")},
           test_schema(iceberg::field_required::no));
@@ -87,15 +87,6 @@ TEST(ArrowWriterTest, TranslatesData) {
     std::string result_string = schema_translator.take_chunk()->ToString();
 
     EXPECT_EQ(result_string, get_expected_translation_output());
-}
-
-TEST(ArrowWriterTest, FailsOnNonStruct) {
-    datalake::arrow_translator schema_translator(
-      test_schema(iceberg::field_required::no));
-    iceberg::value not_a_struct = iceberg::int_value{5};
-    EXPECT_THROW(
-      schema_translator.add_data(std::move(not_a_struct)),
-      std::invalid_argument);
 }
 
 TEST(ArrowWriterTest, FailsOnWrongFieldCount) {
@@ -113,7 +104,7 @@ TEST(ArrowWriterTest, FailsOnWrongFieldCount) {
     too_little_data->fields.emplace_back(boolean_value{true});
 
     EXPECT_THROW(
-      schema_translator.add_data(value{std::move(too_little_data)}),
+      schema_translator.add_data(std::move(*too_little_data)),
       std::invalid_argument);
 }
 
@@ -151,10 +142,10 @@ TEST_P(RequiredFieldTest, DoRequiredFieldTest) {
 
     if (params.should_fail) {
         EXPECT_THROW(
-          schema_translator.add_data(value{std::move(missing_field)}),
+          schema_translator.add_data(std::move(*missing_field)),
           std::invalid_argument);
     } else {
-        schema_translator.add_data(value{std::move(missing_field)});
+        schema_translator.add_data(std::move(*missing_field));
     }
 }
 

--- a/src/v/datalake/tests/batching_parquet_writer_test.cc
+++ b/src/v/datalake/tests/batching_parquet_writer_test.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/batching_parquet_writer.h"
+#include "datalake/tests/test_data.h"
+#include "iceberg/tests/value_generator.h"
+
+#include <arrow/io/file.h>
+#include <arrow/table.h>
+#include <gtest/gtest.h>
+#include <parquet/arrow/reader.h>
+#include "test_utils/tmp_dir.h"
+
+TEST(BatchingParquetWriterTest, WritesParquetFiles) {
+    temporary_dir tmp_dir("batching_parquet_writer");
+    std::filesystem::path file_path = tmp_dir.get_path() / "test_file.parquet";
+    int num_rows = 1000;
+
+    datalake::batching_parquet_writer writer(
+      test_schema(iceberg::field_required::no), 500, 1000000);
+
+    writer.initialize(file_path).get0();
+
+    for (int i = 0; i < num_rows; i++) {
+        auto data = iceberg::tests::make_value(
+          iceberg::tests::value_spec{
+            .forced_fixed_val = iobuf::from("Hello world")},
+          test_schema(iceberg::field_required::no));
+        writer.add_data_struct(std::move(data), 1000).get0();
+    }
+
+    writer.finish().get0();
+
+    // Read the file and check the contents
+    auto reader = arrow::io::ReadableFile::Open(file_path).ValueUnsafe();
+
+    // Open Parquet file reader
+    std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+    ASSERT_TRUE(parquet::arrow::OpenFile(
+                  reader, arrow::default_memory_pool(), &arrow_reader)
+                  .ok());
+
+    // Read entire file as a single Arrow table
+    std::shared_ptr<arrow::Table> table;
+    auto r = arrow_reader->ReadTable(&table);
+    ASSERT_TRUE(r.ok());
+
+    EXPECT_EQ(table->num_rows(), num_rows);
+    EXPECT_EQ(table->num_columns(), 17);
+}

--- a/src/v/datalake/tests/batching_parquet_writer_test.cc
+++ b/src/v/datalake/tests/batching_parquet_writer_test.cc
@@ -10,12 +10,12 @@
 #include "datalake/batching_parquet_writer.h"
 #include "datalake/tests/test_data.h"
 #include "iceberg/tests/value_generator.h"
+#include "test_utils/tmp_dir.h"
 
 #include <arrow/io/file.h>
 #include <arrow/table.h>
 #include <gtest/gtest.h>
 #include <parquet/arrow/reader.h>
-#include "test_utils/tmp_dir.h"
 
 TEST(BatchingParquetWriterTest, WritesParquetFiles) {
     temporary_dir tmp_dir("batching_parquet_writer");

--- a/src/v/datalake/tests/batching_parquet_writer_test.cc
+++ b/src/v/datalake/tests/batching_parquet_writer_test.cc
@@ -10,6 +10,7 @@
 #include "datalake/batching_parquet_writer.h"
 #include "datalake/tests/test_data.h"
 #include "iceberg/tests/value_generator.h"
+#include "iceberg/values.h"
 #include "test_utils/tmp_dir.h"
 
 #include <arrow/io/file.h>
@@ -28,7 +29,7 @@ TEST(BatchingParquetWriterTest, WritesParquetFiles) {
     writer.initialize(file_path).get0();
 
     for (int i = 0; i < num_rows; i++) {
-        auto data = iceberg::tests::make_value(
+        auto data = iceberg::tests::make_struct_value(
           iceberg::tests::value_spec{
             .forced_fixed_val = iobuf::from("Hello world")},
           test_schema(iceberg::field_required::no));

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -37,7 +37,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1);
-    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
+    EXPECT_EQ(result.value()[0].record_count, record_count * batch_count);
 }
 TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     int record_count = 10;
@@ -59,5 +59,6 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
       });
     auto res = reader.consume(std::move(multiplexer), model::no_timeout).get0();
     ASSERT_TRUE(res.has_error());
-    EXPECT_EQ(res.error(), datalake::data_writer_error::uh_oh);
+    EXPECT_EQ(
+      res.error(), datalake::data_writer_error::parquet_conversion_error);
 }

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -16,8 +16,8 @@
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     int record_count = 10;
     int batch_count = 10;
-    auto writer_factory
-      = std::make_unique<datalake::test_data_writer_factory>();
+    auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
+      false);
     datalake::record_multiplexer multiplexer(std::move(writer_factory));
 
     model::test::record_batch_spec batch_spec;
@@ -35,6 +35,29 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     auto result
       = reader.consume(std::move(multiplexer), model::no_timeout).get0();
 
-    ASSERT_EQ(result.size(), 1);
-    EXPECT_EQ(result[0].row_count, record_count * batch_count);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 1);
+    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
+}
+TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
+    int record_count = 10;
+    int batch_count = 10;
+    auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
+      true);
+    datalake::record_multiplexer multiplexer(std::move(writer_factory));
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    ss::circular_buffer<model::record_batch> batches
+      = model::test::make_random_batches(batch_spec).get0();
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+    auto res = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+    ASSERT_TRUE(res.has_error());
+    EXPECT_EQ(res.error(), datalake::data_writer_error::uh_oh);
 }

--- a/src/v/datalake/tests/parquet_writer_test.cc
+++ b/src/v/datalake/tests/parquet_writer_test.cc
@@ -41,7 +41,7 @@ TEST(ParquetWriter, CreatesValidParquetData) {
     std::shared_ptr<arrow::Array> result = translator.take_chunk();
     ASSERT_NE(result, nullptr);
 
-    datalake::arrow_to_iobuf writer(*translator.build_arrow_schema());
+    datalake::arrow_to_iobuf writer(translator.build_arrow_schema());
 
     for (int i = 0; i < 10; i++) {
         writer.add_arrow_array(result);

--- a/src/v/datalake/tests/parquet_writer_test.cc
+++ b/src/v/datalake/tests/parquet_writer_test.cc
@@ -31,7 +31,7 @@ TEST(ParquetWriter, CreatesValidParquetData) {
     iobuf full_result;
 
     for (int i = 0; i < 5; i++) {
-        auto data = iceberg::tests::make_value(
+        auto data = iceberg::tests::make_struct_value(
           iceberg::tests::value_spec{
             .forced_fixed_val = iobuf::from("Hello world")},
           test_schema(iceberg::field_required::no));

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -29,14 +29,17 @@ public:
 
     ss::future<data_writer_error> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */) override {
-        _result.row_count++;
-        data_writer_error status = _return_error ? data_writer_error::uh_oh
-                                                 : data_writer_error::ok;
+        _result.record_count++;
+        data_writer_error status
+          = _return_error ? data_writer_error::parquet_conversion_error
+                          : data_writer_error::ok;
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<data_writer_result> finish() override {
-        return ss::make_ready_future<data_writer_result>(_result);
+    ss::future<result<data_writer_result, data_writer_error>>
+    finish() override {
+        return ss::make_ready_future<
+          result<data_writer_result, data_writer_error>>(_result);
     }
 
 private:

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -13,6 +13,7 @@
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include <cstdint>
@@ -25,13 +26,15 @@ public:
       : _schema(std::move(schema))
       , _result{} {}
 
-    bool add_data_struct(
+    ss::future<bool> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */) override {
         _result.row_count++;
-        return false;
+        return ss::make_ready_future<bool>(false);
     }
 
-    data_writer_result finish() override { return _result; }
+    ss::future<data_writer_result> finish() override {
+        return ss::make_ready_future<data_writer_result>(_result);
+    }
 
 private:
     iceberg::struct_type _schema;

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -180,4 +180,10 @@ value make_value(const value_spec& spec, const field_type& type) {
     return std::visit(generating_value_visitor{spec}, type);
 }
 
+struct_value make_struct_value(const value_spec& spec, const field_type& type) {
+    auto val = std::visit(generating_value_visitor{spec}, type);
+
+    return std::move(*std::get<std::unique_ptr<struct_value>>(val));
+}
+
 } // namespace iceberg::tests

--- a/src/v/iceberg/tests/value_generator.h
+++ b/src/v/iceberg/tests/value_generator.h
@@ -38,5 +38,6 @@ struct value_spec {
 
 // Creates an Iceberg value in accordance to the provided specification.
 value make_value(const value_spec&, const field_type&);
+struct_value make_struct_value(const value_spec&, const field_type&);
 
 } // namespace iceberg::tests


### PR DESCRIPTION
    The batching_parquet_writer is a high-level interface that ties
    together all the low-level components for writing Parquet files from
    iceberg::value. It
    1. Opens a ss::file to store the results
    2. Accepts iceberg::value and collects them in an arrow_translator
    3. Once the row count or size threshold is reached it writes data to
       the file:
       1. takes a chunk from the arrow_translator
       2. Adds the chunk to the parquet_writer
       3. Extracts iobufs from the parquet_writer
       4. Writes them to the open file
    4. When finish() is called it flushes all remaining data and closes
    the files.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* None