### PR TITLE
c/migrations: convert migrations table to an ssx::single_sharded

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -164,13 +164,13 @@ ss::future<> controller::wire_up() {
       .then([this] { return _roles.start(); })
       .then([this] { return _data_migrated_resources.start(); })
       .then([this] {
-          _data_migration_table
-            = std::make_unique<data_migrations::migrations_table>(
-              _data_migrated_resources,
-              std::ref(_tp_state),
-              config::shard_local_cfg().cloud_storage_enabled()
-                && config::shard_local_cfg()
-                     .cloud_storage_disable_archiver_manager());
+          return _data_migration_table.start_on(
+            data_migrations::data_migrations_shard,
+            std::ref(_data_migrated_resources),
+            std::ref(_tp_state),
+            config::shard_local_cfg().cloud_storage_enabled()
+              && config::shard_local_cfg()
+                   .cloud_storage_disable_archiver_manager());
       })
       .then([this] {
           return _authorizer.start(
@@ -308,7 +308,7 @@ ss::future<> controller::start(
     co_await _data_migration_frontend.start(
       _raft0->self().id(),
       _cloud_storage_api.local_is_initialized(),
-      std::ref(*_data_migration_table),
+      std::ref(_data_migration_table),
       std::ref(_feature_table),
       std::ref(_stm),
       std::ref(_partition_leaders),
@@ -364,7 +364,7 @@ ss::future<> controller::start(
           std::ref(_plugin_backend),
           std::ref(_recovery_manager),
           std::ref(_quota_backend),
-          std::ref(*_data_migration_table));
+          std::ref(_data_migration_table.local()));
     }
 
     co_await _members_frontend.start(
@@ -772,7 +772,7 @@ ss::future<> controller::start(
 
     co_await _data_migration_backend.start_on(
       data_migrations::data_migrations_shard,
-      std::ref(*_data_migration_table),
+      std::ref(_data_migration_table.local()),
       std::ref(_data_migration_frontend.local()),
       std::ref(_data_migration_worker),
       std::ref(_partition_leaders.local()),
@@ -862,6 +862,7 @@ ss::future<> controller::stop() {
     co_await _oidc_service.stop();
     co_await _authorizer.stop();
     co_await _ephemeral_credentials.stop();
+    co_await _data_migration_table.stop();
     co_await _data_migrated_resources.stop();
     co_await _roles.stop();
     co_await _credentials.stop();

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -277,7 +277,8 @@ private:
     ss::sharded<partition_balancer_state>
       _partition_balancer_state; // single instance
     ss::sharded<data_migrations::migrated_resources> _data_migrated_resources;
-    std::unique_ptr<data_migrations::migrations_table> _data_migration_table;
+    ssx::single_sharded<data_migrations::migrations_table>
+      _data_migration_table;
     ss::sharded<partition_leaders_table>
       _partition_leaders;                                // instance per core
     ss::sharded<shard_placement_table> _shard_placement; // instance per core

--- a/src/v/cluster/data_migration_frontend.h
+++ b/src/v/cluster/data_migration_frontend.h
@@ -15,6 +15,7 @@
 #include "cluster/fwd.h"
 #include "features/fwd.h"
 #include "rpc/fwd.h"
+#include "ssx/single_sharded.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -27,7 +28,7 @@ public:
     frontend(
       model::node_id,
       bool,
-      migrations_table&,
+      ssx::single_sharded<migrations_table>&,
       ss::sharded<features::feature_table>&,
       ss::sharded<controller_stm>&,
       ss::sharded<partition_leaders_table>&,
@@ -85,7 +86,7 @@ private:
 private:
     model::node_id _self;
     bool _cloud_storage_api_initialized;
-    migrations_table& _table;
+    ssx::single_sharded<migrations_table>& _table;
     ss::sharded<features::feature_table>& _features;
     ss::sharded<controller_stm>& _controller;
     ss::sharded<partition_leaders_table>& _leaders_table;

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -32,6 +32,8 @@ migrations_table::migrations_table(
   , _topics(topics)
   , _enabled(enabled) {}
 
+ss::future<> migrations_table::stop() { return ss::now(); }
+
 bool migrations_table::is_valid_state_transition(state current, state target) {
     switch (current) {
     case state::planned:

--- a/src/v/cluster/data_migration_table.h
+++ b/src/v/cluster/data_migration_table.h
@@ -41,6 +41,8 @@ public:
       ss::sharded<topic_table>& topics,
       bool enabled);
 
+    ss::future<> stop();
+
     using notification_id = named_type<uint64_t, struct notification_id_tag>;
     using notification_callback = ss::noncopyable_function<void(id)>;
 


### PR DESCRIPTION
To avoid ambiguity regarding foreign memory.

It's a net addition performance-wise, just adding a level of indirection. But makes things look cleaner. WDYT?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
