### PR TITLE
tests/gtest_raft_rpunit: monitor_test_fixture to honour leadership changes

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -658,11 +658,13 @@ redpanda_cc_gtest(
     ],
     tags = ["exclusive"],
     deps = [
+        "//src/v/model",
         "//src/v/raft/tests:raft_fixture",
         "//src/v/raft/tests:stm_raft_fixture_gtest",
         "//src/v/test_utils:fixture",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
         "@seastar//:testing",
     ],
 )

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -19,6 +19,7 @@
 #include "model/timeout_clock.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/coordinated_recovery_throttle.h"
+#include "raft/errc.h"
 #include "raft/fwd.h"
 #include "raft/heartbeat_manager.h"
 #include "raft/recovery_memory_quota.h"
@@ -37,6 +38,7 @@
 #include <boost/range/irange.hpp>
 
 #include <ranges>
+#include <system_error>
 namespace raft {
 
 inline constexpr raft::group_id test_group(123);
@@ -495,6 +497,7 @@ public:
                 .then([&state] { return state.result; });
           });
     }
+
     template<typename Func>
     auto
     retry_with_leader(model::timeout_clock::time_point deadline, Func&& f) {
@@ -521,6 +524,24 @@ public:
     }
     void set_heartbeat_interval(std::chrono::milliseconds timeout) {
         _heartbeat_interval.update(std::move(timeout));
+    }
+
+protected:
+    class raft_not_leader_exception : std::exception {};
+
+    template<std::derived_from<raft_fixture> Subclass>
+    ss::future<> test_with_leader(
+      model::timeout_clock::duration timeout,
+      ss::future<> (Subclass::*method)(raft_node_instance& leader)) {
+        co_await retry_with_leader(
+          model::timeout_clock::now() + timeout,
+          [this, method](raft_node_instance& leader) {
+              return ((static_cast<Subclass*>(this)->*method)(leader))
+                .then([] { return errc::success; })
+                .handle_exception_type([](const raft_not_leader_exception&) {
+                    return errc::not_leader;
+                });
+          });
     }
 
 private:

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -7,19 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/fundamental.h"
 #include "raft/tests/raft_fixture.h"
-#include "raft/tests/raft_group_fixture.h"
 #include "test_utils/async.h"
 
-using namespace raft;
+#include <seastar/core/lowres_clock.hh>
 
-class monitor_test_fixture
-  : public raft_fixture
-  , public ::testing::WithParamInterface<std::tuple<bool, size_t>> {
-public:
-    static bool write_caching() { return std::get<0>(GetParam()); }
-    static size_t num_waiters() { return std::get<1>(GetParam()); }
-};
+using namespace raft;
 
 namespace {
 
@@ -49,75 +43,103 @@ auto populate_waiters(
     return ss::when_all_succeed(futures.begin(), futures.end());
 }
 
+class monitor_test_fixture
+  : public raft_fixture
+  , public ::testing::WithParamInterface<std::tuple<bool, size_t>> {
+public:
+    static bool write_caching() { return std::get<0>(GetParam()); }
+    static size_t num_waiters() { return std::get<1>(GetParam()); }
+
+    ss::future<> truncation_detection_test(raft_node_instance& leader) {
+        auto raft = leader.raft();
+        auto all = ::populate_waiters(raft, write_caching(), num_waiters());
+        co_await ss::sleep(500ms);
+        ASSERT_FALSE_CORO(all.available());
+
+        for (auto& [id, node] : nodes()) {
+            if (id == leader.get_vnode().id()) {
+                node->on_dispatch(
+                  [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
+            }
+        }
+
+        std::vector<ss::future<result<replicate_result>>> replicate_f;
+        replicate_f.reserve(num_waiters());
+        for (size_t i = 0; i < num_waiters(); i++) {
+            replicate_f.push_back(raft->replicate(
+              make_batches({{"k", "v"}}),
+              replicate_options{raft::consistency_level::quorum_ack}));
+        }
+        auto results = co_await ss::when_all(
+          replicate_f.begin(), replicate_f.end());
+        for (auto& r : results) {
+            auto res = r.get();
+            ASSERT_TRUE_CORO(res.has_error());
+            if (res.error() == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(res.error(), errc::replicated_entry_truncated);
+        }
+
+        co_await tests::cooperative_spin_wait_with_timeout(
+          2s, [&] { return all.available() && !all.failed(); });
+
+        auto result = all.get();
+        for (size_t i = 0; i < num_waiters(); i++) {
+            if (result.at(i) == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(result.at(i), errc::replicated_entry_truncated);
+        }
+    }
+    ss::future<> replication_monitor_wait_test(raft_node_instance& leader) {
+        auto raft = leader.raft();
+
+        auto all = ::populate_waiters(raft, write_caching(), num_waiters());
+        co_await ss::sleep(500ms);
+        ASSERT_FALSE_CORO(all.available());
+
+        for (size_t i = 0; i < num_waiters(); i++) {
+            auto result = co_await raft->replicate(
+              make_batches({{"k", "v"}}),
+              replicate_options{raft::consistency_level::quorum_ack});
+            if (result.has_error() && result.error() == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_TRUE_CORO(result.has_value()) << result.error();
+        }
+
+        co_await tests::cooperative_spin_wait_with_timeout(
+          2s, [&] { return all.available() && !all.failed(); });
+
+        auto result = all.get();
+        for (size_t i = 0; i < num_waiters(); i++) {
+            if (result.at(i) == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(result.at(i), errc::success);
+        }
+    }
+};
 } // namespace
 
 TEST_P_CORO(monitor_test_fixture, replication_monitor_wait) {
     co_await create_simple_group(5);
 
     co_await set_write_caching(write_caching());
-    auto leader = co_await wait_for_leader(10s);
-    auto raft = node(leader).raft();
 
-    auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(500ms);
-    ASSERT_FALSE_CORO(all.available());
-
-    for (size_t i = 0; i < num_waiters(); i++) {
-        auto result = co_await raft->replicate(
-          make_batches({{"k", "v"}}),
-          replicate_options{raft::consistency_level::quorum_ack});
-        ASSERT_TRUE_CORO(result.has_value()) << result.error();
-    }
-
-    co_await tests::cooperative_spin_wait_with_timeout(
-      2s, [&] { return all.available() && !all.failed(); });
-
-    auto result = all.get();
-    for (size_t i = 0; i < num_waiters(); i++) {
-        ASSERT_EQ_CORO(result.at(i), errc::success);
-    }
+    co_await test_with_leader(
+      60s, &monitor_test_fixture::replication_monitor_wait_test);
 }
 
 TEST_P_CORO(monitor_test_fixture, truncation_detection) {
     set_enable_longest_log_detection(false);
     co_await create_simple_group(3);
-    auto leader = co_await wait_for_leader(10s);
+
     co_await set_write_caching(write_caching());
 
-    auto raft = node(leader).raft();
-    auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(500ms);
-    ASSERT_FALSE_CORO(all.available());
-
-    for (auto& [id, node] : nodes()) {
-        if (id == leader) {
-            node->on_dispatch(
-              [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
-        }
-    }
-
-    std::vector<ss::future<result<replicate_result>>> replicate_f;
-    replicate_f.reserve(num_waiters());
-    for (size_t i = 0; i < num_waiters(); i++) {
-        replicate_f.push_back(raft->replicate(
-          make_batches({{"k", "v"}}),
-          replicate_options{raft::consistency_level::quorum_ack}));
-    }
-    auto results = co_await ss::when_all(
-      replicate_f.begin(), replicate_f.end());
-    for (auto& r : results) {
-        auto res = r.get();
-        ASSERT_TRUE_CORO(res.has_error());
-        ASSERT_EQ_CORO(res.error(), errc::replicated_entry_truncated);
-    }
-
-    co_await tests::cooperative_spin_wait_with_timeout(
-      2s, [&] { return all.available() && !all.failed(); });
-
-    auto result = all.get();
-    for (size_t i = 0; i < num_waiters(); i++) {
-        ASSERT_EQ_CORO(result.at(i), errc::replicated_entry_truncated);
-    }
+    co_await test_with_leader(
+      60s, &monitor_test_fixture::truncation_detection_test);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
1) added a utility function to raft_fixture to execute a testing coro in `retry_with_leader`
2) made both monitor_test_fixture tests use it

I failed to reproduce the original problem but from the logs it's clear leadership was lost.
https://redpandadata.atlassian.net/browse/CORE-7666
https://buildkite.com/redpanda/redpanda/builds/54755#01920b02-453f-449d-a6fa-ccfa717ca67d/6-82553

I added the facility to raft_fixture because I'm looking to reuse it in other tests.

he testing coro returns a `future<>`, so it has to indicate leadership problems via exception. That's for to use marcos like `ASSERT_NE_CORO`.

The testing coro has to be in a separate subclass. We could clone TEST_P_CORO macro to create a class with two coroutines: the inner one that may throw, and the outer one that calls `retry_with_leader` with the inner. But that would mean us maintaining both macros. A macro to create a fixture subclass for each test won't work because Gtest wants parameters-related code specifically in the very child subclass.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
