### PR TITLE
ssx: exit early from sleep_abortable if already aborted

### DIFF
--- a/src/v/ssx/sleep_abortable.h
+++ b/src/v/ssx/sleep_abortable.h
@@ -44,6 +44,11 @@ sleep_abortable(typename Clock::duration dur, AbortSource&... src) {
         }
         seastar::weak_ptr<as_state> state;
     };
+
+    if ((src.abort_requested() || ...)) {
+        return seastar::make_exception_future<>(seastar::sleep_aborted());
+    }
+
     auto state = seastar::make_lw_shared<as_state>();
     state->subscriptions.reserve(sizeof...(AbortSource));
     as_callback cb(*state);

--- a/src/v/ssx/tests/sleep_abortable_test.cc
+++ b/src/v/ssx/tests/sleep_abortable_test.cc
@@ -31,6 +31,14 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort1) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort1_pre) {
+    ss::abort_source as;
+
+    as.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_normal1) {
     ss::abort_source as;
     ssx::sleep_abortable(10ms, as).get();
@@ -51,6 +59,15 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort2) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort2_pre) {
+    ss::abort_source as1;
+    ss::abort_source as2;
+
+    as1.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3) {
     ss::abort_source as1, as2, as3;
 
@@ -60,11 +77,26 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3_pre) {
+    ss::abort_source as1, as2, as3;
+
+    as3.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2, as3);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort4) {
     ss::abort_source as1, as2, as3, as4;
     auto fut = ssx::sleep_abortable(1000s, as1, as2, as3, as4);
     ss::sleep(100ms).get();
     as2.request_abort();
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort4_pre) {
+    ss::abort_source as1, as2, as3, as4;
+    as2.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2, as3, as4);
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 


### PR DESCRIPTION
Caught a few shutdown hangs in unit tests which I tracked down to sleep_abortable being invoked with high durations after abort sources where already aborted.

Do not try to sleep if abort source is already set. ss::sleep_abortable behaves similarly from what I can read.

```
sleeper(typename Clock::duration dur, abort_source& as)
...
auto sc_opt = as.subscribe // returns empty optional if abort source is
already set
...
if (sc_opt) {...} else {
    done.set_exception(sleep_aborted());
}
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
