### PR TITLE
`archival`: use `log_level_for_error()` for failed reupload candidates

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3041,8 +3041,12 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
               return std::make_pair(std::nullopt, std::nullopt);
           },
           [this](candidate_creation_error& error) -> ret_t {
-              vlog(
-                _rtclog.warn, "Failed to make reupload candidate: {}", error);
+              const auto log_level = log_level_for_error(error);
+              vlogl(
+                _rtclog,
+                log_level,
+                "Failed to make reupload candidate: {}",
+                error);
               return std::make_pair(std::nullopt, std::nullopt);
           });
     }


### PR DESCRIPTION
Instead of logging every possible `candidate_creation_error` at the `warn` level, use the existing `log_level_for_error()` function.

Relevant Slack thread: https://redpandadata.slack.com/archives/C02BDN76HUK/p1722881949600539

Backporting to `v24.1.x` and `v24.2.x`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
