### PR TITLE
CORE-7343 License: add fallback license env var

### DIFF
--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -87,7 +87,7 @@ struct license_components {
     ss::sstring signature;
 };
 
-static license_components parse_license(const ss::sstring& license) {
+static license_components parse_license(std::string_view license) {
     static constexpr auto signature_delimiter = ".";
     const auto itr = license.find(signature_delimiter);
     if (itr == ss::sstring::npos) {
@@ -97,7 +97,7 @@ static license_components parse_license(const ss::sstring& license) {
     /// done so that it can have a utf-8 interpretation so the license file
     /// doesn't have to be in binary format
     return license_components{
-      .data = license.substr(0, itr),
+      .data = ss::sstring{license.substr(0, itr)},
       .signature = base64_to_string(
         license.substr(itr + strlen(signature_delimiter)))};
 }
@@ -151,7 +151,7 @@ static void parse_data_section(license& lc, const json::Document& doc) {
     lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
 }
 
-static ss::sstring calculate_sha256_checksum(const ss::sstring& raw_license) {
+static ss::sstring calculate_sha256_checksum(std::string_view raw_license) {
     bytes checksum;
     hash_sha256 h;
     h.update(raw_license);
@@ -161,7 +161,7 @@ static ss::sstring calculate_sha256_checksum(const ss::sstring& raw_license) {
     return to_hex(checksum);
 }
 
-license make_license(const ss::sstring& raw_license) {
+license make_license(std::string_view raw_license) {
     try {
         license lc;
         auto components = parse_license(raw_license);

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -104,7 +104,7 @@ private:
 /// failed, reasons could be:
 /// 1. Malformed license
 /// 2. Invalid license
-license make_license(const ss::sstring& raw_license);
+license make_license(std::string_view raw_license);
 
 } // namespace security
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5337,11 +5337,7 @@ class RedpandaService(RedpandaServiceBase):
     def install_license(self):
         """Install a sample Enterprise License for testing Enterprise features during upgrades"""
         self.logger.debug("Installing an Enterprise License")
-        license = sample_license()
-        assert license, (
-            "No enterprise license found in the environment variable. "
-            "Please follow these instructions to get a sample license for local development: "
-            "https://redpandadata.atlassian.net/l/cp/4eeNEgZW")
+        license = sample_license(assert_exists=True)
         assert self._admin.put_license(license).status_code == 200, \
             "Configuring the Enterprise license failed (required for feature upgrades)"
 

--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -16,6 +16,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.services.redpanda import LoggingConfig
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.utils.rpenv import sample_license
 
 
 class LicenseEnforcementTest(RedpandaTest):
@@ -100,6 +101,54 @@ class LicenseEnforcementTest(RedpandaTest):
         self.redpanda.start_node(first_upgraded,
                                  auto_assign_node_id=True,
                                  omit_seeds_on_idx_one=False)
+
+    @cluster(num_nodes=5, log_allow_list=LOG_ALLOW_LIST)
+    @matrix(clean_node_before_upgrade=[False, True])
+    def test_escape_hatch_license_variable(self, clean_node_before_upgrade):
+        installer = self.redpanda._installer
+
+        prev_version = installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD)
+        latest_version = installer.head_version()
+        self.logger.info(
+            f"Testing with versions: {prev_version=} {latest_version=}")
+
+        self.logger.info(f"Starting all nodes with version: {prev_version}")
+        installer.install(self.redpanda.nodes, prev_version)
+        self.redpanda.start(nodes=self.redpanda.nodes,
+                            omit_seeds_on_idx_one=False)
+
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=60,
+                                 backoff_sec=1,
+                                 err_msg="The cluster hasn't stabilized")
+
+        self.logger.info(f"Enabling an enterprise feature")
+        self.rpk.create_role("XYZ")
+
+        first_upgraded = self.redpanda.nodes[0]
+        self.logger.info(
+            f"Upgrading node {first_upgraded} with an license injected via the environment variable escape hatch expecting it to succeed"
+        )
+        installer.install([first_upgraded], latest_version)
+        self.redpanda.stop_node(first_upgraded)
+
+        if clean_node_before_upgrade:
+            self.logger.info(f"Cleaning node {first_upgraded}")
+            self.redpanda.remove_local_data(first_upgraded)
+
+        license = sample_license(assert_exists=True)
+        self.redpanda.set_environment(
+            {'REDPANDA_FALLBACK_ENTERPRISE_LICENSE': license})
+
+        self.redpanda.start_node(first_upgraded,
+                                 auto_assign_node_id=True,
+                                 omit_seeds_on_idx_one=False)
+
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=60,
+                                 backoff_sec=1,
+                                 err_msg="The cluster hasn't stabilized")
 
     @cluster(num_nodes=5)
     @matrix(root_driven_bootstrap=[False, True])

--- a/tests/rptest/utils/rpenv.py
+++ b/tests/rptest/utils/rpenv.py
@@ -12,7 +12,7 @@
 import os
 
 
-def sample_license():
+def sample_license(assert_exists=False):
     """
     Returns the sample license from the env if it exists, asserts if its
     missing and the environment is CI
@@ -21,6 +21,10 @@ def sample_license():
     if license is None:
         is_ci = os.environ.get("CI", "false")
         assert is_ci == "false"
+        assert not assert_exists, (
+            "No enterprise license found in the environment variable. "
+            "Please follow these instructions to get a sample license for local development: "
+            "https://redpandadata.atlassian.net/l/cp/4eeNEgZW")
         return None
     return license
 


### PR DESCRIPTION
This is part of a series of changes to verify that clusters have a valid enterprise license during major version upgrades if they use enterprise features.

This adds an environment variable that can be used to insert an enterprise license on startup into a non-compliant cluster when it is failing the license enforcement check. This should be an undocumented escape hatch we can use if we ever need to inject a license into this check if we cannot add it into the controller log via `rpk cluster license set` (eg. if we cannot downgrade the broker to a previous version for any reason).

Fixes https://redpandadata.atlassian.net/browse/CORE-7343

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
