### PR TITLE
[v24.1.x] Use `ss::socket_address` instead of `ss::sstring` for `client_address_t`

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1258,10 +1258,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
 
         plan.reserve_from_partition_count(octx.fetch_partition_count());
 
-        const auto client_address = fmt::format(
-          "{}:{}",
-          octx.rctx.connection()->client_host(),
-          octx.rctx.connection()->client_port());
+        const auto client_address = octx.rctx.connection()->local_address();
 
         /**
          * group fetch requests by shard

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -191,7 +191,7 @@ struct fetch_config {
           cfg.abort_source.has_value()
             ? cfg.abort_source.value().get().abort_requested()
             : false,
-          cfg.client_address.value_or(model::client_address_t{"unknown"}));
+          cfg.client_address.value_or(model::client_address_t{}));
         return o;
     }
 };

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -20,6 +20,7 @@
 #include "utils/uuid.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/net/socket_defs.hh>
 #include <seastar/util/bool_class.hh>
 
 #include <boost/container_hash/hash.hpp>
@@ -439,7 +440,7 @@ static_assert(
 
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
-using client_address_t = named_type<ss::sstring, struct client_address_tag>;
+using client_address_t = ss::socket_address;
 
 } // namespace model
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/21605
