### PR TITLE
bazel: test backfill for storage

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -9,6 +9,17 @@ redpanda_test_cc_library(
 )
 
 redpanda_test_cc_library(
+    name = "disk_log_builder_fixture",
+    hdrs = [
+        "disk_log_builder_fixture.h",
+    ],
+    include_prefix = "storage/tests",
+    deps = [
+        ":disk_log_builder",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "disk_log_builder",
     srcs = [
         "utils/disk_log_builder.cc",
@@ -201,5 +212,22 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "timequery_test",
+    timeout = "short",
+    srcs = [
+        "timequery_test.cc",
+    ],
+    deps = [
+        ":disk_log_builder_fixture",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
     ],
 )

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -302,3 +302,23 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "readers_cache_test",
+    timeout = "short",
+    srcs = [
+        "readers_cache_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/config",
+        "//src/v/features",
+        "//src/v/model",
+        "//src/v/storage",
+        "//src/v/storage:resources",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -231,3 +231,19 @@ redpanda_cc_btest(
         "@seastar",
     ],
 )
+
+redpanda_cc_btest(
+    name = "snapshot_test",
+    timeout = "short",
+    srcs = [
+        "snapshot_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:random",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -247,3 +247,23 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "record_batch_builder_test",
+    timeout = "short",
+    srcs = [
+        "record_batch_builder_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:btree",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -172,3 +172,17 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "backlog_controller_test",
+    timeout = "short",
+    srcs = [
+        "backlog_controller_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/storage",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -267,3 +267,17 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "scoped_file_tracker_test",
+    timeout = "short",
+    srcs = [
+        "scoped_file_tracker_test.cc",
+    ],
+    deps = [
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/container:btree",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -281,3 +281,24 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "segment_deduplication_test",
+    timeout = "short",
+    srcs = [
+        "segment_deduplication_test.cc",
+    ],
+    deps = [
+        ":disk_log_builder",
+        ":disk_log_builder_fixture",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/storage:chunk_cache",
+        "//src/v/storage:key_offset_map",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -156,3 +156,19 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "appender_chunk_manipulations_test",
+    timeout = "short",
+    srcs = [
+        "appender_chunk_manipulations.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/random:generators",
+        "//src/v/storage:segment_appender",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -186,3 +186,20 @@ redpanda_cc_btest(
         "@seastar",
     ],
 )
+
+redpanda_cc_btest(
+    name = "concat_segment_reader_test",
+    timeout = "short",
+    srcs = [
+        "concat_segment_reader_test.cc",
+    ],
+    deps = [
+        ":disk_log_builder",
+        "//src/v/bytes:iostream",
+        "//src/v/model/tests:random",
+        "//src/v/storage",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -1,6 +1,14 @@
 load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
+    name = "kvstore_fixture",
+    hdrs = [
+        "kvstore_fixture.h",
+    ],
+    include_prefix = "storage/tests",
+)
+
+redpanda_test_cc_library(
     name = "disk_log_builder",
     srcs = [
         "utils/disk_log_builder.cc",
@@ -127,5 +135,24 @@ redpanda_cc_gtest(
         "//src/v/storage:key_offset_map",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "kvstore_test",
+    timeout = "short",
+    srcs = [
+        "kvstore_test.cc",
+    ],
+    deps = [
+        ":kvstore_fixture",
+        "//src/v/bytes:random",
+        "//src/v/config",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/storage",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
     ],
 )

--- a/src/v/storage/tests/record_batch_builder_test.cc
+++ b/src/v/storage/tests/record_batch_builder_test.cc
@@ -115,10 +115,10 @@ SEASTAR_THREAD_TEST_CASE(serialize_deserialize_then_cmp) {
     const std::size_t total = random_generators::get_int(50, 100);
     std::vector<detail::sample_type> sample_data;
     sample_data.reserve(total);
-    for (auto i = 0; i < total; ++i) {
+    for (size_t i = 0; i < total; ++i) {
         absl::btree_map<ss::sstring, ss::sstring> kv_pairs;
         const std::size_t kv_total = random_generators::get_int(2, 10);
-        for (auto j = 0; j < kv_total; ++j) {
+        for (size_t j = 0; j < kv_total; ++j) {
             kv_pairs.emplace(
               random_generators::gen_alphanum_string(32),
               random_generators::gen_alphanum_string(32));

--- a/src/v/storage/tests/snapshot_test.cc
+++ b/src/v/storage/tests/snapshot_test.cc
@@ -73,9 +73,9 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
         // because for a test its too much to deal with i/o alignment, etc..
         int fd = ::open(mgr.snapshot_path().c_str(), O_WRONLY);
         BOOST_REQUIRE(fd > 0);
-        ::write(fd, &fd, sizeof(fd));
-        ::fsync(fd);
-        ::close(fd);
+        BOOST_REQUIRE(::write(fd, &fd, sizeof(fd)) > 0);
+        BOOST_REQUIRE(::fsync(fd) == 0);
+        BOOST_REQUIRE(::close(fd) == 0);
     }
 
     auto reader = mgr.open_snapshot().get0();
@@ -112,9 +112,9 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
         int fd = ::open(mgr.snapshot_path().c_str(), O_WRONLY);
         BOOST_REQUIRE(fd > 0);
         ::lseek(fd, storage::snapshot_header::ondisk_size, SEEK_SET);
-        ::write(fd, &fd, sizeof(fd));
-        ::fsync(fd);
-        ::close(fd);
+        BOOST_REQUIRE(::write(fd, &fd, sizeof(fd)) > 0);
+        BOOST_REQUIRE(::fsync(fd) == 0);
+        BOOST_REQUIRE(::close(fd) == 0);
     }
 
     auto reader = mgr.open_snapshot().get0();


### PR DESCRIPTION
bazel: test backfill for storage

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
