### PR TITLE
[v24.2.x] `storage`: catch `ss::gate_closed_exception` in `log_manager`

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -433,8 +433,12 @@ ss::future<> log_manager::housekeeping_loop() {
 
         try {
             co_await housekeeping_scan(lowest_ts_to_retain());
-        } catch (const std::exception& e) {
-            vlog(stlog.info, "Error processing housekeeping(): {}", e);
+        } catch (...) {
+            auto eptr = std::current_exception();
+            if (ssx::is_shutdown_exception(eptr)) {
+                std::rethrow_exception(eptr);
+            }
+            vlog(stlog.warn, "Error processing housekeeping(): {}", eptr);
         }
 
         co_await ss::coroutine::switch_to(prev_sg);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23410
