### PR TITLE
Fixed a busy loop that was happening when expiring producer state from consumer groups

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3110,6 +3110,10 @@ void group::maybe_rearm_timer() {
     if (earliest_deadline) {
         auto deadline = std::min(
           earliest_deadline.value(), clock_type::now() + _abort_interval_ms);
+        // never arm the next timer to be earlier than 500ms from now to prevent
+        // busy looping
+        deadline = std::max(
+          clock_type::now() + _abort_interval_ms / 10, deadline);
         try_arm(deadline);
     }
 }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3131,23 +3131,40 @@ ss::future<> group::do_abort_old_txes() {
 
         expired.insert(model::producer_identity{pid, producer.epoch});
     }
-
+    bool has_error = false;
     for (auto pid : expired) {
-        co_await try_abort_old_tx(pid);
+        auto ec = co_await try_abort_old_tx(pid);
+        if (ec != cluster::tx::errc::none) {
+            has_error = true;
+        }
     }
 
-    maybe_rearm_timer();
+    if (!has_error) {
+        // if no error was triggered during abort of transaction we may try to
+        // schedule a next expiration earlier if there are transactions pending
+        // to be expired
+        maybe_rearm_timer();
+    }
 }
 
-ss::future<> group::try_abort_old_tx(model::producer_identity pid) {
-    return get_tx_lock(pid.get_id())->with([this, pid]() {
-        vlog(
-          _ctx_txlog.info,
-          "attempting expiration of producer: {} transaction",
-          pid);
+ss::future<cluster::tx::errc>
+group::try_abort_old_tx(model::producer_identity pid) {
+    auto lock = get_tx_lock(pid.get_id());
+    auto u = co_await lock->get_units();
+    vlog(
+      _ctx_txlog.info,
+      "attempting expiration of producer: {} transaction",
+      pid);
 
-        return do_try_abort_old_tx(pid).discard_result();
-    });
+    auto result = co_await do_try_abort_old_tx(pid);
+    vlogl(
+      _ctx_txlog,
+      result == cluster::tx::errc::none ? ss::log_level::trace
+                                        : ss::log_level::warn,
+      "producer {} transaction expiration result: {}",
+      pid,
+      result);
+    co_return result;
 }
 
 ss::future<cluster::tx::errc>

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -871,7 +871,7 @@ private:
 
     void abort_old_txes();
     ss::future<> do_abort_old_txes();
-    ss::future<> try_abort_old_tx(model::producer_identity);
+    ss::future<cluster::tx::errc> try_abort_old_tx(model::producer_identity);
     ss::future<cluster::tx::errc> do_try_abort_old_tx(model::producer_identity);
     void try_arm(time_point_type);
     void maybe_rearm_timer();


### PR DESCRIPTION
When transaction is expired due to a timeout a group coordinator issues
a request to a transaction coordinator to abort the transaction. The
operation may fail as the currently known coordinator may not be a
leader or the request may timeout.
The result of transaction abort operation was previously ignored. This
lead to a situation in which an error when aborting transaction lead to
a tight loop in group coordinator as it instantly dispatched another
abort retry. With the fix the error when aborting ongoing transaction is
not ignored but rather than that if an error happened it is logged with
warn severity and the coordinator waits for the next scheduled timer
ticked (by default ten seconds) before retrying.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes possible high CPU utilisation caused by transactional coordinator leadership changes