### PR TITLE
CORE-7691 License: minor ux improvements

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -288,7 +288,7 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
                   "license, see https://redpanda.com/license-request. For more "
                   "information, see "
                   "https://docs.redpanda.com/current/get-started/licenses.",
-                  enterprise_features.enabled());
+                  fmt::join(enterprise_features.enabled(), ", "));
             }
         }
     }
@@ -330,7 +330,7 @@ void feature_manager::verify_enterprise_license() {
           "rpk cluster license set). To request a license, see "
           "https://redpanda.com/license-request. For more information, see "
           "https://docs.redpanda.com/current/get-started/licenses.",
-          enterprise_features.enabled())};
+          fmt::join(enterprise_features.enabled(), ", "))};
     }
 
     _verified_enterprise_license.signal();

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -269,6 +269,12 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
               interval_override);
         }
     }
+    try {
+        co_await ss::sleep_abortable(license_check_retry, _as.local());
+    } catch (const ss::sleep_aborted&) {
+        // Shutting down - next iteration will drop out
+        co_return;
+    }
     if (_feature_table.local().is_active(features::feature::license)) {
         auto enterprise_features = report_enterprise_features();
         if (enterprise_features.any()) {
@@ -285,11 +291,6 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
                   enterprise_features.enabled());
             }
         }
-    }
-    try {
-        co_await ss::sleep_abortable(license_check_retry, _as.local());
-    } catch (const ss::sleep_aborted&) {
-        // Shutting down - next iteration will drop out
     }
 }
 


### PR DESCRIPTION
[features: delay first license nag](https://github.com/redpanda-data/redpanda/commit/27d7c1f1e8fdb1856fbb4ce8635f2198cd4eade7) 

If a customer bootstraps a cluster and immediately installs a license we
still print the license nag today. This is confusing to compliant
customers (eg. RP Cloud).

This change delays the license nag by 1 interval.

Note that this means that a savvy customer could increase the license
nag interval to infinity and thereby disable the nag. But that seems
acceptable given that this is just a log message.

[features: fix enterprise feature list format](https://github.com/redpanda-data/redpanda/commit/b2012c3504e391f690887f4abe75d5e5a81e9ce5) 

The list of enabled enterprise features has been formatted incorrectly.

Bad (old): [rbacpartition_auto_balancing_continuous]
Good (new): [rbac, partition_auto_balancing_continuous]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
