### PR TITLE
cst/inv/ducktape: Remove inventory report from test

### DIFF
--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -7,15 +7,12 @@
 # https: // github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
 import collections
-import csv
-import gzip
 import itertools
 import json
 import random
 import re
 import time
 from dataclasses import dataclass
-from io import StringIO
 from typing import DefaultDict, Optional, Tuple
 
 from ducktape.mark import matrix
@@ -28,7 +25,7 @@ from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import SISettings, get_cloud_storage_type, MetricsEndpoint, CloudStorageType
+from rptest.services.redpanda import SISettings, get_cloud_storage_type, MetricsEndpoint
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_result
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
@@ -206,9 +203,6 @@ class CloudStorageScrubberTest(RedpandaTest):
                 # the deleted segment and remove the gap
                 "cloud_storage_enable_segment_merging": False,
                 "cloud_storage_spillover_manifest_size": None,
-                "cloud_storage_inventory_based_scrub_enabled": True,
-                "cloud_storage_inventory_self_managed_report_config": True,
-                "cloud_storage_inventory_report_check_interval_ms": 10000
             },
             si_settings=SISettings(
                 test_context,
@@ -220,41 +214,6 @@ class CloudStorageScrubberTest(RedpandaTest):
         self.bucket_name = self.si_settings.cloud_storage_bucket
         self.rpk = RpkTool(self.redpanda)
         self.expected_error_logs = []
-
-    def _produce_inventory_report(self):
-        data = StringIO()
-        writer = csv.writer(data)
-
-        # Change segment names before adding to data set. As the segment to be dropped is computed later,
-        # at this time its name is not known. If it is present in the data set, it will not be checked in
-        # the bucket and the anomaly will never be generated. This report simply exists as a sanity check
-        # that the scrubber works as expected when the inventory data set is empty. We do not altogether
-        # skip adding the segment, because we still want the data set to be present on disk, so that the
-        # scrubber loads the data and performs segment checks. The presence of the changed segment name
-        # causes the NTP hash dir to be created on disk.
-        # TODO add more assertions once metrics for scrubber run are added
-        for obj in self.cloud_storage_client.list_objects(self.bucket_name):
-            if "log" in obj.key:
-                writer.writerow([self.bucket_name, obj.key + "-change-name"])
-        self.cloud_storage_client.put_object(
-            self.si_settings.cloud_storage_bucket,
-            "report.gz",
-            gzip.compress(data.getvalue().encode()),
-            is_bytes=True)
-
-        root_path = f'redpanda_scrubber_inventory/{self.si_settings.cloud_storage_bucket}/redpanda_scrubber_inventory'
-
-        manifest_json_path = f'{root_path}/2099-09-09T11-11Z/manifest.json'
-        manifest_checksum_path = f'{root_path}/2099-09-09T11-11Z/manifest.checksum'
-
-        self.cloud_storage_client.put_object(
-            self.si_settings.cloud_storage_bucket, manifest_json_path,
-            """{"files": [{
-                "key": "report.gz"
-            }]}""")
-
-        self.cloud_storage_client.put_object(
-            self.si_settings.cloud_storage_bucket, manifest_checksum_path, '')
 
     def _produce(self):
         # Use a smaller working set for debug builds to keep the test timely
@@ -677,11 +636,6 @@ class CloudStorageScrubberTest(RedpandaTest):
 
         self._produce()
         self._assert_no_anomalies()
-
-        # Add an inv. report to the bucket. This will have some keys missing, but scrubbing
-        # should still proceed as expected because HTTP calls will be made when keys are not
-        # found in report.
-        self._produce_inventory_report()
 
         self._delete_spillover_manifest_and_await_anomaly(expected_anomalies)
         self._delete_segment_and_await_anomaly(expected_anomalies)


### PR DESCRIPTION
The test became flaky since adding an inventory report. The cause of the flakiness is leadership transfer during test and the constraint we apply that one report is only processed by a node once. Consider the following scenario:

* Node A leaders partition p1. Node B leads some other partitions.
* Both nodes process the latest report R.
* p1 moves leadership to B. Now despite the test having a short check interval for the report, we only create R once in the test, so B will never process R again.
* On the next scrub, B will not have the data for p1, because when R was processed, rows for p1 were skipped by B, as it did not lead p1 then.
* As data is missing, the scrub will not check for the segment existence, thus not finding anomaly and breaking the test.

The solution is for inv. service on each node to maintain a delta of partition leaderships. If we gain new partitions then we should process the report again for those partitions, so we can next scrub with latest data for the partitions.

This is a mechanically trivial change but will require some time to implement, to avoid the flakiness right now the test is reverted to a state before the changes related to inventory report were introduced.

Once the delta related changes are in place the test can be extended again to cover inventory based scenario.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
