### PR TITLE
[v24.2.x] `archival`: use `log_level_for_error()` for failed reupload candidates

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -3044,8 +3044,12 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
               return std::make_pair(std::nullopt, std::nullopt);
           },
           [this](candidate_creation_error& error) -> ret_t {
-              vlog(
-                _rtclog.warn, "Failed to make reupload candidate: {}", error);
+              const auto log_level = log_level_for_error(error);
+              vlogl(
+                _rtclog,
+                log_level,
+                "Failed to make reupload candidate: {}",
+                error);
               return std::make_pair(std::nullopt, std::nullopt);
           });
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23407
