### PR TITLE
config: add experimental feature properties

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -106,6 +106,7 @@ public:
     virtual void set_value(std::any) = 0;
     virtual void reset() = 0;
     virtual bool is_default() const = 0;
+    virtual bool is_hidden() const = 0;
 
     /**
      * Helper for logging string-ized values of a property, e.g.

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -140,7 +140,7 @@ public:
         w.StartObject();
 
         for (const auto& [name, property] : _properties) {
-            if (property->get_visibility() == visibility::deprecated) {
+            if (property->is_hidden()) {
                 continue;
             }
 
@@ -173,7 +173,7 @@ public:
         w.StartObject();
 
         for (const auto& [name, property] : _properties) {
-            if (property->get_visibility() == visibility::deprecated) {
+            if (property->is_hidden()) {
                 continue;
             }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3353,16 +3353,16 @@ configuration::configuration()
        tls_version::v1_1,
        tls_version::v1_2,
        tls_version::v1_3})
-  , experimental_feature_property_testing_only(
+  , development_feature_property_testing_only(
       *this,
-      "experimental_feature_property_testing_only",
-      "Experimental feature property for testing only.",
+      "development_feature_property_testing_only",
+      "Development feature property for testing only.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
-  , enable_experimental_unrecoverable_data_corrupting_features(
+  , enable_developmental_unrecoverable_data_corrupting_features(
       *this,
-      "enable_experimental_unrecoverable_data_corrupting_features",
-      "Experimental features should never be enabled in a production cluster, "
+      "enable_developmental_unrecoverable_data_corrupting_features",
+      "Development features should never be enabled in a production cluster, "
       "or any cluster where stability, data loss, or the ability to upgrade "
       "are a concern. To enable experimental features, set the value of this "
       "configuration option to the current unix epoch expressed in seconds. "
@@ -3371,9 +3371,9 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       "",
       [this](const ss::sstring& v) -> std::optional<ss::sstring> {
-          if (experimental_features_enabled()) {
+          if (development_features_enabled()) {
               return fmt::format(
-                "Experimental feature flag cannot be changed once enabled.");
+                "Development feature flag cannot be changed once enabled.");
           }
 
           const auto time_since_epoch

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3353,6 +3353,12 @@ configuration::configuration()
        tls_version::v1_1,
        tls_version::v1_2,
        tls_version::v1_3})
+  , experimental_feature_property_testing_only(
+      *this,
+      "experimental_feature_property_testing_only",
+      "Experimental feature property for testing only.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , enable_experimental_unrecoverable_data_corrupting_features(
       *this,
       "enable_experimental_unrecoverable_data_corrupting_features",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3352,7 +3352,44 @@ configuration::configuration()
       {tls_version::v1_0,
        tls_version::v1_1,
        tls_version::v1_2,
-       tls_version::v1_3}) {}
+       tls_version::v1_3})
+  , enable_experimental_unrecoverable_data_corrupting_features(
+      *this,
+      "enable_experimental_unrecoverable_data_corrupting_features",
+      "Experimental features should never be enabled in a production cluster, "
+      "or any cluster where stability, data loss, or the ability to upgrade "
+      "are a concern. To enable experimental features, set the value of this "
+      "configuration option to the current unix epoch expressed in seconds. "
+      "The value must be within one hour of the current time on the broker."
+      "Once experimental features are enabled they cannot be disabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      "",
+      [this](const ss::sstring& v) -> std::optional<ss::sstring> {
+          if (experimental_features_enabled()) {
+              return fmt::format(
+                "Experimental feature flag cannot be changed once enabled.");
+          }
+
+          const auto time_since_epoch
+            = std::chrono::system_clock::now().time_since_epoch();
+
+          try {
+              const auto key = std::chrono::seconds(
+                boost::lexical_cast<int64_t>(v));
+
+              const auto dur = std::chrono::abs(time_since_epoch - key);
+              if (dur > std::chrono::hours(1)) {
+                  return fmt::format(
+                    "Invalid key '{}'. Must be within 1 hour of the current "
+                    "unix epoch in seconds.",
+                    key.count());
+              }
+          } catch (const boost::bad_lexical_cast&) {
+              return fmt::format("Could not convert '{}' to integer", v);
+          }
+
+          return std::nullopt;
+      }) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -701,8 +701,15 @@ private:
     /*
      * This configuration property shouldn't be queried directly. Rather, it is
      * used to enable the use of other feature-specific experimental properties.
+     *
+     * This property is hidden when its value is the same as its default, which
+     * corresponds to the case in which experimental features are not enabled.
+     *
+     * In addition to this property thus being hidden in production scenarios,
+     * it also fixes several tests like rpk-import-export that expect to be able
+     * to set values for all properties that it discovers.
      */
-    property<ss::sstring>
+    hidden_when_default_property<ss::sstring>
       enable_experimental_unrecoverable_data_corrupting_features;
 
     bool experimental_features_enabled() const {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -38,6 +38,8 @@
 #include <chrono>
 #include <vector>
 
+class monitor_unsafe;
+
 namespace config {
 
 /// Redpanda configuration
@@ -627,6 +629,10 @@ struct configuration final : public config_store {
     error_map_t load(const YAML::Node& root_node);
 
 private:
+    // to query if experimental features are enabled in order to log a nag. it
+    // does not use the query to control any experimental feature.
+    friend class ::monitor_unsafe;
+
     /*
      * This configuration property shouldn't be queried directly. Rather, it is
      * used to enable the use of other feature-specific experimental properties.

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -60,6 +60,10 @@ struct configuration;
  *
  * The simplest way to circumvent this is to enable support in one request,
  * and then proceed to interact with experiemntal feature properties.
+ *
+ * Experimental properties are hidden from the outside world until experimental
+ * property support is enabled, at which point the visibility of the property is
+ * identical to the wrapped property.
  */
 template<typename T>
 class experimental_feature_property : public property<T> {
@@ -85,11 +89,20 @@ public:
               }
               return "Experimental feature support is not enabled.";
           })
+      , _conf(conf)
 
     {}
 
+    bool is_hidden() const override {
+        if (experimental_features_enabled(_conf)) {
+            return property<T>::is_hidden();
+        }
+        return true;
+    }
+
 private:
     static bool experimental_features_enabled(const configuration&);
+    configuration& _conf;
 };
 
 struct configuration final : public config_store {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -625,6 +625,19 @@ struct configuration final : public config_store {
     configuration();
 
     error_map_t load(const YAML::Node& root_node);
+
+private:
+    /*
+     * This configuration property shouldn't be queried directly. Rather, it is
+     * used to enable the use of other feature-specific experimental properties.
+     */
+    property<ss::sstring>
+      enable_experimental_unrecoverable_data_corrupting_features;
+
+    bool experimental_features_enabled() const {
+        return !enable_experimental_unrecoverable_data_corrupting_features()
+                  .empty();
+    }
 };
 
 configuration& shard_local_cfg();

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -936,4 +936,22 @@ private:
         }
     }
 };
+
+template<typename T>
+class hidden_when_default_property : public property<T> {
+public:
+    hidden_when_default_property(
+      config_store& conf,
+      std::string_view name,
+      std::string_view desc,
+      base_property::metadata meta,
+      T def,
+      property<T>::validator validator = property<T>::noop_validator)
+      : property<T>(conf, name, desc, meta, def, std::move(validator)) {}
+
+    bool is_hidden() const override {
+        return this->value() == this->default_value();
+    }
+};
+
 }; // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -127,6 +127,10 @@ public:
 
     bool is_default() const override { return _value == _default; }
 
+    bool is_hidden() const override {
+        return get_visibility() == visibility::deprecated;
+    }
+
     const T& operator()() { return value(); }
 
     const T& operator()() const { return value(); }

--- a/src/v/redpanda/admin/cluster_config_schema_util.cc
+++ b/src/v/redpanda/admin/cluster_config_schema_util.cc
@@ -24,7 +24,7 @@ util::generate_json_schema(const config::configuration& conf) {
     property_map properties;
 
     conf.for_each([&properties](const config::base_property& p) {
-        if (p.get_visibility() == config::visibility::deprecated) {
+        if (p.is_hidden()) {
             // Do not mention deprecated settings in schema: they
             // only exist internally to avoid making existing stored
             // configs invalid.

--- a/src/v/redpanda/monitor_unsafe.cc
+++ b/src/v/redpanda/monitor_unsafe.cc
@@ -63,6 +63,17 @@ void monitor_unsafe::invoke_unsafe_log_update(
     }
 }
 
+void monitor_unsafe::log_experimental_feature_warning() {
+    if (!config::shard_local_cfg().experimental_features_enabled()) {
+        return;
+    }
+
+    vlog(
+      clusterlog.warn,
+      "WARNING: experimental features have been enabled which may result in "
+      "instability, unrecoverable data loss, or the inability to upgrade.");
+}
+
 ss::future<> monitor_unsafe::maybe_log_unsafe_nag() {
     auto nag_check_retry
       = config::shard_local_cfg().legacy_unsafe_log_warning_interval_sec();
@@ -77,6 +88,8 @@ ss::future<> monitor_unsafe::maybe_log_unsafe_nag() {
           "rejected.  Try disabling 'legacy_permit_unsafe_log_operation'.  If "
           "you need assistance, please contact Redpanda support");
     }
+
+    log_experimental_feature_warning();
 
     try {
         co_await ss::sleep_abortable(nag_check_retry, _as);

--- a/src/v/redpanda/monitor_unsafe.cc
+++ b/src/v/redpanda/monitor_unsafe.cc
@@ -63,14 +63,14 @@ void monitor_unsafe::invoke_unsafe_log_update(
     }
 }
 
-void monitor_unsafe::log_experimental_feature_warning() {
-    if (!config::shard_local_cfg().experimental_features_enabled()) {
+void monitor_unsafe::log_development_feature_warning() {
+    if (!config::shard_local_cfg().development_features_enabled()) {
         return;
     }
 
     vlog(
       clusterlog.warn,
-      "WARNING: experimental features have been enabled which may result in "
+      "WARNING: development features have been enabled which may result in "
       "instability, unrecoverable data loss, or the inability to upgrade.");
 }
 
@@ -89,7 +89,7 @@ ss::future<> monitor_unsafe::maybe_log_unsafe_nag() {
           "you need assistance, please contact Redpanda support");
     }
 
-    log_experimental_feature_warning();
+    log_development_feature_warning();
 
     try {
         co_await ss::sleep_abortable(nag_check_retry, _as);

--- a/src/v/redpanda/monitor_unsafe.h
+++ b/src/v/redpanda/monitor_unsafe.h
@@ -32,7 +32,7 @@ public:
 
 private:
     void unsafe_log_update();
-    void log_experimental_feature_warning();
+    void log_development_feature_warning();
     ss::future<> maybe_log_unsafe_nag();
 
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/redpanda/monitor_unsafe.h
+++ b/src/v/redpanda/monitor_unsafe.h
@@ -32,6 +32,7 @@ public:
 
 private:
     void unsafe_log_update();
+    void log_experimental_feature_warning();
     ss::future<> maybe_log_unsafe_nag();
 
     ss::sharded<features::feature_table>& _feature_table;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3457,7 +3457,7 @@ class RedpandaService(RedpandaServiceBase):
                                       timeout,
                                       admin_client=admin_client)
 
-    def enable_experimental_feature_support(self, key=int(time.time())):
+    def enable_development_feature_support(self, key=int(time.time())):
         """
         Enable experimental feature support.
 
@@ -3466,7 +3466,7 @@ class RedpandaService(RedpandaServiceBase):
         """
         self.set_cluster_config(
             dict(
-                enable_experimental_unrecoverable_data_corrupting_features=key,
+                enable_developmental_unrecoverable_data_corrupting_features=key,
             ))
 
     def _wait_for_config_version(self,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3457,6 +3457,18 @@ class RedpandaService(RedpandaServiceBase):
                                       timeout,
                                       admin_client=admin_client)
 
+    def enable_experimental_feature_support(self, key=int(time.time())):
+        """
+        Enable experimental feature support.
+
+        The key must be equal to the current broker time expressed as unix epoch
+        in seconds, and be within 1 hour.
+        """
+        self.set_cluster_config(
+            dict(
+                enable_experimental_unrecoverable_data_corrupting_features=key,
+            ))
+
     def _wait_for_config_version(self,
                                  config_version,
                                  expect_restart: bool,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3457,13 +3457,14 @@ class RedpandaService(RedpandaServiceBase):
                                       timeout,
                                       admin_client=admin_client)
 
-    def enable_development_feature_support(self, key=int(time.time())):
+    def enable_development_feature_support(self, key: Optional[int] = None):
         """
         Enable experimental feature support.
 
         The key must be equal to the current broker time expressed as unix epoch
         in seconds, and be within 1 hour.
         """
+        key = int(time.time()) if key == None else key
         self.set_cluster_config(
             dict(
                 enable_developmental_unrecoverable_data_corrupting_features=key,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2290,6 +2290,7 @@ class ClusterEnableExperimentalFeaturesTest(RedpandaTest):
                 # controls freq of nag
                 legacy_unsafe_log_warning_interval_sec=5, ))
         self.admin = Admin(self.redpanda)
+        self._property_name = "experimental_feature_property_testing_only"
 
     def _enable(self):
         # key must be within 1 hour
@@ -2362,3 +2363,18 @@ class ClusterEnableExperimentalFeaturesTest(RedpandaTest):
                    timeout_sec=10,
                    backoff_sec=1.0,
                    err_msg=f"Expected to see experimental feature nag")
+
+    @cluster(num_nodes=3)
+    def test_experimental_property_visibility(self):
+        """
+        Test that a non-active experimental feature is hidden.
+        """
+        # experimental feature property is not visible
+        config = self.admin.get_cluster_config()
+        assert self._property_name not in config
+
+        self._enable()
+
+        # after enabling experimental features it is visible
+        config = self.admin.get_cluster_config()
+        assert self._property_name in config

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2306,3 +2306,19 @@ class ClusterEnableExperimentalFeaturesTest(RedpandaTest):
                 "enable_experimental_unrecoverable_data_corrupting_features"], f"{errors}"
         else:
             raise RuntimeError("Expected error")
+
+    @cluster(num_nodes=3)
+    def test_accept_valid_enable_key(self):
+        """
+        Test that a valid key enables experimental feature property.
+        """
+        # key must be within 1 hour
+        key = int(time.time() - 60)
+        patch_result = self.admin.patch_cluster_config(upsert=dict(
+            enable_experimental_unrecoverable_data_corrupting_features=key))
+        wait_for_version_sync(self.admin, self.redpanda,
+                              patch_result['config_version'])
+        config = self.admin.get_cluster_config()
+        value = config[
+            "enable_experimental_unrecoverable_data_corrupting_features"]
+        assert int(value) == key, f"{value} != {key}"

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2308,7 +2308,7 @@ class DevelopmentFeatureTest(RedpandaTest):
             assert f"Invalid key '{key}'. Must be within 1 hour" in errors[
                 "enable_developmental_unrecoverable_data_corrupting_features"], f"{errors}"
         else:
-            raise RuntimeError("Expected error")
+            assert False, "Expected error"
 
     @cluster(num_nodes=3)
     def test_accept_valid_enable_key(self):
@@ -2339,7 +2339,7 @@ class DevelopmentFeatureTest(RedpandaTest):
                 assert f"Development feature flag cannot be changed once enabled." in errors[
                     "enable_developmental_unrecoverable_data_corrupting_features"], f"{errors}"
             else:
-                raise RuntimeError("Expected error")
+                assert False, "Expected error"
 
     @cluster(num_nodes=3)
     def test_development_feature_nag(self):
@@ -2385,7 +2385,7 @@ class DevelopmentFeatureTest(RedpandaTest):
             assert f"Development feature support is not enabled." in errors[
                 self._property_name], f"{errors}"
         else:
-            raise RuntimeError("Expected error")
+            assert False, "Expected error"
 
         self.redpanda.enable_development_feature_support()
 


### PR DESCRIPTION
`:%s/experimental/development/g`

This PR adds a notion of _experimental feature property_ to the configuration system whose intent is to provide to Redpanda developers a capability that can help with managing feature development across releases.

Note that this work is intended for development only. It is not intended for managing access to beta features, or any feature that is visible in production. That will require input from product, and is a much bigger project.

The strategy proposed by this PR for managing experimental feature development is to use the configuration system to guard access to experimental features (e.g. blocking services from being enabled, etc...) the same way that we use configuration properties today to control features being enabled/disabled. To create an experimental feature property, use the following configuration property wrapper:

```cpp
// configuration.h
class configuration {
    ...
    experimental_feature_property<T> experimental_enable_feature;
};
``` 

Use this wrapper like you would any other `property<T>`. The entire configuration surface area of an experimental feature should be marked with this wrapper.

The wrapper is special though because it has some _default_ behaviors:

1. It isn't visible through external APIs
2. It cannot be read through external APIs
3. It cannot be set through external APIs

This default behavior is flipped when the system has support for experimental properties enabled. In order to enable experimental properties on the system, enable the following configuration option:

    enable_experimental_unrecoverable_data_corrupting_features

This property is a tunable, which means it doesn't show up in UIs by default, but it can be set. However, in order to prevent it from accidentally being set (e.g. copy-paste error, or just curiosity), it requires a special key.

The key is the current unix epoch time (seconds) on the broker, +/- 1 hour. So the following would enable support for experimental features:

```
now=$(date +%s)
rpk cluster config set enable_experimental_unrecoverable_data_corrupting_features $now
```

Once enabled, this configuration option cannot be disabled, acting like a taint and enabling a warning nag. Do not set this in any production setting. It would also be interesting to explore adding maybe the current cluster-id into the key for some extra safety.

*Early startup features*: because the configuration system doesn't understand dependencies between properties, its unreliable to both turn on support and set experimental feature properties at the same time (e.g. in bootstrap config). This can be fixed with a bit of effort, but the workaround for now in tests is just to turn on support, and then if required, restart the broker.

*Environment variable vs feature flag*: An alternative to `enable_experimental_unrecoverable_data_corrupting_features` would be to have a magic environment variable that we set in tests and in development. The current thinking is that such an environment flag may be cumbersome to work with in cloud tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

