### PR TITLE
Remove all uses of `get0`

### DIFF
--- a/src/v/base/outcome_future_utils.h
+++ b/src/v/base/outcome_future_utils.h
@@ -68,7 +68,7 @@ ss::future<result<T, EC>> result_with_timeout(
     static_assert(!is_already_result, "nested result<T> not yet supported");
     using ret_t = result<T, EC>;
     if (f.available()) {
-        return ss::make_ready_future<ret_t>(f.get0());
+        return ss::make_ready_future<ret_t>(f.get());
     }
     auto pr = std::make_unique<ss::promise<ret_t>>();
     auto result = pr->get_future();
@@ -78,7 +78,7 @@ ss::future<result<T, EC>> result_with_timeout(
       [pr = std::move(pr), timer = std::move(timer), error](auto&& f) mutable {
           if (timer.cancel()) {
               try {
-                  pr->set_value(f.get0());
+                  pr->set_value(f.get());
               } catch (...) {
                   pr->set_exception(std::current_exception());
               }

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -626,7 +626,7 @@ SEASTAR_THREAD_TEST_CASE(test_iobuf_input_stream_from_trimmed_iobuf) {
     buf.prepend(ss::temporary_buffer<char>(100));
     buf.trim_front(10);
     auto stream = make_iobuf_input_stream(std::move(buf));
-    auto res = stream.read().get0();
+    auto res = stream.read().get();
     BOOST_TEST(res.size() == 90);
 }
 

--- a/src/v/bytes/tests/iobuf_utils_tests.cc
+++ b/src/v/bytes/tests/iobuf_utils_tests.cc
@@ -20,7 +20,7 @@ SEASTAR_THREAD_TEST_CASE(test_reading_zero_bytes_empty_stream) {
     auto buf = iobuf();
     auto is = make_iobuf_input_stream(std::move(buf));
 
-    auto read_buf = read_iobuf_exactly(is, 0).get0();
+    auto read_buf = read_iobuf_exactly(is, 0).get();
     BOOST_REQUIRE_EQUAL(read_buf.size_bytes(), 0);
 };
 
@@ -29,7 +29,7 @@ SEASTAR_THREAD_TEST_CASE(test_reading_zero_bytes) {
     append_sequence(buf, 5);
     auto is = make_iobuf_input_stream(std::move(buf));
 
-    auto read_buf = read_iobuf_exactly(is, 0).get0();
+    auto read_buf = read_iobuf_exactly(is, 0).get();
     BOOST_REQUIRE_EQUAL(read_buf.size_bytes(), 0);
 };
 
@@ -38,7 +38,7 @@ SEASTAR_THREAD_TEST_CASE(test_reading_some_bytes) {
     append_sequence(buf, 5);
     auto is = make_iobuf_input_stream(std::move(buf));
 
-    auto read_buf = read_iobuf_exactly(is, 16).get0();
+    auto read_buf = read_iobuf_exactly(is, 16).get();
     BOOST_REQUIRE_EQUAL(read_buf.size_bytes(), 16);
 };
 

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -272,9 +272,9 @@ FIXTURE_TEST(test_sts_credentials, fixture) {
     auto token_f = ss::open_file_dma(
                      "test_sts_creds_f",
                      ss::open_flags::create | ss::open_flags::rw)
-                     .get0();
+                     .get();
     ss::sstring token{"token"};
-    token_f.dma_write(0, token.data(), token.size()).get0();
+    token_f.dma_write(0, token.data(), token.size()).get();
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::sts,
@@ -290,8 +290,8 @@ FIXTURE_TEST(test_sts_credentials, fixture) {
         return c.has_value();
     }).get();
 
-    token_f.close().get0();
-    ss::remove_file("test_sts_creds_f").get0();
+    token_f.close().get();
+    ss::remove_file("test_sts_creds_f").get();
 
     auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
     BOOST_REQUIRE_EQUAL("sts-key", aws_creds.access_key_id());
@@ -338,9 +338,9 @@ FIXTURE_TEST(test_short_lived_sts_credentials, fixture) {
     auto token_f = ss::open_file_dma(
                      "test_short_sts_f",
                      ss::open_flags::create | ss::open_flags::rw)
-                     .get0();
+                     .get();
     ss::sstring token{"token"};
-    token_f.dma_write(0, token.data(), token.size()).get0();
+    token_f.dma_write(0, token.data(), token.size()).get();
 
     auto refresh = cloud_roles::make_refresh_credentials(
       model::cloud_credentials_source::sts,
@@ -356,8 +356,8 @@ FIXTURE_TEST(test_short_lived_sts_credentials, fixture) {
         return *count >= 2;
     }).get();
 
-    token_f.close().get0();
-    ss::remove_file("test_short_sts_f").get0();
+    token_f.close().get();
+    ss::remove_file("test_short_sts_f").get();
     auto aws_creds = std::get<cloud_roles::aws_credentials>(c.value());
     BOOST_REQUIRE_EQUAL("sts-key", aws_creds.access_key_id());
     BOOST_REQUIRE_EQUAL("sts-secret", aws_creds.secret_access_key());

--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -42,7 +42,7 @@ FIXTURE_TEST(test_simple_token_request, fixture) {
     ss::abort_source as;
 
     auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
-    auto resp = cl.fetch_credentials().get0();
+    auto resp = cl.fetch_credentials().get();
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(
       iobuf_to_bytes(std::get<iobuf>(resp)),
@@ -55,7 +55,7 @@ FIXTURE_TEST(test_bad_response_handling, fixture) {
     ss::abort_source as;
 
     auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
-    auto resp = cl.fetch_credentials().get0();
+    auto resp = cl.fetch_credentials().get();
     BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
     auto error = std::get<cloud_roles::api_request_error>(resp);
     BOOST_REQUIRE_EQUAL(
@@ -71,7 +71,7 @@ FIXTURE_TEST(test_gateway_down, fixture) {
     ss::abort_source as;
 
     auto cl = cloud_roles::gcp_refresh_impl{address(), region, as};
-    auto resp = cl.fetch_credentials().get0();
+    auto resp = cl.fetch_credentials().get();
     BOOST_REQUIRE(std::holds_alternative<cloud_roles::api_request_error>(resp));
     auto error = std::get<cloud_roles::api_request_error>(resp);
     BOOST_REQUIRE_EQUAL(
@@ -90,7 +90,7 @@ FIXTURE_TEST(test_aws_role_fetch_on_startup, fixture) {
     ss::abort_source as;
 
     auto cl = cloud_roles::aws_refresh_impl{address(), region, as};
-    auto resp = cl.fetch_credentials().get0();
+    auto resp = cl.fetch_credentials().get();
     // assert that calls are made in order:
     // 1. to find the role
     // 2. to get token
@@ -118,17 +118,17 @@ FIXTURE_TEST(test_sts_credentials_fetch, fixture) {
     auto token_f = ss::open_file_dma(
                      cloud_role_tests::token_file,
                      ss::open_flags::create | ss::open_flags::rw)
-                     .get0();
+                     .get();
 
     ss::sstring token{"token"};
-    auto wrote = token_f.dma_write(0, token.data(), token.size()).get0();
+    auto wrote = token_f.dma_write(0, token.data(), token.size()).get();
     BOOST_REQUIRE_EQUAL(wrote, token.size());
 
     auto cl = cloud_roles::aws_sts_refresh_impl{address(), region, as};
-    auto resp = cl.fetch_credentials().get0();
+    auto resp = cl.fetch_credentials().get();
 
-    token_f.close().get0();
-    ss::remove_file(cloud_role_tests::token_file).get0();
+    token_f.close().get();
+    ss::remove_file(cloud_role_tests::token_file).get();
     BOOST_REQUIRE(std::holds_alternative<iobuf>(resp));
     BOOST_REQUIRE_EQUAL(std::get<iobuf>(resp), cloud_role_tests::sts_creds);
 

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -179,7 +179,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
             }(),
             .disable_tls = m.contains("disable-tls") > 0,
           })
-          .get0();
+          .get();
     if (m.contains("hns-enabled")) {
         client_cfg.is_hns_enabled = true;
     }
@@ -212,8 +212,8 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
 // TODO(vlad): factor this out
 static std::pair<ss::input_stream<char>, uint64_t>
 get_input_file_as_stream(const std::filesystem::path& path) {
-    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get0();
-    auto size = file.size().get0();
+    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get();
+    auto size = file.size().get();
     return std::make_pair(ss::make_file_input_stream(std::move(file), 0), size);
 }
 
@@ -241,8 +241,8 @@ static ss::output_stream<char>
 get_output_file_as_stream(const std::filesystem::path& path) {
     auto file = ss::open_file_dma(
                   path.native(), ss::open_flags::rw | ss::open_flags::create)
-                  .get0();
-    return ss::make_file_output_stream(std::move(file)).get0();
+                  .get();
+    return ss::make_file_output_stream(std::move(file)).get();
 }
 
 int main(int args, char** argv, char** env) {
@@ -327,7 +327,7 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.container,
                                                 lcfg.blobs.front(),
                                                 http::default_connect_timeout)
-                                              .get0();
+                                              .get();
                         if (result) {
                             auto resp = result.value()->as_input_stream();
                             vlog(test_log.info, "response: OK");
@@ -354,7 +354,7 @@ int main(int args, char** argv, char** env) {
                                                 payload_size,
                                                 std::move(payload),
                                                 http::default_connect_timeout)
-                                              .get0();
+                                              .get();
                         if (!result) {
                             vlog(
                               test_log.error,

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -188,7 +188,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
             }(),
             .disable_tls = m.contains("disable-tls") > 0,
           })
-          .get0();
+          .get();
     vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
     return test_conf{
       .bucket = bucket_name,
@@ -216,8 +216,8 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
 
 static std::pair<ss::input_stream<char>, uint64_t>
 get_input_file_as_stream(const std::filesystem::path& path) {
-    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get0();
-    auto size = file.size().get0();
+    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get();
+    auto size = file.size().get();
     return std::make_pair(ss::make_file_input_stream(std::move(file), 0), size);
 }
 
@@ -243,8 +243,8 @@ static ss::output_stream<char>
 get_output_file_as_stream(const std::filesystem::path& path) {
     auto file = ss::open_file_dma(
                   path.native(), ss::open_flags::rw | ss::open_flags::create)
-                  .get0();
-    return ss::make_file_output_stream(std::move(file)).get0();
+                  .get();
+    return ss::make_file_output_stream(std::move(file)).get();
 }
 
 int main(int args, char** argv, char** env) {
@@ -277,7 +277,7 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.bucket,
                                                 lcfg.objects.front(),
                                                 http::default_connect_timeout)
-                                              .get0();
+                                              .get();
                         if (result) {
                             auto resp = result.value()->as_input_stream();
                             vlog(test_log.info, "response: OK");
@@ -304,7 +304,7 @@ int main(int args, char** argv, char** env) {
                                                 payload_size,
                                                 std::move(payload),
                                                 http::default_connect_timeout)
-                                              .get0();
+                                              .get();
 
                         if (!result) {
                             vlog(
@@ -314,8 +314,7 @@ int main(int args, char** argv, char** env) {
                         }
                     } else if (lcfg.list_with_prefix) {
                         vlog(test_log.info, "listing objects");
-                        const auto result
-                          = cli.list_objects(lcfg.bucket).get0();
+                        const auto result = cli.list_objects(lcfg.bucket).get();
 
                         if (result) {
                             const auto& val = result.value();

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -421,12 +421,12 @@ SEASTAR_TEST_CASE(test_get_object_success) {
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"),
                                 100ms)
-                              .get0();
+                              .get();
 
         BOOST_REQUIRE(result);
 
         auto input_stream = result.value()->as_input_stream();
-        ss::copy(input_stream, payload_stream).get0();
+        ss::copy(input_stream, payload_stream).get();
         iobuf_parser p(std::move(payload));
         auto actual_payload = p.read_string(p.bytes_left());
         BOOST_REQUIRE_EQUAL(actual_payload, expected_payload);
@@ -444,7 +444,7 @@ SEASTAR_TEST_CASE(test_get_object_failure) {
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"),
                                 100ms)
-                              .get0();
+                              .get();
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
           result.error(), cloud_storage_clients::error_outcome::retry);
@@ -462,7 +462,7 @@ SEASTAR_TEST_CASE(test_delete_object_success) {
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"),
                                 100ms)
-                              .get0();
+                              .get();
 
         BOOST_REQUIRE(result);
         server->stop().get();
@@ -480,7 +480,7 @@ SEASTAR_TEST_CASE(test_delete_object_failure) {
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"),
                                 100ms)
-                              .get0();
+                              .get();
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
@@ -506,7 +506,7 @@ SEASTAR_TEST_CASE(test_delete_object_not_found) {
                 cloud_storage_clients::bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-key-not-found"),
                 100ms)
-              .get0();
+              .get();
 
         BOOST_REQUIRE(result);
         server->stop().get();
@@ -524,7 +524,7 @@ SEASTAR_TEST_CASE(test_delete_bucket_not_found) {
                 cloud_storage_clients::bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-bucket-not-found"),
                 100ms)
-              .get0();
+              .get();
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE(
@@ -543,7 +543,7 @@ SEASTAR_TEST_CASE(test_unexpected_error_message) {
                 cloud_storage_clients::bucket_name("test-bucket"),
                 cloud_storage_clients::object_key("test-unexpected"),
                 100ms)
-              .get0();
+              .get();
         BOOST_REQUIRE(!result);
         server->stop().get();
     });
@@ -568,7 +568,7 @@ SEASTAR_TEST_CASE(test_list_objects_success) {
                                 cloud_storage_clients::bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test"))
-                              .get0();
+                              .get();
 
         BOOST_REQUIRE(result);
         const auto& lst = result.value();
@@ -615,7 +615,7 @@ SEASTAR_TEST_CASE(test_list_objects_with_filter) {
                 http::default_connect_timeout,
                 std::nullopt,
                 [](const auto& item) { return item.key == "test-key2"; })
-              .get0();
+              .get();
 
         BOOST_REQUIRE(result);
         const auto& lst = result.value();
@@ -645,7 +645,7 @@ SEASTAR_TEST_CASE(test_list_objects_failure) {
                                 cloud_storage_clients::bucket_name(
                                   "test-bucket"),
                                 cloud_storage_clients::object_key("test-error"))
-                              .get0();
+                              .get();
 
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
@@ -666,7 +666,7 @@ SEASTAR_TEST_CASE(test_list_objects_with_continuation) {
                                 {},
                                 {},
                                 "ctok")
-                              .get0();
+                              .get();
         BOOST_REQUIRE(result);
         server->stop().get();
     });
@@ -683,7 +683,7 @@ SEASTAR_TEST_CASE(test_delete_objects_success) {
                            cloud_storage_clients::object_key{"key2"},
                            cloud_storage_clients::object_key{"key3"}},
                           http::default_connect_timeout)
-                        .get0();
+                        .get();
         BOOST_REQUIRE(result);
         BOOST_REQUIRE(result.value().undeleted_keys.empty());
         server->stop().get();
@@ -704,7 +704,7 @@ SEASTAR_TEST_CASE(test_delete_objects_errors) {
                           cloud_storage_clients::bucket_name{"okerror"},
                           {keys.begin(), keys.end()},
                           http::default_connect_timeout)
-                        .get0();
+                        .get();
         auto u_keys = std::vector<cloud_storage_clients::object_key>{};
         BOOST_REQUIRE(result);
         std::transform(
@@ -784,7 +784,7 @@ ss::future<> do_test_no_such_configuration(bool acceptable) {
                                 cloud_storage_clients::object_key("no-config"),
                                 100ms,
                                 acceptable)
-                              .get0();
+                              .get();
         // acceptable only affects the log level, the end response is always 404
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
@@ -826,7 +826,7 @@ public:
 
         server->start().get();
         server->set_routes(set_routes).get();
-        auto resolved = net::resolve_dns(s3_conf.server_addr).get0();
+        auto resolved = net::resolve_dns(s3_conf.server_addr).get();
         server->listen(resolved).get();
     }
 
@@ -872,7 +872,7 @@ FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
               });
         fut.emplace_back(std::move(f));
     }
-    ss::when_all_succeed(fut.begin(), fut.end()).get0();
+    ss::when_all_succeed(fut.begin(), fut.end()).get();
     BOOST_REQUIRE(pool.local().size() == 2);
 }
 
@@ -917,7 +917,7 @@ FIXTURE_TEST(test_client_pool_reconnect, client_pool_fixture) {
                      });
         fut.emplace_back(std::move(f));
     }
-    auto result = ss::when_all_succeed(fut.begin(), fut.end()).get0();
+    auto result = ss::when_all_succeed(fut.begin(), fut.end()).get();
     auto count = std::count(result.begin(), result.end(), true);
     BOOST_REQUIRE(count == 20);
 }

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -127,7 +127,7 @@ struct reupload_fixture : public archiver_fixture {
                            128_KiB,
                            10,
                            1_MiB)
-                         .get0();
+                         .get();
         write_random_batches(segment, seg.num_records.value(), 2);
         disk_log_impl()->segments().add(segment);
     }

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -176,7 +176,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     });
 
     retry_chain_node fib(never_abort);
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
 
     auto non_compacted_result = res.non_compacted_upload_result;
     auto compacted_result = res.compacted_upload_result;
@@ -309,7 +309,7 @@ FIXTURE_TEST(test_upload_after_failure, archiver_fixture) {
     });
 
     retry_chain_node fib(never_abort);
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
 
     auto&& [non_compacted_result, compacted_result] = res;
 
@@ -404,7 +404,7 @@ FIXTURE_TEST(
     });
 
     retry_chain_node fib(never_abort);
-    auto res = archiver.upload_next_candidates().get0();
+    auto res = archiver.upload_next_candidates().get();
 
     auto&& [non_compacted_result, compacted_result] = res;
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_succeeded, 0);
@@ -488,7 +488,7 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
     });
 
     retry_chain_node fib(never_abort);
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
 
@@ -612,7 +612,7 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
 
     // Wait for uploads to complete
     retry_chain_node fib(never_abort);
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
 
@@ -786,7 +786,7 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
       amv);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
 
@@ -944,7 +944,7 @@ FIXTURE_TEST(
         std::nullopt,
         ss::default_priority_class(),
         as))
-      .get0();
+      .get();
 
     auto seg = log->segments().begin();
 
@@ -1195,7 +1195,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
 
     retry_chain_node fib(never_abort);
 
-    auto res = upload_next_with_retries(archiver).get0();
+    auto res = upload_next_with_retries(archiver).get();
 
     auto non_compacted_result = res.non_compacted_upload_result;
     auto compacted_result = res.compacted_upload_result;
@@ -1422,7 +1422,7 @@ static void test_partial_upload_impl(
 
     retry_chain_node fib(never_abort);
     test.listen();
-    auto res = test.upload_next_with_retries(archiver, lso).get0();
+    auto res = test.upload_next_with_retries(archiver, lso).get();
 
     auto non_compacted_result = res.non_compacted_upload_result;
     auto compacted_result = res.compacted_upload_result;
@@ -1462,7 +1462,7 @@ static void test_partial_upload_impl(
     }
 
     lso = last_upl2 + model::offset(1);
-    res = test.upload_next_with_retries(archiver, lso).get0();
+    res = test.upload_next_with_retries(archiver, lso).get();
 
     non_compacted_result = res.non_compacted_upload_result;
     compacted_result = res.compacted_upload_result;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1109,7 +1109,7 @@ members_manager::dispatch_join_to_seed_server(
 
     return f.then_wrapped([it, this, req](ss::future<ret_t> fut) {
         try {
-            auto r = fut.get0();
+            auto r = fut.get();
             if (r.has_error()) {
                 vlog(
                   clusterlog.warn,

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -47,7 +47,7 @@ void request::set_error(request_result_t::error_type error) {
         return;
     }
     vassert(
-      _result.available() && result().get0().has_error(),
+      _result.available() && result().get().has_error(),
       "Invalid result state, expected to be available and errored out: {}",
       *this);
 }
@@ -64,8 +64,8 @@ bool request::operator==(const request& other) const {
         compare = compare && _result.failed() == other._result.failed();
         if (compare && !_result.failed()) {
             // both requests succeeded. compare results.
-            auto res = _result.get_shared_future().get0();
-            auto res_other = other._result.get_shared_future().get0();
+            auto res = _result.get_shared_future().get();
+            auto res_other = other._result.get_shared_future().get();
             compare = compare && res.has_error() == res_other.has_error();
             if (compare) {
                 if (res.has_error()) {

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1050,7 +1050,7 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
         req_ptr->set_error(cluster::errc::replication_error);
         co_return cluster::errc::replication_error;
     }
-    auto result = replicated.get0();
+    auto result = replicated.get();
     if (result.has_error()) {
         vlog(_ctx_log.warn, "replication failed: {}", result.error());
         req_ptr->set_error(result.error());

--- a/src/v/cluster/self_test/tests/self_test_request_test.cc
+++ b/src/v/cluster/self_test/tests/self_test_request_test.cc
@@ -29,13 +29,13 @@ SEASTAR_THREAD_TEST_CASE(test_make_netcheck_request) {
           return true;
       };
 
-    auto req = cluster::make_netcheck_request(model::node_id{0}, 52).get0().buf;
+    auto req = cluster::make_netcheck_request(model::node_id{0}, 52).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), 52);
     BOOST_CHECK_EQUAL(std::distance(req.cbegin(), req.cend()), 1);
-    req = cluster::make_netcheck_request(model::node_id{0}, 8192).get0().buf;
+    req = cluster::make_netcheck_request(model::node_id{0}, 8192).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), 8192);
     BOOST_CHECK_EQUAL(std::distance(req.cbegin(), req.cend()), 1);
-    req = cluster::make_netcheck_request(model::node_id{0}, 8193).get0().buf;
+    req = cluster::make_netcheck_request(model::node_id{0}, 8193).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), 8193);
     BOOST_CHECK_EQUAL(std::distance(req.cbegin(), req.cend()), 2);
     /// Verify the first of 2 fragments has the expected size of 8192 while
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(test_make_netcheck_request) {
     BOOST_CHECK_EQUAL(req.cbegin()->size(), 8192);
     BOOST_CHECK_EQUAL((++req.cbegin())->size(), 1);
     const auto size = ((8192 * 52) + 100);
-    req = cluster::make_netcheck_request(model::node_id{0}, size).get0().buf;
+    req = cluster::make_netcheck_request(model::node_id{0}, size).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), size);
     BOOST_CHECK_EQUAL(std::distance(req.cbegin(), req.cend()), 53);
     BOOST_CHECK(check_frags(req.cbegin(), req.cend(), 8192));

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -68,7 +68,7 @@ void wait_for_metadata(
           [&md_cache](const cluster::topic_result& r) {
               return md_cache.get_topic_metadata(r.tp_ns);
           });
-    }).get0();
+    }).get();
 }
 
 FIXTURE_TEST(create_single_topic_test_at_current_broker, cluster_test_fixture) {
@@ -83,7 +83,7 @@ FIXTURE_TEST(create_single_topic_test_at_current_broker, cluster_test_fixture) {
                     .local()
                     .autocreate_topics(
                       test_topics_configuration(), std::chrono::seconds(10))
-                    .get0();
+                    .get();
         success = std::all_of(
           results.begin(), results.end(), [](const cluster::topic_result& r) {
               return r.ec == cluster::errc::success;
@@ -125,7 +125,7 @@ FIXTURE_TEST(test_autocreate_on_non_leader, cluster_test_fixture) {
                     .local()
                     .autocreate_topics(
                       test_topics_configuration(), std::chrono::seconds(10))
-                    .get0();
+                    .get();
         success = std::all_of(
           results.begin(), results.end(), [](const cluster::topic_result& r) {
               return r.ec == cluster::errc::success;

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -39,14 +39,14 @@ void wait_for(model::timeout_clock::duration timeout, Pred&& p) {
       do_until(
         [p = std::forward<Pred>(p)] { return p(); },
         [] { return ss::sleep(std::chrono::milliseconds(400)); }))
-      .get0();
+      .get();
 }
 
 template<typename T>
 void set_configuration(ss::sstring p_name, T v) {
     ss::smp::invoke_on_all([p_name, v = std::move(v)] {
         config::shard_local_cfg().get(p_name).set_value(v);
-    }).get0();
+    }).get();
 }
 
 class cluster_test_fixture {
@@ -233,7 +233,7 @@ public:
      */
     scheduling_groups create_scheduling_groups() {
         scheduling_groups groups;
-        groups.create_groups().get0();
+        groups.create_groups().get();
         return groups;
     }
 
@@ -247,9 +247,9 @@ public:
             return std::any_of(
               _instances.begin(), _instances.end(), [](auto& it) {
                   return it.second->app.controller->linearizable_barrier()
-                    .get0();
+                    .get();
               });
-        }).get0();
+        }).get();
         auto leader_it = std::find_if(
           _instances.begin(), _instances.end(), [](auto& it) {
               return it.second->app.controller->is_raft0_leader();
@@ -263,7 +263,7 @@ public:
                          .create_topics(
                            cluster::without_custom_assignments(std::move(cfgs)),
                            model::no_timeout)
-                         .get0();
+                         .get();
         BOOST_REQUIRE_EQUAL(results.size(), 1);
         auto& result = results.at(0);
         BOOST_REQUIRE_EQUAL(result.ec, cluster::errc::success);
@@ -278,7 +278,7 @@ public:
                      [&](const cluster::assignments_set::value_type& p) {
                          return leaders.get_leader(tp_ns, p.second.id);
                      });
-        }).get0();
+        }).get();
     }
 
     std::tuple<redpanda_thread_fixture*, ss::lw_shared_ptr<cluster::partition>>

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -129,7 +129,7 @@ FIXTURE_TEST(test_serde_only_cmd, cmd_test_fixture) {
     auto deser = cluster::deserialize(
                    std::move(batch),
                    cluster::make_commands_list<fake_serde_only_cmd>())
-                   .get0();
+                   .get();
     ss::visit(deser, [&cmd](fake_serde_only_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key.str, cmd.key.str);
         BOOST_REQUIRE_EQUAL(c.value.str, cmd.value.str);
@@ -143,7 +143,7 @@ FIXTURE_TEST(test_create_topic_cmd_serialization, cmd_test_fixture) {
     auto deser = cluster::deserialize(
                    std::move(batch),
                    cluster::make_commands_list<cluster::create_topic_cmd>())
-                   .get0();
+                   .get();
     ss::visit(deser, [&cmd](cluster::create_topic_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key.tp, cmd.key.tp);
         BOOST_REQUIRE_EQUAL(
@@ -170,7 +170,7 @@ FIXTURE_TEST(test_delete_topic_cmd_serialization, cmd_test_fixture) {
     auto deser = cluster::deserialize(
                    std::move(batch),
                    cluster::make_commands_list<cluster::delete_topic_cmd>())
-                   .get0();
+                   .get();
     ss::visit(deser, [&cmd](cluster::delete_topic_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key.tp, cmd.key.tp);
         BOOST_REQUIRE_EQUAL(c.value, cmd.value);
@@ -191,7 +191,7 @@ FIXTURE_TEST(test_move_partition_replicass_command, cmd_test_fixture) {
       = cluster::deserialize(
           std::move(batch),
           cluster::make_commands_list<cluster::move_partition_replicas_cmd>())
-          .get0();
+          .get();
 
     ss::visit(deser, [&cmd](cluster::move_partition_replicas_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key, cmd.key);

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -39,7 +39,7 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
                  && get_local_cache(node_1).node_count() == 3
                  && get_local_cache(node_2).node_count() == 3;
       })
-      .get0();
+      .get();
 
     remove_node_application(node_2);
     // Change RPC port from 11000 to 13000
@@ -66,7 +66,7 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
           return meta.value().broker.rpc_address()
                  == net::unresolved_address("127.0.0.1", 13002);
       })
-      .get0();
+      .get();
 }
 
 FIXTURE_TEST(test_single_node_update, cluster_test_fixture) {
@@ -89,5 +89,5 @@ FIXTURE_TEST(test_single_node_update, cluster_test_fixture) {
 
         return meta->broker.kafka_advertised_listeners()[0].address
                == net::unresolved_address("127.0.0.1", 15000);
-    }).get0();
+    }).get();
 }

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -47,7 +47,7 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
         return get_local_cache(model::node_id{0}).node_count() == 3
                && get_local_cache(model::node_id{1}).node_count() == 3
                && get_local_cache(model::node_id{2}).node_count() == 3;
-    }).get0();
+    }).get();
 
     std::vector<ss::future<std::vector<cluster::topic_result>>> futures;
 

--- a/src/v/cluster/tests/decommissioning_tests.cc
+++ b/src/v/cluster/tests/decommissioning_tests.cc
@@ -19,13 +19,13 @@ FIXTURE_TEST(test_single_node_decomissioning, rebalancing_tests_fixture) {
                  ->controller->get_members_frontend()
                  .local()
                  .decommission_node(model::node_id(0))
-                 .get0();
+                 .get();
     // we expect that decommissioning will be in progress since we haven't
     // yet added any new nodes
     BOOST_REQUIRE(!res);
 
     add_node(10);
-    wait_for_node_decommissioned(0).get0();
+    wait_for_node_decommissioned(0).get();
 }
 
 // TODO: enable when after we investigate issues on aarch_64
@@ -42,19 +42,19 @@ FIXTURE_TEST(test_two_nodes_decomissioning, rebalancing_tests_fixture) {
                    ->controller->get_members_frontend()
                    .local()
                    .decommission_node(model::node_id(0))
-                   .get0();
+                   .get();
     BOOST_REQUIRE(!res_1);
     info("decommissioning node - 1");
     auto res_2 = (*get_leader_node_application())
                    ->controller->get_members_frontend()
                    .local()
                    .decommission_node(model::node_id(1))
-                   .get0();
+                   .get();
     BOOST_REQUIRE(!res_2);
 
     add_node(10);
     add_node(11);
-    wait_for_node_decommissioned(0).get0();
-    wait_for_node_decommissioned(1).get0();
+    wait_for_node_decommissioned(0).get();
+    wait_for_node_decommissioned(1).get();
 }
 #endif

--- a/src/v/cluster/tests/eviction_stm_test.cc
+++ b/src/v/cluster/tests/eviction_stm_test.cc
@@ -66,9 +66,9 @@ FIXTURE_TEST(test_eviction_stm_deadlock, raft_test_fixture) {
     auto impl = leader_raft->log();
     std::vector<storage::offset_stats> offsets;
     for (auto i = 0; i < 5; ++i) {
-        replicate_random_batches(gr, 20).get0();
+        replicate_random_batches(gr, 20).get();
         offsets.push_back(impl->offsets());
-        impl->force_roll(ss::default_priority_class()).get0();
+        impl->force_roll(ss::default_priority_class()).get();
     }
 
     /// Create an instance of the log eviction stm, however using the subclass

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -133,17 +133,17 @@ FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
                  .local()
                  .get_cluster_health(
                    get_all, cluster::force_refresh::yes, model::no_timeout)
-                 .get0();
+                 .get();
     auto r_2 = n2->controller->get_health_monitor()
                  .local()
                  .get_cluster_health(
                    get_all, cluster::force_refresh::yes, model::no_timeout)
-                 .get0();
+                 .get();
     auto r_3 = n3->controller->get_health_monitor()
                  .local()
                  .get_cluster_health(
                    get_all, cluster::force_refresh::yes, model::no_timeout)
-                 .get0();
+                 .get();
 
     BOOST_TEST_REQUIRE(r_1.has_value());
     BOOST_TEST_REQUIRE(r_2.has_value());

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -35,7 +35,7 @@ FIXTURE_TEST(
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -57,7 +57,7 @@ FIXTURE_TEST(
                   bid1,
                   std::move(rdr1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)r1);
 
     auto rdr2 = random_batch_reader(model::test::record_batch_spec{
@@ -77,7 +77,7 @@ FIXTURE_TEST(
                   bid2,
                   std::move(rdr2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)r2);
 }
 
@@ -87,7 +87,7 @@ FIXTURE_TEST(
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -110,7 +110,7 @@ FIXTURE_TEST(
                   bid1,
                   std::move(rdr1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)r1);
 
     auto rdr2 = random_batch_reader(model::test::record_batch_spec{
@@ -130,7 +130,7 @@ FIXTURE_TEST(
                   bid2,
                   std::move(rdr2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)r2);
 
     BOOST_REQUIRE(r1.value().last_offset < r2.value().last_offset);
@@ -141,7 +141,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -169,7 +169,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
                       std::move(rdr),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
-                    .get0();
+                    .get();
         BOOST_REQUIRE((bool)r1);
         offsets.push_back(r1.value().last_offset);
     }
@@ -196,7 +196,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
                       std::move(rdr),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
-                    .get0();
+                    .get();
         BOOST_REQUIRE((bool)r1);
         BOOST_REQUIRE(r1.value().last_offset == offsets[i]);
     }
@@ -207,7 +207,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -233,9 +233,9 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
                       std::move(rdr),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
-                    .get0();
+                    .get();
         BOOST_REQUIRE((bool)r1);
-        wait_for_kafka_offset_apply(r1.value().last_offset).get0();
+        wait_for_kafka_offset_apply(r1.value().last_offset).get();
     }
 
     {
@@ -257,7 +257,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
                       std::move(rdr),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
-                    .get0();
+                    .get();
         BOOST_REQUIRE(
           r1
           == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
@@ -269,7 +269,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -292,7 +292,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
                   bid1,
                   std::move(rdr1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)r1);
 
     auto rdr2 = random_batch_reader(model::test::record_batch_spec{
@@ -312,7 +312,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
                   bid2,
                   std::move(rdr2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                .get0();
+                .get();
     BOOST_REQUIRE(
       r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }
@@ -322,7 +322,7 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -67,7 +67,7 @@ local_monitor_fixture::local_monitor_fixture() {
     }
 
     _storage_node_api.start_single(_test_path.string(), _test_path.string())
-      .get0();
+      .get();
 
     _local_monitor
       .start(
@@ -92,7 +92,7 @@ local_monitor_fixture::~local_monitor_fixture() {
     if (err) {
         clusterlog.warn("Cleanup got error {} removing test dir.", err);
     }
-    _storage_node_api.stop().get0();
+    _storage_node_api.stop().get();
     _local_monitor.stop().get();
     _feature_table.stop().get();
 }

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -65,7 +65,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
             auto& kvstore = member.storage.local().kvs();
             auto eviction_stm = std::make_unique<cluster::log_eviction_stm>(
               member.consensus.get(), tstlog, kvstore);
-            eviction_stm->start().get0();
+            eviction_stm->start().get();
             eviction_stms.emplace(id, std::move(eviction_stm));
             member.kill_eviction_stm_cb
               = std::make_unique<ss::noncopyable_function<ss::future<>()>>(
@@ -92,7 +92,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
         auto first_ts = model::timestamp::now();
         // append some entries
         [[maybe_unused]] bool res
-          = replicate_compactible_batches(gr, first_ts).get0();
+          = replicate_compactible_batches(gr, first_ts).get();
         // make it so that above batch will be collected by time based
         // retention, by setting the threshold to 2 seconds after it
         retention_timestamp = model::to_timestamp(
@@ -101,7 +101,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                              // the next batch
         auto second_ts = model::timestamp(first_ts() + 200000);
         // append some more entries
-        res = replicate_compactible_batches(gr, second_ts).get0();
+        res = replicate_compactible_batches(gr, second_ts).get();
         validate_logs_replication(gr);
     }
 
@@ -119,7 +119,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                       ss::default_priority_class(),
                       as,
                       storage::ntp_sanitizer_config{.sanitize_only = true}))
-                    .get0();
+                    .get();
                   if (n.log->offsets().start_offset <= model::offset(0)) {
                       return false;
                   }

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -61,7 +61,7 @@ wait_for_leaders_updates(int id, cluster::metadata_cache& cache) {
             leaders.push_back(*leader_id);
         }
         return true;
-    }).get0();
+    }).get();
     return leaders;
 }
 
@@ -80,7 +80,7 @@ FIXTURE_TEST(
 
     tests::cooperative_spin_wait_with_timeout(timeout, [&cache_1, &cache_2] {
         return cache_1.node_count() == 3 && cache_2.node_count() == 3;
-    }).get0();
+    }).get();
 
     // Make sure we have 3 working nodes
     BOOST_REQUIRE_EQUAL(cache_0.node_count(), 3);
@@ -95,7 +95,7 @@ FIXTURE_TEST(
       .create_topics(
         cluster::without_custom_assignments(std::move(topics)),
         model::no_timeout)
-      .get0();
+      .get();
 
     auto leaders_0 = wait_for_leaders_updates(0, cache_0);
     auto leaders_1 = wait_for_leaders_updates(1, cache_1);
@@ -116,7 +116,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
 
     tests::cooperative_spin_wait_with_timeout(timeout, [&cache_1] {
         return cache_1.node_count() == 2;
-    }).get0();
+    }).get();
     // Make sure we have 2 working nodes
     BOOST_REQUIRE_EQUAL(cache_0.node_count(), 2);
     BOOST_REQUIRE_EQUAL(cache_1.node_count(), 2);
@@ -129,7 +129,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
       .create_topics(
         cluster::without_custom_assignments(std::move(topics)),
         model::no_timeout)
-      .get0();
+      .get();
 
     // Add new now to the cluster
     create_node_application(model::node_id{2});
@@ -137,7 +137,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     // Wait for node to join the cluster
     tests::cooperative_spin_wait_with_timeout(timeout, [&cache_1, &cache_2] {
         return cache_1.node_count() == 3 && cache_2.node_count() == 3;
-    }).get0();
+    }).get();
 
     auto leaders_0 = wait_for_leaders_updates(0, cache_0);
     auto leaders_1 = wait_for_leaders_updates(1, cache_1);

--- a/src/v/cluster/tests/notification_latch_test.cc
+++ b/src/v/cluster/tests/notification_latch_test.cc
@@ -22,7 +22,7 @@ SEASTAR_THREAD_TEST_CASE(test_notify_before_timeout) {
     ss::timer<> timer;
     timer.set_callback([&latch] { latch.notify(model::offset(10)); });
     timer.arm(50ms);
-    auto r = latch.wait_for(model::offset(10), model::no_timeout).get0();
+    auto r = latch.wait_for(model::offset(10), model::no_timeout).get();
     BOOST_REQUIRE_EQUAL(r, cluster::errc::success);
 }
 
@@ -33,7 +33,7 @@ SEASTAR_THREAD_TEST_CASE(test_notify_after_timeout) {
     timer.arm(500ms);
     auto r = latch
                .wait_for(model::offset(10), model::timeout_clock::now() + 1ms)
-               .get0();
+               .get();
 
     BOOST_REQUIRE_EQUAL(r, cluster::errc::notification_wait_timeout);
 }
@@ -53,6 +53,6 @@ SEASTAR_THREAD_TEST_CASE(destroy_before_notify_broken_promise) {
         latch.stop();
     }
 
-    BOOST_REQUIRE_EQUAL(fut.get0(), cluster::errc::shutting_down);
+    BOOST_REQUIRE_EQUAL(fut.get(), cluster::errc::shutting_down);
 }
 #endif

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -141,7 +141,7 @@ protected:
     explicit partition_allocator_fixture(
       std::optional<size_t> memory_per_partition,
       std::optional<int32_t> fds_per_partition) {
-        members.start().get0();
+        members.start().get();
         features.start().get();
         _allocator
           .start_single(
@@ -158,7 +158,7 @@ protected:
             config::shard_local_cfg()
               .get("partition_autobalancing_mode")
               .set_value(model::partition_autobalancing_mode::node_add);
-        }).get0();
+        }).get();
     }
 };
 

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -55,7 +55,7 @@ public:
                            .node_count()
                          == node_count;
               });
-        }).get0();
+        }).get();
     }
 
     void add_node(int id) {
@@ -104,7 +104,7 @@ public:
                      ->controller->get_topics_frontend()
                      .local()
                      .autocreate_topics({std::move(cfg)}, 2s)
-                     .get0();
+                     .get();
         wait_for_metadata(
           node_application(0)->controller->get_topics_state().local(), res);
     }
@@ -126,7 +126,7 @@ public:
                     });
               })
               .handle_exception([](std::exception_ptr) { return false; });
-        }).get0();
+        }).get();
 
         auto retries = 10;
         foreign_batches_t ret;
@@ -168,13 +168,13 @@ public:
                 model::node_id leader_id;
                 leader_id = get_local_cache(model::node_id(0))
                               .get_leader(ntp, 1s + model::timeout_clock::now())
-                              .get0();
+                              .get();
 
                 auto shard = get_shard_table(leader_id).shard_for(ntp);
                 auto& pm = get_partition_manager(leader_id);
-                ret = pm.invoke_on(*shard, single_retry).get0();
+                ret = pm.invoke_on(*shard, single_retry).get();
             } catch (...) {
-                ss::sleep(1s).get0();
+                ss::sleep(1s).get();
                 continue;
             }
         }

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -77,7 +77,7 @@ void check_snapshot_sizes(cluster::rm_stm& stm, raft::consensus* c) {
           }
           return ss::now();
       })
-      .get0();
+      .get();
 
     uint64_t snapshots_size = 0;
     for (const auto& file : snapshot_files) {
@@ -112,16 +112,16 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -131,7 +131,7 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
                        std::chrono::milliseconds(
                          std::numeric_limits<int32_t>::max()),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -141,24 +141,24 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
 
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
-    auto op = stm.commit_tx(pid2, tx_seq, 2'000ms).get0();
+    auto op = stm.commit_tx(pid2, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
         return tx_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     check_snapshot_sizes(stm, _raft.get());
@@ -172,7 +172,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
     auto tx_seq = model::tx_seq(0);
 
     wait_for_confirmed_leader();
@@ -189,16 +189,16 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -208,7 +208,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
                        std::chrono::milliseconds(
                          std::numeric_limits<int32_t>::max()),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
@@ -218,24 +218,24 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
-    auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
+    auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
     BOOST_REQUIRE(stm
                     .wait_no_throw(
                       _raft.get()->committed_offset(),
                       model::timeout_clock::now() + 2'000ms)
-                    .get0());
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+                    .get());
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);
     BOOST_REQUIRE(
@@ -244,7 +244,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
       }));
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
         return tx_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     check_snapshot_sizes(stm, _raft.get());
@@ -258,7 +258,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     auto tx_seq = model::tx_seq(0);
 
@@ -276,16 +276,16 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
-    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    auto aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
     auto first_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     auto pid2 = model::producer_identity{2, 0};
     auto term_op = stm
@@ -295,7 +295,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
                        std::chrono::milliseconds(
                          std::numeric_limits<int32_t>::max()),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)term_op);
 
@@ -305,25 +305,25 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
         return first_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
     BOOST_REQUIRE_LE(stm.last_stable_offset(), tx_offset);
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
-    auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
+    auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
     BOOST_REQUIRE(stm
                     .wait_no_throw(
                       _raft.get()->committed_offset(),
                       model::timeout_clock::now() + 2'000ms)
-                    .get0());
-    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
+                    .get());
+    aborted_txs = stm.aborted_transactions(min_offset, max_offset).get();
 
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 1);
     BOOST_REQUIRE(
@@ -333,7 +333,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
 
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, tx_offset]() {
         return tx_offset < stm.last_stable_offset();
-    }).get0();
+    }).get();
 
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     check_snapshot_sizes(stm, _raft.get());
@@ -345,7 +345,7 @@ FIXTURE_TEST(test_tx_unknown_produce, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -358,7 +358,7 @@ FIXTURE_TEST(test_tx_unknown_produce, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
@@ -370,7 +370,7 @@ FIXTURE_TEST(test_tx_unknown_produce, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
@@ -381,7 +381,7 @@ FIXTURE_TEST(test_stale_begin_tx_fenced, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -394,11 +394,11 @@ FIXTURE_TEST(test_stale_begin_tx_fenced, rm_stm_test_fixture) {
       std::numeric_limits<int32_t>::max());
 
     auto begin_tx = [&](model::tx_seq seq) {
-        return stm.begin_tx(pid1, seq, timeout, model::partition_id(0)).get0();
+        return stm.begin_tx(pid1, seq, timeout, model::partition_id(0)).get();
     };
 
     auto commit_tx = [&](model::tx_seq seq) {
-        return stm.commit_tx(pid1, tx_seq, timeout).get0();
+        return stm.commit_tx(pid1, tx_seq, timeout).get();
     };
 
     // begin should succeed.
@@ -428,7 +428,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     auto tx_seq = model::tx_seq(0);
 
@@ -443,7 +443,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
@@ -454,7 +454,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
                        std::chrono::milliseconds(
                          std::numeric_limits<int32_t>::max()),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE((bool)term_op);
 
     auto pid21 = model::producer_identity{2, 1};
@@ -465,7 +465,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
                   std::chrono::milliseconds(
                     std::numeric_limits<int32_t>::max()),
                   model::partition_id(0))
-                .get0();
+                .get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);
@@ -474,7 +474,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE(!(bool)offset_r);
 
     check_snapshot_sizes(stm, _raft.get());
@@ -486,7 +486,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     auto tx_seq = model::tx_seq(0);
 
@@ -501,7 +501,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
                         std::move(rreader.reader),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
-                      .get0();
+                      .get();
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
@@ -512,7 +512,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
                        std::chrono::milliseconds(
                          std::numeric_limits<int32_t>::max()),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);
@@ -521,10 +521,10 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE((bool)offset_r);
 
-    auto op = stm.abort_tx(pid20, tx_seq, 2'000ms).get0();
+    auto op = stm.abort_tx(pid20, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
 
     rreader = make_rreader(pid20, 0, 5, true);
@@ -533,7 +533,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
                    rreader.id,
                    std::move(rreader.reader),
                    raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get0();
+                 .get();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
 
     check_snapshot_sizes(stm, _raft.get());
@@ -548,7 +548,7 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
 
     wait_for_confirmed_leader();
     wait_for_meta_initialized();
@@ -570,7 +570,7 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
     // Few helpers to avoid repeated boiler plate code.
 
     auto aborted_txs = [&](auto begin, auto end) {
-        return stm.aborted_transactions(begin, end).get0();
+        return stm.aborted_transactions(begin, end).get();
     };
 
     // Aborted transactions in a given segment index.
@@ -596,28 +596,28 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
     auto start_tx = [&]() {
         auto pid = model::producer_identity{pid_counter++, 0};
         BOOST_REQUIRE(
-          stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get0());
+          stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());
         auto rreader = make_rreader(pid, 0, 5, true);
         BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.reader), opts).get0());
+          stm.replicate(rreader.id, std::move(rreader.reader), opts).get());
         return pid;
     };
 
     auto commit_tx = [&](auto pid) {
         BOOST_REQUIRE_EQUAL(
-          stm.commit_tx(pid, tx_seq, timeout).get0(), cluster::tx::errc::none);
+          stm.commit_tx(pid, tx_seq, timeout).get(), cluster::tx::errc::none);
     };
 
     auto abort_tx = [&](auto pid) {
         auto rreader = make_rreader(pid, 5, 5, true);
         BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.reader), opts).get0());
+          stm.replicate(rreader.id, std::move(rreader.reader), opts).get());
         BOOST_REQUIRE_EQUAL(
-          stm.abort_tx(pid, tx_seq, timeout).get0(), cluster::tx::errc::none);
+          stm.abort_tx(pid, tx_seq, timeout).get(), cluster::tx::errc::none);
     };
 
     auto roll_log = [&]() {
-        disk_log->force_roll(ss::default_priority_class()).get0();
+        disk_log->force_roll(ss::default_priority_class()).get();
         segment_count++;
         BOOST_REQUIRE_EQUAL(disk_log->segment_count(), segment_count);
     };
@@ -715,7 +715,7 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
         auto rreader = make_rreader(
           model::producer_identity{-1, -1}, 0, 5, false);
         BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.reader), opts).get0());
+          stm.replicate(rreader.id, std::move(rreader.reader), opts).get());
 
         // roll and abort.
         roll_log();
@@ -775,7 +775,7 @@ void sync_ser_verify(T type) {
     iobuf_parser async_in(std::move(copy));
 
     auto sync_deser_type = reflection::adl<T>{}.from(sync_in);
-    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get0();
+    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get();
     BOOST_REQUIRE(sync_deser_type == async_deser_type);
 }
 
@@ -791,7 +791,7 @@ void async_ser_verify(T type) {
     iobuf_parser async_in(std::move(copy));
 
     auto sync_deser_type = reflection::adl<T>{}.from(sync_in);
-    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get0();
+    auto async_deser_type = reflection::async_adl<T>{}.from(async_in).get();
     BOOST_REQUIRE(sync_deser_type == async_deser_type);
 }
 
@@ -856,7 +856,7 @@ FIXTURE_TEST(test_snapshot_v4_v5_equivalence, rm_stm_test_fixture) {
     auto& stm = *_stm;
     stm.testing_only_disable_auto_abort();
 
-    stm.start().get0();
+    stm.start().get();
     wait_for_confirmed_leader();
 
     // Check the stm can apply v4/v5 snapshots
@@ -872,7 +872,7 @@ FIXTURE_TEST(test_snapshot_v4_v5_equivalence, rm_stm_test_fixture) {
           .snapshot_size = static_cast<int32_t>(buf.size_bytes()),
           .offset = stm.last_stable_offset(),
         };
-        apply_snapshot(hdr, std::move(buf)).get0();
+        apply_snapshot(hdr, std::move(buf)).get();
 
         // validate producer stat after snapshot
         // todo (bharathv): fix this check
@@ -893,7 +893,7 @@ FIXTURE_TEST(test_snapshot_v4_v5_equivalence, rm_stm_test_fixture) {
           .snapshot_size = static_cast<int32_t>(buf.size_bytes()),
           .offset = stm.last_stable_offset(),
         };
-        apply_snapshot(hdr, std::move(buf)).get0();
+        apply_snapshot(hdr, std::move(buf)).get();
 
         // validate producer stat after snapshot
         // todo (bharathv): fix this check
@@ -906,7 +906,7 @@ FIXTURE_TEST(test_snapshot_v4_v5_equivalence, rm_stm_test_fixture) {
 FIXTURE_TEST(test_tx_expiration_without_data_batches, rm_stm_test_fixture) {
     create_stm_and_start_raft();
     auto& stm = *_stm;
-    stm.start().get0();
+    stm.start().get();
     stm.testing_only_disable_auto_abort();
 
     wait_for_confirmed_leader();
@@ -919,7 +919,7 @@ FIXTURE_TEST(test_tx_expiration_without_data_batches, rm_stm_test_fixture) {
                        model::tx_seq{0},
                        std::chrono::milliseconds(10),
                        model::partition_id(0))
-                     .get0();
+                     .get();
     BOOST_REQUIRE(term_op.has_value());
     BOOST_REQUIRE_EQUAL(term_op.value(), _raft->confirmed_term());
     tests::cooperative_spin_wait_with_timeout(5s, [this, pid]() {
@@ -929,5 +929,5 @@ FIXTURE_TEST(test_tx_expiration_without_data_batches, rm_stm_test_fixture) {
                  expired.end(),
                  [pid](auto producer) { return producer->id() == pid; })
                != expired.end();
-    }).get0();
+    }).get();
 }

--- a/src/v/cluster/tests/security_frontend_test.cc
+++ b/src/v/cluster/tests/security_frontend_test.cc
@@ -100,7 +100,7 @@ FIXTURE_TEST(test_role_management, cluster_test_fixture) {
         cluster::errc result{cluster::errc::success};
         while (!success) {
             auto ec
-              = fn(app_0->controller->get_security_frontend().local()).get0();
+              = fn(app_0->controller->get_security_frontend().local()).get();
             success = break_codes.contains(ec);
             result = static_cast<cluster::errc>(ec.value());
         }
@@ -199,7 +199,7 @@ FIXTURE_TEST(test_role_management, cluster_test_fixture) {
                     .feature_name = ss::sstring("role_based_access_control"),
                     .action
                     = cluster::feature_update_action::action_t::deactivate})
-                  .get0();
+                  .get();
             success = ec == cluster::errc::success;
         }
     }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1982,7 +1982,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // iobuf -> append_entries_request
         iobuf_parser serde_in(std::move(serde_out));
         auto from_serde
-          = serde::read_async<raft::append_entries_request>(serde_in).get0();
+          = serde::read_async<raft::append_entries_request>(serde_in).get();
 
         BOOST_REQUIRE(from_serde.source_node() == node_id);
         BOOST_REQUIRE(from_serde.target_node() == target_node_id);
@@ -1992,7 +1992,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         auto batches_from_serde = model::consume_reader_to_memory(
                                     std::move(from_serde).release_batches(),
                                     model::no_timeout)
-                                    .get0();
+                                    .get();
         BOOST_REQUIRE(gold.size() > 0);
         BOOST_REQUIRE(batches_from_serde.size() == gold.size());
         for (size_t i = 0; i < gold.size(); i++) {

--- a/src/v/cluster/tests/simple_batch_builder_test.cc
+++ b/src/v/cluster/tests/simple_batch_builder_test.cc
@@ -81,8 +81,8 @@ SEASTAR_THREAD_TEST_CASE(round_trip_test) {
     ss::circular_buffer<model::record_batch> batches;
     batches.push_back(std::move(batch));
 
-    tests::persist_log_file(base_dir, test_ntp, std::move(batches)).get0();
-    auto read = tests::read_log_file(base_dir, test_ntp).get0();
+    tests::persist_log_file(base_dir, test_ntp, std::move(batches)).get();
+    auto read = tests::read_log_file(base_dir, test_ntp).get();
 
     BOOST_REQUIRE_EQUAL(read.size(), 1);
     BOOST_REQUIRE_EQUAL(read[0].header().last_offset_delta, 3);

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -53,8 +53,8 @@ struct topic_table_fixture {
         table
           .start(ss::sharded_parameter(
             [this] { return std::ref(migrated_resources.local()); }))
-          .get0();
-        members.start_single().get0();
+          .get();
+        members.start_single().get();
         features.start().get();
         allocator
           .start_single(
@@ -66,7 +66,7 @@ struct topic_table_fixture {
             config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
             config::mock_binding<std::vector<ss::sstring>>({}),
             config::mock_binding<bool>(false))
-          .get0();
+          .get();
         allocator.local().register_node(
           create_allocation_node(model::node_id(1), 8));
         allocator.local().register_node(
@@ -87,10 +87,10 @@ struct topic_table_fixture {
     ~topic_table_fixture() {
         pb_state.stop().get();
         node_status.stop().get();
-        table.stop().get0();
-        allocator.stop().get0();
+        table.stop().get();
+        allocator.stop().get();
         features.stop().get();
-        members.stop().get0();
+        members.stop().get();
         migrated_resources.stop().get();
         as.request_abort();
     }
@@ -140,7 +140,7 @@ struct topic_table_fixture {
     void add_random_topic() {
         auto cmd = make_create_topic_cmd(
           random_generators::gen_alphanum_string(5), 1, 3);
-        auto res = table.local().apply(std::move(cmd), model::offset(0)).get0();
+        auto res = table.local().apply(std::move(cmd), model::offset(0)).get();
         BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
     }
 
@@ -159,11 +159,11 @@ struct topic_table_fixture {
         auto cmd_3 = make_create_topic_cmd("test_tp_3", 8, 1);
 
         auto res_1
-          = table.local().apply(std::move(cmd_1), model::offset(0)).get0();
+          = table.local().apply(std::move(cmd_1), model::offset(0)).get();
         auto res_2
-          = table.local().apply(std::move(cmd_2), model::offset(0)).get0();
+          = table.local().apply(std::move(cmd_2), model::offset(0)).get();
         auto res_3
-          = table.local().apply(std::move(cmd_3), model::offset(0)).get0();
+          = table.local().apply(std::move(cmd_3), model::offset(0)).get();
 
         BOOST_REQUIRE_EQUAL(res_1, cluster::errc::success);
         BOOST_REQUIRE_EQUAL(res_2, cluster::errc::success);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -86,13 +86,13 @@ FIXTURE_TEST(test_conflicts, topic_table_fixture) {
                      cluster::delete_topic_cmd(
                        make_tp_ns("not_exists"), make_tp_ns("not_exists")),
                      model::offset(0))
-                   .get0();
+                   .get();
     BOOST_REQUIRE_EQUAL(res_1, cluster::errc::topic_not_exists);
 
     auto res_2 = table.local()
                    .apply(
                      make_create_topic_cmd("test_tp_1", 2, 3), model::offset(0))
-                   .get0();
+                   .get();
     BOOST_REQUIRE_EQUAL(res_2, cluster::errc::topic_already_exists);
     BOOST_REQUIRE_EQUAL(deltas.size(), 0);
 }

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -150,13 +150,13 @@ FIXTURE_TEST(
                      cluster::delete_topic_cmd(
                        make_tp_ns("not_exists"), make_tp_ns("not_exists")),
                      model::offset(0))
-                   .get0();
+                   .get();
     BOOST_REQUIRE_EQUAL(res_1, cluster::errc::topic_not_exists);
 
     auto res_2 = table.local()
                    .apply(
                      make_create_topic_cmd("test_tp_1", 2, 3), model::offset(0))
-                   .get0();
+                   .get();
     BOOST_REQUIRE_EQUAL(res_2, cluster::errc::topic_already_exists);
     BOOST_REQUIRE_EQUAL(deltas.size(), 0);
 

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -219,8 +219,8 @@ public:
         execute(std::move(ops), log).get();
 
         //---- Step 3: Force a roll and compact the log.
-        log->flush().get0();
-        log->force_roll(ss::default_priority_class()).get0();
+        log->flush().get();
+        log->force_roll(ss::default_priority_class()).get();
         if (!s._compact) {
             return;
         }

--- a/src/v/cluster/tests/tx_topic_test.cc
+++ b/src/v/cluster/tests/tx_topic_test.cc
@@ -113,7 +113,7 @@ FIXTURE_TEST(test_tm_stm_eviction, redpanda_thread_fixture) {
                        kafka::transactional_id{"tx-1"},
                        std::chrono::milliseconds(0),
                        pid)
-                     .get0();
+                     .get();
     BOOST_REQUIRE_EQUAL(op_code, cluster::tm_stm::op_status::success);
     auto tx_mgr_log = tx_mgr_prt->log();
     tx_mgr_log->flush().get();
@@ -126,7 +126,7 @@ FIXTURE_TEST(test_tm_stm_eviction, redpanda_thread_fixture) {
                   kafka::transactional_id{"tx-2"},
                   std::chrono::milliseconds(0),
                   pid)
-                .get0();
+                .get();
     BOOST_REQUIRE_EQUAL(op_code, cluster::tm_stm::op_status::success);
     BOOST_REQUIRE_EQUAL(2, tx_mgr_log->segment_count());
 

--- a/src/v/cluster/tests/utils.h
+++ b/src/v/cluster/tests/utils.h
@@ -35,7 +35,7 @@ inline void wait_for_metadata(
           [&topic_table](const cluster::topic_result& r) {
               return topic_table.get_topic_metadata(r.tp_ns);
           });
-    }).get0();
+    }).get();
 }
 
 inline bool

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -118,7 +118,7 @@ ss::future<checked<model::term_id, tm_stm::op_status>> tm_stm::do_barrier() {
         [this, term](ss::future<result<raft::replicate_result>> f)
           -> checked<model::term_id, tm_stm::op_status> {
             try {
-                if (!f.get0().has_value()) {
+                if (!f.get().has_value()) {
                     return tm_stm::op_status::unknown;
                 }
                 if (term != _raft->term()) {

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -632,7 +632,7 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
       .then_wrapped([tp_ns = std::move(tp_ns), units = std::move(units)](
                       ss::future<std::error_code> f) mutable {
           try {
-              auto error_code = f.get0();
+              auto error_code = f.get();
               auto ret_f = ss::now();
               return ret_f.then(
                 [tp_ns = std::move(tp_ns), error_code]() mutable {
@@ -786,7 +786,7 @@ ss::future<topic_result> topics_frontend::do_delete_topic(
           .then_wrapped(
             [tp_ns = std::move(tp_ns)](ss::future<std::error_code> f) mutable {
                 try {
-                    auto ec = f.get0();
+                    auto ec = f.get();
                     if (ec != errc::success) {
                         return topic_result(std::move(tp_ns), map_errc(ec));
                     } else {
@@ -832,7 +832,7 @@ ss::future<topic_result> topics_frontend::do_delete_topic(
       .then_wrapped(
         [tp_ns = std::move(tp_ns)](ss::future<std::error_code> f) mutable {
             try {
-                auto ec = f.get0();
+                auto ec = f.get();
                 if (ec != errc::success) {
                     return topic_result(std::move(tp_ns), map_errc(ec));
                 }

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -189,10 +189,10 @@ template<typename T>
 T decode_adl_or_serde(compat_binary test) {
     if (test.name == "adl") {
         iobuf_parser in(std::move(test.data));
-        return reflection::async_adl<T>{}.from(in).get0();
+        return reflection::async_adl<T>{}.from(in).get();
     } else if (test.name == "serde") {
         iobuf_parser in(std::move(test.data));
-        return serde::read_async<T>(in).get0();
+        return serde::read_async<T>(in).get();
     } else {
         vassert(false, "unknown type {}", test.name);
     }
@@ -202,7 +202,7 @@ template<typename T>
 T decode_serde_only(compat_binary test) {
     vassert(test.name == "serde", "Non serde type encountered {}", test.name);
     iobuf_parser in(std::move(test.data));
-    return serde::read_async<T>(in).get0();
+    return serde::read_async<T>(in).get();
 }
 
 template<typename T>

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -520,7 +520,7 @@ compat_copy(raft::append_entries_request r) {
 
     auto a_batches = model::consume_reader_to_memory(
                        std::move(r).release_batches(), model::no_timeout)
-                       .get0();
+                       .get();
 
     ss::circular_buffer<model::record_batch> b_batches;
     for (const auto& batch : a_batches) {
@@ -563,7 +563,7 @@ struct compat_check<raft::append_entries_request> {
         json::write_member(wr, "flush", obj.is_flush_required());
         auto batches = model::consume_reader_to_memory(
                          std::move(obj).release_batches(), model::no_timeout)
-                         .get0();
+                         .get();
         json::write_member(wr, "batches", batches);
     }
 
@@ -629,12 +629,12 @@ struct compat_check<raft::append_entries_request> {
         auto decoded_batches = model::consume_reader_to_memory(
                                  std::move(decoded).release_batches(),
                                  model::no_timeout)
-                                 .get0();
+                                 .get();
 
         auto expected_batches = model::consume_reader_to_memory(
                                   std::move(expected).release_batches(),
                                   model::no_timeout)
-                                  .get0();
+                                  .get();
 
         if (decoded_batches.size() != expected_batches.size()) {
             throw compat_error(fmt::format(

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -24,7 +24,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
     ss::circular_buffer<model::record_batch> batches
-      = model::test::make_random_batches(batch_spec).get0();
+      = model::test::make_random_batches(batch_spec).get();
 
     auto reader = model::make_generating_record_batch_reader(
       [batches = std::move(batches)]() mutable {
@@ -33,7 +33,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
       });
 
     auto result
-      = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+      = reader.consume(std::move(multiplexer), model::no_timeout).get();
 
     ASSERT_EQ(result.size(), 1);
     EXPECT_EQ(result[0].row_count, record_count * batch_count);

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -164,12 +164,12 @@ void test_http_request(
     // Send request
     auto [server, client] = started_client_and_server(conf);
     auto resp_stream
-      = client->request(std::move(header), std::move(body)).get0();
+      = client->request(std::move(header), std::move(body)).get();
 
     // Receive response
     iobuf response_body;
     while (!resp_stream->is_done()) {
-        iobuf res = resp_stream->recv_some().get0();
+        iobuf res = resp_stream->recv_some().get();
         response_body.append(std::move(res));
     }
 
@@ -192,7 +192,7 @@ void test_http_request(
     // Receive response
     iobuf response_body;
     while (!resp_stream->is_done()) {
-        iobuf res = resp_stream->recv_some().get0();
+        iobuf res = resp_stream->recv_some().get();
         response_body.append(std::move(res));
     }
     // Check response
@@ -241,9 +241,9 @@ void test_http_streaming_request(
         iobuf body;
         body.append(request_data->data(), request_data->size());
         auto body_stream = make_iobuf_input_stream(std::move(body));
-        response = client->request(std::move(header), body_stream).get0();
+        response = client->request(std::move(header), body_stream).get();
     } else {
-        response = client->request(std::move(header)).get0();
+        response = client->request(std::move(header)).get();
     }
 
     // Receive response
@@ -253,14 +253,14 @@ void test_http_streaming_request(
         stream.skip(skip).get();
     }
     while (!stream.eof()) {
-        auto buf = stream.read().get0();
+        auto buf = stream.read().get();
         response_body.append(std::move(buf));
     }
 
     // Check response
     check_reply(response->get_headers(), std::move(response_body));
 
-    server->stop().get0();
+    server->stop().get();
 }
 
 /// Check GET streaming request and skip method of the response data source
@@ -435,7 +435,7 @@ public:
         _server_socket = ss::engine().listen(server_addr, lo);
         (void)ss::with_gate(_gate, [this] {
             return ss::async([this] {
-                auto [connection, remoteaddr] = _server_socket.accept().get0();
+                auto [connection, remoteaddr] = _server_socket.accept().get();
                 _socket = std::move(connection);
                 _fin = _socket.input();
                 _fout = _socket.output();
@@ -463,7 +463,7 @@ private:
         int it = 0;
         const int max_iter = 1000;
         while (it++ < max_iter) {
-            auto tmpbuf = _fin.read().get0();
+            auto tmpbuf = _fin.read().get();
             buffer.append(std::move(tmpbuf));
             if (buffer.size_bytes() > _expected_data.size()) {
                 iobuf_parser parser(buffer.copy());
@@ -544,8 +544,7 @@ void test_impostor_request(
     iobuf response_body;
     try {
         // Send request
-        resp_stream
-          = client->request(std::move(header), std::move(body)).get0();
+        resp_stream = client->request(std::move(header), std::move(body)).get();
 
         // Receive response
         if (prefetch_header) {
@@ -553,7 +552,7 @@ void test_impostor_request(
             BOOST_REQUIRE(resp_stream->is_header_done());
         }
         while (!resp_stream->is_done()) {
-            iobuf res = resp_stream->recv_some().get0();
+            iobuf res = resp_stream->recv_some().get();
             response_body.append(std::move(res));
         }
     } catch (...) {

--- a/src/v/http/tests/http_imposter_test.cc
+++ b/src/v/http/tests/http_imposter_test.cc
@@ -40,10 +40,10 @@ FIXTURE_TEST(test_get, fixture) {
     auto client = http::client{
       {.server_addr = {httpd_host_name.data(), httpd_port_number()}}};
 
-    auto response = client.request(std::move(header)).get0();
+    auto response = client.request(std::move(header)).get();
     iobuf response_data;
     while (!response->is_done()) {
-        response_data.append(response->recv_some().get0());
+        response_data.append(response->recv_some().get());
     }
 
     auto headers = response->get_headers();
@@ -72,10 +72,10 @@ FIXTURE_TEST(test_post, fixture) {
     header.insert(
       bh::field::host, {httpd_host_name.data(), httpd_host_name.size()});
 
-    auto response = client.request(std::move(header)).get0();
+    auto response = client.request(std::move(header)).get();
     iobuf response_data;
     while (!response->is_done()) {
-        response_data.append(response->recv_some().get0());
+        response_data.append(response->recv_some().get());
     }
 
     auto headers = response->get_headers();
@@ -106,10 +106,10 @@ FIXTURE_TEST(test_forbidden, fixture) {
         header.insert(
           bh::field::host, {httpd_host_name.data(), httpd_host_name.size()});
 
-        auto response = client.request(std::move(header)).get0();
+        auto response = client.request(std::move(header)).get();
         iobuf response_data;
         while (!response->is_done()) {
-            response_data.append(response->recv_some().get0());
+            response_data.append(response->recv_some().get());
         }
 
         BOOST_REQUIRE_EQUAL(
@@ -123,10 +123,10 @@ FIXTURE_TEST(test_forbidden, fixture) {
         header.insert(
           bh::field::host, {httpd_host_name.data(), httpd_host_name.size()});
 
-        auto response = client.request(std::move(header)).get0();
+        auto response = client.request(std::move(header)).get();
         iobuf response_data;
         while (!response->is_done()) {
-            response_data.append(response->recv_some().get0());
+            response_data.append(response->recv_some().get());
         }
 
         BOOST_REQUIRE_EQUAL(

--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -323,7 +323,7 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
         manifest_path = "nested_manifest.avro";
     }
     auto orig_buf = iobuf{
-      ss::util::read_entire_file(manifest_path.value()).get0()};
+      ss::util::read_entire_file(manifest_path.value()).get()};
     auto m = parse_manifest({struct_type{}}, orig_buf.copy());
     ASSERT_EQ(100, m.entries.size());
     ASSERT_EQ(m.metadata.manifest_content_type, manifest_content_type::data);

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -46,7 +46,7 @@ public:
         ss::smp::invoke_on_all([] {
             auto& config = config::shard_local_cfg();
             config.get("disable_metrics").set_value(false);
-        }).get0();
+        }).get();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, test_mode);

--- a/src/v/kafka/client/test/produce_batcher.cc
+++ b/src/v/kafka/client/test/produce_batcher.cc
@@ -91,7 +91,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_single) {
     BOOST_REQUIRE(ctx.consume().get() == 2);
     BOOST_REQUIRE(ctx.handle_response() == 2);
 
-    auto offsets = ctx.get_response_offsets().get0();
+    auto offsets = ctx.get_response_offsets().get();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
     BOOST_REQUIRE(ctx.consume().get() == 0);
@@ -110,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_seq) {
     BOOST_REQUIRE(ctx.consume().get() == 4);
     BOOST_REQUIRE(ctx.handle_response() == 4);
 
-    auto offsets = ctx.get_response_offsets().get0();
+    auto offsets = ctx.get_response_offsets().get();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
     BOOST_REQUIRE(ctx.consume().get() == 0);
@@ -130,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_overlapped) {
     BOOST_REQUIRE(ctx.handle_response() == 4);
     BOOST_REQUIRE(ctx.handle_response() == 4);
 
-    auto offsets = ctx.get_response_offsets().get0();
+    auto offsets = ctx.get_response_offsets().get();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
     BOOST_REQUIRE(ctx.consume().get() == 0);
@@ -151,7 +151,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_error) {
     BOOST_REQUIRE(
       ctx.handle_response(kafka::error_code::not_leader_for_partition) == 4);
 
-    auto responses = ctx.get_responses().get0();
+    auto responses = ctx.get_responses().get();
     BOOST_REQUIRE(responses.size() == 4);
     // successes
     BOOST_REQUIRE(responses[0].base_offset == model::offset(42));

--- a/src/v/kafka/client/test/produce_partition.cc
+++ b/src/v/kafka/client/test/produce_partition.cc
@@ -55,9 +55,9 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
 
     BOOST_REQUIRE_EQUAL(consumed_batches.size(), 1);
     BOOST_REQUIRE_EQUAL(consumed_batches[0].record_count(), 3);
-    auto c_res0 = c_res0_fut.get0();
+    auto c_res0 = c_res0_fut.get();
     BOOST_REQUIRE_EQUAL(c_res0.base_offset, model::offset{0});
-    auto c_res1 = c_res1_fut.get0();
+    auto c_res1 = c_res1_fut.get();
     BOOST_REQUIRE_EQUAL(c_res1.base_offset, model::offset{2});
 
     auto c_res2_fut = producer.produce(make_batch(model::offset(3), 3));
@@ -71,7 +71,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
 
     BOOST_REQUIRE_EQUAL(consumed_batches.size(), 2);
     BOOST_REQUIRE_EQUAL(consumed_batches[1].record_count(), 3);
-    auto c_res2 = c_res2_fut.get0();
+    auto c_res2 = c_res2_fut.get();
     BOOST_REQUIRE_EQUAL(c_res2.base_offset, model::offset{3});
     producer.stop().get();
 }

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -191,7 +191,7 @@ static partition_produce_stages partition_append(
           ss::future<result<raft::replicate_result>> f) {
             produce_response::partition p{.partition_index = id};
             try {
-                auto r = f.get0();
+                auto r = f.get();
                 if (r.has_value()) {
                     // have to subtract num_of_records - 1 as base_offset
                     // is inclusive

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -262,9 +262,9 @@ FIXTURE_TEST(
 
     kafka::metadata_request req;
     req.data.topics = std::nullopt;
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
-    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get0();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
     auto broker_id = std::to_string(resp.data.brokers[0].node_id());
 

--- a/src/v/kafka/server/tests/api_versions_test.cc
+++ b/src/v/kafka/server/tests/api_versions_test.cc
@@ -18,13 +18,13 @@
 // https://github.com/apache/kafka/blob/eaccb92/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
 
 FIXTURE_TEST(validate_latest_version, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::api_versions_request request;
     request.data.client_software_name = "redpanda";
     request.data.client_software_version = "x.x.x";
-    auto response = client.dispatch(request, kafka::api_version(3)).get0();
+    auto response = client.dispatch(request, kafka::api_version(3)).get();
     BOOST_TEST(response.data.error_code == kafka::error_code::none);
     client.stop().then([&client] { client.shutdown(); }).get();
 
@@ -33,11 +33,11 @@ FIXTURE_TEST(validate_latest_version, redpanda_thread_fixture) {
 }
 
 FIXTURE_TEST(validate_v0, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::api_versions_request request;
-    auto response = client.dispatch(request, kafka::api_version(0)).get0();
+    auto response = client.dispatch(request, kafka::api_version(0)).get();
     BOOST_TEST(response.data.error_code == kafka::error_code::none);
     client.stop().then([&client] { client.shutdown(); }).get();
 
@@ -46,14 +46,14 @@ FIXTURE_TEST(validate_v0, redpanda_thread_fixture) {
 }
 
 FIXTURE_TEST(unsupported_version, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::api_versions_request request;
     auto max_version = kafka::api_version(
       std::numeric_limits<kafka::api_version::type>::max());
     auto response
-      = client.dispatch(request, max_version, kafka::api_version(0)).get0();
+      = client.dispatch(request, max_version, kafka::api_version(0)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(
@@ -76,21 +76,21 @@ FIXTURE_TEST(unsupported_version, redpanda_thread_fixture) {
 
 // Tests for bug that broke flex request parsing for null or empty client ids
 FIXTURE_TEST(flex_with_empty_client_id, redpanda_thread_fixture) {
-    auto client = make_kafka_client("").get0();
+    auto client = make_kafka_client("").get();
     client.connect().get();
 
     kafka::api_versions_request request;
-    auto response = client.dispatch(request, kafka::api_version(3)).get0();
+    auto response = client.dispatch(request, kafka::api_version(3)).get();
     BOOST_TEST(response.data.error_code == kafka::error_code::none);
     client.stop().then([&client] { client.shutdown(); }).get();
 }
 
 FIXTURE_TEST(flex_with_null_client_id, redpanda_thread_fixture) {
-    auto client = make_kafka_client(std::nullopt).get0();
+    auto client = make_kafka_client(std::nullopt).get();
     client.connect().get();
 
     kafka::api_versions_request request;
-    auto response = client.dispatch(request, kafka::api_version(3)).get0();
+    auto response = client.dispatch(request, kafka::api_version(3)).get();
     BOOST_TEST(response.data.error_code == kafka::error_code::none);
     client.stop().then([&client] { client.shutdown(); }).get();
 }

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -50,7 +50,7 @@ join_group_request make_join_group_request(
 struct consumer_offsets_fixture : public redpanda_thread_fixture {
     void
     wait_for_consumer_offsets_topic(const kafka::group_instance_id& group) {
-        auto client = make_kafka_client().get0();
+        auto client = make_kafka_client().get();
 
         client.connect().get();
         kafka::find_coordinator_request req(group);
@@ -81,7 +81,7 @@ struct consumer_offsets_fixture : public redpanda_thread_fixture {
 FIXTURE_TEST(join_empty_group_static_member, consumer_offsets_fixture) {
     kafka::group_instance_id gr("instance-1");
     wait_for_consumer_offsets_topic(gr);
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     auto deferred = ss::defer([&client] {
         client.stop().then([&client] { client.shutdown(); }).get();
     });
@@ -111,7 +111,7 @@ FIXTURE_TEST(empty_offset_commit_request, consumer_offsets_fixture) {
       .get();
     kafka::group_instance_id gr("instance-1");
     wait_for_consumer_offsets_topic(gr);
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     auto deferred = ss::defer([&client] {
         client.stop().then([&client] { client.shutdown(); }).get();
     });
@@ -150,7 +150,7 @@ FIXTURE_TEST(conditional_retention_test, consumer_offsets_fixture) {
     kafka::group_instance_id gr("instance-1");
     wait_for_consumer_offsets_topic(gr);
     // load some data into the topic via offset_commit requests.
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     auto deferred = ss::defer([&client] {
         client.stop().then([&client] { client.shutdown(); }).get();
     });

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -85,12 +85,12 @@ public:
     void test_create_topic(
       kafka::create_topics_request req,
       kafka::api_version version = kafka::api_version(2)) {
-        auto client = make_kafka_client().get0();
+        auto client = make_kafka_client().get();
         client.connect().get();
         auto topics = req.data.topics
                         .copy(); // save a copy because we will move out of req
         bool validate_only = req.data.validate_only;
-        auto resp = client.dispatch(std::move(req), version).get0();
+        auto resp = client.dispatch(std::move(req), version).get();
 
         BOOST_REQUIRE_MESSAGE(
           std::all_of(
@@ -176,7 +176,7 @@ public:
           kafka::metadata_request_topic{request_topic.name});
         auto metadata_resp
           = client.dispatch(std::move(metadata_req), kafka::api_version(1))
-              .get0();
+              .get();
 
         // yank out the metadata for the topic from the response
         auto topic_metadata = std::find_if(
@@ -302,10 +302,9 @@ FIXTURE_TEST(read_replica_and_remote_write, create_topic_fixture) {
         {"redpanda.remote.readreplica", "panda-bucket"},
         {"redpanda.remote.write", "true"}});
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
-    auto resp
-      = client.dispatch(make_req({topic}), kafka::api_version(2)).get0();
+    auto resp = client.dispatch(make_req({topic}), kafka::api_version(2)).get();
 
     BOOST_CHECK(
       resp.data.topics[0].error_code == kafka::error_code::invalid_config);

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -47,18 +47,18 @@ public:
           .validate_only = false,
         }};
 
-        auto client = make_kafka_client().get0();
-        client.connect().get0();
+        auto client = make_kafka_client().get();
+        client.connect().get();
         auto resp
-          = client.dispatch(std::move(req), kafka::api_version(2)).get0();
+          = client.dispatch(std::move(req), kafka::api_version(2)).get();
     }
 
     kafka::delete_topics_response
     send_delete_topics_request(kafka::delete_topics_request req) {
-        auto client = make_kafka_client().get0();
-        client.connect().get0();
+        auto client = make_kafka_client().get();
+        client.connect().get();
 
-        return client.dispatch(std::move(req), kafka::api_version(2)).get0();
+        return client.dispatch(std::move(req), kafka::api_version(2)).get();
     }
 
     void
@@ -76,15 +76,15 @@ public:
     }
 
     kafka::metadata_response get_topic_metadata(const model::topic& tp) {
-        auto client = make_kafka_client().get0();
-        client.connect().get0();
+        auto client = make_kafka_client().get();
+        client.connect().get();
         chunked_vector<kafka::metadata_request_topic> topics;
         topics.push_back(kafka::metadata_request_topic{tp});
         kafka::metadata_request md_req{
           .data
           = {.topics = std::move(topics), .allow_auto_topic_creation = false},
           .list_all_topics = false};
-        return client.dispatch(std::move(md_req)).get0();
+        return client.dispatch(std::move(md_req)).get();
     }
 
     ss::future<kafka::metadata_response> get_all_metadata() {
@@ -193,7 +193,7 @@ FIXTURE_TEST(error_delete_topics_request, delete_topics_request_fixture) {
     tests::cooperative_spin_wait_with_timeout(5s, [this, tp] {
         return get_all_metadata().then(
           [](kafka::metadata_response resp) { return resp.topics.empty(); });
-    }).get0();
+    }).get();
 
     validate_topic_is_deleteted(model::topic("timeout-topic"));
 }

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -241,7 +241,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
     }
 
     fetch_bench_fixture() {
-        wait_for_controller_leadership().get0();
+        wait_for_controller_leadership().get();
 
         // Disable as many background processes as possible to reduce noise.
         test_local_cfg.get("log_disable_housekeeping_for_tests")

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -67,7 +67,7 @@ struct fetch_plan_fixture : redpanda_thread_fixture {
     fetch_plan_fixture() {
         BOOST_TEST_CHECKPOINT("before leadership");
 
-        wait_for_controller_leadership().get0();
+        wait_for_controller_leadership().get();
 
         BOOST_TEST_CHECKPOINT("HERE");
 

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -18,7 +18,7 @@
 #include <limits>
 
 FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     using underlying_t = std::underlying_type_t<kafka::coordinator_type>;
@@ -26,7 +26,7 @@ FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
     req.data.key_type = kafka::coordinator_type(
       std::numeric_limits<underlying_t>::max());
 
-    auto resp = client.dispatch(req, kafka::api_version(1)).get0();
+    auto resp = client.dispatch(req, kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(resp.data.error_code == kafka::error_code::unsupported_version);
@@ -38,12 +38,12 @@ FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
 FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
     wait_for_controller_leadership().get();
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::find_coordinator_request req("key");
 
-    auto resp = client.dispatch(req, kafka::api_version(1)).get0();
+    auto resp = client.dispatch(req, kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(resp.data.error_code == kafka::error_code::none);

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -25,7 +25,7 @@
 using namespace std::chrono_literals;
 
 FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get0();
+    wait_for_controller_leadership().get();
 
     // Synthetic default timestamp for produced data
     auto base_ts = model::timestamp{10000};
@@ -50,7 +50,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
         })
       .get();
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::list_offsets_request req;
@@ -62,7 +62,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
       }},
     });
 
-    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get0();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
@@ -72,7 +72,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
 }
 
 FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get0();
+    wait_for_controller_leadership().get();
     auto ntp = make_data();
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
@@ -84,7 +84,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
           });
     }).get();
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::list_offsets_request req;
@@ -96,7 +96,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
       }},
     });
 
-    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get0();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
@@ -107,7 +107,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
 }
 
 FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get0();
+    wait_for_controller_leadership().get();
     auto ntp = make_data();
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
@@ -119,7 +119,7 @@ FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
           });
     }).get();
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::list_offsets_request req;
@@ -131,7 +131,7 @@ FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
       }},
     });
 
-    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get0();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
@@ -201,16 +201,16 @@ make_produce_request(model::topic_partition tp, model::record_batch&& batch) {
 }
 
 FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get0();
+    wait_for_controller_leadership().get();
     model::ntp ntp(
       model::kafka_namespace,
       model::topic(random_generators::gen_alphanum_string(8)),
       model::partition_id(0));
 
     add_topic(model::topic_namespace_view{ntp}, 1).get();
-    wait_for_partition_offset(ntp, model::offset(0)).get0();
+    wait_for_partition_offset(ntp, model::offset(0)).get();
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     // 3 batches of 3 records, with timestamps incrementing 1ms per record
@@ -254,7 +254,7 @@ FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
         });
 
         auto resp
-          = client.dispatch(std::move(req), kafka::api_version(1)).get0();
+          = client.dispatch(std::move(req), kafka::api_version(1)).get();
 
         BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
         BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
@@ -281,7 +281,7 @@ FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
 
         const auto& batch = batches[i];
         auto resp_midbatch
-          = client.dispatch(std::move(req2), kafka::api_version(1)).get0();
+          = client.dispatch(std::move(req2), kafka::api_version(1)).get();
         BOOST_REQUIRE_EQUAL(resp_midbatch.data.topics.size(), 1);
         BOOST_REQUIRE_EQUAL(resp_midbatch.data.topics[0].partitions.size(), 1);
         if (batch.compressed()) {

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -120,10 +120,10 @@ SEASTAR_THREAD_TEST_CASE(response_futs) {
     m.set_sync_response(make_sync_response());
 
     BOOST_TEST(
-      join_response.get0().data.generation_id
+      join_response.get().data.generation_id
       == make_join_response().data.generation_id);
     BOOST_TEST(
-      sync_response.get0().data.assignment
+      sync_response.get().data.assignment
       == make_sync_response().data.assignment);
 
     BOOST_TEST(!m.is_joining());

--- a/src/v/kafka/server/tests/offset_fetch_test.cc
+++ b/src/v/kafka/server/tests/offset_fetch_test.cc
@@ -18,13 +18,13 @@
 #include <limits>
 
 FIXTURE_TEST(offset_fetch, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     kafka::offset_fetch_request req;
     req.data.group_id = kafka::group_id("g");
 
-    auto resp = client.dispatch(req, kafka::api_version(2)).get0();
+    auto resp = client.dispatch(req, kafka::api_version(2)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(resp.data.error_code == kafka::error_code::not_coordinator);

--- a/src/v/kafka/server/tests/partition_reassignments_test.cc
+++ b/src/v/kafka/server/tests/partition_reassignments_test.cc
@@ -79,7 +79,7 @@ FIXTURE_TEST(
     model::topic test_tp{"topic-1"};
     create_topic(test_tp, 6);
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
     model::partition_id pid0{0};
 
@@ -260,7 +260,7 @@ FIXTURE_TEST(
     int num_partitions = 6;
     create_topic(test_tp, num_partitions);
 
-    auto client = make_kafka_client().get0();
+    auto client = make_kafka_client().get();
     client.connect().get();
 
     {

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -52,10 +52,10 @@ public:
           .validate_only = false,
         }};
 
-        auto client = make_kafka_client().get0();
-        client.connect().get0();
+        auto client = make_kafka_client().get();
+        client.connect().get();
         auto resp
-          = client.dispatch(std::move(req), kafka::api_version(2)).get0();
+          = client.dispatch(std::move(req), kafka::api_version(2)).get();
     }
     kafka::delete_topics_request make_delete_topics_request(
       chunked_vector<model::topic> topics, std::chrono::milliseconds timeout) {
@@ -76,10 +76,10 @@ public:
 
     kafka::delete_topics_response
     send_delete_topics_request(kafka::delete_topics_request req) {
-        auto client = make_kafka_client().get0();
-        client.connect().get0();
+        auto client = make_kafka_client().get();
+        client.connect().get();
 
-        return client.dispatch(std::move(req), kafka::api_version(2)).get0();
+        return client.dispatch(std::move(req), kafka::api_version(2)).get();
     }
     template<typename Func>
     auto do_with_client(Func&& f) {
@@ -129,7 +129,7 @@ public:
         ss::smp::invoke_on_all([] {
             auto& config = config::shard_local_cfg();
             config.get("disable_metrics").set_value(false);
-        }).get0();
+        }).get();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);
@@ -141,18 +141,18 @@ FIXTURE_TEST(test_topic_recreation, recreate_test_fixture) {
     model::topic test_tp{"topic-1"};
     create_topic(test_tp(), 6, 1);
     // wait until created
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
 
     delete_topics({test_tp});
     // wait until deleted
     wait_until_topic_status(
       test_tp, kafka::error_code::unknown_topic_or_partition)
-      .get0();
+      .get();
     create_topic(test_tp(), 6, 1);
 
     tests::cooperative_spin_wait_with_timeout(3s, [this, test_tp] {
         return ss::async([this, test_tp] {
-            auto md = get_topic_metadata(test_tp).get0();
+            auto md = get_topic_metadata(test_tp).get();
             if (md.data.topics.size() != 1) {
                 return false;
             }
@@ -168,7 +168,7 @@ FIXTURE_TEST(test_topic_recreation, recreate_test_fixture) {
                   return p.leader_id == model::node_id{1};
               });
         });
-    }).get0();
+    }).get();
 }
 
 FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
@@ -177,12 +177,12 @@ FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
     // flow frim [ch1061]
     info("Creating {} with {} partitions", test_tp, 6);
     create_topic(test_tp(), 6, 1);
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
     info("Deleting {}", test_tp);
     delete_topics({test_tp});
     wait_until_topic_status(
       test_tp, kafka::error_code::unknown_topic_or_partition)
-      .get0();
+      .get();
     info("Restarting redpanda, first time");
     restart();
     wait_for_controller_leadership().get();
@@ -192,15 +192,15 @@ FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
     delete_topics({test_tp});
     wait_until_topic_status(
       test_tp, kafka::error_code::unknown_topic_or_partition)
-      .get0();
+      .get();
     info("Creating {} with {} partitions", test_tp, 3);
     create_topic(test_tp(), 3, 1);
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
     info("Restarting redpanda, second time");
     restart();
     info("Waiting for recovery");
     wait_for_controller_leadership().get();
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
 
     return tests::cooperative_spin_wait_with_timeout(
              5s,
@@ -228,15 +228,15 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
     // flow from [ch1406]
     info("Creating {} with {} partitions", test_tp, 1);
     create_topic(test_tp(), 1, 1);
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
     info("Deleting {}", test_tp);
     delete_topics({test_tp});
     wait_until_topic_status(
       test_tp, kafka::error_code::unknown_topic_or_partition)
-      .get0();
+      .get();
     info("Creating {} with {} partitions", test_tp, 1);
     create_topic(test_tp(), 1, 1);
-    wait_until_topic_status(test_tp, kafka::error_code::none).get0();
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
     auto ntp = model::ntp(
       model::kafka_namespace,
       model::topic_partition(test_tp, model::partition_id(0)));
@@ -254,7 +254,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
               return false;
           });
     };
-    tests::cooperative_spin_wait_with_timeout(2s, wait_for_ntp_leader).get0();
+    tests::cooperative_spin_wait_with_timeout(2s, wait_for_ntp_leader).get();
     auto shard_id = app.shard_table.local().shard_for(ntp);
     model::offset committed_offset
       = app.partition_manager
@@ -274,7 +274,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
                         .then([p](auto) { return p->committed_offset(); });
                   });
             })
-          .get0();
+          .get();
     info("Restarting redpanda");
     restart();
 
@@ -283,7 +283,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
         info("Expected committed offset {}", committed_offset);
         wait_for_controller_leadership().get();
         tests::cooperative_spin_wait_with_timeout(2s, wait_for_ntp_leader)
-          .get0();
+          .get();
         tests::cooperative_spin_wait_with_timeout(2s, [this, ntp] {
             auto shard_id = app.shard_table.local().shard_for(ntp);
             if (!shard_id) {
@@ -296,7 +296,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
                   return partition
                          && partition->committed_offset() >= model::offset(0);
               });
-        }).get0();
+        }).get();
         auto shard_id = app.shard_table.local().shard_for(ntp);
         app.partition_manager
           .invoke_on(
@@ -305,6 +305,6 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
                 BOOST_REQUIRE(
                   pm.get(ntp)->committed_offset() >= committed_offset);
             })
-          .get0();
+          .get();
     }
 }

--- a/src/v/model/tests/record_batch_reader_test.cc
+++ b/src/v/model/tests/record_batch_reader_test.cc
@@ -96,14 +96,14 @@ make_generating_reader(ss::circular_buffer<record_batch> batches) {
 }
 
 void do_test_consume(record_batch_reader reader) {
-    auto batches = reader.consume(consumer(4), no_timeout).get0();
+    auto batches = reader.consume(consumer(4), no_timeout).get();
     auto o = offset(1);
     for (auto& batch : batches) {
         BOOST_CHECK_EQUAL(batch.base_offset(), o);
         o += 1;
     }
 
-    batches = reader.consume(consumer(4), no_timeout).get0();
+    batches = reader.consume(consumer(4), no_timeout).get();
     BOOST_CHECK_EQUAL(batches.size(), 0);
 }
 
@@ -118,7 +118,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_multiple_slices) {
 }
 
 void do_test_interrupt_consume(record_batch_reader reader) {
-    auto batches = reader.consume(consumer(2), no_timeout).get0();
+    auto batches = reader.consume(consumer(2), no_timeout).get();
     auto o = offset(1);
     for (auto& batch : batches) {
         BOOST_CHECK_EQUAL(batch.base_offset(), o);
@@ -126,21 +126,21 @@ void do_test_interrupt_consume(record_batch_reader reader) {
     }
     BOOST_CHECK_EQUAL(o, offset(3));
 
-    batches = reader.consume(consumer(2), no_timeout).get0();
+    batches = reader.consume(consumer(2), no_timeout).get();
     for (auto& batch : batches) {
         BOOST_CHECK_EQUAL(batch.base_offset(), o);
         o += 1;
     }
     BOOST_CHECK_EQUAL(o, offset(5));
 
-    batches = reader.consume(consumer(2), no_timeout).get0();
+    batches = reader.consume(consumer(2), no_timeout).get();
     for (auto& batch : batches) {
         BOOST_CHECK_EQUAL(batch.base_offset(), o);
         o += 1;
     }
     BOOST_CHECK_EQUAL(o, offset(6));
 
-    batches = reader.consume(consumer(4), no_timeout).get0();
+    batches = reader.consume(consumer(4), no_timeout).get();
     BOOST_CHECK_EQUAL(batches.size(), 0);
 }
 

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -34,7 +34,7 @@ FIXTURE_TEST(test_entries_are_replicated_to_all_nodes, raft_test_fixture) {
     raft_group gr = raft_group(raft::group_id(0), 3);
     gr.enable_all();
 
-    bool success = replicate_random_batches(gr, 10).get0();
+    bool success = replicate_random_batches(gr, 10).get();
 
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
@@ -45,7 +45,7 @@ FIXTURE_TEST(test_replicate_multiple_entries_single_node, raft_test_fixture) {
     raft_group gr = raft_group(raft::group_id(0), 1);
     gr.enable_all();
     for (int i = 0; i < 5; ++i) {
-        bool success = replicate_random_batches(gr, 5).get0();
+        bool success = replicate_random_batches(gr, 5).get();
         BOOST_REQUIRE(success);
     }
 
@@ -65,7 +65,7 @@ FIXTURE_TEST(
     for (int i = 0; i < 5; ++i) {
         bool success = replicate_random_batches(
                          gr, 5, raft::consistency_level::leader_ack)
-                         .get0();
+                         .get();
         BOOST_REQUIRE(success);
     }
 
@@ -87,7 +87,7 @@ FIXTURE_TEST(test_replicate_multiple_entries, raft_test_fixture) {
     auto leader_id = wait_for_group_leader(gr);
     auto leader_raft = gr.get_member(leader_id).consensus;
     for (int i = 0; i < 5; ++i) {
-        bool success = replicate_random_batches(gr, 5).get0();
+        bool success = replicate_random_batches(gr, 5).get();
         BOOST_REQUIRE(success);
     }
 
@@ -107,7 +107,7 @@ FIXTURE_TEST(test_replicate_with_expected_term_leader, raft_test_fixture) {
     auto term = leader_raft->term();
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::leader_ack)
-                     .get0();
+                     .get();
     // check term to make sure there were no leader elections
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
@@ -127,7 +127,7 @@ FIXTURE_TEST(test_replicate_with_expected_term_quorum, raft_test_fixture) {
 
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::quorum_ack)
-                     .get0();
+                     .get();
     // check term to make sure there were no leader elections
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
@@ -146,7 +146,7 @@ FIXTURE_TEST(test_replicate_violating_expected_term_leader, raft_test_fixture) {
     auto term = leader_raft->term() + model::term_id(100);
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::leader_ack)
-                     .get0();
+                     .get();
     // check term to make sure there were no leader elections
     leader_id = wait_for_group_leader(gr);
     leader_raft = gr.get_member(leader_id).consensus;
@@ -165,7 +165,7 @@ FIXTURE_TEST(test_replicate_violating_expected_term_quorum, raft_test_fixture) {
     auto term = leader_raft->term() + model::term_id(100);
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::quorum_ack)
-                     .get0();
+                     .get();
     BOOST_REQUIRE(!success);
 };
 
@@ -182,7 +182,7 @@ FIXTURE_TEST(test_single_node_recovery, raft_test_fixture) {
             break;
         }
     }
-    bool success = replicate_random_batches(gr, 8).get0();
+    bool success = replicate_random_batches(gr, 8).get();
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
 
@@ -202,7 +202,7 @@ FIXTURE_TEST(test_single_node_recovery, raft_test_fixture) {
 FIXTURE_TEST(test_empty_node_recovery, raft_test_fixture) {
     raft_group gr = raft_group(raft::group_id(0), 3);
     gr.enable_all();
-    bool success = replicate_random_batches(gr, 5).get0();
+    bool success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
 
     validate_logs_replication(gr);
@@ -236,7 +236,7 @@ FIXTURE_TEST(test_empty_node_recovery_relaxed_consistency, raft_test_fixture) {
     gr.enable_all();
     bool success = replicate_random_batches(
                      gr, 5, raft::consistency_level::leader_ack)
-                     .get0();
+                     .get();
     BOOST_REQUIRE(success);
 
     validate_logs_replication(gr);
@@ -278,7 +278,7 @@ FIXTURE_TEST(test_single_node_recovery_multi_terms, raft_test_fixture) {
         }
     }
     // append some entries in current term
-    auto success = replicate_random_batches(gr, 5).get0();
+    auto success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
 
     // roll the term
@@ -286,9 +286,9 @@ FIXTURE_TEST(test_single_node_recovery_multi_terms, raft_test_fixture) {
         return leader.consensus
           ->step_down(leader.consensus->term() + model::term_id(1), "test")
           .then([] { return true; });
-    }).get0();
+    }).get();
     // append some entries in next term
-    success = replicate_random_batches(gr, 5).get0();
+    success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
 
     validate_logs_replication(gr);
@@ -331,7 +331,7 @@ FIXTURE_TEST(test_recovery_of_crashed_leader_truncation, raft_test_fixture) {
             rpc::errc::client_request_timeout);
       })
       .discard_result()
-      .get0();
+      .get();
 
     // shut down the leader
     info("shutting down leader {}", first_leader_id);
@@ -346,7 +346,7 @@ FIXTURE_TEST(test_recovery_of_crashed_leader_truncation, raft_test_fixture) {
 
     // append some entries via new leader so old one has some data to
     // truncate
-    bool success = replicate_random_batches(gr, 2).get0();
+    bool success = replicate_random_batches(gr, 2).get();
     BOOST_REQUIRE(success);
 
     validate_logs_replication(gr);
@@ -369,7 +369,7 @@ FIXTURE_TEST(test_append_entries_with_relaxed_consistency, raft_test_fixture) {
 
     bool success = replicate_random_batches(
                      gr, 2, raft::consistency_level::leader_ack)
-                     .get0();
+                     .get();
     BOOST_REQUIRE(success);
 
     validate_logs_replication(gr);
@@ -388,7 +388,7 @@ FIXTURE_TEST(
     gr.enable_all();
     bool success = replicate_random_batches(
                      gr, 10, raft::consistency_level::leader_ack)
-                     .get0();
+                     .get();
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
 
@@ -442,24 +442,24 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
 
     builder | storage::start(std::move(ntp_config)) | storage::add_segment(0);
     auto batch = model::test::make_random_batch(model::offset(0), 1, false);
-    builder.add_batch(std::move(batch)).get0();
+    builder.add_batch(std::move(batch)).get();
     // roll term - this was triggering ch1284 (ghost batches influencing
     // segments roll)
-    builder.add_segment(model::offset(1), model::term_id(1)).get0();
+    builder.add_segment(model::offset(1), model::term_id(1)).get();
     batch = model::test::make_random_batch(model::offset(1), 5, false);
     batch.set_term(model::term_id(1));
-    builder.add_batch(std::move(batch)).get0();
+    builder.add_batch(std::move(batch)).get();
     // gap from 6 to 19
     batch = model::test::make_random_batch(model::offset(20), 30, false);
     batch.set_term(model::term_id(1));
-    builder.add_batch(std::move(batch)).get0();
+    builder.add_batch(std::move(batch)).get();
     // gap from 50 to 67, at term boundary
-    builder.add_segment(model::offset(68), model::term_id(2)).get0();
+    builder.add_segment(model::offset(68), model::term_id(2)).get();
     batch = model::test::make_random_batch(model::offset(68), 11, false);
     batch.set_term(model::term_id(2));
-    builder.add_batch(std::move(batch)).get0();
-    builder.get_log()->flush().get0();
-    builder.stop().get0();
+    builder.add_batch(std::move(batch)).get();
+    builder.get_log()->flush().get();
+    builder.stop().get();
 
     gr.enable_all();
     auto leader_id = wait_for_group_leader(gr);
@@ -527,12 +527,12 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
     auto first_ts = model::timestamp::now();
     // append some entries
     [[maybe_unused]] bool res
-      = replicate_compactible_batches(gr, first_ts).get0();
+      = replicate_compactible_batches(gr, first_ts).get();
 
     auto second_ts = model::timestamp(first_ts() + 100);
     info("Triggerring log collection with timestamp {}", first_ts);
     // append some more entries
-    res = replicate_compactible_batches(gr, second_ts).get0();
+    res = replicate_compactible_batches(gr, second_ts).get();
 
     validate_logs_replication(gr);
 
@@ -549,7 +549,7 @@ FIXTURE_TEST(test_collected_log_recovery, raft_test_fixture) {
             as,
             storage::ntp_sanitizer_config{.sanitize_only = true}))
           .then([] { return true; });
-    }).get0();
+    }).get();
 
     gr.enable_node(disabled_id);
 
@@ -577,7 +577,7 @@ FIXTURE_TEST(test_snapshot_recovery, raft_test_fixture) {
             break;
         }
     }
-    bool success = replicate_random_batches(gr, 5).get0();
+    bool success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
 
@@ -588,20 +588,20 @@ FIXTURE_TEST(test_snapshot_recovery, raft_test_fixture) {
             return false;
         }
         return are_all_commit_indexes_the_same(gr);
-    }).get0();
+    }).get();
 
     // store snapshot
     for (auto& [_, member] : gr.get_members()) {
         member.consensus
           ->write_snapshot(raft::write_snapshot_cfg(
             get_leader_raft(gr)->committed_offset(), iobuf{}))
-          .get0();
+          .get();
         BOOST_REQUIRE_EQUAL(
           member.consensus->get_snapshot_size(),
           get_snapshot_size_from_disk(member));
     }
     gr.enable_node(disabled_id);
-    success = replicate_random_batches(gr, 5).get0();
+    success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
 
@@ -633,12 +633,12 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
         }
     }
     // append some entries
-    bool success = replicate_random_batches(gr, 5).get0();
+    bool success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
     // step down so last entry in snapshot will be a configuration
     auto leader_raft = get_leader_raft(gr);
     leader_raft->step_down(leader_raft->term() + model::term_id(1), "test")
-      .get0();
+      .get();
 
     validate_logs_replication(gr);
     tests::cooperative_spin_wait_with_timeout(2s, [&gr] {
@@ -648,20 +648,20 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
             return false;
         }
         return are_all_commit_indexes_the_same(gr);
-    }).get0();
+    }).get();
 
     // store snapshot
     for (auto& [_, member] : gr.get_members()) {
         member.consensus
           ->write_snapshot(raft::write_snapshot_cfg(
             get_leader_raft(gr)->committed_offset(), iobuf{}))
-          .get0();
+          .get();
         BOOST_REQUIRE_EQUAL(
           member.consensus->get_snapshot_size(),
           get_snapshot_size_from_disk(member));
     }
     gr.enable_node(disabled_id);
-    success = replicate_random_batches(gr, 5).get0();
+    success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
     validate_logs_replication(gr);
 
@@ -677,7 +677,7 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
 FIXTURE_TEST(test_last_visible_offset_relaxed_consistency, raft_test_fixture) {
     raft_group gr = raft_group(raft::group_id(0), 3);
     gr.enable_all();
-    gr.wait_for_leader().get0();
+    gr.wait_for_leader().get();
     // disable two nodes
     std::vector<model::node_id> disabled;
     model::node_id leader_id;
@@ -695,8 +695,7 @@ FIXTURE_TEST(test_last_visible_offset_relaxed_consistency, raft_test_fixture) {
     auto last_visible = leader_raft->last_visible_index();
 
     // replicate some batches with relaxed consistency
-    replicate_random_batches(gr, 20, raft::consistency_level::leader_ack)
-      .get0();
+    replicate_random_batches(gr, 20, raft::consistency_level::leader_ack).get();
 
     // check last visible offset, make sure it is
     auto new_last_visible = leader_raft->last_visible_index();
@@ -725,7 +724,7 @@ FIXTURE_TEST(test_mixed_consisteny_levels, raft_test_fixture) {
         auto lvl = random_generators::get_int(0, 10) > 5
                      ? raft::consistency_level::leader_ack
                      : raft::consistency_level::quorum_ack;
-        success = replicate_random_batches(gr, 2, lvl).get0();
+        success = replicate_random_batches(gr, 2, lvl).get();
         BOOST_REQUIRE(success);
     }
 
@@ -746,7 +745,7 @@ FIXTURE_TEST(test_linearizable_barrier, raft_test_fixture) {
 
     bool success = replicate_random_batches(
                      gr, 500, raft::consistency_level::leader_ack, 10s)
-                     .get0();
+                     .get();
     BOOST_REQUIRE(success);
     leader_raft = gr.get_member(leader_id).consensus;
     result<model::offset> r(raft::errc::timeout);
@@ -779,7 +778,7 @@ FIXTURE_TEST(test_linearizable_barrier_single_node, raft_test_fixture) {
     auto leader_id = wait_for_group_leader(gr);
     auto leader_raft = gr.get_member(leader_id).consensus;
 
-    bool success = replicate_random_batches(gr, 5).get0();
+    bool success = replicate_random_batches(gr, 5).get();
     BOOST_REQUIRE(success);
 
     leader_id = wait_for_group_leader(gr);
@@ -847,7 +846,7 @@ struct request_ordering_test_fixture : public raft_test_fixture {
               raft::replicate_options(consistency));
             // wait for request to be enqueued before dispatching next one
             // (comenting this out should cause this test to fail)
-            r.request_enqueued.get0();
+            r.request_enqueued.get();
             results.push_back(std::move(r.replicate_finished));
         }
         return ss::when_all_succeed(results.begin(), results.end())
@@ -878,7 +877,7 @@ FIXTURE_TEST(test_quorum_ack_write_ordering, request_ordering_test_fixture) {
     auto leader_raft = gr.get_member(leader_id).consensus;
     replicate_indexed_batches(
       leader_raft, 20, raft::consistency_level::quorum_ack)
-      .get0();
+      .get();
     validate_logs_replication(gr);
 
     validate_batch_ordering(20, gr);
@@ -891,7 +890,7 @@ FIXTURE_TEST(test_leader_ack_write_ordering, request_ordering_test_fixture) {
     auto leader_raft = gr.get_member(leader_id).consensus;
     replicate_indexed_batches(
       leader_raft, 20, raft::consistency_level::quorum_ack)
-      .get0();
+      .get();
     validate_logs_replication(gr);
 
     validate_batch_ordering(20, gr);

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -60,7 +60,7 @@ struct bootstrap_fixture : raft::simple_record_fixture {
         // ignore the get_log()
         (void)_storage.log_mgr()
           .manage(storage::ntp_config(_ntp, "test.dir"))
-          .get0();
+          .get();
     }
 
     std::vector<storage::append_result> write_n(const std::size_t n) {
@@ -72,11 +72,11 @@ struct bootstrap_fixture : raft::simple_record_fixture {
         res.push_back(
           datas(n)
             .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-            .get0());
+            .get());
         res.push_back(
           configs(n, raft::group_configuration::v_6)
             .for_each_ref(get_log()->make_appender(cfg), cfg.timeout)
-            .get0());
+            .get());
         get_log()->flush().get();
         return res;
     }
@@ -102,7 +102,7 @@ FIXTURE_TEST(write_configs, bootstrap_fixture) {
     }
     auto cfg = raft::details::read_bootstrap_state(
                  get_log(), model::offset(0), _as)
-                 .get0();
+                 .get();
     info(
       "data batches:{}, config batches: {}, data batches:{}, config batches:{}",
       replies[0],
@@ -121,21 +121,21 @@ FIXTURE_TEST(mixed_config_versions, bootstrap_fixture) {
 
     datas(20)
       .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
-      .get0();
+      .get();
     configs(3, raft::group_configuration::v_4)
       .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
-      .get0();
+      .get();
     configs(2, raft::group_configuration::v_5)
       .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
-      .get0();
+      .get();
     configs(5, raft::group_configuration::v_6)
       .for_each_ref(get_log()->make_appender(append_cfg), append_cfg.timeout)
-      .get0();
+      .get();
     get_log()->flush().get();
 
     auto state = raft::details::read_bootstrap_state(
                    get_log(), model::offset(0), _as)
-                   .get0();
+                   .get();
 
     // 20 data batches
     BOOST_REQUIRE_EQUAL(state.data_batches_seen(), 20);
@@ -161,7 +161,7 @@ FIXTURE_TEST(mixed_config_versions, bootstrap_fixture) {
 FIXTURE_TEST(empty_log, bootstrap_fixture) {
     auto cfg = raft::details::read_bootstrap_state(
                  get_log(), model::offset(0), _as)
-                 .get0();
+                 .get();
 
     BOOST_REQUIRE_EQUAL(cfg.data_batches_seen(), 0);
     BOOST_REQUIRE_EQUAL(cfg.config_batches_seen(), 0);

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -173,7 +173,7 @@ SEASTAR_THREAD_TEST_CASE(test_config_extracting_reader) {
           BOOST_REQUIRE_EQUAL(configurations[1].offset, offsets[1]);
           BOOST_REQUIRE_EQUAL(configurations[1].cfg, cfg_2);
       })
-      .get0();
+      .get();
 }
 
 /**

--- a/src/v/raft/tests/mutex_buffer_test.cc
+++ b/src/v/raft/tests/mutex_buffer_test.cc
@@ -32,8 +32,8 @@ FIXTURE_TEST(test_single_request_dispatch, fixture) {
     buf.start(&fixture::add_postfix);
 
     auto f = buf.enqueue(request{"test"});
-    BOOST_REQUIRE_EQUAL(f.get0().content, "test-response");
-    buf.stop().get0();
+    BOOST_REQUIRE_EQUAL(f.get().content, "test-response");
+    buf.stop().get();
 }
 
 FIXTURE_TEST(test_requests_buffering, fixture) {
@@ -42,7 +42,7 @@ FIXTURE_TEST(test_requests_buffering, fixture) {
     std::vector<ss::future<response>> enqueued;
     enqueued.reserve(5);
     {
-        auto u = lock.get_units().get0();
+        auto u = lock.get_units().get();
         for (auto i = 0; i < 5; ++i) {
             enqueued.push_back(
               buf.enqueue(request{ssx::sformat("test-{}", i)}));
@@ -53,19 +53,19 @@ FIXTURE_TEST(test_requests_buffering, fixture) {
     auto i = 0;
     for (auto& f : enqueued) {
         BOOST_REQUIRE_EQUAL(
-          f.get0().content, ssx::sformat("test-{}-response", i));
+          f.get().content, ssx::sformat("test-{}-response", i));
         i++;
     }
 
-    buf.stop().get0();
+    buf.stop().get();
 }
 
 FIXTURE_TEST(after_close_buffer_should_stop_accepting_requests, fixture) {
     // stop buffer first
-    buf.stop().get0();
+    buf.stop().get();
 
     BOOST_REQUIRE_THROW(
-      buf.enqueue(request{"should-fail"}).get0(), ss::gate_closed_exception);
+      buf.enqueue(request{"should-fail"}).get(), ss::gate_closed_exception);
 }
 
 FIXTURE_TEST(should_propagate_exception, fixture) {
@@ -83,7 +83,7 @@ FIXTURE_TEST(should_propagate_exception, fixture) {
     std::vector<ss::future<response>> enqueued;
     enqueued.reserve(5);
     {
-        auto u = lock.get_units().get0();
+        auto u = lock.get_units().get();
 
         for (auto i = 0; i < 5; ++i) {
             enqueued.push_back(
@@ -102,5 +102,5 @@ FIXTURE_TEST(should_propagate_exception, fixture) {
         }
     }
 
-    buf.stop().get0();
+    buf.stop().get();
 }

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -51,10 +51,10 @@ struct simple_raft_fixture {
             [kv_conf]() { return kv_conf; },
             [this]() { return default_log_cfg(); },
             std::ref(_feature_table))
-          .get0();
-        _storage.invoke_on_all(&storage::api::start).get0();
+          .get();
+        _storage.invoke_on_all(&storage::api::start).get();
         _as.start().get();
-        _connections.start(std::ref(_as)).get0();
+        _connections.start(std::ref(_as)).get();
         _recovery_throttle
           .start(
             ss::sharded_parameter([] { return config::mock_binding(100_MiB); }),
@@ -102,9 +102,9 @@ struct simple_raft_fixture {
             std::ref(_storage),
             std::ref(_recovery_throttle),
             std::ref(_feature_table))
-          .get0();
+          .get();
 
-        _group_mgr.invoke_on_all(&raft::group_manager::start).get0();
+        _group_mgr.invoke_on_all(&raft::group_manager::start).get();
 
         _raft = _storage.local()
                   .log_mgr()
@@ -121,7 +121,7 @@ struct simple_raft_fixture {
                         log,
                         raft::with_learner_recovery_throttle::yes);
                   })
-                  .get0();
+                  .get();
     }
 
     void start_raft(storage::ntp_config::default_overrides overrides = {}) {
@@ -139,7 +139,7 @@ struct simple_raft_fixture {
                 [](auto& local) noexcept { local.request_abort(); })
               .get();
             _recovery_throttle.stop().get();
-            _group_mgr.stop().get0();
+            _group_mgr.stop().get();
             if (_raft) {
                 _raft.release();
             }
@@ -174,21 +174,21 @@ struct simple_raft_fixture {
         using namespace std::chrono_literals;
         tests::cooperative_spin_wait_with_timeout(10s, [this] {
             return _raft->is_elected_leader();
-        }).get0();
+        }).get();
     }
 
     void wait_for_confirmed_leader() {
         using namespace std::chrono_literals;
         tests::cooperative_spin_wait_with_timeout(10s, [this] {
             return _raft->is_leader();
-        }).get0();
+        }).get();
     }
 
     void wait_for_meta_initialized() {
         using namespace std::chrono_literals;
         tests::cooperative_spin_wait_with_timeout(10s, [this] {
             return _raft->meta().commit_index >= model::offset(0);
-        }).get0();
+        }).get();
     }
 
     model::node_id _self;

--- a/src/v/raft/tests/term_assigning_reader_test.cc
+++ b/src/v/raft/tests/term_assigning_reader_test.cc
@@ -27,7 +27,7 @@ SEASTAR_THREAD_TEST_CASE(test_assigning_batch_term) {
         std::move(src_reader), term);
     auto batches_with_term = model::consume_reader_to_memory(
                                std::move(assigning_reader), model::no_timeout)
-                               .get0();
+                               .get();
 
     BOOST_REQUIRE_EQUAL(batches_with_term.size(), 10);
     for (auto& b : batches_with_term) {
@@ -46,7 +46,7 @@ SEASTAR_THREAD_TEST_CASE(test_assigning_batch_term_release) {
         std::move(src_reader), term);
     auto batches_with_term = model::consume_reader_to_memory(
                                std::move(assigning_reader), model::no_timeout)
-                               .get0();
+                               .get();
 
     BOOST_REQUIRE_EQUAL(batches_with_term.size(), 10);
     for (auto& b : batches_with_term) {

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -72,7 +72,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
     }
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    auto readers = raft::details::share_n(std::move(rdr), 2).get0();
+    auto readers = raft::details::share_n(std::move(rdr), 2).get();
     auto meta = raft::protocol_metadata{
       .group = raft::group_id(1),
       .commit_index = model::offset(100),
@@ -110,11 +110,11 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
 
     auto batches_result = model::consume_reader_to_memory(
                             std::move(readers.back()), model::no_timeout)
-                            .get0();
+                            .get();
     std::move(d)
       .release_batches()
       .consume(checking_consumer(std::move(batches_result)), model::no_timeout)
-      .get0();
+      .get();
 }
 
 model::broker create_test_broker() {
@@ -567,7 +567,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
     // share readers to have a copy of data to compare
-    auto readers = raft::details::share_n(std::move(rdr), 2).get0();
+    auto readers = raft::details::share_n(std::move(rdr), 2).get();
 
     auto meta = raft::protocol_metadata{
       .group = raft::group_id(1),
@@ -614,9 +614,9 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
 
     auto batches_result = model::consume_reader_to_memory(
                             std::move(readers.back()), model::no_timeout)
-                            .get0();
+                            .get();
     std::move(decoded_req)
       .release_batches()
       .consume(checking_consumer(std::move(batches_result)), model::no_timeout)
-      .get0();
+      .get();
 }

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -87,7 +87,7 @@ ss::future<> vote_stm::dispatch_one(vnode n) {
           [this, n](ss::future<result<vote_reply>> f) {
               auto voter_reply = _replies.find(n);
               try {
-                  auto r = f.get0();
+                  auto r = f.get();
                   if (r.has_value()) {
                       vlog(
                         _ctxlog.info,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -243,15 +243,15 @@ private:
                         return ss::futurize_invoke(
                                  handler, std::move(req), auth_state)
                           .handle_exception(
-                            exception_intercepter<
+                            exception_intercepter<std::remove_reference_t<
                               decltype(handler(std::move(req), auth_state)
-                                         .get0())>(url, auth_state));
+                                         .get())>>(url, auth_state));
 
                     } else {
                         return ss::futurize_invoke(handler, std::move(req))
                           .handle_exception(
-                            exception_intercepter<
-                              decltype(handler(std::move(req)).get0())>(
+                            exception_intercepter<std::remove_reference_t<
+                              decltype(handler(std::move(req)).get())>>(
                               url, auth_state));
                     }
                 });
@@ -312,17 +312,17 @@ private:
                 return ss::futurize_invoke(
                          handler, std::move(req), std::move(rep), auth_state)
                   .handle_exception(
-                    exception_intercepter<
+                    exception_intercepter<std::remove_reference_t<
                       decltype(handler(
                                  std::move(req), std::move(rep), auth_state)
-                                 .get0())>(url, auth_state));
+                                 .get())>>(url, auth_state));
 
             } else {
                 return ss::futurize_invoke(
                          handler, std::move(req), std::move(rep))
                   .handle_exception(
-                    exception_intercepter<
-                      decltype(handler(std::move(req), std::move(rep)).get0())>(
+                    exception_intercepter<std::remove_reference_t<
+                      decltype(handler(std::move(req), std::move(rep)).get())>>(
                       url, auth_state));
             }
         };
@@ -383,9 +383,9 @@ private:
             return ss::futurize_invoke(
                      _handler, std::move(request), std::move(reply))
               .handle_exception(
-                _server.exception_intercepter<
+                _server.exception_intercepter<std::remove_reference_t<
                   decltype(_handler(std::move(request), std::move(reply))
-                             .get0())>(url, auth_state));
+                             .get())>>(url, auth_state));
         }
 
         admin_server& _server;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -274,7 +274,7 @@ public:
         ss::smp::invoke_on_all([] {
             auto& config = config::shard_local_cfg();
             config.get("disable_metrics").set_value(false);
-        }).get0();
+        }).get();
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);
@@ -432,7 +432,7 @@ public:
               .set_value(data_transforms_enabled);
             config.get("cloud_storage_disable_archiver_manager")
               .set_value(legacy_upload_mode_enabled);
-        }).get0();
+        }).get();
     }
 
     YAML::Node proxy_config(uint16_t proxy_port = 8082) {

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -83,7 +83,7 @@ bool ser_deser_verify_hash(T&& type) {
 
     // Deserialize
     iobuf_parser in(std::move(out));
-    auto result = reflection::async_adl<T>{}.from(in).get0();
+    auto result = reflection::async_adl<T>{}.from(in).get();
 
     // Reserialize
     iobuf second_out;
@@ -100,7 +100,7 @@ bool ser_deser_verify(T type) {
 
     // Deserialize
     iobuf_parser in(std::move(out));
-    auto result = reflection::async_adl<T>{}.from(in).get0();
+    auto result = reflection::async_adl<T>{}.from(in).get();
     return result == type;
 }
 

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -205,7 +205,7 @@ ss::future<> rpc_server::dispatch_method_once(
                     bool error = true;
                     netbuf reply_buf;
                     try {
-                        reply_buf = fut.get0();
+                        reply_buf = fut.get();
                         reply_buf.set_status(rpc::status::success);
                         error = false;
                     } catch (const rpc_internal_body_parsing_exception& e) {

--- a/src/v/rpc/service.h
+++ b/src/v/rpc/service.h
@@ -100,7 +100,7 @@ struct service::execution_helper {
                           input_f.get_exception());
                     }
                     ctx.signal_body_parse();
-                    auto input = input_f.get0();
+                    auto input = input_f.get();
                     return f(std::move(input), ctx);
                 })
                 .then([method, &ctx](Output out) mutable {

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -40,7 +40,7 @@ SEASTAR_THREAD_TEST_CASE(netbuf_pod) {
     // forces the computation of the header
     auto bufs = std::move(n).as_scattered().get().release().release();
     auto in = make_iobuf_input_stream(iobuf(std::move(bufs)));
-    const pod dst = rpc::parse_framed<pod>(in).get0();
+    const pod dst = rpc::parse_framed<pod>(in).get();
     BOOST_REQUIRE_EQUAL(src.x, dst.x);
     BOOST_REQUIRE_EQUAL(src.y, dst.y);
     BOOST_REQUIRE_EQUAL(src.z, dst.z);

--- a/src/v/rpc/test/response_handler_tests.cc
+++ b/src/v/rpc/test/response_handler_tests.cc
@@ -51,7 +51,7 @@ FIXTURE_TEST(fail_with_timeout, test_fixture) {
     ss::sleep(1s).get();
 
     BOOST_REQUIRE_EQUAL(
-      rh.get_future().get0().error(), rpc::errc::client_request_timeout);
+      rh.get_future().get().error(), rpc::errc::client_request_timeout);
     BOOST_REQUIRE_EQUAL(triggered, true);
 };
 
@@ -59,7 +59,7 @@ FIXTURE_TEST(fail_other_error_with_timeout, test_fixture) {
     auto rh = create_handler(100s);
 
     rh.set_exception(std::runtime_error("test"));
-    BOOST_REQUIRE_THROW(auto res = rh.get_future().get0(), std::runtime_error);
+    BOOST_REQUIRE_THROW(auto res = rh.get_future().get(), std::runtime_error);
     BOOST_REQUIRE_EQUAL(triggered, false);
 };
 
@@ -67,7 +67,7 @@ FIXTURE_TEST(success_case_with_timout, test_fixture) {
     auto rh = create_handler(100s);
     rh.set_value(std::make_unique<test_str_ctx>());
 
-    auto v = rh.get_future().get0();
+    auto v = rh.get_future().get();
 
     BOOST_REQUIRE_EQUAL(triggered, false);
 };

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -29,11 +29,11 @@ class rpc_base_integration_fixture {
 public:
     explicit rpc_base_integration_fixture(uint16_t port)
       : _listen_address("127.0.0.1", port)
-      , _ssg(ss::create_smp_service_group({5000}).get0())
+      , _ssg(ss::create_smp_service_group({5000}).get())
       , _sg(ss::default_scheduling_group()) {}
 
     virtual ~rpc_base_integration_fixture() {
-        destroy_smp_service_group(_ssg).get0();
+        destroy_smp_service_group(_ssg).get();
     }
 
     virtual void start_server() = 0;
@@ -51,7 +51,7 @@ public:
           .server_addr = _listen_address,
           .credentials
           = credentials
-              ? credentials->build_reloadable_certificate_credentials().get0()
+              ? credentials->build_reloadable_certificate_credentials().get()
               : nullptr};
     }
 
@@ -93,7 +93,7 @@ public:
           resolved,
           credentials
             ? credentials->build_reloadable_server_credentials(std::move(cb))
-                .get0()
+                .get()
             : nullptr);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
@@ -154,7 +154,7 @@ public:
           resolved,
           credentials
             ? credentials->build_reloadable_server_credentials(std::move(cb))
-                .get0()
+                .get()
             : nullptr);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
@@ -174,7 +174,7 @@ private:
                                        },
                                        true,
                                        std::logical_and<>())
-                                       .get0();
+                                       .get();
         if (!all_initialized) {
             throw std::runtime_error("Configure server first!!!");
         }

--- a/src/v/security/audit/tests/audit_log_test.cc
+++ b/src/v/security/audit/tests/audit_log_test.cc
@@ -89,20 +89,20 @@ FIXTURE_TEST(test_audit_init_phase, kafka_client_fixture) {
     set_auditing_config_options(event_size).get();
     enable_sasl_and_restart("username");
 
-    wait_for_controller_leadership().get0();
+    wait_for_controller_leadership().get();
     auto& audit_mgr = app.audit_mgr;
 
     /// with auditing disabled, calls to enqueue should be no-ops
-    const auto n_events = pending_audit_events(audit_mgr.local()).get0();
+    const auto n_events = pending_audit_events(audit_mgr.local()).get();
     audit_mgr
       .invoke_on_all([](sa::audit_log_manager& m) {
           for (auto i = 0; i < 20; ++i) {
               BOOST_ASSERT(m.enqueue_authn_event(make_random_authn_options()));
           }
       })
-      .get0();
+      .get();
 
-    BOOST_CHECK_EQUAL(pending_audit_events(audit_mgr.local()).get0(), n_events);
+    BOOST_CHECK_EQUAL(pending_audit_events(audit_mgr.local()).get(), n_events);
 
     /// with auditing enabled, the system should block when the threshold of
     /// audit_queue_max_buffer_size_per_shard has been reached
@@ -182,11 +182,11 @@ FIXTURE_TEST(test_audit_init_phase, kafka_client_fixture) {
                               },
                               true,
                               std::logical_and<>())
-                            .get0();
+                            .get();
 
     BOOST_CHECK(enqueued);
     BOOST_CHECK_EQUAL(
-      pending_audit_events(audit_mgr.local()).get0(), number_events);
+      pending_audit_events(audit_mgr.local()).get(), number_events);
 
     /// Verify that eventually, all messages are drained
     ss::smp::invoke_on_all([] {

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -78,7 +78,7 @@ template<typename Iterator, typename Func>
 requires requires(Func f, Iterator i) {
     *(++i);
     { i != i } -> std::convertible_to<bool>;
-    seastar::futurize_invoke(f, *i).get0();
+    seastar::futurize_invoke(f, *i).get();
 }
 inline auto async_transform(Iterator begin, Iterator end, Func&& func) {
     using result_type = decltype(seastar::futurize_invoke(func, *begin).get0());
@@ -115,7 +115,7 @@ requires requires(Func f, Rng r) {
     r.begin();
     r.end();
     { r.begin() != r.begin() } -> std::convertible_to<bool>;
-    seastar::futurize_invoke(f, *r.begin()).get0();
+    seastar::futurize_invoke(f, *r.begin()).get();
 }
 inline auto async_transform(Rng& rng, Func&& func) {
     return async_transform(rng.begin(), rng.end(), std::forward<Func>(func));
@@ -145,8 +145,8 @@ template<typename Iterator, typename Func>
 requires requires(Func f, Iterator i) {
     *(++i);
     { i != i } -> std::convertible_to<bool>;
-    seastar::futurize_invoke(f, *i).get0().begin();
-    seastar::futurize_invoke(f, *i).get0().end();
+    seastar::futurize_invoke(f, *i).get().begin();
+    seastar::futurize_invoke(f, *i).get().end();
 }
 inline auto async_flat_transform(Iterator begin, Iterator end, Func&& func) {
     using result_type = decltype(seastar::futurize_invoke(func, *begin).get0());
@@ -171,7 +171,7 @@ requires requires(Func f, Rng r) {
     r.begin();
     r.end();
     { r.begin() != r.begin() } -> std::convertible_to<bool>;
-    seastar::futurize_invoke(f, *r.begin()).get0();
+    seastar::futurize_invoke(f, *r.begin()).get();
 }
 inline auto async_flat_transform(Rng& rng, Func&& func) {
     return async_flat_transform(
@@ -384,7 +384,7 @@ template<typename Iter, typename UnaryAsyncPredicate>
 requires requires(UnaryAsyncPredicate f, Iter i) {
     *(++i);
     { i != i } -> std::convertible_to<bool>;
-    seastar::futurize_invoke(f, *i).get0();
+    seastar::futurize_invoke(f, *i).get();
 }
 seastar::future<Iter> partition(Iter begin, Iter end, UnaryAsyncPredicate p) {
     auto itr = begin;

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -81,7 +81,8 @@ requires requires(Func f, Iterator i) {
     seastar::futurize_invoke(f, *i).get();
 }
 inline auto async_transform(Iterator begin, Iterator end, Func&& func) {
-    using result_type = decltype(seastar::futurize_invoke(func, *begin).get0());
+    using result_type = std::remove_reference_t<
+      decltype(seastar::futurize_invoke(func, *begin).get())>;
     return detail::async_transform<result_type>(
       std::move(begin),
       std::move(end),
@@ -149,7 +150,8 @@ requires requires(Func f, Iterator i) {
     seastar::futurize_invoke(f, *i).get().end();
 }
 inline auto async_flat_transform(Iterator begin, Iterator end, Func&& func) {
-    using result_type = decltype(seastar::futurize_invoke(func, *begin).get0());
+    using result_type = std::remove_reference_t<
+      decltype(seastar::futurize_invoke(func, *begin).get())>;
     using value_type = typename result_type::value_type;
     return detail::async_transform<value_type>(
       std::move(begin),

--- a/src/v/ssx/tests/async_transforms.cc
+++ b/src/v/ssx/tests/async_transforms.cc
@@ -31,7 +31,7 @@ SEASTAR_THREAD_TEST_CASE(async_transform_iter_test) {
     std::iota(expected.begin(), expected.end(), 2);
 
     std::vector<int> out_iter
-      = ssx::async_transform(input.begin(), input.end(), plus(2)).get0();
+      = ssx::async_transform(input.begin(), input.end(), plus(2)).get();
     BOOST_TEST(std::equal(
       out_iter.begin(), out_iter.end(), expected.begin(), expected.end()));
 }
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(async_transform_range_test) {
     std::vector<int> expected(10);
     std::iota(expected.begin(), expected.end(), 2);
 
-    std::vector<int> out_range = ssx::async_transform(input, plus(2)).get0();
+    std::vector<int> out_range = ssx::async_transform(input, plus(2)).get();
     BOOST_TEST(std::equal(
       out_range.begin(), out_range.end(), expected.begin(), expected.end()));
 }
@@ -55,7 +55,7 @@ SEASTAR_THREAD_TEST_CASE(async_transform_move_test) {
                                           input_copy.begin(),
                                           input_copy.end(),
                                           [](ss::sstring s) { return s; })
-                                          .get0();
+                                          .get();
     BOOST_TEST(
       std::equal(input.begin(), input.end(), expected.begin(), expected.end()));
 }
@@ -83,7 +83,7 @@ SEASTAR_THREAD_TEST_CASE(async_transform_noncopyable_test) {
                                              [](noncopyable_foo& ncf) {
                                                  return std::move(ncf);
                                              })
-                                             .get0();
+                                             .get();
     BOOST_TEST(results[0].value() == 1);
     BOOST_TEST(results[1].value() == 2);
     BOOST_TEST(results[2].value() == 3);
@@ -97,7 +97,7 @@ SEASTAR_THREAD_TEST_CASE(parallel_transform_iter_test) {
     std::iota(expected.begin(), expected.end(), 2);
 
     std::vector<int> out_iter
-      = ssx::parallel_transform(input.begin(), input.end(), plus(2)).get0();
+      = ssx::parallel_transform(input.begin(), input.end(), plus(2)).get();
     BOOST_TEST(std::equal(
       out_iter.begin(), out_iter.end(), expected.begin(), expected.end()));
 }
@@ -110,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(parallel_transform_range_test) {
     std::iota(expected.begin(), expected.end(), 2);
 
     std::vector<int> out_range
-      = ssx::parallel_transform(std::move(input), plus(2)).get0();
+      = ssx::parallel_transform(std::move(input), plus(2)).get();
     BOOST_TEST(std::equal(
       out_range.begin(), out_range.end(), expected.begin(), expected.end()));
 }

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -38,7 +38,7 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
       200_MiB,
       ss::default_priority_class(),
       storage::with_cache::yes));
-    auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });
+    auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get(); });
 
     // Test parameters
     const size_t ntp_count = 4;
@@ -63,7 +63,7 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
             cfg = storage::ntp_config(
               ntp, mngr.config().base_dir, std::move(overrides));
         }
-        auto log = mngr.manage(std::move(cfg)).get0();
+        auto log = mngr.manage(std::move(cfg)).get();
         logs_to_fuzz.emplace_back(
           std::make_unique<storage::opfuzz>(std::move(log), ops_per_ntp));
     }
@@ -75,7 +75,7 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
               vassert(false, "Error:{} fuzzing log: {}", e, w->log());
           });
       })
-      .get0();
+      .get();
 }
 FIXTURE_TEST(test_random_remove, storage_test_fixture) {
     // BLOCK on logging so that we can make sense of the logs
@@ -85,7 +85,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
       200_MiB,
       ss::default_priority_class(),
       storage::with_cache::yes));
-    auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });
+    auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get(); });
 
     // Test parameters
     const size_t ntp_count = 10;
@@ -105,7 +105,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
     for (const auto& ntp : ntps_to_fuzz) {
         auto directory = ssx::sformat(
           "{}/{}", mngr.config().base_dir, ntp.path());
-        auto log = mngr.manage(storage::ntp_config(ntp, directory)).get0();
+        auto log = mngr.manage(storage::ntp_config(ntp, directory)).get();
         logs_to_fuzz.emplace_back(
           std::make_unique<storage::opfuzz>(std::move(log), ops_per_ntp));
     }
@@ -118,7 +118,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
               vassert(false, "Error:{} fuzzing log: {}", e, w->log());
           });
       })
-      .get0();
+      .get();
 
     std::vector<size_t> random_ntp_removal_sequence;
     std::generate_n(

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -608,7 +608,7 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
               }
               return ss::make_exception_future<append_result>(append_err);
           }
-          auto ret = append_fut.get0();
+          auto ret = append_fut.get();
           auto index_err = std::move(index_fut).get_exception();
           vlog(
             stlog.error,
@@ -748,7 +748,7 @@ auto with_segment(ss::lw_shared_ptr<segment> s, Func&& f) {
     return f(s).then_wrapped([s](
                                ss::future<ss::lw_shared_ptr<segment>> new_seg) {
         try {
-            auto ptr = new_seg.get0();
+            auto ptr = new_seg.get();
             return ss::make_ready_future<ss::lw_shared_ptr<segment>>(ptr);
         } catch (...) {
             return s->close()

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -281,7 +281,7 @@ static ss::future<segment_set> unsafe_do_recover(
           to_recover.begin(),
           to_recover.end(),
           [](ss::lw_shared_ptr<segment>& segment) {
-              auto stat = segment->reader().stat().get0();
+              auto stat = segment->reader().stat().get();
               if (stat.st_size != 0) {
                   return true;
               }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -616,7 +616,7 @@ ss::future<> build_compaction_index(
       gclog.info,
       "tx reducer path: {} stats {}",
       w.filename(),
-      index_builder.get0());
+      index_builder.get());
 }
 
 bool compacted_index_needs_rebuild(compacted_index::recovery_state state) {

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -207,7 +207,7 @@ private:
 /**
  * Use the snapshot manager to open a new snapshot:
  *
- *    snapshot_writer writer = manager.start_snapshot().get0();
+ *    snapshot_writer writer = manager.start_snapshot().get();
  *
  * Initialize the snapshot with metadata:
  *

--- a/src/v/storage/tests/backlog_controller_test.cc
+++ b/src/v/storage/tests/backlog_controller_test.cc
@@ -82,7 +82,7 @@ struct backlog_controller_fixture {
 };
 
 FIXTURE_TEST(test_feedback_loop, backlog_controller_fixture) {
-    ctrl->start().get0();
+    ctrl->start().get();
     /**
      * current backlog is equal to 0, setpoint is set to 20, error = 20.0
      * since error hasn't changed and want some more backlog we will down

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -134,12 +134,12 @@ FIXTURE_TEST(format_verification_roundtrip, compacted_topic_fixture) {
       ss::default_priority_class(),
       32_KiB,
       &as);
-    auto footer = rdr.load_footer().get0();
+    auto footer = rdr.load_footer().get();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
     BOOST_REQUIRE_EQUAL(
       footer.version, storage::compacted_index::footer::current_version);
     BOOST_REQUIRE(footer.crc != 0);
-    auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
+    auto vec = compaction_index_reader_to_memory(std::move(rdr)).get();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);
     BOOST_REQUIRE_EQUAL(vec[0].offset, model::offset(42));
     BOOST_REQUIRE_EQUAL(vec[0].delta, 66);
@@ -162,12 +162,12 @@ FIXTURE_TEST(
       ss::default_priority_class(),
       32_KiB,
       &as);
-    auto footer = rdr.load_footer().get0();
+    auto footer = rdr.load_footer().get();
     BOOST_REQUIRE_EQUAL(footer.keys, 1);
     BOOST_REQUIRE_EQUAL(
       footer.version, storage::compacted_index::footer::current_version);
     BOOST_REQUIRE(footer.crc != 0);
-    auto vec = compaction_index_reader_to_memory(std::move(rdr)).get0();
+    auto vec = compaction_index_reader_to_memory(std::move(rdr)).get();
     BOOST_REQUIRE_EQUAL(vec.size(), 1);
     BOOST_REQUIRE_EQUAL(vec[0].offset, model::offset(42));
     BOOST_REQUIRE_EQUAL(vec[0].delta, 66);
@@ -208,10 +208,10 @@ FIXTURE_TEST(key_reducer_no_truncate_filter, compacted_topic_fixture) {
                         .consume(
                           storage::internal::compaction_key_reducer(),
                           model::no_timeout)
-                        .get0();
+                        .get();
 
     // get all keys
-    auto vec = compaction_index_reader_to_memory(rdr).get0();
+    auto vec = compaction_index_reader_to_memory(rdr).get();
     BOOST_REQUIRE_EQUAL(vec.size(), 100);
 
     info("key bitmap: {}", key_bitmap.toString());
@@ -255,7 +255,7 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
                                 storage::internal::compaction_key_reducer(
                                   1_KiB + 16),
                                 model::no_timeout)
-                              .get0();
+                              .get();
 
     /*
       There are 2 keys exactly.
@@ -274,10 +274,10 @@ FIXTURE_TEST(key_reducer_max_mem, compacted_topic_fixture) {
                                 storage::internal::compaction_key_reducer(
                                   2_KiB + 2 * entry_size * 2),
                                 model::no_timeout)
-                              .get0();
+                              .get();
 
     // get all keys
-    auto vec = compaction_index_reader_to_memory(rdr).get0();
+    auto vec = compaction_index_reader_to_memory(rdr).get();
     BOOST_REQUIRE_EQUAL(vec.size(), 100);
 
     info("small key bitmap: {}", small_mem_bitmap.toString());
@@ -318,9 +318,9 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
 
     rdr.verify_integrity().get();
     auto bitmap
-      = storage::internal::natural_index_of_entries_to_keep(rdr).get0();
+      = storage::internal::natural_index_of_entries_to_keep(rdr).get();
     {
-        auto vec = compaction_index_reader_to_memory(rdr).get0();
+        auto vec = compaction_index_reader_to_memory(rdr).get();
         BOOST_REQUIRE_EQUAL(vec.size(), 100);
     }
     info("key bitmap: {}", bitmap.toString());
@@ -349,7 +349,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
           &as);
         final_rdr.verify_integrity().get();
         {
-            auto vec = compaction_index_reader_to_memory(final_rdr).get0();
+            auto vec = compaction_index_reader_to_memory(final_rdr).get();
             BOOST_REQUIRE_EQUAL(vec.size(), 2);
             BOOST_REQUIRE_EQUAL(vec[0].offset, model::offset(98));
             BOOST_REQUIRE_EQUAL(vec[1].offset, model::offset(99));
@@ -357,7 +357,7 @@ FIXTURE_TEST(index_filtered_copy_tests, compacted_topic_fixture) {
         {
             auto offset_list = storage::internal::generate_compacted_list(
                                  model::offset(0), final_rdr)
-                                 .get0();
+                                 .get();
 
             BOOST_REQUIRE(offset_list.contains(model::offset(98)));
             BOOST_REQUIRE(offset_list.contains(model::offset(99)));

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -33,7 +33,7 @@ FIXTURE_TEST(kitchen_sink, log_builder_fixture) {
       | add_random_batch(102, 2, maybe_compress_batches::yes) | add_segment(104)
       | add_batch(std::move(batch)) | add_random_batches(105, 3);
 
-    auto stats = get_stats().get0();
+    auto stats = get_stats().get();
 
     b | stop();
     BOOST_TEST(stats.seg_count == 3);
@@ -97,8 +97,8 @@ FIXTURE_TEST(size_bytes_after_offset, log_builder_fixture) {
 static void do_write_zeroes(ss::sstring name) {
     auto fd = ss::open_file_dma(
                 name, ss::open_flags::create | ss::open_flags::rw)
-                .get0();
-    auto out = ss::make_file_output_stream(std::move(fd)).get0();
+                .get();
+    auto out = ss::make_file_output_stream(std::move(fd)).get();
     ss::temporary_buffer<char> b(4096);
     std::memset(b.get_write(), 0, 4096);
     out.write(b.get(), b.size()).get();
@@ -109,8 +109,8 @@ static void do_write_zeroes(ss::sstring name) {
 static void do_write_garbage(ss::sstring name) {
     auto fd = ss::open_file_dma(
                 name, ss::open_flags::create | ss::open_flags::rw)
-                .get0();
-    auto out = ss::make_file_output_stream(std::move(fd)).get0();
+                .get();
+    auto out = ss::make_file_output_stream(std::move(fd)).get();
     const auto b = random_generators::gen_alphanum_string(100);
     out.write(b.data(), b.size()).get();
     out.flush().get();
@@ -131,11 +131,11 @@ FIXTURE_TEST(test_valid_segment_name_with_zeroes_data, log_builder_fixture) {
     do_write_garbage(ssx::sformat("{}/271-1850-v1.base_index", dir));
 
     b | start(ntp);
-    auto stats = get_stats().get0();
+    auto stats = get_stats().get();
     b | stop();
 
     BOOST_REQUIRE(
-      !ss::file_exists(ssx::sformat("{}/270-1850-v1.log", dir)).get0());
+      !ss::file_exists(ssx::sformat("{}/270-1850-v1.log", dir)).get());
     BOOST_TEST(stats.seg_count == 0);
     BOOST_TEST(stats.batch_count == 0);
     BOOST_TEST(stats.record_count >= 0);
@@ -166,7 +166,7 @@ FIXTURE_TEST(iterator_invalidation, log_builder_fixture) {
                                     data,
                                     std::nullopt,
                                     std::nullopt))
-                          .get0();
+                          .get();
     auto config_batches = b.consume(log_reader_config(
                                       model::offset(0),
                                       model::model_limits<model::offset>::max(),
@@ -176,8 +176,8 @@ FIXTURE_TEST(iterator_invalidation, log_builder_fixture) {
                                       configuration,
                                       std::nullopt,
                                       std::nullopt))
-                            .get0();
-    auto all_batches = b.consume().get0();
+                            .get();
+    auto all_batches = b.consume().get();
     b | stop();
     BOOST_REQUIRE_EQUAL(data_batches.size(), 2);
     BOOST_REQUIRE_EQUAL(config_batches.size(), 2);

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -47,7 +47,7 @@ FIXTURE_TEST(half_next_page, fixture) {
     info("Segment: {}", seg);
     seg.flush().get();
     b | add_random_batch(1, 1, maybe_compress_batches::yes);
-    auto recs = b.consume().get0();
+    auto recs = b.consume().get();
     BOOST_REQUIRE_EQUAL(recs.size(), 2);
     for (auto& rec : recs) {
         BOOST_REQUIRE_EQUAL(rec.header().crc, model::crc_record_batch(rec));

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -23,7 +23,7 @@ template<typename T>
 static void set_configuration(ss::sstring p_name, T v) {
     ss::smp::invoke_on_all([p_name, v = std::move(v)] {
         config::shard_local_cfg().get(p_name).set_value(v);
-    }).get0();
+    }).get();
 }
 
 FIXTURE_TEST(key_space, kvstore_test_fixture) {
@@ -120,12 +120,12 @@ FIXTURE_TEST(kvstore_empty, kvstore_test_fixture) {
         batch.push_back(kvs->put(
           storage::kvstore::key_space::testing, key, std::move(value)));
         if (batch.size() > 10) {
-            ss::when_all(batch.begin(), batch.end()).get0();
+            ss::when_all(batch.begin(), batch.end()).get();
             batch.clear();
         }
     }
     if (!batch.empty()) {
-        ss::when_all(batch.begin(), batch.end()).get0();
+        ss::when_all(batch.begin(), batch.end()).get();
         batch.clear();
     }
 

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -41,7 +41,7 @@ void write_batches(ss::lw_shared_ptr<segment> seg) {
                      .get();
     for (auto& b : batches) {
         b.header().header_crc = model::internal_header_only_crc(b.header());
-        (void)seg->append(std::move(b)).get0();
+        (void)seg->append(std::move(b)).get();
     }
     seg->flush().get();
 }
@@ -103,7 +103,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                   default_segment_readahead_size,
                   default_segment_readahead_count,
                   0)
-                 .get0();
+                 .get();
     seg->close().get();
 
     // auto ntp2 = empty
@@ -116,7 +116,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    default_segment_readahead_size,
                    default_segment_readahead_count,
                    1_MiB)
-                  .get0();
+                  .get();
     write_batches(seg3);
     seg3->close().get();
 
@@ -128,7 +128,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    default_segment_readahead_size,
                    default_segment_readahead_count,
                    1_MiB)
-                  .get0();
+                  .get();
     write_garbage(seg4->appender());
     seg4->close().get();
 
@@ -141,9 +141,9 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     BOOST_CHECK_EQUAL(m.get(ntps[1].ntp())->segment_count(), 0);
     BOOST_CHECK_EQUAL(m.get(ntps[2].ntp())->segment_count(), 1);
     BOOST_CHECK_EQUAL(m.get(ntps[3].ntp())->segment_count(), 0);
-    BOOST_CHECK(!file_exists(seg->reader().filename()).get0());
-    BOOST_CHECK(file_exists(seg3->reader().filename()).get0());
-    BOOST_CHECK(!file_exists(seg4->reader().filename()).get0());
+    BOOST_CHECK(!file_exists(seg->reader().filename()).get());
+    BOOST_CHECK(file_exists(seg3->reader().filename()).get());
+    BOOST_CHECK(!file_exists(seg4->reader().filename()).get());
     BOOST_CHECK(
-      file_exists(seg4->reader().filename() + ".cannotrecover").get0());
+      file_exists(seg4->reader().filename() + ".cannotrecover").get());
 }

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -49,11 +49,11 @@ public:
 
         auto fd = ss::open_file_dma(
                     base_name, ss::open_flags::create | ss::open_flags::rw)
-                    .get0();
+                    .get();
         auto fidx = ss::open_file_dma(
                       base_name + ".index",
                       ss::open_flags::create | ss::open_flags::rw)
-                      .get0();
+                      .get();
         fd = ss::file(ss::make_shared(file_io_sanitizer(
           std::move(fd),
           std::filesystem::path{base_name},
@@ -99,12 +99,12 @@ public:
     void do_write_garbage(ss::sstring name) {
         auto fd = ss::open_file_dma(
                     name, ss::open_flags::create | ss::open_flags::rw)
-                    .get0();
+                    .get();
         fd = ss::file(ss::make_shared(file_io_sanitizer(
           std::move(fd),
           std::filesystem::path{name},
           ntp_sanitizer_config{.sanitize_only = true})));
-        auto out = ss::make_file_output_stream(std::move(fd)).get0();
+        auto out = ss::make_file_output_stream(std::move(fd)).get();
         const auto b = random_generators::gen_alphanum_string(100);
         out.write(b.data(), b.size()).get();
         out.flush().get();

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -99,7 +99,7 @@ ss::file open_file(std::string_view filename) {
              filename,
              ss::open_flags::create | ss::open_flags::rw
                | ss::open_flags::truncate)
-      .get0();
+      .get();
 }
 
 segment_appender
@@ -153,7 +153,7 @@ static void run_test_can_append_multiple_flushes(size_t fallocate_size) {
         appender.flush().get();
 
         auto in = make_file_input_stream(f, 0);
-        iobuf result = read_iobuf_exactly(in, expected.size_bytes()).get0();
+        iobuf result = read_iobuf_exactly(in, expected.size_bytes()).get();
         BOOST_REQUIRE_EQUAL(result.size_bytes(), expected.size_bytes());
         BOOST_REQUIRE_EQUAL(result, expected);
         in.close().get();
@@ -190,7 +190,7 @@ static void run_test_can_append_mixed(size_t fallocate_size) {
         BOOST_CHECK_EQUAL(access(appender).inflight_dispatched(), 0);
         BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
         auto in = make_file_input_stream(f, acc);
-        iobuf result = read_iobuf_exactly(in, step).get0();
+        iobuf result = read_iobuf_exactly(in, step).get();
         fmt::print(
           "==> i:{}, step:{}, acc:{}, og.size:{}, expected.size{}\n",
           i,
@@ -262,7 +262,7 @@ static void run_test_can_append_10MB(size_t fallocate_size) {
         BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
 
         auto in = make_file_input_stream(f, i * one_meg);
-        iobuf result = read_iobuf_exactly(in, one_meg).get0();
+        iobuf result = read_iobuf_exactly(in, one_meg).get();
         BOOST_CHECK_EQUAL(original, result);
         in.close().get();
     }
@@ -302,7 +302,7 @@ static void run_test_can_append_10MB_sequential_write_sequential_read(
     appender.flush().get();
     for (size_t i = 0; i < 10; ++i) {
         auto in = make_file_input_stream(f, i * one_meg);
-        iobuf result = read_iobuf_exactly(in, one_meg).get0();
+        iobuf result = read_iobuf_exactly(in, one_meg).get();
         iobuf tmp_o = original.share(i * one_meg, one_meg);
         // read_iobuf_exactly can return a short read, but we do not expect that
         // here.
@@ -543,7 +543,7 @@ static void run_test_can_append_little_data(size_t fallocate_size) {
         appender.append(&c, 1).get();
         appender.flush().get();
         auto in = make_file_input_stream(f, i);
-        auto result = in.read_exactly(1).get0();
+        auto result = in.read_exactly(1).get();
         if (c != result[0]) {
             std::vector<char> tmp;
             tmp.reserve(7);
@@ -599,7 +599,7 @@ static void run_test_fallocate_size(size_t fallocate_size) {
         BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
 
         auto in = make_file_input_stream(f, i * one_meg);
-        iobuf result = read_iobuf_exactly(in, one_meg).get0();
+        iobuf result = read_iobuf_exactly(in, one_meg).get();
         BOOST_CHECK_EQUAL(original, result);
         in.close().get();
     }

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -60,7 +60,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_read_single_batch_smaller_offset) {
     auto buf = model::test::make_random_batches(model::offset(1), 1).get();
     write(std::move(buf), b);
     // To-do Kostas Add support for pipe consume!
-    auto res = b.consume().get0();
+    auto res = b.consume().get();
     b | stop();
     BOOST_REQUIRE(res.empty());
 }
@@ -79,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_read_single_batch_same_offset) {
     b | start() | add_segment(1);
     auto batches = model::test::make_random_batches(model::offset(1), 1).get();
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     check_batches(res, batches);
 }
@@ -98,7 +98,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_read_multiple_batches) {
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     check_batches(res, batches);
 }
@@ -117,7 +117,7 @@ SEASTAR_THREAD_TEST_CASE(test_does_not_read_past_committed_offset_one_segment) {
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     BOOST_REQUIRE(res.empty());
 }
@@ -137,7 +137,7 @@ SEASTAR_THREAD_TEST_CASE(
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     ss::circular_buffer<model::record_batch> first;
     first.push_back(std::move(batches.back()));
@@ -158,7 +158,7 @@ SEASTAR_THREAD_TEST_CASE(test_does_not_read_past_max_bytes) {
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     ss::circular_buffer<model::record_batch> first;
     first.push_back(std::move(*batches.begin()));
@@ -179,7 +179,7 @@ SEASTAR_THREAD_TEST_CASE(test_reads_at_least_one_batch) {
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     ss::circular_buffer<model::record_batch> first;
     first.push_back(std::move(batches.front()));
@@ -201,7 +201,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_batch_range) {
     b | start();
     b | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     BOOST_REQUIRE_EQUAL_COLLECTIONS(
       std::next(res.begin(), 2),
@@ -247,7 +247,7 @@ SEASTAR_THREAD_TEST_CASE(test_batch_type_filter) {
           std::nullopt,
           std::nullopt);
 
-        auto res = b.consume(config).get0();
+        auto res = b.consume(config).get();
 
         std::set<int> types;
         for (auto& batch : res) {
@@ -288,7 +288,7 @@ SEASTAR_THREAD_TEST_CASE(test_does_not_read_past_max_offset) {
     disk_log_builder b;
     b | start() | add_segment(batches.front().base_offset());
     write(copy(batches), b);
-    auto res = b.consume(reader_config).get0();
+    auto res = b.consume(reader_config).get();
     b | stop();
     check_batches(res, batches);
 }

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -45,10 +45,10 @@ constexpr model::offset expected_last(model::offset t_offset) {
 FIXTURE_TEST(test_truncate_whole, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
@@ -58,7 +58,7 @@ FIXTURE_TEST(test_truncate_whole, storage_test_fixture) {
     log
       ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
-      .get0();
+      .get();
 
     auto read_batches = read_and_validate_all_batches(log);
     auto lstats = log->offsets();
@@ -71,12 +71,12 @@ FIXTURE_TEST(test_truncate_whole, storage_test_fixture) {
 FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     append_random_batches(log, 6, model::term_id(0));
-    log->flush().get0();
+    log->flush().get();
 
     auto all_batches = read_and_validate_all_batches(log);
     auto truncate_offset = all_batches[4].base_offset();
@@ -86,7 +86,7 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
     log
       ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
-      .get0();
+      .get();
     info("reading all batches");
     auto read_batches = read_and_validate_all_batches(log);
 
@@ -106,10 +106,10 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_segment, storage_test_fixture) {
 FIXTURE_TEST(test_truncate_in_the_middle_of_batch, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     append_batch(
       log, model::test::make_random_batch(model::offset{0}, 10, true));
@@ -134,12 +134,12 @@ FIXTURE_TEST(test_truncate_in_the_middle_of_batch, storage_test_fixture) {
 FIXTURE_TEST(test_truncate_empty_log, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     append_random_batches(log, 1, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     auto all_batches = read_and_validate_all_batches(log);
     auto lstats = log->offsets();
@@ -151,10 +151,10 @@ FIXTURE_TEST(test_truncate_middle_of_old_segment, storage_test_fixture) {
     std::cout.setf(std::ios::unitbuf);
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     // Generate from 10 up to 100 batches
     for (auto i = 0; i < 10; i++) {
@@ -170,7 +170,7 @@ FIXTURE_TEST(test_truncate_middle_of_old_segment, storage_test_fixture) {
     log
       ->truncate(storage::truncate_config(
         all_batches.back().base_offset(), ss::default_priority_class()))
-      .get0();
+      .get();
     all_batches.pop_back(); // we just removed the last one!
     auto final_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(all_batches.size(), final_batches.size());
@@ -188,10 +188,10 @@ FIXTURE_TEST(test_truncate_middle_of_old_segment, storage_test_fixture) {
 FIXTURE_TEST(truncate_whole_log_and_then_again, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
@@ -202,11 +202,11 @@ FIXTURE_TEST(truncate_whole_log_and_then_again, storage_test_fixture) {
     log
       ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
-      .get0();
+      .get();
     log
       ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
-      .get0();
+      .get();
 
     auto read_batches = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read_batches.size(), 0);
@@ -218,10 +218,10 @@ FIXTURE_TEST(truncate_whole_log_and_then_again, storage_test_fixture) {
 FIXTURE_TEST(truncate_before_read, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     std::vector<model::record_batch_header> headers;
     for (auto i = 0; i < 10; i++) {
         append_random_batches(log, 1, model::term_id(i));
@@ -234,12 +234,12 @@ FIXTURE_TEST(truncate_before_read, storage_test_fixture) {
 
     // first create the reader
     auto reader_ptr = std::make_unique<model::record_batch_reader>(
-      log->make_reader(std::move(cfg)).get0());
+      log->make_reader(std::move(cfg)).get());
     // truncate
     auto f = log->truncate(
       storage::truncate_config(model::offset(0), ss::default_priority_class()));
     // Memory log works fine
-    reader_ptr->consume(batch_validating_consumer{}, model::no_timeout).get0();
+    reader_ptr->consume(batch_validating_consumer{}, model::no_timeout).get();
     reader_ptr = nullptr;
     f.get();
     auto read_batches = read_and_validate_all_batches(log);
@@ -253,12 +253,12 @@ FIXTURE_TEST(
   test_truncate_in_the_middle_of_segment_and_append, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     append_random_batches(log, 6, model::term_id(0));
-    log->flush().get0();
+    log->flush().get();
 
     auto all_batches = read_and_validate_all_batches(log);
     auto truncate_offset = all_batches[4].base_offset();
@@ -268,7 +268,7 @@ FIXTURE_TEST(
     log
       ->truncate(
         storage::truncate_config(truncate_offset, ss::default_priority_class()))
-      .get0();
+      .get();
     info("reading all batches");
     auto read_batches = read_and_validate_all_batches(log);
 
@@ -284,7 +284,7 @@ FIXTURE_TEST(
     }
     // Append new batches
     auto headers = append_random_batches(log, 6, model::term_id(0));
-    log->flush().get0();
+    log->flush().get();
     auto read_after_append = read_and_validate_all_batches(log);
     // 4 batches were not truncated
     BOOST_REQUIRE_EQUAL(read_after_append.size(), headers.size() + 4);
@@ -293,10 +293,10 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(
       log,
       15,
@@ -312,7 +312,7 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
             ts));
           return ret;
       });
-    log->flush().get0();
+    log->flush().get();
 
     for (auto lstats = log->offsets(); lstats.dirty_offset > model::offset{};
          lstats = log->offsets()) {
@@ -320,7 +320,7 @@ FIXTURE_TEST(test_truncate_last_single_record_batch, storage_test_fixture) {
         log
           ->truncate(storage::truncate_config(
             truncate_offset, ss::default_priority_class()))
-          .get0();
+          .get();
         auto all_batches = read_and_validate_all_batches(log);
         auto expected = truncate_offset - headers.back().record_count;
         headers.pop_back();
@@ -338,7 +338,7 @@ FIXTURE_TEST(
     auto cfg = default_log_config(test_dir);
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     auto overrides = std::make_unique<storage::ntp_config::default_overrides>();
@@ -350,13 +350,13 @@ FIXTURE_TEST(
     auto log = mgr
                  .manage(storage::ntp_config(
                    ntp, mgr.config().base_dir, std::move(overrides)))
-                 .get0();
+                 .get();
     append_random_batches(log, 10, model::term_id(0));
     append_random_batches(log, 10, model::term_id(0));
-    log->flush().get0();
+    log->flush().get();
     auto ts = now();
     append_random_batches(log, 10, model::term_id(0));
-    log->flush().get0();
+    log->flush().get();
     // garbadge collect first append series
     ss::abort_source as;
     log
@@ -367,12 +367,12 @@ FIXTURE_TEST(
         std::nullopt,
         ss::default_priority_class(),
         as))
-      .get0();
+      .get();
     // truncate at 0, offset earlier then the one present in log
     log
       ->truncate(storage::truncate_config(
         model::offset(0), ss::default_priority_class()))
-      .get0();
+      .get();
 
     auto lstats = log->offsets();
     BOOST_REQUIRE_EQUAL(lstats.dirty_offset, model::offset{});
@@ -436,12 +436,12 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
     {
         storage::log_manager mgr = make_log_manager(cfg);
         info("config: {}", mgr.config());
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
 
-        auto log = mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
+        auto log = mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get();
 
         append_random_batches(log, 10, model::term_id(0));
-        log->flush().get0();
+        log->flush().get();
 
         // truncate in the middle
         auto all_batches = read_and_validate_all_batches(log);
@@ -476,9 +476,8 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
     storage::log_manager rec_mgr = make_log_manager(cfg);
 
     auto rec_deferred = ss::defer(
-      [&rec_mgr]() mutable { rec_mgr.stop().get0(); });
-    auto rec_log
-      = rec_mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get0();
+      [&rec_mgr]() mutable { rec_mgr.stop().get(); });
+    auto rec_log = rec_mgr.manage(storage::ntp_config(ntp, cfg.base_dir)).get();
     auto& impl = *rec_log;
 
     BOOST_REQUIRE_EQUAL(impl.segment_count(), 3);
@@ -512,7 +511,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     auto overrides = std::make_unique<storage::ntp_config::default_overrides>();
@@ -524,18 +523,18 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     auto log = mgr
                  .manage(storage::ntp_config(
                    ntp, mgr.config().base_dir, std::move(overrides)))
-                 .get0();
+                 .get();
 
     append_random_batches(log, 10, model::term_id(0));
     auto lstats = log->offsets();
 
     append_random_batches(log, 10, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     auto ts = now();
 
     append_random_batches(log, 10, model::term_id(2));
-    log->flush().get0();
+    log->flush().get();
     ss::abort_source as;
 
     // The call to 'compact' simply triggers a notification
@@ -553,8 +552,8 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     auto f2 = log->truncate_prefix(storage::truncate_prefix_config(
       model::next_offset(lstats.dirty_offset), ss::default_priority_class()));
 
-    f1.get0();
-    f2.get0();
+    f1.get();
+    f2.get();
 
     BOOST_REQUIRE_EQUAL(
       (*log->segments().begin())->offsets().get_base_offset(),
@@ -662,10 +661,10 @@ FIXTURE_TEST(
   test_prefix_truncate_in_the_middle_of_batch, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     append_batch(
       log, model::test::make_random_batch(model::offset{0}, 10, true));
@@ -705,10 +704,10 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_prefix_truncate_then_truncate_all, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     append_batch(
       log, model::test::make_random_batch(model::offset{0}, 10, true));
@@ -742,10 +741,10 @@ FIXTURE_TEST(test_index_max_timestamp_update, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     append_batch(
       log,
       model::test::make_random_batch(

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -79,7 +79,7 @@ FIXTURE_TEST(index_round_trip, offset_index_utils_fixture) {
           i);
     }
     info("About to flush index");
-    _idx->flush().get0();
+    _idx->flush().get();
     auto data = _data.share_iobuf();
     info("{} - serializing from bytes into mem: buffer{}", _idx, data);
     auto raw_idx = serde::from_iobuf<storage::index_state>(

--- a/src/v/storage/tests/offset_to_filepos_test.cc
+++ b/src/v/storage/tests/offset_to_filepos_test.cc
@@ -45,7 +45,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_not_found) {
                     segment,
                     segment->index().base_timestamp(),
                     ss::default_priority_class())
-                    .get0();
+                    .get();
     BOOST_REQUIRE(result.error() == std::errc::invalid_seek);
 }
 
@@ -79,7 +79,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_not_found) {
                     segment,
                     segment->index().max_timestamp(),
                     ss::default_priority_class())
-                    .get0();
+                    .get();
     BOOST_REQUIRE(result.error() == std::errc::invalid_seek);
 }
 
@@ -116,7 +116,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_found) {
                     segment,
                     segment->index().base_timestamp(),
                     ss::default_priority_class())
-                    .get0();
+                    .get();
     storage::offset_to_file_pos_result expected{
       model::offset{3},
       positions[2],
@@ -157,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_found) {
                     segment,
                     segment->index().base_timestamp(),
                     ss::default_priority_class())
-                    .get0();
+                    .get();
     storage::offset_to_file_pos_result expected{
       model::offset{3},
       positions[3], // the end byte offset of the batch containing the needle
@@ -196,7 +196,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_allowed_to_be_missing) {
                     segment->index().max_timestamp(),
                     ss::default_priority_class(),
                     should_fail_on_missing_offset::no)
-                    .get0();
+                    .get();
     storage::offset_to_file_pos_result expected{
       model::offset{1},
       segment->size_bytes(),

--- a/src/v/storage/tests/produce_consume_test.cc
+++ b/src/v/storage/tests/produce_consume_test.cc
@@ -60,7 +60,7 @@ SEASTAR_THREAD_TEST_CASE(produce_consume_concurrency) {
           .discard_result();
     });
 
-    ss::when_all(std::move(prod), std::move(consumer), [] {}).get0();
+    ss::when_all(std::move(prod), std::move(consumer), [] {}).get();
 
     builder | storage::stop();
 }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -97,12 +97,12 @@ FIXTURE_TEST(
   test_assinging_offsets_in_single_segment_log, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     auto batches = read_and_validate_all_batches(log);
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
@@ -117,14 +117,14 @@ FIXTURE_TEST(
 FIXTURE_TEST(append_twice_to_same_segment, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     auto headers_2 = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     std::move(
       std::begin(headers_2), std::end(headers_2), std::back_inserter(headers));
     auto batches = read_and_validate_all_batches(log);
@@ -142,12 +142,12 @@ FIXTURE_TEST(test_assigning_offsets_in_multiple_segment, storage_test_fixture) {
     cfg.max_segment_size = config::mock_binding<size_t>(1_KiB);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     auto batches = read_and_validate_all_batches(log);
 
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
@@ -164,10 +164,10 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
     cfg.max_segment_size = config::mock_binding<size_t>(10);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(
       log,
       10,
@@ -183,7 +183,7 @@ FIXTURE_TEST(test_single_record_per_segment, storage_test_fixture) {
             ts));
           return batches;
       });
-    log->flush().get0();
+    log->flush().get();
     auto batches = read_and_validate_all_batches(log);
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
@@ -200,10 +200,10 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
     cfg.max_segment_size = config::mock_binding<size_t>(10 * 1024);
     storage::log_manager mgr = make_log_manager(std::move(cfg));
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     auto headers = append_random_batches(
       log,
       10,
@@ -222,7 +222,7 @@ FIXTURE_TEST(test_segment_rolling, storage_test_fixture) {
       },
       storage::log_append_config::fsync::no,
       false);
-    log->flush().get0();
+    log->flush().get();
     auto batches = read_and_validate_all_batches(log);
     info("Flushed log: {}", log);
     BOOST_REQUIRE_EQUAL(headers.size(), batches.size());
@@ -264,10 +264,10 @@ FIXTURE_TEST(test_reading_range_from_a_log, storage_test_fixture) {
     info("Configuration: {}", mgr.config());
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto headers = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     auto batches = read_and_validate_all_batches(log);
 
     // range from base of beging to last of end
@@ -315,8 +315,8 @@ FIXTURE_TEST(
     info("Configuration: {}", mgr.config());
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto headers = append_random_batches(
       log,
       10,
@@ -365,8 +365,8 @@ FIXTURE_TEST(test_truncation_with_write_caching, storage_test_fixture) {
     info("Configuration: {}", mgr.config());
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto headers = append_random_batches(
       log,
       10,
@@ -427,10 +427,10 @@ FIXTURE_TEST(test_truncation_with_write_caching, storage_test_fixture) {
 FIXTURE_TEST(test_rolling_term, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     std::vector<model::record_batch_header> headers;
     model::offset current_offset = model::offset{0};
     for (auto i = 0; i < 5; i++) {
@@ -458,10 +458,10 @@ FIXTURE_TEST(test_rolling_term, storage_test_fixture) {
 FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager();
     info("Testing type: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
     std::vector<model::record_batch_header> headers;
     ss::circular_buffer<model::record_batch> batches;
     std::vector<size_t> term_batches_counts;
@@ -484,7 +484,7 @@ FIXTURE_TEST(test_append_batches_from_multiple_terms, storage_test_fixture) {
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     std::move(reader)
       .for_each_ref(log->make_appender(append_cfg), append_cfg.timeout)
-      .get0();
+      .get();
     log->flush().get();
 
     auto read_batches = read_and_validate_all_batches(log);
@@ -599,17 +599,17 @@ FIXTURE_TEST(
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(100));
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(110));
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(120));
-    disk_log->force_roll(ss::default_priority_class()).get0();
+    disk_log->force_roll(ss::default_priority_class()).get();
 
     append_batch_with_no_max_ts(log, model::term_id(0), model::timestamp(200));
     // reordered timestamps
@@ -635,11 +635,11 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
     info("Configuration: {}", mgr.config());
     BOOST_REQUIRE(feature_table.local().is_active(
       features::feature::broker_time_based_retention));
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto disk_log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto disk_log = mgr.manage(std::move(ntp_cfg)).get();
 
     // keep track of broker timestamp, to predict expected evictions
     auto broker_t0 = model::timestamp_clock::now();
@@ -649,14 +649,14 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
     // broker timestamp: broker_t0
     append_custom_timestamp_batches(
       disk_log, 10, model::term_id(0), model::timestamp(100));
-    disk_log->force_roll(ss::default_priority_class()).get0();
+    disk_log->force_roll(ss::default_priority_class()).get();
 
     // 2. segment timestamps from 200 to 230
     // b ts: broker_t0 + broker_ts_sep
     ss::sleep(broker_ts_sep).get();
     append_custom_timestamp_batches(
       disk_log, 30, model::term_id(0), model::timestamp(200));
-    disk_log->force_roll(ss::default_priority_class()).get0();
+    disk_log->force_roll(ss::default_priority_class()).get();
 
     // 3. segment timestamps from 231 to 250
     // b_ts: broker_t0 + broker_ts_sep + broker_ts_sep
@@ -678,7 +678,7 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
       ss::default_priority_class(),
       as);
     auto before = disk_log->offsets();
-    disk_log->housekeeping(ccfg_no_compact).get0();
+    disk_log->housekeeping(ccfg_no_compact).get();
     auto after = disk_log->offsets();
     BOOST_REQUIRE_EQUAL(after.start_offset, before.start_offset);
 
@@ -732,14 +732,14 @@ FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
     auto headers = append_random_batches(log, 10);
-    log->flush().get0();
+    log->flush().get();
     auto all_batches = read_and_validate_all_batches(log);
     size_t first_size = std::accumulate(
       all_batches.begin(),
@@ -833,11 +833,11 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     (void)log->monitor_eviction(as).then(
       [&last_evicted_offset](model::offset o) mutable {
           last_evicted_offset.set_value(o);
@@ -848,7 +848,7 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       10,
       model::term_id(0),
       custom_ts_batch_generator(model::timestamp::now()));
-    log->flush().get0();
+    log->flush().get();
     ss::sleep(1s).get(); // ensure time separation for broker timestamp
     model::timestamp gc_ts
       = model::timestamp::now(); // this ts is after the above batch
@@ -868,15 +868,15 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       ss::default_priority_class(),
       as);
 
-    log->housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get();
 
-    auto offset = last_evicted_offset.get_future().get0();
-    log->housekeeping(ccfg).get0();
+    auto offset = last_evicted_offset.get_future().get();
+    log->housekeeping(ccfg).get();
     auto lstats_after = log->offsets();
 
     BOOST_REQUIRE_EQUAL(lstats_before.start_offset, lstats_after.start_offset);
     // wait for compaction
-    log->housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get();
     log
       ->truncate_prefix(storage::truncate_prefix_config{
         model::next_offset(offset), ss::default_priority_class()})
@@ -954,14 +954,14 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
     overrides_t ov;
     ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
 
-    append_exactly(log, 10, 100).get0();
+    append_exactly(log, 10, 100).get();
     BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(9));
 
     std::vector<ss::future<>> futures;
@@ -1003,10 +1003,10 @@ FIXTURE_TEST(write_concurrently_with_gc, storage_test_fixture) {
         futures.push_back(append());
     }
 
-    ss::when_all(futures.begin(), futures.end()).get0();
+    ss::when_all(futures.begin(), futures.end()).get();
 
     as.request_abort();
-    loop.get0();
+    loop.get();
     auto lstats_after = log->offsets();
     BOOST_REQUIRE_EQUAL(
       lstats_after.dirty_offset,
@@ -1060,7 +1060,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
     builder.get_log()
       ->truncate(storage::truncate_config(
         model::offset(6), ss::default_priority_class()))
-      .get0();
+      .get();
 
     builder | storage::add_segment(6);
     builder.stop().get();
@@ -1085,8 +1085,8 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
     storage::ntp_config ntp_cfg(
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
 
     auto offsets_after_recovery = log->offsets();
 
@@ -1101,7 +1101,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
       model::test::make_random_batch(model::offset(0), 1, false));
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    rdr.for_each_ref(std::move(appender), model::no_timeout).get0();
+    rdr.for_each_ref(std::move(appender), model::no_timeout).get();
 
     // we truncate at {6} so we expect dirty offset equal {5}
     BOOST_REQUIRE_EQUAL(offsets_after_recovery.dirty_offset, model::offset(5));
@@ -1159,12 +1159,12 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       std::nullopt,
       ss::default_priority_class(),
       as);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto offsets_after_recovery = log->offsets();
     info("After recovery: {}", log);
     // trigger compaction
-    log->housekeeping(compaction_cfg).get0();
+    log->housekeeping(compaction_cfg).get();
     auto offsets_after_compact = log->offsets();
     info("After compaction, offsets: {}, {}", offsets_after_compact, log);
 
@@ -1180,7 +1180,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
       model::test::make_random_batch(model::offset(0), 1, false));
 
     auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    std::move(rdr).for_each_ref(std::move(appender), model::no_timeout).get0();
+    std::move(rdr).for_each_ref(std::move(appender), model::no_timeout).get();
 
     // before append offsets should be equal to {1}, as we stopped there
     BOOST_REQUIRE_EQUAL(offsets_after_recovery.dirty_offset, model::offset(1));
@@ -1228,7 +1228,7 @@ void append_single_record_batch(
 
         std::move(reader)
           .for_each_ref(log->make_appender(cfg), cfg.timeout)
-          .get0();
+          .get();
     }
 }
 
@@ -1254,35 +1254,35 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
         storage::log_manager mgr = make_log_manager(cfg);
 
         info("config: {}", mgr.config());
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp("default", "test", 0);
         auto log
-          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
         // 1) append few single record batches in term 1
         append_single_record_batch(log, 14, model::term_id(1));
-        log->flush().get0();
+        log->flush().get();
         // 2) truncate in the middle of segment
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
         log
           ->truncate(
             storage::truncate_config(truncate_at, ss::default_priority_class()))
-          .get0();
+          .get();
         // 3) append some more batches to the same segment
         append_single_record_batch(log, 10, model::term_id(1));
-        log->flush().get0();
+        log->flush().get();
         //  4) roll term by appending to new segment
         append_single_record_batch(log, 1, model::term_id(8));
-        log->flush().get0();
+        log->flush().get();
     }
     // 5) restart log manager
     {
         storage::log_manager mgr = make_log_manager(cfg);
 
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp("default", "test", 0);
         auto log
-          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
         auto read = read_and_validate_all_batches(log);
 
         for (model::offset o(0); o < log->offsets().committed_offset; ++o) {
@@ -1302,7 +1302,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
         storage::log_manager mgr = make_log_manager(cfg);
 
         info("config: {}", mgr.config());
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp("default", "test", 0);
         auto log = mgr
                      .manage(storage::ntp_config(
@@ -1310,7 +1310,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
                        mgr.config().base_dir,
                        std::make_unique<storage::ntp_config::default_overrides>(
                          overrides)))
-                     .get0();
+                     .get();
         // append some batches to first segment (all batches have the same key)
         append_single_record_batch(log, 14, model::term_id(1));
 
@@ -1321,31 +1321,31 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           std::nullopt,
           ss::default_priority_class(),
           as);
-        log->flush().get0();
+        log->flush().get();
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
         log
           ->truncate(
             storage::truncate_config(truncate_at, ss::default_priority_class()))
-          .get0();
+          .get();
         // roll segment
         append_single_record_batch(log, 10, model::term_id(2));
-        log->flush().get0();
+        log->flush().get();
 
         // roll segment
         append_single_record_batch(log, 1, model::term_id(8));
         // compact log
-        log->housekeeping(c_cfg).get0();
+        log->housekeeping(c_cfg).get();
     }
 
     // force recovery
     {
         BOOST_TEST_MESSAGE("recovering");
         storage::log_manager mgr = make_log_manager(cfg);
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp("default", "test", 0);
         auto log
-          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+          = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
         auto read = read_and_validate_all_batches(log);
         auto lstats = log->offsets();
@@ -1368,7 +1368,7 @@ FIXTURE_TEST(
     storage::log_manager mgr = make_log_manager(cfg);
 
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1376,7 +1376,7 @@ FIXTURE_TEST(
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
     // append some batches to first segment (all batches have the same key)
     append_single_record_batch(log, 14, model::term_id(1));
 
@@ -1387,20 +1387,20 @@ FIXTURE_TEST(
       std::nullopt,
       ss::default_priority_class(),
       as);
-    log->flush().get0();
+    log->flush().get();
     model::offset truncate_at(7);
     info("Truncating at offset:{}", truncate_at);
     BOOST_REQUIRE_EQUAL(log->segment_count(), 1);
     log
       ->truncate(
         storage::truncate_config(truncate_at, ss::default_priority_class()))
-      .get0();
+      .get();
     append_single_record_batch(log, 10, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     // segment should be rolled after truncation
     BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
 
     auto read = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read.begin()->base_offset(), model::offset(6));
@@ -1418,16 +1418,16 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     using overrides_t = storage::ntp_config::default_overrides;
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 0);
 
     // Write 100 * 1_KiB batches, should yield only 1 segment
-    auto result = append_exactly(log, 100, 1_KiB).get0(); // 100*1_KiB
+    auto result = append_exactly(log, 100, 1_KiB).get(); // 100*1_KiB
     int size1 = disk_log->segments().size();
     BOOST_REQUIRE_EQUAL(size1, 1);
 
@@ -1436,7 +1436,7 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     disk_log->force_roll(ss::default_priority_class()).get();
 
     // 30 * 1_KiB should yield 2 new segments.
-    result = append_exactly(log, 30, 1_KiB).get0();
+    result = append_exactly(log, 30, 1_KiB).get();
     int size2 = disk_log->segments().size();
     BOOST_REQUIRE_EQUAL(size2 - size1, 2);
 
@@ -1447,7 +1447,7 @@ FIXTURE_TEST(check_max_segment_size, storage_test_fixture) {
     disk_log->force_roll(ss::default_priority_class()).get();
 
     // 60 * 1_KiB batches should yield 2 segments.
-    result = append_exactly(log, 60, 1_KiB).get0(); // 60*1_KiB
+    result = append_exactly(log, 60, 1_KiB).get(); // 60*1_KiB
     int size3 = disk_log->segments().size();
     BOOST_REQUIRE_EQUAL(size3 - size2, 2);
 }
@@ -1472,18 +1472,18 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
 
         ss::abort_source as;
         storage::log_manager mgr = make_log_manager(cfg);
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp("default", "test", 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-        auto log = mgr.manage(std::move(ntp_cfg)).get0();
+        auto log = mgr.manage(std::move(ntp_cfg)).get();
         auto disk_log = log;
 
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 0);
 
         // Write 100 * 1_KiB batches, should yield 1 full segment
-        auto result = append_exactly(log, 50, 1_KiB).get0(); // 100*1_KiB
+        auto result = append_exactly(log, 50, 1_KiB).get(); // 100*1_KiB
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 1);
-        result = append_exactly(log, 100, 1_KiB).get0(); // 100*1_KiB
+        result = append_exactly(log, 100, 1_KiB).get(); // 100*1_KiB
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 2);
 
         // A too-low segment size: should be clamped to the lower bound
@@ -1493,10 +1493,10 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
 
         // Exceeding the apparent segment size doesn't roll, because it was
         // clamped
-        result = append_exactly(log, 5, 1_KiB).get0();
+        result = append_exactly(log, 5, 1_KiB).get();
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 3);
         // Exceeding the lower bound segment size does cause a roll
-        result = append_exactly(log, 55, 1_KiB).get0();
+        result = append_exactly(log, 55, 1_KiB).get();
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 4);
 
         // A too-high segment size: should be clamped to the upper bound
@@ -1505,7 +1505,7 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 5);
         // Exceeding the upper bound causes a roll, even if we didn't reach
         // the user-configured segment size
-        result = append_exactly(log, 201, 1_KiB).get0();
+        result = append_exactly(log, 201, 1_KiB).get();
         BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 6);
     } catch (...) {
         ex = std::current_exception();
@@ -1535,12 +1535,12 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion
                                  | model::cleanup_policy_bitflags::compaction;
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
 
     storage::ntp_config ntp_cfg(
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     auto sz_initial = log->get_probe().partition_size();
     info("sz_initial={}", sz_initial);
@@ -1552,7 +1552,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
 
     append_exactly(
       log, input_batch_count, batch_size, bytes::from_string("key"))
-      .get0(); // 100*1_KiB
+      .get(); // 100*1_KiB
 
     // Test becomes non-deterministic if we allow flush in background: flush
     // explicitly instead.
@@ -1622,13 +1622,13 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     std::vector<ss::shared_ptr<storage::log>> logs;
     for (int i = 0; i < 5; ++i) {
         auto ntp = model::ntp("default", ssx::sformat("test-{}", i), 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-        auto log = mgr.manage(std::move(ntp_cfg)).get0();
-        append_exactly(log, 2000, 100).get0();
+        auto log = mgr.manage(std::move(ntp_cfg)).get();
+        append_exactly(log, 2000, 100).get();
         logs.push_back(log);
     }
     std::vector<size_t> sizes;
@@ -1655,7 +1655,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
 
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1663,7 +1663,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     // build some segments
     append_single_record_batch(log, 20, model::term_id(1));
@@ -1673,7 +1673,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(1));
     log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 50, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(log->segment_count(), 4);
 
@@ -1698,7 +1698,7 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
 
     // There are 4 segments, and the last is the active segments. The first two
     // will merge, and the third will be compacted but not merged.
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 4);
 
     // Check if it honors max_compactible offset by resetting it to the base
@@ -1706,19 +1706,19 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     const auto first_segment_offsets = log->segments().front()->offsets();
     c_cfg.compact.max_collectible_offset
       = first_segment_offsets.get_base_offset();
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 4);
 
     // The segment count will be reduced again.
     c_cfg.compact.max_collectible_offset = model::offset::max();
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 3);
 
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
 
     // No change since we can't combine with appender segment.
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
     all_have_broker_timestamp();
 }
@@ -1734,7 +1734,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
 
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1742,7 +1742,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     // build some segments
     auto disk_log = log;
@@ -1753,7 +1753,7 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(3));
     append_single_record_batch(log, 50, model::term_id(4));
     append_single_record_batch(log, 50, model::term_id(5));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
@@ -1766,18 +1766,18 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
       as);
 
     // compact all the individual segments
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the two segments with term 2 can be combined
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // no more pairs with the same term
-    log->housekeeping(c_cfg).get0();
-    log->housekeeping(c_cfg).get0();
-    log->housekeeping(c_cfg).get0();
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
+    log->housekeeping(c_cfg).get();
+    log->housekeeping(c_cfg).get();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     for (int i = 0; i < 5; i++) {
@@ -1798,7 +1798,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
 
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1806,7 +1806,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
 
@@ -1828,7 +1828,7 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
@@ -1841,24 +1841,24 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
 
     // the first two segments are combined 2+2=4 < 6 MB
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     // the new first and second are too big 4+5 > 6 MB but the second and third
     // can be combined 5 + 15KB < 6 MB
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
     // then the next 16 KB can be folded in
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
     // that's all that can be done. the next seg is an appender
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 }
 
@@ -1873,7 +1873,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     storage::log_manager mgr = make_log_manager(cfg);
 
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1881,7 +1881,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
     append_single_record_batch(log, 20, model::term_id(1));
@@ -1891,7 +1891,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     append_single_record_batch(log, 40, model::term_id(3));
     disk_log->force_roll(ss::default_priority_class()).get();
     append_single_record_batch(log, 50, model::term_id(4));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
 
@@ -1906,23 +1906,23 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     {
         auto locks = storage::internal::write_lock_segments(
                        segments, std::chrono::seconds(1), 1)
-                       .get0();
+                       .get();
         BOOST_REQUIRE(locks.size() == segments.size());
     }
 
     {
-        auto lock = segments[2]->write_lock().get0();
+        auto lock = segments[2]->write_lock().get();
         BOOST_REQUIRE_THROW(
           storage::internal::write_lock_segments(
             segments, std::chrono::seconds(1), 1)
-            .get0(),
+            .get(),
           ss::semaphore_timed_out);
     }
 
     {
         auto locks = storage::internal::write_lock_segments(
                        segments, std::chrono::seconds(1), 1)
-                       .get0();
+                       .get();
         BOOST_REQUIRE(locks.size() == segments.size());
     }
 }
@@ -1934,7 +1934,7 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -1942,13 +1942,13 @@ FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
     // first small batch
-    append_exactly(log, 1, 128).get0();
+    append_exactly(log, 1, 128).get();
     // then large batches
-    append_exactly(log, 1, 128_KiB).get0();
-    append_exactly(log, 1, 128_KiB).get0();
-    log->flush().get0();
+    append_exactly(log, 1, 128_KiB).get();
+    append_exactly(log, 1, 128_KiB).get();
+    log->flush().get();
 
     storage::log_reader_config reader_cfg(
       model::offset(0),
@@ -1998,7 +1998,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
 
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2006,7 +2006,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
 
@@ -2026,7 +2026,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
@@ -2053,7 +2053,7 @@ FIXTURE_TEST(compaction_backlog_calculation, storage_test_fixture) {
         + 2 * segments[2]->size_bytes() + segments[3]->size_bytes()
         + self_seg_compaction_sz);
     // self compaction steps
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
     auto new_backlog_size = log->compaction_backlog();
@@ -2077,7 +2077,7 @@ FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
 
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2085,7 +2085,7 @@ FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
 
@@ -2105,7 +2105,7 @@ FIXTURE_TEST(not_compacted_log_backlog, storage_test_fixture) {
     add_segment(16_KiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(16_KiB, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
@@ -2139,7 +2139,7 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2147,7 +2147,7 @@ FIXTURE_TEST(disposing_in_use_reader, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
     for (auto i = 1; i < 100; ++i) {
         append_single_record_batch(log, 1, model::term_id(1), 128, true);
     }
@@ -2206,7 +2206,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("config: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2214,7 +2214,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto append = [&] {
         // Append single batch
@@ -2306,7 +2306,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
 
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2314,7 +2314,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
 
@@ -2351,7 +2351,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
 
                 std::move(reader)
                   .for_each_ref(log->make_appender(cfg), cfg.timeout)
-                  .get0();
+                  .get();
             }
         } while (disk_log->segments().back()->size_bytes() < size);
     };
@@ -2361,7 +2361,7 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
     add_segment(1_MiB, model::term_id(1));
     disk_log->force_roll(ss::default_priority_class()).get();
     add_segment(1_MiB, model::term_id(1));
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 
@@ -2374,8 +2374,8 @@ FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {
       as);
 
     // self compaction steps
-    log->housekeeping(c_cfg).get0();
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
+    log->housekeeping(c_cfg).get();
 
     // read all batches
     auto first_read = read_and_validate_all_batches(log);
@@ -2419,7 +2419,7 @@ FIXTURE_TEST(reader_prevents_log_shutdown, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2427,9 +2427,9 @@ FIXTURE_TEST(reader_prevents_log_shutdown, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
     // append some batches
-    append_exactly(log, 5, 128).get0();
+    append_exactly(log, 5, 128).get();
 
     // drain whole log with reader so it is not reusable anymore.
     storage::log_reader_config reader_cfg(
@@ -2457,7 +2457,7 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2465,7 +2465,7 @@ FIXTURE_TEST(test_querying_term_last_offset, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
     // append some baches in term 0
     append_random_batches(log, 10, model::term_id(0));
     auto lstats_term_0 = log->offsets();
@@ -2526,7 +2526,7 @@ void write_batch(
       .timeout = model::no_timeout,
     };
 
-    std::move(reader).for_each_ref(log->make_appender(cfg), cfg.timeout).get0();
+    std::move(reader).for_each_ref(log->make_appender(cfg), cfg.timeout).get();
 }
 
 absl::
@@ -2570,7 +2570,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     auto log = mgr
                  .manage(storage::ntp_config(
@@ -2578,7 +2578,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto disk_log = log;
 
@@ -2603,7 +2603,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     disk_log->force_roll(ss::default_priority_class()).get();
 
-    log->flush().get0();
+    log->flush().get();
 
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
@@ -2618,7 +2618,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
 
     BOOST_REQUIRE_EQUAL(before_compaction.size(), 4);
     // compact
-    log->housekeeping(c_cfg).get0();
+    log->housekeeping(c_cfg).get();
     auto after_compaction = compact_in_memory(log);
 
     BOOST_REQUIRE(before_compaction == after_compaction);
@@ -2639,7 +2639,7 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
 
     auto ntp = model::ntp("default", "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     int cnt = 0;
     int max = 500;
@@ -2763,7 +2763,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     int cnt = 0;
     int max = 50;
@@ -2911,7 +2911,7 @@ FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {
                    mgr.config().base_dir,
                    std::make_unique<storage::ntp_config::default_overrides>(
                      overrides)))
-                 .get0();
+                 .get();
 
     auto large_batch = [](int key) {
         storage::record_batch_builder builder(
@@ -3043,7 +3043,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
     info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -3052,7 +3052,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       ntp,
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     // (1) append some random data, with limited number of distinct keys, so
@@ -3061,7 +3061,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       log, 20);
 
     // (2) remember log offset, roll log, and produce more messages
-    log->flush().get0();
+    log->flush().get();
     auto first_stats = log->offsets();
     info("Offsets to be compacted {}", first_stats);
     disk_log->force_roll(ss::default_priority_class()).get();
@@ -3070,7 +3070,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
 
     // (3) roll log and trigger compaction, analyzing offset gaps before and
     // after, to observe compaction behavior.
-    log->flush().get0();
+    log->flush().get();
     auto second_stats = log->offsets();
     auto pre_compact_gaps = analyze(*disk_log);
     disk_log->force_roll(ss::default_priority_class()).get();
@@ -3082,7 +3082,7 @@ FIXTURE_TEST(test_max_compact_offset, storage_test_fixture) {
       std::nullopt,
       ss::default_priority_class(),
       as);
-    log->housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get();
     auto final_stats = log->offsets();
     auto post_compact_gaps = analyze(*disk_log);
 
@@ -3111,7 +3111,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -3120,7 +3120,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       ntp,
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     // (1) append some random data, with limited number of distinct keys, so
@@ -3129,7 +3129,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
       log, 20);
 
     // (2) remember log offset, roll log, and produce more messages
-    log->flush().get0();
+    log->flush().get();
 
     disk_log->force_roll(ss::default_priority_class()).get();
     headers = append_random_batches<key_limited_random_batch_generator>(
@@ -3137,7 +3137,7 @@ FIXTURE_TEST(test_self_compaction_while_reader_is_open, storage_test_fixture) {
 
     // (3) roll log and trigger compaction, analyzing offset gaps before and
     // after, to observe compaction behavior.
-    log->flush().get0();
+    log->flush().get();
 
     disk_log->force_roll(ss::default_priority_class()).get();
     storage::housekeeping_config ccfg(
@@ -3163,7 +3163,7 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -3172,13 +3172,13 @@ FIXTURE_TEST(test_simple_compaction_rebuild_index, storage_test_fixture) {
       ntp,
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     // Append some linear kv ints
     int num_appends = 5;
     append_random_batches<linear_int_kv_batch_generator>(log, num_appends);
-    log->flush().get0();
+    log->flush().get();
     disk_log->force_roll(ss::default_priority_class()).get();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
 
@@ -3230,7 +3230,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     ss::abort_source as;
     storage::log_manager mgr = f.make_log_manager(cfg);
     tlog.info("Configuration: {}", mgr.config());
-    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto ntp = model::ntp("default", "test", 0);
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
@@ -3239,7 +3239,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       ntp,
       mgr.config().base_dir,
       std::make_unique<storage::ntp_config::default_overrides>(overrides));
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto disk_log = log;
 
     auto append_batch = [](
@@ -3279,7 +3279,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
         for (int i = 0; i < args.msg_per_segment; i++) {
             append_batch(log, model::term_id(0), key);
         }
-        disk_log->force_roll(ss::default_priority_class()).get0();
+        disk_log->force_roll(ss::default_priority_class()).get();
     }
     append_batch(log, model::term_id(0)); // write single message for final
                                           // segment after last roll
@@ -3299,7 +3299,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       std::nullopt,
       ss::default_priority_class(),
       as);
-    log->housekeeping(ccfg).get0();
+    log->housekeeping(ccfg).get();
     auto final_stats = log->offsets();
     auto final_gaps = analyze(*disk_log);
     tlog.info("post-compact stats: {}, analysis: {}", final_stats, final_gaps);
@@ -3522,7 +3522,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         ss::abort_source as;
         storage::log_manager mgr = make_log_manager(cfg);
 
-        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
+        auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
         auto ntp = model::ntp(model::kafka_namespace, "test", 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
         storage::ntp_config::default_overrides overrides;
@@ -3551,7 +3551,7 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
             ntp_cfg.set_overrides(overrides);
         }
 
-        auto log = mgr.manage(std::move(ntp_cfg)).get0();
+        auto log = mgr.manage(std::move(ntp_cfg)).get();
         auto deferred_rm = ss::defer(
           [&mgr, ntp]() mutable { mgr.remove(ntp).get(); });
 
@@ -3597,7 +3597,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
 
     auto ntp = model::ntp(model::kafka_namespace, "test", 0);
     auto log
-      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get0();
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
 
     int cnt = 0;
     int max = 500;

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -220,7 +220,7 @@ public:
             config::shard_local_cfg()
               .get("log_segment_size_min")
               .set_value(std::optional<uint64_t>{});
-        }).get0();
+        }).get();
         feature_table.start().get();
         feature_table
           .invoke_on_all(
@@ -306,9 +306,9 @@ public:
         auto lstats = log->offsets();
         storage::log_reader_config cfg(
           lstats.start_offset, max_offset, ss::default_priority_class());
-        auto reader = log->make_reader(std::move(cfg)).get0();
+        auto reader = log->make_reader(std::move(cfg)).get();
         return reader.consume(batch_validating_consumer{}, model::no_timeout)
-          .get0();
+          .get();
     }
 
     // clang-format off
@@ -355,7 +355,7 @@ public:
             auto res = std::move(reader)
                          .for_each_ref(
                            log->make_appender(append_cfg), append_cfg.timeout)
-                         .get0();
+                         .get();
             if (flush_after_append) {
                 log->flush().get();
             }
@@ -411,9 +411,9 @@ public:
         storage::log_reader_config cfg(
           start, end, ss::default_priority_class());
         tlog.info("read_range_to_vector: {}", cfg);
-        auto reader = log->make_reader(std::move(cfg)).get0();
+        auto reader = log->make_reader(std::move(cfg)).get();
         return std::move(reader)
           .consume(batch_validating_consumer(), model::no_timeout)
-          .get0();
+          .get();
     }
 };

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -87,7 +87,7 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
               ss::default_priority_class(),
               std::nullopt);
 
-            auto res = log->timequery(config).get0();
+            auto res = log->timequery(config).get();
             BOOST_TEST(res);
             BOOST_TEST(res->time == model::timestamp(start_offset));
             BOOST_TEST(res->offset == start_offset);
@@ -105,7 +105,7 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
           ss::default_priority_class(),
           std::nullopt);
 
-        auto res = log->timequery(config).get0();
+        auto res = log->timequery(config).get();
         BOOST_TEST(res);
         BOOST_TEST(res->time == model::timestamp(ts));
         BOOST_TEST(res->offset == model::offset(ts));
@@ -130,7 +130,7 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
 
         auto offset = (ts - 100) * 5 + 100;
 
-        auto res = log->timequery(config).get0();
+        auto res = log->timequery(config).get();
         BOOST_TEST(res);
         BOOST_TEST(res->time == model::timestamp(ts));
         BOOST_TEST(res->offset == model::offset(offset));
@@ -192,7 +192,7 @@ FIXTURE_TEST(timequery_multiple_messages_per_batch, log_builder_fixture) {
           ss::default_priority_class(),
           std::nullopt);
 
-        auto res = log->timequery(config).get0();
+        auto res = log->timequery(config).get();
         BOOST_TEST(res);
         BOOST_TEST(res->time == model::timestamp(start_offset));
         BOOST_TEST(res->offset == start_offset);
@@ -223,13 +223,13 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
       ss::default_priority_class(),
       std::nullopt);
 
-    auto empty_res = log->timequery(config).get0();
+    auto empty_res = log->timequery(config).get();
     BOOST_TEST(!empty_res);
 
     // ask for 999 it should return first segment
     config.time = model::timestamp(999);
 
-    auto res = log->timequery(config).get0();
+    auto res = log->timequery(config).get();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1000));
     BOOST_TEST(res->offset == model::offset(0));
@@ -265,7 +265,7 @@ FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log->timequery(config).get0();
+    auto res = log->timequery(config).get();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1600));
     BOOST_TEST(res->offset == model::offset(1));
@@ -298,7 +298,7 @@ FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log->timequery(config).get0();
+    auto res = log->timequery(config).get();
     BOOST_TEST(res);
     BOOST_TEST(res->time == model::timestamp(1000));
     BOOST_TEST(res->offset == model::offset(0));
@@ -346,7 +346,7 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
           ss::default_priority_class(),
           std::nullopt);
 
-        auto res = log->timequery(config).get0();
+        auto res = log->timequery(config).get();
 
         if (offset == model::offset(4)) {
             // A timequery will always return from within the
@@ -372,7 +372,7 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
       ss::default_priority_class(),
       std::nullopt);
 
-    auto res = log->timequery(config).get0();
+    auto res = log->timequery(config).get();
 
     BOOST_TEST(res);
     BOOST_TEST(res->offset == model::offset(0));
@@ -414,7 +414,7 @@ FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
       std::nullopt);
 
     const auto& [expected_offset, expected_ts] = batch_spec.back();
-    auto res = log->timequery(config).get0();
+    auto res = log->timequery(config).get();
     BOOST_TEST(res);
     BOOST_TEST(res->time == expected_ts);
     BOOST_TEST(res->offset == expected_offset);

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -152,7 +152,7 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
                               to_vector_consumer(), model::no_timeout);
                         });
                   })
-                  .get0();
+                  .get();
             storage.stop().get();
             feature_table.stop().get();
             return batches;

--- a/src/v/utils/copy_range.h
+++ b/src/v/utils/copy_range.h
@@ -42,7 +42,7 @@ copy_range(Iterator begin, Iterator end, AsyncAction action, Container c) {
         if (f.failed()) {
             return ss::make_exception_future<Container>(f.get_exception());
         }
-        *i++ = f.get0();
+        *i++ = f.get();
         if (ss::need_preempt()) {
             return copy_range(
               std::move(begin),
@@ -73,7 +73,7 @@ template<typename Container, typename Iterator, typename AsyncAction>
 requires requires(AsyncAction aa, Iterator it, Container c) {
     ss::futurize_invoke(aa, *it++);
     requires ss::is_future<decltype(ss::futurize_invoke(aa, *it))>::value;
-    *std::inserter(c, c.end()) = ss::futurize_invoke(aa, *it).get0();
+    *std::inserter(c, c.end()) = ss::futurize_invoke(aa, *it).get();
 }
 inline ss::future<Container>
 copy_range(Iterator begin, Iterator end, AsyncAction action) {
@@ -103,7 +103,7 @@ requires requires(AsyncAction aa, Range r, Container c) {
     ss::futurize_invoke(aa, *r.begin());
     requires ss::is_future<decltype(ss::futurize_invoke(
       aa, *r.begin()))>::value;
-    *std::inserter(c, c.end()) = ss::futurize_invoke(aa, *r.begin()).get0();
+    *std::inserter(c, c.end()) = ss::futurize_invoke(aa, *r.begin()).get();
 }
 inline ss::future<Container> copy_range(Range& r, AsyncAction action) {
     return copy_range<Container>(std::begin(r), std::end(r), std::move(action));

--- a/src/v/utils/tests/directory_walker_test.cc
+++ b/src/v/utils/tests/directory_walker_test.cc
@@ -107,7 +107,7 @@ SEASTAR_THREAD_TEST_CASE(test_empty_dir) {
     auto dir = std::filesystem::path(
       "test.dir_" + random_generators::gen_alphanum_string(4));
     ss::recursive_touch_directory(dir.string()).get();
-    BOOST_REQUIRE(directory_walker::empty(dir).get0());
+    BOOST_REQUIRE(directory_walker::empty(dir).get());
     ss::recursive_touch_directory((dir / "xxx").string()).get();
-    BOOST_REQUIRE(!directory_walker::empty(dir).get0());
+    BOOST_REQUIRE(!directory_walker::empty(dir).get());
 }

--- a/src/v/utils/tests/remote_test.cc
+++ b/src/v/utils/tests/remote_test.cc
@@ -14,7 +14,7 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(test_free_on_right_cpu) {
-    auto p = ss::smp::submit_to(1, [] { return remote<int>(10); }).get0();
+    auto p = ss::smp::submit_to(1, [] { return remote<int>(10); }).get();
     p.get() += 1;
     ss::smp::submit_to(1, [p = std::move(p)]() mutable {
         auto local = std::move(p);
@@ -49,7 +49,7 @@ SEASTAR_THREAD_TEST_CASE(test_free_on_right_cpu_with_foreign_ptr) {
     auto p = ss::smp::submit_to(1, [] {
                  return remote<obj_with_foreign_ptr>(
                    0, ss::make_foreign(std::make_unique<int>(42)));
-             }).get0();
+             }).get();
     p.get().x += 1;
     ss::smp::submit_to(1, [p = std::move(p)]() mutable {
         auto local = std::move(p);

--- a/src/v/utils/tests/retry_test.cc
+++ b/src/v/utils/tests/retry_test.cc
@@ -37,14 +37,14 @@ struct retry_counter {
 SEASTAR_THREAD_TEST_CASE(retry_then_succed) {
     auto retry_count = retry_with_backoff(
                          5, retry_counter(2), std::chrono::milliseconds(1))
-                         .get0();
+                         .get();
     BOOST_REQUIRE_EQUAL(retry_count, 3);
 };
 
 SEASTAR_THREAD_TEST_CASE(retry_then_fail) {
     BOOST_CHECK_THROW(
       retry_with_backoff(2, retry_counter(10), std::chrono::milliseconds(1))
-        .get0(),
+        .get(),
       std::logic_error);
 };
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
`get0` has been deprecated in the latest versions of seastar. This PR removes all uses of it from Redpanda's codebase so we can build against the latest seastar version without having to ignore deprecation errors.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
