### PR TITLE
rptest: do not expect cached segment readers at the end of the test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
@@ -297,9 +297,6 @@ class TieredStorageReaderStressTest(RedpandaTest):
             # The stats indicate saturation with tiered storage reads.
             assert stats['partition_readers_delayed'] or stats[
                 'segment_readers_delayed']
-            # There are still some segment readers cached as expected, they shouldn't
-            # all have been trimmed.
-            assert stats['segment_readers']
 
         def is_metric_zero(fn, label):
             for node, stats in self._get_stats().items():


### PR DESCRIPTION
This assertion fails from time to time. It seems perfectly fine there not to be any cached readers available.

If there aren't any running queries using readers and we are under memory pressure the next query will likely evict all segment readers to free up resources. Reader eviction (and memory accounting) is asynchronous but the metric/probe update is synchronous.

If we get metrics in-between last query acquiring memory resources (or slightly after) and before the actual physical eviction happened then we expect the metric to be 0.

It is possible for the last query to be aborted altogether in-between requesting resources and actually creating a reader which would also lead to metric being 0.

I consider this acceptable behavior so removing the assert.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
