### PR TITLE
bazel: add initial support for clang-tidy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,14 @@ build:sanitizer --copt -O1
 build:sanitizer --@seastar//:system_allocator=True
 
 # =================================
+# clang-tidy
+# =================================
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_18_toolchain//:clang-tidy
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+build:clang-tidy --output_groups=report
+
+# =================================
 # Security
 # =================================
 

--- a/BUILD
+++ b/BUILD
@@ -17,3 +17,9 @@ gazelle_test(
     size = "small",
     workspace = "//:BUILD",
 )
+
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -264,3 +264,13 @@ crate.annotation(
     extra_aliased_targets = {"wasmtime_c": "wasmtime_c"},
     gen_build_script = "off",
 )
+
+# ====================================
+# clang-tidy
+# ====================================
+bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
+git_override(
+    module_name = "bazel_clang_tidy",
+    commit = "e85311053ec3c32ff418b433af4469b9c77e6b16",
+    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)


### PR DESCRIPTION
Example:

    $ bazel build //src/v/bytes:iobuf --config clang-tidy
    INFO: Analyzed target //src/v/bytes:iobuf (1 packages loaded, 4 targets configured).
    INFO: Found 1 target...
    Aspect @@bazel_clang_tidy~//clang_tidy:clang_tidy.bzl%clang_tidy_aspect of //src/v/bytes:iobuf up-to-date:
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/iobuf.cc.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/io_allocation_size.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/io_byte_iterator.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/io_fragment.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/io_iterator_consumer.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/io_placeholder.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/details/out_of_range.h.iobuf.clang-tidy.yaml
      bazel-bin/src/v/bytes/bazel_clang_tidy_src/v/bytes/iobuf.h.iobuf.clang-tidy.yaml
    INFO: Elapsed time: 0.554s, Critical Path: 0.01s
    INFO: 1 process: 1 internal.
    INFO: Build completed successfully, 1 total action

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
