### PR TITLE
base: Add unreachable macro

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_library(
         "source_location.h",
         "type_traits.h",
         "units.h",
+        "unreachable.h",
         "vassert.h",
         "vformat.h",
         "vlog.h",

--- a/src/v/base/unreachable.h
+++ b/src/v/base/unreachable.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/log.hh>
+
+namespace details {
+// NOLINTNEXTLINE
+inline seastar::logger _g_unreachable_assert_logger("assert-unreachable");
+} // namespace details
+
+// NOLINTNEXTLINE
+#define unreachable()                                                          \
+    /* NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while) */                     \
+    do {                                                                       \
+        ::details::_g_unreachable_assert_logger.error(                         \
+          "This code should not be reached ({}:{})", __FILE__, __LINE__);      \
+        ::details::_g_unreachable_assert_logger.error(                         \
+          "Backtrace below:\n{}", seastar::current_backtrace());               \
+        __builtin_trap();                                                      \
+    } while (0)

--- a/src/v/cloud_topics/batcher/batcher.cc
+++ b/src/v/cloud_topics/batcher/batcher.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/batcher/batcher.h"
 
+#include "base/unreachable.h"
 #include "cloud_io/remote.h"
 #include "cloud_topics/batcher/aggregator.h"
 #include "cloud_topics/batcher/serializer.h"
@@ -249,7 +250,7 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
         vlog(_logger.error, "Unexpected batcher error: {}", err);
         co_return errc::unexpected_failure;
     }
-    __builtin_unreachable();
+    unreachable();
 }
 
 template<class Clock>


### PR DESCRIPTION
Add macro wrapper for the `__builtin_unreachable`. The macro adds additional logging and generates a backtrace before terminating the app.

The `__builtin_unreachable` should only be used in places which can't be reached. Example is a switch statement over `enum class` values which uses `return` statement in every case. In this case the compiler will statically check that every possible enum value is present in the `switch` statement so it's guaranteed that we will not reach the `__builtin_unreachable` at the end:

```cpp
switch(e) {
case errc:timedout:
    return 0;
default:
    return 1;
}
__builtin_unreachable();
```

In some cases the code may depend on some runtime information or could easily be changed in the future in such way that will allow execution to actually invoke `__builtin_unreachable()`. This will lead to UB. In order to avoid this `unreachable` macro was added. The macro behaves similarly to `vassert` and it doesn't trigger UB.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none