### PR TITLE
protobuf: actually output map types

### DIFF
--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -11,11 +11,13 @@ redpanda_cc_library(
     include_prefix = "serde/protobuf",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/bytes:hash",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:fragmented_vector",
         "//src/v/utils:vint",
         "@protobuf",
+        "@seastar",
     ],
 )

--- a/src/v/serde/protobuf/parser.h
+++ b/src/v/serde/protobuf/parser.h
@@ -9,6 +9,8 @@
  * by the Apache License, Version 2.0
  */
 
+#pragma once
+
 #include "bytes/hash.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"

--- a/src/v/serde/protobuf/parser.h
+++ b/src/v/serde/protobuf/parser.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "bytes/hash.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
 #include "container/fragmented_vector.h"
@@ -46,10 +47,19 @@ struct repeated {
  * A dynamic representation of a proto3 map.
  */
 struct map {
-    using key = std::
-      variant<double, float, int32_t, int64_t, uint32_t, uint64_t, bool, iobuf>;
+    using key = std::variant<
+      std::monostate, // Can be unset
+      double,
+      float,
+      int32_t,
+      int64_t,
+      uint32_t,
+      uint64_t,
+      bool,
+      iobuf>;
 
     using value = std::variant<
+      std::monostate, // Can be unset
       double,
       float,
       int32_t, // Can be an enum value

--- a/src/v/serde/protobuf/tests/three.proto
+++ b/src/v/serde/protobuf/tests/three.proto
@@ -76,3 +76,11 @@ message Version4 {
         bool data = 3;
     }
 }
+
+message Map {
+    map<string, string> meta = 1;
+}
+
+message Entries {
+    map<string, int32> entry = 1;
+}


### PR DESCRIPTION
Maps are weird in proto3. Internally they are a repeated synthetic message type
with a key and value, because we're not checking if the type is a map,
we're outputting those as messages. Fix that by when we complete a
message see if it's a map entry then convert it to the proper internal
map type.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
