### PR TITLE
iceberg: add comment about struct field ordering

### DIFF
--- a/src/v/iceberg/values.h
+++ b/src/v/iceberg/values.h
@@ -108,6 +108,8 @@ using value = std::variant<
   std::unique_ptr<map_value>>;
 
 struct struct_value {
+    // The order of these fields must align with the corresponding struct type
+    // as defined in the schema, see `iceberg::struct_type`.
     chunked_vector<std::optional<value>> fields;
 };
 bool operator==(const struct_value&, const struct_value&);


### PR DESCRIPTION


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none