### PR TITLE
archival: use correct segment size in adjacent segment merger

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3231,13 +3231,10 @@ ss::future<bool> ntp_archiver::do_upload_remote(
 }
 
 size_t ntp_archiver::get_local_segment_size() const {
-    auto log_segment_size = config::shard_local_cfg().log_segment_size.value();
-    const auto& cfg = _parent.raft()->log_config();
-    if (cfg.has_overrides()) {
-        log_segment_size = cfg.get_overrides().segment_size.value_or(
-          log_segment_size);
-    }
-    return log_segment_size;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(
+      *_parent.raft()->log());
+
+    return disk_log.max_segment_size();
 }
 
 ss::future<bool>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -221,6 +221,8 @@ public:
     static ss::future<>
     remove_kvstore_state(const model::ntp&, storage::kvstore&);
 
+    size_t max_segment_size() const;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -352,7 +354,6 @@ private:
     size_t get_log_truncation_counter() const noexcept override;
 
 private:
-    size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size
     // configuration. This takes into consideration any segment size
     // overrides since the last time it was called.


### PR DESCRIPTION
Adjacent segment merger implemented its own logic for determining the segment size. Today, the logic is a bit more complex and also does min/max clamping of the segment size based on cluster configuration.

This commit changes adjacent segment merger to use the same logic as local storage does.

The problematic scenario was one in which cluster wide min-max values were set say to 1MiB-16MiB but the topic level property was set to 128MiB. Local storage would create 16MiB segments which are uploaded as-is by archival. Later, adjacent segment merger would merge them to try and reach the 128MiB target. This resulted in undesired write amplification.

Now, adjacent segment merger properly infers the local segment size so this scenario doesn't happen anymore.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
