### PR TITLE
`cluster::topic_table`: topic-level notifications

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -265,7 +265,7 @@ private:
       model::revision_id bootstrap_revision,
       absl::flat_hash_map<model::ntp, model::revision_id> topic_table_snapshot);
 
-    void process_delta(const topic_table::delta&);
+    void process_delta(const topic_table::ntp_delta&);
 
     ss::future<> reconcile_ntp_fiber(
       model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>);

--- a/src/v/cluster/data_migration_backend.h
+++ b/src/v/cluster/data_migration_backend.h
@@ -175,7 +175,7 @@ private:
 
     /* deferred event handlers */
     // call only with _mutex lock grabbed
-    ss::future<> process_delta(cluster::topic_table_delta&& delta);
+    ss::future<> process_delta(cluster::topic_table_ntp_delta&& delta);
 
     /* helpers */
     std::optional<backend::migration_reconciliation_states_t::iterator>
@@ -293,7 +293,7 @@ private:
           : sought_state(sought_state) {}
     };
     absl::flat_hash_map<id, advance_info> _advance_requests;
-    chunked_vector<topic_table_delta> _unprocessed_deltas;
+    chunked_vector<topic_table_ntp_delta> _unprocessed_deltas;
     chunked_hash_map<model::node_id, check_ntp_states_reply> _rpc_responses;
 
     /* Node-local data for partition-scoped work */

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -87,7 +87,7 @@ bool partition_balancer_backend::is_enabled() const {
 }
 
 void partition_balancer_backend::start() {
-    _topic_table_updates = _state.topics().register_lw_notification(
+    _topic_table_updates = _state.topics().register_lw_ntp_notification(
       [this]() { on_topic_table_update(); });
     _member_updates = _state.members().register_members_updated_notification(
       [this](model::node_id n, model::membership_state state) {
@@ -287,7 +287,7 @@ void partition_balancer_backend::tick() {
 
 ss::future<> partition_balancer_backend::stop() {
     vlog(clusterlog.info, "stopping...");
-    _state.topics().unregister_lw_notification(_topic_table_updates);
+    _state.topics().unregister_lw_ntp_notification(_topic_table_updates);
     _state.members().unregister_members_updated_notification(_member_updates);
     _health_monitor.unregister_node_callback(_health_monitor_updates);
     _timer.cancel();

--- a/src/v/cluster/shard_balancer.h
+++ b/src/v/cluster/shard_balancer.h
@@ -62,8 +62,6 @@ public:
     errc trigger_rebalance();
 
 private:
-    void process_delta(const topic_table::delta&);
-
     ss::future<> init_shard_placement(
       mutex::units& lock,
       const chunked_hash_map<raft::group_id, model::ntp>& local_group2ntp,

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -28,22 +28,6 @@
 
 #include <seastar/core/sharded.hh>
 
-inline void validate_delta(
-  const std::vector<cluster::topic_table::ntp_delta>& d,
-  int new_partitions,
-  int removed_partitions) {
-    size_t additions = std::count_if(
-      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
-          return d.type == cluster::topic_table_ntp_delta_type::added;
-      });
-    size_t deletions = std::count_if(
-      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
-          return d.type == cluster::topic_table_ntp_delta_type::removed;
-      });
-    BOOST_REQUIRE_EQUAL(additions, new_partitions);
-    BOOST_REQUIRE_EQUAL(deletions, removed_partitions);
-}
-
 struct topic_table_fixture {
     static constexpr uint32_t partitions_per_shard = 7000;
     static constexpr uint32_t partitions_reserve_shard0 = 2;

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -29,16 +29,16 @@
 #include <seastar/core/sharded.hh>
 
 inline void validate_delta(
-  const std::vector<cluster::topic_table::delta>& d,
+  const std::vector<cluster::topic_table::ntp_delta>& d,
   int new_partitions,
   int removed_partitions) {
     size_t additions = std::count_if(
-      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::topic_table_delta_type::added;
+      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
+          return d.type == cluster::topic_table_ntp_delta_type::added;
       });
     size_t deletions = std::count_if(
-      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::topic_table_delta_type::removed;
+      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
+          return d.type == cluster::topic_table_ntp_delta_type::removed;
       });
     BOOST_REQUIRE_EQUAL(additions, new_partitions);
     BOOST_REQUIRE_EQUAL(deletions, removed_partitions);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -20,7 +20,44 @@
 
 using namespace std::chrono_literals;
 
+static void validate_topic_deltas(
+  const std::vector<cluster::topic_table::topic_delta>& d,
+  int new_topics,
+  int removed_topics) {
+    size_t additions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::topic_delta& d) {
+          return d.type == cluster::topic_table_topic_delta_type::added;
+      });
+    size_t deletions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::topic_delta& d) {
+          return d.type == cluster::topic_table_topic_delta_type::removed;
+      });
+    BOOST_REQUIRE_EQUAL(additions, new_topics);
+    BOOST_REQUIRE_EQUAL(deletions, removed_topics);
+}
+
+static void validate_ntp_deltas(
+  const std::vector<cluster::topic_table::ntp_delta>& d,
+  int new_partitions,
+  int removed_partitions) {
+    size_t additions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
+          return d.type == cluster::topic_table_ntp_delta_type::added;
+      });
+    size_t deletions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::ntp_delta& d) {
+          return d.type == cluster::topic_table_ntp_delta_type::removed;
+      });
+    BOOST_REQUIRE_EQUAL(additions, new_partitions);
+    BOOST_REQUIRE_EQUAL(deletions, removed_partitions);
+}
+
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
+    std::vector<cluster::topic_table_topic_delta> topic_deltas;
+    table.local().register_topic_delta_notification([&](const auto& d) {
+        topic_deltas.insert(topic_deltas.end(), d.begin(), d.end());
+    });
+
     std::vector<cluster::topic_table_ntp_delta> deltas;
     table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
@@ -41,11 +78,17 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     BOOST_REQUIRE_EQUAL(
       md.find(make_tp_ns("test_tp_3"))->second.get_assignments().size(), 8);
 
-    validate_delta(deltas, 21, 0);
+    validate_topic_deltas(topic_deltas, 3, 0);
+    validate_ntp_deltas(deltas, 21, 0);
 }
 
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     create_topics();
+
+    std::vector<cluster::topic_table_topic_delta> topic_deltas;
+    table.local().register_topic_delta_notification([&](const auto& d) {
+        topic_deltas.insert(topic_deltas.end(), d.begin(), d.end());
+    });
 
     std::vector<cluster::topic_table_ntp_delta> deltas;
     table.local().register_ntp_delta_notification(
@@ -71,11 +114,17 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     BOOST_REQUIRE_EQUAL(
       md.find(make_tp_ns("test_tp_1"))->second.get_assignments().size(), 1);
 
-    validate_delta(deltas, 0, 20);
+    validate_topic_deltas(topic_deltas, 0, 2);
+    validate_ntp_deltas(deltas, 0, 20);
 }
 
 FIXTURE_TEST(test_conflicts, topic_table_fixture) {
     create_topics();
+
+    std::vector<cluster::topic_table_topic_delta> topic_deltas;
+    table.local().register_topic_delta_notification([&](const auto& d) {
+        topic_deltas.insert(topic_deltas.end(), d.begin(), d.end());
+    });
 
     std::vector<cluster::topic_table_ntp_delta> deltas;
     table.local().register_ntp_delta_notification(
@@ -94,6 +143,7 @@ FIXTURE_TEST(test_conflicts, topic_table_fixture) {
                      make_create_topic_cmd("test_tp_1", 2, 3), model::offset(0))
                    .get0();
     BOOST_REQUIRE_EQUAL(res_2, cluster::errc::topic_already_exists);
+    BOOST_REQUIRE_EQUAL(topic_deltas.size(), 0);
     BOOST_REQUIRE_EQUAL(deltas.size(), 0);
 }
 
@@ -118,6 +168,11 @@ FIXTURE_TEST(get_getting_config, topic_table_fixture) {
 
 FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     create_topics();
+
+    std::vector<cluster::topic_table_topic_delta> topic_deltas;
+    table.local().register_topic_delta_notification([&](const auto& d) {
+        topic_deltas.insert(topic_deltas.end(), d.begin(), d.end());
+    });
 
     std::vector<cluster::topic_table_ntp_delta> deltas;
     table.local().register_ntp_delta_notification(
@@ -161,7 +216,8 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
 
     BOOST_REQUIRE_EQUAL(md->get_assignments().size(), 15);
     // require 3 partition additions
-    validate_delta(deltas, 3, 0);
+    BOOST_REQUIRE_EQUAL(topic_deltas.size(), 0);
+    validate_ntp_deltas(deltas, 3, 0);
 }
 
 void validate_brokers_revisions(

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -21,8 +21,8 @@
 using namespace std::chrono_literals;
 
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
-    std::vector<cluster::topic_table_delta> deltas;
-    table.local().register_delta_notification(
+    std::vector<cluster::topic_table_ntp_delta> deltas;
+    table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
 
     create_topics();
@@ -47,8 +47,8 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     create_topics();
 
-    std::vector<cluster::topic_table_delta> deltas;
-    table.local().register_delta_notification(
+    std::vector<cluster::topic_table_ntp_delta> deltas;
+    table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
 
     BOOST_REQUIRE(!table.local()
@@ -77,8 +77,8 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
 FIXTURE_TEST(test_conflicts, topic_table_fixture) {
     create_topics();
 
-    std::vector<cluster::topic_table_delta> deltas;
-    table.local().register_delta_notification(
+    std::vector<cluster::topic_table_ntp_delta> deltas;
+    table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
 
     auto res_1 = table.local()
@@ -119,8 +119,8 @@ FIXTURE_TEST(get_getting_config, topic_table_fixture) {
 FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     create_topics();
 
-    std::vector<cluster::topic_table_delta> deltas;
-    table.local().register_delta_notification(
+    std::vector<cluster::topic_table_ntp_delta> deltas;
+    table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
 
     cluster::create_partitions_configuration cfg(make_tp_ns("test_tp_2"), 3);

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -141,8 +141,8 @@ FIXTURE_TEST(
   test_dispatching_conflicts, topic_table_updates_dispatcher_fixture) {
     create_topics();
 
-    std::vector<cluster::topic_table_delta> deltas;
-    table.local().register_delta_notification(
+    std::vector<cluster::topic_table_ntp_delta> deltas;
+    table.local().register_ntp_delta_notification(
       [&](const auto& d) { deltas.insert(deltas.end(), d.begin(), d.end()); });
 
     auto res_1 = table.local()

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -240,7 +240,7 @@ public:
         }
     };
 
-    using delta = topic_table_delta;
+    using ntp_delta = topic_table_ntp_delta;
 
     using underlying_t = chunked_hash_map<
       model::topic_namespace,
@@ -260,10 +260,10 @@ public:
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
 
-    using delta_range_t
-      = boost::iterator_range<fragmented_vector<delta>::const_iterator>;
-    using delta_cb_t = ss::noncopyable_function<void(delta_range_t)>;
-    using lw_cb_t = ss::noncopyable_function<void()>;
+    using ntp_delta_range_t
+      = boost::iterator_range<fragmented_vector<ntp_delta>::const_iterator>;
+    using ntp_delta_cb_t = ss::noncopyable_function<void(ntp_delta_range_t)>;
+    using lw_ntp_cb_t = ss::noncopyable_function<void()>;
 
     /// A helper struct that has various replica-related metadata all in one
     /// place, so that the API user doesn't have to query several maps manually.
@@ -303,32 +303,34 @@ public:
 
     explicit topic_table(data_migrations::migrated_resources&);
 
-    cluster::notification_id_type register_delta_notification(delta_cb_t cb) {
-        auto id = _notification_id++;
-        _notifications.emplace_back(id, std::move(cb));
+    cluster::notification_id_type
+    register_ntp_delta_notification(ntp_delta_cb_t cb) {
+        auto id = _ntp_notification_id++;
+        _ntp_notifications.emplace_back(id, std::move(cb));
         return id;
     }
 
-    void unregister_delta_notification(cluster::notification_id_type id) {
+    void unregister_ntp_delta_notification(cluster::notification_id_type id) {
         std::erase_if(
-          _notifications,
-          [id](const std::pair<cluster::notification_id_type, delta_cb_t>& n) {
+          _ntp_notifications,
+          [id](
+            const std::pair<cluster::notification_id_type, ntp_delta_cb_t>& n) {
               return n.first == id;
           });
     }
 
     /// similar to delta notifications but lightweight because a copy of delta
     /// is not included in the notification.
-    cluster::notification_id_type register_lw_notification(lw_cb_t cb) {
-        auto id = _lw_notification_id++;
-        _lw_notifications.emplace_back(id, std::move(cb));
+    cluster::notification_id_type register_lw_ntp_notification(lw_ntp_cb_t cb) {
+        auto id = _lw_ntp_notification_id++;
+        _lw_ntp_notifications.emplace_back(id, std::move(cb));
         return id;
     }
 
-    void unregister_lw_notification(cluster::notification_id_type id) {
+    void unregister_lw_ntp_notification(cluster::notification_id_type id) {
         std::erase_if(
-          _lw_notifications,
-          [id](const std::pair<cluster::notification_id_type, lw_cb_t>& n) {
+          _lw_ntp_notifications,
+          [id](const std::pair<cluster::notification_id_type, lw_ntp_cb_t>& n) {
               return n.first == id;
           });
     }
@@ -624,7 +626,7 @@ private:
     struct waiter {
         explicit waiter(uint64_t id)
           : id(id) {}
-        ss::promise<fragmented_vector<delta>> promise;
+        ss::promise<fragmented_vector<ntp_delta>> promise;
         ss::abort_source::subscription sub;
         uint64_t id;
     };
@@ -673,13 +675,14 @@ private:
     // revision that updated the map.
     model::revision_id _topics_map_revision{0};
 
-    fragmented_vector<delta> _pending_deltas;
-    cluster::notification_id_type _notification_id{0};
-    cluster::notification_id_type _lw_notification_id{0};
-    std::vector<std::pair<cluster::notification_id_type, delta_cb_t>>
-      _notifications;
-    std::vector<std::pair<cluster::notification_id_type, lw_cb_t>>
-      _lw_notifications;
+    fragmented_vector<ntp_delta> _pending_ntp_deltas;
+    cluster::notification_id_type _ntp_notification_id{0};
+    cluster::notification_id_type _lw_ntp_notification_id{0};
+    std::vector<std::pair<cluster::notification_id_type, ntp_delta_cb_t>>
+      _ntp_notifications;
+    std::vector<std::pair<cluster::notification_id_type, lw_ntp_cb_t>>
+      _lw_ntp_notifications;
+
     topic_table_probe _probe;
     force_recoverable_partitions_t _partitions_to_force_reconfigure;
     model::revision_id _partitions_to_force_reconfigure_revision{0};

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -216,6 +216,30 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
 }
 
 std::ostream&
+operator<<(std::ostream& o, const topic_table_topic_delta_type& tp) {
+    switch (tp) {
+    case topic_table_topic_delta_type::added:
+        return o << "added";
+    case topic_table_topic_delta_type::removed:
+        return o << "removed";
+    case topic_table_topic_delta_type::properties_updated:
+        return o << "properties_updated";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_table_topic_delta& d) {
+    fmt::print(
+      o,
+      "{{creation_revision:{}, ns_tp: {}, type: {}, revision: {}}}",
+      d.creation_revision,
+      d.ns_tp,
+      d.type,
+      d.revision);
+    return o;
+}
+
+std::ostream&
 operator<<(std::ostream& o, const topic_table_ntp_delta_type& tp) {
     switch (tp) {
     case topic_table_ntp_delta_type::added:

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -215,23 +215,24 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
     __builtin_unreachable();
 }
 
-std::ostream& operator<<(std::ostream& o, const topic_table_delta_type& tp) {
+std::ostream&
+operator<<(std::ostream& o, const topic_table_ntp_delta_type& tp) {
     switch (tp) {
-    case topic_table_delta_type::added:
+    case topic_table_ntp_delta_type::added:
         return o << "added";
-    case topic_table_delta_type::removed:
+    case topic_table_ntp_delta_type::removed:
         return o << "removed";
-    case topic_table_delta_type::replicas_updated:
+    case topic_table_ntp_delta_type::replicas_updated:
         return o << "replicas_updated";
-    case topic_table_delta_type::properties_updated:
+    case topic_table_ntp_delta_type::properties_updated:
         return o << "properties_updated";
-    case topic_table_delta_type::disabled_flag_updated:
+    case topic_table_ntp_delta_type::disabled_flag_updated:
         return o << "disabled_flag_updated";
     }
     __builtin_unreachable();
 }
 
-std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
+std::ostream& operator<<(std::ostream& o, const topic_table_ntp_delta& d) {
     fmt::print(
       o, "{{ntp: {}, type: {}, revision: {}}}", d.ntp, d.type, d.revision);
     return o;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1231,32 +1231,33 @@ std::ostream& operator<<(std::ostream&, const partition_operation_type&);
 
 /// Notification of topic table state change related to a single ntp
 
-enum class topic_table_delta_type {
+enum class topic_table_ntp_delta_type {
     added,
     removed,
     replicas_updated,
     properties_updated,
     disabled_flag_updated,
 };
-std::ostream& operator<<(std::ostream&, const topic_table_delta_type&);
+std::ostream& operator<<(std::ostream&, const topic_table_ntp_delta_type&);
 
-struct topic_table_delta {
+struct topic_table_ntp_delta {
     model::ntp ntp;
     raft::group_id group;
     model::revision_id revision;
-    topic_table_delta_type type;
+    topic_table_ntp_delta_type type;
 
-    topic_table_delta(
+    topic_table_ntp_delta(
       model::ntp ntp,
       raft::group_id gr,
       model::revision_id rev,
-      topic_table_delta_type type)
+      topic_table_ntp_delta_type type)
       : ntp(std::move(ntp))
       , group(gr)
       , revision(rev)
       , type(type) {}
 
-    friend std::ostream& operator<<(std::ostream&, const topic_table_delta&);
+    friend std::ostream&
+    operator<<(std::ostream&, const topic_table_ntp_delta&);
 };
 
 struct create_acls_cmd_data

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1229,6 +1229,38 @@ enum class partition_operation_type {
 };
 std::ostream& operator<<(std::ostream&, const partition_operation_type&);
 
+/// Notification of topic table state change related to a topic as a whole
+
+enum class topic_table_topic_delta_type {
+    added,
+    removed,
+    properties_updated,
+};
+std::ostream& operator<<(std::ostream&, const topic_table_topic_delta_type&);
+
+struct topic_table_topic_delta {
+    // revision of topic creation command (can be used to identify a topic
+    // incarnation).
+    model::revision_id creation_revision;
+    model::topic_namespace ns_tp;
+    // revision corresponding to the change itself.
+    model::revision_id revision;
+    topic_table_topic_delta_type type;
+
+    topic_table_topic_delta(
+      model::revision_id creation_rev,
+      model::topic_namespace ns_tp,
+      model::revision_id rev,
+      topic_table_topic_delta_type type)
+      : creation_revision(creation_rev)
+      , ns_tp(std::move(ns_tp))
+      , revision(rev)
+      , type(type) {}
+
+    friend std::ostream&
+    operator<<(std::ostream&, const topic_table_topic_delta&);
+};
+
 /// Notification of topic table state change related to a single ntp
 
 enum class topic_table_ntp_delta_type {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -120,8 +120,8 @@ ss::future<> group_manager::start() {
      * are cleaned-up.
      */
     _topic_table_notify_handle
-      = _topic_table.local().register_delta_notification(
-        [this](cluster::topic_table::delta_range_t deltas) {
+      = _topic_table.local().register_ntp_delta_notification(
+        [this](cluster::topic_table::ntp_delta_range_t deltas) {
             handle_topic_delta(deltas);
         });
 
@@ -396,7 +396,7 @@ ss::future<> group_manager::stop() {
     _pm.local().unregister_manage_notification(_manage_notify_handle);
     _pm.local().unregister_unmanage_notification(_unmanage_notify_handle);
     _gm.local().unregister_leadership_notification(_leader_notify_handle);
-    _topic_table.local().unregister_delta_notification(
+    _topic_table.local().unregister_ntp_delta_notification(
       _topic_table_notify_handle);
 
     for (auto& e : _partitions) {
@@ -501,13 +501,13 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
 }
 
 void group_manager::handle_topic_delta(
-  cluster::topic_table::delta_range_t deltas) {
+  cluster::topic_table::ntp_delta_range_t deltas) {
     // topic-partition deletions in the kafka namespace are the only deltas that
     // are relevant to the group manager
     chunked_vector<model::topic_partition> tps;
     for (const auto& delta : deltas) {
         if (
-          delta.type == cluster::topic_table_delta_type::removed
+          delta.type == cluster::topic_table_ntp_delta_type::removed
           && delta.ntp.ns == model::kafka_namespace) {
             tps.emplace_back(delta.ntp.tp);
         }

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -245,7 +245,7 @@ private:
       ss::lw_shared_ptr<cluster::partition>,
       std::optional<model::node_id>);
 
-    void handle_topic_delta(cluster::topic_table::delta_range_t);
+    void handle_topic_delta(cluster::topic_table::ntp_delta_range_t);
 
     ss::future<> cleanup_removed_topic_partitions(
       const chunked_vector<model::topic_partition>&);


### PR DESCRIPTION
Previously, topic table only had NTP-level notifications. But some clients don't need this granularity and are only interested in topic-level changes. Implement topic-level deltas and notifications to provide that. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none