### PR TITLE
tests: remove `@ok_to_fail` and `@ok_to_fail_fips` annotations

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -21,7 +21,6 @@ from rptest.services.redpanda import SaslCredentials, SecurityConfig, MetricsEnd
 from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.util import wait_until_result
 from ducktape.errors import TimeoutError
-from ducktape.mark import ok_to_fail
 
 # How much memory to assign to redpanda per partition. Redpanda will be started
 # with MIB_PER_PARTITION * PARTITIONS_PER_SHARD * CORE_COUNT memory
@@ -302,7 +301,6 @@ class AuditLogTest(RedpandaTest):
             # to me able to assert on other properties of the test run.
             return make_result_set(t1, repeater)
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/16199
     @cluster(num_nodes=5)
     def test_audit_log(self):
         """

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -15,7 +15,7 @@ from rptest.services.cluster import cluster
 from rptest.services.rpk_consumer import RpkConsumer
 
 from rptest.services.producer_swarm import ProducerSwarm
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 
 
 class CompactionMode(str, enum.Enum):
@@ -76,7 +76,6 @@ class ManyClientsTest(RedpandaTest):
         self._test_many_clients(compaction_mode=CompactionMode.REALISTIC)
 
     @cluster(num_nodes=7)
-    @ok_to_fail
     def test_many_clients_pathological_compaction(self):
         self._test_many_clients(compaction_mode=CompactionMode.PATHOLOGICAL)
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -17,7 +17,7 @@ from collections import Counter
 
 from confluent_kafka import KafkaError, KafkaException
 from ducktape.cluster.cluster_spec import ClusterSpec
-from ducktape.mark import matrix, ok_to_fail, parametrize
+from ducktape.mark import matrix, parametrize
 from ducktape.utils.util import wait_until, TimeoutError
 import numpy
 

--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -136,6 +136,9 @@ class KafkaCliConsumer(BackgroundThreadService):
                 f"{self._instance_name} running on {node.name} failed to stop after SIGKILL"
             )
 
+    def clean_node(self, node):
+        pass
+
     def _report_progress(self):
         while (not self._stopping.is_set()):
             with self._lock:

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -9,7 +9,7 @@
 import socket
 import time
 from ducktape.errors import TimeoutError
-from ducktape.mark import parametrize, matrix, ok_to_fail
+from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -15,7 +15,7 @@ import traceback
 from collections import namedtuple, defaultdict
 from typing import DefaultDict, List, Optional
 
-from ducktape.mark import matrix, ok_to_fail_fips
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cat import KafkaCat
@@ -31,6 +31,7 @@ from rptest.util import (
     wait_for_local_storage_truncate,
     firewall_blocked,
 )
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.si_utils import BucketView, NTPR
 from rptest.utils.si_utils import gen_segment_name_from_meta, gen_local_path_from_remote
 from rptest.services.admin import Admin
@@ -234,7 +235,7 @@ class ArchivalTest(RedpandaTest):
                                         'true')
 
     # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 from keycloak import KeycloakOpenID
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
@@ -724,7 +724,6 @@ class AuditLogTestsAppLifecycle(AuditLogTestBase):
                     True), lambda record_count: record_count == 3,
             "Single redpanda start event per node")
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/16198
     @skip_fips_mode
     @cluster(num_nodes=5)
     def test_drain_on_audit_disabled(self):

--- a/tests/rptest/tests/compatibility/arroyo_test.py
+++ b/tests/rptest/tests/compatibility/arroyo_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import ok_to_fail
 from rptest.services.cluster import cluster
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -30,7 +30,7 @@ from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import ignore, parametrize
 from kafka import KafkaConsumer, TopicPartition
 from kafka import errors as kerr
 from kafka.admin import KafkaAdminClient
@@ -1025,6 +1025,7 @@ class ConsumerGroupStaticMembersRebalance(RedpandaTest):
             consumer_session_timeout=10000)
 
     #this test fails as the consumer are fenced when Redpanda is
+    @ignore
     @cluster(num_nodes=4)
     @skip_debug_mode
     def test_force_kill_all_redpanda_nodes(self):

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -30,7 +30,7 @@ from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize, ok_to_fail
+from ducktape.mark import parametrize
 from kafka import KafkaConsumer, TopicPartition
 from kafka import errors as kerr
 from kafka.admin import KafkaAdminClient
@@ -1027,7 +1027,6 @@ class ConsumerGroupStaticMembersRebalance(RedpandaTest):
     #this test fails as the consumer are fenced when Redpanda is
     @cluster(num_nodes=4)
     @skip_debug_mode
-    @ok_to_fail
     def test_force_kill_all_redpanda_nodes(self):
         def restart_then_stop_consumer():
             self.logger.info("stopping redpanda")

--- a/tests/rptest/tests/control_character_flag_test.py
+++ b/tests/rptest/tests/control_character_flag_test.py
@@ -9,13 +9,14 @@
 import time
 
 import requests.exceptions
-from ducktape.mark import parametrize, ok_to_fail_fips
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions, ver_string
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class ControlCharacterPermittedBase(RedpandaTest):
@@ -134,7 +135,7 @@ class ControlCharacterNag(ControlCharacterPermittedBase):
             "You have enabled unsafe log operations")
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(initial_version=(22, 2, 9))
     @parametrize(initial_version=(22, 3, 11))

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -29,7 +29,7 @@ from ducktape.tests.test import TestContext
 from rptest.clients.types import TopicSpec
 from rptest.tests.e2e_finjector import Finjector
 from rptest.clients.rpk import RpkTool, RpkException
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 from contextlib import nullcontext
 import requests
 import re
@@ -687,7 +687,6 @@ class DataMigrationsApiTest(RedpandaTest):
         self.cancel(migration_id, topic_name)
         self.assert_no_topics()
 
-    @ok_to_fail
     @cluster(num_nodes=4, log_allow_list=MIGRATION_LOG_ALLOW_LIST)
     @matrix(transfer_leadership=[True, False],
             params=generate_tmptpdi_params())

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -17,7 +17,6 @@ from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
 from rptest.utils.mode_checks import skip_debug_mode
-from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 from rptest.utils.si_utils import BucketView, NTP
 import time

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -11,7 +11,7 @@ import csv
 import io
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -11,7 +11,7 @@ import subprocess
 import os
 
 from rptest.services.cluster import cluster
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 
 from rptest.services.librdkafka_test_case import LibrdkafkaTestcase
 from rptest.tests.redpanda_test import RedpandaTest
@@ -79,7 +79,6 @@ class LibrdkafkaTest(RedpandaTest):
                                                  "default_topic_partitions": 4
                                              })
 
-    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/7148
     @cluster(num_nodes=4)
     @matrix(test_num=tests_to_run())
     @skip_debug_mode

--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -11,7 +11,7 @@ import subprocess
 import os
 
 from rptest.services.cluster import cluster
-from ducktape.mark import matrix
+from ducktape.mark import ignore, matrix
 
 from rptest.services.librdkafka_test_case import LibrdkafkaTestcase
 from rptest.tests.redpanda_test import RedpandaTest
@@ -59,6 +59,8 @@ def tests_to_run():
         84,
         # using mocked cluster, not relevant
         105,
+        # failing always - requires proper RCA done
+        75,
     ])
     return [t for t in range(120) if t not in ignored_tests]
 

--- a/tests/rptest/tests/memory_stress_test.py
+++ b/tests/rptest/tests/memory_stress_test.py
@@ -9,7 +9,7 @@
 
 from enum import Enum
 
-from ducktape.mark import ok_to_fail, parametrize
+from ducktape.mark import parametrize
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kaf_consumer import KafConsumer
@@ -36,7 +36,6 @@ class MemoryStressTest(RedpandaTest):
         # enabling each test case to customize its ResourceSettings
         pass
 
-    @ok_to_fail
     @cluster(num_nodes=5)
     @skip_debug_mode
     @parametrize(memory_share_for_fetch=0.05)

--- a/tests/rptest/tests/memory_stress_test.py
+++ b/tests/rptest/tests/memory_stress_test.py
@@ -9,7 +9,7 @@
 
 from enum import Enum
 
-from ducktape.mark import parametrize
+from ducktape.mark import ignore, parametrize
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.kaf_consumer import KafConsumer
@@ -36,8 +36,8 @@ class MemoryStressTest(RedpandaTest):
         # enabling each test case to customize its ResourceSettings
         pass
 
+    @ignore
     @cluster(num_nodes=5)
-    @skip_debug_mode
     @parametrize(memory_share_for_fetch=0.05)
     @parametrize(memory_share_for_fetch=0.5)
     @parametrize(memory_share_for_fetch=0.7)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -16,9 +16,9 @@ import requests
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark import ignore, matrix, ok_to_fail_fips
+from ducktape.mark import ignore, matrix
 
-from rptest.utils.mode_checks import skip_debug_mode
+from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
@@ -1018,7 +1018,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                                             stop_timeout=90)
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -15,7 +15,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 
-from ducktape.mark import matrix, ok_to_fail_fips
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.cluster import cluster
@@ -24,7 +24,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, SISettings
 from rptest.services.redpanda_installer import RedpandaInstaller
-from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode
+from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode, skip_fips_mode
 from rptest.utils.node_operations import FailureInjectorBackgroundThread, NodeOpsExecutor, generate_random_workload
 
 from rptest.clients.offline_log_viewer import OfflineLogViewer
@@ -289,7 +289,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             assert self.consumer.consumer_status.validator.invalid_reads == 0, f"Invalid reads in topic: {self.topic}, invalid reads count: {self.consumer.consumer_status.validator.invalid_reads}"
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @skip_debug_mode
     @cluster(num_nodes=8,
              log_allow_list=CHAOS_LOG_ALLOW_LIST +

--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -17,7 +17,7 @@ from ducktape.utils.util import wait_until
 
 import ducktape.errors
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize, ok_to_fail_fips
+from ducktape.mark import parametrize
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services.admin import (Admin, RedpandaNode, RoleMemberList,
                                    RoleUpdate, RoleErrorCode, RoleError,
@@ -29,6 +29,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.admin_api_auth_test import create_user_and_wait
 from rptest.tests.metrics_reporter_test import MetricsReporterServer
 from rptest.util import expect_exception, expect_http_error, wait_until_result
+from rptest.utils.mode_checks import skip_fips_mode
 
 ALICE = SaslCredentials("alice", "itsMeH0nest", "SCRAM-SHA-256")
 
@@ -641,7 +642,7 @@ class RBACLicenseTest(RBACTestBase):
         )
 
     @cluster(num_nodes=1)
-    @ok_to_fail_fips  # See NOTE below
+    @skip_fips_mode  # See NOTE below
     def test_license_nag(self):
         wait_until(self._license_nag_is_set,
                    timeout_sec=30,

--- a/tests/rptest/tests/rbac_upgrade_test.py
+++ b/tests/rptest/tests/rbac_upgrade_test.py
@@ -8,14 +8,13 @@
 
 import time
 
-from ducktape.mark import ok_to_fail_fips
-
 from rptest.services.admin import Admin, Role, RoleMember
 from rptest.util import wait_until_result
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.redpanda_installer import wait_for_num_versions
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class UpgradeMigrationCreatingDefaultRole(RedpandaTest):
@@ -45,7 +44,7 @@ class UpgradeMigrationCreatingDefaultRole(RedpandaTest):
             "license is required to use enterprise features")
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @ok_to_fail_fips  # See NOTE below
+    @skip_fips_mode  # See NOTE below
     def test_rbac_migration(self):
         # Create some users to add to the default role
         self.admin.create_user("alice")

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -16,7 +16,7 @@ from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.util import expect_exception
 
-from ducktape.mark import matrix, ok_to_fail_fips
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
 from rptest.services.redpanda import CloudStorageType, CloudStorageTypeAndUrlStyle, MetricsEndpoint, RedpandaService, get_cloud_storage_type, get_cloud_storage_url_style, get_cloud_storage_type_and_url_style, make_redpanda_service
@@ -26,6 +26,7 @@ from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.util import (wait_until, wait_until_result)
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class BucketUsage(NamedTuple):
@@ -408,7 +409,7 @@ class TestReadReplicaService(EndToEndTest):
             assert len(objects_after) >= len(objects_before)
 
     # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=9, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
     @matrix(
         partition_count=[10],
@@ -486,7 +487,7 @@ class ReadReplicasUpgradeTest(EndToEndTest):
         self.second_cluster = None
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=8)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -14,7 +14,7 @@ import time
 from ducktape.cluster.remoteaccount import RemoteCommandError, RemoteAccountSSHConfig
 from ducktape.cluster.windows_remoteaccount import WindowsRemoteAccount
 from ducktape.errors import TimeoutError
-from ducktape.mark import env, ok_to_fail, parametrize
+from ducktape.mark import env, parametrize
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, RpkException
@@ -376,7 +376,6 @@ class RedpandaKerberosExternalActiveDirectoryTest(RedpandaKerberosTestBase):
         super(RedpandaKerberosExternalActiveDirectoryTest, self).setUp()
 
     @env(ACTIVE_DIRECTORY_REALM=IsCIOrNotEmpty())
-    @ok_to_fail  # Not all CI builders have access to an ADDS - let's find out which ones.
     @cluster(num_nodes=2)
     def test_metadata(self):
         principal = f"client/localhost"

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -14,7 +14,7 @@ import time
 from ducktape.cluster.remoteaccount import RemoteCommandError, RemoteAccountSSHConfig
 from ducktape.cluster.windows_remoteaccount import WindowsRemoteAccount
 from ducktape.errors import TimeoutError
-from ducktape.mark import env, parametrize
+from ducktape.mark import env, ignore, parametrize
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, RpkException
@@ -375,6 +375,7 @@ class RedpandaKerberosExternalActiveDirectoryTest(RedpandaKerberosTestBase):
     def setUp(self):
         super(RedpandaKerberosExternalActiveDirectoryTest, self).setUp()
 
+    @ignore  # Not all CI builders have access to an ADDS - let's find out which ones - ignoring for now
     @env(ACTIVE_DIRECTORY_REALM=IsCIOrNotEmpty())
     @cluster(num_nodes=2)
     def test_metadata(self):

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -14,7 +14,7 @@ import time
 from ducktape.cluster.remoteaccount import RemoteCommandError, RemoteAccountSSHConfig
 from ducktape.cluster.windows_remoteaccount import WindowsRemoteAccount
 from ducktape.errors import TimeoutError
-from ducktape.mark import env, ok_to_fail, ok_to_fail_fips, parametrize
+from ducktape.mark import env, ok_to_fail, parametrize
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, RpkException
@@ -23,6 +23,7 @@ from rptest.services.cluster import cluster
 from rptest.services.kerberos import KrbKdc, KrbClient, RedpandaKerberosNode, AuthenticationError, KRB5_CONF_PATH, render_krb5_config, ActiveDirectoryKdc
 from rptest.services.redpanda import LoggingConfig, RedpandaService, SecurityConfig
 from rptest.tests.sasl_reauth_test import get_sasl_metrics, REAUTH_METRIC, EXPIRATION_METRIC
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.rpenv import IsCIOrNotEmpty
 
 LOG_CONFIG = LoggingConfig('info',
@@ -179,7 +180,7 @@ class RedpandaKerberosLicenseTest(RedpandaKerberosTestBase):
         )
 
     @cluster(num_nodes=3)
-    @ok_to_fail_fips  # See NOTE below
+    @skip_fips_mode  # See NOTE below
     def test_license_nag(self):
         wait_until(self._license_nag_is_set,
                    timeout_sec=30,

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -10,7 +10,7 @@
 import threading
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize, ok_to_fail_fips
+from ducktape.mark import parametrize
 
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.python_librdkafka import PythonLibrdkafka
@@ -21,6 +21,7 @@ from rptest.services.cluster import cluster
 from rptest.services.tls import TLSCertManager
 from rptest.tests.sasl_reauth_test import get_sasl_metrics, REAUTH_METRIC, EXPIRATION_METRIC
 from rptest.util import expect_exception
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.tests.tls_metrics_test import FaketimeTLSProvider
 
 import requests
@@ -621,7 +622,7 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
         )
 
     @cluster(num_nodes=3)
-    @ok_to_fail_fips  # See NOTE below
+    @skip_fips_mode  # See NOTE below
     @parametrize(authn_config={"sasl_mechanisms": ["OAUTHBEARER", "SCRAM"]})
     @parametrize(authn_config={"http_authentication": ["OIDC", "BASIC"]})
     def test_license_nag(self, authn_config):

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -11,7 +11,6 @@ import os
 from time import sleep
 
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.mark import ok_to_fail
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -72,7 +71,6 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
         super(RedpandaFIPSStartupTest,
               self).__init__(test_context=test_context)
 
-    @ok_to_fail  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_startup(self):
         """
@@ -124,7 +122,6 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
             metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
             expected_mode=RedpandaServiceBase.FIPSMode.permissive)
 
-    @ok_to_fail  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_non_homogenous(self):
         """
@@ -256,7 +253,6 @@ class RedpandaFIPSStartupLicenseTest(RedpandaFIPSStartupTestBase):
             f"Overriding default license log annoy interval to: {self.LICENSE_CHECK_INTERVAL_SEC}s"
         )
 
-    @ok_to_fail  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_fips_license_nag(self):
         wait_until(self._license_nag_is_set,

--- a/tests/rptest/tests/rpk_plugin_test.py
+++ b/tests/rptest/tests/rpk_plugin_test.py
@@ -10,7 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
-from ducktape.mark import ok_to_fail_fips
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class RpkPluginTest(RedpandaTest):
@@ -19,7 +19,7 @@ class RpkPluginTest(RedpandaTest):
         self._ctx = ctx
         self._rpk = RpkTool(self.redpanda)
 
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=1)
     def test_managed_byoc(self):
         """
@@ -82,7 +82,7 @@ class RpkPluginTest(RedpandaTest):
         assert not find_flag(out["flags"], "-X", "brokers=127.0.0.1:9092")
         assert not find_flag(out["flags"], "--verbose", "")
 
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=1)
     def test_non_managed_plugin(self):
         assert ".rpk.ac-pluginmock" in self._rpk.plugin_list()

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -21,7 +21,7 @@ import socket
 
 from confluent_kafka.schema_registry import SchemaRegistryClient, topic_subject_name_strategy, record_subject_name_strategy, topic_record_subject_name_strategy, Schema, SchemaRegistryError, SchemaReference
 from confluent_kafka.serialization import (MessageField, SerializationContext)
-from ducktape.mark import parametrize, matrix, ok_to_fail_fips
+from ducktape.mark import parametrize, matrix
 from ducktape.services.background_thread import BackgroundThreadService
 from ducktape.utils.util import wait_until
 
@@ -39,6 +39,7 @@ from rptest.tests.cluster_config_test import wait_for_version_status_sync
 from rptest.tests.pandaproxy_test import User, PandaProxyTLSProvider
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, inject_remote_script, search_logs_with_timeout
+from rptest.utils.mode_checks import skip_fips_mode
 
 
 class SchemaIdValidationMode(str, Enum):
@@ -3852,7 +3853,7 @@ class SchemaRegistryLicenseTest(RedpandaTest):
         )
 
     @cluster(num_nodes=3)
-    @ok_to_fail_fips  # See NOTE below
+    @skip_fips_mode  # See NOTE below
     @parametrize(mode=SchemaIdValidationMode.REDPANDA)
     @parametrize(mode=SchemaIdValidationMode.COMPAT)
     def test_license_nag(self, mode):

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -16,7 +16,7 @@ from threading import Condition
 from collections import defaultdict
 from typing import List
 
-from ducktape.mark import matrix, ok_to_fail_fips
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -31,6 +31,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
 from rptest.services.redpanda import SISettings, CloudStorageTypeAndUrlStyle, get_cloud_storage_type, get_cloud_storage_type_and_url_style, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
 from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD, get_test_case_from_name
 
@@ -547,7 +548,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.thread_pool.shutdown()
 
     # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=4)
     @matrix(
         cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -12,7 +12,7 @@ import time
 from collections import defaultdict
 from packaging.version import Version
 
-from ducktape.mark import parametrize, matrix, ok_to_fail_fips
+from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
@@ -27,6 +27,7 @@ from rptest.util import (
     produce_until_segments,
     wait_until_segments,
 )
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.si_utils import BucketView
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
@@ -387,7 +388,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         super().setUp()
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -22,8 +22,8 @@ from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
 from rptest.tests.workload_upgrade_config_defaults import SetLogSegmentMsMinConfig
-from rptest.utils.mode_checks import skip_debug_mode
-from ducktape.mark import matrix, ok_to_fail_fips
+from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
+from ducktape.mark import matrix
 
 
 def expand_version(
@@ -251,7 +251,7 @@ class RedpandaUpgradeTest(PreallocNodesTest):
         return Admin(self.redpanda).get_features()['cluster_version']
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @ok_to_fail_fips
+    @skip_fips_mode
     @skip_debug_mode
     @cluster(num_nodes=4)
     # TODO(vlad): Allow this test on ABS once we have at least two versions

--- a/tests/rptest/transactions/compaction_e2e_test.py
+++ b/tests/rptest/transactions/compaction_e2e_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec


### PR DESCRIPTION
Removes `@ok_to_fail` and `@ok_to_fail_fips` annotations from tests. After this merges, no test will produce `OPASS` or `OFAIL` status. However, the `OPassed | OFailed | OPassedFIPS | OFailedFIPS` columns will still be shown in the report. They will be removed on a future PR that updates the reference to ducktape to an ok-to-fail-less branch of our fork (currently being worked on).

In addition, 5 tests that always fail on all environments are disabled with `@ignore` to avoid running them.

fixes https://redpandadata.atlassian.net/browse/DEVPROD-2154

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
