### PR TITLE
admin: fix unused parameter warning

### DIFF
--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -188,8 +188,7 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
 }
 
 ss::future<std::unique_ptr<ss::http::reply>> admin_server::get_debug_bundle(
-  std::unique_ptr<ss::http::request> req,
-  std::unique_ptr<ss::http::reply> rep) {
+  std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply> rep) {
     auto res = co_await _debug_bundle_service.local().rpk_debug_bundle_status();
     if (res.has_error()) {
         co_return make_error_body(res.assume_error(), std::move(rep));


### PR DESCRIPTION
admin: fix unused parameter warning

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
