### PR TITLE
Migrations to block partition writes and abort uncommited transactions

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1549,7 +1549,7 @@ backend::work_scope backend::get_work_scope(
     case state::cut_over:
         return {state::finished, false, true};
     case state::canceling:
-        return {state::cancelled, false, true};
+        return {state::cancelled, true, true};
     default:
         return {{}, false, false};
     };

--- a/src/v/cluster/data_migration_worker.h
+++ b/src/v/cluster/data_migration_worker.h
@@ -84,6 +84,9 @@ private:
       state sought_state,
       const outbound_partition_work_info&);
 
+    ss::future<errc> block(ss::lw_shared_ptr<partition> partition, bool block);
+    ss::future<errc> flush(ss::lw_shared_ptr<partition> partition);
+
     model::node_id _self;
     partition_leaders_table& _leaders_table;
     partition_manager& _partition_manager;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -225,6 +225,8 @@ public:
 
     const producers_t& get_producers() const { return _producers; }
 
+    ss::future<tx::errc> abort_all_txes();
+
 protected:
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -326,7 +326,7 @@ private:
 
     void abort_old_txes();
     ss::future<std::chrono::milliseconds> do_abort_old_txes();
-    ss::future<> try_abort_old_tx(tx::producer_ptr);
+    ss::future<tx::errc> try_abort_old_tx(tx::producer_ptr);
     ss::future<tx::errc> do_try_abort_old_tx(tx::producer_ptr);
     void maybe_rearm_autoabort_timer(tx::time_point_type);
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -215,7 +215,7 @@ public:
 
     ss::future<result<tx::partition_transactions>> get_transactions();
 
-    ss::future<std::error_code> mark_expired(model::producer_identity pid);
+    ss::future<tx::errc> mark_expired(model::producer_identity pid);
 
     ss::future<> remove_persistent_state() override;
 

--- a/src/v/kafka/server/tests/replicated_partition_test.cc
+++ b/src/v/kafka/server/tests/replicated_partition_test.cc
@@ -36,7 +36,7 @@ FIXTURE_TEST(test_replicated_partition_end_offset, redpanda_thread_fixture) {
         return app.partition_manager.invoke_on(
           *shard, [&ntp](cluster::partition_manager& pm) {
               auto p = pm.get(ntp);
-              return p->get_leader_id().has_value();
+              return p->is_leader();
           });
     }).get();
 

--- a/src/v/raft/replicate.h
+++ b/src/v/raft/replicate.h
@@ -57,7 +57,7 @@ struct replicate_stages {
     replicate_stages(ss::future<>, ss::future<result<replicate_result>>);
     explicit replicate_stages(raft::errc);
     // after this future is ready, request in enqueued in raft and it will not
-    // be reorderd
+    // be reordered
     ss::future<> request_enqueued;
     // after this future is ready, request was successfully replicated with
     // requested consistency level

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -190,7 +190,7 @@ admin_server::mark_transaction_expired_handler(
 
           return rm_stm_ptr->mark_expired(pid).then(
             [this, ntp, req = std::move(req)](auto res) {
-                return throw_on_error(*req, res, ntp).then([] {
+                return throw_on_error(*req, std::error_code{res}, ntp).then([] {
                     return ss::json::json_return_type(ss::json::json_void());
                 });
             });

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -287,7 +287,8 @@ class DataMigrationsApiTest(RedpandaTest):
             'archival'  # a variety of archival errors is observed
         ])
     def test_creating_when_cluster_misconfigured2(self):
-        self.creating_when_cluster_misconfigured("cloud_storage_enabled")
+        self.creating_when_cluster_misconfigured(
+            "cloud_storage_disable_archiver_manager")
 
     def creating_when_cluster_misconfigured(self, param_to_disable):
         self.redpanda.set_cluster_config({param_to_disable: False},


### PR DESCRIPTION
When a partition is migrated away:
- make sure no writes sneak in after a final flush
- abort any uncommitted transactions affecting this partition

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
