### PR TITLE
[v24.1.x] cluster_recovery_backend_test: only reset relevant config

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -198,7 +198,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     // Create a new cluster.
     raft0 = nullptr;
     restart(should_wipe::yes);
-    config::shard_local_cfg().for_each([](auto& p) { p.reset(); });
+    task_local_cfg.get("log_segment_size_jitter_percent").reset();
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] {
         return app.storage.local().get_cluster_uuid().has_value();
     });


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18553
Fixes: https://github.com/redpanda-data/redpanda/issues/23504,