### PR TITLE
parquet: plain encoding

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -58,3 +58,20 @@ redpanda_cc_library(
         "@abseil-cpp//absl/numeric:int128",
     ],
 )
+
+redpanda_cc_library(
+    name = "encoding",
+    srcs = [
+        "encoding.cc",
+    ],
+    hdrs = [
+        "encoding.h",
+    ],
+    include_prefix = "serde/parquet",
+    deps = [
+        ":value",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:fragmented_vector",
+    ],
+)

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -43,3 +43,18 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "value",
+    hdrs = [
+        "value.h",
+    ],
+    include_prefix = "serde/parquet",
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:fragmented_vector",
+        "//src/v/utils:uuid",
+        "@abseil-cpp//absl/numeric:int128",
+    ],
+)

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -3,6 +3,8 @@ v_cc_library(
   NAME serde_parquet
   SRCS
     metadata.cc
+    encoding.cc
+    flattened_schema.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/serde/parquet/encoding.cc
+++ b/src/v/serde/parquet/encoding.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/encoding.h"
+
+#include <algorithm>
+#include <climits>
+
+namespace serde::parquet {
+
+iobuf encode_plain(const chunked_vector<boolean_value>& vals) {
+    iobuf buf;
+    size_t i = 0;
+    while (i < vals.size()) {
+        size_t pass_size = std::min<size_t>(vals.size() - i, CHAR_BIT);
+        uint8_t tmp = 0;
+        size_t shift = 0;
+        for (; shift < pass_size; ++i, ++shift) {
+            if (vals[i].val) {
+                tmp |= 1U << shift;
+            }
+        }
+        buf.append(&tmp, 1);
+    }
+    return buf;
+}
+
+iobuf encode_plain(const chunked_vector<int32_value>& vals) {
+    iobuf buf;
+    for (const auto& v : vals) {
+        int32_t i = ss::cpu_to_le(v.val);
+        // NOLINTNEXTLINE(*reinterpret-cast*)
+        buf.append(reinterpret_cast<const uint8_t*>(&i), sizeof(int32_t));
+    }
+    return buf;
+}
+
+iobuf encode_plain(const chunked_vector<int64_value>& vals) {
+    iobuf buf;
+    for (const auto& v : vals) {
+        int64_t i = ss::cpu_to_le(v.val);
+        // NOLINTNEXTLINE(*reinterpret-cast*)
+        buf.append(reinterpret_cast<const uint8_t*>(&i), sizeof(int64_t));
+    }
+    return buf;
+}
+
+iobuf encode_plain(const chunked_vector<float32_value>& vals) {
+    iobuf buf;
+    for (const auto& v : vals) {
+        // NOLINTNEXTLINE(*reinterpret-cast*)
+        buf.append(reinterpret_cast<const uint8_t*>(&v.val), sizeof(float));
+    }
+    return buf;
+}
+
+iobuf encode_plain(const chunked_vector<float64_value>& vals) {
+    iobuf buf;
+    for (const auto& v : vals) {
+        // NOLINTNEXTLINE(*reinterpret-cast*)
+        buf.append(reinterpret_cast<const uint8_t*>(&v.val), sizeof(double));
+    }
+    return buf;
+}
+
+iobuf encode_plain(chunked_vector<byte_array_value> vals) {
+    iobuf buf;
+    for (auto& v : vals) {
+        int32_t i = ss::cpu_to_le(static_cast<int32_t>(v.val.size_bytes()));
+        // NOLINTNEXTLINE(*reinterpret-cast*)
+        buf.append(reinterpret_cast<const uint8_t*>(&i), sizeof(int32_t));
+        buf.append(std::move(v.val));
+    }
+    return buf;
+}
+
+iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals) {
+    iobuf buf;
+    for (auto& v : vals) {
+        buf.append(std::move(v.val));
+    }
+    return buf;
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/encoding.h
+++ b/src/v/serde/parquet/encoding.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/value.h"
+#include "src/v/serde/parquet/value.h"
+
+namespace serde::parquet {
+
+iobuf encode_plain(const chunked_vector<boolean_value>& vals);
+
+iobuf encode_plain(const chunked_vector<int32_value>& vals);
+
+iobuf encode_plain(const chunked_vector<int64_value>& vals);
+
+iobuf encode_plain(const chunked_vector<float32_value>& vals);
+
+iobuf encode_plain(const chunked_vector<float64_value>& vals);
+
+iobuf encode_plain(chunked_vector<byte_array_value> vals);
+
+iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -6,11 +6,11 @@ load("//bazel:test.bzl", "redpanda_cc_gtest")
 redpanda_cc_gtest(
     name = "value_test",
     timeout = "short",
-    cpu = 1,
-    memory = "64MiB",
     srcs = [
         "value_test.cc",
     ],
+    cpu = 1,
+    memory = "64MiB",
     deps = [
         "//src/v/serde/parquet:value",
         "//src/v/test_utils:gtest",
@@ -73,3 +73,19 @@ TEST_CASES = range(4)
     )
     for test_case in TEST_CASES
 ]
+
+redpanda_cc_gtest(
+    name = "encoding_test",
+    timeout = "short",
+    srcs = [
+        "encoding_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/serde/parquet:encoding",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -1,6 +1,23 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//bazel:build.bzl", "redpanda_cc_binary")
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "value_test",
+    timeout = "short",
+    cpu = 1,
+    memory = "64MiB",
+    srcs = [
+        "value_test.cc",
+    ],
+    deps = [
+        "//src/v/serde/parquet:value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
 
 redpanda_cc_binary(
     name = "generate_metadata_binary",

--- a/src/v/serde/parquet/tests/encoding_test.cc
+++ b/src/v/serde/parquet/tests/encoding_test.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/encoding.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+// NOLINTNEXTLINE(*internal-linkage*)
+void PrintTo(const iobuf& b, std::ostream* os) {
+    *os << b.hexdump(b.size_bytes());
+}
+
+namespace serde::parquet {
+
+namespace {
+void buf_append(iobuf& b, uint8_t byte) { b.append(&byte, 1); }
+template<typename... Args>
+iobuf buf_from(const Args&... args) {
+    iobuf b;
+    (buf_append(b, args), ...);
+    return b;
+}
+
+template<size_t N>
+iobuf buf(const char* bytes) {
+    iobuf b;
+    b.append(bytes, N);
+    return b;
+}
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+TEST(PlainEncoding, BooleanBitPacking) {
+    auto encoded = encode_plain(chunked_vector<boolean_value>{});
+    EXPECT_EQ(encoded, buf_from());
+    encoded = encode_plain(chunked_vector<boolean_value>{{true}});
+    EXPECT_EQ(encoded, buf_from(0b00000001));
+    encoded = encode_plain(chunked_vector<boolean_value>{{true}, {true}});
+    EXPECT_EQ(encoded, buf_from(0b00000011));
+    encoded = encode_plain(
+      chunked_vector<boolean_value>{{true}, {false}, {true}});
+    EXPECT_EQ(encoded, buf_from(0b00000101));
+    encoded = encode_plain(chunked_vector<boolean_value>{
+      {true},
+      {false},
+      {true},
+      {true},
+      {true},
+      {false},
+      {false},
+      {false},
+      {true},
+      {false},
+      {true}});
+    EXPECT_EQ(encoded, buf_from(0b00011101, 0b00000101));
+}
+
+TEST(PlainEncoding, Int32) {
+    auto encoded = encode_plain(chunked_vector<int32_value>{
+      {42},
+      {0},
+      {65},
+      {std::numeric_limits<int32_t>::max()},
+      {std::numeric_limits<int32_t>::min()}});
+    EXPECT_EQ(
+      encoded,
+      buf<5 * 4>("\x2A\x00\x00\x00"
+                 "\x00\x00\x00\x00"
+                 "\x41\x00\x00\x00"
+                 "\xFF\xFF\xFF\x7F"
+                 "\x00\x00\x00\x80"));
+}
+
+TEST(PlainEncoding, Int64) {
+    auto encoded = encode_plain(chunked_vector<int64_value>{
+      {42},
+      {0},
+      {65},
+      {std::numeric_limits<int32_t>::min()},
+      {std::numeric_limits<int32_t>::max()},
+      {std::numeric_limits<int64_t>::min()},
+      {std::numeric_limits<int64_t>::max()}});
+    EXPECT_EQ(
+      encoded,
+      buf<8 * 7>("\x2A\x00\x00\x00\x00\x00\x00\x00"
+                 "\x00\x00\x00\x00\x00\x00\x00\x00"
+                 "\x41\x00\x00\x00\x00\x00\x00\x00"
+                 "\x00\x00\x00\x80\xFF\xFF\xFF\xFF"
+                 "\xFF\xFF\xFF\x7F\x00\x00\x00\x00"
+                 "\x00\x00\x00\x00\x00\x00\x00\x80"
+                 "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F"));
+}
+
+TEST(PlainEncoding, Float32) {
+    auto encoded = encode_plain(chunked_vector<float32_value>{
+      {std::numeric_limits<float>::min()},
+      {std::numeric_limits<float>::max()},
+      {std::numeric_limits<float>::quiet_NaN()},
+      {std::numeric_limits<float>::signaling_NaN()},
+      {+0.0},
+      {-0.0},
+    });
+    EXPECT_EQ(
+      encoded,
+      buf<4 * 6>("\x00\x00\x80\x00"
+                 "\xFF\xFF\x7F\x7F"
+                 "\x00\x00\xC0\x7F"
+                 "\x00\x00\xA0\x7F"
+                 "\x00\x00\x00\x00"
+                 "\x00\x00\x00\x80"));
+}
+
+TEST(PlainEncoding, Float64) {
+    auto encoded = encode_plain(chunked_vector<float64_value>{
+      {std::numeric_limits<double>::min()},
+      {std::numeric_limits<double>::max()},
+      {std::numeric_limits<double>::quiet_NaN()},
+      {std::numeric_limits<double>::signaling_NaN()},
+      {+0.0},
+      {-0.0},
+    });
+    EXPECT_EQ(
+      encoded,
+      buf<8 * 6>("\x00\x00\x00\x00\x00\x00\x10\x00"
+                 "\xFF\xFF\xFF\xFF\xFF\xFF\xEF\x7F"
+                 "\x00\x00\x00\x00\x00\x00\xF8\x7F"
+                 "\x00\x00\x00\x00\x00\x00\xF4\x7F"
+                 "\x00\x00\x00\x00\x00\x00\x00\x00"
+                 "\x00\x00\x00\x00\x00\x00\x00\x80"));
+}
+
+namespace {
+
+template<typename T>
+chunked_vector<T> buffers(std::initializer_list<iobuf> buffers) {
+    chunked_vector<T> v;
+    for (auto& b : buffers) {
+        v.push_back(T{b.copy()});
+    }
+    return v;
+}
+
+} // namespace
+
+TEST(PlainEncoding, VarBytes) {
+    auto encoded = encode_plain(
+      buffers<byte_array_value>({buf<3>("\x00\x01\x02"), buf<2>("\xFF\xF8")}));
+    EXPECT_EQ(
+      encoded,
+      buf<13>("\x03\x00\x00\x00\x00\x01\x02"
+              "\x02\x00\x00\x00\xFF\xF8"));
+}
+
+TEST(PlainEncoding, FixedBytes) {
+    auto encoded = encode_plain(buffers<fixed_byte_array_value>({
+      buf<1>("\x00"),
+      buf<1>("\x05"),
+      buf<1>("\xFF"),
+      buf<1>("\xEE"),
+    }));
+    EXPECT_EQ(encoded, buf<4>("\x00\x05\xFF\xEE"));
+}
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/value_test.cc
+++ b/src/v/serde/parquet/tests/value_test.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/value.h"
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+using namespace serde::parquet;
+
+TEST(Value, Lists) {
+    chunked_vector<list_element> list;
+    // It's not actually valid to have heterogenuous lists in parquet, but
+    // our current encoding of the data structures isn't that strict.
+    list.emplace_back(int32_value(2));
+    list.emplace_back(boolean_value(true));
+    value v = std::move(list);
+    EXPECT_TRUE(std::holds_alternative<chunked_vector<list_element>>(v));
+}
+
+TEST(Value, Maps) {
+    chunked_vector<map_entry> map;
+    map.emplace_back(int32_value(2), std::make_optional(boolean_value(true)));
+    value v = std::move(map);
+    EXPECT_TRUE(std::holds_alternative<chunked_vector<map_entry>>(v));
+}

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "container/fragmented_vector.h"
+#include "utils/uuid.h"
+
+#include <absl/numeric/int128.h>
+
+#include <cstdint>
+#include <variant>
+
+// A subset of parquet values that is needed for iceberg.
+
+namespace serde::parquet {
+
+struct null_value {};
+struct boolean_value {
+    bool val;
+};
+struct int32_value {
+    int32_t val;
+};
+struct int64_value {
+    int64_t val;
+};
+struct float32_value {
+    float val;
+};
+struct float64_value {
+    double val;
+};
+struct decimal_value {
+    absl::int128 val;
+};
+// DATE is used to for a logical date type, without a time of day. It must
+// annotate an int32 that stores the number of days from the Unix epoch, 1
+// January 1970.
+struct date_value {
+    int32_t val;
+};
+// TIME is used for a logical time type without a date with millisecond or
+// microsecond precision. The type has two type parameters: UTC adjustment (true
+// or false) and unit (MILLIS or MICROS, NANOS).
+struct time_value {
+    int64_t val;
+};
+// In data annotated with the TIMESTAMP logical type, each value is a single
+// int64 number that can be decoded into year, month, day, hour, minute, second
+// and subsecond fields using calculations detailed below. Please note that a
+// value defined this way does not necessarily correspond to a single instant on
+// the time-line and such interpretations are allowed on purpose.
+struct timestamp_value {
+    int64_t val;
+};
+struct string_value {
+    iobuf val;
+};
+struct uuid_value {
+    uuid_t val;
+};
+struct byte_array_value {
+    iobuf val;
+};
+struct fixed_byte_array_value {
+    iobuf val;
+};
+
+struct list_element;
+struct map_entry;
+
+// Parquet proper actually supports a lot more types than this, but we only need
+// a few of them for iceberg.
+using value = std::variant<
+  null_value,
+  boolean_value,
+  int32_value,
+  int64_value,
+  float32_value,
+  float64_value,
+  decimal_value,
+  date_value,
+  time_value,
+  timestamp_value,
+  string_value,
+  uuid_value,
+  byte_array_value,
+  fixed_byte_array_value,
+  chunked_vector<list_element>,
+  chunked_vector<map_entry>>;
+
+struct list_element {
+    value element;
+};
+
+struct map_entry {
+    // Only non-primative values are supported here
+    // no lists and maps are not valid.
+    value key;
+    std::optional<value> val;
+};
+
+} // namespace serde::parquet


### PR DESCRIPTION
Introduce the value domain for parquet (the subset of types we'll need for iceberg), along with plain encoding.

Plain encoding reference: https://parquet.apache.org/docs/file-format/data-pages/encodings/#plain-plain--0

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
