### PR TITLE
gha: use oidc

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -12,6 +12,9 @@ env:
   ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
   MILESTONE_ARG: ${{ github.event.client_payload.slash_command.args.named.milestone }}
   TARGET_FULL_REPO: ${{ github.event.client_payload.slash_command.args.named.org }}/${{ github.event.client_payload.slash_command.args.named.repo }}
+permissions:
+  id-token: write
+  contents: read
 jobs:
   # assumptions:
   #   label "kind/backport" exists
@@ -25,14 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
@@ -69,14 +69,11 @@ jobs:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
       - uses: actions/checkout@v4
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -24,8 +24,7 @@ jobs:
       target_milestone: ${{ steps.get_backport_type.outputs.target_milestone }}
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -46,13 +45,13 @@ jobs:
         run: $SCRIPT_DIR/get_backport_type.sh
         shell: bash
       - name: Failed reaction
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v4
         if: failure()
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: "-1"
+          reactions: "-1"
       - name: Post Error
         if: failure()
         env:
@@ -69,8 +68,7 @@ jobs:
     env:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -160,20 +158,20 @@ jobs:
         run: $SCRIPT_DIR/create_pr.sh
         shell: bash
       - name: Add reaction
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: hooray
+          reactions: hooray
       - name: Failed reaction
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v4
         if: failure()
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: "-1"
+          reactions: "-1"
       - name: Post Error
         if: failure()
         env:

--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -1,3 +1,4 @@
+---
 name: backport-command
 on:
   repository_dispatch:
@@ -11,7 +12,6 @@ env:
   ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
   MILESTONE_ARG: ${{ github.event.client_payload.slash_command.args.named.milestone }}
   TARGET_FULL_REPO: ${{ github.event.client_payload.slash_command.args.named.org }}/${{ github.event.client_payload.slash_command.args.named.repo }}
-
 jobs:
   # assumptions:
   #   label "kind/backport" exists
@@ -26,21 +26,18 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
-
       - name: Get type of backport (issue or PR)
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -48,7 +45,6 @@ jobs:
         id: get_backport_type
         run: $SCRIPT_DIR/get_backport_type.sh
         shell: bash
-
       - name: Failed reaction
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
@@ -57,7 +53,6 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: "-1"
-
       - name: Post Error
         if: failure()
         env:
@@ -65,7 +60,6 @@ jobs:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         run: $SCRIPT_DIR/post_error.sh
         shell: bash
-
   # creates backport issue if commented on issue, or
   # creates backport PR if commented on PR
   # eg /backport v21.11.x
@@ -77,21 +71,18 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
-
       - name: Get user
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -101,13 +92,11 @@ jobs:
           echo "username=$username" >> $GITHUB_OUTPUT
           echo "repo=$TARGET_REPO" >> $GITHUB_OUTPUT
           echo "email=vbot@redpanda.com" >> $GITHUB_OUTPUT
-
       - name: Get assignees
         env:
           ASSIGNEES: ${{ toJson(github.event.client_payload.github.payload.issue.assignees) }}
         id: assignees
         run: echo "assignees=$(echo $ASSIGNEES | jq -r '.[].login' | paste -s -d ',' -)" >> $GITHUB_OUTPUT
-
       - name: Discover and create milestone
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -115,7 +104,6 @@ jobs:
         id: create_milestone
         run: $SCRIPT_DIR/create_milestone.sh
         shell: bash
-
       - name: Create issue
         if: needs.backport-type.outputs.commented_on == 'issue'
         env:
@@ -125,9 +113,8 @@ jobs:
           ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
           ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
         id: create_issue
-        run: $SCRIPT_DIR/create_issue.sh 
+        run: $SCRIPT_DIR/create_issue.sh
         shell: bash
-          
       - name: Get commits of PR
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
@@ -137,14 +124,12 @@ jobs:
         run: |
           backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
           echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
-
       - uses: actions/checkout@v4
         if: needs.backport-type.outputs.commented_on == 'pr'
         with:
           repository: ${{ steps.user.outputs.username }}/${{ steps.user.outputs.repo }}
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           path: ./fork
-
       - name: Backport commits and get details
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
@@ -159,7 +144,6 @@ jobs:
         id: pr_details
         run: $SCRIPT_DIR/pr_details.sh
         shell: bash
-
       - name: Create pull request
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
@@ -173,9 +157,8 @@ jobs:
           ORIG_PR_URL: ${{ github.event.client_payload.pull_request.html_url }}
           GIT_USER: ${{ steps.user.outputs.username }}
         id: create_pr
-        run: $SCRIPT_DIR/create_pr.sh 
+        run: $SCRIPT_DIR/create_pr.sh
         shell: bash
-
       - name: Add reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -183,7 +166,6 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray
-
       - name: Failed reaction
         uses: peter-evans/create-or-update-comment@v1
         if: failure()
@@ -192,7 +174,6 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: "-1"
-
       - name: Post Error
         if: failure()
         env:
@@ -200,7 +181,6 @@ jobs:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         run: $SCRIPT_DIR/post_error.sh
         shell: bash
-
       - name: Create Issue On Error
         if: failure()
         env:

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -10,9 +10,11 @@ env:
 jobs:
   backport-on-merge:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
@@ -23,14 +25,11 @@ jobs:
         if: success() && steps.findPr.outputs.number
         env:
           PR: ${{ steps.findPr.outputs.pr }}
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -1,24 +1,18 @@
+---
 # Invoke the backport bot whenever we merge into dev.
-
 name: backport-on-merge
-
 on:
   push:
-    branches:
-      - dev
-
+    branches: [dev]
 env:
   SCRIPT_DIR: "${{ github.workspace }}/.github/workflows/scripts/backport-command"
   PR_NUMBER: ${{ github.event.number }}
-
 jobs:
   backport-on-merge:
     runs-on: ubuntu-latest
-
     steps:
       - name: checkout
         uses: actions/checkout@v4
-
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -49,12 +49,12 @@ jobs:
           buildkite_pipeline: redpanda
           command: ${{ github.event.client_payload.slash_command.command }}
       - name: Success reaction
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reaction-type: hooray
+          reactions: hooray
       - name: Error response
         if: failure()
         uses: ./ghca/actions/slash-command-error

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -16,15 +16,15 @@ on:
 jobs:
   run-build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -1,8 +1,8 @@
+---
 name: BK slash-command
-
 on:
   repository_dispatch:
-    types: 
+    types:
       - cdt-command
       - ci-repeat-command
       - dt-command
@@ -23,7 +23,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
@@ -31,20 +30,17 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-
       - uses: actions/checkout@v4
-        with: 
-          repository: redpanda-data/sparse-checkout 
+        with:
+          repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           path: sparse-checkout
-
-      - uses: ./sparse-checkout 
+      - uses: ./sparse-checkout
         with:
           repository: redpanda-data/vtools
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           patterns: actions
-          path: ghca 
-
+          path: ghca
       - name: Buildkite slash command action
         uses: ./ghca/actions/buildkite-slash-commands
         with:
@@ -52,7 +48,6 @@ jobs:
           buildkite_org: redpanda
           buildkite_pipeline: redpanda
           command: ${{ github.event.client_payload.slash_command.command }}
-
       - name: Success reaction
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -60,7 +55,6 @@ jobs:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray
-
       - name: Error response
         if: failure()
         uses: ./ghca/actions/slash-command-error

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -1,12 +1,11 @@
+---
 name: check formatting
 on:
   release:
     types: [published]
-
 jobs:
   trigger-bump:
     runs-on: ubuntu-latest
-
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -14,7 +13,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
@@ -22,20 +20,17 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-
       - uses: actions/checkout@v4
-        with: 
-          repository: redpanda-data/sparse-checkout 
+        with:
+          repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           path: sparse-checkout
-
-      - uses: ./sparse-checkout 
+      - uses: ./sparse-checkout
         with:
           repository: redpanda-data/vtools
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           patterns: actions
-          path: ghca 
-
+          path: ghca
       - name: Trigger Versions Bump Buildkite Job
         uses: ./ghca/actions/buildkite-pipeline-trigger
         with:

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   trigger-bump:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -7,6 +7,9 @@ jobs:
   add_jira_comment:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,14 +22,11 @@ jobs:
         run: pip install -r ${SCRIPT_DIR}/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/jira

--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -5,6 +5,7 @@ on:
     types: [created]
 jobs:
   add_jira_comment:
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,7 +14,6 @@ jobs:
           python-version: '3.9'
           cache: 'pip'
       - name: install dependencies
-        if: ${{ !github.event.issue.pull_request }}
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
         run: pip install -r ${SCRIPT_DIR}/requirements.txt
@@ -32,7 +32,6 @@ jobs:
             ,sdlc/prod/github/jira
           parse-json-secrets: true
       - name: Add comment to JIRA Issue
-        if: ${{ !github.event.issue.pull_request }}
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
           JIRA_TOKEN: ${{ env.JIRA_TOKEN  }}

--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -1,44 +1,43 @@
+---
 name: Add comment to JIRA Issue
 on:
-    issue_comment:
-        types:
-            - created
-
+  issue_comment:
+    types: [created]
 jobs:
-    add_jira_comment:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                python-version: '3.9'
-                cache: 'pip'
-            - name: install dependencies
-              if: ${{ !github.event.issue.pull_request }}
-              env:
-                SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
-              run: pip install -r ${SCRIPT_DIR}/requirements.txt
-            - name: install pandoc
-              run: sudo apt-get update && sudo apt-get install -y pandoc
-            - name: configure aws credentials
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-                aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-                aws-region: us-west-2
-            - name: get secrets from aws sm
-              uses: aws-actions/aws-secretsmanager-get-secrets@v2
-              with:
-                secret-ids: |
-                  ,sdlc/prod/github/jira
-                parse-json-secrets: true
-            - name: Add comment to JIRA Issue
-              if: ${{ !github.event.issue.pull_request }}
-              env:
-                SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
-                JIRA_TOKEN: ${{ env.JIRA_TOKEN  }}
-                JIRA_USER: ${{ env.JIRA_USER  }}
-                ISSUE_URL: ${{ github.event.issue.html_url }}
-                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                ISSUE_COMMENT: ${{ github.event.comment.body }}
-              run: python ${SCRIPT_DIR}/jira_helper.py UPDATE_COMMENT --verbose -p CORE
+  add_jira_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: install dependencies
+        if: ${{ !github.event.issue.pull_request }}
+        env:
+          SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
+        run: pip install -r ${SCRIPT_DIR}/requirements.txt
+      - name: install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/jira
+          parse-json-secrets: true
+      - name: Add comment to JIRA Issue
+        if: ${{ !github.event.issue.pull_request }}
+        env:
+          SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
+          JIRA_TOKEN: ${{ env.JIRA_TOKEN  }}
+          JIRA_USER: ${{ env.JIRA_USER  }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_COMMENT: ${{ github.event.comment.body }}
+        run: python ${SCRIPT_DIR}/jira_helper.py UPDATE_COMMENT --verbose -p CORE

--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -1,3 +1,4 @@
+---
 name: Manage JIRA Issue
 on:
   issues:
@@ -9,8 +10,6 @@ on:
       - deleted
       - labeled
       - unlabeled
-
-
 jobs:
   manage_jira_issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   manage_jira_issue:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -25,14 +28,11 @@ jobs:
         run: pip install -r ${SCRIPT_DIR}/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/jira

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -1,9 +1,8 @@
+---
 name: Lint cpp
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - '**.h'
       - '**.cc'
@@ -19,20 +18,19 @@ on:
       - '**.cpp'
       - '**.proto'
       - '**.java'
-
 jobs:
   cpp:
     name: Lint files with clang-format
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Install Baselisk
-      run: |
-        mkdir -v -p $HOME/.local/bin
-        wget -O $HOME/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
-        chmod +x $HOME/.local/bin/bazel
-    - name: Run clang-format
-      run: |
-        bazel run //tools:clang_format
-        git diff --exit-code
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Baselisk
+        run: |
+          mkdir -v -p $HOME/.local/bin
+          wget -O $HOME/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+          chmod +x $HOME/.local/bin/bazel
+      - name: Run clang-format
+        run: |
+          bazel run //tools:clang_format
+          git diff --exit-code

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -9,6 +9,7 @@ on:
       - '**.cpp'
       - '**.proto'
       - '**.java'
+      - '.github/workflows/lint-cpp.yml'
     tags-ignore:
       - '**'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - '**.cpp'
       - '**.proto'
       - '**.java'
+      - '.github/workflows/lint-cpp.yml'
 jobs:
   cpp:
     name: Lint files with clang-format

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+          cache-dependency-path: src/go/rpk/go.mod
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -1,9 +1,8 @@
+---
 name: Lint golang
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - 'src/go/**'
     tags-ignore:
@@ -11,49 +10,41 @@ on:
   pull_request:
     paths:
       - 'src/go/**'
-
 jobs:
   go:
     name: Lint go files
     runs-on: ubuntu-latest
     steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup go
-      uses: actions/setup-go@v5
-      with:
-        go-version: stable
-
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: latest
-        args: --timeout 10m --verbose
-        working-directory: src/go/rpk/
-
-    - name: Install gofumpt
-      env:
-        GOFUMPT_VER: 0.5.0
-      run: |
-        mkdir -v -p "$HOME/.local/bin"
-        wget -O "$HOME/.local/bin/gofumpt" "https://github.com/mvdan/gofumpt/releases/download/v${GOFUMPT_VER}/gofumpt_v${GOFUMPT_VER}_linux_amd64"
-        chmod 0700 "$HOME/.local/bin/gofumpt"
-
-    - name: Run gofumpt
-      run: |
-        find src/go -type f  -not -name '*.connect.go' -not -name '*.pb.go' -not -name 'zz*' -name '*.go' | xargs -n1 "$HOME/.local/bin/gofumpt" -w -lang=1.20
-        git diff --exit-code
-
-    - name: go mod tidy (rpk)
-      working-directory: src/go/rpk
-      run: |
-        go mod tidy
-        git diff --exit-code -- go.mod go.sum
-
-    - name: Check goreleaser configuration file
-      uses: goreleaser/goreleaser-action@v5
-      with:
-        version: v1.24.0
-        args: check src/go/.goreleaser.yaml
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout 10m --verbose
+          working-directory: src/go/rpk/
+      - name: Install gofumpt
+        env:
+          GOFUMPT_VER: 0.5.0
+        run: |
+          mkdir -v -p "$HOME/.local/bin"
+          wget -O "$HOME/.local/bin/gofumpt" "https://github.com/mvdan/gofumpt/releases/download/v${GOFUMPT_VER}/gofumpt_v${GOFUMPT_VER}_linux_amd64"
+          chmod 0700 "$HOME/.local/bin/gofumpt"
+      - name: Run gofumpt
+        run: |
+          find src/go -type f  -not -name '*.connect.go' -not -name '*.pb.go' -not -name 'zz*' -name '*.go' | xargs -n1 "$HOME/.local/bin/gofumpt" -w -lang=1.20
+          git diff --exit-code
+      - name: go mod tidy (rpk)
+        working-directory: src/go/rpk
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+      - name: Check goreleaser configuration file
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: v1.24.0
+          args: check src/go/.goreleaser.yaml

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -5,11 +5,13 @@ on:
     branches: [dev]
     paths:
       - 'src/go/**'
+      - '.github/workflows/lint-golang.yml'
     tags-ignore:
       - '**'
   pull_request:
     paths:
       - 'src/go/**'
+      - '.github/workflows/lint-golang.yml'
 jobs:
   go:
     name: Lint go files

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,9 +1,8 @@
+---
 name: Lint python
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - '**.py'
     tags-ignore:
@@ -11,18 +10,14 @@ on:
   pull_request:
     paths:
       - '**.py'
-
 jobs:
   py:
     name: Lint python files
     runs-on: ubuntu-latest
     steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install yapf
-      run: pip install yapf==0.40.1
-
-    - name: Run yapf
-      run: find . -type f -name '*.py' | xargs -n8 yapf -d
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install yapf
+        run: pip install yapf==0.40.1
+      - name: Run yapf
+        run: find . -type f -name '*.py' | xargs -n8 yapf -d

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -5,11 +5,13 @@ on:
     branches: [dev]
     paths:
       - '**.py'
+      - '.github/workflows/lint-python.yml'
     tags-ignore:
       - '**'
   pull_request:
     paths:
       - '**.py'
+      - '.github/workflows/lint-python.yml'
 jobs:
   py:
     name: Lint python files

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -5,12 +5,14 @@ on:
     branches: [dev]
     paths:
       - '**.sh'
+      - '.github/workflows/lint-sh.yml'
     tags-ignore:
       - '**'
   pull_request:
     paths:
       - '**.sh'
       - tests/docker/ducktape-deps/tinygo-wasi-transforms
+      - '.github/workflows/lint-sh.yml'
 jobs:
   sh:
     name: Lint shell scripts

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -1,9 +1,8 @@
+---
 name: Lint sh
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - '**.sh'
     tags-ignore:
@@ -11,24 +10,20 @@ on:
   pull_request:
     paths:
       - '**.sh'
-      -  tests/docker/ducktape-deps/tinygo-wasi-transforms
-
+      - tests/docker/ducktape-deps/tinygo-wasi-transforms
 jobs:
   sh:
     name: Lint shell scripts
     runs-on: ubuntu-latest
     steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install shfmt
-      env:
-        SHFMT_VER: 3.6.0
-      run: |
-        mkdir -v -p "$HOME/.local/bin"
-        wget -O "$HOME/.local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/v${SHFMT_VER}/shfmt_v${SHFMT_VER}_linux_amd64"
-        chmod 0700 "$HOME/.local/bin/shfmt"
-
-    - name: Run shfmt
-      run: shfmt -i 2 -ci -s -d .
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install shfmt
+        env:
+          SHFMT_VER: 3.6.0
+        run: |
+          mkdir -v -p "$HOME/.local/bin"
+          wget -O "$HOME/.local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/v${SHFMT_VER}/shfmt_v${SHFMT_VER}_linux_amd64"
+          chmod 0700 "$HOME/.local/bin/shfmt"
+      - name: Run shfmt
+        run: shfmt -i 2 -ci -s -d .

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,18 @@
+---
+name: lint-yaml
+on:
+  push:
+    branches: [dev]
+    paths:
+      - '.yamllint'
+      - '.github/workflows/*.yml'
+  pull_request:
+    paths:
+      - '.yamllint'
+      - '.github/workflows/*.yml'
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yamllint -f github .yamllint .github/workflows/*.yml

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -1,9 +1,8 @@
+---
 name: Compile and check P models
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - 'tests/models/**'
     tags-ignore:
@@ -11,17 +10,16 @@ on:
   pull_request:
     paths:
       - 'tests/models/**'
-
 jobs:
   cpp:
     name: Compile and check P models
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Compile
-      working-directory: tests/models
-      run: ../../tools/p/p compile
-    - name: Check
-      working-directory: tests/models
-      run: ../../tools/p/p check -tc tcMultiPartitionProduce -t 10
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Compile
+        working-directory: tests/models
+        run: ../../tools/p/p compile
+      - name: Check
+        working-directory: tests/models
+        run: ../../tools/p/p check -tc tcMultiPartitionProduce -t 10

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -5,11 +5,13 @@ on:
     branches: [dev]
     paths:
       - 'tests/models/**'
+      - '.github/workflows/p.yml'
     tags-ignore:
       - '**'
   pull_request:
     paths:
       - 'tests/models/**'
+      - '.github/workflows/p.yml'
 jobs:
   cpp:
     name: Compile and check P models

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,9 +1,7 @@
-# https://github.com/actions/labeler
-
+---
 name: "Pull Request Labeler"
 on:
-- pull_request_target
-
+  - pull_request_target
 jobs:
   triage:
     permissions:
@@ -11,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,8 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - name: trigger redpanda promote pipeline
-        uses: "buildkite/trigger-pipeline-action@v2.0.0"
+      - uses: buildkite/trigger-pipeline-action@v2
         with:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   trigger-promote:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,8 +1,8 @@
+---
 name: promote
 on:
   release:
     types: [published]
-
 jobs:
   trigger-promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -1,10 +1,8 @@
+---
 name: Release rp-storage-tool
-
 on:
   push:
-    tags:
-      - 'v*'
-
+    tags: ['v*']
 jobs:
   release-rp-storage-tool:
     if: ${{ github.repository == 'redpanda-data/redpanda' || github.event_name == 'pull_request' }}

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 jobs:
   release-rp-storage-tool:
-    if: ${{ github.repository == 'redpanda-data/redpanda' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'redpanda-data/redpanda' }}
     name: Release - ${{ matrix.platform.release_for }}
     strategy:
       matrix:
@@ -17,14 +17,12 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: configure aws credentials
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: get secrets from aws sm
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
@@ -48,7 +46,6 @@ jobs:
           docker cp $id:/usr/local/bin/rp-storage-tool ./
           ./rp-storage-tool --help
       - name: Push to public bucket
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_RP_STORAGE_UPLOADER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_RP_STORAGE_UPLOADER_SECRET }}

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -15,21 +15,20 @@ jobs:
           - release_for: linux-arm64
             os: ubuntu-latest-2-arm64
     runs-on: ${{ matrix.platform.os }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/rp_storage_tool_uploader
           parse-json-secrets: true
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Build binary
         run: |
           export DOCKER_BUILDKIT=1

--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2022 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
@@ -6,7 +7,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
 name: Render PR Body Release Notes
 on:
   pull_request:

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -1,9 +1,8 @@
+---
 name: Lint & Test rp-storage-tool
-
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - 'tools/rp_storage_tool/**'
     tags-ignore:
@@ -11,7 +10,6 @@ on:
   pull_request:
     paths:
       - 'tools/rp_storage_tool/**'
-
 jobs:
   check:
     name: Compile check
@@ -30,21 +28,18 @@ jobs:
         with:
           command: check
           args: --manifest-path tools/rp_storage_tool/Cargo.toml
-
   test:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -5,11 +5,13 @@ on:
     branches: [dev]
     paths:
       - 'tools/rp_storage_tool/**'
+      - '.github/workflows/rp-storage-tool-checks.yml'
     tags-ignore:
       - '**'
   pull_request:
     paths:
       - 'tools/rp_storage_tool/**'
+      - '.github/workflows/rp-storage-tool-checks.yml'
 jobs:
   check:
     name: Compile check

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2020 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
@@ -6,12 +7,10 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
 name: rpk
 on:
   push:
-    branches:
-      - 'dev'
+    branches: [dev]
     paths:
       - 'src/go/rpk/**'
       - '.github/workflows/rpk-build.yml'
@@ -19,7 +18,6 @@ on:
     paths:
       - 'src/go/rpk/**'
       - '.github/workflows/rpk-build.yml'
-
 jobs:
   test:
     name: Test rpk
@@ -29,16 +27,13 @@ jobs:
         arch: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
           cache-dependency-path: 'src/go/rpk/go.sum'
-
       - name: Run tests
         working-directory: src/go/rpk/
         run: go run gotest.tools/gotestsum@v1.11.0 -- -cover ./...

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,3 +1,4 @@
+---
 name: Slash Command Dispatch
 on:
   issue_comment:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,8 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
-      - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v2
+      - uses: peter-evans/slash-command-dispatch@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           permission: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,24 +1,23 @@
+---
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
 # See all the configuration options here: https://github.com/actions/stale#all-options
 name: Mark stale issues
-
 on:
   schedule:
-  - cron: '32 6 * * 1-5'
-
+    - cron: '32 6 * * 1-5'
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 90 # 3 months
-        days-before-close: 14 # 2 weeks
-        stale-issue-message: "This issue hasn't seen activity in 3 months. If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
-        close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
-        stale-issue-label: 'stale'
-        exempt-issue-labels: 'preserve,remediation'
-        any-of-labels: 'kind/bug,ci-failure'
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90  # 3 months
+          days-before-close: 14  # 2 weeks
+          stale-issue-message: "This issue hasn't seen activity in 3 months. If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+          close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'preserve,remediation'
+          any-of-labels: 'kind/bug,ci-failure'

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2023 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
@@ -6,31 +7,24 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
 name: transform-sdk-build
 on:
   push:
-    tags:
-      - '*'
-    branches:
-      - '*'
+    tags: ['*']
+    branches: ['*']
     paths:
       - 'src/transform-sdk/**'
       - '.github/workflows/transform-sdk-build.yml'
   pull_request:
-    branches:
-      - dev
-      - 'v*'
+    branches: [dev, 'v*']
     paths:
       - 'src/transform-sdk/**'
       - '.github/workflows/transform-sdk-build.yml'
-
 env:
   RUST_VERSION: '1.80'
   GO_VERSION: '1.22'
   TINYGO_VERSION: 'v0.31.0-rpk2'
   BINARYEN_VERSION: '117'
-
 jobs:
   build-integration-tests:
     name: Build integration tests
@@ -51,7 +45,6 @@ jobs:
           name: wasm-integration-test
           path: src/transform-sdk/tests/wasm-integration-test
           retention-days: 1
-
   test-golang:
     name: Test Golang Transform SDK
     runs-on: ubuntu-latest
@@ -71,7 +64,6 @@ jobs:
           version: latest
           args: --timeout 5m
           working-directory: src/transform-sdk/go/transform
-
   integration-test-golang:
     name: Integration Test Golang Transform SDK
     needs: [test-golang, build-integration-tests]
@@ -110,7 +102,6 @@ jobs:
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
-
   test-rust:
     name: Test Rust Transform SDK
     runs-on: ubuntu-latest
@@ -131,7 +122,6 @@ jobs:
       - name: Run clippy
         working-directory: src/transform-sdk/rust
         run: cargo clippy --all
-
   integration-test-rust:
     name: Integration Test Rust Transform SDK
     needs: [test-rust, build-integration-tests]
@@ -168,7 +158,6 @@ jobs:
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
-
   test-cpp:
     name: Test C++ Transform SDK
     runs-on: ubuntu-latest
@@ -177,10 +166,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake
-
       - name: Run tests
         working-directory: src/transform-sdk/cpp
         env:
@@ -190,11 +177,9 @@ jobs:
           cmake -B build
           cmake --build build
           ctest --output-on-failure --test-dir build
-
       - name: Run clang-tidy
         working-directory: src/transform-sdk/cpp
         run: clang-tidy --quiet -p build/compile_commands.json src/transform_sdk.cc
-
   integration-test-cpp:
     name: Integration Test C++ Transform SDK
     needs: [test-cpp, build-integration-tests]
@@ -222,7 +207,6 @@ jobs:
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
-
   test-js:
     name: Test JS Transform SDK
     runs-on: ubuntu-latest
@@ -231,10 +215,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake git
-
       - name: Run tests
         working-directory: src/transform-sdk/js
         env:
@@ -244,11 +226,9 @@ jobs:
           cmake --preset debug
           cmake --build --preset debug
           ctest --output-on-failure --test-dir build/debug
-
       - name: Run clang-tidy
         working-directory: src/transform-sdk/js
         run: clang-tidy --quiet -p build/debug/compile_commands.json js_vm.cc js_vm_test.cc main.cc
-
   integration-test-js:
     name: Integration Test JS Transform SDK
     needs: [test-js, build-integration-tests]

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -11,7 +11,7 @@ name: transform-sdk-build
 on:
   push:
     tags: ['*']
-    branches: ['*']
+    branches: [dev, 'v*']
     paths:
       - 'src/transform-sdk/**'
       - '.github/workflows/transform-sdk-build.yml'

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Build integration tests
         working-directory: src/transform-sdk/tests
         run: go test -c -o ./wasm-integration-test
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Run tests
         working-directory: src/transform-sdk/go/transform
         run: go test -v ./...
@@ -68,6 +70,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Set up Tinygo
         working-directory: src/transform-sdk/go/transform
         run: |

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -30,10 +30,8 @@ jobs:
     name: Build integration tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Build integration tests
@@ -49,17 +47,14 @@ jobs:
     name: Test Golang Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run tests
         working-directory: src/transform-sdk/go/transform
         run: go test -v ./...
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout 5m
@@ -69,10 +64,8 @@ jobs:
     needs: [test-golang, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Set up Tinygo
@@ -106,8 +99,7 @@ jobs:
     name: Test Rust Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -127,8 +119,7 @@ jobs:
     needs: [test-rust, build-integration-tests]
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Rust
         run: |
           rustup update --no-self-update ${{ env.RUST_VERSION }}
@@ -164,8 +155,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake
       - name: Run tests
@@ -187,8 +177,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Build integration tests
         working-directory: src/transform-sdk/cpp/examples
         run: cmake -B build && cmake --build build
@@ -213,8 +202,7 @@ jobs:
     container:
       image: fedora:40
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Clang
         run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake git
       - name: Run tests
@@ -236,8 +224,7 @@ jobs:
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -1,3 +1,4 @@
+---
 # Copyright 2023 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
@@ -6,13 +7,10 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
 name: transform-sdk-release
 on:
   push:
-    tags:
-      - 'transform-sdk/*'
-
+    tags: ['transform-sdk/*']
 jobs:
   list-golang:
     name: List Golang Transform SDK
@@ -22,12 +20,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.22
-
       - name: Create golang specific tag
         id: gotag
         uses: actions/github-script@v7
@@ -46,33 +42,27 @@ jobs:
       - name: List module
         working-directory: src/transform-sdk/go
         # https://go.dev/doc/modules/publishing
-        run: 
-          go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{steps.gotag.outputs.result}}
-
+        run: go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{steps.gotag.outputs.result}}
   publish-rust:
     name: Publish Rust Transform SDK
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
-
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/cargo_registry_token
           parse-json-secrets: true
-
       - name: Publish
         working-directory: src/transform-sdk/rust
         run: |
@@ -80,7 +70,6 @@ jobs:
           ./scripts/publish.py --version ${{github.ref_name}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
-
   publish-javascript:
     name: Publish JavaScript Transform SDK
     runs-on: ubuntu-latest
@@ -90,24 +79,20 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-
       - name: Check out code
         uses: actions/checkout@v4
-
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/npm_token
           parse-json-secrets: true
-
       - name: Publish
         run: |
           VERSION=$(python -c "print('${{github.ref_name}}'.removeprefix('transform-sdk/v'), end='')")

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -18,10 +18,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.22
       - name: Create golang specific tag
@@ -47,8 +45,7 @@ jobs:
     name: Publish Rust Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
       - name: configure aws credentials
@@ -74,13 +71,11 @@ jobs:
     name: Publish JavaScript Transform SDK
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -45,18 +45,18 @@ jobs:
   publish-rust:
     name: Publish Rust Transform SDK
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
         run: rustup update stable --no-self-update && rustup default stable
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/cargo_registry_token
@@ -71,20 +71,20 @@ jobs:
   publish-javascript:
     name: Publish JavaScript Transform SDK
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/checkout@v4
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/npm_token

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22
+          cache-dependency-path: src/transform-sdk/go/transform/go.sum
       - name: Create golang specific tag
         id: gotag
         uses: actions/github-script@v7

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 900
+  indentation:
+    spaces: 2
+  truthy:
+    allowed-values: ['true', 'false', 'on']


### PR DESCRIPTION
jira: [PESDLC-1736]

update gha workflows to use [oidc](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) to retrieve secrets

also, cleanup and fixes along the way:
* fixed gha yaml indenting inconsistency so new lines are interpreted at the correct level; added `lint-yaml.yml` workflow to verify from now on
* updated actions to latest versions to incorporate bug fixes and address warning message: `The following actions uses node12 which is deprecated...`
* fixed `actions/setup-go` not finding `go.sum` for dependency caching
* eliminated duplicate PR check run in `transform-sdk-build` workflow
* fixed `release-rp-storage-tool` timeout waiting for arm runner

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none


[PESDLC-1736]: https://redpandadata.atlassian.net/browse/PESDLC-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ