### PR TITLE
rpk: brokers list exposing Host/Port/Rack/UUID

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.59.1
-	github.com/redpanda-data/common-go/rpadmin v0.1.6
+	github.com/redpanda-data/common-go/rpadmin v0.1.7
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.4.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -208,8 +208,8 @@ github.com/prometheus/common v0.59.1 h1:LXb1quJHWm1P6wq/U824uxYi4Sg0oGvNeUm1z5dJ
 github.com/prometheus/common v0.59.1/go.mod h1:GpWM7dewqmVYcd7SmRaiWVe9SSqjf0UrwnYnpEZNuT0=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.6 h1:OpKO0h5unnZq8n1RJ3G6Hr8HT8ff/Ma0or5X1BNIMcM=
-github.com/redpanda-data/common-go/rpadmin v0.1.6/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
+github.com/redpanda-data/common-go/rpadmin v0.1.7 h1:zj3HiZuvAdOvOdi7oyTn4FYOPulO7BhvhLx9acOy810=
+github.com/redpanda-data/common-go/rpadmin v0.1.7/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
@@ -1,20 +1,44 @@
 package brokers
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	return &cobra.Command{
+	var decom bool
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List the brokers in your cluster",
-		Args:    cobra.ExactArgs(0),
+		Long: `List the brokers in your cluster.
+
+This command lists all brokers in the cluster, active and inactive, unless they have been decommissioned.
+Using the "--include-decommissioned" flag, it lists decommissioned brokers with associated UUIDs too.
+
+The output table contains the following columns:
+
+ID               Node ID, an exclusive identifier for a broker
+HOST             Internal RPC address for communication between brokers
+PORT             Internal RPC port for communication between brokers
+RACK             Assigned rack ID
+CORES            Number of cores (shards) on a broker
+MEMBERSHIP       Whether a broker is decommissioned or not
+IS-ALIVE         Whether a broker is alive or offline
+VERSION          Broker version
+UUID (Optional)  Additional exclusive identifier for a broker
+
+NOTE: The UUID column is hidden when the cluster doesn't expose the UUID in the Admin API, or the API call fails to retrieve UUIDs.
+`,
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
@@ -26,27 +50,82 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			bs, err := cl.Brokers(cmd.Context())
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
-			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
+			headers := []string{"ID", "Host", "Port", "Rack", "Cores", "Membership", "Is-Alive", "Version"}
 
 			args := func(b *rpadmin.Broker) []interface{} {
-				ret := []interface{}{b.NodeID, b.NumCores, b.MembershipStatus}
+				version, _ := redpanda.VersionFromString(b.Version)
+				ret := []interface{}{b.NodeID, b.InternalRPCAddress, b.InternalRPCPort, formatOutput(b.Rack), b.NumCores, b.MembershipStatus, *b.IsAlive, formatOutput(version.String())}
 				return ret
 			}
-			for _, b := range bs {
-				if b.IsAlive != nil {
-					headers = append(headers, "Is-Alive", "Broker-Version")
-					orig := args
-					args = func(b *rpadmin.Broker) []interface{} {
-						return append(orig(b), *b.IsAlive, b.Version)
-					}
-					break
+
+			idUUIDMapping, err := cl.GetBrokerUuids(cmd.Context())
+			if err != nil {
+				fmt.Printf("unable to retrieve node UUIDs: %v", err)
+			}
+			if idUUIDMapping != nil {
+				headers = append(headers, "UUID")
+				org := args
+				args = func(b *rpadmin.Broker) []interface{} {
+					return append(org(b), mapUUID(b.NodeID, idUUIDMapping))
 				}
 			}
+
 			tw := out.NewTable(headers...)
 			defer tw.Flush()
 			for _, b := range bs {
 				tw.Print(args(&b)...)
 			}
+
+			if decom && idUUIDMapping != nil {
+				decomNodes := extractDecomNodes(bs, idUUIDMapping)
+				for _, b := range decomNodes {
+					tw.Print(b.NodeID, "-", "-", "-", "-", "-", "-", "-", b.UUID)
+				}
+			}
 		},
 	}
+	cmd.Flags().BoolVarP(&decom, "include-decommissioned", "d", false, "If true, include decommissioned brokers")
+	return cmd
+}
+
+// mapUUID returns a UUID from "mapping" which node ID maps to "nodeID".
+func mapUUID(nodeID int, mapping []rpadmin.BrokerUuids) string {
+	var UUIDs []string
+	for _, node := range mapping {
+		if nodeID == node.NodeID {
+			UUIDs = append(UUIDs, node.UUID)
+		}
+	}
+	if len(UUIDs) == 0 {
+		return "-"
+	}
+	return strings.Join(UUIDs, ", ")
+}
+
+// extractDecomNodes compares and returns nodes in brokerUUIDs (with UUIDs) not in brokers.
+func extractDecomNodes(brokers []rpadmin.Broker, brokerUUIDs []rpadmin.BrokerUuids) []rpadmin.BrokerUuids {
+	activeNodeMap := make(map[int]bool)
+
+	for _, br := range brokers {
+		activeNodeMap[br.NodeID] = true
+	}
+
+	var decomNodes []rpadmin.BrokerUuids
+	for _, bu := range brokerUUIDs {
+		if !activeNodeMap[bu.NodeID] {
+			decomNodes = append(decomNodes, rpadmin.BrokerUuids{
+				NodeID: bu.NodeID,
+				UUID:   bu.UUID,
+			})
+		}
+	}
+
+	return decomNodes
+}
+
+func formatOutput(s string) string {
+	if s == "" || s == "0.0.0" {
+		return "-"
+	}
+	return s
 }


### PR DESCRIPTION
Relevant to https://github.com/redpanda-data/common-go/pull/27.

`rpk redpanda admin brokers list` now exposes additional fields that makes troubleshooting easier.

Before:
```
NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
0        2          active             true      v24.2.3 - be49068f63acc31d34b9d186cdfa62087fd99222
1        2          active             true      v24.2.3 - be49068f63acc31d34b9d186cdfa62087fd99222
2        2          active             true      v24.2.3 - be49068f63acc31d34b9d186cdfa62087fd99222
```

After:
```
ID    HOST       PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
0     localhost  33146  a     2      active      true      24.2.3   e4ff0f11-6fc2-4df1-b129-bbf2630e7c18
1     localhost  33147  -     2      active      true      24.2.3   8b4649c4-7a92-4818-a93e-a3a244fad6e5
3     localhost  33148  -     2      active      true      24.2.3   b00efb2e-6beb-46b1-86f8-6fa2566bfa9b
```
It uses the fairly new `/v1/broker_uuids` endpoint for the UUID field. If a cluster doesn't support the endpoint, the command just hide the column. 

If multiple node UUIDs being found for a node ID, the command prints all with a comma separated fashion in the same row. It could happen when a new node joins the cluster using the same node ID, e.g. being hard-corded in redpanda.yaml. This is not encouraged though.

```
ID    HOST       PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
0     localhost  33146  a     2      active      true      24.2.3   e4ff0f11-6fc2-4df1-b129-bbf2630e7c18
1     localhost  33147  -     2      active      true      24.2.3   8b4649c4-7a92-4818-a93e-a3a244fad6e5
3     localhost  33148  -     2      active      true      24.2.3   b00efb2e-6beb-46b1-86f8-6fa2566bfa9b, 88fc966d-1b6c-470b-beb7-fa3ba162f998
```

With the new `--include-decommissioned` flag, it can list all decommissioned brokers along with its ID and UUID. This is useful when we deal with the `node_id_overrides` feature, https://github.com/redpanda-data/redpanda/pull/22972

```
ID    HOST       PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
0     localhost  33146  a     2      active      true      24.2.3   e4ff0f11-6fc2-4df1-b129-bbf2630e7c18
1     localhost  33147  -     2      active      true      24.2.3   8b4649c4-7a92-4818-a93e-a3a244fad6e5
3     localhost  33148  -     2      active      true      24.2.3   b00efb2e-6beb-46b1-86f8-6fa2566bfa9b, 88fc966d-1b6c-470b-beb7-fa3ba162f998
2     -          -      -     -      -           -         -        d671a64b-02c2-4bbf-8437-73deac4db43a
```

Added a detailed help text too.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* rpk: `redpanda admin brokers list` exposes Host/Port/Rack/UUID additionally


