### PR TITLE
iceberg: deflake update_schema_action_test

### DIFF
--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -382,6 +382,7 @@ redpanda_cc_gtest(
     srcs = [
         "update_schema_action_test.cc",
     ],
+    cpu = 1,
     deps = [
         ":test_schemas",
         "//src/v/cloud_io/tests:scoped_remote",


### PR DESCRIPTION
I don't fully understnad why but tests that use remote_io trip up when run with multiple cores.

```
ERROR 2024-09-28 17:36:49,541 [shard 1:main] seastar - shared_ptr accessed on non-owner cpu, at: 0x796ee6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x220536b /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x2206e58 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x22077f0 /home/andrew/x build/debug/clang/rp_deps_install/lib/libseastar.so+0x1994272 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1994aaf 0x98afbb 0x98a069 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbcd71 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbc86d /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xc06cb /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab1632 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab7bd6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1aba755 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1b32038 /home/andrew/xfs/vbuild/d /clang/rp_deps_install/lib/libseastar.so+0x1997a79 /lib/x86_64-linux-gnu/libc.so.6+0x94ac2 /lib/x86_64-linux-gnu/libc.so.6+0x12684f
   --------
   seastar::smp_message_queue::async_work_item<seastar::future<void> seastar::sharded<cloud_storage_clients::client_pool>::start<unsigned long&, cloud_storage_clients::s3_configuration&>(unsigned long&, cloud_storage_clients::s3_configuration&)::'lambda'(unsigned int)::operator()(unsigned int)::'lambda'()>
ERROR 2024-09-28 17:36:49,541 [shard 2:main] seastar - shared_ptr accessed on non-owner cpu, at: 0x796ee6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x220536b /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x2206e58 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x22077f0 /home/andrew/x build/debug/clang/rp_deps_install/lib/libseastar.so+0x1994272 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1994aaf 0x98afbb 0x98a069 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbcd71 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbc86d /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_i ils.so+0xc06cb /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab1632 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab7bd6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1aba755 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1b32038 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1997a79 /lib/x86_64-linux-gnu/libc.so.6+0x94ac2 /lib/x86_64-linux-gnu/libc.so.6+0x12684f
   --------
   seastar::smp_message_queue::async_work_item<seastar::future<void> seastar::sharded<cloud_storage_clients::client_pool>::start<unsigned long&, cloud_storage_clients::s3_configuration&>(unsigned long&, cloud_storage_clients::s3_configuration&)::'lambda'(unsigned int)::operator()(unsigned int)::'lambda'()>
ERROR 2024-09-28 17:36:49,541 [shard 3:main] seastar - shared_ptr accessed on non-owner cpu, at: 0x796ee6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x220536b /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x2206e58 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x22077f0 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1994272 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1994aaf 0x98afbb 0x98a069 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbcd71 /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_io_utils.so+0xbc86d /home/andrew/xfs/vbuild/debug/clang/lib/libv_v_cloud_i ils.so+0xc06cb /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab1632 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1ab7bd6 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1aba755 /home/andrew/xfs/vbuild/debug/clang/rp_deps_install/lib/libseastar.so+0x1b32038 /home/andrew/xfs/vbuild/d /clang/rp_deps_install/lib/libseastar.so+0x1997a79 /lib/x86_64-linux-gnu/libc.so.6+0x94ac2 /lib/x86_64-linux-gnu/libc.so.6+0x12684f
   --------
   seastar::smp_message_queue::async_work_item<seastar::future<void> seastar::sharded<cloud_storage_clients::client_pool>::start<unsigned long&, cloud_storage_clients::s3_configuration&>(unsigned long&, cloud_storage_clients::s3_configuration&)::'lambda'(unsigned int)::operator()(unsigned int)::'lambda'()>

```

In this case, it's extra unfortunate because the test doesn't really use remote_io, and instead just instantiate them because `transaction` takes it in its constructor for the sake of other actions.

In any case, this makes the bazel test use 1 core. I couldn't reproduce this with CMake, which already runs the iceberg_rpunit with 1 core.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
