### PR TITLE
[v24.1.x] `storage`: catch `ss::gate_closed_exception` in `log_manager` (manual backport)

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -433,8 +433,12 @@ ss::future<> log_manager::housekeeping_loop() {
 
         try {
             co_await housekeeping_scan(collection_threshold());
-        } catch (const std::exception& e) {
-            vlog(stlog.info, "Error processing housekeeping(): {}", e);
+        } catch (...) {
+            auto eptr = std::current_exception();
+            if (ssx::is_shutdown_exception(eptr)) {
+                std::rethrow_exception(eptr);
+            }
+            vlog(stlog.warn, "Error processing housekeeping(): {}", eptr);
         }
 
         co_await ss::coroutine::switch_to(prev_sg);


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/23410.

`git cherry-pick` failed due to unrelated changes in current version of `redpanda` not present in `v24.1.x`. 

Fixes https://github.com/redpanda-data/redpanda/issues/23445/

## Backports Required


- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
