### PR TITLE
Migrations: fix shutdown busyloop

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -155,7 +155,8 @@ ss::future<> backend::start() {
             co_await handle_migration_update(id);
         }
 
-        ssx::repeat_until_gate_closed(_gate, [this]() { return loop_once(); });
+        ssx::repeat_until_gate_closed_or_aborted(
+          _gate, _as, [this]() { return loop_once(); });
 
         vlog(dm_log.info, "backend started");
     } else {

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -185,11 +185,21 @@ ss::future<> backend::stop() {
 }
 
 ss::future<> backend::loop_once() {
-    co_await _sem.wait(_as);
-    _sem.consume(_sem.available_units());
-    {
-        auto units = co_await _mutex.get_units(_as);
-        co_await work_once();
+    try {
+        co_await _sem.wait(_as);
+        _sem.consume(_sem.available_units());
+        {
+            auto units = co_await _mutex.get_units(_as);
+            co_await work_once();
+        }
+    } catch (...) {
+        const auto& e = std::current_exception();
+        vlogl(
+          dm_log,
+          ssx::is_shutdown_exception(e) ? ss::log_level::trace
+                                        : ss::log_level::warn,
+          "Exception in migration backend main loop: {}",
+          e);
     }
 }
 

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -242,8 +242,7 @@ ss::future<> backend::work_once() {
                   vlog(
                     dm_log.info,
                     "as part of migration {}, topic work for moving nt {} to "
-                    "state "
-                    "{} returned {}, retrying",
+                    "state {} returned {}, retrying",
                     result.migration,
                     result.nt,
                     result.sought_state,


### PR DESCRIPTION
On shutdown there's a hot loop between abort and gate close. Fix it by stopping the loop on abort.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
