### PR TITLE
Remove use of deprecated `seastar::reactor::handle_signal`

### DIFF
--- a/src/v/utils/stop_signal.h
+++ b/src/v/utils/stop_signal.h
@@ -16,17 +16,17 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/reactor.hh>
+#include <seastar/core/signal.hh>
 
 class stop_signal {
 public:
     stop_signal() {
-        ss::engine().handle_signal(SIGINT, [this] { signaled(); });
-        ss::engine().handle_signal(SIGTERM, [this] { signaled(); });
+        ss::handle_signal(SIGINT, [this] { signaled(); });
+        ss::handle_signal(SIGTERM, [this] { signaled(); });
     }
     ~stop_signal() {
-        ss::engine().handle_signal(SIGINT, [] {});
-        ss::engine().handle_signal(SIGTERM, [] {});
+        ss::handle_signal(SIGINT, [] {});
+        ss::handle_signal(SIGTERM, [] {});
 
         // We should signal for unit tests, because some background tasks does
         // not finish without it


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Upstream seastar has deprecated the `seastar::reactor::handle_signal` method in favor of `seastar::handle_signal`. This PR swaps all uses in Redpanda with the new function.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
