### PR TITLE
[v24.2.x] Fixed a busy loop that was happening when expiring producer state from consumer groups

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3054,6 +3054,10 @@ void group::maybe_rearm_timer() {
     if (earliest_deadline) {
         auto deadline = std::min(
           earliest_deadline.value(), clock_type::now() + _abort_interval_ms);
+        // never arm the next timer to be earlier than 500ms from now to prevent
+        // busy looping
+        deadline = std::max(
+          clock_type::now() + _abort_interval_ms / 10, deadline);
         try_arm(deadline);
     }
 }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3075,23 +3075,40 @@ ss::future<> group::do_abort_old_txes() {
 
         expired.insert(model::producer_identity{pid, producer.epoch});
     }
-
+    bool has_error = false;
     for (auto pid : expired) {
-        co_await try_abort_old_tx(pid);
+        auto ec = co_await try_abort_old_tx(pid);
+        if (ec != cluster::tx::errc::none) {
+            has_error = true;
+        }
     }
 
-    maybe_rearm_timer();
+    if (!has_error) {
+        // if no error was triggered during abort of transaction we may try to
+        // schedule a next expiration earlier if there are transactions pending
+        // to be expired
+        maybe_rearm_timer();
+    }
 }
 
-ss::future<> group::try_abort_old_tx(model::producer_identity pid) {
-    return get_tx_lock(pid.get_id())->with([this, pid]() {
-        vlog(
-          _ctx_txlog.info,
-          "attempting expiration of producer: {} transaction",
-          pid);
+ss::future<cluster::tx::errc>
+group::try_abort_old_tx(model::producer_identity pid) {
+    auto lock = get_tx_lock(pid.get_id());
+    auto u = co_await lock->get_units();
+    vlog(
+      _ctx_txlog.info,
+      "attempting expiration of producer: {} transaction",
+      pid);
 
-        return do_try_abort_old_tx(pid).discard_result();
-    });
+    auto result = co_await do_try_abort_old_tx(pid);
+    vlogl(
+      _ctx_txlog,
+      result == cluster::tx::errc::none ? ss::log_level::trace
+                                        : ss::log_level::warn,
+      "producer {} transaction expiration result: {}",
+      pid,
+      result);
+    co_return result;
 }
 
 ss::future<cluster::tx::errc>

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -869,7 +869,7 @@ private:
 
     void abort_old_txes();
     ss::future<> do_abort_old_txes();
-    ss::future<> try_abort_old_tx(model::producer_identity);
+    ss::future<cluster::tx::errc> try_abort_old_tx(model::producer_identity);
     ss::future<cluster::tx::errc> do_try_abort_old_tx(model::producer_identity);
     void try_arm(time_point_type);
     void maybe_rearm_timer();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23599
