### PR TITLE
[v23.3.x] gha: use oidc

### DIFF
--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -1,12 +1,11 @@
+---
 name: check formatting
 on:
   release:
     types: [published]
-
 jobs:
   trigger-bump:
     runs-on: ubuntu-latest
-
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -14,7 +13,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-
       - name: get secrets from aws sm
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
@@ -22,20 +20,17 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-
       - uses: actions/checkout@v4
-        with: 
-          repository: redpanda-data/sparse-checkout 
+        with:
+          repository: redpanda-data/sparse-checkout
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           path: sparse-checkout
-
-      - uses: ./sparse-checkout 
+      - uses: ./sparse-checkout
         with:
           repository: redpanda-data/vtools
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           patterns: actions
-          path: ghca 
-
+          path: ghca
       - name: Trigger Versions Bump Buildkite Job
         uses: ./ghca/actions/buildkite-pipeline-trigger
         with:

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   trigger-bump:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   trigger-promote:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,8 +1,8 @@
+---
 name: promote
 on:
   release:
     types: [published]
-
 jobs:
   trigger-promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -1,10 +1,8 @@
+---
 name: Release rp-storage-tool
-
 on:
   push:
-    tags:
-      - 'v*'
-
+    tags: ['v*']
 jobs:
   release-rp-storage-tool:
     if: ${{ github.repository == 'redpanda-data/redpanda' || github.event_name == 'pull_request' }}

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v*']
 jobs:
   release-rp-storage-tool:
-    if: ${{ github.repository == 'redpanda-data/redpanda' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'redpanda-data/redpanda' }}
     name: Release - ${{ matrix.platform.release_for }}
     strategy:
       matrix:
@@ -17,14 +17,12 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: configure aws credentials
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: get secrets from aws sm
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
@@ -48,7 +46,6 @@ jobs:
           docker cp $id:/usr/local/bin/rp-storage-tool ./
           ./rp-storage-tool --help
       - name: Push to public bucket
-        if: ${{ github.ref_type == 'tag' || github.event_name != 'pull_request' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_RP_STORAGE_UPLOADER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_RP_STORAGE_UPLOADER_SECRET }}

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -15,21 +15,20 @@ jobs:
           - release_for: linux-arm64
             os: ubuntu-latest-2-arm64
     runs-on: ${{ matrix.platform.os }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: get secrets from aws sm
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/rp_storage_tool_uploader
           parse-json-secrets: true
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Build binary
         run: |
           export DOCKER_BUILDKIT=1

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 900
+  indentation:
+    spaces: 2
+  truthy:
+    allowed-values: ['true', 'false', 'on']


### PR DESCRIPTION
Backport of PR #23423
Fixes #23437
jira: [PESDLC-1736]

This PR updates the workflow files triggered from the `v23.3.x` branch that use action `aws-actions/configure-aws-credentials` to run with OIDC tokens.

There were many conflicts when I first attempted to cherry-pick all the commits from PR #23423 that were unrelated to OIDC tokens and/or changed workflow files that wouldn't run on this `v23.3.x` branch, so I only cherry-picked a subset of the commits that are needed. This reduced the changeset to just these files:

1. `cloud-installpack-bk-trigger.yml`
2. `promote.yml`
3. `release-rp-storage-tool.yml`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


[PESDLC-1736]: https://redpandadata.atlassian.net/browse/PESDLC-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ