### PR TITLE
[v24.2.x] storage: adaptive falloc respect segment size

### DIFF
--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -125,7 +125,8 @@ struct reupload_fixture : public archiver_fixture {
                            seg.term,
                            ss::default_priority_class(),
                            128_KiB,
-                           10)
+                           10,
+                           1_MiB)
                          .get0();
         write_random_batches(segment, seg.num_records.value(), 2);
         disk_log_impl()->segments().add(segment);

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -280,7 +280,8 @@ void archiver_fixture::initialize_shard(
                        d.term,
                        ss::default_priority_class(),
                        128_KiB,
-                       10)
+                       10,
+                       1_MiB)
                      .get0();
         vlog(fixt_log.trace, "write random batches to segment");
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1552,7 +1552,8 @@ ss::future<> disk_log_impl::new_segment(
         t,
         pc,
         config::shard_local_cfg().storage_read_buffer_size(),
-        config::shard_local_cfg().storage_read_readahead_count())
+        config::shard_local_cfg().storage_read_readahead_count(),
+        _max_segment_size)
       .then([this](ss::lw_shared_ptr<segment> handles) mutable {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -305,7 +305,8 @@ ss::future<> kvstore::roll() {
                  std::nullopt,
                  _resources,
                  _feature_table,
-                 _ntp_sanitizer_config)
+                 _ntp_sanitizer_config,
+                 _conf.max_segment_size)
           .then([this](ss::lw_shared_ptr<segment> seg) {
               _segment = std::move(seg);
           });
@@ -348,7 +349,8 @@ ss::future<> kvstore::roll() {
                        std::nullopt,
                        _resources,
                        _feature_table,
-                       _ntp_sanitizer_config)
+                       _ntp_sanitizer_config,
+                       _conf.max_segment_size)
                 .then([this](ss::lw_shared_ptr<segment> seg) {
                     _segment = std::move(seg);
                 });

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -452,6 +452,7 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
   ss::io_priority_class pc,
   size_t read_buf_size,
   unsigned read_ahead,
+  size_t segment_size_hint,
   record_version_type version) {
     auto gate_holder = _gate.hold();
 
@@ -468,7 +469,8 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
       create_cache(ntp.cache_enabled()),
       _resources,
       _feature_table,
-      std::move(ntp_sanitizer_cfg));
+      std::move(ntp_sanitizer_cfg),
+      segment_size_hint);
 }
 
 std::optional<batch_cache_index>

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -209,6 +209,7 @@ public:
       ss::io_priority_class pc,
       size_t read_buffer_size,
       unsigned read_ahead,
+      size_t segment_size_hint,
       record_version_type = record_version_type::v1);
 
     const log_config& config() const { return _config; }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -805,7 +805,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   std::optional<batch_cache_index> batch_cache,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config) {
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  size_t segment_size_hint) {
     auto path = segment_full_path(ntpc, base_offset, term, version);
     vlog(stlog.info, "Creating new segment {}", path);
     return open_segment(
@@ -816,16 +817,25 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
              resources,
              feature_table,
              ntp_sanitizer_config)
-      .then([path, &ntpc, pc, &resources, ntp_sanitizer_config](
-              ss::lw_shared_ptr<segment> seg) mutable {
+      .then([path,
+             &ntpc,
+             pc,
+             segment_size_hint,
+             &resources,
+             ntp_sanitizer_config](ss::lw_shared_ptr<segment> seg) mutable {
           return with_segment(
             std::move(seg),
-            [path, &ntpc, pc, &resources, ntp_sanitizer_config](
+            [path,
+             &ntpc,
+             pc,
+             segment_size_hint,
+             &resources,
+             ntp_sanitizer_config](
               const ss::lw_shared_ptr<segment>& seg) mutable {
                 return internal::make_segment_appender(
                          path,
                          internal::number_of_chunks_from_config(ntpc),
-                         internal::segment_size_from_config(ntpc),
+                         segment_size_hint,
                          pc,
                          resources,
                          std::move(ntp_sanitizer_config))

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -386,7 +386,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   std::optional<batch_cache_index> batch_cache,
   storage_resources&,
   ss::sharded<features::feature_table>& feature_table,
-  std::optional<ntp_sanitizer_config> ntp_sanitizer_config);
+  std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
+  size_t segment_size_hint);
 
 // bitflags operators
 [[gnu::always_inline]] inline segment::bitflags

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -229,20 +229,6 @@ size_t number_of_chunks_from_config(const ntp_config& ntpc) {
     return def;
 }
 
-uint64_t segment_size_from_config(const ntp_config& ntpc) {
-    auto def = config::shard_local_cfg().log_segment_size();
-
-    if (!ntpc.has_overrides()) {
-        return def;
-    }
-    auto& o = ntpc.get_overrides();
-    if (o.segment_size) {
-        return o.segment_size.value();
-    } else {
-        return def;
-    }
-}
-
 ss::future<roaring::Roaring>
 natural_index_of_entries_to_keep(compacted_index_reader reader) {
     reader.reset();

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -101,7 +101,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                   model::term_id(1),
                   ss::default_priority_class(),
                   default_segment_readahead_size,
-                  default_segment_readahead_count)
+                  default_segment_readahead_count,
+                  0)
                  .get0();
     seg->close().get();
 
@@ -113,7 +114,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::term_id(1),
                    ss::default_priority_class(),
                    default_segment_readahead_size,
-                   default_segment_readahead_count)
+                   default_segment_readahead_count,
+                   1_MiB)
                   .get0();
     write_batches(seg3);
     seg3->close().get();
@@ -124,7 +126,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::term_id(1),
                    ss::default_priority_class(),
                    default_segment_readahead_size,
-                   default_segment_readahead_count)
+                   default_segment_readahead_count,
+                   1_MiB)
                   .get0();
     write_garbage(seg4->appender());
     seg4->close().get();


### PR DESCRIPTION
#23462

In the segment appender we dynamically compute the size to which we fallocate the segment based on the maximum size. When we introduced segment size clamping, we forgot to apply it here which led to it to use the non-clamped value leading to unexpected behavior like the one reported below:

> We see that the current segment has been fallocated/ftruncated to
> 32MiB. The segments still get closed at 16MiB at which point they are
> being shrunk. This still wastes lots of preallocation which isn't cheap
> and obviously also wastes disk space for the active segment.
> —@StephanDollberg

(cherry picked from commit 20d5695c58d4c778724ab47b6eeb3fe3163e4e05)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
