### PR TITLE
ct: Add L0 read path

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -3,6 +3,7 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = [
     "//src/v/cloud_topics/batcher:__pkg__",
     "//src/v/cloud_topics/batcher/tests:__pkg__",
+    "//src/v/cloud_topics/reader:__pkg__",
     "//src/v/cloud_topics/tests:__pkg__",
 ])
 

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -4,6 +4,7 @@ package(default_visibility = [
     "//src/v/cloud_topics/batcher:__pkg__",
     "//src/v/cloud_topics/batcher/tests:__pkg__",
     "//src/v/cloud_topics/reader:__pkg__",
+    "//src/v/cloud_topics/reader/tests:__pkg__",
     "//src/v/cloud_topics/tests:__pkg__",
 ])
 

--- a/src/v/cloud_topics/README.md
+++ b/src/v/cloud_topics/README.md
@@ -1,0 +1,17 @@
+### Missing bits
+
+* In the write path we should populate batch cache with `raft_data` batches
+  instead of `dl_placeholder` batches. Currently, the `dl_placeholder` batches
+  are replicated and so they're added to the batch cache. If we want low to
+  achieve low latency for tailing consumers we need to make sure that they're
+  reading from the batch cache.
+* Reader caching. Currently, the code just consumes from the partition and then
+  creates a `placeholder_extent` for every `dl_placeholder` batch. Then the
+  extent gets materialized (which involves expensive I/O). The data pulled by
+  the `placeholder_extent` contains information that belongs to different NTPs
+  but the reader only uses one that belongs to the NTP from which it's reading
+  from. We need to cache L0 objects in memory so the data will be reused.
+* Resource usage limitations. There should be a mechanism to limit memory use,
+  inbound and outbound network and disk bandwidth. This will probably look like
+  a per-shard token bucket for every resource. We should also limit retries in
+  case of errors in a centralized way (circuit breaker or token bucket).

--- a/src/v/cloud_topics/batcher/aggregator.cc
+++ b/src/v/cloud_topics/batcher/aggregator.cc
@@ -64,9 +64,7 @@ void make_dl_placeholder_batches(
         };
 
         storage::record_batch_builder builder(
-          model::record_batch_type::
-            version_fence /*TODO: use dl_placeholder batch type*/,
-          b.base);
+          model::record_batch_type::dl_placeholder, b.base);
 
         // TX data (producer id, control flag) are not copied from 'src' yet.
 

--- a/src/v/cloud_topics/errc.h
+++ b/src/v/cloud_topics/errc.h
@@ -16,8 +16,13 @@ namespace experimental::cloud_topics {
 enum class errc : int16_t {
     success,
     timeout,
-    upload_failure,
-    shutting_down,
+    upload_failure,     // Generic upload error
+    shutting_down,      // Umbrella shutdown error
+    cache_read_error,   // Failed to read data from cache
+    cache_write_error,  // Failed to write data to the cache
+    download_not_found, // 404 response during the download
+    download_failure,   // Generic download failure
+    slow_down,          // Cloud-storage throttling response
     unexpected_failure,
 };
 
@@ -34,6 +39,16 @@ struct errc_category final : public std::error_category {
             return "upload_failure";
         case errc::shutting_down:
             return "shutting_down";
+        case errc::cache_read_error:
+            return "cache_read_error";
+        case errc::cache_write_error:
+            return "cache_write_error";
+        case errc::download_not_found:
+            return "download_not_found";
+        case errc::download_failure:
+            return "download_failure";
+        case errc::slow_down:
+            return "slow_down";
         case errc::unexpected_failure:
             return "unexpected_failure";
         }

--- a/src/v/cloud_topics/reader/BUILD
+++ b/src/v/cloud_topics/reader/BUILD
@@ -34,3 +34,29 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "placeholder_extent_reader",
+    srcs = [
+        "placeholder_extent_reader.cc",
+    ],
+    hdrs = [
+        "placeholder_extent_reader.h",
+    ],
+    include_prefix = "cloud_topics/reader",
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_io:basic_cache_service_api",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:placeholder",
+        "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/reader:placeholder_extent",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/storage",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reader/BUILD
+++ b/src/v/cloud_topics/reader/BUILD
@@ -1,0 +1,36 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = ["//src/v/cloud_topics/reader/tests:__pkg__"])
+
+redpanda_cc_library(
+    name = "placeholder_extent",
+    srcs = [
+        "placeholder_extent.cc",
+    ],
+    hdrs = [
+        "placeholder_extent.h",
+    ],
+    include_prefix = "cloud_topics/reader",
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_io:basic_cache_service_api",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:placeholder",
+        "//src/v/cloud_topics:types",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/ssx:sformat",
+        "//src/v/storage",
+        "//src/v/storage:record_batch_utils",
+        "//src/v/utils:human",
+        "//src/v/utils:retry_chain_node",
+        "//src/v/utils:uuid",
+        "@abseil-cpp//absl/container:btree",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reader/placeholder_extent.cc
+++ b/src/v/cloud_topics/reader/placeholder_extent.cc
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reader/placeholder_extent.h"
+
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/io_result.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <chrono>
+
+namespace experimental::cloud_topics {
+
+/// Map error codes from one type to another
+template<class Src, class Dst>
+struct errc_converter;
+
+template<>
+struct errc_converter<cloud_io::download_result, errc> {
+    errc operator()(cloud_io::download_result r) {
+        switch (r) {
+        case cloud_io::download_result::notfound:
+            return errc::download_not_found;
+        case cloud_io::download_result::failed:
+            return errc::download_failure;
+        case cloud_io::download_result::timedout:
+            return errc::timeout;
+        case cloud_io::download_result::success:
+            return errc::success;
+        };
+    }
+};
+
+/// Convert ready future to expected<> type
+template<errc unexpected = errc::unexpected_failure, class T>
+result<T> result_from_ready_future(ss::future<T>&& ready) {
+    if (ready.failed()) {
+        auto err = ready.get_exception();
+        if (ssx::is_shutdown_exception(err)) {
+            return errc::shutting_down;
+        }
+        return unexpected;
+    }
+    return ready.get();
+}
+
+/// Convert ready future to result<> type, log unexpected
+/// exception using provided functor
+template<errc unexpected = errc::unexpected_failure, class T, class FormatFunc>
+result<T> result_from_ready_future(ss::future<T>&& ready, FormatFunc fmt) {
+    if (ready.failed()) {
+        auto err = ready.get_exception();
+        if (ssx::is_shutdown_exception(err)) {
+            return errc::shutting_down;
+        }
+        fmt(err);
+        return unexpected;
+    }
+    return ready.get();
+}
+
+/// Convert result<> type to expected<>
+///
+/// The type of the error code should be known
+template<class T, class E>
+result<T> result_convert(result<T>&& res) {
+    if (res.has_error()) {
+        errc_converter<E, errc> conv;
+        return conv(res.error());
+    }
+    return res.value();
+}
+
+template<class Clock>
+basic_placeholder_extent<Clock>::basic_placeholder_extent(
+  model::record_batch batch) {
+    base_offset = batch.base_offset();
+    iobuf payload = std::move(batch).release_data();
+    iobuf_parser parser(std::move(payload));
+    auto record = model::parse_one_record_from_buffer(parser);
+    iobuf value = std::move(record).release_value();
+    placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
+
+    L0_object = ss::make_lw_shared<hydrated_L0_object>({
+      .id = placeholder.id,
+    });
+}
+
+template<class Clock>
+model::record_batch basic_placeholder_extent<Clock>::make_raft_data_batch() {
+    auto offset = placeholder.offset;
+    auto size = placeholder.size_bytes;
+    vassert(
+      size() > model::packed_record_batch_header_size,
+      "L0 object is smaller ({}) than the batch header",
+      size());
+    auto header_bytes = L0_object->payload.share(
+      offset(), model::packed_record_batch_header_size);
+    auto records_bytes = L0_object->payload.share(
+      offset() + model::packed_record_batch_header_size,
+      size() - model::packed_record_batch_header_size);
+    auto header = storage::batch_header_from_disk_iobuf(
+      std::move(header_bytes));
+    // NOTE: the serialized raft_data batch doesn't have the offset set
+    // so we need to populate it from the placeholder batch. We also need
+    // to make sure that crc is correct.
+    header.base_offset = base_offset;
+    header.crc = model::crc_record_batch(header, records_bytes);
+    crc::crc32c crc;
+    model::crc_record_batch_header(crc, header);
+    header.header_crc = crc.value();
+    model::record_batch batch(
+      header,
+      std::move(records_bytes),
+      model::record_batch::tag_ctor_ng{}); // TODO: fix compression
+    return batch;
+}
+
+template<class Clock>
+ss::future<result<bool>> basic_placeholder_extent<Clock>::materialize(
+  cloud_storage_clients::bucket_name bucket,
+  cloud_io::remote_api<Clock>* api,
+  cloud_io::basic_cache_service_api<Clock>* cache,
+  basic_retry_chain_node<Clock>* rtc) {
+    bool hydrated = false;
+    // This iobuf contains the record batch replaced by the placeholder. It
+    // might potentially contain data that belongs to other placeholder
+    // batches and in order to get the extent of the record batch
+    // placeholder we need to use byte offset and size.
+    iobuf L0_object_content;
+
+    // 2. download object from S3
+    auto cache_file_name = std::filesystem::path(
+      ssx::sformat("{}", placeholder.id()));
+    // TODO: replace this with proper object name
+    // currently this value is used as both cloud storage name
+    // and cache name. This shouldn't necessary be the case in the
+    // future.
+
+    std::optional<cloud_io::cache_element_status> status = std::nullopt;
+    basic_retry_chain_node<Clock> is_cached_rtc(retry_strategy::backoff, rtc);
+    retry_permit rp = is_cached_rtc.retry();
+    while (rp.is_allowed && !status.has_value()) {
+        auto is_cached_result
+          = result_from_ready_future<errc::cache_read_error>(
+            co_await ss::coroutine::as_future(
+              cache->is_cached(cache_file_name)));
+
+        if (!is_cached_result.has_value()) {
+            co_return is_cached_result.error();
+        }
+
+        switch (is_cached_result.value()) {
+        case cloud_io::cache_element_status::available:
+        case cloud_io::cache_element_status::not_available:
+            status = is_cached_result.value();
+            break;
+        case cloud_io::cache_element_status::in_progress:
+            // Another fiber is trying to put value into the cache.
+            // Wait until the operation is completed but stay within the
+            // time budget.
+            if (rp.abort_source != nullptr) {
+                co_await ss::sleep_abortable(rp.delay, *rp.abort_source);
+            } else {
+                co_await ss::sleep<Clock>(rp.delay);
+            }
+            rp = is_cached_rtc.retry();
+            continue;
+        }
+    }
+
+    if (!rp.is_allowed) {
+        co_return errc::timeout;
+    }
+
+    if (
+      !status.has_value()
+      || status.value() == cloud_io::cache_element_status::available) {
+        auto res = co_await materialize_from_cache(cache_file_name, cache);
+        if (res.has_error()) {
+            co_return res.error();
+        }
+        L0_object->payload = std::move(res.value());
+    } else {
+        auto res = co_await materialize_from_cloud_storage(
+          cache_file_name, bucket, api, cache, rtc);
+        if (res.has_error()) {
+            co_return res.error();
+        }
+        L0_object->payload = std::move(res.value());
+    }
+    co_return hydrated;
+}
+
+template<class Clock>
+ss::future<result<iobuf>>
+basic_placeholder_extent<Clock>::materialize_from_cache(
+  std::filesystem::path cache_file_name,
+  cloud_io::basic_cache_service_api<Clock>* cache) {
+    iobuf result_buf;
+
+    auto buffer_size = config::shard_local_cfg().storage_read_buffer_size();
+    auto read_ahead = config::shard_local_cfg().storage_read_readahead_count();
+    auto io_priority = ss::default_priority_class(); // FIXME
+    auto fut = co_await ss::coroutine::as_future(
+      cache->get(cache_file_name, io_priority, buffer_size, read_ahead));
+    auto sz_stream_result = result_from_ready_future<errc::cache_read_error>(
+      std::move(fut));
+    if (sz_stream_result.has_error()) {
+        co_return sz_stream_result.error();
+    }
+    auto sz_stream = std::move(sz_stream_result.value());
+    if (!sz_stream.has_value()) {
+        co_return errc::cache_read_error;
+    }
+
+    auto target = make_iobuf_ref_output_stream(result_buf);
+    co_await ss::copy(sz_stream->body, target);
+    co_await sz_stream->body.close();
+    co_return result_buf;
+}
+
+template<class Clock>
+ss::future<result<iobuf>>
+basic_placeholder_extent<Clock>::materialize_from_cloud_storage(
+  std::filesystem::path cache_file_name,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_io::remote_api<Clock>* api,
+  cloud_io::basic_cache_service_api<Clock>* cache,
+  basic_retry_chain_node<Clock>* rtc) {
+    // Populate the cache
+    iobuf payload;
+    cloud_io::basic_download_request<Clock> req{
+                .transfer_details = {
+                    .bucket = bucket, 
+                    .key = cloud_storage_clients::object_key(cache_file_name), 
+                    .parent_rtc = *rtc,
+                    },
+                .display_str = "L0",
+                .payload = payload};
+
+    auto dl_result = result_from_ready_future(
+      co_await ss::coroutine::as_future(api->download_object(std::move(req))),
+      [](std::exception_ptr e) {
+          vlog(cd_log.error, "Unexpected error during L0 download: {}", e);
+      });
+
+    if (dl_result.has_error()) {
+        co_return dl_result.error();
+    }
+
+    if (dl_result.value() != cloud_io::download_result::success) {
+        errc_converter<cloud_io::download_result, errc> conv;
+        co_return conv(dl_result.value());
+    }
+
+    auto buf_str = make_iobuf_input_stream(payload.copy());
+    // TODO: use circuit-breaker here, if the operation fails
+    // repeatedly it can be temporarily short-circuited to avoid
+    // burning cycles.
+    auto sr_guard = result_from_ready_future(
+      co_await ss::coroutine::as_future(
+        cache->reserve_space(payload.size_bytes(), 1)),
+      [](std::exception_ptr e) {
+          vlog(cd_log.error, "Failed to reserve space: {}", e);
+      });
+
+    // The failure to reserve space should only trigger an error
+    // if the cause of the error is a cluster shutdown. If the
+    // failure is caused by anything else we can still return
+    // data to the client. The effect of this is that the client
+    // will not retry the request and will not make things worse
+    // by increasing the load. And we do have data from the cloud
+    // storage at this point anyway.
+
+    if (!sr_guard.has_error()) {
+        // TODO: use proper priority class
+        auto put_future = co_await ss::coroutine::as_future(cache->put(
+          cache_file_name,
+          buf_str,
+          sr_guard.value(),
+          ss::default_priority_class()));
+
+        if (put_future.failed()) {
+            auto e = put_future.get_exception();
+            if (ssx::is_shutdown_exception(e)) {
+                co_return errc::shutting_down;
+            }
+            vlog(
+              cd_log.warn,
+              "Failed to put L0 object into the cache: {}. The error will not "
+              "be "
+              "propagated to the client but Redpanda may use more resources.",
+              e);
+        }
+    } else if (sr_guard.error() == errc::shutting_down) {
+        co_return errc::shutting_down;
+    }
+
+    co_return std::move(payload);
+}
+
+template struct basic_placeholder_extent<ss::lowres_clock>;
+template struct basic_placeholder_extent<ss::manual_clock>;
+
+} // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/reader/placeholder_extent.h
+++ b/src/v/cloud_topics/reader/placeholder_extent.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iostream.h"
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/io_result.h"
+#include "cloud_io/remote.h"
+#include "cloud_topics/dl_placeholder.h"
+#include "cloud_topics/errc.h"
+#include "cloud_topics/logger.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "storage/record_batch_utils.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <chrono>
+#include <exception>
+
+using namespace std::chrono_literals;
+
+namespace experimental::cloud_topics {
+
+// Extent represents dl_placeholder with the data
+// that it represents stored in cloud storage cache or
+// main memory.
+// The extent can be hydrated (the data is moved from the cloud
+// storage to disk) or materialized (data is moved to the main
+// memory).
+
+struct hydrated_L0_object {
+    object_id id;
+    iobuf payload;
+};
+
+// Materialized placeholder extent
+template<class Clock>
+struct basic_placeholder_extent {
+    model::offset base_offset;
+    dl_placeholder placeholder;
+    ss::lw_shared_ptr<hydrated_L0_object> L0_object;
+
+    /// Convert record batch to dl_placeholder value and return an empty
+    /// extent which later has to be hydrated.
+    explicit basic_placeholder_extent(model::record_batch batch);
+
+    /// Fetch data referenced by the placeholder batch and the content of the
+    /// dl_placeholder.
+    /// Return 'true' if the object was downloaded from the cloud storage.
+    /// Otherwise, if the object was populated from the cache, return 'false'.
+    ss::future<result<bool>> materialize(
+      cloud_storage_clients::bucket_name bucket,
+      cloud_io::remote_api<Clock>* api,
+      cloud_io::basic_cache_service_api<Clock>* cache,
+      basic_retry_chain_node<Clock>* rtc);
+
+    // Get dl_placeholder and the payload of the object and generate a record
+    // batch
+    model::record_batch make_raft_data_batch();
+
+private:
+    ss::future<result<iobuf>> materialize_from_cache(
+      std::filesystem::path cache_file_name,
+      cloud_io::basic_cache_service_api<Clock>* cache);
+
+    ss::future<result<iobuf>> materialize_from_cloud_storage(
+      std::filesystem::path cache_file_name,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_io::remote_api<Clock>* api,
+      cloud_io::basic_cache_service_api<Clock>* cache,
+      basic_retry_chain_node<Clock>* rtc);
+};
+
+// Materialized placeholder extent
+using placeholder_extent = basic_placeholder_extent<ss::lowres_clock>;
+
+} // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/reader/placeholder_extent_reader.cc
+++ b/src/v/cloud_topics/reader/placeholder_extent_reader.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reader/placeholder_extent_reader.h"
+
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/io_result.h"
+#include "cloud_io/remote.h"
+#include "cloud_topics/dl_placeholder.h"
+#include "cloud_topics/errc.h"
+#include "cloud_topics/logger.h"
+#include "cloud_topics/reader/placeholder_extent.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <chrono>
+#include <exception>
+
+using namespace std::chrono_literals;
+
+namespace experimental::cloud_topics {
+
+/// Convert record batch to dl_placeholder value and return an empty
+/// extent which later has to be hydrated.
+size_t get_extent_size(const model::record_batch& placeholder) {
+    /// FIXME: This code makes unnecessary copy
+    vassert(
+      placeholder.header().type == model::record_batch_type::dl_placeholder,
+      "Unsupported batch type {}",
+      placeholder.header());
+    iobuf payload = placeholder.data().copy();
+    iobuf_parser parser(std::move(payload));
+    auto record = model::parse_one_record_from_buffer(parser);
+    iobuf value = std::move(record).release_value();
+    auto p = serde::from_iobuf<dl_placeholder>(std::move(value));
+    return p.size_bytes;
+}
+
+inline ss::future<result<ss::circular_buffer<placeholder_extent>>>
+materialize_sorted_run(
+  ss::circular_buffer<model::record_batch> placeholders,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_io::remote_api<>* api,
+  cloud_io::basic_cache_service_api<>* cache,
+  retry_chain_node* rtc) {
+    absl::node_hash_map<uuid_t, ss::lw_shared_ptr<hydrated_L0_object>> hydrated;
+    ss::circular_buffer<placeholder_extent> extents;
+    for (auto&& p : placeholders) {
+        auto extent = placeholder_extent(std::move(p));
+
+        extents.push_back(extent);
+        // reuse hydrated objects if possible
+        auto it = hydrated.find(extent.placeholder.id());
+        if (it != hydrated.end()) {
+            auto& payload = it->second->payload;
+            // TODO: check that id of the payload matches
+            extent.L0_object->payload = payload.share(0, payload.size_bytes());
+        } else {
+            auto res = co_await extent.materialize(bucket, api, cache, rtc);
+            if (res.has_error()) {
+                co_return res.error();
+            }
+            hydrated.insert(
+              std::make_pair(extent.placeholder.id, extent.L0_object));
+        }
+    }
+    co_return std::move(extents);
+}
+
+class joining_record_batch_reader_impl
+  : public model::record_batch_reader::impl {
+public:
+    joining_record_batch_reader_impl(
+      model::record_batch_reader rdr,
+      const storage::log_reader_config& cfg,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_io::remote_api<>& api,
+      cloud_io::basic_cache_service_api<>& cache,
+      retry_chain_node* rtc)
+      : _underlying(std::move(rdr))
+      , _config(cfg)
+      , _bucket(std::move(bucket))
+      , _api(api)
+      , _cache(cache)
+      , _rtc(rtc) {}
+
+    bool is_end_of_stream() const override {
+        bool is_eos = _config.start_offset >= _config.max_offset
+                      || _underlying.is_end_of_stream();
+        return is_eos;
+    }
+
+    ss::future<model::record_batch_reader::storage_t>
+    do_load_slice(model::timeout_clock::time_point tm) override {
+        struct consumer {
+            consumer(
+              storage::log_reader_config* config,
+              ss::circular_buffer<model::record_batch>* rb)
+              : _config(config)
+              , _read_buffer(rb) {}
+
+            ss::future<ss::stop_iteration> operator()(model::record_batch rb) {
+                if (rb.header().base_offset < _config->start_offset) {
+                    // Skip data which was already consumed
+                    co_return ss::stop_iteration::no;
+                }
+                if (rb.header().last_offset() > _config->max_offset) {
+                    // Stop on EOS
+                    co_return ss::stop_iteration::yes;
+                }
+                // Account bytes based on placeholder content, not header
+                _num_bytes += get_extent_size(rb);
+                auto last_offset = rb.header().last_offset();
+                _read_buffer->push_back(std::move(rb));
+                _config->start_offset = model::next_offset(last_offset);
+                bool done = _config->start_offset >= _config->max_offset
+                            || _num_bytes > _config->max_bytes;
+                auto res = done ? ss::stop_iteration::yes
+                                : ss::stop_iteration::no;
+                co_return res;
+            }
+
+            void end_of_stream() {}
+
+        private:
+            storage::log_reader_config* _config;
+            ss::circular_buffer<model::record_batch>* _read_buffer;
+            size_t _num_bytes{0};
+        };
+
+        ss::circular_buffer<model::record_batch> read_buffer;
+        consumer cons(&_config, &read_buffer);
+        co_await _underlying.consume(cons, tm);
+
+        auto extents = co_await materialize_sorted_run(
+          std::move(read_buffer), _bucket, &_api, &_cache, &_rtc);
+        if (extents.has_error()) {
+            vlog(
+              cd_log.error,
+              "Failed to materialize sorted run: {}",
+              extents.error().message());
+            throw std::system_error(extents.error());
+        }
+
+        ss::circular_buffer<model::record_batch> slice;
+        for (auto& e : extents.value()) {
+            slice.push_back(e.make_raft_data_batch());
+        }
+
+        co_return std::move(slice);
+    }
+
+    void print(std::ostream& o) override { o << "joining_record_batch_reader"; }
+
+    ss::future<> finally() noexcept override { return ss::now(); }
+
+private:
+    // Underlying storage partition reader
+    model::record_batch_reader _underlying;
+    storage::log_reader_config _config;
+    cloud_storage_clients::bucket_name _bucket;
+    // TODO: cache extent so it can be reused with the reader
+    // cloud storage apis
+    cloud_io::remote_api<>& _api;
+    cloud_io::basic_cache_service_api<>& _cache;
+    retry_chain_node _rtc;
+};
+
+model::record_batch_reader make_placeholder_extent_reader(
+  storage::log_reader_config cfg,
+  cloud_storage_clients::bucket_name bucket,
+  model::record_batch_reader underlying,
+  cloud_io::remote_api<ss::lowres_clock>& api,
+  cloud_io::basic_cache_service_api<ss::lowres_clock>& cache,
+  retry_chain_node& rtc) {
+    auto impl = std::make_unique<joining_record_batch_reader_impl>(
+      std::move(underlying), cfg, std::move(bucket), api, cache, &rtc);
+    return model::record_batch_reader(std::move(impl));
+}
+
+} // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/reader/placeholder_extent_reader.h
+++ b/src/v/cloud_topics/reader/placeholder_extent_reader.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/remote.h"
+#include "model/record_batch_reader.h"
+#include "storage/log_reader.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+namespace experimental::cloud_topics {
+
+model::record_batch_reader make_placeholder_extent_reader(
+  storage::log_reader_config cfg,
+  cloud_storage_clients::bucket_name bucket,
+  model::record_batch_reader underlying,
+  cloud_io::remote_api<ss::lowres_clock>& api,
+  cloud_io::basic_cache_service_api<ss::lowres_clock>& cache,
+  retry_chain_node& rtc);
+
+}

--- a/src/v/cloud_topics/reader/tests/BUILD
+++ b/src/v/cloud_topics/reader/tests/BUILD
@@ -32,3 +32,20 @@ redpanda_test_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "placeholder_extent_test",
+    timeout = "short",
+    srcs = [
+        "placeholder_extent_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/reader:placeholder_extent",
+        "//src/v/cloud_topics/reader/tests:placeholder_extent_fixture",
+        "//src/v/model",
+        "//src/v/ssx:sformat",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reader/tests/BUILD
+++ b/src/v/cloud_topics/reader/tests/BUILD
@@ -49,3 +49,21 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "placeholder_extent_reader_test",
+    timeout = "short",
+    srcs = [
+        "placeholder_extent_reader_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_topics/reader:placeholder_extent_reader",
+        "//src/v/cloud_topics/reader/tests:placeholder_extent_fixture",
+        "//src/v/model",
+        "//src/v/ssx:sformat",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reader/tests/BUILD
+++ b/src/v/cloud_topics/reader/tests/BUILD
@@ -1,0 +1,34 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "placeholder_extent_fixture",
+    srcs = [
+        "placeholder_extent_fixture.cc",
+    ],
+    hdrs = [
+        "mocks.h",
+        "placeholder_extent_fixture.h",
+    ],
+    include_prefix = "cloud_topics/reader/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/bytes:iostream",
+        "//src/v/bytes:random",
+        "//src/v/cloud_io:basic_cache_service_api",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:placeholder",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/ssx:sformat",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/storage:record_batch_utils",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reader/tests/mocks.h
+++ b/src/v/cloud_topics/reader/tests/mocks.h
@@ -1,0 +1,240 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/vlog.h"
+#include "bytes/bytes.h"
+#include "bytes/iostream.h"
+#include "cloud_io/basic_cache_service_api.h"
+#include "cloud_io/io_result.h"
+#include "cloud_io/remote.h"
+#include "cloud_storage_clients/types.h"
+#include "gmock/gmock.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+#include "random/generators.h"
+
+#include <seastar/core/file-types.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+
+using namespace std::chrono_literals;
+
+struct remote_mock_download {
+    virtual ~remote_mock_download() = default;
+    virtual std::pair<iobuf, cloud_io::download_result>
+    _do_download_object(cloud_storage_clients::object_key key) = 0;
+};
+
+class remote_mock final
+  : public cloud_io::remote_api<ss::lowres_clock>
+  , public remote_mock_download {
+public:
+    using reset_input_stream
+      = cloud_io::remote_api<ss::lowres_clock>::reset_input_stream;
+
+    MOCK_METHOD(
+      ss::future<cloud_io::download_result>,
+      object_exists,
+      (const cloud_storage_clients::bucket_name&,
+       const cloud_storage_clients::object_key&,
+       retry_chain_node&,
+       std::string_view),
+      (override));
+
+    MOCK_METHOD(
+      ss::future<cloud_io::upload_result>,
+      upload_object,
+      (cloud_io::basic_upload_request<ss::lowres_clock>),
+      (override));
+
+    MOCK_METHOD(
+      ss::future<cloud_io::upload_result>,
+      upload_stream,
+      (cloud_io::basic_transfer_details<ss::lowres_clock>,
+       uint64_t,
+       const reset_input_stream&,
+       lazy_abort_source&,
+       const std::string_view,
+       std::optional<size_t>),
+      (override));
+
+    MOCK_METHOD(
+      ss::future<cloud_io::download_result>,
+      download_stream,
+      (cloud_io::basic_transfer_details<ss::lowres_clock>,
+       const cloud_io::try_consume_stream&,
+       const std::string_view,
+       bool,
+       std::optional<cloud_storage_clients::http_byte_range>,
+       std::function<void(size_t)>),
+      (override));
+
+    MOCK_METHOD(
+      (std::pair<iobuf, cloud_io::download_result>),
+      _do_download_object,
+      (cloud_storage_clients::object_key key),
+      (override));
+
+    ss::future<cloud_io::download_result> download_object(
+      cloud_io::basic_download_request<ss::lowres_clock> req) override {
+        auto [buf, err] = _do_download_object(req.transfer_details.key);
+        req.payload = std::move(buf);
+        co_return err;
+    }
+
+    void expect_download_object(
+      cloud_storage_clients::object_key key,
+      cloud_io::download_result res,
+      iobuf body) {
+        EXPECT_CALL(*this, _do_download_object(std::move(key)))
+          .Times(1)
+          .WillOnce(::testing::Return(std::make_pair(std::move(body), res)));
+    }
+
+    template<class Exception>
+    void expect_download_object_throw(
+      cloud_storage_clients::object_key key, Exception err) {
+        EXPECT_CALL(*this, _do_download_object(std::move(key)))
+          .Times(1)
+          .WillOnce(::testing::Throw(err));
+    }
+};
+
+class cache_mock : public cloud_io::basic_cache_service_api<ss::lowres_clock> {
+public:
+    MOCK_METHOD(
+      ss::future<std::optional<cloud_io::cache_item_str>>,
+      get,
+      (std::filesystem::path key,
+       ss::io_priority_class io_priority,
+       size_t read_buffer_size,
+       unsigned int read_ahead),
+      ());
+
+    MOCK_METHOD(
+      ss::future<>,
+      put,
+      (std::filesystem::path key,
+       ss::input_stream<char>& data,
+       cloud_io::basic_space_reservation_guard<ss::lowres_clock>& reservation,
+       ss::io_priority_class io_priority,
+       size_t write_buffer_size,
+       unsigned int write_behind),
+      ());
+
+    MOCK_METHOD(
+      ss::future<cloud_io::cache_element_status>,
+      is_cached,
+      (const std::filesystem::path&),
+      ());
+
+    MOCK_METHOD(
+      ss::future<cloud_io::basic_space_reservation_guard<ss::lowres_clock>>,
+      reserve_space,
+      (uint64_t, size_t),
+      ());
+
+    MOCK_METHOD(
+      void, reserve_space_release, (uint64_t, size_t, uint64_t, size_t), ());
+
+    void expect_is_cached(
+      std::filesystem::path p, cloud_io::cache_element_status s) {
+        auto fut = ss::make_ready_future<cloud_io::cache_element_status>(s);
+        EXPECT_CALL(*this, is_cached(p))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
+    void expect_is_cached(
+      std::filesystem::path p,
+      std::vector<cloud_io::cache_element_status> seq) {
+        auto& exp = EXPECT_CALL(*this, is_cached(p)).Times(seq.size());
+
+        for (auto s : seq) {
+            auto fut = ss::make_ready_future<cloud_io::cache_element_status>(s);
+            exp.WillOnce(::testing::Return(std::move(fut)));
+        }
+    }
+
+    void
+    expect_is_cached_throws(std::filesystem::path p, std::exception_ptr e) {
+        auto fut = ss::make_exception_future<cloud_io::cache_element_status>(e);
+        EXPECT_CALL(*this, is_cached(p))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
+    void expect_get(
+      std::filesystem::path p, std::optional<cloud_io::cache_item_str> item) {
+        auto fut
+          = ss::make_ready_future<std::optional<cloud_io::cache_item_str>>(
+            std::move(item));
+        EXPECT_CALL(*this, get(p, ::testing::_, ::testing::_, ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
+    void expect_get_throws(std::filesystem::path p, std::exception_ptr e) {
+        auto fut
+          = ss::make_exception_future<std::optional<cloud_io::cache_item_str>>(
+            e);
+        EXPECT_CALL(*this, get(p, ::testing::_, ::testing::_, ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(fut)));
+    }
+
+    void expect_put(std::filesystem::path p, std::exception_ptr e = nullptr) {
+        ss::future<> result = ss::now();
+        if (e != nullptr) {
+            result = ss::make_exception_future<>(e);
+        }
+        EXPECT_CALL(
+          *this,
+          put(
+            p,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
+
+    void expect_reserve_space(
+      size_t size_bytes,
+      size_t num_objects,
+      cloud_io::basic_space_reservation_guard<ss::lowres_clock> r) {
+        auto result = ss::make_ready_future<
+          cloud_io::basic_space_reservation_guard<ss::lowres_clock>>(
+          std::move(r));
+        EXPECT_CALL(*this, reserve_space(size_bytes, num_objects))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
+
+    void expect_reserve_space_throw(std::exception_ptr e) {
+        auto result = ss::make_exception_future<
+          cloud_io::basic_space_reservation_guard<ss::lowres_clock>>(
+          std::move(e));
+        EXPECT_CALL(*this, reserve_space(::testing::_, ::testing::_))
+          .Times(1)
+          .WillOnce(::testing::Return(std::move(result)));
+    }
+};

--- a/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.cc
+++ b/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.cc
@@ -1,0 +1,317 @@
+#include "placeholder_extent_fixture.h"
+
+#include "cloud_storage_clients/types.h"
+#include "cloud_topics/dl_placeholder.h"
+#include "gmock/gmock.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "random/generators.h"
+#include "ssx/sformat.h"
+#include "storage/record_batch_builder.h"
+#include "storage/record_batch_utils.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+
+#include <exception>
+#include <filesystem>
+#include <stdexcept>
+
+namespace cloud_topics = experimental::cloud_topics;
+static ss::logger test_log("placeholder_extent_fixture");
+
+ss::future<> placeholder_extent_fixture::add_random_batches(int record_count) {
+    vassert(expected.empty(), "Already initialized");
+    auto res = co_await model::test::make_random_batches(
+      model::offset(0), record_count, false);
+    for (auto&& b : res) {
+        b.header().crc = model::crc_record_batch(b.header(), b.data());
+        crc::crc32c crc;
+        model::crc_record_batch_header(crc, b.header());
+        b.header().header_crc = crc.value();
+        expected.push_back(std::move(b));
+    }
+}
+
+void placeholder_extent_fixture::produce_placeholders(
+  bool use_cache,
+  int group_by,
+  std::queue<injected_failure> injected_failures,
+  int begin,
+  int end) {
+    // Serialize batch as an iobuf
+    auto serialize_batch = [](model::record_batch batch) -> iobuf {
+        // serialize to disk format
+        auto hdr_iobuf = storage::batch_header_to_disk_iobuf(batch.header());
+        auto rec_iobuf = std::move(batch).release_data();
+        iobuf res;
+        res.append(std::move(hdr_iobuf));
+        res.append(std::move(rec_iobuf));
+        return res;
+    };
+    // Generate a placeholder batch based on current offset/size and the
+    // source record batch
+    auto generate_placeholder =
+      [](
+        uuid_t id,
+        size_t offset,
+        size_t size,
+        const model::record_batch& source) -> model::record_batch {
+        cloud_topics::dl_placeholder p{
+          .id = cloud_topics::object_id(id),
+          .offset = cloud_topics::first_byte_offset_t(offset),
+          .size_bytes = cloud_topics::byte_range_size_t(size),
+        };
+
+        storage::record_batch_builder builder(
+          model::record_batch_type::dl_placeholder, source.base_offset());
+
+        builder.add_raw_kv(
+          serde::to_iobuf(cloud_topics::dl_placeholder_record_key::payload),
+          serde::to_iobuf(p));
+        // Match number of records in the batch with the 'source'
+        for (auto i = 1; i < source.record_count(); i++) {
+            iobuf empty;
+            builder.add_raw_kv(
+              serde::to_iobuf(cloud_topics::dl_placeholder_record_key::empty),
+              std::move(empty));
+        }
+        return std::move(builder).build();
+    };
+    // List of placeholder batches alongside the list of L0 objects
+    // that has to be added to the cloud storage mock and (optionally) cache
+    // mock
+    struct placeholders_and_uploads {
+        fragmented_vector<model::record_batch> placeholders;
+        std::map<std::filesystem::path, iobuf> uploads;
+    };
+    // Produce data for the partition and the cloud/cache. Group data
+    // together using 'group_by' parameter.
+    auto generate_placeholders_and_uploads =
+      [&](
+        std::queue<model::record_batch> sources,
+        std::queue<iobuf> serialized_batches) -> placeholders_and_uploads {
+        fragmented_vector<model::record_batch> placeholders;
+        std::map<std::filesystem::path, iobuf> uploads;
+        while (!sources.empty()) {
+            iobuf current;
+            auto id = uuid_t::create();
+            for (int i = 0; i < group_by; i++) {
+                auto buf = std::move(serialized_batches.front());
+                serialized_batches.pop();
+                auto batch = std::move(sources.front());
+                sources.pop();
+                auto placeholder = generate_placeholder(
+                  id, current.size_bytes(), buf.size_bytes(), batch);
+                placeholders.push_back(std::move(placeholder));
+                current.append(std::move(buf));
+            }
+            auto fname = std::filesystem::path(ssx::sformat("{}", id));
+            uploads[fname] = std::move(current);
+        }
+        return {
+          .placeholders = std::move(placeholders),
+          .uploads = std::move(uploads),
+        };
+    };
+    std::queue<model::record_batch> sources;
+    std::queue<iobuf> serialized_batches;
+    int ix = 0;
+    for (const auto& b : expected) {
+        if (ix < begin || ix > end) {
+            ix++;
+            vlog(
+              test_log.info,
+              "Skip batch: {}:{}",
+              b.header().base_offset,
+              b.header().last_offset());
+            continue;
+        } else {
+            ix++;
+            vlog(
+              test_log.info,
+              "Expected batch: {}:{}",
+              b.header().base_offset,
+              b.header().last_offset());
+        }
+        // serialize the batch
+        // add batch to the cache
+        auto buf = serialize_batch(b.copy());
+        serialized_batches.push(buf.copy());
+        sources.push(b.copy());
+    }
+    auto [placeholders, uploads] = generate_placeholders_and_uploads(
+      std::move(sources), std::move(serialized_batches));
+    vlog(
+      test_log.info,
+      "Generated {} placeholders and {} L0 objects",
+      placeholders.size(),
+      uploads.size());
+
+    for (auto&& kv : uploads) {
+        auto sz = kv.second.size_bytes();
+        injected_failure failure = {};
+        if (!injected_failures.empty()) {
+            failure = injected_failures.back();
+            injected_failures.pop();
+        }
+        if (use_cache) {
+            // Simplified event flow:
+            // cache.is_cached() -> available
+            // cache.get() -> payload
+
+            switch (failure.is_cached) {
+            case injected_is_cached_failure::none:
+                cache.expect_is_cached(
+                  kv.first, cloud_io::cache_element_status::available);
+                break;
+            case injected_is_cached_failure::stall_then_ok:
+                cache.expect_is_cached(
+                  kv.first,
+                  std::vector<cloud_io::cache_element_status>{
+                    cloud_io::cache_element_status::in_progress,
+                    cloud_io::cache_element_status::available});
+                break;
+            case injected_is_cached_failure::noop:
+                // The code is supposed to timeout before even
+                // invoking any methods.
+                continue;
+            case injected_is_cached_failure::stall_then_fail:
+                throw std::runtime_error("Not implemented");
+            case injected_is_cached_failure::throw_error:
+                cache.expect_is_cached_throws(
+                  kv.first,
+                  std::make_exception_ptr(std::runtime_error("dummy")));
+                continue;
+            case injected_is_cached_failure::throw_shutdown:
+                cache.expect_is_cached_throws(
+                  kv.first,
+                  std::make_exception_ptr(ss::gate_closed_exception()));
+                continue;
+            };
+
+            cloud_io::cache_item_str s{
+              .body = make_iobuf_input_stream(kv.second.copy()),
+              .size = sz,
+            };
+            switch (failure.cache_get) {
+            case injected_cache_get_failure::none:
+                cache.expect_get(kv.first, std::move(s));
+                break;
+            case injected_cache_get_failure::return_error:
+                cache.expect_get(kv.first, std::nullopt);
+                break;
+            case injected_cache_get_failure::throw_error:
+                cache.expect_get_throws(
+                  kv.first,
+                  std::make_exception_ptr(std::runtime_error("dummy")));
+                break;
+            case injected_cache_get_failure::throw_shutdown:
+                cache.expect_get_throws(
+                  kv.first,
+                  std::make_exception_ptr(ss::gate_closed_exception()));
+                break;
+            };
+        } else {
+            // Simplified event flow:
+            // cache.is_cached() -> not_available
+            // remote.download_object() -> payload
+            // cache.reserve_space() -> guard
+            // cache.put(payload, guard)
+            cache.expect_is_cached(
+              kv.first, cloud_io::cache_element_status::not_available);
+            switch (failure.cloud_get) {
+            case injected_cloud_get_failure::none:
+                remote.expect_download_object(
+                  cloud_storage_clients::object_key(kv.first),
+                  cloud_io::download_result::success,
+                  kv.second.copy());
+                break;
+            case injected_cloud_get_failure::return_failure:
+                remote.expect_download_object(
+                  cloud_storage_clients::object_key(kv.first),
+                  cloud_io::download_result::failed,
+                  kv.second.copy());
+                continue;
+            case injected_cloud_get_failure::return_notfound:
+                remote.expect_download_object(
+                  cloud_storage_clients::object_key(kv.first),
+                  cloud_io::download_result::notfound,
+                  kv.second.copy());
+                continue;
+            case injected_cloud_get_failure::return_timeout:
+                remote.expect_download_object(
+                  cloud_storage_clients::object_key(kv.first),
+                  cloud_io::download_result::timedout,
+                  kv.second.copy());
+                continue;
+            case injected_cloud_get_failure::throw_shutdown:
+                remote.expect_download_object_throw(
+                  cloud_storage_clients::object_key(kv.first),
+                  ss::abort_requested_exception());
+                continue;
+            case injected_cloud_get_failure::throw_error:
+                remote.expect_download_object_throw(
+                  cloud_storage_clients::object_key(kv.first),
+                  std::runtime_error("boo"));
+                continue;
+            }
+            switch (failure.cache_rsv) {
+            case injected_cache_rsv_failure::none:
+                cache.expect_reserve_space(
+                  sz,
+                  1,
+                  cloud_io::basic_space_reservation_guard<ss::lowres_clock>(
+                    cache, 0, 0));
+                break;
+            case injected_cache_rsv_failure::throw_error:
+                cache.expect_reserve_space_throw(
+                  std::make_exception_ptr(std::runtime_error("boo")));
+                continue;
+            case injected_cache_rsv_failure::throw_shutdown:
+                cache.expect_reserve_space_throw(
+                  std::make_exception_ptr(ss::abort_requested_exception()));
+                continue;
+            }
+            switch (failure.cache_put) {
+            case injected_cache_put_failure::none:
+                cache.expect_put(kv.first);
+                break;
+            case injected_cache_put_failure::throw_error:
+                cache.expect_put(
+                  kv.first, std::make_exception_ptr(std::runtime_error("boo")));
+                break;
+            case injected_cache_put_failure::throw_shutdown:
+                cache.expect_put(
+                  kv.first,
+                  std::make_exception_ptr(ss::abort_requested_exception()));
+                break;
+            }
+        }
+    }
+    partition = std::move(placeholders);
+    for (const auto& b : partition) {
+        vlog(
+          test_log.info,
+          "Placeholder batch: {}:{}",
+          b.header().base_offset,
+          b.header().last_offset());
+    }
+}
+
+model::offset placeholder_extent_fixture::get_expected_committed_offset() {
+    if (expected.empty()) {
+        return model::offset{};
+    }
+    return expected.back().last_offset();
+}
+
+model::record_batch_reader placeholder_extent_fixture::make_log_reader() {
+    vlog(
+      test_log.info,
+      "make_log_reader called, partition's size: {}, expected size: {}",
+      partition.size(),
+      expected.size());
+    return model::make_fragmented_memory_record_batch_reader(
+      std::move(partition));
+}

--- a/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.h
+++ b/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.h
@@ -1,0 +1,108 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/vlog.h"
+#include "bytes/bytes.h"
+#include "bytes/iostream.h"
+#include "cloud_io/basic_cache_service_api.h"
+#include "container/fragmented_vector.h"
+#include "mocks.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/manual_clock.hh>
+
+#include <chrono>
+#include <exception>
+#include <limits>
+#include <queue>
+
+enum class injected_cache_get_failure {
+    none,
+    return_error,   // cache get returns nullopt because the file does not
+                    // exist
+    throw_error,    // actually throws an exception
+    throw_shutdown, // throws shutdown exception
+};
+
+enum class injected_cache_put_failure {
+    none,
+    throw_shutdown, // throws 'shutdown' error
+    throw_error,    // throws unexpected exception
+};
+
+enum class injected_cache_rsv_failure {
+    none,
+    throw_shutdown, // throws 'shutdown' error
+    throw_error,    // throws unexpected exception
+};
+
+enum class injected_is_cached_failure {
+    none,
+    stall_then_ok,   // returns in_progress, next call returns available
+    stall_then_fail, // returns in_progress, next call returns
+                     // not_available
+    noop,            // is_cached is not called
+    throw_error,     // throws exception
+    throw_shutdown,  // throws shutdown exception
+};
+
+enum class injected_cloud_get_failure {
+    none,
+    return_failure,  // returns 'failed' error code
+    return_notfound, // returns 'KeyNotFound' error
+    return_timeout,  // returns timeout
+    throw_shutdown,  // throws 'shutdown' error
+    throw_error,     // throws unexpected exception
+};
+
+/// The struct describes the injected failures for one particular placeholder
+struct injected_failure {
+    // cache get operation
+    injected_cache_get_failure cache_get{injected_cache_get_failure::none};
+    // cache put operation
+    injected_cache_put_failure cache_put{injected_cache_put_failure::none};
+    // cache reserve space
+    injected_cache_rsv_failure cache_rsv{injected_cache_rsv_failure::none};
+    // check cache for status
+    injected_is_cached_failure is_cached{injected_is_cached_failure::none};
+    // cloud storage get
+    injected_cloud_get_failure cloud_get{injected_cloud_get_failure::none};
+};
+
+class placeholder_extent_fixture : public seastar_test {
+public:
+    // Generate random batches.
+    // This is a source of truth for the test. The goal is to consume
+    // these batches from placeholder/cache/cloud indirection.
+    ss::future<> add_random_batches(int record_count);
+
+    // Generate the 'partition' collection from the source of truth. If the
+    // 'cache' is set to 'true' the data is added to the cloud storage cache.
+    // The 'group_by' parameter control how many batches are stored per L0
+    // object.
+    // 'failures' parameters contains set of injected failures
+    void produce_placeholders(
+      bool use_cache,
+      int group_by,
+      std::queue<injected_failure> failures = {},
+      int begin = std::numeric_limits<int>::min(),
+      int end = std::numeric_limits<int>::max());
+
+    model::offset get_expected_committed_offset();
+
+    model::record_batch_reader make_log_reader();
+
+    fragmented_vector<model::record_batch> partition;
+    fragmented_vector<model::record_batch> expected;
+    remote_mock remote;
+    cache_mock cache;
+};

--- a/src/v/cloud_topics/reader/tests/placeholder_extent_reader_test.cc
+++ b/src/v/cloud_topics/reader/tests/placeholder_extent_reader_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/vlog.h"
+#include "cloud_topics/reader/placeholder_extent_reader.h"
+#include "cloud_topics/reader/tests/placeholder_extent_fixture.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <system_error>
+
+inline ss::logger test_log("placeholder_extent_reader_gtest");
+
+using namespace cloud_storage;
+using namespace std::chrono_literals;
+
+namespace cloud_topics = experimental::cloud_topics;
+
+struct fragmented_vector_consumer {
+    ss::future<ss::stop_iteration> operator()(model::record_batch rb) {
+        target->push_back(std::move(rb));
+        co_return ss::stop_iteration::no;
+    }
+
+    void end_of_stream() {}
+
+    fragmented_vector<model::record_batch>* target;
+};
+
+TEST_F_CORO(placeholder_extent_fixture, full_scan_test) {
+    const int num_batches = 10;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(true, 1);
+    auto underlying = make_log_reader();
+    storage::log_reader_config config(
+      model::offset(0),
+      get_expected_committed_offset(),
+      ss::default_priority_class());
+    ss::abort_source as;
+    retry_chain_node rtc(as, 1s, 100ms);
+    auto reader = cloud_topics::make_placeholder_extent_reader(
+      config,
+      cloud_storage_clients::bucket_name("test-bucket-name"),
+      std::move(underlying),
+      remote,
+      cache,
+      rtc);
+    fragmented_vector<model::record_batch> actual;
+    fragmented_vector_consumer consumer{
+      .target = &actual,
+    };
+    co_await reader.consume(consumer, model::timeout_clock::now() + 10s);
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_TRUE_CORO(actual == expected);
+}
+
+// Same as 'full_scan_test' but the range can be arbitrary
+ss::future<> test_aggregated_log_partial_scan(
+  placeholder_extent_fixture* fx, int num_batches, int begin, int end) {
+    co_await fx->add_random_batches(num_batches);
+    fx->produce_placeholders(true, 1, {}, begin, end);
+
+    // Copy batches that we expect to read
+    model::offset base;
+    model::offset last;
+    fragmented_vector<model::record_batch> expected_view;
+    for (int i = begin; i <= end; i++) {
+        const auto& hdr = fx->expected.at(i);
+        if (base == model::offset{}) {
+            base = hdr.base_offset();
+        }
+        last = hdr.last_offset();
+        expected_view.push_back(fx->expected.at(i).copy());
+    }
+    vlog(
+      test_log.info,
+      "Fetching offsets {} to {}, expect to read {} batches",
+      base,
+      last,
+      expected_view.size());
+    for (const auto& b : expected_view) {
+        vlog(
+          test_log.info,
+          "Expect fetching {}:{}",
+          b.base_offset(),
+          b.last_offset());
+    }
+
+    auto underlying = fx->make_log_reader();
+    storage::log_reader_config config(base, last, ss::default_priority_class());
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 1s, 100ms);
+
+    auto reader = cloud_topics::make_placeholder_extent_reader(
+      config,
+      cloud_storage_clients::bucket_name("test-bucket-name"),
+      std::move(underlying),
+      fx->remote,
+      fx->cache,
+      rtc);
+
+    fragmented_vector<model::record_batch> actual;
+    fragmented_vector_consumer consumer{
+      .target = &actual,
+    };
+
+    co_await reader.consume(consumer, model::timeout_clock::now() + 10s);
+    ASSERT_EQ_CORO(actual.size(), expected_view.size());
+    ASSERT_TRUE_CORO(actual == expected_view);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, scan_range) {
+    co_await test_aggregated_log_partial_scan(this, 10, 0, 0);
+}

--- a/src/v/cloud_topics/reader/tests/placeholder_extent_test.cc
+++ b/src/v/cloud_topics/reader/tests/placeholder_extent_test.cc
@@ -1,0 +1,415 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_topics/reader/placeholder_extent.h"
+#include "cloud_topics/reader/tests/placeholder_extent_fixture.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/util/later.hh>
+
+#include <chrono>
+#include <exception>
+#include <queue>
+
+namespace cloud_topics = experimental::cloud_topics;
+ss::logger test_log("placeholder_extent_test_log");
+
+TEST_F_CORO(placeholder_extent_fixture, materialize_from_cache) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(true, 1);
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_FALSE_CORO(res.has_error());
+
+    fragmented_vector<model::record_batch> actual;
+    actual.emplace_back(extent.make_raft_data_batch());
+
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_EQ_CORO(actual, expected);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_get_fails) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_get = injected_cache_get_failure::return_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_get_throws) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_get = injected_cache_get_failure::throw_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_get_shutdown) {
+    // Test situation when the
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_get = injected_cache_get_failure::throw_shutdown}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, is_cached_throws) {
+    // Test situation when the
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.is_cached = injected_is_cached_failure::throw_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::cache_read_error);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, is_cached_throws_shutdown) {
+    // Test situation when the
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.is_cached = injected_is_cached_failure::throw_shutdown}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, is_cached_stall_then_success) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.is_cached = injected_is_cached_failure::stall_then_ok}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_FALSE_CORO(res.has_error());
+
+    fragmented_vector<model::record_batch> actual;
+    actual.emplace_back(extent.make_raft_data_batch());
+
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_EQ_CORO(actual, expected);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, is_cached_stall_then_timeout) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      true,
+      1,
+      std::queue<injected_failure>(
+        {{.is_cached = injected_is_cached_failure::noop}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 100ms, 1ms, retry_strategy::backoff);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+
+    co_await ss::sleep(100ms);
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::timeout);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, materialize_from_cloud) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(false, 1);
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_FALSE_CORO(res.has_error());
+
+    fragmented_vector<model::record_batch> actual;
+    actual.emplace_back(extent.make_raft_data_batch());
+
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_EQ_CORO(actual, expected);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cloud_get_return_failure) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cloud_get = injected_cloud_get_failure::return_failure}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::download_failure);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cloud_get_throw_shutdown) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cloud_get = injected_cloud_get_failure::throw_shutdown}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cloud_get_return_notfound) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cloud_get = injected_cloud_get_failure::return_notfound}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::download_not_found);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cloud_get_return_timeout) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cloud_get = injected_cloud_get_failure::return_timeout}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::timeout);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cloud_get_throw_error) {
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cloud_get = injected_cloud_get_failure::throw_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::unexpected_failure);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_reserve_space_throws) {
+    // If we fail to reserve space the request should still succeed
+    // but 'cache.put' can't be invoked.
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_rsv = injected_cache_rsv_failure::throw_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_FALSE_CORO(res.has_error());
+
+    fragmented_vector<model::record_batch> actual;
+    actual.emplace_back(extent.make_raft_data_batch());
+
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_EQ_CORO(actual, expected);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_reserve_space_throws_shutdown) {
+    // If we fail to reserve space because of the shutdown the result
+    // should be an errc::shutdown code.
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_rsv = injected_cache_rsv_failure::throw_shutdown}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_put_throws) {
+    // If we fail to put element into the cache the request should still succeed
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_put = injected_cache_put_failure::throw_error}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_FALSE_CORO(res.has_error());
+
+    fragmented_vector<model::record_batch> actual;
+    actual.emplace_back(extent.make_raft_data_batch());
+
+    ASSERT_EQ_CORO(actual.size(), expected.size());
+    ASSERT_EQ_CORO(actual, expected);
+}
+
+TEST_F_CORO(placeholder_extent_fixture, cache_put_throws_shutdown) {
+    // If we fail to put because of the shutdown the result
+    // should be an errc::shutdown code.
+    const int num_batches = 1;
+    co_await add_random_batches(num_batches);
+    produce_placeholders(
+      false,
+      1,
+      std::queue<injected_failure>(
+        {{.cache_put = injected_cache_put_failure::throw_shutdown}}));
+
+    ss::abort_source as;
+    retry_chain_node rtc(as, 10s, 200ms, retry_strategy::disallow);
+
+    cloud_topics::placeholder_extent extent(partition.front().copy());
+    auto res = co_await extent.materialize(
+      cloud_storage_clients::bucket_name("foo"), &remote, &cache, &rtc);
+
+    ASSERT_TRUE_CORO(res.has_error());
+    ASSERT_EQ_CORO(res.error(), cloud_topics::errc::shutting_down);
+}

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -390,6 +390,10 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::partition_properties_update";
     case record_batch_type::datalake_coordinator:
         return o << "batch_type::datalake_coordinator";
+    case record_batch_type::dl_placeholder:
+        return o << "batch_type::dl_placeholder";
+    case record_batch_type::dl_stm_command:
+        return o << "batch_type::dl_overlay";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -55,7 +55,9 @@ enum class record_batch_type : int8_t {
     partition_properties_update
     = 34, // special batch type used to update partition properties
     datalake_coordinator = 35, // datalake::coordinator::*
-    MAX = datalake_coordinator,
+    dl_placeholder = 36,       // placeholder batch type used by cloud topics
+    dl_stm_command = 37,       // dl_stm command batch
+    MAX = dl_stm_command,
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);


### PR DESCRIPTION
The PR implements the reader which consumes `dl_placeholder` batches from the partition and materializes them by downloading the data from the cloud storage or fetching it from the cache.

The PR adds an abstract base class for the `cloud_storage::cache` class. The interface is located in the `cloud_io` package.

WIP, not all code pushed yet.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none