### PR TITLE
test: apply ubsan suppressions to all redpanda invocations

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2553,6 +2553,10 @@ class RedpandaService(RedpandaServiceBase):
 
         self._expect_max_controller_records = 1000
 
+    def redpanda_env_preamble(self):
+        # Pass environment variables via FOO=BAR shell expressions
+        return " ".join([f"{k}={v}" for (k, v) in self._environment.items()])
+
     def set_seed_servers(self, node_list):
         assert len(node_list) > 0
         self._seed_servers = node_list
@@ -2961,9 +2965,7 @@ class RedpandaService(RedpandaServiceBase):
                 dict(LLVM_PROFILE_FILE=
                      f"\"{RedpandaService.COVERAGE_PROFRAW_CAPTURE}\""))
 
-        # Pass environment variables via FOO=BAR shell expressions
-        env_preamble = " ".join(
-            [f"{k}={v}" for (k, v) in self._environment.items()])
+        env_preamble = self.redpanda_env_preamble()
 
         cmd = (
             f"{preamble} {env_preamble} nohup {self.find_binary('redpanda')}"
@@ -3879,7 +3881,8 @@ class RedpandaService(RedpandaServiceBase):
         """
         Returns the redpanda binary version as a string.
         """
-        version_cmd = f"{self.find_binary('redpanda')} --version"
+        env_preamble = self.redpanda_env_preamble()
+        version_cmd = f"{env_preamble} {self.find_binary('redpanda')} --version"
         VERSION_LINE_RE = re.compile(".*(v\\d+\\.\\d+\\.\\d+).*")
         # NOTE: not all versions of Redpanda support the --version field, even
         # though they print out the version.


### PR DESCRIPTION
When running `redpanda --version` apply ubsan suppressions like we do when we run redpanda normally.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

