### PR TITLE
iceberg: manifest file packing

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -182,6 +182,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "manifest_file_packer",
+    srcs = [
+        "manifest_file_packer.cc",
+    ],
+    hdrs = [
+        "manifest_file_packer.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":manifest_list",
+        "//src/v/container:fragmented_vector",
+    ],
+)
+
+redpanda_cc_library(
     name = "manifest_io",
     srcs = [
         "manifest_io.cc",

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -36,6 +36,7 @@ v_cc_library(
     manifest_entry_type.cc
     manifest_entry_values.cc
     manifest_io.cc
+    manifest_file_packer.cc
     manifest_list_avro.cc
     partition_key.cc
     partition_key_type.cc

--- a/src/v/iceberg/manifest_file_packer.cc
+++ b/src/v/iceberg/manifest_file_packer.cc
@@ -1,0 +1,68 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/manifest_file_packer.h"
+
+namespace iceberg {
+
+namespace {
+struct bin {
+    explicit bin(size_t target)
+      : target_weight(target)
+      , total_weight(0) {}
+    const size_t target_weight;
+    size_t total_weight;
+    chunked_vector<manifest_file> items;
+
+    bool can_add(const manifest_file& f) const {
+        if (total_weight == 0) {
+            return true;
+        }
+        return total_weight + f.manifest_length <= target_weight;
+    }
+
+    void add(manifest_file f) {
+        total_weight += f.manifest_length;
+        items.emplace_back(std::move(f));
+    }
+
+    // Resets this bin, returning the items.
+    chunked_vector<manifest_file> reset() {
+        total_weight = 0;
+        return std::exchange(items, {});
+    }
+};
+} // namespace
+
+chunked_vector<chunked_vector<manifest_file>> manifest_packer::pack(
+  size_t target_size_bytes, chunked_vector<manifest_file> files) {
+    // Since we want to begin our packing from the back of the list, reverse
+    // the list.
+    std::reverse(files.begin(), files.end());
+    bin bin{target_size_bytes};
+    chunked_vector<chunked_vector<manifest_file>> binned_files;
+    for (auto& f : files) {
+        if (!bin.can_add(f)) {
+            binned_files.emplace_back(bin.reset());
+        }
+        bin.add(std::move(f));
+    }
+    if (bin.items.size()) {
+        binned_files.emplace_back(bin.reset());
+    }
+    // Since our input has been reversed, return the resulting bins to their
+    // original order by reversing files in each  bin and then reversing the
+    // order of the bins.
+    for (auto& bin : binned_files) {
+        std::reverse(bin.begin(), bin.end());
+    }
+    std::reverse(binned_files.begin(), binned_files.end());
+    return binned_files;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/manifest_file_packer.h
+++ b/src/v/iceberg/manifest_file_packer.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "iceberg/manifest_list.h"
+
+namespace iceberg {
+
+class manifest_packer {
+public:
+    using bin_t = chunked_vector<manifest_file>;
+    // Simple bin-packer for manifest files. Bins are packed back to front.
+    // This means that for a list of files that is repeatedly prepended to and
+    // packed, the resulting front bin will be well below the target size.
+    //
+    // This is a useful property, e.g. to opt out of merging the files in the
+    // front bin when it is too small, to let more manifest files be prepended.
+    static chunked_vector<bin_t>
+    pack(size_t target_size_bytes, chunked_vector<manifest_file> files);
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -79,6 +79,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "manifest_file_packer_test",
+    timeout = "short",
+    srcs = [
+        "manifest_file_packer_test.cc",
+    ],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/iceberg:manifest_file_packer",
+        "//src/v/iceberg:manifest_list",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "manifest_io_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ rp_test(
     datatypes_json_test.cc
     datatypes_test.cc
     manifest_entry_type_test.cc
+    manifest_file_packer_test.cc
     manifest_io_test.cc
     manifest_serialization_test.cc
     partition_key_test.cc

--- a/src/v/iceberg/tests/manifest_file_packer_test.cc
+++ b/src/v/iceberg/tests/manifest_file_packer_test.cc
@@ -1,0 +1,171 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "container/fragmented_vector.h"
+#include "iceberg/manifest_file_packer.h"
+#include "iceberg/manifest_list.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <vector>
+
+using namespace iceberg;
+
+namespace {
+
+manifest_file make_file(size_t size_bytes) {
+    return manifest_file{
+      .manifest_path = "dummy",
+      .manifest_length = size_bytes,
+    };
+}
+
+chunked_vector<manifest_file> make_files(const std::vector<size_t>& sizes) {
+    chunked_vector<manifest_file> ret;
+    std::ranges::transform(sizes, std::back_inserter(ret), make_file);
+    return ret;
+}
+
+chunked_vector<manifest_packer::bin_t>
+make_bins(const std::vector<std::vector<size_t>>& bin_sizes) {
+    chunked_vector<chunked_vector<manifest_file>> ret;
+    std::ranges::transform(bin_sizes, std::back_inserter(ret), make_files);
+    return ret;
+}
+
+ss::sstring to_string(const chunked_vector<manifest_packer::bin_t>& bins) {
+    std::ostringstream o;
+    o << "{";
+    for (const auto& bin : bins) {
+        o << "{";
+        for (const auto& f : bin) {
+            o << fmt::format("{} ", f.manifest_length);
+        }
+        o << "}";
+    }
+    o << "}";
+    return o.str();
+}
+
+} // namespace
+
+TEST(ManifestPackerTest, TestEmptyInputs) {
+    for (auto target_sz : {0, 100}) {
+        auto input = make_files({});
+        auto bins = manifest_packer::pack(target_sz, std::move(input));
+        ASSERT_EQ(0, bins.size());
+    }
+}
+
+// Targeted test demonstrating that bins are packed from the back to front.
+TEST(ManifestPackerTest, TestPackBackToFront) {
+    auto input = make_files({10, 10, 10, 10, 90, 100, 100, 100});
+    auto bins = manifest_packer::pack(100, std::move(input));
+    auto expected = make_bins({{10, 10, 10}, {10, 90}, {100}, {100}, {100}});
+    ASSERT_EQ(bins, expected)
+      << fmt::format("{} vs expected {}", to_string(bins), to_string(expected));
+}
+
+// Small files towards the back won't be packed if they don't fit.
+TEST(ManifestPackerTest, TestPackSmallBackDoesntFit) {
+    auto input = make_files({10, 10, 10, 10, 90, 100, 100, 10});
+    auto bins = manifest_packer::pack(100, std::move(input));
+    auto expected = make_bins({{10, 10, 10}, {10, 90}, {100}, {100}, {10}});
+    ASSERT_EQ(bins, expected)
+      << fmt::format("{} vs expected {}", to_string(bins), to_string(expected));
+}
+
+// Small files towards the back can still be packed if they fit.
+TEST(ManifestPackerTest, TestPackSmallBackFits) {
+    auto input = make_files({10, 10, 10, 10, 90, 100, 90, 10});
+    auto bins = manifest_packer::pack(100, std::move(input));
+    auto expected = make_bins({{10, 10, 10}, {10, 90}, {100}, {90, 10}});
+    ASSERT_EQ(bins, expected)
+      << fmt::format("{} vs expected {}", to_string(bins), to_string(expected));
+}
+
+struct expectation_params {
+    size_t target;
+    std::vector<std::vector<size_t>> expected;
+};
+
+class ManifestPackerParamTest
+  : public ::testing::TestWithParam<expectation_params> {};
+
+TEST_P(ManifestPackerParamTest, TestInputs) {
+    auto params = GetParam();
+    const auto expected = make_bins(params.expected);
+    auto input = make_files({1, 2, 3, 4, 5});
+    auto bins = manifest_packer::pack(params.target, std::move(input));
+    ASSERT_EQ(bins, expected)
+      << fmt::format("{} vs expected {}", to_string(bins), to_string(expected));
+}
+
+// Test cases taken from:
+// https://github.com/apache/iceberg-python/blob/b8b2f66be8c74b6567577b16a70c573fdd31ec56/tests/utils/test_bin_packing.py#L97
+INSTANTIATE_TEST_SUITE_P(
+  Expectations,
+  ManifestPackerParamTest,
+  ::testing::Values(
+    expectation_params{
+      .target = 3,
+      .expected = {{1, 2}, {3}, {4}, {5}},
+    },
+    expectation_params{
+      .target = 4,
+      .expected = {{1, 2}, {3}, {4}, {5}},
+    },
+    expectation_params{
+      .target = 5,
+      .expected = {{1}, {2, 3}, {4}, {5}},
+    },
+    expectation_params{
+      .target = 6,
+      .expected = {{1, 2, 3}, {4}, {5}},
+    },
+    expectation_params{
+      .target = 7,
+      .expected = {{1, 2}, {3, 4}, {5}},
+    },
+    expectation_params{
+      .target = 8,
+      .expected = {{1, 2}, {3, 4}, {5}},
+    },
+    expectation_params{
+      .target = 9,
+      .expected = {{1, 2, 3}, {4, 5}},
+    },
+    expectation_params{
+      .target = 10,
+      .expected = {{1, 2, 3}, {4, 5}},
+    },
+    expectation_params{
+      .target = 11,
+      .expected = {{1, 2, 3}, {4, 5}},
+    },
+    expectation_params{
+      .target = 12,
+      .expected = {{1, 2}, {3, 4, 5}},
+    },
+    expectation_params{
+      .target = 13,
+      .expected = {{1, 2}, {3, 4, 5}},
+    },
+    expectation_params{
+      .target = 14,
+      .expected = {{1}, {2, 3, 4, 5}},
+    },
+    expectation_params{
+      .target = 15,
+      .expected = {{1, 2, 3, 4, 5}},
+    }),
+  [](const testing::TestParamInfo<expectation_params>& info) {
+      return fmt::format("{}_target_size_{}", info.index, info.param.target);
+  });


### PR DESCRIPTION
Iceberg has two modes for appending data:
- Fast append: new files are always added to a brand new manifest, and the new manifest is added to the manifest list.
- Merge append: manifests are bin-packed to a target size (e.g. 8MiB), and bins of manifests are merged to create larger manifests, thereby reducing the number of manifests in a given manifest list.

While fast appends are easier to implement, they are not scalable for a streaming system like Redpanda, especially while we don't have compaction. To limit the rate of metadata generated, Redpanda will merge append by default.

To that end, this introduces a simple bin packer for manifest files to group together manifests to a target size. The implementation is a simplified version of a more generic version in the Icberg python library (functionally it is the same though).

For reference, [here](https://github.com/apache/iceberg-python/blob/b8b2f66be8c74b6567577b16a70c573fdd31ec56/pyiceberg/utils/bin_packing.py) is the python implementation. Note, merge appends use pack_end, which is implemented in this PR.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
