### PR TITLE
iceberg: add merge append action

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -282,6 +282,35 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "merge_append_action",
+    srcs = [
+        "merge_append_action.cc",
+    ],
+    hdrs = [
+        "merge_append_action.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        ":manifest",
+        ":manifest_file_packer",
+        ":snapshot",
+        ":table_requirement",
+        "//src/v/random:generators",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":action",
+        ":manifest_entry",
+        ":manifest_io",
+        ":manifest_list",
+        ":schema",
+        ":table_metadata",
+        ":values_bytes",
+        "//src/v/base",
+    ],
+)
+
+redpanda_cc_library(
     name = "partition",
     hdrs = [
         "partition.h",
@@ -609,6 +638,8 @@ redpanda_cc_library(
     include_prefix = "iceberg",
     deps = [
         ":action",
+        ":manifest_io",
+        ":merge_append_action",
         ":schema",
         ":table_metadata",
         ":table_requirement",

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -39,6 +39,7 @@ v_cc_library(
     manifest_io.cc
     manifest_file_packer.cc
     manifest_list_avro.cc
+    merge_append_action.cc
     partition_key.cc
     partition_key_type.cc
     partition_json.cc

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -1,0 +1,543 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "iceberg/merge_append_action.h"
+
+#include "base/units.h"
+#include "base/vlog.h"
+#include "iceberg/logger.h"
+#include "iceberg/manifest.h"
+#include "iceberg/manifest_file_packer.h"
+#include "iceberg/manifest_list.h"
+#include "iceberg/snapshot.h"
+#include "iceberg/table_requirement.h"
+#include "iceberg/values_bytes.h"
+#include "random/generators.h"
+
+#include <iterator>
+#include <limits>
+
+namespace iceberg {
+
+namespace {
+manifest_path get_manifest_path(
+  const ss::sstring& location, const uuid_t& commit_uuid, size_t num) {
+    return manifest_path{
+      fmt::format("{}/metadata/{}-m{}.avro", location, commit_uuid, num)};
+}
+manifest_list_path get_manifest_list_path(
+  const ss::sstring& location,
+  snapshot_id snap_id,
+  const uuid_t& commit_uuid,
+  size_t num) {
+    return manifest_path{fmt::format(
+      "{}/metadata/snap-{}-{}-{}.avro", location, snap_id(), commit_uuid, num)};
+}
+
+action::errc to_action_errc(manifest_io::errc e) {
+    switch (e) {
+    case manifest_io::errc::failed:
+        return action::errc::io_failed;
+    case manifest_io::errc::shutting_down:
+        return action::errc::shutting_down;
+    case manifest_io::errc::timedout:
+        // NOTE: treat IO timeouts the same as other IO failures.
+        // TODO: build out retry logic.
+        return action::errc::io_failed;
+    }
+}
+
+snapshot_id random_snap_id() {
+    return snapshot_id{random_generators::get_int<int64_t>(
+      0, std::numeric_limits<int64_t>::max())};
+}
+
+snapshot_id generate_unused_snap_id(const table_metadata& m) {
+    auto sid = random_snap_id();
+    if (!m.snapshots.has_value() || m.snapshots->empty()) {
+        return sid;
+    }
+    // Repeatedly try to generate a new snapshot id that isn't used already.
+    const auto& snaps = *m.snapshots;
+    while (std::ranges::find(snaps, sid, &snapshot::id) != snaps.end()) {
+        sid = random_snap_id();
+    }
+    return sid;
+}
+
+void update_partition_summaries(
+  const data_file& f, chunked_vector<field_summary_val>& summaries) {
+    // NOTE: callers should have validated that partition keys of the data
+    // files have the same number of fields as the partition key used to
+    // construct the summaries.
+    const auto& pk_val_fields = f.partition.val->fields;
+    for (size_t i = 0; i < summaries.size(); ++i) {
+        const auto& file_val_field = pk_val_fields[i];
+        if (!file_val_field.has_value()) {
+            summaries[i].contains_null = true;
+            continue;
+        }
+        // TODO: contains_nan
+        const auto& file_prim_val = std::get<primitive_value>(
+          file_val_field.value());
+        if (!summaries[i].lower_bound.has_value()) {
+            summaries[i].lower_bound = make_copy(file_prim_val);
+        } else {
+            auto& lb = summaries[i].lower_bound.value();
+            if (file_prim_val < lb) {
+                lb = make_copy(file_prim_val);
+            }
+        }
+        if (!summaries[i].upper_bound.has_value()) {
+            summaries[i].upper_bound = make_copy(file_prim_val);
+        } else {
+            auto& ub = summaries[i].upper_bound.value();
+            if (ub < file_prim_val) {
+                ub = make_copy(file_prim_val);
+            }
+        }
+    }
+}
+
+chunked_vector<field_summary> release_with_bytes(field_summary_val::list_t l) {
+    chunked_vector<field_summary> ret;
+    ret.reserve(l.size());
+    for (auto& v : l) {
+        ret.emplace_back(std::move(v).release_with_bytes());
+    }
+    return ret;
+}
+
+} // namespace
+
+field_summary_val::list_t
+field_summary_val::empty_summaries(const partition_key_type& pk_type) {
+    field_summary_val::list_t ret;
+    const auto num_fields = pk_type.type.fields.size();
+    ret.reserve(num_fields);
+    for (size_t i = 0; i < num_fields; ++i) {
+        ret.emplace_back(field_summary_val{});
+    }
+    return ret;
+}
+
+field_summary field_summary_val::release_with_bytes() && {
+    std::optional<bytes> lb;
+    std::optional<bytes> ub;
+    if (lower_bound.has_value()) {
+        lb = value_to_bytes(value{std::move(lower_bound).value()});
+    }
+    if (upper_bound.has_value()) {
+        ub = value_to_bytes(value{std::move(upper_bound).value()});
+    }
+    return field_summary{
+      .contains_null = contains_null,
+      .contains_nan = contains_nan,
+      .lower_bound = std::move(lb),
+      .upper_bound = std::move(ub),
+    };
+}
+
+ss::future<action::action_outcome> merge_append_action::build_updates() && {
+    vlog(
+      log.info,
+      "Building append update for {} data files",
+      new_data_files_.size());
+    // Look for the current schema.
+    const auto schema_id = table_.current_schema_id;
+    auto schema_it = std::ranges::find(
+      table_.schemas, schema_id, &schema::schema_id);
+    if (schema_it == table_.schemas.end()) {
+        vlog(log.error, "Table schema {} is missing from metadata", schema_id);
+        co_return action::errc::unexpected_state;
+    }
+    const auto& schema = *schema_it;
+
+    // Look for the current partition spec.
+    const auto& pspecs = table_.partition_specs;
+    auto pspec_it = std::ranges::find(
+      pspecs, table_.default_spec_id, &partition_spec::spec_id);
+    if (pspec_it == pspecs.end()) {
+        vlog(
+          log.error,
+          "Partition spec {} is missing from metadata",
+          table_.default_spec_id);
+        co_return action::errc::unexpected_state;
+    }
+    if (pspecs.size() != 1) {
+        // TODO: when we support multiple partition specs, we'll need to group
+        // them by spec id and write manifest files per spec.
+        vlog(
+          log.error,
+          "Currently exactly one partition spec is supported: {} found",
+          pspecs.size());
+        co_return action::errc::unexpected_state;
+    }
+
+    // Validate our input files that their partition keys look sane.
+    const auto& pspec = *pspec_it;
+    for (const auto& f : new_data_files_) {
+        if (f.partition.val == nullptr) {
+            vlog(
+              log.error,
+              "Metadata for data file {} is missing partition key",
+              f.file_path);
+            co_return action::errc::unexpected_state;
+        }
+        auto f_num_fields = f.partition.val->fields.size();
+        if (f_num_fields != pspec.fields.size()) {
+            vlog(
+              log.error,
+              "Partition key for data file {} has {} fields, expected {}",
+              f.file_path,
+              f_num_fields,
+              pspec.fields.size());
+            co_return action::errc::unexpected_state;
+        }
+    }
+
+    // Get the manifest list for the current snapshot, if any.
+    manifest_list mlist;
+    std::optional<snapshot_id> old_snap_id;
+    if (table_.snapshots.has_value() && !table_.snapshots->empty()) {
+        if (!table_.current_snapshot_id.has_value()) {
+            // We have snapshots, but it's unclear which one to base our update
+            // off of.
+            vlog(
+              log.error,
+              "Table's current snapshot id is not set but there are {} "
+              "snapshots",
+              table_.snapshots->size());
+            co_return action::errc::unexpected_state;
+        }
+        // Look for the current snapshot.
+        const auto table_cur_snap_id = *table_.current_snapshot_id;
+        const auto& snaps = *table_.snapshots;
+        auto snap_it = std::ranges::find(
+          snaps, table_cur_snap_id, &snapshot::id);
+        if (snap_it == snaps.end()) {
+            // We have snapshots, but the one we thought we needed to base our
+            // update off of is missing.
+            vlog(
+              log.error,
+              "Table's current snapshot id {} is missing",
+              table_cur_snap_id);
+            co_return action::errc::unexpected_state;
+        }
+        auto mlist_res = co_await io_.download_manifest_list(
+          manifest_list_path{snap_it->manifest_list_path});
+        if (mlist_res.has_error()) {
+            co_return to_action_errc(mlist_res.error());
+        }
+        mlist = std::move(mlist_res).value();
+        old_snap_id = table_cur_snap_id;
+    } else if (table_.current_snapshot_id.has_value()) {
+        vlog(
+          log.error,
+          "Table's current snapshot id is set to {} but there are no "
+          "snapshots",
+          table_.current_snapshot_id.value());
+        co_return action::errc::unexpected_state;
+    }
+    const auto new_seq_num = sequence_number{table_.last_sequence_number() + 1};
+    const auto new_snap_id = generate_unused_snap_id(table_);
+
+    // TODO: support more than one partition spec by grouping the merged
+    // manifests by spec id.
+    auto pk_type = partition_key_type::create(pspec, schema);
+    const table_snapshot_ctx ctx{
+      .commit_uuid = commit_uuid_,
+      .schema = schema,
+      .pspec = pspec,
+      .pk_type = pk_type,
+      .snap_id = new_snap_id,
+      .seq_num = new_seq_num,
+    };
+
+    auto mfiles_res = co_await pack_mlist_and_new_data(
+      ctx, std::move(mlist), std::move(new_data_files_));
+    if (mfiles_res.has_error()) {
+        co_return to_action_errc(mfiles_res.error());
+    }
+    manifest_list new_mlist{std::move(mfiles_res.value())};
+
+    // NOTE: 0 here is the attempt number for this manifest list. Other Iceberg
+    // implementations retry appends on failure and increment an count for
+    // naming uniqueness. Retries for us are expected to take the form of an
+    // entirely new transaction.
+    const auto new_mlist_path = get_manifest_list_path(
+      table_.location, new_snap_id, commit_uuid_, 0);
+
+    vlog(
+      log.info,
+      "Uploading manifest list {} containing {} manifest files",
+      new_mlist_path,
+      new_mlist.files.size());
+    const auto mlist_up_res = co_await io_.upload_manifest_list(
+      new_mlist_path, new_mlist);
+    if (mlist_up_res.has_error()) {
+        co_return to_action_errc(mlist_up_res.error());
+    }
+
+    // Return the snapshot metadata.
+    snapshot s{
+      .id = new_snap_id,
+      .parent_snapshot_id = old_snap_id,
+      .sequence_number = new_seq_num,
+      .timestamp_ms = model::timestamp::now(),
+      .summary = {
+          .operation = snapshot_operation::append,
+          .other = {},
+      },
+      .manifest_list_path = new_mlist_path().native(),
+      .schema_id = schema.schema_id,
+    };
+    updates_and_reqs ret;
+    ret.updates.emplace_back(table_update::add_snapshot{std::move(s)});
+    ret.updates.emplace_back(table_update::set_snapshot_ref{
+          .ref_name = "main",
+          .ref = snapshot_reference{
+            .snapshot_id = new_snap_id,
+            .type = snapshot_ref_type::branch,
+          },
+        });
+    ret.requirements.emplace_back(table_requirement::assert_ref_snapshot_id{
+      .ref = "main",
+      .snapshot_id = old_snap_id,
+    });
+    co_return ret;
+}
+
+ss::future<checked<size_t, manifest_io::errc>>
+merge_append_action::upload_as_manifest(
+  const manifest_path& path,
+  const schema& schema,
+  const partition_spec& pspec,
+  chunked_vector<manifest_entry> entries) {
+    vlog(
+      log.info,
+      "Uploading manifest with {} entries to {}",
+      entries.size(),
+      path);
+    manifest m{
+        .metadata = manifest_metadata{
+            .schema = schema.copy(),
+            .partition_spec = pspec.copy(),
+            .format_version = format_version::v2,
+            .manifest_content_type = manifest_content_type::data,
+        },
+        .entries = std::move(entries),
+    };
+    co_return co_await io_.upload_manifest(path, m);
+}
+
+ss::future<checked<chunked_vector<manifest_file>, manifest_io::errc>>
+merge_append_action::maybe_merge_mfiles_and_new_data(
+  chunked_vector<manifest_file> to_merge,
+  chunked_vector<data_file> new_data_files,
+  const table_snapshot_ctx& ctx) {
+    size_t added_rows{0};
+    size_t added_files{0};
+    vlog(
+      log.info,
+      "Considering {} existing manifest files and {} data files to merge",
+      to_merge.size(),
+      new_data_files.size());
+    // First construct some manifest entries for the new data files. Regardless
+    // of if we upload a brand new manifest or merge with an existing manifest,
+    // the new data files will need new entries.
+    chunked_vector<manifest_entry> new_data_entries;
+    auto partition_summaries = field_summary_val::empty_summaries(ctx.pk_type);
+    for (auto& f : new_data_files) {
+        update_partition_summaries(f, partition_summaries);
+        added_rows += f.record_count;
+        manifest_entry e{
+          .status = manifest_entry_status::added,
+          .snapshot_id = ctx.snap_id,
+          .sequence_number = std::nullopt,
+          .file_sequence_number = std::nullopt,
+          .data_file = std::move(f),
+        };
+        new_data_entries.emplace_back(std::move(e));
+    }
+    chunked_vector<manifest_file> ret;
+    if (to_merge.size() < default_min_to_merge_new_files) {
+        // Upload and return. This bin is too small to merge.
+        const auto new_manifest_path = get_manifest_path(
+          table_.location, ctx.commit_uuid, generate_manifest_num());
+        added_files = new_data_entries.size();
+        const auto mfile_up_res = co_await upload_as_manifest(
+          new_manifest_path,
+          ctx.schema,
+          ctx.pspec,
+          std::move(new_data_entries));
+        if (mfile_up_res.has_error()) {
+            co_return mfile_up_res.error();
+        }
+        // Since this bin was too small to merge, we won't do anything else to
+        // its manifests, just add them back to the returned container.
+        ret.emplace_back(manifest_file{
+          .manifest_path = new_manifest_path().native(),
+          .manifest_length = mfile_up_res.value(),
+          .partition_spec_id = ctx.pspec.spec_id,
+          .content = manifest_file_content::data,
+          .seq_number = ctx.seq_num,
+          .min_seq_number = ctx.seq_num,
+          .added_snapshot_id = ctx.snap_id,
+          .added_files_count = added_files,
+          .existing_files_count = 0,
+          .deleted_files_count = 0,
+          .added_rows_count = added_rows,
+          .existing_rows_count = 0,
+          .deleted_rows_count = 0,
+          .partitions = release_with_bytes(std::move(partition_summaries)),
+        });
+        std::move(to_merge.begin(), to_merge.end(), std::back_inserter(ret));
+        co_return ret;
+    }
+    auto merged_mfile_res = co_await merge_mfiles(
+      std::move(to_merge),
+      ctx,
+      std::move(partition_summaries),
+      std::move(new_data_entries),
+      added_rows);
+    if (merged_mfile_res.has_error()) {
+        co_return merged_mfile_res.error();
+    }
+    ret.emplace_back(std::move(merged_mfile_res.value()));
+    co_return ret;
+}
+
+ss::future<checked<manifest_file, manifest_io::errc>>
+merge_append_action::merge_mfiles(
+  chunked_vector<manifest_file> to_merge,
+  const table_snapshot_ctx& ctx,
+  field_summary_val::list_t added_summaries,
+  chunked_vector<manifest_entry> added_entries,
+  size_t added_rows) {
+    vlog(
+      log.info,
+      "Merging {} manifest files and {} added manifest entries",
+      to_merge.size(),
+      added_entries.size());
+    auto added_files = added_entries.size();
+    auto merged_entries = std::move(added_entries);
+    size_t existing_rows = 0;
+    size_t existing_files = 0;
+    auto min_seq_num = ctx.seq_num;
+    auto partition_summaries = added_summaries.empty()
+                                 ? field_summary_val::empty_summaries(
+                                     ctx.pk_type)
+                                 : std::move(added_summaries);
+    for (const auto& mfile : to_merge) {
+        // Download the manifest file and collect the entries into the merged
+        // container.
+        auto mfile_res = co_await io_.download_manifest(
+          manifest_path{mfile.manifest_path}, ctx.pk_type);
+        if (mfile_res.has_error()) {
+            co_return mfile_res.error();
+        }
+        auto m = std::move(mfile_res).value();
+        existing_files += m.entries.size();
+        for (auto& e : m.entries) {
+            update_partition_summaries(e.data_file, partition_summaries);
+            existing_rows += e.data_file.record_count;
+            // Rewrite sequence numbers for previously added entries.
+            // These entries refer to files committed prior to this action.
+            if (e.status == manifest_entry_status::added) {
+                e.status = manifest_entry_status::existing;
+                e.sequence_number = e.sequence_number.value_or(
+                  mfile.seq_number);
+                e.file_sequence_number = e.file_sequence_number.value_or(
+                  file_sequence_number{mfile.seq_number()});
+            }
+            if (e.sequence_number.has_value()) {
+                min_seq_num = std::min(min_seq_num, e.sequence_number.value());
+            }
+        }
+        std::move(
+          m.entries.begin(),
+          m.entries.end(),
+          std::back_inserter(merged_entries));
+    }
+    const auto merged_manifest_path = get_manifest_path(
+      table_.location, ctx.commit_uuid, generate_manifest_num());
+    const auto mfile_up_res = co_await upload_as_manifest(
+      merged_manifest_path, ctx.schema, ctx.pspec, std::move(merged_entries));
+    if (mfile_up_res.has_error()) {
+        co_return mfile_up_res.error();
+    }
+    manifest_file merged_file{
+      .manifest_path = merged_manifest_path().native(),
+      .manifest_length = mfile_up_res.value(),
+      .partition_spec_id = ctx.pspec.spec_id,
+      .content = manifest_file_content::data,
+      .seq_number = ctx.seq_num,
+      .min_seq_number = min_seq_num,
+      .added_snapshot_id = ctx.snap_id,
+      .added_files_count = added_files,
+      .existing_files_count = existing_files,
+      .deleted_files_count = 0,
+      .added_rows_count = added_rows,
+      .existing_rows_count = existing_rows,
+      .deleted_rows_count = 0,
+      .partitions = release_with_bytes(std::move(partition_summaries)),
+    };
+    co_return merged_file;
+}
+
+ss::future<checked<chunked_vector<manifest_file>, manifest_io::errc>>
+merge_append_action::pack_mlist_and_new_data(
+  const table_snapshot_ctx& ctx,
+  manifest_list old_mlist,
+  chunked_vector<data_file> new_data_files) {
+    auto num_old_files = old_mlist.files.size();
+    auto binned_mfiles = manifest_packer::pack(
+      default_target_size_bytes, std::move(old_mlist.files));
+    vlog(
+      log.info,
+      "Packed {} manifests into {} bins",
+      num_old_files,
+      binned_mfiles.size());
+    if (binned_mfiles.empty()) {
+        // If we had no manifests at all, at least create an empty bin to add
+        // new manifests to below.
+        binned_mfiles.emplace_back(chunked_vector<manifest_file>{});
+    }
+    chunked_vector<manifest_file> new_mfiles;
+    // Always add files to the first bin, which by convention will be the
+    // latest data. We may not merge existing manifests if the bin is
+    // small, but we'll at least add metadata for the new data files.
+    auto merged_bins_res = co_await maybe_merge_mfiles_and_new_data(
+      std::move(binned_mfiles[0]), std::move(new_data_files), ctx);
+    if (merged_bins_res.has_error()) {
+        co_return merged_bins_res.error();
+    }
+    auto merged_bins = std::move(merged_bins_res.value());
+    std::move(
+      merged_bins.begin(), merged_bins.end(), std::back_inserter(new_mfiles));
+
+    // Merge the rest of the bins.
+    for (size_t i = 1; i < binned_mfiles.size(); i++) {
+        auto& bin = binned_mfiles[i];
+        if (bin.size() == 1) {
+            // The bin has only a single manifest so there's nothing to do,
+            // just add it as is.
+            new_mfiles.emplace_back(std::move(bin[0]));
+            continue;
+        }
+        auto merged_bin_res = co_await merge_mfiles(std::move(bin), ctx);
+        if (merged_bin_res.has_error()) {
+            co_return merged_bin_res.error();
+        }
+        new_mfiles.emplace_back(std::move(merged_bin_res.value()));
+    }
+    co_return new_mfiles;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -1,0 +1,152 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "base/outcome.h"
+#include "iceberg/action.h"
+#include "iceberg/manifest_entry.h"
+#include "iceberg/manifest_io.h"
+#include "iceberg/manifest_list.h"
+#include "iceberg/schema.h"
+#include "iceberg/table_metadata.h"
+
+namespace iceberg {
+
+// Container for a metadata required to build manifest_file::partitions (the
+// field summaries for each partition key field).
+//
+// Unlike the field_summary in manifest_file, which stores bytes per bound,
+// this is value-comparable by maintaining the bounds as values instead of
+// serialized bytes.
+struct field_summary_val {
+    using list_t = chunked_vector<field_summary_val>;
+    // Creates a list of field summaries meant to summarize the fields of the
+    // given partition key type.
+    static list_t empty_summaries(const partition_key_type&);
+    // Returns this summary with the bounds converted to bytes.
+    field_summary release_with_bytes() &&;
+
+    bool contains_null{false};
+    std::optional<bool> contains_nan;
+    std::optional<primitive_value> lower_bound;
+    std::optional<primitive_value> upper_bound;
+};
+
+// An action that builds and uploads metadata to append a given list of data
+// files to the table's latest snapshot, merging together existing manifests if
+// there are too many.
+//
+// The state that is built by this action is only observable by Iceberg clients
+// if the resulting update is successfully committed to the catalog.
+//
+// Other Iceberg action implementations retry appends some configurable number
+// of times. Retries here are left to the caller, who is expected to
+// periodically append uncommitted files with a new transaction.
+//
+// Does not deduplicate new data files against files referenced by existing
+// manifests. This is left to the caller, if desired.
+//
+// TODO: currently throws for tables with multiple partition specs.
+// TODO: doesn't clean up any wasted (e.g. on error) manifest files.
+// TODO: shouldn't be too difficult to parallelize IO.
+class merge_append_action : public action {
+public:
+    static constexpr size_t default_min_to_merge_new_files = 100;
+    static constexpr size_t default_target_size_bytes = 8_MiB;
+    merge_append_action(
+      manifest_io& io,
+      const table_metadata& table,
+      chunked_vector<data_file> files,
+      size_t min_to_merge_new_files = default_min_to_merge_new_files,
+      size_t mfile_target_size_bytes = default_target_size_bytes)
+      : io_(io)
+      , table_(table)
+      , commit_uuid_(uuid_t::create())
+      , min_to_merge_new_files_(min_to_merge_new_files)
+      , mfile_target_size_bytes_(mfile_target_size_bytes)
+      , new_data_files_(std::move(files)) {}
+
+protected:
+    ss::future<action_outcome> build_updates() && final;
+
+private:
+    // Context containing various fields resolved from the table metadata. The
+    // fields here all pertain to the new snapshot created by this action.
+    struct table_snapshot_ctx {
+        const uuid_t& commit_uuid;
+        const schema& schema;
+        const partition_spec& pspec;
+        const partition_key_type& pk_type;
+        const snapshot_id snap_id;
+        const sequence_number seq_num;
+    };
+
+    // Returns a number that can be used to uniquely identify the next manifest
+    // upload within this action.
+    size_t generate_manifest_num() { return next_manifest_num_++; }
+
+    // Uploads the given manifest entries as a new manifest, returning the size
+    // of the resulting file.
+    ss::future<checked<size_t, manifest_io::errc>> upload_as_manifest(
+      const manifest_path& path,
+      const schema& schema,
+      const partition_spec& pspec,
+      chunked_vector<manifest_entry> entries);
+
+    // Takes the given list of manifest files and merges them with the given
+    // new data files if the list of files is long enough, or just adds a new
+    // manifest for the new data files otherwise.
+    //
+    // Returns the resulting list of manifest files, which will be size 1 in
+    // the merging case, or the input size + 1 otherwise.
+    ss::future<checked<chunked_vector<manifest_file>, manifest_io::errc>>
+    maybe_merge_mfiles_and_new_data(
+      chunked_vector<manifest_file> to_merge,
+      chunked_vector<data_file> new_data_files,
+      const table_snapshot_ctx& ctx);
+
+    // Takes the given list of manifest files and merges them with the optional
+    // new manifest entries (i.e. data file metadata).
+    ss::future<checked<manifest_file, manifest_io::errc>> merge_mfiles(
+      chunked_vector<manifest_file> to_merge,
+      const table_snapshot_ctx& ctx,
+      field_summary_val::list_t added_summaries = {},
+      chunked_vector<manifest_entry> added_entries = {},
+      size_t added_rows = 0);
+
+    // Takes the given manifest list and bin-packs them to reduce the number of
+    // manifests, adding new data files either to a new manifest or the latest
+    // bin if the number of files in the bin has reached a threshold.
+    //
+    // Returns the resulting list of manifest files, which should encompass all
+    // data from the latest snapshot + new data files, and can be written as a
+    // new manifest list and committed as a new snapshot.
+    ss::future<checked<chunked_vector<manifest_file>, manifest_io::errc>>
+    pack_mlist_and_new_data(
+      const table_snapshot_ctx& ctx,
+      manifest_list old_mlist,
+      chunked_vector<data_file> new_data_files);
+
+private:
+    manifest_io& io_;
+    const table_metadata& table_;
+    const uuid_t commit_uuid_;
+
+    // The size in number of manifest files at which the _latest_ bin (the one
+    // new files are added to) should be merged.
+    const size_t min_to_merge_new_files_;
+
+    // The target size in bytes to bin-pack manifest files.
+    const size_t mfile_target_size_bytes_;
+
+    size_t next_manifest_num_{0};
+    chunked_vector<data_file> new_data_files_;
+};
+
+} // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -151,6 +151,32 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "merge_append_action_test",
+    timeout = "short",
+    srcs = [
+        "merge_append_action_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":test_schemas",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage/tests:s3_imposter_gtest",
+        "//src/v/iceberg:manifest",
+        "//src/v/iceberg:manifest_entry",
+        "//src/v/iceberg:manifest_io",
+        "//src/v/iceberg:merge_append_action",
+        "//src/v/iceberg:partition",
+        "//src/v/iceberg:transaction",
+        "//src/v/iceberg:values_bytes",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "partition_json_test",
     timeout = "short",
     srcs = [
@@ -358,6 +384,9 @@ redpanda_cc_gtest(
     ],
     deps = [
         ":test_schemas",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage/tests:s3_imposter_gtest",
+        "//src/v/iceberg:manifest_io",
         "//src/v/iceberg:transaction",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ rp_test(
     manifest_file_packer_test.cc
     manifest_io_test.cc
     manifest_serialization_test.cc
+    merge_append_action_test.cc
     partition_key_test.cc
     partition_key_type_test.cc
     partition_test.cc

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -1,0 +1,401 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "iceberg/manifest_entry.h"
+#include "iceberg/manifest_io.h"
+#include "iceberg/merge_append_action.h"
+#include "iceberg/partition.h"
+#include "iceberg/tests/test_schemas.h"
+#include "iceberg/transaction.h"
+#include "iceberg/values_bytes.h"
+#include "model/timestamp.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+using namespace std::chrono_literals;
+
+class MergeAppendActionTest
+  : public s3_imposter_fixture
+  , public ::testing::Test {
+public:
+    MergeAppendActionTest()
+      : sr(cloud_io::scoped_remote::create(10, conf))
+      , io(remote(), bucket_name) {
+        set_expectations_and_listen({});
+    }
+    cloud_io::remote& remote() { return sr->remote.local(); }
+
+    table_metadata create_table() {
+        auto s = schema{
+          .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+          .schema_id = schema::id_t{0},
+          .identifier_field_ids = {},
+        };
+        chunked_vector<schema> schemas;
+        schemas.emplace_back(s.copy());
+        chunked_vector<partition_spec> pspecs;
+        pspecs.emplace_back(partition_spec{
+          .spec_id = partition_spec::id_t{0},
+          .fields = {
+            // Creates a partition key of type [int].
+            partition_field{
+              .source_id = nested_field::id_t{2},
+              .field_id = partition_field::id_t{1000},
+              .name = "bar",
+              .transform = identity_transform{},
+            },
+          },
+        });
+        return table_metadata{
+          .format_version = format_version::v2,
+          .table_uuid = uuid_t::create(),
+          .location = "foo/bar",
+          .last_sequence_number = sequence_number{0},
+          .last_updated_ms = model::timestamp::now(),
+          .last_column_id = s.highest_field_id().value(),
+          .schemas = std::move(schemas),
+          .current_schema_id = schema::id_t{0},
+          .partition_specs = std::move(pspecs),
+          .default_spec_id = partition_spec::id_t{0},
+          .last_partition_id = partition_field::id_t{-1},
+        };
+    }
+
+    partition_key make_int_pk(int32_t v) {
+        auto pk_struct = std::make_unique<struct_value>();
+        pk_struct->fields.emplace_back(int_value{v});
+        return {std::move(pk_struct)};
+    }
+
+    chunked_vector<data_file> create_data_files(
+      const ss::sstring& path_base,
+      size_t num_files,
+      size_t record_count,
+      int32_t pk_value = 42) {
+        chunked_vector<data_file> ret;
+        ret.reserve(num_files);
+        const auto records_per_file = record_count / num_files;
+        const auto leftover_records = record_count % num_files;
+        for (size_t i = 0; i < num_files; i++) {
+            const auto path = fmt::format("{}-{}", path_base, i);
+            ret.emplace_back(data_file{
+              .content_type = data_file_content_type::data,
+              .file_path = path,
+              .partition = partition_key{make_int_pk(pk_value)},
+              .record_count = records_per_file,
+              .file_size_bytes = 1_KiB,
+            });
+        }
+        ret[0].record_count += leftover_records;
+        return ret;
+    }
+
+    std::unique_ptr<cloud_io::scoped_remote> sr;
+    manifest_io io;
+};
+
+TEST_F(MergeAppendActionTest, TestMergeByCount) {
+    const size_t num_to_merge_at
+      = merge_append_action::default_min_to_merge_new_files;
+    const size_t files_per_man = 2;
+    const size_t rows_per_man = 25;
+    transaction tx(io, create_table());
+    // Repeatedly add new data files. Each iteration creates a new manifest
+    // because we're below the merge count threshhold.
+    for (size_t i = 0; i < num_to_merge_at; i++) {
+        const auto expected_snapshots = i + 1;
+        const auto expected_manifests = expected_snapshots;
+        auto res = tx.merge_append(
+                       create_data_files("foo", files_per_man, rows_per_man))
+                     .get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        const auto& table = tx.table();
+        ASSERT_TRUE(table.snapshots.has_value());
+        ASSERT_TRUE(table.current_snapshot_id.has_value());
+        ASSERT_EQ(table.snapshots.value().size(), expected_snapshots);
+
+        auto latest_mlist_path
+          = table.snapshots.value().back().manifest_list_path;
+        auto latest_mlist = io.download_manifest_list(
+                                manifest_list_path{latest_mlist_path})
+                              .get();
+        ASSERT_TRUE(latest_mlist.has_value());
+        ASSERT_EQ(latest_mlist.value().files.size(), expected_manifests);
+    }
+
+    // At the merge threshold, we expect the latest snapshot contains a merged
+    // manifest.
+    auto res = tx.merge_append(
+                   create_data_files("foo", files_per_man, rows_per_man))
+                 .get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    const auto& table = tx.table();
+    ASSERT_TRUE(table.snapshots.has_value());
+    ASSERT_EQ(table.snapshots.value().size(), num_to_merge_at + 1);
+
+    // Validate that the latest snapshot indeed contains a single manifest.
+    auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
+    auto latest_mlist
+      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+    ASSERT_TRUE(latest_mlist.has_value());
+    ASSERT_EQ(latest_mlist.value().files.size(), 1);
+    const auto& merged_mfile = latest_mlist.value().files[0];
+
+    // Check that the manifest file's metadata seem sane.
+    ASSERT_EQ(merged_mfile.partition_spec_id(), 0);
+    ASSERT_EQ(merged_mfile.added_files_count, files_per_man);
+    ASSERT_EQ(merged_mfile.added_rows_count, rows_per_man);
+    ASSERT_EQ(
+      merged_mfile.existing_files_count, num_to_merge_at * files_per_man);
+    ASSERT_EQ(merged_mfile.existing_rows_count, num_to_merge_at * rows_per_man);
+    ASSERT_EQ(merged_mfile.deleted_files_count, 0);
+    ASSERT_EQ(merged_mfile.deleted_rows_count, 0);
+}
+
+TEST_F(MergeAppendActionTest, TestMergeByBytes) {
+    // Inflate the datafile names so our manifest entries will be large, and
+    // our manifest files will therefore be large.
+    const ss::sstring path_base(1000000, 'x');
+    // The default 8MiB merge threshold will allow for 8+1 1MB entries before
+    // merging: the +1 is expected because when we add the 9th datafile, it
+    // doesn't yet have a manifest, and is ignored for manifest bin-packing.
+    const size_t num_to_merge_at = 9;
+    const size_t files_per_man = 1;
+    const size_t rows_per_man = 25;
+    transaction tx(io, create_table());
+    for (size_t i = 0; i < num_to_merge_at; i++) {
+        const auto expected_snapshots = i + 1;
+        const auto expected_manifests = expected_snapshots;
+        auto res = tx.merge_append(create_data_files(
+                                     path_base, files_per_man, rows_per_man))
+                     .get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        const auto& table = tx.table();
+        ASSERT_TRUE(table.snapshots.has_value());
+        ASSERT_TRUE(table.current_snapshot_id.has_value());
+        ASSERT_EQ(table.snapshots.value().size(), expected_snapshots);
+
+        auto latest_mlist_path
+          = table.snapshots.value().back().manifest_list_path;
+        auto latest_mlist = io.download_manifest_list(
+                                manifest_list_path{latest_mlist_path})
+                              .get();
+        ASSERT_TRUE(latest_mlist.has_value());
+        ASSERT_EQ(latest_mlist.value().files.size(), expected_manifests);
+    }
+
+    // At the merge threshold, we expect the latest snapshot contains a merged
+    // manifest.
+    auto res = tx.merge_append(
+                   create_data_files(path_base, files_per_man, rows_per_man))
+                 .get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    const auto& table = tx.table();
+    ASSERT_TRUE(table.snapshots.has_value());
+    ASSERT_EQ(table.snapshots.value().size(), num_to_merge_at + 1);
+
+    // Validate that the latest snapshot indeed contains a three manifests:
+    // - the one containing 8 merged 1MB paths
+    // - the two we added that weren't merged
+    auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
+    auto latest_mlist
+      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+    ASSERT_TRUE(latest_mlist.has_value());
+    ASSERT_EQ(latest_mlist.value().files.size(), 3);
+
+    // The newest file has the highest sequence number and add-counters ticked.
+    const auto& latest_mfile = latest_mlist.value().files[0];
+    ASSERT_EQ(latest_mfile.partition_spec_id(), 0);
+    auto latest_seq = latest_mfile.seq_number;
+    ASSERT_EQ(latest_seq(), 10);
+    ASSERT_EQ(latest_mfile.min_seq_number, latest_mfile.seq_number);
+    ASSERT_EQ(latest_mfile.added_files_count, files_per_man);
+    ASSERT_EQ(latest_mfile.added_rows_count, rows_per_man);
+    ASSERT_EQ(latest_mfile.existing_files_count, 0);
+    ASSERT_EQ(latest_mfile.existing_rows_count, 0);
+    ASSERT_EQ(latest_mfile.deleted_files_count, 0);
+    ASSERT_EQ(latest_mfile.deleted_rows_count, 0);
+
+    // The next file also has add-counters ticked because it wasn't updated
+    // after its initial write, also indicated by the lower sequence number.
+    const auto& middle_mfile = latest_mlist.value().files[1];
+    ASSERT_EQ(middle_mfile.seq_number(), latest_seq() - 1);
+    ASSERT_EQ(middle_mfile.min_seq_number, middle_mfile.seq_number);
+    ASSERT_EQ(middle_mfile.partition_spec_id(), 0);
+    ASSERT_EQ(middle_mfile.added_files_count, files_per_man);
+    ASSERT_EQ(middle_mfile.added_rows_count, rows_per_man);
+    ASSERT_EQ(middle_mfile.existing_files_count, 0);
+    ASSERT_EQ(middle_mfile.existing_rows_count, 0);
+    ASSERT_EQ(middle_mfile.deleted_files_count, 0);
+    ASSERT_EQ(middle_mfile.deleted_rows_count, 0);
+
+    // The last file is the merged file.
+    const auto& merged_mfile = latest_mlist.value().files[2];
+    ASSERT_EQ(merged_mfile.seq_number(), latest_seq());
+    ASSERT_EQ(merged_mfile.min_seq_number(), 1);
+    ASSERT_EQ(merged_mfile.partition_spec_id(), 0);
+    ASSERT_EQ(merged_mfile.added_files_count, 0);
+    ASSERT_EQ(merged_mfile.added_rows_count, 0);
+    ASSERT_EQ(merged_mfile.existing_files_count, 8 * files_per_man);
+    ASSERT_EQ(merged_mfile.existing_rows_count, 8 * rows_per_man);
+    ASSERT_EQ(merged_mfile.deleted_files_count, 0);
+    ASSERT_EQ(merged_mfile.deleted_rows_count, 0);
+}
+
+TEST_F(MergeAppendActionTest, TestUniqueSnapshotIds) {
+    transaction tx(io, create_table());
+    const auto& table = tx.table();
+    chunked_hash_set<snapshot_id> snap_ids;
+    const size_t num_snapshots = 1000;
+    for (auto i = 0; i < 1000; i++) {
+        const auto expected_snapshots = i + 1;
+        auto res = tx.merge_append(create_data_files("foo", 1, 1)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        ASSERT_TRUE(table.snapshots.has_value());
+        ASSERT_TRUE(table.current_snapshot_id.has_value());
+        ASSERT_EQ(table.snapshots.value().size(), expected_snapshots);
+        ASSERT_EQ(table.snapshots->back().id, *table.current_snapshot_id);
+
+        // Each snapshot should get a unique snapshot id.
+        ASSERT_TRUE(snap_ids.emplace(table.current_snapshot_id.value()).second);
+    }
+    // Sanity check that the snapshots' ids match with what we collected when
+    // building the snapshots.
+    ASSERT_EQ(num_snapshots, snap_ids.size());
+    const auto& snaps = table.snapshots.value();
+    chunked_hash_set<snapshot_id> snap_ids_from_snaps;
+    for (const auto& snap : snaps) {
+        ASSERT_TRUE(snap_ids_from_snaps.emplace(snap.id).second);
+    }
+    ASSERT_EQ(snap_ids, snap_ids_from_snaps);
+}
+
+TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
+    const size_t num_to_merge_at
+      = merge_append_action::default_min_to_merge_new_files;
+    transaction tx(io, create_table());
+    const auto& table = tx.table();
+    chunked_hash_set<snapshot_id> snap_ids;
+    const int32_t base_pk = 300;
+    for (size_t i = 0; i < num_to_merge_at; i++) {
+        int32_t pk = base_pk + i;
+        const auto expected_manifests = i + 1;
+        auto res = tx.merge_append(create_data_files("foo", 1, 1, pk)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+
+        // Download the resulting manifest list and make sure we only added a
+        // manifest (no merge yet).
+        auto latest_mlist_path
+          = table.snapshots.value().back().manifest_list_path;
+        auto latest_mlist_res = io.download_manifest_list(
+                                    manifest_list_path{latest_mlist_path})
+                                  .get();
+        ASSERT_TRUE(latest_mlist_res.has_value());
+        ASSERT_EQ(expected_manifests, latest_mlist_res.value().files.size());
+
+        // Do some validation on the partition summaries.
+        const auto& latest_mfile = latest_mlist_res.value().files.front();
+        ASSERT_EQ(0, latest_mfile.partition_spec_id());
+        const auto& latest_partitions = latest_mfile.partitions;
+        ASSERT_EQ(1, latest_partitions.size());
+        ASSERT_FALSE(latest_partitions[0].contains_nan);
+        ASSERT_FALSE(latest_partitions[0].contains_null);
+
+        // Since we haven't merged any files, we expect the latest manifest to
+        // only contain data from the files we just appended, which span only a
+        // single partition.
+        auto lower_bound = latest_partitions[0].lower_bound;
+        auto upper_bound = latest_partitions[0].upper_bound;
+        ASSERT_TRUE(lower_bound.has_value());
+        ASSERT_EQ(lower_bound, upper_bound);
+        ASSERT_EQ(lower_bound.value(), value_to_bytes(int_value{pk}));
+    }
+    // Write one more manifest, triggering a merge.
+    const int32_t last_pk = base_pk + num_to_merge_at + 123;
+    auto res = tx.merge_append(create_data_files("foo", 1, 1, last_pk)).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
+    auto latest_mlist_res
+      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+    ASSERT_TRUE(latest_mlist_res.has_value());
+    ASSERT_EQ(1, latest_mlist_res.value().files.size());
+
+    // The resulting merged manifest should include partition information from
+    // the prior manifest files.
+    const auto& merged_mfile = latest_mlist_res.value().files[0];
+    ASSERT_EQ(0, merged_mfile.partition_spec_id());
+    const auto& latest_partitions = merged_mfile.partitions;
+    ASSERT_EQ(1, latest_partitions.size());
+    ASSERT_FALSE(latest_partitions[0].contains_nan);
+    ASSERT_FALSE(latest_partitions[0].contains_null);
+    ASSERT_EQ(
+      latest_partitions[0].lower_bound, value_to_bytes(int_value{base_pk}));
+    ASSERT_EQ(
+      latest_partitions[0].upper_bound, value_to_bytes(int_value{last_pk}));
+}
+
+TEST_F(MergeAppendActionTest, TestBadMetadata) {
+    chunked_vector<table_metadata> bad_tables;
+    auto check_bad = [this](table_metadata t) {
+        transaction tx(io, std::move(t));
+        auto res = tx.merge_append(create_data_files("foo", 1, 1)).get();
+        ASSERT_TRUE(res.has_error());
+        ASSERT_EQ(res.error(), action::errc::unexpected_state);
+    };
+    {
+        // No schemas.
+        auto t = create_table();
+        t.schemas.clear();
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+    {
+        // Current snapshot is bogus.
+        auto t = create_table();
+        t.current_snapshot_id = snapshot_id{1234};
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+    {
+        // No partition specs.
+        auto t = create_table();
+        t.partition_specs.clear();
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+    {
+        // More than one partition spec.
+        auto t = create_table();
+        t.partition_specs.emplace_back(partition_spec{});
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+    {
+        // Current schema is bogus.
+        auto t = create_table();
+        t.current_schema_id = schema::id_t{1234};
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+    {
+        // Current spec is bogus.
+        auto t = create_table();
+        t.default_spec_id = partition_spec::id_t{1234};
+        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
+    }
+}
+
+TEST_F(MergeAppendActionTest, TestBadFile) {
+    transaction tx(io, create_table());
+    auto bad_files = create_data_files("foo", 1, 1);
+    for (auto& f : bad_files) {
+        f.partition = partition_key{};
+    }
+    auto res = tx.merge_append(std::move(bad_files)).get();
+    ASSERT_TRUE(res.has_error());
+    ASSERT_EQ(res.error(), action::errc::unexpected_state);
+}

--- a/src/v/iceberg/transaction.cc
+++ b/src/v/iceberg/transaction.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 #include "iceberg/transaction.h"
 
+#include "iceberg/merge_append_action.h"
 #include "iceberg/schema.h"
 #include "iceberg/table_requirement.h"
 #include "iceberg/table_update_applier.h"
@@ -63,6 +64,13 @@ transaction::txn_outcome transaction::update_metadata(updates_and_reqs ur) {
 
 ss::future<transaction::txn_outcome> transaction::set_schema(schema s) {
     auto a = std::make_unique<update_schema_action>(table_, std::move(s));
+    co_return co_await apply(std::move(a));
+}
+
+ss::future<transaction::txn_outcome>
+transaction::merge_append(chunked_vector<data_file> files) {
+    auto a = std::make_unique<merge_append_action>(
+      io_, table_, std::move(files));
     co_return co_await apply(std::move(a));
 }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Implements a new merge_append action that adds a given group of data
files to the table, potentially merging them to an existing manifest if
there are too many manifests.

This resembles the implementation in the pyiceberg library[1]: we
bin-pack manifest_files into groups of 8MiB and merge all bins but the
latest one. If the latest bin contains fewer than 100 manifests, it is
left alone, otherwise it is also merged. In the future, these will be
configurable, but for now, this commit adds these default parameters.

Unlike the python implementation, which groups together merges based on
partition spec, this implementation throws if there is more than one
partition spec. This is left as short-term future work.

[1] https://github.com/apache/iceberg-python/blob/e5a58b34dd830c6ffea11649613b693f70f7cbb4/pyiceberg/table/update/snapshot.py#L475

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
