### PR TITLE
Deployment args formatting fix

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -958,8 +958,11 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         ])
 
         self.logger.info('patching deployment to allow downscaling')
-        deployment_args = deployment_args.decode().replace(
-            '--allow-downscaling=false', '--allow-downscaling=true', 1)
+        if isinstance(deployment_args, bytes):
+            deployment_args = deployment_args.decode()
+        deployment_args = deployment_args.replace('--allow-downscaling=false',
+                                                  '--allow-downscaling=true',
+                                                  1)
         patch = [{
             'op': 'replace',
             'path': '/spec/template/spec/containers/0/args',


### PR DESCRIPTION
kubectl.cmd is not guaranteed to return type bytes, it can also return a str so only call decode() if the type is bytes. This is causing intermittent CI failures. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* None

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
