### PR TITLE
security: convert gss::buffer to string for printing

### DIFF
--- a/src/v/security/gssapi_authenticator.cc
+++ b/src/v/security/gssapi_authenticator.cc
@@ -64,7 +64,11 @@ static void display_status_1(std::string_view m, OM_uint32 code, int type) {
             vlog(seclog.info, "gss status from {}", m);
             break;
         } else {
-            vlog(seclog.info, "GSS_API error {}: {}", m, msg);
+            vlog(
+              seclog.info,
+              "GSS_API error {}: {}",
+              m,
+              msg.operator std::string_view());
         }
 
         if (!msg_ctx) {


### PR DESCRIPTION
It seems that in fmt v8 either a copy of gss::buffer wasn't being made, or the explicit conversion operator to std::string_view was being made prior to a copy of the fmt argument.

Now in fmt v9 it looks like fmt is trying to make a copy before any conversion. So this PR just invokves the conversion up front and passes a std::string_view down into fmt.

    external/fmt~/include/fmt/core.h:1735:47: error: call to deleted constructor of 'security::gss::buffer'
     1735 |   const auto& arg = arg_mapper<Context>().map(FMT_FORWARD(val));
          |                                               ^~~~~~~~~~~~~~~~
    external/fmt~/include/fmt/core.h:204:26: note: expanded from macro 'FMT_FORWARD'
      204 | #define FMT_FORWARD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
          |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    external/fmt~/include/fmt/core.h:1777:10: note: in instantiation of function template specialization 'fmt::detail::make_value<fmt::basic_format_context<fmt::appender, char>, security::gss::buffer &>' requested here
     1777 |   return make_value<Context>(val);
          |          ^
    external/fmt~/include/fmt/core.h:1899:23: note: in instantiation of function template specialization 'fmt::detail::make_arg<true, fmt::basic_format_context<fmt::appender, char>, fmt::detail::type::custom_type, security::gss::buffer &, 0>' requested here
     1899 |         data_{detail::make_arg<
          |                       ^
    external/fmt~/include/fmt/core.h:1918:10: note: in instantiation of function template specialization 'fmt::format_arg_store<fmt::basic_format_context<fmt::appender, char>, vlog::file_line, std::string_view, security::gss::buffer>::format_arg_store<vlog::file_line &, std::string_view &, security::gss::buffer &>' requested here
     1918 |   return {FMT_FORWARD(args)...};
          |          ^
    external/fmt~/include/fmt/core.h:3235:36: note: in instantiation of function template specialization 'fmt::make_format_args<fmt::basic_format_context<fmt::appender, char>, vlog::file_line &, std::string_view &, security::gss::buffer &>' requested here
     3235 |   return vformat_to(out, fmt, fmt::make_format_args(args...));
          |                                    ^
    external/_main~non_module_dependencies~seastar/include/seastar/util/log.hh:301:33: note: in instantiation of function template specialization 'fmt::format_to<seastar::internal::log_buf::inserter_iterator, vlog::file_line, std::string_view &, security::gss::buffer &, 0>' requested here
      301 |                     return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
          |                                 ^
    external/_main~non_module_dependencies~seastar/include/seastar/util/log.hh:423:9: note: in instantiation of function template specialization 'seastar::logger::log<vlog::file_line, std::string_view &, security::gss::buffer &>' requested here
      423 |         log(log_level::info, std::move(fmt), std::forward<Args>(args)...);
          |         ^
    src/v/security/gssapi_authenticator.cc:67:25: note: in instantiation of function template specialization 'seastar::logger::info<vlog::file_line, std::string_view &, security::gss::buffer &>' requested here
       67 |             vlog(seclog.info, "GSS_API error {}: {}", m, msg);
          |                         ^
    bazel-out/k8-fastbuild/bin/src/v/security/_virtual_includes/security/security/gssapi.h:56:5: note: 'buffer' has been explicitly marked deleted here
       56 |     buffer(const buffer&) = delete;
          |     ^

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
