### PR TITLE
clang-tidy: updates

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,7 @@ build:sanitizer --@seastar//:system_allocator=True
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_18_toolchain//:clang-tidy
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+build:clang-tidy --copt -Wno-pragma-once-outside-header
 build:clang-tidy --output_groups=report
 
 # =================================

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -271,6 +271,6 @@ crate.annotation(
 bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
 git_override(
     module_name = "bazel_clang_tidy",
-    commit = "e85311053ec3c32ff418b433af4469b9c77e6b16",
+    commit = "a95424548c494470258a23128f70244f7a79dac2",
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )

--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -68,6 +68,10 @@ redpanda_cc_library(
         "logger.h",
     ],
     include_prefix = "cloud_io",
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -123,6 +123,9 @@ redpanda_cc_library(
     ],
     include_prefix = "cluster",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/cluster/notification.h
+++ b/src/v/cluster/notification.h
@@ -16,6 +16,6 @@ namespace cluster {
 
 // generic type used for various registration handles such as in ntp_callbacks.h
 using notification_id_type = named_type<int32_t, struct notification_id>;
-constexpr notification_id_type notification_id_type_invalid{-1};
+inline constexpr notification_id_type notification_id_type_invalid{-1};
 
 } // namespace cluster

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -7,6 +7,7 @@ redpanda_test_cc_library(
     ],
     include_prefix = "cluster/tests",
     deps = [
+        "//src/v/cluster",
     ],
 )
 
@@ -18,6 +19,7 @@ redpanda_test_cc_library(
     ],
     include_prefix = "cluster/tests",
     deps = [
+        "//src/v/cluster",
     ],
 )
 
@@ -28,6 +30,7 @@ redpanda_test_cc_library(
     ],
     include_prefix = "cluster/tests",
     deps = [
+        "//src/v/base",
     ],
 )
 

--- a/src/v/cluster/version.h
+++ b/src/v/cluster/version.h
@@ -19,6 +19,6 @@ namespace cluster {
 // passed over the network via the health_manager, and persisted in
 // the feature_manager
 using cluster_version = named_type<int64_t, struct cluster_version_tag>;
-constexpr cluster_version invalid_version = cluster_version{-1};
+inline constexpr cluster_version invalid_version = cluster_version{-1};
 
 } // namespace cluster

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -45,6 +45,9 @@ redpanda_cc_library(
     ],
     include_prefix = "container",
     visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/container:btree",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/hashing/jump_consistent_hash.h
+++ b/src/v/hashing/jump_consistent_hash.h
@@ -15,8 +15,7 @@
 
 /// google's jump consistent hash
 /// https://arxiv.org/pdf/1406.2294.pdf
-constexpr static inline uint32_t
-jump_consistent_hash(uint64_t key, uint32_t num_buckets) {
+constexpr uint32_t jump_consistent_hash(uint64_t key, uint32_t num_buckets) {
     int64_t b = -1, j = 0;
     while (j < num_buckets) {
         b = j;

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -7,6 +7,7 @@ redpanda_test_cc_library(
     ],
     include_prefix = "kafka/client/test",
     deps = [
+        "//src/v/reflection:adl",
     ],
 )
 

--- a/src/v/pandaproxy/BUILD
+++ b/src/v/pandaproxy/BUILD
@@ -333,6 +333,7 @@ redpanda_cc_library(
     include_prefix = "pandaproxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "//src/v/strings:string_switch",
     ],
 )

--- a/src/v/pandaproxy/schema_registry/subject_name_strategy.h
+++ b/src/v/pandaproxy/schema_registry/subject_name_strategy.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/seastarx.h"
 #include "strings/string_switch.h"
 
 namespace pandaproxy::schema_registry {

--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -7,6 +7,9 @@ redpanda_cc_library(
     ],
     include_prefix = "security/audit",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -6,6 +6,9 @@ redpanda_test_cc_library(
         "randoms.h",
     ],
     include_prefix = "security/tests",
+    deps = [
+        "//src/v/bytes:random",
+    ],
 )
 
 redpanda_cc_btest(

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -6,6 +6,9 @@ redpanda_test_cc_library(
         "kvstore_fixture.h",
     ],
     include_prefix = "storage/tests",
+    deps = [
+        "//src/v/config",
+    ],
 )
 
 redpanda_test_cc_library(

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -38,6 +38,7 @@ redpanda_test_cc_library(
     include_prefix = "test_utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "@seastar//:testing",
     ],
 )

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -95,6 +95,9 @@ redpanda_cc_library(
         "inet_address_wrapper.h",
     ],
     include_prefix = "utils",
+    deps = [
+        "//src/v/base",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/wasm/BUILD
+++ b/src/v/wasm/BUILD
@@ -106,6 +106,9 @@ redpanda_cc_library(
     ],
     include_prefix = "wasm",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+    ],
 )
 
 redpanda_cc_library(


### PR DESCRIPTION
* Brings in fix for implementation_deps
* Brings in fix for missing external header directories
* An assortment of missing bazel dep fixes found by clang-tidy compiling header-only cc_libraries that don't have proper deps set.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

