### PR TITLE
gha: rm use of rp_storage_tool_uploader

### DIFF
--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            ,sdlc/prod/github/rp_storage_tool_uploader
-          parse-json-secrets: true
       - uses: actions/checkout@v4
       - name: Build binary
         run: |
@@ -45,10 +40,6 @@ jobs:
           docker cp $id:/usr/local/bin/rp-storage-tool ./
           ./rp-storage-tool --help
       - name: Push to public bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_RP_STORAGE_UPLOADER_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_RP_STORAGE_UPLOADER_SECRET }}
-          AWS_DEFAULT_REGION: us-west-2
         run: |
           arch=$(uname -m)
           os=$(uname | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
The IAM role assumed by this workflow runner has permissions to upload.

jira: [DEVPROD-1936]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none

[DEVPROD-1936]: https://redpandadata.atlassian.net/browse/DEVPROD-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ