### PR TITLE
http: Make rest entity methods const

### DIFF
--- a/src/v/http/rest_client/rest_entity.cc
+++ b/src/v/http/rest_client/rest_entity.cc
@@ -18,7 +18,7 @@ rest_entity::rest_entity(std::string_view root_url)
       root_url.ends_with("/") ? root_url : fmt::format("{}/", root_url)} {}
 
 request_builder rest_entity::create(
-  optional_headers headers, optional_query_params query_params) {
+  optional_headers headers, optional_query_params query_params) const {
     request_builder rb;
     return apply_optionals(rb, headers, query_params)
       .path(resource_url())
@@ -26,7 +26,7 @@ request_builder rest_entity::create(
 }
 
 request_builder rest_entity::list(
-  optional_headers headers, optional_query_params query_params) {
+  optional_headers headers, optional_query_params query_params) const {
     request_builder rb;
     return apply_optionals(rb, headers, query_params)
       .path(resource_url())
@@ -37,7 +37,7 @@ request_builder rest_entity::get(
   ss::sstring identifier,
   ss::sstring subpath,
   optional_headers headers,
-  optional_query_params query_params) {
+  optional_query_params query_params) const {
     auto target = fmt::format("{}/{}", resource_url(), identifier);
     if (!subpath.empty()) {
         target = fmt::format("{}/{}", target, subpath);
@@ -51,7 +51,7 @@ request_builder rest_entity::get(
 request_builder rest_entity::update(
   ss::sstring identifier,
   optional_headers headers,
-  optional_query_params query_params) {
+  optional_query_params query_params) const {
     request_builder rb;
     return apply_optionals(rb, headers, query_params)
       .path(fmt::format("{}/{}", resource_url(), identifier))
@@ -61,7 +61,7 @@ request_builder rest_entity::update(
 request_builder rest_entity::delete_(
   ss::sstring identifier,
   optional_headers headers,
-  optional_query_params query_params) {
+  optional_query_params query_params) const {
     request_builder rb;
     return apply_optionals(rb, headers, query_params)
       .path(fmt::format("{}/{}", resource_url(), identifier))
@@ -71,7 +71,7 @@ request_builder rest_entity::delete_(
 request_builder& rest_entity::apply_optionals(
   request_builder& rb,
   optional_headers headers,
-  optional_query_params query_params) {
+  optional_query_params query_params) const {
     if (headers.has_value()) {
         rb.headers(headers.value());
     }

--- a/src/v/http/rest_client/rest_entity.h
+++ b/src/v/http/rest_client/rest_entity.h
@@ -56,10 +56,10 @@ public:
 
     virtual request_builder create(
       optional_headers headers = std::nullopt,
-      optional_query_params query_params = std::nullopt);
+      optional_query_params query_params = std::nullopt) const;
     virtual request_builder list(
       optional_headers headers = std::nullopt,
-      optional_query_params query_params = std::nullopt);
+      optional_query_params query_params = std::nullopt) const;
 
     // The get method retrieves an object of the type of this rest entity using
     // the identifier, eg get("1") maps to call GET /api/v1/person/1. An
@@ -69,15 +69,15 @@ public:
       ss::sstring identifier,
       ss::sstring subpath = "",
       optional_headers headers = std::nullopt,
-      optional_query_params query_params = std::nullopt);
+      optional_query_params query_params = std::nullopt) const;
     virtual request_builder update(
       ss::sstring identifier,
       optional_headers headers = std::nullopt,
-      optional_query_params query_params = std::nullopt);
+      optional_query_params query_params = std::nullopt) const;
     virtual request_builder delete_(
       ss::sstring identifier,
       optional_headers headers = std::nullopt,
-      optional_query_params query_params = std::nullopt);
+      optional_query_params query_params = std::nullopt) const;
 
     ss::sstring resource_url() const;
 
@@ -85,7 +85,7 @@ private:
     virtual request_builder& apply_optionals(
       request_builder& rb,
       optional_headers headers,
-      optional_query_params query_params);
+      optional_query_params query_params) const;
 
     ss::sstring _root_url;
 };


### PR DESCRIPTION
Make rest entity methods const - addressing feedback for https://github.com/redpanda-data/redpanda/pull/23534#discussion_r1786992306

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
