### PR TITLE
CORE-7747: iceberg: catalog client with oauth flow

### DIFF
--- a/src/v/http/BUILD
+++ b/src/v/http/BUILD
@@ -14,6 +14,9 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@boost//:algorithm",
         "@seastar",
     ],
 )

--- a/src/v/http/BUILD
+++ b/src/v/http/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
     ],
     include_prefix = "http",
     deps = [
+        ":utils",
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",

--- a/src/v/http/CMakeLists.txt
+++ b/src/v/http/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     utils.cc
     request_builder.cc
     rest_client/rest_entity.cc
+    utils.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/http/tests/BUILD
+++ b/src/v/http/tests/BUILD
@@ -89,6 +89,7 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/bytes:iobuf_parser",
         "//src/v/http:utils",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/http/tests/uri_encoding_test.cc
+++ b/src/v/http/tests/uri_encoding_test.cc
@@ -9,9 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
+#include "bytes/iobuf_parser.h"
 #include "http/utils.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+using namespace testing;
 
 TEST(uri_encoding, encode_special_chars) {
     constexpr auto input = "afgz0119!#$&'()*+,/:;=?@[]afgz0119";
@@ -24,4 +28,25 @@ TEST(uri_encoding, encode_special_chars) {
       http::uri_encode(input, http::uri_encode_slash::no),
       "afgz0119%21%23%24%26%27%28%29%2a%2b%2c/"
       "%3a%3b%3d%3f%40%5b%5dafgz0119");
+}
+
+TEST(uri_encoding, form_encoded_data) {
+    const absl::flat_hash_map<ss::sstring, ss::sstring> input{
+      {"afgz0119!#$&'()*+,/:;=?@[]afgz0119",
+       "afgz0119!#$&'()*+,/:;=?@[]afgz0119"},
+      {"foo", "bar"}};
+    iobuf_parser p{http::form_encode_data(input)};
+
+    // Order of kv pairs is not guaranteed due to map iteration order
+    ASSERT_THAT(
+      p.read_string(p.bytes_left()),
+      AnyOf(
+        "foo=bar&afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%40%"
+        "5b%"
+        "5dafgz0119=afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
+        "40%"
+        "5b%5dafgz0119",
+        "afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
+        "40%5b%5dafgz0119=afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%"
+        "3b%3d%3f%40%5b%5dafgz0119&foo=bar"));
 }

--- a/src/v/http/utils.cc
+++ b/src/v/http/utils.cc
@@ -13,6 +13,8 @@
 
 #include "bytes/bytes.h"
 
+#include <boost/algorithm/string/join.hpp>
+
 namespace {
 
 inline void append_hex_utf8(ss::sstring& result, char ch) {
@@ -47,6 +49,18 @@ ss::sstring uri_encode(std::string_view input, uri_encode_slash encode_slash) {
         }
     }
     return result;
+}
+
+iobuf form_encode_data(
+  const absl::flat_hash_map<ss::sstring, ss::sstring>& data) {
+    std::vector<ss::sstring> pairs;
+    for (const auto& [k, v] : data) {
+        pairs.emplace_back(fmt::format(
+          "{}={}",
+          uri_encode(k, uri_encode_slash::yes),
+          uri_encode(v, uri_encode_slash::yes)));
+    }
+    return iobuf::from(boost::algorithm::join(pairs, "&"));
 }
 
 } // namespace http

--- a/src/v/http/utils.h
+++ b/src/v/http/utils.h
@@ -12,13 +12,19 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "bytes/iobuf.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
+
+#include <absl/container/flat_hash_map.h>
 
 namespace http {
 
 using uri_encode_slash = ss::bool_class<struct uri_encode_slash_t>;
 ss::sstring uri_encode(std::string_view input, uri_encode_slash encode_slash);
+
+iobuf form_encode_data(
+  const absl::flat_hash_map<ss::sstring, ss::sstring>& data);
 
 } // namespace http

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -62,6 +62,7 @@ v_cc_library(
     values_avro.cc
     values_bytes.cc
     rest_client/parsers.cc
+    rest_client/retry_policy.cc
   DEPS
     Avro::avro
     v::bytes

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -63,6 +63,7 @@ v_cc_library(
     values_bytes.cc
     rest_client/parsers.cc
     rest_client/retry_policy.cc
+    rest_client/catalog_client.cc
   DEPS
     Avro::avro
     v::bytes

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -61,6 +61,7 @@ v_cc_library(
     values.cc
     values_avro.cc
     values_bytes.cc
+    rest_client/parsers.cc
   DEPS
     Avro::avro
     v::bytes
@@ -72,3 +73,4 @@ v_cc_library(
 )
 
 add_subdirectory(tests)
+add_subdirectory(rest_client/tests)

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -31,3 +31,19 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
     ],
 )
+
+redpanda_cc_library(
+    name = "retry_policy",
+    srcs = [
+        "retry_policy.cc",
+    ],
+    hdrs = [
+        "retry_policy.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    deps = [
+        ":rest_client_types",
+        "//src/v/http",
+        "//src/v/net",
+    ],
+)

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -47,3 +47,29 @@ redpanda_cc_library(
         "//src/v/net",
     ],
 )
+
+redpanda_cc_library(
+    name = "rest_catalog_client",
+    srcs = [
+        "catalog_client.cc",
+    ],
+    hdrs = [
+        "catalog_client.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    deps = [
+        ":rest_client_parsers",
+        ":rest_client_types",
+        ":retry_policy",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/http",
+        "//src/v/http:request_builder",
+        "//src/v/http:utils",
+        "//src/v/json",
+        "//src/v/utils:named_type",
+        "//src/v/utils:retry_chain_node",
+        "@abseil-cpp//absl/strings",
+        "@seastar",
+    ],
+)

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -1,0 +1,33 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = ["//src/v/iceberg:__subpackages__"])
+
+redpanda_cc_library(
+    name = "rest_client_types",
+    hdrs = [
+        "types.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    deps = [
+        "//src/v/base",
+        "//src/v/thirdparty/ada",
+        "@boost//:beast",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "rest_client_parsers",
+    srcs = [
+        "parsers.cc",
+    ],
+    hdrs = [
+        "parsers.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    deps = [
+        ":rest_client_types",
+        "//src/v/json",
+        "//src/v/utils:named_type",
+    ],
+)

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/rest_client/catalog_client.h"
+
+#include "bytes/iobuf_parser.h"
+#include "http/request_builder.h"
+#include "http/utils.h"
+#include "iceberg/rest_client/parsers.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <absl/strings/str_join.h>
+#include <absl/strings/strip.h>
+
+namespace {
+
+template<typename T>
+T trim_slashes(std::optional<T> input, typename T::type default_value) {
+    if (!input.has_value()) {
+        return T{default_value};
+    }
+    return T{absl::StripSuffix(absl::StripPrefix(input.value()(), "/"), "/")};
+}
+
+} // namespace
+
+namespace iceberg::rest_client {
+
+expected<json::Document> parse_json(iobuf&& raw_response) {
+    iobuf_parser p{std::move(raw_response)};
+    auto raw_json = p.read_string(p.bytes_left());
+
+    json::Document doc;
+    doc.Parse(raw_json);
+
+    if (doc.HasParseError()) {
+        return tl::unexpected(json_parse_error{
+          .context = "parse_json",
+          .error = parse_error_msg{GetParseError_En(doc.GetParseError())}});
+    }
+
+    return doc;
+}
+
+catalog_client::catalog_client(
+  client_source& client_source,
+  ss::sstring endpoint,
+  credentials credentials,
+  std::optional<base_path> base_path,
+  std::optional<prefix_path> prefix,
+  std::optional<api_version> api_version,
+  std::optional<oauth_token> token,
+  std::unique_ptr<retry_policy> retry_policy)
+  : _client_source{client_source}
+  , _endpoint{std::move(endpoint)}
+  , _credentials{std::move(credentials)}
+  , _path_components{std::move(base_path), std::move(prefix), std::move(api_version)}
+  , _oauth_token{std::move(token)}
+  , _retry_policy{
+      retry_policy ? std::move(retry_policy)
+                   : std::make_unique<default_retry_policy>()} {}
+
+ss::future<expected<oauth_token>>
+catalog_client::acquire_token(retry_chain_node& rtc) {
+    const auto token_request
+      = http::request_builder{}
+          .method(boost::beast::http::verb::post)
+          .path(_path_components.token_api_path())
+          .header("content-type", "application/x-www-form-urlencoded");
+    auto payload = http::form_encode_data({
+      {"grant_type", "client_credentials"},
+      {"client_id", _credentials.client_id},
+      {"client_secret", _credentials.client_secret},
+      // TODO - parameterize this scope, the principal_role should be an input
+      // to the catalog client
+      {"scope", "PRINCIPAL_ROLE:ALL"},
+    });
+    co_return (co_await perform_request(rtc, token_request, std::move(payload)))
+      .and_then(parse_json)
+      .and_then(parse_oauth_token);
+}
+
+ss::sstring catalog_client::root_path() const {
+    return _path_components.root_path();
+}
+
+ss::future<expected<ss::sstring>>
+catalog_client::ensure_token(retry_chain_node& rtc) {
+    const bool need_token = !_oauth_token.has_value()
+                            || _oauth_token->expires_at
+                                 < ss::lowres_clock::now();
+    if (need_token) {
+        co_return (co_await acquire_token(rtc))
+          .and_then([this](auto t) -> expected<ss::sstring> {
+              _oauth_token.emplace(t);
+              return t.token;
+          });
+    }
+    co_return _oauth_token->token;
+}
+
+ss::future<expected<iobuf>> catalog_client::perform_request(
+  retry_chain_node& rtc,
+  http::request_builder request_builder,
+  std::optional<iobuf> payload) {
+    if (payload.has_value()) {
+        request_builder.with_content_length(payload.value().size_bytes());
+    }
+
+    auto request = request_builder.host(_endpoint).build();
+    if (!request.has_value()) {
+        co_return tl::unexpected(request.error());
+    }
+
+    std::vector<http_call_error> retriable_errors{};
+
+    auto client_ptr = _client_source.get().acquire();
+    while (true) {
+        const auto permit = rtc.retry();
+        if (!permit.is_allowed) {
+            co_await client_ptr->shutdown_and_stop();
+            co_return tl::unexpected(
+              retries_exhausted{.errors = std::move(retriable_errors)});
+        }
+
+        std::optional<iobuf> request_payload;
+        if (payload.has_value()) {
+            request_payload.emplace(payload->copy());
+        }
+        auto response_f = co_await ss::coroutine::as_future(
+          client_ptr->request_and_collect_response(
+            std::move(request.value()), std::move(request_payload)));
+        auto call_res = _retry_policy->should_retry(std::move(response_f));
+
+        if (call_res.has_value()) {
+            co_await client_ptr->shutdown_and_stop();
+            co_return std::move(call_res->body);
+        }
+
+        auto& error = call_res.error();
+        if (!error.can_be_retried) {
+            co_await client_ptr->shutdown_and_stop();
+            co_return tl::unexpected(std::move(error.err));
+        }
+
+        if (error.is_transport_error()) {
+            co_await client_ptr->shutdown_and_stop();
+            client_ptr = _client_source.get().acquire();
+        }
+
+        retriable_errors.emplace_back(std::move(error.err));
+        co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
+    }
+    co_await client_ptr->shutdown_and_stop();
+}
+
+path_components::path_components(
+  std::optional<base_path> base,
+  std::optional<prefix_path> prefix,
+  std::optional<api_version> api_version)
+  : _base{trim_slashes(std::move(base), "")}
+  , _prefix{trim_slashes(std::move(prefix), "")}
+  , _api_version{trim_slashes(std::move(api_version), "v1")} {}
+
+ss::sstring path_components::root_path() const {
+    std::vector<ss::sstring> parts;
+    if (!_base().empty()) {
+        parts.push_back(_base());
+    }
+
+    parts.push_back(_api_version());
+
+    if (!_prefix().empty()) {
+        parts.push_back(_prefix());
+    }
+
+    return absl::StrJoin(parts, "/") + "/";
+}
+
+ss::sstring path_components::token_api_path() const {
+    std::vector<ss::sstring> parts;
+    if (!_base().empty()) {
+        parts.push_back(_base());
+    }
+
+    parts.push_back(_api_version());
+    return absl::StrJoin(parts, "/") + "/oauth/tokens";
+}
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "http/client.h"
+#include "http/request_builder.h"
+#include "iceberg/rest_client/retry_policy.h"
+#include "iceberg/rest_client/types.h"
+#include "json/document.h"
+#include "utils/named_type.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+namespace iceberg::rest_client {
+
+using base_path = named_type<ss::sstring, struct base_path_t>;
+using prefix_path = named_type<ss::sstring, struct prefix_t>;
+using api_version = named_type<ss::sstring, struct api_version_t>;
+
+// A client source generates low level http clients for the catalog client to
+// make API calls with. Once a generic http client pool is implemented, it can
+// use the same interface and hand out client leases instead of unique ptrs.
+struct client_source {
+    // A client returned by this method call is owned by the caller. It should
+    // be shut down after use by the caller.
+    virtual std::unique_ptr<http::abstract_client> acquire() = 0;
+    virtual ~client_source() = default;
+};
+
+// Holds parts of a root path used by catalog client
+struct path_components {
+    path_components(
+      std::optional<base_path> base = std::nullopt,
+      std::optional<prefix_path> prefix = std::nullopt,
+      std::optional<api_version> api_version = std::nullopt);
+
+    // Returns root path for use in API calls not related to oauth token, joins
+    // base, api version and prefix with slashes and adds a terminating slash.
+    // eg for polaris:
+    // /api/catalog/v1/prefix
+    ss::sstring root_path() const;
+    // Same as root path but does not include the prefix, eg for polaris:
+    // /api/catalog/v1/oauth/tokens
+    ss::sstring token_api_path() const;
+
+private:
+    base_path _base;
+    prefix_path _prefix;
+    api_version _api_version;
+};
+
+// helper intended to catch JSON parse errors when parsing an iobuf to json
+// document before passing the document to more specific parsers
+expected<json::Document> parse_json(iobuf&& raw_response);
+
+// The catalog client enables high level operations against a catalog rest api.
+// It also ensures that a token is available before making calls. A client is
+// lightweight and expected to be created for single operations or closely
+// related operations.
+class catalog_client {
+public:
+    /// \brief Construct a catalog client
+    /// \param client_source returns unique ptrs to clients for making API calls
+    /// \param endpoint the rest catalog server hostname to connect to,
+    /// including scheme
+    /// \param credentials credentials to be used to acquire oauth token from
+    /// catalog server
+    /// \param base_path an optional path to be prefixed to all API calls made
+    /// by this client
+    /// \param prefix an optional prefix to be added after the
+    /// API version, applied to all calls made by this client, except for oauth
+    /// token requests
+    /// \param api_version api version used to construct URLs,
+    /// defaults to v1
+    /// \param token an optional oauth token which will be used
+    /// if valid. If expired, a new one will be acquired \param retry_policy a
+    /// retry policy used to determine how failing calls will be retried
+    catalog_client(
+      client_source& client_source,
+      ss::sstring endpoint,
+      credentials credentials,
+      std::optional<base_path> base_path = std::nullopt,
+      std::optional<prefix_path> prefix = std::nullopt,
+      std::optional<api_version> api_version = std::nullopt,
+      std::optional<oauth_token> token = std::nullopt,
+      std::unique_ptr<retry_policy> retry_policy = nullptr);
+
+private:
+    // The root url calculated from base url, prefix and api version. Given a
+    // base url of "/b", an api version "v2" and a prefix of "x/y", the root url
+    // is "/b/v2/x/y/". The root url is prefixed before rest entities used when
+    // making calls to the catalog service
+    ss::sstring root_path() const;
+
+    // Acquires token from catalog API by exchanging credentials
+    ss::future<expected<oauth_token>> acquire_token(retry_chain_node& rtc);
+
+    // Ensures a token is acquired if current token is unset (default state) or
+    // expired. Acquired token is cached for future calls.
+    ss::future<expected<ss::sstring>> ensure_token(retry_chain_node& rtc);
+
+    // Builds the request from supplied builder after validating it, performs
+    // the request with optional payload, and takes care of retrying according
+    // to policy
+    ss::future<expected<iobuf>> perform_request(
+      retry_chain_node& rtc,
+      http::request_builder request_builder,
+      std::optional<iobuf> payload = std::nullopt);
+
+    std::reference_wrapper<client_source> _client_source;
+    ss::sstring _endpoint;
+    credentials _credentials;
+    path_components _path_components;
+    std::optional<oauth_token> _oauth_token{std::nullopt};
+    std::unique_ptr<retry_policy> _retry_policy;
+
+    friend class catalog_client_tester;
+};
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/parsers.cc
+++ b/src/v/iceberg/rest_client/parsers.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/rest_client/parsers.h"
+
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+
+namespace {
+
+constexpr auto oauth_token_schema = R"JSON({
+    "type": "object",
+    "properties": {
+        "access_token": {
+            "type": "string"
+        },
+        "scope": {
+            "type": "string"
+        },
+        "token_type": {
+            "type": "string"
+        },
+        "expires_in": {
+            "type": "integer"
+        }
+    },
+    "required": [
+        "access_token",
+        "expires_in"
+    ]
+})JSON";
+}
+
+namespace iceberg::rest_client {
+
+parse_error_msg get_schema_validation_error(const json::SchemaValidator& v) {
+    json::StringBuffer sb;
+    json::Writer<json::StringBuffer> w{sb};
+    v.GetError().Accept(w);
+    return parse_error_msg{sb.GetString()};
+}
+
+expected<oauth_token> parse_oauth_token(json::Document&& doc) {
+    json::Document schema;
+    if (schema.Parse(oauth_token_schema).HasParseError()) {
+        return tl::unexpected(json_parse_error{
+          .context = "parse_oauth_token::invalid_schema_validator_input",
+          .error = parse_error_msg{GetParseError_En(schema.GetParseError())}});
+    }
+
+    json::SchemaDocument schema_doc{schema};
+
+    if (json::SchemaValidator v{schema_doc}; !doc.Accept(v)) {
+        return tl::unexpected(json_parse_error{
+          .context = "parse_oauth_token::response_does_not_match_schema",
+          .error = get_schema_validation_error(v)});
+    }
+
+    auto expires_in_sec = std::chrono::seconds{doc["expires_in"].GetInt()};
+    return oauth_token{
+      .token = doc["access_token"].GetString(),
+      .expires_at = ss::lowres_clock::now() + expires_in_sec};
+}
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/parsers.h
+++ b/src/v/iceberg/rest_client/parsers.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "iceberg/rest_client/types.h"
+#include "json/document.h"
+#include "json/schema.h"
+
+namespace iceberg::rest_client {
+
+// Extracts a readable/loggable error from a json schema validator which has
+// failed.
+parse_error_msg get_schema_validation_error(const json::SchemaValidator& v);
+
+// Parses oauth token from a JSON response sent from catalog server
+expected<oauth_token> parse_oauth_token(json::Document&& doc);
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/retry_policy.cc
+++ b/src/v/iceberg/rest_client/retry_policy.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/rest_client/retry_policy.h"
+
+#include "net/connection.h"
+
+namespace {
+
+using iceberg::rest_client::failure;
+
+failure unretriable(std::string_view msg) {
+    return failure{.can_be_retried = false, .err = ss::sstring{msg}};
+}
+
+failure retriable(std::string_view msg) {
+    return failure{.can_be_retried = true, .err = ss::sstring{msg}};
+}
+
+using enum boost::beast::http::status;
+constexpr auto retriable_statuses = std::to_array(
+  {internal_server_error,
+   bad_gateway,
+   service_unavailable,
+   gateway_timeout,
+   request_timeout,
+   too_many_requests});
+
+bool is_abort_or_gate_close_exception(const std::exception_ptr& ex) {
+    try {
+        std::rethrow_exception(ex);
+    } catch (const ss::abort_requested_exception&) {
+        return true;
+    } catch (const ss::gate_closed_exception&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+
+namespace iceberg::rest_client {
+
+retry_policy::result_t default_retry_policy::should_retry(
+  ss::future<http::downloaded_response> response_f) const {
+    vassert(response_f.available(), "future is not resolved");
+    if (!response_f.failed()) {
+        // future resolved successfully, check the status code
+        return should_retry(response_f.get());
+    } else {
+        // future failed, check the exception kind
+        return tl::unexpected(should_retry(response_f.get_exception()));
+    }
+}
+
+retry_policy::result_t
+default_retry_policy::should_retry(http::downloaded_response response) const {
+    const auto status = response.status;
+    // the successful status class contains all status codes starting with 2
+    if (
+      boost::beast::http::to_status_class(status)
+      == boost::beast::http::status_class::successful) {
+        return response;
+    }
+
+    const auto can_be_retried = std::ranges::find(retriable_statuses, status)
+                                != retriable_statuses.end();
+    return tl::unexpected(
+      failure{.can_be_retried = can_be_retried, .err = status});
+}
+
+failure default_retry_policy::should_retry(std::exception_ptr ex) const {
+    try {
+        std::rethrow_exception(ex);
+    } catch (const std::system_error& err) {
+        if (net::is_reconnect_error(err)) {
+            return retriable(err.what());
+        }
+        return unretriable(err.what());
+    } catch (const ss::timed_out_error& err) {
+        return retriable(err.what());
+    } catch (const boost::system::system_error& err) {
+        if (
+          err.code() != boost::beast::http::error::end_of_stream
+          && err.code() != boost::beast::http::error::partial_message) {
+            return unretriable(err.what());
+        }
+        return retriable(err.what());
+    } catch (const ss::gate_closed_exception&) {
+        throw;
+    } catch (const ss::abort_requested_exception&) {
+        throw;
+    } catch (const ss::nested_exception& nested) {
+        if (
+          is_abort_or_gate_close_exception(nested.inner)
+          || is_abort_or_gate_close_exception(nested.outer)) {
+            throw;
+        };
+        return unretriable(fmt::format(
+          "{} [outer: {}, inner: {}]",
+          nested.what(),
+          nested.outer,
+          nested.inner));
+    } catch (...) {
+        return unretriable(fmt::format("{}", std::current_exception()));
+    }
+}
+
+bool failure::is_transport_error() const {
+    return std::holds_alternative<ss::sstring>(err);
+}
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/retry_policy.h
+++ b/src/v/iceberg/rest_client/retry_policy.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "http/client.h"
+#include "iceberg/rest_client/types.h"
+
+namespace iceberg::rest_client {
+
+// Represents an http call which failed, encodes information about possible
+// retriability and cause
+struct failure {
+    bool can_be_retried;
+    http_call_error err;
+    bool is_transport_error() const;
+};
+
+struct retry_policy {
+    using result_t = tl::expected<http::downloaded_response, failure>;
+
+    // Given a ready future which will yield a downloaded_response, judges
+    // whether it is:
+    // 1. successful
+    // 2. has failed and can be retried
+    // 3. has failed and cannot be retried
+    virtual result_t
+    should_retry(ss::future<http::downloaded_response> response_f) const
+      = 0;
+
+    // If the ready future did not fail, this method checks the response http
+    // status
+    virtual result_t should_retry(http::downloaded_response response) const = 0;
+
+    // Handles the case where the future failed with an exception. Shutdown
+    // related errors are rethrown, all other errors are classified into
+    // retriable or unretriable.
+    virtual failure should_retry(std::exception_ptr ex) const = 0;
+    virtual ~retry_policy() = default;
+};
+
+struct default_retry_policy : public retry_policy {
+    result_t
+    should_retry(ss::future<http::downloaded_response> response_f) const final;
+    result_t should_retry(http::downloaded_response response) const final;
+    failure should_retry(std::exception_ptr ex) const final;
+};
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/tests/BUILD
+++ b/src/v/iceberg/rest_client/tests/BUILD
@@ -13,3 +13,17 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "retry_policy_tests",
+    timeout = "short",
+    srcs = [
+        "retry_policy_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/iceberg/rest_client:retry_policy",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/iceberg/rest_client/tests/BUILD
+++ b/src/v/iceberg/rest_client/tests/BUILD
@@ -1,0 +1,15 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "rest_client_parser_tests",
+    timeout = "short",
+    srcs = [
+        "parser_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/iceberg/rest_client:rest_client_parsers",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/iceberg/rest_client/tests/BUILD
+++ b/src/v/iceberg/rest_client/tests/BUILD
@@ -27,3 +27,19 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "catalog_client_tests",
+    timeout = "short",
+    srcs = [
+        "catalog_client_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/iceberg/rest_client:rest_catalog_client",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/iceberg/rest_client/tests/CMakeLists.txt
+++ b/src/v/iceberg/rest_client/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME rc_parsers
+  SOURCES
+    parser_tests.cc
+  LIBRARIES
+    v::gtest_main
+    v::iceberg
+  ARGS "-- -c1"
+)

--- a/src/v/iceberg/rest_client/tests/CMakeLists.txt
+++ b/src/v/iceberg/rest_client/tests/CMakeLists.txt
@@ -21,3 +21,15 @@ rp_test(
     v::iceberg
   ARGS "-- -c1"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME rc_catalog_client
+  SOURCES
+    catalog_client_tests.cc
+  LIBRARIES
+    v::gtest_main
+    v::iceberg
+  ARGS "-- -c1"
+)

--- a/src/v/iceberg/rest_client/tests/CMakeLists.txt
+++ b/src/v/iceberg/rest_client/tests/CMakeLists.txt
@@ -9,3 +9,15 @@ rp_test(
     v::iceberg
   ARGS "-- -c1"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME rc_retry_policy
+  SOURCES
+    retry_policy_tests.cc
+  LIBRARIES
+    v::gtest_main
+    v::iceberg
+  ARGS "-- -c1"
+)

--- a/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
+++ b/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf_parser.h"
+#include "iceberg/rest_client/catalog_client.h"
+
+#include <seastar/core/sleep.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace r = iceberg::rest_client;
+namespace t = ::testing;
+namespace bh = boost::beast::http;
+
+using namespace std::chrono_literals;
+
+namespace {
+constexpr auto endpoint = "http://localhost:8181";
+const r::credentials credentials{.client_id = "id", .client_secret = "secret"};
+
+template<typename Variant, typename Outer>
+void assert_type_and_value(Outer input, Variant expected) {
+    EXPECT_TRUE(std::holds_alternative<Variant>(input));
+    EXPECT_EQ(std::get<Variant>(input), expected);
+}
+
+} // namespace
+
+class mock_client : public http::abstract_client {
+public:
+    MOCK_METHOD(
+      ss::future<http::downloaded_response>,
+      request_and_collect_response,
+      (bh::request_header<>&&,
+       std::optional<iobuf>,
+       ss::lowres_clock::duration),
+      (override));
+    MOCK_METHOD(ss::future<>, shutdown_and_stop, (), (override));
+};
+
+// A client source for testing. Allows setting expectation on a client before
+// returning to the catalog client.
+struct client_source : public r::client_source {
+    client_source(
+      std::function<void(std::reference_wrapper<mock_client>)> expectation)
+      : _expectation{std::move(expectation)} {}
+
+    std::unique_ptr<http::abstract_client> acquire() final {
+        auto ptr = std::make_unique<mock_client>();
+        _expectation(*(ptr.get()));
+
+        // Client passed to caller should always be shut down, and exactly once
+        EXPECT_CALL(*(ptr.get()), shutdown_and_stop())
+          .Times(1)
+          .WillOnce(t::Return(ss::make_ready_future()));
+        return ptr;
+    }
+
+private:
+    std::function<void(std::reference_wrapper<mock_client>)> _expectation;
+};
+
+namespace iceberg::rest_client {
+
+class catalog_client_tester {
+public:
+    explicit catalog_client_tester(catalog_client& c)
+      : _c{c} {}
+
+    ss::sstring root_path() const { return _c.root_path(); }
+
+    ss::future<expected<ss::sstring>> get_current_token() const {
+        ss::abort_source as;
+        retry_chain_node rtc{as, 5s, 200ms};
+        co_return co_await _c.ensure_token(rtc);
+    }
+
+private:
+    catalog_client& _c;
+};
+
+} // namespace iceberg::rest_client
+
+TEST(path_components, path_with_base_and_prefix) {
+    r::path_components pc{
+      r::base_path{"b"}, r::prefix_path{"pre"}, r::api_version{"v1"}};
+    ASSERT_EQ(pc.root_path(), "b/v1/pre/");
+    ASSERT_EQ(pc.token_api_path(), "b/v1/oauth/tokens");
+}
+
+TEST(path_components, path_with_no_optional_parts) {
+    r::path_components pc{};
+    ASSERT_EQ(pc.root_path(), "v1/");
+    ASSERT_EQ(pc.token_api_path(), "v1/oauth/tokens");
+}
+
+TEST(path_components, path_with_prefix) {
+    r::path_components pc{std::nullopt, r::prefix_path{"pre"}};
+    ASSERT_EQ(pc.root_path(), "v1/pre/");
+    ASSERT_EQ(pc.token_api_path(), "v1/oauth/tokens");
+}
+
+TEST(client, root_url_computed) {
+    client_source cs{[](mock_client&) {}};
+    r::catalog_client cc{
+      cs,
+      endpoint,
+      credentials,
+      r::base_path{"api/catalog/"},
+      r::prefix_path{"x"},
+      r::api_version{"v2"}};
+    r::catalog_client_tester t{cc};
+    ASSERT_EQ(t.root_path(), "api/catalog/v2/x/");
+}
+
+ss::future<http::downloaded_response> validate_token_request(
+  bh::request_header<>&& r,
+  std::optional<iobuf> payload,
+  [[maybe_unused]] ss::lowres_clock::duration timeout) {
+    EXPECT_EQ(r.at(bh::field::host), "localhost:8181");
+    EXPECT_EQ(
+      r.at(bh::field::content_type), "application/x-www-form-urlencoded");
+    EXPECT_TRUE(payload.has_value());
+    iobuf_parser p{std::move(payload.value())};
+    auto received = p.read_string(p.bytes_left());
+    std::ranges::sort(received);
+
+    ss::sstring expected{
+      "grant_type=client_credentials&scope=PRINCIPAL_ROLE%3aALL&client_secret="
+      "secret&client_id=id"};
+    std::ranges::sort(expected);
+
+    EXPECT_EQ(received, expected);
+
+    co_return http::downloaded_response{
+      .status = bh::status::ok,
+      .body = iobuf::from(R"J({"access_token": "token", "expires_in": 1})J")};
+}
+
+TEST(token_tests, acquire_token) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillOnce(validate_token_request);
+    }};
+    r::catalog_client cc{cs, endpoint, credentials};
+    r::catalog_client_tester t{cc};
+    auto token = t.get_current_token().get();
+    ASSERT_TRUE(token.has_value());
+    ASSERT_EQ(token, "token");
+}
+
+TEST(token_tests, supplied_token_used) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_)).Times(0);
+    }};
+    const r::oauth_token supplied_token{
+      .token = "t", .expires_at = ss::lowres_clock::now() + 1h};
+    r::catalog_client cc{
+      cs,
+      endpoint,
+      credentials,
+      std::nullopt,
+      std::nullopt,
+      r::api_version{"v1"},
+      supplied_token};
+
+    r::catalog_client_tester t{cc};
+    auto token = t.get_current_token().get();
+    ASSERT_TRUE(token.has_value());
+    ASSERT_EQ(token, supplied_token.token);
+}
+
+TEST(token_tests, supplied_token_expired) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillOnce(validate_token_request);
+    }};
+    const r::oauth_token expired_token{
+      .token = "t", .expires_at = ss::lowres_clock::now()};
+    r::catalog_client cc{
+      cs,
+      endpoint,
+      credentials,
+      std::nullopt,
+      std::nullopt,
+      r::api_version{"v1"},
+      expired_token};
+
+    ss::sleep(1s).get();
+    r::catalog_client_tester t{cc};
+    auto token = t.get_current_token().get();
+    ASSERT_TRUE(token.has_value());
+    ASSERT_EQ(token, "token");
+}
+
+TEST(token_tests, handle_bad_json) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillOnce(t::Return(ss::make_ready_future<http::downloaded_response>(
+            http::downloaded_response{
+              .status = bh::status::ok, .body = iobuf::from(R"J({)J")})));
+    }};
+    r::catalog_client cc{cs, endpoint, credentials};
+    r::catalog_client_tester t{cc};
+    auto token = t.get_current_token().get();
+    ASSERT_FALSE(token.has_value());
+    ASSERT_THAT(
+      token.error(),
+      t::VariantWith<r::json_parse_error>(
+        t::Field(&r::json_parse_error::context, "parse_json")));
+}
+
+TEST(token_tests, handle_non_retriable_http_status) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillOnce(t::Return(ss::make_ready_future<http::downloaded_response>(
+            http::downloaded_response{
+              .status = bh::status::bad_request, .body = iobuf()})));
+    }};
+
+    r::catalog_client cc{cs, endpoint, credentials};
+    r::catalog_client_tester t{cc};
+
+    auto token = t.get_current_token().get();
+    ASSERT_FALSE(token.has_value());
+    ASSERT_THAT(
+      token.error(),
+      t::VariantWith<r::http_call_error>(
+        t::VariantWith<bh::status>(bh::status::bad_request)));
+}
+
+TEST(token_tests, handle_retriable_http_status) {
+    client_source cs{[](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillOnce(t::Return(ss::make_ready_future<http::downloaded_response>(
+            http::downloaded_response{
+              .status = bh::status::gateway_timeout, .body = iobuf()})))
+          .WillOnce(t::Return(ss::make_ready_future<http::downloaded_response>(
+            http::downloaded_response{
+              .status = bh::status::ok,
+              .body = iobuf::from(
+                R"J({"access_token": "token", "expires_in": 1})J")})));
+    }};
+    r::catalog_client cc{cs, endpoint, credentials};
+    r::catalog_client_tester t{cc};
+
+    auto token = t.get_current_token().get();
+    ASSERT_TRUE(token.has_value());
+    ASSERT_EQ(token, "token");
+}
+
+TEST(token_tests, handle_retries_exhausted) {
+    auto ret = [](
+                 [[maybe_unused]] bh::request_header<>&& r,
+                 [[maybe_unused]] std::optional<iobuf> payload,
+                 [[maybe_unused]] ss::lowres_clock::duration timeout) {
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{.status = bh::status::gateway_timeout});
+    };
+
+    client_source cs{[&ret](mock_client& m) {
+        EXPECT_CALL(m, request_and_collect_response(t::_, t::_, t::_))
+          .WillRepeatedly(ret);
+    }};
+
+    r::catalog_client cc{cs, endpoint, credentials};
+    r::catalog_client_tester t{cc};
+
+    auto token = t.get_current_token().get();
+    ASSERT_FALSE(token.has_value());
+    ASSERT_THAT(
+      token.error(),
+      t::VariantWith<r::retries_exhausted>(t::Field(
+        &r::retries_exhausted::errors,
+        t::Each(t::VariantWith<bh::status>(bh::status::gateway_timeout)))));
+}

--- a/src/v/iceberg/rest_client/tests/parser_tests.cc
+++ b/src/v/iceberg/rest_client/tests/parser_tests.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/rest_client/parsers.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace r = iceberg::rest_client;
+using namespace testing;
+
+json::Document make_doc(ss::sstring s) {
+    json::Document d;
+    d.Parse(s);
+    return d;
+}
+
+TEST(oauth_token, invalid_doc_fails_schema) {
+    auto result = r::parse_oauth_token(make_doc("{}"));
+    ASSERT_FALSE(result.has_value());
+    ASSERT_THAT(
+      result.error(),
+      VariantWith<r::json_parse_error>(Field(
+        &r::json_parse_error::context,
+        "parse_oauth_token::response_does_not_match_schema")));
+}
+
+TEST(oauth_token, type_mismatch_fails_schema) {
+    auto result = r::parse_oauth_token(
+      make_doc(R"J({"access_token": "", "expires_in": "42"})J"));
+    ASSERT_FALSE(result.has_value());
+    ASSERT_THAT(
+      result.error(),
+      VariantWith<r::json_parse_error>(Field(
+        &r::json_parse_error::context,
+        "parse_oauth_token::response_does_not_match_schema")));
+}
+
+TEST(oauth_token, valid_doc_parse) {
+    using namespace std::chrono_literals;
+    auto result = r::parse_oauth_token(
+      make_doc(R"J({"access_token": "", "expires_in": 42})J"));
+    ASSERT_TRUE(result.has_value());
+    const auto& token = result.value();
+    ASSERT_EQ(token.token, "");
+    // Assume that it doesn't take more than 2 seconds to get to this assertion
+    ASSERT_THAT(
+      token.expires_at - ss::lowres_clock::now(), AllOf(Le(42s), Ge(40s)));
+}

--- a/src/v/iceberg/rest_client/tests/retry_policy_tests.cc
+++ b/src/v/iceberg/rest_client/tests/retry_policy_tests.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/rest_client/retry_policy.h"
+
+#include <gtest/gtest.h>
+
+namespace r = iceberg::rest_client;
+using enum boost::beast::http::status;
+
+namespace {
+template<typename Ex>
+r::failure throw_and_catch(Ex ex) {
+    try {
+        throw ex;
+    } catch (...) {
+        return r::default_retry_policy{}.should_retry(std::current_exception());
+    }
+}
+} // namespace
+
+TEST(default_retry_policy, status_ok) {
+    r::default_retry_policy p;
+    auto result = p.should_retry(
+      http::downloaded_response{.status = ok, .body = iobuf::from("success")});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().body, iobuf::from("success"));
+}
+
+TEST(default_retry_policy, status_retriable) {
+    r::default_retry_policy p;
+    for (const auto status : std::to_array(
+           {internal_server_error,
+            bad_gateway,
+            service_unavailable,
+            gateway_timeout,
+            too_many_requests,
+            request_timeout})) {
+        auto result = p.should_retry(http::downloaded_response{
+          .status = status, .body = iobuf::from("retry")});
+        ASSERT_FALSE(result.has_value());
+        ASSERT_TRUE(result.error().can_be_retried);
+    }
+}
+
+TEST(default_retry_policy, status_not_retriable) {
+    r::default_retry_policy p;
+    for (const auto status : std::to_array(
+           {bad_request, unauthorized, method_not_allowed, not_acceptable})) {
+        auto result = p.should_retry(http::downloaded_response{
+          .status = status, .body = iobuf::from("retry")});
+        ASSERT_FALSE(result.has_value());
+        ASSERT_FALSE(result.error().can_be_retried);
+    }
+}
+
+TEST(default_retry_policy, boost_system_errors) {
+    auto retriable = throw_and_catch(
+      boost::system::system_error{boost::beast::http::error::end_of_stream});
+    ASSERT_TRUE(retriable.can_be_retried);
+    auto unretriable = throw_and_catch(
+      boost::system::system_error{boost::beast::http::error::bad_alloc});
+    ASSERT_FALSE(unretriable.can_be_retried);
+}
+
+TEST(default_retry_policy, system_errors) {
+    auto retriable = throw_and_catch(
+      std::system_error{ETIMEDOUT, std::generic_category()});
+    ASSERT_TRUE(retriable.can_be_retried);
+    auto unretriable = throw_and_catch(
+      std::system_error{ETIMEDOUT, ss::tls::error_category()});
+    ASSERT_FALSE(unretriable.can_be_retried);
+}
+
+TEST(default_retry_policy, rethrown_exceptions) {
+    EXPECT_THROW(
+      throw_and_catch(ss::gate_closed_exception{}), ss::gate_closed_exception);
+    EXPECT_THROW(
+      throw_and_catch(ss::abort_requested_exception{}),
+      ss::abort_requested_exception);
+}
+
+TEST(default_retry_policy, nested_exception) {
+    EXPECT_THROW(
+      throw_and_catch(ss::nested_exception{
+        std::make_exception_ptr(ss::gate_closed_exception{}),
+        std::make_exception_ptr(std::runtime_error{"out"})}),
+      ss::nested_exception);
+    EXPECT_THROW(
+      throw_and_catch(ss::nested_exception{
+        std::make_exception_ptr(std::invalid_argument{""}),
+        std::make_exception_ptr(ss::abort_requested_exception{})}),
+      ss::nested_exception);
+
+    auto result = throw_and_catch(ss::nested_exception{
+      std::make_exception_ptr(std::invalid_argument{"i"}),
+      std::make_exception_ptr(std::invalid_argument{"o"})});
+    ASSERT_FALSE(result.can_be_retried);
+    ASSERT_TRUE(std::holds_alternative<ss::sstring>(result.err));
+    ASSERT_EQ(
+      "seastar::nested_exception [outer: std::invalid_argument (o), "
+      "inner: std::invalid_argument (i)]",
+      std::get<ss::sstring>(result.err));
+}

--- a/src/v/iceberg/rest_client/types.h
+++ b/src/v/iceberg/rest_client/types.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sstring.hh>
+
+#include <ada/expected.h>
+
+namespace iceberg::rest_client {
+
+using parse_error_msg = named_type<ss::sstring, struct parse_error_msg_t>;
+
+struct json_parse_error {
+    ss::sstring context;
+    parse_error_msg error;
+};
+
+// The domain error represents the sum of all error types which can be
+// encountered during rest-client operations.
+using domain_error = std::variant<json_parse_error>;
+
+// The core result type used by all operations in the iceberg/rest-client which
+// can fail. Allows chaining of operations together and short-circuiting when an
+// earlier operation in the chain has failed.
+template<typename T>
+using expected = tl::expected<T, domain_error>;
+
+// Oauth token returned by the catalog server, in exchange for credentials
+struct oauth_token {
+    ss::sstring token;
+    ss::lowres_clock::time_point expires_at;
+};
+
+// Static credentials expected to be supplied by redpanda when requesting an
+// oauth token
+struct credentials {
+    ss::sstring client_id;
+    ss::sstring client_secret;
+};
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/types.h
+++ b/src/v/iceberg/rest_client/types.h
@@ -21,8 +21,9 @@
 
 namespace iceberg::rest_client {
 
-// An http call related error, either a status code or a string describing an
-// exception caught during the call.
+// An error seen during an http call, represented either by a status code, or a
+// string in case of an exception.
+// TODO - use exception_ptr instead of string
 using http_call_error = std::variant<boost::beast::http::status, ss::sstring>;
 
 using parse_error_msg = named_type<ss::sstring, struct parse_error_msg_t>;
@@ -32,9 +33,16 @@ struct json_parse_error {
     parse_error_msg error;
 };
 
-// The domain error represents the sum of all error types which can be
-// encountered during rest-client operations.
-using domain_error = std::variant<json_parse_error>;
+// Error returned when retry limit is exhausted due to a breached time deadline.
+// Contains errors encountered during retries for logging
+struct retries_exhausted {
+    std::vector<http_call_error> errors;
+};
+
+// Represents the sum of all error types which can be encountered during
+// rest-client operations.
+using domain_error
+  = std::variant<json_parse_error, http_call_error, retries_exhausted>;
 
 // The core result type used by all operations in the iceberg/rest-client which
 // can fail. Allows chaining of operations together and short-circuiting when an

--- a/src/v/iceberg/rest_client/types.h
+++ b/src/v/iceberg/rest_client/types.h
@@ -17,8 +17,13 @@
 #include <seastar/core/sstring.hh>
 
 #include <ada/expected.h>
+#include <boost/beast/http/status.hpp>
 
 namespace iceberg::rest_client {
+
+// An http call related error, either a status code or a string describing an
+// exception caught during the call.
+using http_call_error = std::variant<boost::beast::http::status, ss::sstring>;
 
 using parse_error_msg = named_type<ss::sstring, struct parse_error_msg_t>;
 


### PR DESCRIPTION
Adds a basic rest catalog client impl with oauth token flow. No iceberg API calls are added yet other than token fetch.

Implementation of the catalog client interface will be added in the next PR.

Additionally a couple of supporting constructs are added:

* a retry policy modeled after cloud storage clients retry policy but extracted out for isolated testing
* an abstraction of http client to enable mocking
* oauth token parser and schema validator

The catalog client takes in a reference to the http client interface which can be supplied from a pool. It caches the token acquired from a call for use until the token expires.

A mechanism to shut down the client reference on a transport error is not yet added, it will be implemented in the next PR.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* None