### PR TITLE
CORE-7738: pp/httpd: Remove extra decode on path param get

### DIFF
--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1073,6 +1073,19 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         result = result_raw.json()
         # assert result["schema"] == json.dumps(schema_def)
 
+        self.logger.debug(
+            "Post schema 1 with escape chars in the subject name")
+        name = f"{topic}%25252fkey"
+        name_quoted = urllib.parse.quote(name)
+        result_raw = self._post_subjects_subject_versions(subject=name_quoted,
+                                                          data=schema_1_data)
+        self.logger.warn(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+        result_raw = self._get_subjects_subject_versions(subject=name_quoted)
+        assert result_raw.status_code == requests.codes.ok
+        subjs = self._get_subjects().json()
+        assert name in subjs, f"Expected '{name}' in subjects response, got {json.dumps(subjs, indent=1)}"
+
     @cluster(num_nodes=3)
     def test_post_subjects_subject_versions_version_many(self):
         """


### PR DESCRIPTION
seastar::http::request::get_path_param performs URL decoding automatically. When this path was updated to use the new method, the pre-existing URL decode behavior was left in place.

This is usually not noticeable because decoding an un-encoded string is a no-op. However, that's not the case if the decoded string itself contains URL escape sequences.

For example, given the path parameter "foo%252Fbar":
  - decoded once:   "foo%2Fbar"
  - decoded twice:  "foo/bar"

So this commit removes the "extra" decode step from the PP httpd module and adds a ducktape test to confirm that URL escape sequences are preserved in a client-provided subject name, the specific case that led to this fix.

Unfortunately, get_path_param destroys some information such that distinguishing between an absent parameter and an ill-formed parameter is no longer possible. So this commit includes a bit of extra logic for the nominally unlikely case where get_path_param returns an empty string.

CORE-7738

TODO
- [x] Confirm that this needs backporting all the way to v23.3
   - looks like 24.1.x+ is sufficient https://github.com/redpanda-data/redpanda/pull/17899

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug where URL path params to `PandaProxy` and `SchemaRegistry` would be URL decoded twice, destroying escape sequences present in the original request.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
