### PR TITLE
cloud_roles: fix unused return value warning

### DIFF
--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
 
     {
         bh::request_header<> h{};
-        applier.add_auth(h);
+        BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer a-token");
         BOOST_REQUIRE_EQUAL(
           h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
       .oauth_token = cloud_roles::oauth_token_str{"second-token"}});
     {
         bh::request_header<> h{};
-        applier.add_auth(h);
+        BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer second-token");
         BOOST_REQUIRE_EQUAL(
           h.at("x-ms-version"), cloud_roles::azure_storage_api_version);


### PR DESCRIPTION
```
/home/nwatkins/src/redpanda-clang-18/src/v/cloud_roles/tests/credential_tests.cc:89:9: error: the value returned by this function should not be disregarded; neglecting it may lead to errors [bugprone-unused-return-value,-warnings-as-errors]
   89 |         applier.add_auth(h);
      |         ^~~~~~~~~~~~~~~~~~~
/home/nwatkins/src/redpanda-clang-18/src/v/cloud_roles/tests/credential_tests.cc:99:9: error: the value returned by this function should not be disregarded; neglecting it may lead to errors [bugprone-unused-return-value,-warnings-as-errors]
   99 |         applier.add_auth(h);
      |  
       ^~~~~~~~~~~~~~~~~~~
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

