### PR TITLE
cdt-perf: Reduce OMB test runtime

### DIFF
--- a/tests/rptest/perf/openmessaging_perf_test.py
+++ b/tests/rptest/perf/openmessaging_perf_test.py
@@ -39,7 +39,7 @@ class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
             "message_size": 1024,
             "payload_file": "payload/payload-1Kb.data",
             "consumer_backlog_size_GB": 0,
-            "test_duration_minutes": 5,
+            "test_duration_minutes": 2,
             "warmup_duration_minutes": 2,
         }
         driver = {

--- a/tests/rptest/perf/small_batches_test.py
+++ b/tests/rptest/perf/small_batches_test.py
@@ -27,7 +27,7 @@ class SmallBatchesTest(RedpandaTest):
             "message_size": 100,
             "payload_file": "payload/payload-100b.data",
             "consumer_backlog_size_GB": 0,
-            "test_duration_minutes": 5,
+            "test_duration_minutes": 2,
             "warmup_duration_minutes": 2,
         }
         driver = {

--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -63,7 +63,7 @@ class TSReadOpenmessagingTest(RedpandaTest):
             "payload_file": "payload/payload-1Kb.data",
             "consumer_backlog_size_GB": 20,
             "test_duration_minutes": 1,
-            "warmup_duration_minutes": 5,
+            "warmup_duration_minutes": 2,
         }
 
         benchmark = OpenMessagingBenchmark(self._ctx,

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -52,7 +52,7 @@ class TSWriteOpenmessagingTest(RedpandaTest):
             "message_size": 1024,
             "payload_file": "payload/payload-1Kb.data",
             "consumer_backlog_size_GB": 0,
-            "test_duration_minutes": 5,
+            "test_duration_minutes": 2,
             "warmup_duration_minutes": 2,
         }
         driver = {


### PR DESCRIPTION
Reduce the test runtime such that we can instead do an extra run.

Also shorten the TS read bench warmup time which was 5 minutes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

