### PR TITLE
gha: fix /backport command

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         id: backport_commits
         run: |
-          backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --paginate --jq '.[].sha[0:10]')
+          backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")')
           echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: needs.backport-type.outputs.commented_on == 'pr'


### PR DESCRIPTION
jira: [PESDLC-2118]

The `/backport` command is [broken](https://github.com/redpanda-data/redpanda/actions/runs/11115132569/job/30882995089#step:9:26) if there is more than 1 commit in a PR because the list of git commits have newlines:
```
bash$ backport_commits=$(gh api "repos/redpanda-data/redpanda/pulls/23492/commits" --paginate --jq '.[].sha[0:10]')
bash$ echo "backport_commits=$backport_commits"
backport_commits=c254729c5a
9a5f7d7d58
2bc21e9516
c9223a24ae
```

This patch fixes by having the commits separated by spaces:
```
bash$ backport_commits=$(gh api "repos/redpanda-data/redpanda/pulls/23492/commits" --paginate --jq '[.[].sha[0:10]]|join(" ")')
bash$ echo "backport_commits=$backport_commits"
backport_commits=c254729c5a 9a5f7d7d58 2bc21e9516 c9223a24ae
```

see https://github.com/redpanda-data/redpanda/pull/23492#issuecomment-2384291012

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[PESDLC-2118]: https://redpandadata.atlassian.net/browse/PESDLC-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ