### PR TITLE
tests: test legacy dashboard in rpk generate

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1479,12 +1479,17 @@ class RpkTool:
         # Retry if NOT_COORDINATOR is observed when command exits 1
         return try_offset_delete(retries=5)
 
-    def generate_grafana(self, dashboard):
-
+    def generate_grafana(self, dashboard, datasource="", metrics_endpoint=""):
         cmd = [
             self._rpk_binary(), "generate", "grafana-dashboard", "--dashboard",
-            dashboard
+            dashboard, "-X", "admin.hosts=" + self._redpanda.admin_endpoints()
         ]
+
+        if datasource != "":
+            cmd += ["--datasource", datasource]
+
+        if metrics_endpoint != "":
+            cmd += ["--metrics-endpoint", metrics_endpoint]
 
         return self._execute(cmd)
 

--- a/tests/rptest/tests/rpk_generate_test.py
+++ b/tests/rptest/tests/rpk_generate_test.py
@@ -21,28 +21,32 @@ class RpkGenerateTest(RedpandaTest):
         self._ctx = ctx
         self._rpk = RpkTool(self.redpanda)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=1)
     def test_generate_grafana(self):
         """
-          Test that rpk generate grafana-dashboard will generate the required dashboard
-          and that it's a proper JSON file.
-          """
+        Test that rpk generate grafana-dashboard will generate the required dashboard
+        and that it's a proper JSON file.
+        """
 
         # dashboard is the dictionary of the current dashboards and their title.
-        dashboards = {
-            "operations": "Redpanda Ops Dashboard",
-            "consumer-metrics": "Kafka Java Consumer",
-            "consumer-offsets": "Kafka Consumer Offsets",
-            "topic-metrics": "Kafka Topic Metrics"
-        }
-        for name, expectedTitle in dashboards.items():
-            out = self._rpk.generate_grafana(name)
+        dashboards = [
+            "operations", "consumer-metrics", "consumer-offsets",
+            "topic-metrics", "legacy"
+        ]
+        for name in dashboards:
+            datasource = ""
+            metrics_endpoint = ""
+            if name == "legacy":
+                datasource = "redpanda"
+                n = self.redpanda.get_node(1)
+                metrics_endpoint = self.redpanda.admin_endpoint(
+                    n) + "/public_metrics"
+            out = self._rpk.generate_grafana(name,
+                                             datasource=datasource,
+                                             metrics_endpoint=metrics_endpoint)
             try:
-                dash = json.loads(out)
-
-                # We only validate one known value, the main goal is to identify if it's a valid JSON
-                title = dash["title"]
-                assert title == expectedTitle, f"Received dashboard title: '{title}', expected: '{expectedTitle}'"
+                # We just need to assert that it was able to retrieve and parse the dashboard as valid json
+                json.loads(out)
             except json.JSONDecodeError as err:
                 self.logger.error(
                     f"unable to parse generated' {name}' dashboard : {err}")


### PR DESCRIPTION
The legacy dashboard uses the admin API to get the metrics and auto-generate a dashboard.

Also, remove the Title assertion as this depends on an external repo. We just need to test if rpk is able to download and parse.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [X] v23.3.x

## Release Notes
* none

