### PR TITLE
rpk: topic describe --regex supports internal topics

### DIFF
--- a/src/go/rpk/pkg/cli/topic/utils.go
+++ b/src/go/rpk/pkg/cli/topic/utils.go
@@ -52,7 +52,7 @@ func parseKVs(in []string) (map[string]string, error) {
 
 func regexTopics(adm *kadm.Client, expressions []string) ([]string, error) {
 	// Now we list all topics to match against our expressions.
-	topics, err := adm.ListTopics(context.Background())
+	topics, err := adm.ListTopicsWithInternal(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("unable to list topics: %w", err)
 	}


### PR DESCRIPTION
With the `--regex` flag, rpk filters out internal topics, e.g. `__consumer_offsets`, but typically we want to see those topics too. With this PR, it no longer filers out internal topics. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
