### PR TITLE
`cluster`: add `tombstone_retention_ms`/`delete.retention.ms`

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -483,6 +483,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       false,
       std::nullopt,
+      tristate<std::chrono::milliseconds>{},
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -22,6 +22,7 @@
 #include "model/namespace.h"
 #include "model/timestamp.h"
 #include "storage/types.h"
+#include "utils/tristate.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sharded.hh>
@@ -318,6 +319,12 @@ metadata_cache::get_default_record_value_subject_name_strategy() const {
     return pandaproxy::schema_registry::subject_name_strategy::topic_name;
 }
 
+std::optional<std::chrono::milliseconds>
+metadata_cache::get_default_delete_retention_ms() const {
+    // TODO: return config::shard_local_cfg().tombstone_retention_ms();
+    return std::nullopt;
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -335,6 +342,12 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_retention_local_target_bytes()};
     tp.retention_local_target_ms = tristate<std::chrono::milliseconds>{
       get_default_retention_local_target_ms()};
+    /*TODO(willem):
+    tp.delete_retention_ms = tristate<std::chrono::milliseconds>{
+    get_default_delete_retention_ms()};
+    */
+    tp.delete_retention_ms = tristate<std::chrono::milliseconds>{
+      disable_tristate};
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -321,8 +321,7 @@ metadata_cache::get_default_record_value_subject_name_strategy() const {
 
 std::optional<std::chrono::milliseconds>
 metadata_cache::get_default_delete_retention_ms() const {
-    // TODO: return config::shard_local_cfg().tombstone_retention_ms();
-    return std::nullopt;
+    return config::shard_local_cfg().tombstone_retention_ms();
 }
 
 topic_properties metadata_cache::get_default_properties() const {
@@ -342,12 +341,8 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_retention_local_target_bytes()};
     tp.retention_local_target_ms = tristate<std::chrono::milliseconds>{
       get_default_retention_local_target_ms()};
-    /*TODO(willem):
     tp.delete_retention_ms = tristate<std::chrono::milliseconds>{
-    get_default_delete_retention_ms()};
-    */
-    tp.delete_retention_ms = tristate<std::chrono::milliseconds>{
-      disable_tristate};
+      get_default_delete_retention_ms()};
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -202,6 +202,8 @@ public:
     bool get_default_record_value_schema_id_validation() const;
     pandaproxy::schema_registry::subject_name_strategy
     get_default_record_value_subject_name_strategy() const;
+    std::optional<std::chrono::milliseconds>
+    get_default_delete_retention_ms() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -59,6 +59,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .cloud_topic_enabled = properties.cloud_topic_enabled,
             .iceberg_translation_interval_ms
             = properties.iceberg_translation_interval_ms,
+            .tombstone_retention_ms = properties.delete_retention_ms,
           });
     }
     return {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -169,6 +169,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.iceberg_enabled = iceberg_enabled;
     ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.iceberg_translation_interval_ms = iceberg_translation_interval_ms;
+    ret.tombstone_retention_ms = delete_retention_ms;
     return ret;
 }
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -40,8 +40,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "flush_ms: {}, "
       "flush_bytes: {}, "
       "remote_label: {}, iceberg_enabled: {}, "
-      "leaders_preference: {} ",
-      "iceberg_translation_interval_ms: {} ",
+      "leaders_preference: {}, "
+      "iceberg_translation_interval_ms: {}, "
+      "delete_retention_ms: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -77,7 +78,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.remote_label,
       properties.iceberg_enabled,
       properties.leaders_preference,
-      properties.iceberg_translation_interval_ms);
+      properties.iceberg_translation_interval_ms,
+      properties.delete_retention_ms);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(
@@ -123,7 +125,8 @@ bool topic_properties::has_overrides() const {
         || flush_bytes.has_value() || remote_label.has_value()
         || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
         || leaders_preference.has_value()
-        || iceberg_translation_interval_ms.has_value();
+        || iceberg_translation_interval_ms.has_value()
+        || delete_retention_ms.is_engaged();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -257,7 +260,9 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       false,
       std::nullopt,
       false,
-      std::nullopt};
+      std::nullopt,
+      tristate<std::chrono::milliseconds>{disable_tristate},
+    };
 }
 
 } // namespace reflection

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -75,7 +75,8 @@ struct topic_properties
       bool iceberg_enabled,
       std::optional<config::leaders_preference> leaders_preference,
       bool cloud_topic_enabled,
-      std::optional<std::chrono::milliseconds> iceberg_translation_interval)
+      std::optional<std::chrono::milliseconds> iceberg_translation_interval,
+      tristate<std::chrono::milliseconds> delete_retention_ms)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -116,7 +117,8 @@ struct topic_properties
       , iceberg_enabled(iceberg_enabled)
       , leaders_preference(std::move(leaders_preference))
       , cloud_topic_enabled(cloud_topic_enabled)
-      , iceberg_translation_interval_ms(iceberg_translation_interval) {}
+      , iceberg_translation_interval_ms(iceberg_translation_interval)
+      , delete_retention_ms(delete_retention_ms) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -191,6 +193,8 @@ struct topic_properties
 
     std::optional<std::chrono::milliseconds> iceberg_translation_interval_ms;
 
+    tristate<std::chrono::milliseconds> delete_retention_ms{disable_tristate};
+
     bool is_compacted() const;
     bool has_overrides() const;
     bool requires_remote_erase() const;
@@ -236,7 +240,8 @@ struct topic_properties
           iceberg_enabled,
           leaders_preference,
           cloud_topic_enabled,
-          iceberg_translation_interval_ms);
+          iceberg_translation_interval_ms,
+          delete_retention_ms);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -63,6 +63,11 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
           schema_id_validation_validator::ec);
     }
 
+    if (!topic_multi_property_validation(cmd.value.cfg.properties)) {
+        return ss::make_ready_future<std::error_code>(
+          errc::topic_invalid_config);
+    }
+
     std::optional<model::initial_revision_id> remote_revision
       = cmd.value.cfg.properties.remote_topic_properties
           ? std::make_optional(
@@ -796,6 +801,22 @@ std::error_code topic_table::validate_force_reconfigurable_partitions(
     return result;
 }
 
+bool topic_table::topic_multi_property_validation(
+  const topic_properties& properties) const {
+    // delete.retention.ms validation. Cannot be enabled alongside tiered
+    // storage.
+    if (!properties.delete_retention_ms.is_disabled()) {
+        if (
+          properties.shadow_indexing.has_value()
+          && properties.shadow_indexing.value()
+               != model::shadow_indexing_mode::disabled) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 template<typename T>
 void incremental_update(
   std::optional<T>& property, property_update<std::optional<T>> override) {
@@ -1037,6 +1058,10 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
 
     if (!schema_id_validation_validator::is_valid(updated_properties)) {
         co_return schema_id_validation_validator::ec;
+    }
+
+    if (!topic_multi_property_validation(updated_properties)) {
+        co_return make_error_code(errc::topic_invalid_config);
     }
 
     // Apply the changes

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1049,6 +1049,8 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(
       updated_properties.iceberg_translation_interval_ms,
       overrides.iceberg_translation_interval_ms);
+    incremental_update(
+      updated_properties.delete_retention_ms, overrides.delete_retention_ms);
 
     auto& properties = tp->second.get_configuration().properties;
     // no configuration change, no need to generate delta

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -682,6 +682,15 @@ private:
     std::error_code validate_force_reconfigurable_partition(
       const ntp_with_majority_loss&) const;
 
+    // Validation for the final property configuration from a
+    // update_topic_properties_cmd application. Allows user to perform
+    // validations that depend on more than one topic property.
+    //
+    // Returns true if the configured topic_properties is valid, and false
+    // otherwise.
+    bool
+    topic_multi_property_validation(const topic_properties& properties) const;
+
     underlying_t _topics;
     lifecycle_markers_t _lifecycle_markers;
     disabled_partitions_t _disabled_partitions;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -636,6 +636,7 @@ struct incremental_topic_updates
       leaders_preference;
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_translation_interval_ms;
+    property_update<tristate<std::chrono::milliseconds>> delete_retention_ms;
 
     // To allow us to better control use of the deprecated shadow_indexing
     // field, use getters and setters instead.
@@ -674,7 +675,8 @@ struct incremental_topic_updates
           leaders_preference,
           remote_read,
           remote_write,
-          iceberg_translation_interval_ms);
+          iceberg_translation_interval_ms,
+          delete_retention_ms);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -16,6 +16,7 @@
 #include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"
+#include "utils/tristate.h"
 
 namespace compat {
 
@@ -653,7 +654,8 @@ struct instance_generator<cluster::topic_properties> {
           false,
           std::nullopt,
           false,
-          std::nullopt};
+          std::nullopt,
+          tristate<std::chrono::milliseconds>{disable_tristate}};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -630,6 +630,7 @@ inline void rjson_serialize(
       w,
       "iceberg_translation_interval_ms",
       tps.iceberg_translation_interval_ms);
+    write_member(w, "delete_retention_ms", tps.delete_retention_ms);
     w.EndObject();
 }
 
@@ -705,6 +706,7 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
       rd,
       "iceberg_translation_interval_ms",
       obj.iceberg_translation_interval_ms);
+    read_member(rd, "delete_retention_ms", obj.delete_retention_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -874,7 +874,6 @@ configuration::configuration()
        .visibility = visibility::user},
       {},
       validate_connection_rate)
-
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",
@@ -945,6 +944,16 @@ configuration::configuration()
       "How often to trigger background compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10s)
+  , tombstone_retention_ms(
+      *this,
+      "tombstone_retention_ms",
+      "The retention time for tombstone records in a compacted topic. Cannot "
+      "be enabled at the same time as any of `cloud_storage_enabled`, "
+      "`cloud_storage_enable_remote_read`, or "
+      "`cloud_storage_enable_remote_write`.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_tombstone_retention_ms)
   , log_disable_housekeeping_for_tests(
       *this,
       "log_disable_housekeeping_for_tests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -246,6 +246,8 @@ struct configuration final : public config_store {
     // same as log.retention.ms in kafka
     retention_duration_property log_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
+    // same as delete.retention.ms in kafka
+    property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     // same as retention.size in kafka - TODO: size not implemented

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -15,6 +15,7 @@
 #include "config/configuration.h"
 #include "model/namespace.h"
 #include "model/validation.h"
+#include "serde/rw/chrono.h"
 #include "ssx/sformat.h"
 #include "utils/inet_address_wrapper.h"
 
@@ -242,6 +243,41 @@ validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os) {
       os.has_value()
       && (os.value().starts_with("http://") || os.value().starts_with("https://"))) {
         return "String starting with URL protocol is not valid";
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ss::sstring> validate_tombstone_retention_ms(
+  const std::optional<std::chrono::milliseconds>& ms) {
+    if (ms.has_value()) {
+        // For simplicity's sake, cloud storage enable/read/write permissions
+        // cannot be enabled at the same time as tombstone_retention_ms at the
+        // cluster level, to avoid the case in which redpanda refuses to create
+        // new, misconfigured topics due to cluster defaults
+        const auto& cloud_storage_enabled
+          = config::shard_local_cfg().cloud_storage_enabled;
+        const auto& cloud_storage_remote_write
+          = config::shard_local_cfg().cloud_storage_enable_remote_write;
+        const auto& cloud_storage_remote_read
+          = config::shard_local_cfg().cloud_storage_enable_remote_read;
+        if (
+          cloud_storage_enabled() || cloud_storage_remote_write()
+          || cloud_storage_remote_read()) {
+            return fmt::format(
+              "cannot set {} if any of ({}, {}, {}) are enabled at the cluster "
+              "level",
+              config::shard_local_cfg().tombstone_retention_ms.name(),
+              cloud_storage_enabled.name(),
+              cloud_storage_remote_write.name(),
+              cloud_storage_remote_read.name());
+        }
+
+        if (ms.value() < 1ms || ms.value() > serde::max_serializable_ms) {
+            return fmt::format(
+              "tombstone_retention_ms should be in range: [1, {}]",
+              serde::max_serializable_ms);
+        }
     }
 
     return std::nullopt;

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -56,4 +56,7 @@ validate_audit_excluded_topics(const std::vector<ss::sstring>&);
 std::optional<ss::sstring>
 validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os);
 
+std::optional<ss::sstring> validate_tombstone_retention_ms(
+  const std::optional<std::chrono::milliseconds>& ms);
+
 }; // namespace config

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -808,6 +808,23 @@ config_response_container_t make_topic_configs(
         }
     }
 
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      topic_property_delete_retention_ms,
+      metadata_cache.get_default_delete_retention_ms(),
+      topic_property_delete_retention_ms,
+      hide_disabled_tristate(
+        topic_properties.delete_retention_ms,
+        metadata_cache.get_default_delete_retention_ms()),
+      include_synonyms,
+      /*TODO:
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().tombstone_retention_ms.desc()),
+      */
+      std::nullopt);
+
     constexpr std::string_view key_validation
       = "Enable validation of the schema id for keys on a record";
     constexpr std::string_view val_validation

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -100,7 +100,7 @@ consteval describe_configs_type property_config_type() {
         std::is_same_v<T, model::cleanup_policy_bitflags> ||
         std::is_same_v<T, model::timestamp_type> ||
         std::is_same_v<T, config::data_directory_path> ||
-        std::is_same_v<T, pandaproxy::schema_registry::subject_name_strategy> || 
+        std::is_same_v<T, pandaproxy::schema_registry::subject_name_strategy> ||
         std::is_same_v<T, model::vcluster_id> ||
         std::is_same_v<T, model::write_caching_mode> ||
         std::is_same_v<T, config::leaders_preference>;
@@ -310,6 +310,20 @@ override_if_not_default(const std::optional<T>& override, const T& def) {
     } else {
         return std::nullopt;
     }
+}
+
+// This function hides the presence of an override for a `tristate` topic
+// property when its value is {disabled} and the cluster default does not have a
+// value ({std::nullopt}). This helps to ensure the property source is
+// `DEFAULT_CONFIG` for this state, as some `tristate` properties may want their
+// "default" state to be {disabled}.
+template<typename T>
+tristate<T> hide_disabled_tristate(
+  const tristate<T>& topic_override, const std::optional<T>& cluster_default) {
+    if (topic_override.is_disabled() && !cluster_default.has_value()) {
+        return tristate<T>{std::nullopt};
+    }
+    return topic_override;
 }
 
 template<typename T, typename Func>

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -818,12 +818,9 @@ config_response_container_t make_topic_configs(
         topic_properties.delete_retention_ms,
         metadata_cache.get_default_delete_retention_ms()),
       include_synonyms,
-      /*TODO:
       maybe_make_documentation(
         include_documentation,
-        config::shard_local_cfg().tombstone_retention_ms.desc()),
-      */
-      std::nullopt);
+        config::shard_local_cfg().tombstone_retention_ms.desc()));
 
     constexpr std::string_view key_validation
       = "Enable validation of the schema id for keys on a record";

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -41,6 +41,7 @@
 namespace kafka {
 
 namespace {
+
 bool is_supported(std::string_view name) {
     static constexpr auto supported_configs = std::to_array(
       {topic_property_compression,
@@ -74,7 +75,8 @@ bool is_supported(std::string_view name) {
        topic_property_flush_bytes,
        topic_property_iceberg_enabled,
        topic_property_leaders_preference,
-       topic_property_iceberg_translation_interval_ms});
+       topic_property_iceberg_translation_interval_ms,
+       topic_property_delete_retention_ms});
 
     if (std::any_of(
           supported_configs.begin(),
@@ -116,7 +118,8 @@ using validators = make_validator_types<
   vcluster_id_validator,
   write_caching_configs_validator,
   iceberg_config_validator,
-  cloud_topic_config_validator>;
+  cloud_topic_config_validator,
+  delete_retention_ms_validator>;
 
 static void
 append_topic_configs(request_context& ctx, create_topics_response& response) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -10,6 +10,7 @@
 
 #include "cluster/config_frontend.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "config/node_config.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/incremental_alter_configs.h"

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -368,6 +368,14 @@ create_topic_properties_update(
                   op);
                 continue;
             }
+            if (cfg.name == topic_property_delete_retention_ms) {
+                parse_and_set_tristate(
+                  update.properties.delete_retention_ms,
+                  cfg.value,
+                  op,
+                  delete_retention_ms_validator{});
+                continue;
+            }
 
         } catch (const validation_error& e) {
             vlog(
@@ -423,6 +431,7 @@ inline std::string_view map_config_name(std::string_view input) {
       .match("log.message.timestamp.type", "log_message_timestamp_type")
       .match("log.compression.type", "log_compression_type")
       .match("log.roll.ms", "log_segment_ms")
+      .match("log.cleaner.delete.retention.ms", "tombstone_retention_ms")
       .default_match(input);
 }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -21,6 +21,7 @@
 #include "model/timestamp.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "strings/string_switch.h"
+#include "utils/tristate.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -67,16 +68,6 @@ config_map_t config_map(const std::vector<creatable_topic_configs>& config) {
     return make_config_map(config);
 }
 
-// Either parse configuration or return nullopt
-template<typename T>
-static std::optional<T>
-get_config_value(const config_map_t& config, std::string_view key) {
-    if (auto it = config.find(key); it != config.end()) {
-        return boost::lexical_cast<T>(it->second);
-    }
-    return std::nullopt;
-}
-
 template<class T>
 requires std::
   is_same_v<T, std::chrono::duration<typename T::rep, typename T::period>>
@@ -107,7 +98,7 @@ get_string_value(const config_map_t& config, std::string_view key) {
 }
 
 // Either parse configuration or return nullopt
-static std::optional<bool>
+std::optional<bool>
 get_bool_value(const config_map_t& config, std::string_view key) {
     if (auto it = config.find(key); it != config.end()) {
         try {
@@ -128,7 +119,7 @@ get_bool_value(const config_map_t& config, std::string_view key) {
     return std::nullopt;
 }
 
-static model::shadow_indexing_mode
+model::shadow_indexing_mode
 get_shadow_indexing_mode(const config_map_t& config) {
     auto arch_enabled = get_bool_value(config, topic_property_remote_write);
     auto si_enabled = get_bool_value(config, topic_property_remote_read);
@@ -154,28 +145,6 @@ get_shadow_indexing_mode(const config_map_t& config) {
                  : model::shadow_indexing_mode::fetch;
     }
     return mode;
-}
-
-// Special case for options where Kafka allows -1
-// In redpanda the mapping is following
-//
-// -1 (feature disabled)   =>  tristate.is_disabled() == true;
-// no value                =>  tristate.has_value() == false;
-// value present           =>  tristate.has_value() == true;
-
-template<typename T>
-static tristate<T>
-get_tristate_value(const config_map_t& config, std::string_view key) {
-    auto v = get_config_value<int64_t>(config, key);
-    // no value set
-    if (!v) {
-        return tristate<T>(std::nullopt);
-    }
-    // disabled case
-    if (v <= 0) {
-        return tristate<T>(disable_tristate);
-    }
-    return tristate<T>(std::make_optional<T>(*v));
 }
 
 template<typename T>
@@ -280,6 +249,14 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.iceberg_translation_interval_ms
       = get_duration_value<std::chrono::milliseconds>(
         config_entries, topic_property_iceberg_translation_interval_ms, true);
+
+    /*TODO:
+      Disable tombstone.retention.ms if it, along with the cluster default, is
+      unset.
+    */
+    cfg.properties.delete_retention_ms
+      = get_tristate_value<std::chrono::milliseconds>(
+        config_entries, topic_property_delete_retention_ms);
 
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -432,6 +432,7 @@ FIXTURE_TEST(
       "redpanda.iceberg.enabled",
       "redpanda.leaders.preference",
       "redpanda.iceberg.translation.interval.ms",
+      "delete.retention.ms",
     };
 
     // All properties_request
@@ -520,6 +521,7 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     properties.emplace("write.caching", "true");
     properties.emplace("flush.ms", "225");
     properties.emplace("flush.bytes", "32468");
+    properties.emplace("delete.retention.ms", "-1");
 
     auto resp = alter_configs(
       make_alter_topic_config_resource_cv(test_tp, properties));
@@ -535,6 +537,7 @@ FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "cleanup.policy", "compact", describe_resp);
     assert_property_value(
       test_tp, "redpanda.remote.read", "true", describe_resp);
+    assert_property_value(test_tp, "delete.retention.ms", "-1", describe_resp);
 }
 
 FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
@@ -551,6 +554,7 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     properties_1.emplace("write.caching", "true");
     properties_1.emplace("flush.ms", "225");
     properties_1.emplace("flush.bytes", "32468");
+    properties_1.emplace("delete.retention.ms", "5678");
 
     absl::flat_hash_map<ss::sstring, ss::sstring> properties_2;
     properties_2.emplace("retention.bytes", "4096");
@@ -558,6 +562,7 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     properties_2.emplace("write.caching", "false");
     properties_2.emplace("flush.ms", "100");
     properties_2.emplace("flush.bytes", "990");
+    properties_2.emplace("delete.retention.ms", "8765");
 
     auto cv = make_alter_topic_config_resource_cv(topic_1, properties_1);
     cv.push_back(make_alter_topic_config_resource(topic_2, properties_2));
@@ -579,12 +584,16 @@ FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
     assert_property_value(topic_1, "write.caching", "true", describe_resp_1);
     assert_property_value(topic_1, "flush.ms", "225", describe_resp_1);
     assert_property_value(topic_1, "flush.bytes", "32468", describe_resp_1);
+    assert_property_value(
+      topic_1, "delete.retention.ms", "5678", describe_resp_1);
 
     auto describe_resp_2 = describe_configs(topic_2);
     assert_property_value(topic_2, "retention.bytes", "4096", describe_resp_2);
     assert_property_value(topic_2, "write.caching", "false", describe_resp_2);
     assert_property_value(topic_2, "flush.ms", "100", describe_resp_2);
     assert_property_value(topic_2, "flush.bytes", "990", describe_resp_2);
+    assert_property_value(
+      topic_2, "delete.retention.ms", "8765", describe_resp_2);
 }
 
 FIXTURE_TEST(
@@ -646,6 +655,7 @@ FIXTURE_TEST(
     properties.emplace("write.caching", "true");
     properties.emplace("flush.ms", "225");
     properties.emplace("flush.bytes", "32468");
+    properties.emplace("delete.retention.ms", "5678");
 
     auto resp = alter_configs(
       make_alter_topic_config_resource_cv(test_tp, properties));
@@ -661,6 +671,8 @@ FIXTURE_TEST(
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "225", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "32468", describe_resp);
+    assert_property_value(
+      test_tp, "delete.retention.ms", "5678", describe_resp);
 
     /**
      * Set custom properties again, previous settings should be overriden
@@ -671,6 +683,7 @@ FIXTURE_TEST(
     new_properties.emplace("write.caching", "false");
     new_properties.emplace("flush.ms", "9999");
     new_properties.emplace("flush.bytes", "8888");
+    new_properties.emplace("delete.retention.ms", "7777");
 
     alter_configs(make_alter_topic_config_resource_cv(test_tp, new_properties));
 
@@ -687,6 +700,8 @@ FIXTURE_TEST(
     assert_property_value(test_tp, "write.caching", "false", new_describe_resp);
     assert_property_value(test_tp, "flush.ms", "9999", new_describe_resp);
     assert_property_value(test_tp, "flush.bytes", "8888", new_describe_resp);
+    assert_property_value(
+      test_tp, "delete.retention.ms", "7777", new_describe_resp);
 }
 
 FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
@@ -710,6 +725,9 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     properties.emplace(
       "flush.bytes",
       std::make_pair("5678", kafka::config_resource_operation::set));
+    properties.emplace(
+      "delete.retention.ms",
+      std::make_pair("5678", kafka::config_resource_operation::set));
 
     auto resp = incremental_alter_configs(
       make_incremental_alter_topic_config_resource_cv(test_tp, properties));
@@ -725,6 +743,8 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "1234", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "5678", describe_resp);
+    assert_property_value(
+      test_tp, "delete.retention.ms", "5678", describe_resp);
 
     /**
      * Set only few properties, only they should be updated
@@ -752,6 +772,8 @@ FIXTURE_TEST(test_incremental_alter_config, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "false", new_describe_resp);
     assert_property_value(test_tp, "flush.ms", "1234", new_describe_resp);
     assert_property_value(test_tp, "flush.bytes", "5678", new_describe_resp);
+    assert_property_value(
+      test_tp, "delete.retention.ms", "5678", new_describe_resp);
 }
 
 FIXTURE_TEST(
@@ -797,6 +819,9 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     properties.emplace(
       "flush.bytes",
       std::make_pair("8888", kafka::config_resource_operation::set));
+    properties.emplace(
+      "delete.retention.ms",
+      std::make_pair("7777", kafka::config_resource_operation::set));
 
     auto resp = incremental_alter_configs(
       make_incremental_alter_topic_config_resource_cv(test_tp, properties));
@@ -812,6 +837,8 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     assert_property_value(test_tp, "write.caching", "true", describe_resp);
     assert_property_value(test_tp, "flush.ms", "9999", describe_resp);
     assert_property_value(test_tp, "flush.bytes", "8888", describe_resp);
+    assert_property_value(
+      test_tp, "delete.retention.ms", "7777", describe_resp);
 
     /**
      * Remove custom properties
@@ -831,6 +858,9 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
       std::pair{std::nullopt, kafka::config_resource_operation::remove});
     new_properties.emplace(
       "flush.bytes",
+      std::pair{std::nullopt, kafka::config_resource_operation::remove});
+    new_properties.emplace(
+      "delete.retention.ms",
       std::pair{std::nullopt, kafka::config_resource_operation::remove});
 
     resp = incremental_alter_configs(
@@ -868,6 +898,16 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
         config::shard_local_cfg()
           .raft_replica_max_pending_flush_bytes()
           .value()),
+      new_describe_resp);
+    assert_property_value(
+      test_tp,
+      "delete.retention.ms",
+      /* TODO:
+      fmt::format(
+        "{}",
+        config::shard_local_cfg().tombstone_retention_ms().value_or(-1ms)),
+      */
+      fmt::format("{}", -1ms),
       new_describe_resp);
 }
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -902,12 +902,9 @@ FIXTURE_TEST(test_incremental_alter_config_remove, alter_config_test_fixture) {
     assert_property_value(
       test_tp,
       "delete.retention.ms",
-      /* TODO:
       fmt::format(
         "{}",
         config::shard_local_cfg().tombstone_retention_ms().value_or(-1ms)),
-      */
-      fmt::format("{}", -1ms),
       new_describe_resp);
 }
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1724,6 +1724,23 @@ void config_multi_property_validation(
         auto name = ss::sstring(updated_config.cloud_storage_cache_size.name());
         errors[name] = invalid_cache.value();
     }
+
+    // For simplicity's sake, cloud storage read/write permissions cannot be
+    // enabled at the same time as tombstone_retention_ms at the cluster level,
+    // to avoid the case in which topics are created with TS read/write
+    // permissions and bugs are encountered later with tombstone removal.
+    if (updated_config.tombstone_retention_ms().has_value() &&
+	(updated_config.cloud_storage_enabled()
+	 || updated_config.cloud_storage_enable_remote_read()
+	 || updated_config.cloud_storage_enable_remote_write())) {
+        errors["cloud_storage_enabled"] = ssx::sformat(
+          "cannot set {} if any of ({}, {}, {}) are enabled at the cluster "
+          "level",
+          updated_config.tombstone_retention_ms.name(),
+          updated_config.cloud_storage_enabled.name(),
+          updated_config.cloud_storage_enable_remote_read.name(),
+          updated_config.cloud_storage_enable_remote_write.name());
+    }
 }
 } // namespace
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -275,8 +275,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           collection_threshold,
           _config.retention_bytes(),
           current_log.handle->stm_manager()->max_collectible_offset(),
-          /*TODO: current_log.handle->config().tombstone_retention_ms()*/
-          std::nullopt,
+          current_log.handle->config().tombstone_retention_ms(),
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg),

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -83,6 +83,10 @@ public:
         std::optional<std::chrono::milliseconds>
           iceberg_translation_interval_ms{std::nullopt};
 
+        // Should not be enabled at the same time as any other tiered storage
+        // properties.
+        tristate<std::chrono::milliseconds> tombstone_retention_ms;
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };
@@ -292,6 +296,47 @@ public:
           std::numeric_limits<size_t>::max());
         return _overrides ? _overrides->flush_bytes.value_or(cluster_default)
                           : cluster_default;
+    }
+
+    std::optional<std::chrono::milliseconds> tombstone_retention_ms() const {
+        if (is_read_replica_mode_enabled()) {
+            // RRR sanity check.
+            return std::nullopt;
+        }
+        /*TODO(willem):
+          auto& cluster_default
+            = config::shard_local_cfg().tombstone_retention_ms();
+        */
+        if (_overrides) {
+            // Tombstone deletion should not be enabled at the same time as
+            // tiered storage.
+            if (
+              _overrides->shadow_indexing_mode.has_value()
+              && _overrides->shadow_indexing_mode.value()
+                   != model::shadow_indexing_mode::disabled) {
+                return std::nullopt;
+            }
+            // If the tristate is disabled, return nullopt.
+            if (_overrides->tombstone_retention_ms.is_disabled()) {
+                return std::nullopt;
+            }
+            // If the tristate has a value, use it.
+            if (_overrides->tombstone_retention_ms.has_optional_value()) {
+                return _overrides->tombstone_retention_ms.value();
+            }
+
+            // If the tristate holds an empty optional, fall back to cluster
+            // default.
+            /*TODO(willem):
+              return cluster_default;
+             */
+        }
+        // Fall back to cluster default, since _overrides being nullptr signals
+        // that remote.read and remote.write is disabled for this topic.
+        /*TODO(willem):
+          return cluster_default;
+         */
+        return std::nullopt;
     }
 
     std::optional<model::cleanup_policy_bitflags>

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -303,10 +303,8 @@ public:
             // RRR sanity check.
             return std::nullopt;
         }
-        /*TODO(willem):
-          auto& cluster_default
-            = config::shard_local_cfg().tombstone_retention_ms();
-        */
+        auto& cluster_default
+          = config::shard_local_cfg().tombstone_retention_ms();
         if (_overrides) {
             // Tombstone deletion should not be enabled at the same time as
             // tiered storage.
@@ -327,16 +325,11 @@ public:
 
             // If the tristate holds an empty optional, fall back to cluster
             // default.
-            /*TODO(willem):
-              return cluster_default;
-             */
+            return cluster_default;
         }
         // Fall back to cluster default, since _overrides being nullptr signals
         // that remote.read and remote.write is disabled for this topic.
-        /*TODO(willem):
-          return cluster_default;
-         */
-        return std::nullopt;
+        return cluster_default;
     }
 
     std::optional<model::cleanup_policy_bitflags>

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -495,7 +495,7 @@ struct compaction_config {
     // which is a segment's clean_compact_timestamp + tombstone_retention_ms.
     // This means tombstones take at least two rounds of compaction to remove a
     // tombstone: at least one pass to make a segment clean, and another pass
-    // some time after tombstone.retention.ms to remove tombstones.
+    // some time after tombstone_retention_ms to remove tombstones.
     //
     // Tombstone removal is only supported for topics with remote writes
     // disabled. As a result, this field will only have a value for compaction

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -242,7 +242,10 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         assert configs is not None, "didn't find Configs: section"
 
         def maybe_int(key: str, value: str):
-            if key in ["retention_ms", "retention_bytes", 'segment_bytes']:
+            if key in [
+                    "retention_ms", "retention_bytes", 'segment_bytes',
+                    'delete_retention_ms'
+            ]:
                 return int(value)
             return value
 

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -41,6 +41,7 @@ class TopicSpec:
     PROPERTY_FLUSH_BYTES = "flush.bytes"
     PROPERTY_ICEBERG_ENABLED = "redpanda.iceberg.enabled"
     PROPERTY_ICEBERG_TRANSLATION_INTERVAL = "redpanda.iceberg.translation.interval.ms"
+    PROPERTY_DELETE_RETENTION_MS = "delete.retention.ms"
 
     class CompressionTypes(str, Enum):
         """
@@ -122,7 +123,8 @@ class TopicSpec:
         | None = None,
             initial_retention_local_target_bytes: int | None = None,
             initial_retention_local_target_ms: int | None = None,
-            virtual_cluster_id: str | None = None):
+            virtual_cluster_id: str | None = None,
+            delete_retention_ms: int | None = None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -148,6 +150,7 @@ class TopicSpec:
         self.initial_retention_local_target_bytes = initial_retention_local_target_bytes
         self.initial_retention_local_target_ms = initial_retention_local_target_ms
         self.virtual_cluster_id = virtual_cluster_id
+        self.delete_retention_ms = delete_retention_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -50,6 +50,8 @@ class AlterTopicConfiguration(RedpandaTest):
     @parametrize(property=TopicSpec.PROPERTY_RETENTION_TIME, value=360000)
     @parametrize(property=TopicSpec.PROPERTY_TIMESTAMP_TYPE,
                  value="LogAppendTime")
+    @parametrize(property=TopicSpec.PROPERTY_DELETE_RETENTION_MS,
+                 value=123456789)
     def test_altering_topic_configuration(self, property, value):
         topic = self.topics[0].name
         self.client().alter_topic_configs(topic, {property: value})
@@ -70,7 +72,8 @@ class AlterTopicConfiguration(RedpandaTest):
         kcl.raw_alter_topic_config(
             1, topic, {
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
-                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
+                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime",
+                TopicSpec.PROPERTY_DELETE_RETENTION_MS: 1234567890
             })
         kafka_tools = KafkaCliTools(self.redpanda)
         spec = kafka_tools.describe_topic(topic)
@@ -78,6 +81,7 @@ class AlterTopicConfiguration(RedpandaTest):
         assert spec.replication_factor == 3
         assert spec.retention_ms == 360000
         assert spec.message_timestamp_type == "LogAppendTime"
+        assert spec.delete_retention_ms == 1234567890
 
     @cluster(num_nodes=3)
     def test_altering_multiple_topic_configurations(self):
@@ -87,13 +91,15 @@ class AlterTopicConfiguration(RedpandaTest):
             topic, {
                 TopicSpec.PROPERTY_SEGMENT_SIZE: 1024 * 1024,
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
-                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
+                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime",
+                TopicSpec.PROPERTY_DELETE_RETENTION_MS: 1234567890
             })
         spec = kafka_tools.describe_topic(topic)
 
         assert spec.segment_bytes == 1024 * 1024
         assert spec.retention_ms == 360000
         assert spec.message_timestamp_type == "LogAppendTime"
+        assert spec.delete_retention_ms == 1234567890
 
     def random_string(self, size):
         return ''.join(

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -679,6 +679,11 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # to RP's data dir for it to start
                 continue
 
+            if name == 'tombstone_retention_ms':
+                # Don't modify tombstone_retention_ms, leave it as nullopt in case of
+                # cloud storage read/write properties.
+                continue
+
             if name == 'record_key_subject_name_strategy' or name == 'record_value_subject_name_strategy':
                 valid_value = random.choice(
                     [e for e in p['enum_values'] if e != initial_value])

--- a/tests/rptest/tests/delete_retention_ms_test.py
+++ b/tests/rptest/tests/delete_retention_ms_test.py
@@ -1,0 +1,248 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from collections import namedtuple
+from ducktape.mark import matrix, defaults
+from ducktape.utils.util import wait_until
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_exception
+
+
+class DeleteRetentionMsTest(RedpandaTest):
+    def __init__(self, ctx):
+        self.ctx = ctx
+        super().__init__(ctx)
+
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_get_cluster_config(self):
+        # Default value
+        cluster_default = self.rpk.cluster_config_get('tombstone_retention_ms')
+        assert cluster_default == 'null'
+
+    @cluster(num_nodes=1)
+    def test_set_cluster_config(self):
+        self.rpk.cluster_config_set('tombstone_retention_ms', 1234567890)
+        cluster_prop = self.rpk.cluster_config_get('tombstone_retention_ms')
+        assert cluster_prop == "1234567890"
+
+        topic_name = "tapioca"
+        topic = TopicSpec(name=topic_name)
+        self.rpk.create_topic(topic_name, partitions=1)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '1234567890'
+
+    @cluster(num_nodes=1)
+    def test_alter_topic_config(self):
+        topic_name = "tapioca"
+        topic = TopicSpec(name=topic_name)
+        self.rpk.create_topic(topic_name, partitions=1)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+
+        # Upon topic construction, this property is actually "disabled" by default.
+        assert topic_desc['delete.retention.ms'][0] == '-1'
+        assert topic_desc['delete.retention.ms'][1] == 'DEFAULT_CONFIG'
+
+        # Set value
+        self.rpk.alter_topic_config(topic_name, 'delete.retention.ms',
+                                    1234567890)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '1234567890'
+        assert topic_desc['delete.retention.ms'][1] == 'DYNAMIC_TOPIC_CONFIG'
+
+        # Set cluster value
+        self.rpk.cluster_config_set('tombstone_retention_ms', 100)
+
+        # Assert topic property and source haven't changed.
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '1234567890'
+        assert topic_desc['delete.retention.ms'][1] == 'DYNAMIC_TOPIC_CONFIG'
+
+        # Delete topic config
+        self.rpk.delete_topic_config(topic_name, 'delete.retention.ms')
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '100'
+        assert topic_desc['delete.retention.ms'][1] == 'DEFAULT_CONFIG'
+
+        # Disable topic value
+        self.rpk.alter_topic_config(topic_name, 'delete.retention.ms', -1)
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '-1'
+        assert topic_desc['delete.retention.ms'][1] == 'DYNAMIC_TOPIC_CONFIG'
+
+        # Set empty cluster value and delete topic config
+        self.rpk.cluster_config_set('tombstone_retention_ms', "")
+        self.rpk.delete_topic_config(topic_name, 'delete.retention.ms')
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '-1'
+        assert topic_desc['delete.retention.ms'][1] == 'DEFAULT_CONFIG'
+
+        # Disable topic config
+        self.rpk.delete_topic_config(topic_name, 'delete.retention.ms')
+        topic_desc = self.rpk.describe_topic_configs(topic_name)
+        assert topic_desc['delete.retention.ms'][0] == '-1'
+        assert topic_desc['delete.retention.ms'][1] == 'DEFAULT_CONFIG'
+
+    @cluster(num_nodes=1)
+    def test_create_topic_configurations_cluster_defaults(self):
+        topic_name = "tapioca"
+        TopicAndClusterConf = namedtuple('TopicAndClusterConf', [
+            'delete_retention_ms', 'cloud_storage_remote_read',
+            'cloud_storage_remote_write', 'valid'
+        ])
+        # We cannot enable delete.retention.ms if any cloud storage properties are also enabled.
+        test_cases = [
+            TopicAndClusterConf(delete_retention_ms=None,
+                                cloud_storage_remote_read='false',
+                                cloud_storage_remote_write='false',
+                                valid=True),
+            TopicAndClusterConf(delete_retention_ms=None,
+                                cloud_storage_remote_read='true',
+                                cloud_storage_remote_write='false',
+                                valid=True),
+            TopicAndClusterConf(delete_retention_ms=None,
+                                cloud_storage_remote_read='false',
+                                cloud_storage_remote_write='true',
+                                valid=True),
+            TopicAndClusterConf(delete_retention_ms=None,
+                                cloud_storage_remote_read='true',
+                                cloud_storage_remote_write='true',
+                                valid=True),
+            TopicAndClusterConf(delete_retention_ms=1000,
+                                cloud_storage_remote_read='false',
+                                cloud_storage_remote_write='false',
+                                valid=True),
+            TopicAndClusterConf(delete_retention_ms=1000,
+                                cloud_storage_remote_read='true',
+                                cloud_storage_remote_write='false',
+                                valid=False),
+            TopicAndClusterConf(delete_retention_ms=1000,
+                                cloud_storage_remote_read='false',
+                                cloud_storage_remote_write='true',
+                                valid=False),
+            TopicAndClusterConf(delete_retention_ms=1000,
+                                cloud_storage_remote_read='true',
+                                cloud_storage_remote_write='true',
+                                valid=False),
+        ]
+        for test_case in test_cases:
+            self.rpk.cluster_config_set('cloud_storage_enable_remote_read',
+                                        test_case.cloud_storage_remote_read)
+            self.rpk.cluster_config_set('cloud_storage_enable_remote_write',
+                                        test_case.cloud_storage_remote_write)
+
+            # Sanity check cluster defaults after setting them.
+            assert self.rpk.cluster_config_get(
+                'cloud_storage_enable_remote_read'
+            ) == test_case.cloud_storage_remote_read
+
+            assert self.rpk.cluster_config_get(
+                'cloud_storage_enable_remote_write'
+            ) == test_case.cloud_storage_remote_write
+
+            config = {}
+            if test_case.delete_retention_ms is not None:
+                config = {'delete.retention.ms': test_case.delete_retention_ms}
+                expected_delete_retention_ms = str(
+                    test_case.delete_retention_ms)
+            else:
+                expected_delete_retention_ms = '-1'
+
+            if test_case.valid:
+                # Expect a successful topic creation.
+                self.rpk.create_topic(topic_name, partitions=1, config=config)
+                topic_desc = self.rpk.describe_topic_configs(topic_name)
+                assert topic_desc['delete.retention.ms'][
+                    0] == expected_delete_retention_ms
+                # Delete the topic so that we can try again with the next test case.
+                self.rpk.delete_topic(topic_name)
+            else:
+                # Expect a failure due to misconfiguration.
+                with expect_exception(
+                        RpkException, lambda e:
+                        'Unsupported delete.retention.ms configuration, cannot be enabled at the same time as redpanda.remote.read or redpanda.remote.write.'
+                        in str(e)):
+                    self.rpk.create_topic(topic_name,
+                                          partitions=1,
+                                          config=config)
+
+    @cluster(num_nodes=1)
+    def test_create_topic_configurations(self):
+        topic_name = "tapioca"
+        TopicConf = namedtuple(
+            'TopicConf',
+            ['delete_retention_ms', 'remote_read', 'remote_write', 'valid'])
+        # We cannot enable delete.retention.ms if any cloud storage properties are also enabled.
+        test_cases = [
+            TopicConf(delete_retention_ms=None,
+                      remote_read='false',
+                      remote_write='false',
+                      valid=True),
+            TopicConf(delete_retention_ms=None,
+                      remote_read='true',
+                      remote_write='false',
+                      valid=True),
+            TopicConf(delete_retention_ms=None,
+                      remote_read='false',
+                      remote_write='true',
+                      valid=True),
+            TopicConf(delete_retention_ms=None,
+                      remote_read='true',
+                      remote_write='true',
+                      valid=True),
+            TopicConf(delete_retention_ms=1000,
+                      remote_read='false',
+                      remote_write='false',
+                      valid=True),
+            TopicConf(delete_retention_ms=1000,
+                      remote_read='true',
+                      remote_write='false',
+                      valid=False),
+            TopicConf(delete_retention_ms=1000,
+                      remote_read='false',
+                      remote_write='true',
+                      valid=False),
+            TopicConf(delete_retention_ms=1000,
+                      remote_read='true',
+                      remote_write='true',
+                      valid=False),
+        ]
+        for test_case in test_cases:
+            config = {
+                'redpanda.remote.read': test_case.remote_read,
+                'redpanda.remote.write': test_case.remote_write
+            }
+
+            if test_case.delete_retention_ms is not None:
+                config['delete.retention.ms'] = test_case.delete_retention_ms
+                expected_delete_retention_ms = str(
+                    test_case.delete_retention_ms)
+            else:
+                expected_delete_retention_ms = '-1'
+
+            if test_case.valid:
+                # Expect a successful topic creation.
+                self.rpk.create_topic(topic_name, partitions=1, config=config)
+                topic_desc = self.rpk.describe_topic_configs(topic_name)
+                assert topic_desc['delete.retention.ms'][
+                    0] == expected_delete_retention_ms
+                # Delete the topic so that we can try again with the next test case.
+                self.rpk.delete_topic(topic_name)
+            else:
+                # Expect a failure due to misconfiguration.
+                with expect_exception(
+                        RpkException, lambda e:
+                        'Unsupported delete.retention.ms configuration, cannot be enabled at the same time as redpanda.remote.read or redpanda.remote.write.'
+                        in str(e)):
+                    self.rpk.create_topic(topic_name,
+                                          partitions=1,
+                                          config=config)

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -295,6 +295,14 @@ class DescribeTopicsTest(RedpandaTest):
                 doc_string=
                 "Controls how often iceberg translation is attempted on the topic partitions."
             ),
+            "delete.retention.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                #TODO(willem): doc_string="The retention time for tombstone records in a compacted topic"
+                doc_string="",
+                #TODO(willem): remove DYNAMIC_TOPIC_CONFIG once cluster default is added
+                source_type="DYNAMIC_TOPIC_CONFIG")
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -299,10 +299,9 @@ class DescribeTopicsTest(RedpandaTest):
             ConfigProperty(
                 config_type="LONG",
                 value="-1",
-                #TODO(willem): doc_string="The retention time for tombstone records in a compacted topic"
-                doc_string="",
-                #TODO(willem): remove DYNAMIC_TOPIC_CONFIG once cluster default is added
-                source_type="DYNAMIC_TOPIC_CONFIG")
+                doc_string=
+                "The retention time for tombstone records in a compacted topic. Cannot be enabled at the same time as any of `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, or `cloud_storage_enable_remote_write`."
+            )
         }
 
         tp_spec = TopicSpec()

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -138,14 +138,12 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
     if version >= 10:
         topic_properties |= {
-            'iceberg_enabled':
-            rdr.read_bool(),
-            'leaders_preference':
-            rdr.read_optional(read_leaders_preference),
-            'cloud_topic_enabled':
-            rdr.read_bool(),
+            'iceberg_enabled': rdr.read_bool(),
+            'leaders_preference': rdr.read_optional(read_leaders_preference),
+            'cloud_topic_enabled': rdr.read_bool(),
             'iceberg_translation_interval_ms':
             rdr.read_optional(Reader.read_int64),
+            'delete_retention_ms': rdr.read_tristate(Reader.read_int64)
         }
 
     return topic_properties


### PR DESCRIPTION
As a follow up to https://github.com/redpanda-data/redpanda/pull/23231 and https://github.com/redpanda-data/redpanda/pull/23380, this PR adds both the cluster-level configuration property `tombstone_retention_ms` and the topic-level property `delete.retention.ms`.

The cluster level property `tombstone_retention_ms` controls the default value for `delete.retention.ms`, which is equivalent to the [Kafka topic property](https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#delete-retention-ms). 

There is a tight coupling between the tiered storage properties (both at a topic and a cluster level) and these configurations. Namely,

* `tombstone_retention_ms` cannot be enabled at the same time as any of `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, `cloud_storage_enable_remote_write`.
* `delete.retention.ms` cannot be enabled at the same time as any of `redpanda.remote.read`, `redpanda.remote.write`.

These restrictions are in place to ensure the deletion of tombstone records does not occur for topics with tiered storage enabled, a current restriction for compacted topics in `redpanda`.

Docs issue: https://github.com/redpanda-data/documentation-private/issues/2759

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Features

* Adds the topic property `delete.retention.ms`, as well as the cluster property `tombstone_retention_ms`. Configuring these allow for the removal of tombstone records in compacted topics with tiered storage disabled in `redpanda`.
