### PR TITLE
iceberg: add operator< for values

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -102,6 +102,30 @@ bool iobuf::operator==(const iobuf& o) const {
     return true;
 }
 
+bool iobuf::operator<(const iobuf& o) const {
+    auto lhs = byte_iterator(cbegin(), cend());
+    auto lhs_end = byte_iterator(cend(), cend());
+    auto rhs = byte_iterator(o.cbegin(), o.cend());
+    auto rhs_end = byte_iterator(o.cend(), o.cend());
+    while (lhs != lhs_end && rhs != rhs_end) {
+        char l = *lhs;
+        char r = *rhs;
+        if (l < r) {
+            return true;
+        }
+        if (l > r) {
+            return false;
+        }
+        ++lhs;
+        ++rhs;
+    }
+    if (rhs != rhs_end) {
+        // lhs is a prefix of rhs.
+        return true;
+    }
+    return false;
+}
+
 bool iobuf::operator==(std::string_view o) const {
     if (_size != o.size()) {
         return false;

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -234,6 +234,7 @@ public:
     /// ignores allocation strategy, and number of details::io_fragments
     /// it is a byte-per-byte comparator
     bool operator==(const iobuf&) const;
+    bool operator<(const iobuf&) const;
     bool operator!=(const iobuf&) const;
 
     bool operator==(std::string_view) const;

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -44,6 +44,14 @@ SEASTAR_THREAD_TEST_CASE(test_copy_equal) {
     BOOST_CHECK_EQUAL(buf, copy);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_lt) {
+    BOOST_CHECK_LT(iobuf::from(""), iobuf::from("cat"));
+    BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("dog"));
+    BOOST_CHECK_LT(iobuf::from("cat"), iobuf::from("catastrophe"));
+    BOOST_CHECK_EQUAL(false, iobuf::from("cat") < iobuf::from("cat"));
+    BOOST_CHECK_EQUAL(false, iobuf{} < iobuf{});
+}
+
 SEASTAR_THREAD_TEST_CASE(test_appended_data_is_retained) {
     iobuf buf;
     append_sequence(buf, 5);

--- a/src/v/iceberg/tests/values_test.cc
+++ b/src/v/iceberg/tests/values_test.cc
@@ -454,3 +454,30 @@ TEST(ValuesTest, TestPrimitivesCopy) {
         ASSERT_EQ(v, value{std::move(v_copy)});
     }
 }
+
+TEST(ValuesTest, TestLessThan) {
+    auto vals = unique_values_primitive_types();
+    for (const auto& v : vals) {
+        ASSERT_FALSE(v < v);
+    }
+    ASSERT_LT(value{boolean_value{false}}, value{boolean_value{true}});
+    ASSERT_LT(value{int_value{0}}, value{int_value{1}});
+    ASSERT_LT(value{long_value{0}}, value{long_value{1}});
+    ASSERT_LT(value{float_value{0.0}}, value{float_value{1.0}});
+    ASSERT_LT(value{double_value{0.0}}, value{double_value{1.0}});
+    ASSERT_LT(value{decimal_value{0}}, value{decimal_value{1}});
+    ASSERT_LT(value{date_value{0}}, value{date_value{1}});
+    ASSERT_LT(value{time_value{0}}, value{time_value{1}});
+    ASSERT_LT(value{timestamp_value{0}}, value{timestamp_value{1}});
+    ASSERT_LT(value{timestamptz_value{0}}, value{timestamptz_value{1}});
+    ASSERT_LT(
+      value{string_value{iobuf::from("aaa")}},
+      value{string_value{iobuf::from("aab")}});
+    ASSERT_LT(
+      value{binary_value{iobuf::from("aaa")}},
+      value{binary_value{iobuf::from("aab")}});
+    ASSERT_LT(value{uuid_value{uuid_t{}}}, value{uuid_value{uuid_t::create()}});
+    ASSERT_LT(
+      value{fixed_value{iobuf::from("aaa")}},
+      value{fixed_value{iobuf::from("aab")}});
+}

--- a/src/v/iceberg/values.h
+++ b/src/v/iceberg/values.h
@@ -95,6 +95,7 @@ using primitive_value = std::variant<
   binary_value,
   decimal_value>;
 bool operator==(const primitive_value&, const primitive_value&);
+bool operator<(const primitive_value&, const primitive_value&);
 primitive_value make_copy(const primitive_value&);
 
 struct struct_value;

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -36,6 +36,11 @@ SEASTAR_THREAD_TEST_CASE(test_uuid_default_construct) {
       uuid, uuid_t::from_string("00000000-0000-0000-0000-000000000000"));
 }
 
+SEASTAR_THREAD_TEST_CASE(test_lt) {
+    BOOST_REQUIRE_LT(
+      uuid_t{}, uuid_t::from_string("00000000-0000-0000-0000-000000000001"));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_named_uuid_type) {
     auto uuid1 = test_uuid(uuid_t::create());
     auto uuid2 = test_uuid(uuid_t::create());

--- a/src/v/utils/uuid.cc
+++ b/src/v/utils/uuid.cc
@@ -55,3 +55,5 @@ std::istream& operator>>(std::istream& is, uuid_t& u) {
 }
 
 uuid_t::operator ss::sstring() const { return fmt::format("{}", _uuid); }
+
+bool operator<(const uuid_t& l, const uuid_t& r) { return l.uuid() < r.uuid(); }

--- a/src/v/utils/uuid.h
+++ b/src/v/utils/uuid.h
@@ -64,3 +64,5 @@ private:
 
     underlying_t _uuid;
 };
+
+bool operator<(const uuid_t& l, const uuid_t& r);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
It will be useful to be able to compare Iceberg values, e.g. to keep track of the lower bound and upper bound of the partition keys kept in each manifest_file. To that end, this adds a less-than operator to iceberg::value, and consequently, to iobuf and uuid as well.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
