### PR TITLE
resource_mgmt: mark method const

### DIFF
--- a/src/v/resource_mgmt/memory_sampling.cc
+++ b/src/v/resource_mgmt/memory_sampling.cc
@@ -35,7 +35,8 @@ constexpr std::string_view confluence_reference() {
 }
 
 fmt::appender fmt::formatter<seastar::memory::allocation_site>::format(
-  const seastar::memory::allocation_site& site, fmt::format_context& ctx) {
+  const seastar::memory::allocation_site& site,
+  fmt::format_context& ctx) const {
     return fmt::format_to(
       ctx.out(),
       "size: {} count: {} at: {}",

--- a/src/v/resource_mgmt/memory_sampling.h
+++ b/src/v/resource_mgmt/memory_sampling.h
@@ -35,7 +35,7 @@ template<>
 struct fmt::formatter<seastar::memory::allocation_site>
   : fmt::formatter<std::string_view> {
     fmt::appender
-    format(const seastar::memory::allocation_site&, fmt::format_context&);
+    format(const seastar::memory::allocation_site&, fmt::format_context&) const;
 };
 
 /// Very simple service enabling memory profiling on all shards.


### PR DESCRIPTION
with fmt>9 and clang18 there were complaints that this method wasn't const qualified.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

