### PR TITLE
gha: increase commits cherry-picked in backport

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         id: backport_commits
         run: |
-          backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
+          backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --paginate --jq '.[].sha[0:10]')
           echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: needs.backport-type.outputs.commented_on == 'pr'


### PR DESCRIPTION
The `/backport` command will only cherry-pick the first 30 commits of the PR. This PR fixes that by cherry-picking all commits.

Also, reduce commit sha from 40 chars to 10 chars for brevity in displaying cherry-pick command.

jira: [PESDLC-2095]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[PESDLC-2095]: https://redpandadata.atlassian.net/browse/PESDLC-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ