### PR TITLE
datalake/coordinator: add deterministic state

### DIFF
--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -8,6 +8,20 @@ redpanda_cc_rpc_library(
 )
 
 redpanda_cc_library(
+    name = "data_file",
+    hdrs = [
+        "data_file.h",
+    ],
+    include_prefix = "datalake/coordinator",
+    deps = [
+        "//src/v/base",
+        "//src/v/serde",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "model",
     hdrs = [
         "types.h",

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -1,6 +1,8 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 load("//src/v/rpc:compiler.bzl", "redpanda_cc_rpc_library")
 
+package(default_visibility = ["//src/v/datalake/coordinator:__subpackages__"])
+
 redpanda_cc_rpc_library(
     name = "generated_datalake_coordinator_rpc",
     src = "rpc.json",
@@ -35,6 +37,23 @@ redpanda_cc_library(
         "//src/v/model",
         # todo: split writer further once it evolves
         "//src/v/datalake:writer",
+    ],
+)
+
+redpanda_cc_library(
+    name = "state",
+    srcs = [
+        "state.cc",
+    ],
+    hdrs = [
+        "state.h",
+    ],
+    include_prefix = "datalake/coordinator",
+    deps = [
+        ":translated_offset_range",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "//src/v/serde",
     ],
 )
 

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -59,6 +59,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "translated_offset_range",
+    hdrs = [
+        "translated_offset_range.h",
+    ],
+    include_prefix = "datalake/coordinator",
+    deps = [
+        ":data_file",
+        "//src/v/base",
+        "//src/v/container:fragmented_vector",
+        "//src/v/serde",
+        "@fmt",
+    ],
+)
+
+redpanda_cc_library(
     name = "frontend",
     srcs = [
         "frontend.cc",

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -78,6 +78,25 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "state_update",
+    srcs = [
+        "state_update.cc",
+    ],
+    hdrs = [
+        "state_update.h",
+    ],
+    include_prefix = "datalake/coordinator",
+    deps = [
+        ":state",
+        ":translated_offset_range",
+        "//src/v/base",
+        "//src/v/container:fragmented_vector",
+        "//src/v/model",
+        "//src/v/serde",
+    ],
+)
+
+redpanda_cc_library(
     name = "translated_offset_range",
     hdrs = [
         "translated_offset_range.h",

--- a/src/v/datalake/coordinator/CMakeLists.txt
+++ b/src/v/datalake/coordinator/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
     SRCS
         frontend.cc
         service.cc
+        state.cc
         state_machine.cc
     DEPS
         generated_datalake_coordinator_rpc

--- a/src/v/datalake/coordinator/CMakeLists.txt
+++ b/src/v/datalake/coordinator/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
         service.cc
         state.cc
         state_machine.cc
+        state_update.cc
     DEPS
         generated_datalake_coordinator_rpc
         v::cluster
@@ -20,3 +21,5 @@ v_cc_library(
         v::rpc
         Seastar::seastar
 )
+
+add_subdirectory(tests)

--- a/src/v/datalake/coordinator/data_file.h
+++ b/src/v/datalake/coordinator/data_file.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "serde/envelope.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+
+namespace datalake::coordinator {
+
+// Represents a file that exists in object storage.
+struct data_file
+  : serde::envelope<data_file, serde::version<0>, serde::compat_version<0>> {
+    auto serde_fields() {
+        return std::tie(remote_path, row_count, file_size_bytes);
+    }
+    ss::sstring remote_path = "";
+    size_t row_count = 0;
+    size_t file_size_bytes = 0;
+    // TODO: add kafka schema id
+
+    friend std::ostream& operator<<(std::ostream& o, const data_file& f) {
+        o << fmt::format(
+          "{{remote_path: {}, row_count: {}, file_size_bytes: {}}}",
+          f.remote_path,
+          f.row_count,
+          f.file_size_bytes);
+        return o;
+    }
+};
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state.cc
+++ b/src/v/datalake/coordinator/state.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/coordinator/state.h"
+
+namespace datalake::coordinator {
+
+std::optional<std::reference_wrapper<const partition_state>>
+topics_state::partition_state(const model::topic_partition& tp) const {
+    auto state_iter = topic_to_state.find(tp.topic);
+    if (state_iter == topic_to_state.end()) {
+        return std::nullopt;
+    }
+    const auto& topic_state = state_iter->second;
+    auto prt_iter = topic_state.pid_to_pending_files.find(tp.partition);
+    if (prt_iter == topic_state.pid_to_pending_files.end()) {
+        return std::nullopt;
+    }
+    return prt_iter->second;
+}
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state.h
+++ b/src/v/datalake/coordinator/state.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "datalake/coordinator/translated_offset_range.h"
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+
+#include <deque>
+
+namespace datalake::coordinator {
+
+// Represents the state to be managed by the datalake coordinator's replicated
+// state machine.
+
+// State tracked per Kafka partition. Groups of files get added added to this
+// state, each group corresponding to an offset range. The ranges added to this
+// state must have no overlaps and no gaps in order to ensure exactly once
+// delivery of files to the Iceberg table.
+//
+// Files are added to this state as "pending entries". Once the files are
+// committed to Iceberg, we cease tracking of the files and instead keep track
+// of the highest Kafka offset of the committed files.
+//
+// By tracking pending files only, we rely on the Iceberg catalog to be the
+// source of truth of existing metadata. This allows Redpanda to maintain a
+// much smaller memory footprint per table, and to tolerate concurrent updates
+// to the table more easily (e.g. consider reconciling an external writer to
+// the table if we tracked all files in the table instead of just pending
+// files).
+struct partition_state
+  : public serde::
+      envelope<partition_state, serde::version<0>, serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(pending_entries, last_committed); }
+
+    // Files that have yet to be added to the Iceberg catalog. Ordered in
+    // increasing offset order.
+    //
+    // It is expected that files are only added to this list if they form a
+    // contiguous offset range.
+    std::deque<translated_offset_range> pending_entries;
+
+    // The last (inclusive) Kafka offset confirmed to be sent to the Iceberg
+    // catalog for a given partition.
+    //
+    // When set, is expected that this corresponds to the end of a pending
+    // entry, and upon setting, that all entries up to and including that entry
+    // are removed from pending entries.
+    //
+    // Is nullopt iff we have never committed any files to the table.
+    std::optional<kafka::offset> last_committed;
+};
+
+// Tracks the state managed for each Kafka partition. Since data workers are
+// run per partition, this separation allows us to bookkeep progress of each
+// worker.
+struct topic_state
+  : public serde::
+      envelope<topic_state, serde::version<0>, serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(pid_to_pending_files); }
+
+    // Map from Redpanda partition id to the files pending per partition.
+    chunked_hash_map<model::partition_id, partition_state> pid_to_pending_files;
+
+    // TODO: add table-wide metadata like Kafka schema id, Iceberg table uuid,
+    // etc.
+};
+
+// Tracks the state of each topic.
+struct topics_state
+  : public serde::
+      envelope<topics_state, serde::version<0>, serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(topic_to_state); }
+
+    // Map from the Redpanda topic to the state managed per topic, e.g. pending
+    // files per partition.
+    chunked_hash_map<model::topic, topic_state> topic_to_state;
+
+    // Returns the state for the given partition.
+    std::optional<std::reference_wrapper<const partition_state>>
+    partition_state(const model::topic_partition&) const;
+};
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state_update.cc
+++ b/src/v/datalake/coordinator/state_update.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/coordinator/state_update.h"
+
+#include "datalake/coordinator/state.h"
+#include "datalake/coordinator/translated_offset_range.h"
+
+#include <iterator>
+
+namespace datalake::coordinator {
+
+checked<add_files_update, stm_update_error> add_files_update::build(
+  const topics_state& state,
+  const model::topic_partition& tp,
+  chunked_vector<translated_offset_range> entries) {
+    add_files_update update{
+      .tp = tp,
+      .entries = std::move(entries),
+    };
+    if (!update.can_apply(state)) {
+        return stm_update_error::failed;
+    }
+    return update;
+}
+
+bool add_files_update::can_apply(const topics_state& state) {
+    if (entries.empty()) {
+        return false;
+    }
+    auto prt_state_opt = state.partition_state(tp);
+    if (!prt_state_opt.has_value()) {
+        // No entries at all, this partition hasn't ever added any files.
+        return true;
+    }
+    const auto& prt_state = prt_state_opt.value().get();
+    if (
+      prt_state.pending_entries.empty()
+      && !prt_state.last_committed.has_value()) {
+        // No entries at all, this partition hasn't ever added any files.
+        return true;
+    }
+    auto last_added_offset
+      = prt_state.pending_entries.empty()
+          ? prt_state.last_committed.value()
+          : kafka::offset{prt_state.pending_entries.back().last_offset()};
+    auto update_range_start_offset = entries.begin()->start_offset;
+    if (kafka::next_offset(last_added_offset) == update_range_start_offset) {
+        // The last offset for the partition aligns exactly with where we're
+        // adding new data.
+        return true;
+    }
+    // Misalignment, likely because the current `state` doesn't match the state
+    // the update was built with.
+    return false;
+}
+
+checked<std::nullopt_t, stm_update_error>
+add_files_update::apply(topics_state& state) {
+    if (!can_apply(state)) {
+        return stm_update_error::failed;
+    }
+    if (entries.empty()) {
+        return std::nullopt;
+    }
+    const auto& topic = tp.topic;
+    const auto& pid = tp.partition;
+    auto& tp_state = state.topic_to_state[topic];
+    auto& partition_state = tp_state.pid_to_pending_files[pid];
+    std::move(
+      entries.begin(),
+      entries.end(),
+      std::back_inserter(partition_state.pending_entries));
+    return std::nullopt;
+}
+
+checked<mark_files_committed_update, stm_update_error>
+mark_files_committed_update::build(
+  const topics_state& state,
+  const model::topic_partition& tp,
+  kafka::offset o) {
+    mark_files_committed_update update{
+      .tp = tp,
+      .new_committed = o,
+    };
+    if (!update.can_apply(state)) {
+        return stm_update_error::failed;
+    }
+    return update;
+}
+
+bool mark_files_committed_update::can_apply(const topics_state& state) {
+    auto prt_state = state.partition_state(tp);
+    if (!prt_state.has_value() || prt_state->get().pending_entries.empty()) {
+        // Can't mark files committed if there are no files.
+        return false;
+    }
+    if (
+      prt_state->get().last_committed.has_value()
+      && prt_state->get().last_committed.value() >= new_committed) {
+        // The state already has committed up to the given offset.
+        return false;
+    }
+    // At this point, the desired offset looks okay. Examine the entries to
+    // make sure the new committed offset corresponds to one of them.
+    for (const auto& entry_state : prt_state->get().pending_entries) {
+        if (entry_state.last_offset == new_committed) {
+            return true;
+        }
+    }
+    return false;
+}
+
+checked<std::nullopt_t, stm_update_error>
+mark_files_committed_update::apply(topics_state& state) {
+    if (!can_apply(state)) {
+        return stm_update_error::failed;
+    }
+    const auto& topic = tp.topic;
+    const auto& pid = tp.partition;
+
+    // Mark all files that fall entirely below `new_committed` as committed.
+    auto& files_state = state.topic_to_state[topic].pid_to_pending_files[pid];
+    while (!files_state.pending_entries.empty()
+           && files_state.pending_entries.front().last_offset
+                <= new_committed) {
+        files_state.pending_entries.pop_front();
+    }
+    files_state.last_committed = new_committed;
+    return std::nullopt;
+}
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state_update.h
+++ b/src/v/datalake/coordinator/state_update.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/outcome.h"
+#include "container/fragmented_vector.h"
+#include "datalake/coordinator/state.h"
+#include "datalake/coordinator/translated_offset_range.h"
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+
+namespace datalake::coordinator {
+
+// Represents the deterministic updates to the coordinator STM state.
+
+enum class update_key : uint8_t {
+    add_files = 0,
+    mark_files_committed = 1,
+};
+
+enum class stm_update_error {
+    failed,
+};
+
+// An update to add files for a given Kafka partition.
+struct add_files_update
+  : public serde::
+      envelope<add_files_update, serde::version<0>, serde::compat_version<0>> {
+    static constexpr auto key{update_key::add_files};
+    static checked<add_files_update, stm_update_error> build(
+      const topics_state&,
+      const model::topic_partition&,
+      chunked_vector<translated_offset_range>);
+    auto serde_fields() { return std::tie(tp, entries); }
+
+    bool can_apply(const topics_state&);
+    checked<std::nullopt_t, stm_update_error> apply(topics_state&);
+
+    model::topic_partition tp;
+
+    // Expected to be ordered from lowest offset to highest offset.
+    chunked_vector<translated_offset_range> entries;
+};
+
+// An update to untrack pending files, e.g. after committing them to Iceberg.
+struct mark_files_committed_update
+  : public serde::envelope<
+      mark_files_committed_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    static constexpr auto key{update_key::mark_files_committed};
+    static checked<mark_files_committed_update, stm_update_error>
+    build(const topics_state&, const model::topic_partition&, kafka::offset);
+    auto serde_fields() { return std::tie(tp, new_committed); }
+
+    bool can_apply(const topics_state&);
+    checked<std::nullopt_t, stm_update_error> apply(topics_state&);
+
+    model::topic_partition tp;
+
+    // All pending entries whose offset range falls entirely below this offset
+    // (inclusive) should be removed.
+    kafka::offset new_committed;
+};
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -1,0 +1,19 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "state_update_test",
+    timeout = "short",
+    srcs = [
+        "state_update_test.cc",
+    ],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/datalake:writer",
+        "//src/v/datalake/coordinator:state",
+        "//src/v/datalake/coordinator:state_update",
+        "//src/v/datalake/coordinator:translated_offset_range",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/datalake/coordinator/tests/CMakeLists.txt
+++ b/src/v/datalake/coordinator/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME coordinator
+  SOURCES
+    state_update_test.cc
+  LIBRARIES
+    v::datalake_coordinator
+    v::gtest_main
+  LABELS datalake
+  ARGS "-- -c 1"
+)
+

--- a/src/v/datalake/coordinator/tests/state_update_test.cc
+++ b/src/v/datalake/coordinator/tests/state_update_test.cc
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "container/fragmented_vector.h"
+#include "datalake/coordinator/state.h"
+#include "datalake/coordinator/state_update.h"
+#include "datalake/coordinator/translated_offset_range.h"
+#include "model/fundamental.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace datalake::coordinator;
+
+namespace {
+const model::topic topic{"test_topic"};
+const model::partition_id pid{0};
+const model::topic_partition tp{topic, pid};
+
+// Returns file entries corresponding to the given offset ranges.
+chunked_vector<translated_offset_range> make_pending_files(
+  const std::vector<std::pair<int64_t, int64_t>>& offset_bounds) {
+    chunked_vector<translated_offset_range> files;
+    files.reserve(offset_bounds.size());
+    for (const auto& [begin, end] : offset_bounds) {
+        files.emplace_back(translated_offset_range{
+          .start_offset = kafka::offset{begin},
+          .last_offset = kafka::offset{end},
+          // Other args irrelevant.
+        });
+    }
+    return files;
+}
+
+// Asserts that the given state has the expected partition state.
+void check_partition(
+  const topics_state& state,
+  const model::topic_partition& tp,
+  std::optional<int64_t> expected_committed,
+  const std::vector<std::pair<int64_t, int64_t>>& offset_bounds) {
+    auto prt_state_opt = state.partition_state(tp);
+    ASSERT_TRUE(prt_state_opt.has_value());
+    const auto& prt_state = prt_state_opt.value().get();
+    if (expected_committed.has_value()) {
+        ASSERT_TRUE(prt_state.last_committed.has_value());
+        EXPECT_EQ(prt_state.last_committed.value()(), *expected_committed);
+    } else {
+        EXPECT_FALSE(prt_state.last_committed.has_value());
+    }
+
+    ASSERT_EQ(prt_state.pending_entries.size(), offset_bounds.size());
+    for (size_t i = 0; i < offset_bounds.size(); ++i) {
+        auto expected_begin = offset_bounds[i].first;
+        auto expected_end = offset_bounds[i].second;
+        EXPECT_EQ(prt_state.pending_entries.at(i).start_offset, expected_begin);
+        EXPECT_EQ(prt_state.pending_entries.at(i).last_offset, expected_end);
+    }
+}
+
+// Asserts that the given ranges can't be applied to the given partition state.
+void check_add_doesnt_apply(
+  topics_state& state,
+  const model::topic_partition& tp,
+  const std::vector<std::pair<int64_t, int64_t>>& offset_bounds) {
+    // We should fail to build the update in the first place.
+    auto update = add_files_update::build(
+      state, tp, make_pending_files(offset_bounds));
+    EXPECT_TRUE(update.has_error());
+
+    // Also explicitly build the bad update and make sure it doesn't apply.
+    auto res
+      = add_files_update{.tp = tp, .entries = make_pending_files(offset_bounds)}
+          .apply(state);
+    EXPECT_TRUE(res.has_error());
+}
+
+// Asserts that the commit offset can't be applied to the partition state.
+void check_commit_doesnt_apply(
+  topics_state& state,
+  const model::topic_partition& tp,
+  int64_t commit_offset) {
+    // We should fail to build the update in the first place.
+    auto update = mark_files_committed_update::build(
+      state, tp, kafka::offset{commit_offset});
+    EXPECT_TRUE(update.has_error());
+
+    // Also explicitly build the bad update and make sure it doesn't apply.
+    auto res
+      = mark_files_committed_update{.tp = tp, .new_committed = kafka::offset{commit_offset}}
+          .apply(state);
+    EXPECT_TRUE(res.has_error());
+}
+
+} // namespace
+
+TEST(StateUpdateTest, TestAddFile) {
+    topics_state state;
+    auto update = add_files_update::build(
+      state, tp, make_pending_files({{0, 100}}));
+    // We can always add files to a topic or partition that isn't yet tracked.
+    ASSERT_FALSE(update.has_error());
+    EXPECT_FALSE(state.partition_state(tp).has_value());
+
+    // Now apply the update and check that we have the expected tracked file.
+    auto res = update.value().apply(state);
+    ASSERT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, std::nullopt, {{0, 100}}));
+
+    // Apply the same update won't work because it doesn't align with the back
+    // of the last entry, as well as a few others that don't align.
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{0, 100}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{0, 101}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{100, 100}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{102, 102}}));
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, std::nullopt, {{0, 100}}));
+
+    // Now build one that does align properly.
+    update = add_files_update::build(
+      state, tp, make_pending_files({{101, 200}}));
+    ASSERT_FALSE(update.has_error());
+    res = update.value().apply(state);
+    ASSERT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, std::nullopt, {{0, 100}, {101, 200}}));
+}
+
+TEST(StateUpdateTest, TestAddFileWithCommittedOffset) {
+    // First, set up an existing committed offset, e.g. if we've committed all
+    // our files up to offset 100.
+    topics_state state;
+    state.topic_to_state[topic].pid_to_pending_files[pid].last_committed
+      = kafka::offset{100};
+
+    // Try a few adds that don't apply because they don't align with the
+    // committed offset.
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{0, 100}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{100, 100}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{102, 102}}));
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 100, {}));
+
+    // Now successfully add some.
+    auto update = add_files_update::build(
+      state, tp, make_pending_files({{101, 101}, {102, 200}}));
+    ASSERT_FALSE(update.has_error());
+    auto res = update.value().apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 100, {{101, 101}, {102, 200}}));
+
+    // Try a few more that don't align, this time with a non-empty pending
+    // files list.
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{100, 100}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{101, 101}}));
+    ASSERT_NO_FATAL_FAILURE(check_add_doesnt_apply(state, tp, {{200, 200}}));
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 100, {{101, 101}, {102, 200}}));
+
+    // Now successfully add some, this time with a non-empty pending files.
+    update = add_files_update::build(
+      state, tp, make_pending_files({{201, 201}}));
+    ASSERT_FALSE(update.has_error());
+    res = update.value().apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 100, {{101, 101}, {102, 200}, {201, 201}}));
+}
+
+TEST(StateUpdateTest, TestMarkCommitted) {
+    topics_state state;
+
+    // When there's no pending files, we can't commit anything.
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 0));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 100));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 101));
+
+    // Even if we explicitly have a committed offset already, we still have no
+    // pending files and therefore can't commit.
+    state.topic_to_state[topic].pid_to_pending_files[pid].last_committed
+      = kafka::offset{100};
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 0));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 100));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 101));
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 100, {}));
+
+    // Now add some files.
+    auto res = add_files_update::build(
+                 state, tp, make_pending_files({{101, 200}}))
+                 .value()
+                 .apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 100, {{101, 200}}));
+
+    // The commit should only succeed if it aligns with a file end offset.
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 100));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 101));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 199));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 201));
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 100, {{101, 200}}));
+
+    res = mark_files_committed_update::build(state, tp, kafka::offset{200})
+            .value()
+            .apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 200, {}));
+
+    // Now let's try commit when there are multiple pending files.
+    // First, add multiple files.
+    res = add_files_update::build(
+            state, tp, make_pending_files({{201, 205}, {206, 210}, {211, 220}}))
+            .value()
+            .apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 200, {{201, 205}, {206, 210}, {211, 220}}));
+
+    // Again, commits that aren't aligned with an end offset will fail.
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 200));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 201));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 206));
+    ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 211));
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 200, {{201, 205}, {206, 210}, {211, 220}}));
+
+    // But it should work with one of the inner files.
+    res = mark_files_committed_update::build(state, tp, kafka::offset{205})
+            .value()
+            .apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(
+      check_partition(state, tp, 205, {{206, 210}, {211, 220}}));
+
+    // And it should work with the last file.
+    res = mark_files_committed_update::build(state, tp, kafka::offset{220})
+            .value()
+            .apply(state);
+    EXPECT_FALSE(res.has_error());
+    ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 220, {}));
+}

--- a/src/v/datalake/coordinator/translated_offset_range.h
+++ b/src/v/datalake/coordinator/translated_offset_range.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "datalake/coordinator/data_file.h"
+#include "model/fundamental.h"
+#include "serde/envelope.h"
+
+#include <fmt/core.h>
+
+namespace datalake::coordinator {
+
+// Represents a translated contiguous range of Kafka offsets.
+struct translated_offset_range
+  : serde::envelope<
+      translated_offset_range,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(start_offset, last_offset, files); }
+    // First Kafka offset (inclusive) represented in this range.
+    kafka::offset start_offset;
+    // Last Kafka offset (inclusive) represented in this range.
+    kafka::offset last_offset;
+    chunked_vector<data_file> files;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const translated_offset_range& r) {
+        o << fmt::format(
+          "{{start_offset: {}, last_offset: {}, files: {}}}",
+          r.start_offset,
+          r.last_offset,
+          r.files);
+        return o;
+    }
+};
+
+} // namespace datalake::coordinator


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds deterministic state that will be used as the basis for the upcoming coordinator and its STM. We will use this to keep track of the files pending to be committed to Iceberg for each Kafka partition. As files are committed, the state will be updated accordingly, removing the tracked files.

This only includes the underlying data structures that intend on using for the STM. It isn't yet plugged into the state machine.

Along the way I duplicated a couple structs from the writer: data_file and translated_offset_range. This may be temporary, as the code for the worker is still in flight. Or we may keep it, given it's a nice way to decouple worker from coordinator. For now though it's just helpful to have the coordinator code be entirely separate from the worker.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
