### PR TITLE
[v24.2.x] ssx: exit early from sleep_abortable if already aborted

### DIFF
--- a/src/v/ssx/include/ssx/sleep_abortable.h
+++ b/src/v/ssx/include/ssx/sleep_abortable.h
@@ -44,6 +44,11 @@ sleep_abortable(typename Clock::duration dur, AbortSource&... src) {
         }
         seastar::weak_ptr<as_state> state;
     };
+
+    if ((src.abort_requested() || ...)) {
+        return seastar::make_exception_future<>(seastar::sleep_aborted());
+    }
+
     auto state = seastar::make_lw_shared<as_state>();
     state->subscriptions.reserve(sizeof...(AbortSource));
     as_callback cb(*state);

--- a/src/v/ssx/tests/sleep_abortable_test.cc
+++ b/src/v/ssx/tests/sleep_abortable_test.cc
@@ -31,6 +31,14 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort1) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort1_pre) {
+    ss::abort_source as;
+
+    as.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_normal1) {
     ss::abort_source as;
     ssx::sleep_abortable(10ms, as).get();
@@ -51,6 +59,15 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort2) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort2_pre) {
+    ss::abort_source as1;
+    ss::abort_source as2;
+
+    as1.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3) {
     ss::abort_source as1, as2, as3;
 
@@ -60,11 +77,26 @@ SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3) {
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort3_pre) {
+    ss::abort_source as1, as2, as3;
+
+    as3.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2, as3);
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
 SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort4) {
     ss::abort_source as1, as2, as3, as4;
     auto fut = ssx::sleep_abortable(1000s, as1, as2, as3, as4);
     ss::sleep(100ms).get();
     as2.request_abort();
+    BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
+}
+
+SEASTAR_THREAD_TEST_CASE(sleep_abortable_abort4_pre) {
+    ss::abort_source as1, as2, as3, as4;
+    as2.request_abort();
+    auto fut = ssx::sleep_abortable(1000s, as1, as2, as3, as4);
     BOOST_REQUIRE_THROW(fut.get(), ss::sleep_aborted);
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23540
