### PR TITLE
[CORE-7096] Hook admin API to debug bundle service

### DIFF
--- a/src/v/debug_bundle/json.h
+++ b/src/v/debug_bundle/json.h
@@ -44,6 +44,9 @@ debug_bundle::result<T> from_json(const json::Value& v) {
     };
 
     if constexpr (reflection::is_std_optional<T>) {
+        if (v.IsNull()) {
+            return std::nullopt;
+        }
         auto r = from_json<typename T::value_type>(v);
         if (r.has_value()) {
             return T{std::move(r).assume_value()};

--- a/src/v/debug_bundle/tests/json_test.cc
+++ b/src/v/debug_bundle/tests/json_test.cc
@@ -23,6 +23,7 @@
 #include <rapidjson/error/en.h>
 
 #include <chrono>
+#include <optional>
 #include <type_traits>
 
 using namespace debug_bundle;
@@ -36,11 +37,13 @@ public:
 };
 
 using optional_int = std::optional<int>;
+using optional_str = std::optional<ss::sstring>;
 using named_int = named_type<int, struct test_named_tag>;
 
 using JsonTestTypes = ::testing::Types<
   int,
   optional_int,
+  optional_str,
   named_int,
   uint64_t,
   std::chrono::seconds,
@@ -66,6 +69,9 @@ TYPED_TEST(JsonTypeTest, BasicType) {
     } else if constexpr (std::is_same_v<TypeParam, optional_int>) {
         this->json_input = R"(42)";
         this->expected = optional_int{42};
+    } else if constexpr (std::is_same_v<TypeParam, optional_str>) {
+        this->json_input = R"(null)";
+        this->expected = std::nullopt;
     } else if constexpr (std::is_same_v<TypeParam, named_int>) {
         this->json_input = R"(42)";
         this->expected = named_int{42};
@@ -192,6 +198,9 @@ TYPED_TEST(JsonTypeTest, TypeIsInvalid) {
     } else if constexpr (std::is_same_v<TypeParam, optional_int>) {
         this->json_input = R"("42")";
         this->expected = optional_int{42};
+    } else if constexpr (std::is_same_v<TypeParam, optional_str>) {
+        this->json_input = R"(42)";
+        this->expected = std::nullopt;
     } else if constexpr (std::is_same_v<TypeParam, named_int>) {
         this->json_input = R"("42")";
         this->expected = named_int{42};

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -177,6 +177,7 @@ redpanda_cc_library(
         "api-doc/transaction.json.hh",
         "api-doc/transform.json.hh",
         "api-doc/usage.json.hh",
+        "debug_bundle.h",
         "server.h",
         "util.h",
     ],

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -167,8 +167,9 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
           std::move(job_id).assume_error(), std::move(rep));
     }
 
-    auto params = from_json<debug_bundle::debug_bundle_parameters>(
-      obj, "config", false);
+    auto params
+      = from_json<std::optional<debug_bundle::debug_bundle_parameters>>(
+        obj, "config", false);
     if (params.has_error()) {
         co_return make_error_body(
           std::move(params).assume_error(), std::move(rep));
@@ -176,7 +177,9 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
 
     auto res = co_await _debug_bundle_service.local()
                  .initiate_rpk_debug_bundle_collection(
-                   job_id.assume_value(), std::move(params).assume_value());
+                   job_id.assume_value(),
+                   std::move(params).assume_value().value_or(
+                     debug_bundle::debug_bundle_parameters{}));
     if (res.has_error()) {
         co_return make_error_body(res.assume_error(), std::move(rep));
     }

--- a/src/v/redpanda/admin/debug_bundle.h
+++ b/src/v/redpanda/admin/debug_bundle.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/http/file_handler.hh>
+
+namespace debug_bundle {
+
+/**
+ * A handler for reading files from the disk and streaming them to the client.
+ */
+class file_handler final : public ss::httpd::file_interaction_handler {
+public:
+    file_handler() = default;
+
+    /**
+     * read a file from the disk and stream it in the reply.
+     * @param file the full path to a file on the disk
+     * @param req the reuest
+     * @param rep the reply
+     */
+    ss::future<std::unique_ptr<ss::http::reply>> handle(
+      const ss::sstring& file,
+      std::unique_ptr<ss::http::request> req,
+      std::unique_ptr<ss::http::reply> rep) final;
+};
+
+} // namespace debug_bundle

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -335,6 +335,8 @@ admin_server::admin_server(
 }
 
 ss::future<> admin_server::start() {
+    co_await _debug_bundle_file_handler.start();
+
     _blocked_reactor_notify_reset_timer.set_callback([this] {
         return ss::smp::invoke_on_all([ms = _default_blocked_reactor_notify] {
             ss::engine().update_blocked_reactor_notify_ms(ms);
@@ -353,7 +355,8 @@ ss::future<> admin_server::start() {
 
 ss::future<> admin_server::stop() {
     _blocked_reactor_notify_reset_timer.cancel();
-    return _server.stop();
+    co_await _server.stop();
+    co_await _debug_bundle_file_handler.stop();
 }
 
 void admin_server::configure_admin_routes() {

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -24,6 +24,7 @@
 #include "model/metadata.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/fwd.h"
+#include "redpanda/admin/debug_bundle.h"
 #include "resource_mgmt/cpu_profiler.h"
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/connection_cache.h"
@@ -40,7 +41,6 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/http/exception.hh>
-#include <seastar/http/file_handler.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/http/json_path.hh>
 #include <seastar/http/request.hh>
@@ -739,6 +739,7 @@ private:
     ss::sharded<kafka::server>& _kafka_server;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     ss::sharded<debug_bundle::service>& _debug_bundle_service;
+    ss::sharded<debug_bundle::file_handler> _debug_bundle_file_handler;
 
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1795,3 +1795,7 @@ class Admin:
     def delete_debug_bundle(self, job_id: UUID, node: MaybeNode = None):
         path = f"debug/bundle/{job_id}"
         return self._request("DELETE", path, node=node)
+
+    def get_debug_bundle_file(self, filename: str, node: MaybeNode = None):
+        path = f"debug/bundle/file/{filename}"
+        return self._request("GET", path, node=node)

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1799,3 +1799,7 @@ class Admin:
     def get_debug_bundle_file(self, filename: str, node: MaybeNode = None):
         path = f"debug/bundle/file/{filename}"
         return self._request("GET", path, node=node)
+
+    def delete_debug_bundle_file(self, filename: str, node: MaybeNode = None):
+        path = f"debug/bundle/file/{filename}"
+        return self._request("DELETE", path, node=node)

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -11,19 +11,17 @@ from enum import Enum
 from logging import Logger
 import random
 import json
-import requests
 import time
-from time import sleep
 import urllib.parse
-from requests.adapters import HTTPAdapter
-from requests.exceptions import RequestException
-from urllib3.util.retry import Retry
-from ducktape.cluster.cluster import ClusterNode
-from typing import Any, List, Optional, Callable, NamedTuple, Protocol, cast
-from rptest.util import wait_until_result
-from requests.exceptions import HTTPError
-from requests import Response
+from typing import Any, Optional, Callable, NamedTuple, Protocol, cast
 from json.decoder import JSONDecodeError
+from ducktape.cluster.cluster import ClusterNode
+import requests
+from requests import Response
+from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError, RequestException
+from urllib3.util.retry import Retry
+from rptest.util import wait_until_result
 
 DEFAULT_TIMEOUT = 30
 

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -14,13 +14,26 @@ from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin, DebugBundleStartConfig, DebugBundleStartConfigParams
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import LoggingConfig
 from rptest.tests.redpanda_test import RedpandaTest
+
+log_config = LoggingConfig('info',
+                           logger_levels={
+                               'admin_api_server': 'trace',
+                               'debug-bundle-service': 'trace'
+                           })
 
 
 class DebugBundleTest(RedpandaTest):
     """
     Smoke test for debug bundle admin API
     """
+    def __init__(self, context, num_brokers=1, **kwargs) -> None:
+        super(DebugBundleTest, self).__init__(context,
+                                              num_brokers=num_brokers,
+                                              log_config=log_config,
+                                              **kwargs)
+
     @cluster(num_nodes=1)
     @matrix(ignore_none=[True, False])
     def test_post_debug_bundle(self, ignore_none: bool):

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from uuid import uuid4
+import requests
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.services.admin import Admin, DebugBundleStartConfig, DebugBundleStartConfigParams
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DebugBundleTest(RedpandaTest):
+    """
+    Smoke test for debug bundle admin API
+    """
+    @cluster(num_nodes=1)
+    @matrix(ignore_none=[True, False])
+    def test_post_debug_bundle(self, ignore_none: bool):
+        admin = Admin(self.redpanda)
+        node = random.choice(self.redpanda.started_nodes())
+
+        job_id = uuid4()
+        res = admin.post_debug_bundle(DebugBundleStartConfig(
+            job_id=job_id,
+            config=DebugBundleStartConfigParams(cpu_profiler_wait_seconds=16,
+                                                metrics_interval_seconds=16)),
+                                      ignore_none=ignore_none,
+                                      node=node)
+
+        assert res.status_code == requests.codes.ok, res.json()
+
+        # Start a second debug bundle with the same job_id, expect a conflict
+        try:
+            admin.post_debug_bundle(
+                DebugBundleStartConfig(job_id=job_id,
+                                       config=DebugBundleStartConfigParams(
+                                           cpu_profiler_wait_seconds=16,
+                                           metrics_interval_seconds=16)),
+                ignore_none=ignore_none,
+                node=node)
+            assert False, f"Expected a conflict {res.content}"
+        except requests.HTTPError as e:
+            assert e.response.status_code == requests.codes.conflict, res.json(
+            )
+
+        # Get the debug bundle status, expect running
+        res = admin.get_debug_bundle(node=node)
+        assert res.status_code == requests.codes.ok, res.json()
+        assert res.json()['status'] == 'running', res.json()
+        assert res.json()['job_id'] == str(job_id), res.json()
+
+        # Wait until the debug bundle has completed
+        try:
+            wait_until(lambda: admin.get_debug_bundle(node=node).json()[
+                'status'] != 'running',
+                       timeout_sec=60,
+                       backoff_sec=1)
+        except Exception as e:
+            self.redpanda.logger.warning(
+                f"response: {admin.get_debug_bundle(node=node).json()}")
+            raise e
+
+        # Get the debug bundle status, expect success
+        res = admin.get_debug_bundle(node=node)
+        assert res.status_code == requests.codes.ok, res.json()
+        assert res.json()['status'] == 'success', res.json()
+        assert res.json()['job_id'] == str(job_id), res.json()
+        assert res.json()['filename'] == f"{job_id}.zip", res.json()
+
+        # Delete the debug bundle after it has completed, expect a conflict
+        try:
+            admin.delete_debug_bundle(job_id=job_id, node=node)
+            assert False, f"Expected a conflict {res.content}"
+        except requests.HTTPError as e:
+            assert e.response.status_code == requests.codes.conflict, res.json(
+            )

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -117,3 +117,8 @@ class DebugBundleTest(RedpandaTest):
         file = f"{data_dir}/{filename}"
         assert self._get_sha256sum(node, file) == hashlib.sha256(
             res.content).hexdigest()
+
+        res = admin.delete_debug_bundle_file(filename=filename, node=node)
+        assert res.status_code == requests.codes.no_content, res.json()
+        assert res.headers['Content-Type'] == 'application/json', res.json()
+        assert not node.account.exists(file)


### PR DESCRIPTION
Continuation of [CORE-7095](https://github.com/redpanda-data/redpanda/pull/23366)

Implement:
1. `GET /debug/bundle/file/{filename}`
1. `DELETE /debug/bundle/file/{filename}`

Add ducktape tests for all endpoints:
1. `POST /v1/debug/bundle`
1. `GET /v1/debug/bundle`
1. `DELETE /v1/debug/bundle/{jobid}`
1. `GET /debug/bundle/file/{filename}` (returns `not_implemented`)
1. `DELETE /debug/bundle/file/{filename}` (returns `not_implemented`)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


[CORE-7095]: https://redpandadata.atlassian.net/browse/CORE-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ