### PR TITLE
iceberg: add catalog interface

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -76,6 +76,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "catalog",
+    hdrs = [
+        "catalog.h",
+    ],
+    include_prefix = "iceberg",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":partition",
+        ":schema",
+        ":transaction",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "datatypes",
     srcs = [
         "datatypes.cc",

--- a/src/v/iceberg/catalog.h
+++ b/src/v/iceberg/catalog.h
@@ -1,0 +1,81 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "base/seastarx.h"
+#include "iceberg/partition.h"
+#include "iceberg/schema.h"
+#include "iceberg/transaction.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+namespace iceberg {
+
+struct table_identifier {
+    chunked_vector<ss::sstring> ns;
+    ss::sstring table;
+};
+
+class catalog {
+public:
+    enum class errc {
+        // There was a problem at the IO layer.
+        io_error,
+
+        // IO has timed out. Depending on the caller, may be worth retrying.
+        timedout,
+
+        // There was some unexpected state (e.g. a broken invariant in the
+        // loaded metadata).
+        unexpected_state,
+
+        // There was a problem that indicates the system is shutting down. Best
+        // to quiesce operation.
+        shutting_down,
+
+        // E.g. a given table already exists.
+        already_exists,
+
+        // E.g. a table is not found.
+        not_found,
+    };
+
+    // Creates a table with the given metadata.
+    //
+    // Returns the resulting table_metadata. Callers are free to use the
+    // returned table_metadata to construct transactions.
+    virtual ss::future<checked<table_metadata, errc>> create_table(
+      const table_identifier& table_ident,
+      const schema& schema,
+      const partition_spec& spec)
+      = 0;
+
+    // Gets and returns the resulting table_metadata. Callers are free to use
+    // the returned table_metadata to construct transactions.
+    virtual ss::future<checked<table_metadata, errc>>
+    load_table(const table_identifier& table_ident) = 0;
+
+    // Commits the given transaction to the catalog.
+    //
+    // Note that regardless of whether this succeeds or fails, the resulting
+    // table_metadata may not match exactly with the transaction's state, e.g.
+    // because the underlying table changed before committing but didn't break
+    // any of the transactional requirements.
+    //
+    // Success does mean that the updates made their way to the table, but
+    // failure doesn't necessarily mean that the transaction was not committed.
+    //
+    // Callers are expected to use the identifier used when creating or loading
+    // the table.
+    virtual ss::future<checked<std::nullopt_t, errc>>
+    commit_txn(const table_identifier& table_ident, transaction) = 0;
+};
+
+} // namespace iceberg


### PR DESCRIPTION
Adds a bare-bones interface for interacting with external catalogs. The main goal is to wrap an Iceberg REST client, though this interface will also be useful in defining a filesystem catalog (useful for testing).

One implementation can be seen here as a draft: https://github.com/redpanda-data/redpanda/pull/23592

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
