### PR TITLE
transform: fix narrowing integer conversion warning

### DIFF
--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -1018,16 +1018,18 @@ TEST_P(TransformRpcTest, TestTransformOffsetRPCs) {
 
     for (size_t i = 0; i < num_transforms; i++) {
         auto request_key = model::transform_offsets_key{};
-        request_key.id = model::transform_id{i};
+        request_key.id = model::transform_id{
+          static_cast<model::transform_id::type>(i)};
         request_key.output_topic = model::output_topic_index{0};
         set_errors_to_inject(random_generators::get_int(0, 2));
         for (size_t j = 0; j < num_src_partitions; j++) {
-            request_key.partition = model::partition_id{j};
+            request_key.partition = model::partition_id{
+              static_cast<model::partition_id::type>(j)};
             auto read_result = client()->offset_fetch(request_key).get();
             ASSERT_TRUE(!read_result.has_error());
             ASSERT_EQ(read_result.value(), std::nullopt);
             auto request_val = model::transform_offsets_value{
-              .offset = kafka::offset{j}};
+              .offset = kafka::offset{static_cast<kafka::offset::type>(j)}};
             auto coordinator = client()->find_coordinator(request_key).get();
             ASSERT_TRUE(coordinator.has_value());
             auto result = client()


### PR DESCRIPTION
transform: fix narrowing integer conversion warning

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
