### PR TITLE
serde/parquet: add level encoding

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -73,5 +73,6 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
+        "//src/v/utils:vint",
     ],
 )

--- a/src/v/serde/parquet/encoding.h
+++ b/src/v/serde/parquet/encoding.h
@@ -16,6 +16,12 @@
 
 namespace serde::parquet {
 
+// This is the plain encoding that must be supported for types. It is intended
+// to be the simplest encoding. Values are encoded back to back.
+//
+// See:
+// https://parquet.apache.org/docs/file-format/data-pages/encodings/#plain-plain--0
+
 iobuf encode_plain(const chunked_vector<boolean_value>& vals);
 
 iobuf encode_plain(const chunked_vector<int32_value>& vals);
@@ -29,5 +35,16 @@ iobuf encode_plain(const chunked_vector<float64_value>& vals);
 iobuf encode_plain(chunked_vector<byte_array_value> vals);
 
 iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals);
+
+// Levels (definition and repetition) are encoded using Parquet's hybrid
+// run-length encoding/bitpacking schema. Bit packing requires the maximum
+// value to be known in advance.
+//
+// See:
+// https://parquet.apache.org/docs/file-format/nestedencoding/
+// https://parquet.apache.org/docs/file-format/data-pages/encodings/#run-length-encoding--bit-packing-hybrid-rle--3
+//
+// If `levels` is empty `max_value` should be `0`.
+iobuf encode_levels(uint8_t max_value, const chunked_vector<uint8_t>& levels);
 
 } // namespace serde::parquet


### PR DESCRIPTION
Before data is encoded v2 data pages, the "levels" are written. These
are the definition and repetition levels. These are used for knowing the
nesting depth of values (needed for knowing what level a null value was)
and the index if the value is a repeated type.

You can read more about levels generally here:
https://blog.x.com/engineering/en_us/a/2013/dremel-made-simple-with-parquet

We choose to implement this as simply as possible for the first
iteration by always choosing run length coding for values. The low bit
in the header is used to determine if the run length (0) or bit packing
is used (1). Hence the reason for `unsigned_vint::to_bytes(length <<
1)`.
A more complicated algorithm could be used to alternate between
bitpacking and run length encoding. This is a similar tradeoff to what
DuckDB makes.

Otherwise there are links in the code for pointers to the relevant spec.
The codebases for duckdb and parquet-go were studied for the development
of this feature, and relevant code pointers are as follows:

https://github.com/parquet-go/parquet-go/blob/1b52c8764200633b0bbd093fc9fed9b96ded799d/writer.go#L1066
https://github.com/duckdb/duckdb/blob/123b82b9053c4843559035b6723c867b2618b2d9/extension/parquet/column_writer.cpp#L92

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
