### PR TITLE
`kafka`: improve `CreateTopics` error and boolean handling

### DIFF
--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -33,6 +33,7 @@
 
 #include <array>
 #include <chrono>
+#include <iterator>
 #include <optional>
 #include <string_view>
 
@@ -365,7 +366,8 @@ ss::future<response_ptr> create_topics_handler::handle(
       });
     valid_range_end = quota_exceeded_it;
 
-    auto to_create = to_cluster_type(begin, valid_range_end);
+    auto to_create = to_cluster_type(
+      begin, valid_range_end, std::back_inserter(response.data.topics));
 
     // Create the topics with controller on core 0
     auto c_res = co_await ctx.topics_frontend().create_topics(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -111,7 +111,14 @@ static std::optional<bool>
 get_bool_value(const config_map_t& config, std::string_view key) {
     if (auto it = config.find(key); it != config.end()) {
         try {
-            return string_switch<std::optional<bool>>(it->second)
+            // Ignore case.
+            auto str_value = it->second;
+            std::transform(
+              str_value.begin(),
+              str_value.end(),
+              str_value.begin(),
+              [](const auto& c) { return std::tolower(c); });
+            return string_switch<std::optional<bool>>(str_value)
               .match("true", true)
               .match("false", false);
         } catch (const std::runtime_error&) {

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -26,6 +26,7 @@
 
 #include <bits/stdint-intn.h>
 #include <bits/stdint-uintn.h>
+#include <boost/lexical_cast/bad_lexical_cast.hpp>
 
 #include <chrono>
 #include <cstddef>
@@ -109,10 +110,13 @@ get_string_value(const config_map_t& config, std::string_view key) {
 static std::optional<bool>
 get_bool_value(const config_map_t& config, std::string_view key) {
     if (auto it = config.find(key); it != config.end()) {
-        return string_switch<std::optional<bool>>(it->second)
-          .match("true", true)
-          .match("false", false)
-          .default_match(std::nullopt);
+        try {
+            return string_switch<std::optional<bool>>(it->second)
+              .match("true", true)
+              .match("false", false);
+        } catch (const std::runtime_error&) {
+            throw boost::bad_lexical_cast();
+        };
     }
     return std::nullopt;
 }

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -428,3 +428,19 @@ FIXTURE_TEST(invalid_boolean_property, create_topic_fixture) {
       resp.data.topics[0].error_message == "Configuration is invalid");
     BOOST_CHECK(resp.data.topics[0].name == "topic1");
 }
+
+FIXTURE_TEST(case_insensitive_boolean_property, create_topic_fixture) {
+    auto topic = make_topic(
+      "topic1",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"redpanda.remote.write", "tRuE"}, {"redpanda.remote.read", "FALSE"}});
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto resp = client.dispatch(make_req({topic}), kafka::api_version(5)).get();
+
+    BOOST_CHECK(resp.data.topics[0].error_code == kafka::error_code::none);
+    BOOST_CHECK(resp.data.topics[0].name == "topic1");
+}

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -335,3 +335,77 @@ FIXTURE_TEST(test_v5_validate_configs_resp, create_topic_fixture) {
         false),
       kafka::api_version(5));
 }
+
+FIXTURE_TEST(create_multiple_topics_mixed_invalid, create_topic_fixture) {
+    auto topic_a = make_topic(
+      "topic_a",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{{"redpanda.remote.write", "true"}});
+
+    auto topic_b = make_topic(
+      "topic_b",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"retention.bytes", "this_should_be_an_integer"}});
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto resp = client
+                  .dispatch(make_req({topic_a, topic_b}), kafka::api_version(5))
+                  .get();
+
+    BOOST_CHECK(resp.data.topics.size() == 2);
+
+    BOOST_CHECK(resp.data.topics[0].error_code == kafka::error_code::none);
+    BOOST_CHECK(resp.data.topics[0].name == "topic_a");
+
+    BOOST_CHECK(
+      resp.data.topics[1].error_code == kafka::error_code::invalid_config);
+    BOOST_CHECK(resp.data.topics[1].name == "topic_b");
+}
+
+FIXTURE_TEST(create_multiple_topics_all_invalid, create_topic_fixture) {
+    auto topic_a = make_topic(
+      "topic_a",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"redpanda.remote.write", "yes_this_is_true"}});
+
+    auto topic_b = make_topic(
+      "topic_b",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"retention.bytes", "this_should_be_an_integer"}});
+
+    auto topic_c = make_topic(
+      "topic_c",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{{"segment.ms", "0x2A"}});
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto resp = client
+                  .dispatch(
+                    make_req({topic_a, topic_b, topic_c}),
+                    kafka::api_version(5))
+                  .get();
+
+    BOOST_CHECK(resp.data.topics.size() == 3);
+
+    BOOST_CHECK(resp.data.topics[0].name == "topic_a");
+    BOOST_CHECK(
+      resp.data.topics[0].error_code == kafka::error_code::invalid_config);
+
+    BOOST_CHECK(resp.data.topics[1].name == "topic_b");
+    BOOST_CHECK(
+      resp.data.topics[1].error_code == kafka::error_code::invalid_config);
+
+    BOOST_CHECK(resp.data.topics[2].name == "topic_c");
+    BOOST_CHECK(
+      resp.data.topics[2].error_code == kafka::error_code::invalid_config);
+}

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -409,3 +409,22 @@ FIXTURE_TEST(create_multiple_topics_all_invalid, create_topic_fixture) {
     BOOST_CHECK(
       resp.data.topics[2].error_code == kafka::error_code::invalid_config);
 }
+
+FIXTURE_TEST(invalid_boolean_property, create_topic_fixture) {
+    auto topic = make_topic(
+      "topic1",
+      std::nullopt,
+      std::nullopt,
+      std::map<ss::sstring, ss::sstring>{
+        {"redpanda.remote.write", "affirmative"}});
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto resp = client.dispatch(make_req({topic}), kafka::api_version(5)).get();
+
+    BOOST_CHECK(
+      resp.data.topics[0].error_code == kafka::error_code::invalid_config);
+    BOOST_CHECK(
+      resp.data.topics[0].error_message == "Configuration is invalid");
+    BOOST_CHECK(resp.data.topics[0].name == "topic1");
+}

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -380,6 +380,21 @@ class CreateTopicsTest(RedpandaTest):
             rpk.create_topic('topic-1',
                              config={'redpanda.remote.read': 'affirmative'})
 
+    @cluster(num_nodes=3)
+    def test_case_insensitive_boolean_property(self):
+        """
+        Validates that boolean properties are case insensitive.
+        """
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic('topic-1',
+                         config={
+                             'redpanda.remote.read': 'tRuE',
+                             'redpanda.remote.write': 'FALSE'
+                         })
+        cfg = rpk.describe_topic_configs('topic-1')
+        assert cfg['redpanda.remote.read'][0] == 'true'
+        assert cfg['redpanda.remote.write'][0] == 'false'
+
 
 class CreateTopicsResponseTest(RedpandaTest):
     SUCCESS_EC = 0

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -369,6 +369,17 @@ class CreateTopicsTest(RedpandaTest):
             "Topic {kafka-topic3} has a replication factor")
         assert num_found == 0, f'Expected to find 0 messages about topic-3, but found {num_found}'
 
+    @cluster(num_nodes=3)
+    def test_invalid_boolean_property(self):
+        """
+        Validates that an invalid boolean property results in an invalid configuration response.
+        """
+        rpk = RpkTool(self.redpanda)
+        with expect_exception(RpkException,
+                              lambda e: 'Configuration is invalid' in str(e)):
+            rpk.create_topic('topic-1',
+                             config={'redpanda.remote.read': 'affirmative'})
+
 
 class CreateTopicsResponseTest(RedpandaTest):
     SUCCESS_EC = 0


### PR DESCRIPTION
This PR covers three cases:

### 1. Invalid boolean properties

Previously, invalid boolean property values would be silently ignored during the handling of a `CreateTopics` request, e.g

```
$ rpk topic create tapioca -c redpanda.remote.read=yes_this_is_true
TOPIC    STATUS
tapioca  OK
$ rpk topic describe topic
CONFIGS
=======
KEY                   VALUE   SOURCE
redpanda.remote.read  false   DEFAULT_CONFIG
```

would result in the topic `tapioca` being created instead of returning an error. The topic's value for `redpanda.remote.read` silently defaults to the cluster default (`false` in the example above).

This is unlike Kafka, in which an invalid configuration error is propagated back to the user:

```
$ ./kafka-topics.sh --create --topic tapioca --bootstrap-server localhost:9092 --config preallocate=yes_this_is_true
Error while executing topic command : Invalid value yes_this_is_true for configuration preallocate: Expected value to be either true or false
[2024-10-08 12:39:32,885] ERROR org.apache.kafka.common.config.ConfigException: Invalid value yes_this_is_true for configuration preallocate: Expected value to be either true or false
	at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:706)
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:531)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:524)
	at org.apache.kafka.storage.internals.log.LogConfig.validate(LogConfig.java:692)
	at org.apache.kafka.storage.internals.log.LogConfig.validate(LogConfig.java:684)
	at org.apache.kafka.tools.TopicCommand.parseTopicConfigsToBeAdded(TopicCommand.java:176)
	at org.apache.kafka.tools.TopicCommand.access$000(TopicCommand.java:81)
	at org.apache.kafka.tools.TopicCommand$CommandTopicPartition.<init>(TopicCommand.java:267)
	at org.apache.kafka.tools.TopicCommand$TopicService.createTopic(TopicCommand.java:460)
	at org.apache.kafka.tools.TopicCommand.execute(TopicCommand.java:105)
	at org.apache.kafka.tools.TopicCommand.mainNoExit(TopicCommand.java:90)
	at org.apache.kafka.tools.TopicCommand.main(TopicCommand.java:85)
 (org.apache.kafka.tools.TopicCommand)
```

#### Fix this inconsistency by returning an `kafka::error_code::invalid_config` when an invalid boolean value is provided.

```
$ rpk topic create tapioca -c redpanda.remote.read=yes_this_is_true
TOPIC    STATUS
tapioca  INVALID_CONFIG: Configuration is invalid
```

### 2. Case-insensitive boolean properties
 
Previously, the only boolean values that would be considered valid in a `CreateTopics` request would be `true` and `false`. All other cases, such as `True`, `TRUE`, `fAlSe`, etc., would again map to the "silently ignored" state mentioned above, e.g.
 
```
$ rpk topic create tapioca -c redpanda.remote.read=True
TOPIC    STATUS
tapioca  OK
$ rpk topic describe tapioca
CONFIGS
=======
KEY                   VALUE   SOURCE
redpanda.remote.read  false   DEFAULT_CONFIG
```

This is unlike Kafka, in which the boolean property's value is case-insensitive:

```
$ ./kafka-topics.sh --create --topic tapioca --bootstrap-server localhost:9092 --config preallocate=True
Created topic tapioca.

(Kafka topic has set `preallocate=true`)
```

#### Fix this inconsistency by making `CreateTopics` requests in `redpanda` case-insensitive for boolean values. 

```
$ rpk topic create tapioca -c redpanda.remote.read=tRuE
TOPIC    STATUS
tapioca  OK
$ rpk topic describe tapioca
CONFIGS
=======
KEY                   VALUE   SOURCE
redpanda.remote.read  true    DYNAMIC_TOPIC_CONFIG
```

### 3. Other invalid topic configuration error handling

A few functions use unprotected `boost::lexical_cast` calls to convert input parameters to their required type. 

Before, when these calls failed and threw a `bad_lexical_cast` exception, it would not be caught and instead propagated to the `request_context` layer, retrying the command until it eventually times out. 

`$ rpk topic create tapioca -c retention.bytes=this_should_be_an_integer`

`redpanda` output:

```
WARN  2024-10-09 13:24:15,329 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:15,626 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:16,081 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:16,914 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:19,145 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:21,654 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
WARN  2024-10-09 13:24:24,164 [shard  1:main] kafka - connection_context.cc:872 - Error processing request: boost::wrapexcept<boost::bad_lexical_cast> (bad lexical cast: source type value could not be interpreted as target)
```

`rpk` output:

```
unable to create topics [tapioca]: broker closed the connection immediately after a request was issued, which happens when SASL is required but not provided: is SASL missing?
```

This also has the effect of "all-or-nothing" topic creation, in which one bad configuration results in none of the topics being created, which is unlike the Kafka behaviour.

#### Fix this inconsistency by catching and gracefully returning error codes instead for invalid topic configurations. 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* Improve handling of boolean property values during a `CreateTopics` request by making parsing case-insensitive. 
* Improve handling of boolean values during a `CreateTopics` request by no longer silently ignoring an invalid value, instead throwing a configuration error.
* Improve handling of certain invalid topic configuration parameters that would lead to a timeout failure instead of a graceful error code during a `CreateTopics` request.