### PR TITLE
ssx/async_algorithm: avoid std::for_each to honor [[nodiscard]]

### DIFF
--- a/src/v/ssx/async_algorithm.h
+++ b/src/v/ssx/async_algorithm.h
@@ -106,7 +106,9 @@ template<std::random_access_iterator I, typename Fn>
 iter_size<I> for_each_limit(const I begin, const I end, ssize_t limit, Fn f) {
     auto chunk_size = std::min(limit, end - begin);
     I chunk_end = begin + chunk_size;
-    std::for_each(begin, chunk_end, std::move(f));
+    for (I i = begin; i != chunk_end; ++i) {
+        f(*i);
+    }
     return {chunk_end, chunk_size};
 }
 


### PR DESCRIPTION
`std::for_each` does not honor `[[nodiscard]]` attributes of functions or return types. Avoiding it to guard from mistakes like passing a future-returning function to `ssx::async_for_each`. `ss::future` is marked `[[nodiscard]]` in Seastar.

separated from https://github.com/redpanda-data/redpanda/pull/23556

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
