### PR TITLE
Added missing Avro values and schema conversion

### DIFF
--- a/src/v/iceberg/schema_avro.cc
+++ b/src/v/iceberg/schema_avro.cc
@@ -69,9 +69,12 @@ struct avro_primitive_type_visitor {
     avro::Schema operator()(const decimal_type& type) {
         auto bytes_for_p = static_cast<int>(
           std::ceil((type.precision * std::log2(10) + 1) / 8));
-        auto ret = avro::FixedSchema(bytes_for_p, "");
-        ret.root()->setLogicalType(
-          avro::LogicalType(avro::LogicalType::DECIMAL));
+        auto ret = avro::FixedSchema(bytes_for_p, "decimal");
+        avro::LogicalType l_type(avro::LogicalType::DECIMAL);
+        l_type.setPrecision(type.precision);
+        l_type.setScale(type.scale);
+        ret.root()->setLogicalType(l_type);
+
         return ret;
     }
     avro::Schema operator()(const date_type&) {
@@ -105,7 +108,8 @@ struct avro_primitive_type_visitor {
         return ret;
     }
     avro::Schema operator()(const fixed_type& type) {
-        auto ret = avro::FixedSchema(static_cast<int>(type.length), "");
+        auto ret = avro::FixedSchema(
+          static_cast<int>(type.length), "fixed_bytes");
         return ret;
     }
     avro::Schema operator()(const binary_type&) { return avro::BytesSchema(); }
@@ -313,8 +317,18 @@ field_type type_from_avro(const avro::NodePtr& n) {
     case avro::AVRO_UNION:
         // NOTE: should be handled by maybe_optional_from_avro().
         throw std::invalid_argument("Avro union type not supported");
-    case avro::AVRO_FIXED:
+    case avro::AVRO_FIXED: {
+        auto logical_type = n->logicalType();
+        if (logical_type.type() == avro::LogicalType::DECIMAL) {
+            // casting to uint32_t should be safe, the only reason the values
+            // are signed is that unsigned counterparts are missing in java.
+            return decimal_type{
+              .precision = static_cast<uint32_t>(logical_type.precision()),
+              .scale = static_cast<uint32_t>(logical_type.scale()),
+            };
+        }
         return fixed_type{n->fixedSize()};
+    }
     case avro::AVRO_SYMBOLIC:
         throw std::invalid_argument("Avro symbolic type not supported");
     case avro::AVRO_UNKNOWN:

--- a/src/v/iceberg/tests/test_schemas.cc
+++ b/src/v/iceberg/tests/test_schemas.cc
@@ -59,8 +59,26 @@ field_type test_nested_schema_type() {
       nested_field::create(17, "age", field_required::yes, int_type{}));
     nested_struct.fields.emplace_back(nested_field::create(
       15, "person", field_required::no, std::move(person_struct)));
+
     field_type nested_type = std::move(nested_struct);
     return nested_type;
+}
+
+field_type test_nested_schema_type_avro() {
+    auto t = test_nested_schema_type();
+    auto s_type = std::get<struct_type>(std::move(t));
+    s_type.fields.emplace_back(nested_field::create(
+      18,
+      "some_decimal",
+      field_required::no,
+      decimal_type{.precision = 10, .scale = 2}));
+
+    s_type.fields.emplace_back(nested_field::create(
+      19, "the_fixed_64_bytes", field_required::no, fixed_type{.length = 64}));
+
+    s_type.fields.emplace_back(
+      nested_field::create(20, "an_uuid", field_required::no, uuid_type{}));
+    return s_type;
 }
 
 // Schema taken from

--- a/src/v/iceberg/tests/test_schemas.h
+++ b/src/v/iceberg/tests/test_schemas.h
@@ -15,6 +15,10 @@ namespace iceberg {
 // Expected type from test_nested_schema_json_str.
 field_type test_nested_schema_type();
 
+// Contains additional fields that are currently supported by avro:
+// decimals, fixed and UUID
+field_type test_nested_schema_type_avro();
+
 // Nested schema taken from
 // https://github.com/apache/iceberg-go/blob/704a6e78c13ea63f1ff4bb387f7d4b365b5f0f82/schema_test.go#L644
 extern const char* test_nested_schema_json_str;

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -100,7 +100,8 @@ struct generating_primitive_value_visitor {
         }
         switch (spec_.pattern) {
         case value_pattern::zeros:
-            return fixed_value{iobuf{}};
+            return fixed_value{
+              bytes_to_iobuf(bytes::from_string(std::string(t.length, 0)))};
         case value_pattern::random:
             return fixed_value{random_generators::make_iobuf(t.length)};
         }

--- a/src/v/iceberg/tests/value_generator.cc
+++ b/src/v/iceberg/tests/value_generator.cc
@@ -55,8 +55,11 @@ struct generating_primitive_value_visitor {
           spec_.forced_num_val.value_or(generate_numeric_val()))};
     }
     value operator()(const decimal_type&) {
+        if (spec_.forced_num_val) {
+            return decimal_value{absl::MakeInt128(0, generate_numeric_val())};
+        }
         return decimal_value{
-          spec_.forced_num_val.value_or(generate_numeric_val())};
+          absl::MakeInt128(generate_numeric_val(), generate_numeric_val())};
     }
     value operator()(const date_type&) {
         return date_value{static_cast<int>(

--- a/src/v/iceberg/tests/values_avro_test.cc
+++ b/src/v/iceberg/tests/values_avro_test.cc
@@ -18,7 +18,7 @@
 using namespace iceberg;
 
 TEST(ValuesAvroTest, TestZeroVals) {
-    auto schema_field_type = test_nested_schema_type();
+    auto schema_field_type = test_nested_schema_type_avro();
     auto schema = struct_type_to_avro(
       std::get<struct_type>(schema_field_type), "nested");
     auto zero_val = tests::make_value({}, schema_field_type);
@@ -34,7 +34,7 @@ TEST(ValuesAvroTest, TestZeroVals) {
 
 TEST(ValuesAvroTest, TestRandomVals) {
     constexpr int num_iterations = 10;
-    auto schema_field_type = test_nested_schema_type();
+    auto schema_field_type = test_nested_schema_type_avro();
     auto schema = struct_type_to_avro(
       std::get<struct_type>(schema_field_type), "nested");
 

--- a/src/v/iceberg/values_avro.cc
+++ b/src/v/iceberg/values_avro.cc
@@ -39,6 +39,23 @@ void maybe_throw_wrong_type(
     }
 }
 
+void maybe_throw_wrong_logical_type(
+  const avro::LogicalType& expected, const avro::LogicalType& actual) {
+    if (
+      expected.type() != actual.type() || expected.scale() != actual.scale()
+      || expected.precision() != actual.precision()) {
+        throw std::invalid_argument(fmt::format(
+          "Expected (type: {}, precision: {}, scale: {}) logical_type but got: "
+          "(type: {}, precision: {}, scale: {})",
+          expected.type(),
+          expected.precision(),
+          expected.scale(),
+          actual.type(),
+          actual.precision(),
+          actual.scale()));
+    }
+}
+
 // Throws an exception if the given schema isn't valid for the given type.
 void maybe_throw_invalid_schema(
   const avro::NodePtr& actual_schema, const avro::Type& expected_type) {
@@ -50,9 +67,7 @@ void maybe_throw_invalid_schema(
     const auto& actual_type = actual_schema->type();
     maybe_throw_wrong_type(expected_type, actual_type);
 }
-// XXX: need to figure out how to correctly instantiate avro::GenericFixed to
-// support the unimplemented fields. Or move to an impl that uses iobufs. Throw
-// for now.
+
 struct primitive_value_avro_visitor {
     explicit primitive_value_avro_visitor(const avro::NodePtr& avro_schema)
       : avro_schema_(avro_schema) {}
@@ -113,11 +128,23 @@ struct primitive_value_avro_visitor {
         }
         return {data};
     }
-    avro::GenericDatum operator()(const decimal_value&) {
-        throw std::invalid_argument("XXX decimal not implemented");
+    avro::GenericDatum operator()(const decimal_value& v) {
+        std::vector<uint8_t> bytes(16);
+        auto low = absl::Int128Low64(v.val);
+        auto high = absl::Int128High64(v.val);
+        // Store in big-endian order (most significant byte at index 0)
+        for (size_t i = 0; i < 8; ++i) {
+            bytes[i + 8] = static_cast<uint8_t>(low >> ((7 - i) * 8));
+            bytes[i] = static_cast<uint8_t>(high >> ((7 - i) * 8));
+        }
+
+        return {avro_schema_, avro::GenericFixed(avro_schema_, bytes)};
     }
-    avro::GenericDatum operator()(const fixed_value&) {
-        throw std::invalid_argument("XXX fixed not implemented");
+    avro::GenericDatum operator()(const fixed_value& fixed) {
+        std::vector<uint8_t> bytes(fixed.val.size_bytes());
+        iobuf::iterator_consumer it(fixed.val.cbegin(), fixed.val.cend());
+        it.consume_to(fixed.val.size_bytes(), bytes.data());
+        return {avro_schema_, avro::GenericFixed(avro_schema_, bytes)};
     }
     avro::GenericDatum operator()(const uuid_value&) {
         throw std::invalid_argument("XXX uuid not implemented");
@@ -289,8 +316,22 @@ struct primitive_value_parsing_visitor {
         maybe_throw_wrong_type(data_.type(), avro::AVRO_STRING);
         return string_value{iobuf::from(data_.value<std::string>())};
     }
-    value operator()(const fixed_type&) {
-        throw std::invalid_argument("XXX fixed not implemented");
+    value operator()(const fixed_type& schema_type) {
+        maybe_throw_wrong_type(data_.type(), avro::AVRO_FIXED);
+        auto lt = avro::LogicalType(avro::LogicalType::NONE);
+        maybe_throw_wrong_logical_type(data_.logicalType(), lt);
+
+        const auto& v = data_.value<avro::GenericFixed>().value();
+        if (v.size() != schema_type.length) {
+            throw std::invalid_argument(fmt::format(
+              "Fixed type length mismatch, schema length: {}, current value "
+              "length: {}",
+              schema_type.length,
+              v.size()));
+        }
+        iobuf b;
+        b.append(v.data(), v.size());
+        return fixed_value{.val = std::move(b)};
     }
     value operator()(const uuid_type&) {
         throw std::invalid_argument("XXX uuid not implemented");
@@ -302,8 +343,29 @@ struct primitive_value_parsing_visitor {
         b.append(v.data(), v.size());
         return binary_value{std::move(b)};
     }
-    value operator()(const decimal_type&) {
-        throw std::invalid_argument("XXX decimal not implemented");
+    value operator()(const decimal_type& dt) {
+        maybe_throw_wrong_type(data_.type(), avro::AVRO_FIXED);
+        auto lt = avro::LogicalType(avro::LogicalType::DECIMAL);
+        lt.setPrecision(dt.precision);
+        lt.setScale(dt.scale);
+        maybe_throw_wrong_logical_type(data_.logicalType(), lt);
+        const auto& v = data_.value<avro::GenericFixed>().value();
+        if (v.size() > 16) {
+            throw std::invalid_argument(fmt::format(
+              "decimals with more than 16 bytes are not supported, current "
+              "value size: {}",
+              v.size()));
+        }
+        int64_t high_half{0};
+        uint64_t low_half{0};
+        for (size_t i = 0; i < std::min<size_t>(v.size(), 8); ++i) {
+            high_half |= int64_t(v[i]) << (7 - i) * 8;
+        };
+        for (size_t i = 8; i < std::min<size_t>(v.size(), 16); ++i) {
+            low_half |= uint64_t(v[i]) << (15 - i) * 8;
+        };
+
+        return decimal_value{.val = absl::MakeInt128(high_half, low_half)};
     }
 };
 


### PR DESCRIPTION
Added Avro schema and value conversion for UUID, fixed length byte array and decimal types. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none