### PR TITLE
iceberg: use iobuf_writer for json

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -64,6 +64,18 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "json_writer",
+    hdrs = [
+        "json_writer.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        "//src/v/json",
+        "//src/v/strings:utf8",
+    ],
+)
+
+redpanda_cc_library(
     name = "datatypes",
     srcs = [
         "datatypes.cc",
@@ -93,6 +105,7 @@ redpanda_cc_library(
     deps = [
         ":datatypes",
         ":json_utils",
+        ":json_writer",
         "//src/v/json",
         "//src/v/strings:string_switch",
     ],
@@ -335,6 +348,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":json_utils",
+        ":json_writer",
         ":transform_json",
         "//src/v/strings:string_switch",
     ],
@@ -458,6 +472,7 @@ redpanda_cc_library(
         ":datatypes",
         ":datatypes_json",
         ":json_utils",
+        ":json_writer",
         ":schema",
         "//src/v/json",
     ],
@@ -487,6 +502,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":json_utils",
+        ":json_writer",
         "//src/v/model",
         "//src/v/strings:string_switch",
         "@abseil-cpp//absl/container:btree",
@@ -536,6 +552,7 @@ redpanda_cc_library(
     ],
     include_prefix = "iceberg",
     deps = [
+        ":json_writer",
         ":table_metadata",
         "//src/v/json",
     ],

--- a/src/v/iceberg/datatypes_json.cc
+++ b/src/v/iceberg/datatypes_json.cc
@@ -134,7 +134,7 @@ namespace json {
 namespace {
 class rjson_visitor {
 public:
-    explicit rjson_visitor(json::Writer<json::StringBuffer>& w)
+    explicit rjson_visitor(iceberg::json_writer& w)
       : w(w) {}
     void operator()(const iceberg::boolean_type&) { w.String("boolean"); }
     void operator()(const iceberg::int_type&) { w.String("int"); }
@@ -163,12 +163,11 @@ public:
     void operator()(const iceberg::map_type& t) { rjson_serialize(w, t); }
 
 private:
-    json::Writer<json::StringBuffer>& w;
+    iceberg::json_writer& w;
 };
 } // anonymous namespace
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::nested_field& f) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::nested_field& f) {
     w.StartObject();
     w.Key("id");
     w.Int(f.id());
@@ -182,12 +181,11 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::primitive_type& t) {
+  iceberg::json_writer& w, const iceberg::primitive_type& t) {
     std::visit(rjson_visitor{w}, t);
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::struct_type& t) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::struct_type& t) {
     w.StartObject();
     w.Key("type");
     w.String("struct");
@@ -200,8 +198,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::list_type& t) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::list_type& t) {
     w.StartObject();
     w.Key("type");
     w.String("list");
@@ -214,8 +211,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::map_type& t) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::map_type& t) {
     w.StartObject();
     w.Key("type");
     w.String("map");
@@ -232,8 +228,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::field_type& t) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::field_type& t) {
     std::visit(rjson_visitor{w}, t);
 }
 

--- a/src/v/iceberg/datatypes_json.h
+++ b/src/v/iceberg/datatypes_json.h
@@ -9,10 +9,8 @@
 #pragma once
 
 #include "iceberg/datatypes.h"
-#include "json/_include_first.h"
+#include "iceberg/json_writer.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
-#include "json/writer.h"
 
 namespace iceberg {
 
@@ -26,17 +24,11 @@ nested_field_ptr parse_field(const json::Value&);
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::nested_field& f);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::primitive_type& t);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::struct_type& t);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::list_type& t);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::map_type& t);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::field_type& t);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::nested_field& f);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::primitive_type& t);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::struct_type& t);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::list_type& t);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::map_type& t);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::field_type& t);
 
 } // namespace json

--- a/src/v/iceberg/json_writer.h
+++ b/src/v/iceberg/json_writer.h
@@ -1,0 +1,34 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "json/chunked_buffer.h"
+#include "json/iobuf_writer.h"
+#include "strings/utf8.h"
+
+namespace iceberg {
+
+using json_writer = json::iobuf_writer<json::chunked_buffer>;
+
+// NOTE: uses std::string since we're likely parsing JSON alongside a
+// thirdparty library that uses std::string.
+template<typename T>
+std::string to_json_str(const T& t) {
+    json::chunked_buffer buf;
+    iceberg::json_writer w(buf);
+    rjson_serialize(w, t);
+    auto p = iobuf_parser(std::move(buf).as_iobuf());
+    std::string str;
+    str.resize(p.bytes_left());
+    p.consume_to(p.bytes_left(), str.data());
+    validate_utf8(str);
+    return str;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/manifest_avro.cc
+++ b/src/v/iceberg/manifest_avro.cc
@@ -35,9 +35,9 @@
 namespace iceberg {
 
 namespace {
-schema schema_from_str(const std::string& s) {
+schema schema_from_str(std::string_view s) {
     json::Document parsed_schema;
-    parsed_schema.Parse(s);
+    parsed_schema.Parse(s.data(), s.size());
     return parse_schema(parsed_schema);
 }
 

--- a/src/v/iceberg/manifest_avro.cc
+++ b/src/v/iceberg/manifest_avro.cc
@@ -35,12 +35,6 @@
 namespace iceberg {
 
 namespace {
-ss::sstring schema_to_json_str(const schema& s) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, s);
-    return buf.GetString();
-}
 schema schema_from_str(const std::string& s) {
     json::Document parsed_schema;
     parsed_schema.Parse(s);
@@ -96,20 +90,13 @@ partition_spec partition_spec_from_str(const partition_spec_strs& strs) {
     }
     return parsed_spec;
 }
-ss::sstring partition_spec_to_str(const partition_spec& spec) {
-    json::StringBuffer spec_buf;
-    json::Writer<json::StringBuffer> w_spec(spec_buf);
-    rjson_serialize(w_spec, spec);
-    return spec_buf.GetString();
-}
 
 std::map<std::string, std::string>
 metadata_to_map(const manifest_metadata& meta) {
-    auto partition_spec_strs = partition_spec_to_str(meta.partition_spec);
     return {
-      {"schema", schema_to_json_str(meta.schema)},
+      {"schema", to_json_str(meta.schema)},
       {"content", std::string{content_type_to_str(meta.manifest_content_type)}},
-      {"partition-spec", partition_spec_to_str(meta.partition_spec)},
+      {"partition-spec", to_json_str(meta.partition_spec)},
       {"partition-spec-id", fmt::to_string(meta.partition_spec.spec_id())},
       {"format-version", std::string{format_to_str(meta.format_version)}}};
 }

--- a/src/v/iceberg/partition_json.cc
+++ b/src/v/iceberg/partition_json.cc
@@ -51,7 +51,7 @@ partition_spec parse_partition_spec(const json::Value& v) {
 namespace json {
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::partition_field& m) {
+  iceberg::json_writer& w, const iceberg::partition_field& m) {
     w.StartObject();
     w.Key("source-id");
     w.Int(m.source_id());
@@ -65,7 +65,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::partition_spec& m) {
+  iceberg::json_writer& w, const iceberg::partition_spec& m) {
     w.StartObject();
     w.Key("spec-id");
     w.Int(m.spec_id());

--- a/src/v/iceberg/partition_json.h
+++ b/src/v/iceberg/partition_json.h
@@ -8,11 +8,9 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "iceberg/json_writer.h"
 #include "iceberg/partition.h"
-#include "json/_include_first.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
-#include "json/writer.h"
 
 namespace iceberg {
 
@@ -24,8 +22,7 @@ partition_spec parse_partition_spec(const json::Value&);
 namespace json {
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::partition_field& m);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::partition_spec& m);
+  iceberg::json_writer& w, const iceberg::partition_field& m);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::partition_spec& m);
 
 } // namespace json

--- a/src/v/iceberg/schema_avro.cc
+++ b/src/v/iceberg/schema_avro.cc
@@ -188,8 +188,8 @@ avro::Schema field_to_avro(const nested_field& field) {
 }
 
 avro::Schema
-struct_type_to_avro(const struct_type& type, const ss::sstring& name) {
-    avro::RecordSchema avro_schema(name);
+struct_type_to_avro(const struct_type& type, std::string_view name) {
+    avro::RecordSchema avro_schema(std::string{name});
     const auto& fields = type.fields;
     for (const auto& field_ptr : fields) {
         const auto child_schema = field_to_avro(*field_ptr);

--- a/src/v/iceberg/schema_avro.h
+++ b/src/v/iceberg/schema_avro.h
@@ -20,7 +20,7 @@ namespace iceberg {
 // The resulting schema is annotated with Iceberg attributes (e.g. 'field-id',
 // 'element-id').
 avro::Schema field_to_avro(const nested_field& field);
-avro::Schema struct_type_to_avro(const struct_type&, const ss::sstring& name);
+avro::Schema struct_type_to_avro(const struct_type&, std::string_view name);
 
 // Translates the given Avro schema into its corresponding field/type, throwing
 // an exception if the schema is not a valid Iceberg schema (e.g. missing

--- a/src/v/iceberg/schema_json.cc
+++ b/src/v/iceberg/schema_json.cc
@@ -54,8 +54,7 @@ schema parse_schema(const json::Value& v) {
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::schema& s) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::schema& s) {
     w.StartObject();
     w.Key("type");
     w.String("struct");

--- a/src/v/iceberg/schema_json.h
+++ b/src/v/iceberg/schema_json.h
@@ -8,11 +8,9 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "iceberg/json_writer.h"
 #include "iceberg/schema.h"
-#include "json/_include_first.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
-#include "json/writer.h"
 
 namespace iceberg {
 
@@ -22,7 +20,6 @@ schema parse_schema(const json::Value&);
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::schema& s);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::schema& s);
 
 } // namespace json

--- a/src/v/iceberg/snapshot_json.cc
+++ b/src/v/iceberg/snapshot_json.cc
@@ -141,8 +141,7 @@ snapshot_reference parse_snapshot_ref(const json::Value& v) {
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::snapshot& s) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::snapshot& s) {
     w.StartObject();
     w.Key("snapshot-id");
     w.Int64(s.id());
@@ -174,7 +173,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::snapshot_reference& s) {
+  iceberg::json_writer& w, const iceberg::snapshot_reference& s) {
     w.StartObject();
     w.Key("snapshot-id");
     w.Int64(s.snapshot_id());

--- a/src/v/iceberg/snapshot_json.cc
+++ b/src/v/iceberg/snapshot_json.cc
@@ -34,7 +34,7 @@ constexpr std::string_view operation_to_str(snapshot_operation o) {
     }
 }
 
-snapshot_operation operation_from_str(const ss::sstring& operation_str) {
+snapshot_operation operation_from_str(std::string_view operation_str) {
     using enum snapshot_operation;
     return string_switch<snapshot_operation>(operation_str)
       .match(operation_to_str(append), append)
@@ -53,7 +53,7 @@ constexpr std::string_view ref_type_to_str(snapshot_ref_type t) {
     }
 }
 
-snapshot_ref_type ref_type_from_str(const ss::sstring& ref_type_str) {
+snapshot_ref_type ref_type_from_str(std::string_view ref_type_str) {
     using enum snapshot_ref_type;
     return string_switch<snapshot_ref_type>(ref_type_str)
       .match(ref_type_to_str(tag), tag)

--- a/src/v/iceberg/snapshot_json.h
+++ b/src/v/iceberg/snapshot_json.h
@@ -8,11 +8,9 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "iceberg/json_writer.h"
 #include "iceberg/snapshot.h"
-#include "json/_include_first.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
-#include "json/writer.h"
 
 namespace iceberg {
 
@@ -23,9 +21,8 @@ snapshot_reference parse_snapshot_ref(const json::Value&);
 
 namespace json {
 
+void rjson_serialize(iceberg::json_writer& w, const iceberg::snapshot& s);
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::snapshot& s);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::snapshot_reference& s);
+  iceberg::json_writer& w, const iceberg::snapshot_reference& s);
 
 } // namespace json

--- a/src/v/iceberg/table_metadata_json.cc
+++ b/src/v/iceberg/table_metadata_json.cc
@@ -205,8 +205,7 @@ table_metadata parse_table_meta(const json::Value& v) {
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::sort_field& f) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::sort_field& f) {
     w.StartObject();
     w.Key("transform");
     w.String(iceberg::transform_to_str(f.transform));
@@ -223,8 +222,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::sort_order& m) {
+void rjson_serialize(iceberg::json_writer& w, const iceberg::sort_order& m) {
     w.StartObject();
     w.Key("order-id");
     w.Int(m.order_id());
@@ -238,7 +236,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::table_metadata& m) {
+  iceberg::json_writer& w, const iceberg::table_metadata& m) {
     w.StartObject();
     w.Key("format-version");
     w.Int(iceberg::format_version_to_int(m.format_version));

--- a/src/v/iceberg/table_metadata_json.h
+++ b/src/v/iceberg/table_metadata_json.h
@@ -8,11 +8,9 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "iceberg/json_writer.h"
 #include "iceberg/table_metadata.h"
-#include "json/_include_first.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
-#include "json/writer.h"
 
 namespace iceberg {
 
@@ -24,11 +22,8 @@ table_metadata parse_table_meta(const json::Value&);
 
 namespace json {
 
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::sort_field& m);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::sort_order& m);
-void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const iceberg::table_metadata& m);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::sort_field& m);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::sort_order& m);
+void rjson_serialize(iceberg::json_writer& w, const iceberg::table_metadata& m);
 
 } // namespace json

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_gtest(
         ":test_schemas",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:datatypes_json",
+        "//src/v/iceberg:json_writer",
         "//src/v/json",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
@@ -183,6 +184,7 @@ redpanda_cc_gtest(
         "partition_json_test.cc",
     ],
     deps = [
+        "//src/v/iceberg:json_writer",
         "//src/v/iceberg:partition",
         "//src/v/iceberg:partition_json",
         "//src/v/test_utils:gtest",
@@ -264,6 +266,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         ":test_schemas",
+        "//src/v/iceberg:json_writer",
         "//src/v/iceberg:schema",
         "//src/v/iceberg:schema_json",
         "//src/v/json",
@@ -293,6 +296,7 @@ redpanda_cc_gtest(
         "snapshot_json_test.cc",
     ],
     deps = [
+        "//src/v/iceberg:json_writer",
         "//src/v/iceberg:snapshot",
         "//src/v/iceberg:snapshot_json",
         "//src/v/json",
@@ -323,6 +327,7 @@ redpanda_cc_gtest(
         "table_metadata_json_test.cc",
     ],
     deps = [
+        "//src/v/iceberg:json_writer",
         "//src/v/iceberg:table_metadata",
         "//src/v/iceberg:table_metadata_json",
         "//src/v/test_utils:gtest",

--- a/src/v/iceberg/tests/datatypes_json_test.cc
+++ b/src/v/iceberg/tests/datatypes_json_test.cc
@@ -11,31 +11,22 @@
 #include "iceberg/datatypes_json.h"
 #include "iceberg/tests/test_schemas.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
 
 #include <gtest/gtest.h>
 
 using namespace iceberg;
 
-namespace {
-ss::sstring type_to_json_str(const field_type& t) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, t);
-    return buf.GetString();
-}
-} // namespace
-
 // Round trip test for the struct type of a schema taken from
 // https://github.com/apache/iceberg-go/blob/704a6e78c13ea63f1ff4bb387f7d4b365b5f0f82/schema_test.go#L644
 TEST(DataTypeJsonSerde, TestFieldType) {
     field_type expected_type = test_nested_schema_type();
-    const ss::sstring expected_type_str = type_to_json_str(expected_type);
+    const ss::sstring expected_type_str = iceberg::to_json_str(expected_type);
 
     json::Document parsed_orig_json;
     parsed_orig_json.Parse(test_nested_schema_json_str);
     auto parsed_orig_type = parse_type(parsed_orig_json);
-    const ss::sstring parsed_orig_as_str = type_to_json_str(parsed_orig_type);
+    const ss::sstring parsed_orig_as_str = iceberg::to_json_str(
+      parsed_orig_type);
     ASSERT_EQ(expected_type, parsed_orig_type)
       << fmt::format("{}\nvs\n{}", expected_type_str, parsed_orig_as_str);
 
@@ -43,7 +34,7 @@ TEST(DataTypeJsonSerde, TestFieldType) {
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     auto parsed_roundtrip_type_moved = parse_type(parsed_roundtrip_json);
     auto parsed_roundtrip_type = std::move(parsed_roundtrip_type_moved);
-    const ss::sstring parsed_roundtrip_as_str = type_to_json_str(
+    const ss::sstring parsed_roundtrip_as_str = iceberg::to_json_str(
       parsed_roundtrip_type);
     // NOLINTNEXTLINE(bugprone-use-after-move)
     ASSERT_NE(parsed_roundtrip_type_moved, parsed_roundtrip_type);

--- a/src/v/iceberg/tests/partition_json_test.cc
+++ b/src/v/iceberg/tests/partition_json_test.cc
@@ -14,15 +14,6 @@
 
 using namespace iceberg;
 
-namespace {
-ss::sstring spec_to_json_str(const partition_spec& s) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, s);
-    return buf.GetString();
-}
-} // namespace
-
 TEST(PartitionJsonSerde, TestEmptyPartitionSpec) {
     const auto test_str = R"(
         {
@@ -36,7 +27,7 @@ TEST(PartitionJsonSerde, TestEmptyPartitionSpec) {
     ASSERT_EQ(1, parsed.spec_id());
     ASSERT_TRUE(parsed.fields.empty());
 
-    const auto parsed_orig_as_str = spec_to_json_str(parsed);
+    const auto parsed_orig_as_str = iceberg::to_json_str(parsed);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip = parse_partition_spec(parsed_roundtrip_json);
@@ -84,7 +75,7 @@ TEST(PartitionJsonSerde, TestPartitionSpec) {
     ASSERT_EQ(bucket_transform{16}, parsed.fields[1].transform);
     ASSERT_EQ(truncate_transform{4}, parsed.fields[2].transform);
 
-    const auto parsed_orig_as_str = spec_to_json_str(parsed);
+    const auto parsed_orig_as_str = to_json_str(parsed);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip = parse_partition_spec(parsed_roundtrip_json);

--- a/src/v/iceberg/tests/schema_json_test.cc
+++ b/src/v/iceberg/tests/schema_json_test.cc
@@ -7,24 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "iceberg/json_writer.h"
 #include "iceberg/schema.h"
 #include "iceberg/schema_json.h"
 #include "iceberg/tests/test_schemas.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
 
 #include <gtest/gtest.h>
 
 using namespace iceberg;
-
-namespace {
-ss::sstring schema_to_json_str(const schema& t) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, t);
-    return buf.GetString();
-}
-} // namespace
 
 TEST(SchemaJsonSerde, TestNestedSchema) {
     json::Document parsed_orig_json;
@@ -38,7 +29,7 @@ TEST(SchemaJsonSerde, TestNestedSchema) {
     ASSERT_EQ(parsed_schema.identifier_field_ids.size(), 1);
     ASSERT_EQ((*parsed_schema.identifier_field_ids.begin())(), 1);
 
-    const ss::sstring parsed_orig_as_str = schema_to_json_str(parsed_schema);
+    const ss::sstring parsed_orig_as_str = to_json_str(parsed_schema);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     auto parsed_roundtrip_schema = parse_schema(parsed_roundtrip_json);

--- a/src/v/iceberg/tests/snapshot_json_test.cc
+++ b/src/v/iceberg/tests/snapshot_json_test.cc
@@ -7,29 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "iceberg/json_writer.h"
 #include "iceberg/snapshot.h"
 #include "iceberg/snapshot_json.h"
 #include "json/document.h"
-#include "json/stringbuffer.h"
 
 #include <gtest/gtest.h>
 
 using namespace iceberg;
-
-namespace {
-ss::sstring snapshot_to_json_str(const snapshot& s) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, s);
-    return buf.GetString();
-}
-ss::sstring snapshot_ref_to_json_str(const snapshot_reference& s) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, s);
-    return buf.GetString();
-}
-} // namespace
 
 TEST(SnapshotJsonSerde, TestSnapshot) {
     const auto test_snapshot_str = R"(
@@ -61,7 +46,7 @@ TEST(SnapshotJsonSerde, TestSnapshot) {
     ASSERT_TRUE(snap.schema_id.has_value());
     ASSERT_EQ(0, snap.schema_id.value());
 
-    const auto parsed_orig_as_str = snapshot_to_json_str(snap);
+    const auto parsed_orig_as_str = iceberg::to_json_str(snap);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip_snap = parse_snapshot(parsed_roundtrip_json);
@@ -95,7 +80,7 @@ TEST(SnapshotJsonSerde, TestSnapshotMissingOptionals) {
     ASSERT_STREQ("s3://b/wh/.../s1.avro", snap.manifest_list_path.c_str());
     ASSERT_FALSE(snap.schema_id.has_value());
 
-    const auto parsed_orig_as_str = snapshot_to_json_str(snap);
+    const auto parsed_orig_as_str = iceberg::to_json_str(snap);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip_snap = parse_snapshot(parsed_roundtrip_json);
@@ -123,7 +108,7 @@ TEST(SnapshotJsonSerde, TestSnapshotReferences) {
     ASSERT_TRUE(ref.min_snapshots_to_keep.has_value());
     ASSERT_EQ(ref.min_snapshots_to_keep.value(), 12345);
 
-    const auto parsed_orig_as_str = snapshot_ref_to_json_str(ref);
+    const auto parsed_orig_as_str = iceberg::to_json_str(ref);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip_ref = parse_snapshot_ref(parsed_roundtrip_json);
@@ -145,7 +130,7 @@ TEST(SnapshotJsonSerde, TestSnapshotReferencesMissingOptionals) {
     ASSERT_FALSE(ref.max_ref_age_ms.has_value());
     ASSERT_FALSE(ref.min_snapshots_to_keep.has_value());
 
-    const auto parsed_orig_as_str = snapshot_ref_to_json_str(ref);
+    const auto parsed_orig_as_str = iceberg::to_json_str(ref);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip_ref = parse_snapshot_ref(parsed_roundtrip_json);

--- a/src/v/iceberg/tests/table_metadata_json_test.cc
+++ b/src/v/iceberg/tests/table_metadata_json_test.cc
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "iceberg/json_writer.h"
 #include "iceberg/table_metadata.h"
 #include "iceberg/table_metadata_json.h"
 
 #include <gtest/gtest.h>
 
 using namespace iceberg;
-
-namespace {
-ss::sstring meta_to_json_str(const table_metadata& m) {
-    json::StringBuffer buf;
-    json::Writer<json::StringBuffer> w(buf);
-    rjson_serialize(w, m);
-    return buf.GetString();
-}
-} // namespace
 
 TEST(TableMetadataJsonSerde, TestTableMetadata) {
     // This metadata was mostly taken from the Iceberg Rust project.
@@ -131,7 +123,7 @@ TEST(TableMetadataJsonSerde, TestTableMetadata) {
     ASSERT_TRUE(parsed.refs->contains("main"));
     ASSERT_TRUE(parsed.refs->contains("foo"));
 
-    const auto parsed_orig_as_str = meta_to_json_str(parsed);
+    const auto parsed_orig_as_str = iceberg::to_json_str(parsed);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip = parse_table_meta(parsed_roundtrip_json);
@@ -204,7 +196,7 @@ TEST(TableMetadataJsonSerde, TestTableMetadataNoOptionals) {
     ASSERT_EQ(3, parsed.sort_orders[0].order_id());
     ASSERT_EQ(2, parsed.sort_orders[0].fields.size());
 
-    const auto parsed_orig_as_str = meta_to_json_str(parsed);
+    const auto parsed_orig_as_str = iceberg::to_json_str(parsed);
     json::Document parsed_roundtrip_json;
     parsed_roundtrip_json.Parse(parsed_orig_as_str);
     const auto roundtrip = parse_table_meta(parsed_roundtrip_json);

--- a/src/v/iceberg/transform_json.cc
+++ b/src/v/iceberg/transform_json.cc
@@ -39,7 +39,7 @@ ss::sstring transform_to_str(const transform& t) {
     return std::visit(transform_str_visitor{}, t);
 }
 
-transform transform_from_str(const ss::sstring& s) {
+transform transform_from_str(std::string_view s) {
     if (s.starts_with("bucket")) {
         auto n_str = extract_between('[', ']', s);
         auto n = std::stoul(ss::sstring(n_str));

--- a/src/v/iceberg/transform_json.h
+++ b/src/v/iceberg/transform_json.h
@@ -18,6 +18,6 @@ namespace iceberg {
 // NOTE: while there are no complex JSON types here, the transforms are
 // expected to be serialized as a part of JSON files (e.g. table metadata).
 ss::sstring transform_to_str(const transform&);
-transform transform_from_str(const ss::sstring&);
+transform transform_from_str(std::string_view);
 
 } // namespace iceberg


### PR DESCRIPTION
Swaps out the string-based JSON writer for an iobuf_writer with a chunked_buffer. While we're at it, cleans up some identical to-string code scattered around with a template that uses the new writer.

This will make it trivial to upload JSON, as cloud_io code expects iobufs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
