### PR TITLE
iceberg: add batching parquet writer factory

### DIFF
--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -71,7 +71,7 @@ batching_parquet_writer::initialize(std::filesystem::path output_file_path) {
         co_return data_writer_error::file_io_error;
     }
 
-    _result.file_path = _output_file_path.string();
+    _result.remote_path = _output_file_path.string();
     co_return data_writer_error::ok;
 }
 
@@ -102,7 +102,7 @@ ss::future<data_writer_error> batching_parquet_writer::add_data_struct(
     co_return data_writer_error::ok;
 }
 
-ss::future<result<data_writer_result, data_writer_error>>
+ss::future<result<coordinator::data_file, data_writer_error>>
 batching_parquet_writer::finish() {
     auto write_result = co_await write_row_group();
     if (write_result != data_writer_error::ok) {
@@ -153,7 +153,7 @@ ss::future<data_writer_error> batching_parquet_writer::write_row_group() {
     iobuf out;
     try {
         auto chunk = _iceberg_to_arrow.take_chunk();
-        _result.record_count += _row_count;
+        _result.row_count += _row_count;
         _row_count = 0;
         _byte_count = 0;
         _arrow_to_iobuf.add_arrow_array(chunk);

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -204,7 +204,7 @@ batching_parquet_writer_factory::batching_parquet_writer_factory(
   , _row_count_threshold{row_count_threshold}
   , _byte_count_treshold{byte_count_threshold} {}
 
-ss::future<std::unique_ptr<data_writer>>
+ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
 batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
     auto ret = std::make_unique<batching_parquet_writer>(
       std::move(schema), _row_count_threshold, _byte_count_treshold);
@@ -213,9 +213,7 @@ batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
     std::filesystem::path file_path = _local_directory / filename;
     auto err = co_await ret->initialize(file_path);
     if (err != data_writer_error::ok) {
-        // FIXME: This method should return a result and let the multiplexer
-        // deal with it appropriately
-        co_return nullptr;
+        co_return err;
     }
     co_return ret;
 }

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -22,6 +22,8 @@
 #include <seastar/coroutine/as_future.hh>
 
 #include <cstdint>
+#include <memory>
+#include <utility>
 
 namespace datalake {
 
@@ -159,4 +161,29 @@ ss::future<> batching_parquet_writer::abort() {
     }
 }
 
+batching_parquet_writer_factory::batching_parquet_writer_factory(
+  std::filesystem::path local_directory,
+  ss::sstring file_name_prefix,
+  size_t row_count_threshold,
+  size_t byte_count_threshold)
+  : _local_directory{std::move(local_directory)}
+  , _file_name_prefix{std::move(file_name_prefix)}
+  , _row_count_threshold{row_count_threshold}
+  , _byte_count_treshold{byte_count_threshold} {}
+
+ss::future<std::unique_ptr<data_writer>>
+batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
+    auto ret = std::make_unique<batching_parquet_writer>(
+      std::move(schema), _row_count_threshold, _byte_count_treshold);
+    std::string filename = fmt::format(
+      "{}-{}.parquet", _file_name_prefix, uuid_t::create());
+    std::filesystem::path file_path = _local_directory / filename;
+    auto err = co_await ret->initialize(file_path);
+    if (err != data_writer_error::ok) {
+        // FIXME: This method should return a result and let the multiplexer
+        // deal with it appropriately
+        co_return nullptr;
+    }
+    co_return ret;
+}
 } // namespace datalake

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -204,9 +204,9 @@ batching_parquet_writer_factory::batching_parquet_writer_factory(
   , _row_count_threshold{row_count_threshold}
   , _byte_count_treshold{byte_count_threshold} {}
 
-ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
 batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
-    auto ret = std::make_unique<batching_parquet_writer>(
+    auto ret = ss::make_shared<batching_parquet_writer>(
       std::move(schema), _row_count_threshold, _byte_count_treshold);
     std::string filename = fmt::format(
       "{}-{}.parquet", _file_name_prefix, uuid_t::create());

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -84,7 +84,7 @@ public:
       size_t row_count_threshold,
       size_t byte_count_threshold);
 
-    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override;
 
 private:

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -21,6 +21,7 @@
 #include <base/seastarx.h>
 
 #include <filesystem>
+#include <memory>
 
 namespace datalake {
 // batching_parquet_writer ties together the low-level components for iceberg to
@@ -73,6 +74,24 @@ private:
     ss::file _output_file;
     ss::output_stream<char> _output_stream;
     data_writer_result _result;
+};
+
+class batching_parquet_writer_factory : public data_writer_factory {
+public:
+    batching_parquet_writer_factory(
+      std::filesystem::path local_directory,
+      ss::sstring file_name_prefix,
+      size_t row_count_threshold,
+      size_t byte_count_threshold);
+
+    ss::future<std::unique_ptr<data_writer>>
+    create_writer(iceberg::struct_type schema) override;
+
+private:
+    std::filesystem::path _local_directory;
+    ss::sstring _file_name_prefix;
+    size_t _row_count_threshold;
+    size_t _byte_count_treshold;
 };
 
 } // namespace datalake

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -84,7 +84,7 @@ public:
       size_t row_count_threshold,
       size_t byte_count_threshold);
 
-    ss::future<std::unique_ptr<data_writer>>
+    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override;
 
 private:

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -50,7 +50,7 @@ public:
     ss::future<data_writer_error>
     add_data_struct(iceberg::struct_value data, int64_t approx_size) override;
 
-    ss::future<result<data_writer_result, data_writer_error>> finish() override;
+    ss::future<result<coordinator::data_file, data_writer_error>> finish() override;
 
     // Close the file handle, delete any temporary data and clean up any other
     // state.
@@ -73,7 +73,7 @@ private:
     std::filesystem::path _output_file_path;
     ss::file _output_file;
     ss::output_stream<char> _output_stream;
-    data_writer_result _result;
+    coordinator::data_file _result;
 };
 
 class batching_parquet_writer_factory : public data_writer_factory {

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -50,7 +50,8 @@ public:
     ss::future<data_writer_error>
     add_data_struct(iceberg::struct_value data, int64_t approx_size) override;
 
-    ss::future<result<coordinator::data_file, data_writer_error>> finish() override;
+    ss::future<result<coordinator::data_file, data_writer_error>>
+    finish() override;
 
     // Close the file handle, delete any temporary data and clean up any other
     // state.

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/outcome.h"
+#include "coordinator/data_file.h"
 #include "datalake/schemaless_translator.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
@@ -25,17 +26,6 @@ enum class data_writer_error {
     file_io_error,
 };
 
-struct data_writer_result
-  : serde::envelope<
-      data_writer_result,
-      serde::version<0>,
-      serde::compat_version<0>> {
-    ss::sstring file_path = "";
-    size_t record_count = 0;
-    size_t file_size_bytes = 0;
-
-    auto serde_fields() { return std::tie(record_count); }
-};
 
 struct data_writer_error_category : std::error_category {
     const char* name() const noexcept override { return "Data Writer Error"; }
@@ -69,7 +59,7 @@ public:
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
 
-    virtual ss::future<result<data_writer_result, data_writer_error>>
+    virtual ss::future<result<coordinator::data_file, data_writer_error>>
     finish() = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -77,7 +77,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    virtual ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -78,7 +78,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual std::unique_ptr<data_writer>
+    virtual ss::future<std::unique_ptr<data_writer>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -23,7 +23,6 @@ enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,
     file_io_error,
-
 };
 
 struct data_writer_result
@@ -78,7 +77,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual ss::future<std::unique_ptr<data_writer>>
+    virtual ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -24,8 +24,8 @@ enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,
     file_io_error,
+    no_data,
 };
-
 
 struct data_writer_error_category : std::error_category {
     const char* name() const noexcept override { return "Data Writer Error"; }
@@ -38,6 +38,8 @@ struct data_writer_error_category : std::error_category {
             return "Parquet Conversion Error";
         case data_writer_error::file_io_error:
             return "File IO Error";
+        case data_writer_error::no_data:
+            return "No data";
         }
     }
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -97,13 +97,12 @@ ss::future<data_writer&> record_multiplexer::get_writer() {
     if (!_writer) {
         auto& translator = get_translator();
         auto schema = translator.get_schema();
-        _writer = co_await _writer_factory->create_writer(std::move(schema));
-        if (!_writer) {
-            // FIXME: modify create_writer to return a result and check that
-            // here. This method should also return a result. That is coming in
-            // one of the next commits. For now throw & catch.
+        auto writer_result = co_await _writer_factory->create_writer(std::move(schema));
+        if (!writer_result.has_value()) {
+            // FIXME: handle this error correctly
             throw std::runtime_error("Could not create data writer");
         }
+        _writer = std::move(writer_result.value());
     }
     co_return *_writer;
 }

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -10,7 +10,9 @@
 #include "datalake/record_multiplexer.h"
 
 #include "datalake/data_writer_interface.h"
+#include "datalake/logger.h"
 #include "datalake/schemaless_translator.h"
+#include "datalake/tests/test_data_writer.h"
 #include "iceberg/values.h"
 #include "model/record.h"
 #include "storage/parser_utils.h"
@@ -49,13 +51,18 @@ record_multiplexer::operator()(model::record_batch batch) {
         iceberg::struct_value data = translator.translate_event(
           std::move(key), std::move(val), timestamp, offset);
         // Send it to the writer
-        auto& writer = get_writer();
-        data_writer_error writer_status = co_await writer.add_data_struct(
-          std::move(data), estimated_size);
-        if (writer_status != data_writer_error::ok) {
+
+        try {
+            auto& writer = co_await get_writer();
+            _writer_status = co_await writer.add_data_struct(
+              std::move(data), estimated_size);
+        } catch (const std::runtime_error& err) {
+            datalake_log.error("Failed to add data to writer");
+            _writer_status =data_writer_error::parquet_conversion_error;
+        }
+        if (_writer_status != data_writer_error::ok) {
             // If a write fails, the writer is left in an indeterminate state,
             // we cannot continue in this case.
-            _writer_status = writer_status;
             co_return ss::stop_iteration::yes;
         }
     }
@@ -86,12 +93,18 @@ schemaless_translator& record_multiplexer::get_translator() {
     return _translator;
 }
 
-data_writer& record_multiplexer::get_writer() {
+ss::future<data_writer&> record_multiplexer::get_writer() {
     if (!_writer) {
         auto& translator = get_translator();
         auto schema = translator.get_schema();
-        _writer = _writer_factory->create_writer(std::move(schema));
+        _writer = co_await _writer_factory->create_writer(std::move(schema));
+        if (!_writer) {
+            // FIXME: modify create_writer to return a result and check that
+            // here. This method should also return a result. That is coming in
+            // one of the next commits. For now throw & catch.
+            throw std::runtime_error("Could not create data writer");
+        }
     }
-    return *_writer;
+    co_return *_writer;
 }
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -69,14 +69,14 @@ record_multiplexer::operator()(model::record_batch batch) {
     co_return ss::stop_iteration::no;
 }
 
-ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
+ss::future<result<chunked_vector<coordinator::data_file>, data_writer_error>>
 record_multiplexer::end_of_stream() {
     if (_writer_status != data_writer_error::ok) {
         co_return _writer_status;
     }
     // TODO: once we have multiple _writers this should be a loop
     if (_writer) {
-        chunked_vector<data_writer_result> ret;
+        chunked_vector<coordinator::data_file> ret;
         auto res = co_await _writer->finish();
         if (res.has_value()) {
             ret.push_back(res.value());
@@ -85,7 +85,7 @@ record_multiplexer::end_of_stream() {
             co_return res.error();
         }
     } else {
-        co_return chunked_vector<data_writer_result>{};
+        co_return chunked_vector<coordinator::data_file>{};
     }
 }
 

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -47,7 +47,7 @@ public:
 
 private:
     schemaless_translator& get_translator();
-    data_writer& get_writer();
+    ss::future<data_writer&> get_writer();
 
     // TODO: in a future PR this will be a map of translators keyed by schema_id
     schemaless_translator _translator;

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -47,14 +47,15 @@ public:
 
 private:
     schemaless_translator& get_translator();
-    ss::future<data_writer&> get_writer();
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
+    get_writer();
 
     // TODO: in a future PR this will be a map of translators keyed by schema_id
     schemaless_translator _translator;
     std::unique_ptr<data_writer_factory> _writer_factory;
 
     // TODO: similarly this will be a map keyed by schema_id
-    std::unique_ptr<data_writer> _writer;
+    ss::shared_ptr<data_writer> _writer;
 
     data_writer_error _writer_status = data_writer_error::ok;
 };

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -11,9 +11,12 @@
 
 #include "base/outcome.h"
 #include "container/fragmented_vector.h"
+#include "datalake/coordinator/translated_offset_range.h"
 #include "datalake/data_writer_interface.h"
 #include "datalake/schemaless_translator.h"
+#include "model/fundamental.h"
 #include "model/record.h"
+#include "serde/envelope.h"
 
 #include <seastar/core/future.hh>
 
@@ -42,7 +45,7 @@ public:
     explicit record_multiplexer(
       std::unique_ptr<data_writer_factory> writer_factory);
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
-    ss::future<result<chunked_vector<coordinator::data_file>, data_writer_error>>
+    ss::future<result<coordinator::translated_offset_range, data_writer_error>>
     end_of_stream();
 
 private:
@@ -58,6 +61,8 @@ private:
     ss::shared_ptr<data_writer> _writer;
 
     data_writer_error _writer_status = data_writer_error::ok;
+
+    std::optional<coordinator::translated_offset_range> _result;
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -42,7 +42,7 @@ public:
     explicit record_multiplexer(
       std::unique_ptr<data_writer_factory> writer_factory);
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
-    ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
+    ss::future<result<chunked_vector<coordinator::data_file>, data_writer_error>>
     end_of_stream();
 
 private:

--- a/src/v/datalake/tests/batching_parquet_writer_test.cc
+++ b/src/v/datalake/tests/batching_parquet_writer_test.cc
@@ -44,8 +44,8 @@ TEST(BatchingParquetWriterTest, WritesParquetFiles) {
 
     auto result = writer.finish().get0();
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value().file_path, file_path);
-    EXPECT_EQ(result.value().record_count, num_rows);
+    EXPECT_EQ(result.value().remote_path, file_path);
+    EXPECT_EQ(result.value().row_count, num_rows);
     auto true_file_size = std::filesystem::file_size(file_path);
     EXPECT_EQ(result.value().file_size_bytes, true_file_size);
 

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -44,7 +44,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1);
-    EXPECT_EQ(result.value()[0].record_count, record_count * batch_count);
+    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
 }
 TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     int record_count = 10;
@@ -102,7 +102,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1);
-    EXPECT_EQ(result.value()[0].record_count, record_count * batch_count);
+    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
 
     // Open the resulting file and check that it has data in it with the
     // appropriate counts.

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -7,11 +7,18 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+#include "datalake/batching_parquet_writer.h"
 #include "datalake/record_multiplexer.h"
 #include "datalake/tests/test_data_writer.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/tmp_dir.h"
 
+#include <arrow/io/file.h>
+#include <arrow/table.h>
 #include <gtest/gtest.h>
+#include <parquet/arrow/reader.h>
+
+#include <filesystem>
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     int record_count = 10;
@@ -61,4 +68,67 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     ASSERT_TRUE(res.has_error());
     EXPECT_EQ(
       res.error(), datalake::data_writer_error::parquet_conversion_error);
+}
+
+TEST(DatalakeMultiplexerTest, WritesDataFiles) {
+    // Almost an integration test:
+    // Stitch together as many parts of the data path as is reasonable in a
+    // single test and make sure we can go from Kafka log to Parquet files on
+    // disk.
+    temporary_dir tmp_dir("datalake_multiplexer_test");
+
+    int record_count = 50;
+    int batch_count = 20;
+
+    auto writer_factory
+      = std::make_unique<datalake::batching_parquet_writer_factory>(
+        tmp_dir.get_path(), "data", 100, 10000);
+    datalake::record_multiplexer multiplexer(std::move(writer_factory));
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    ss::circular_buffer<model::record_batch> batches
+      = model::test::make_random_batches(batch_spec).get0();
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+
+    auto result
+      = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 1);
+    EXPECT_EQ(result.value()[0].record_count, record_count * batch_count);
+
+    // Open the resulting file and check that it has data in it with the
+    // appropriate counts.
+    int file_count = 0;
+    for (const auto& entry :
+         std::filesystem::directory_iterator(tmp_dir.get_path())) {
+        file_count++;
+        auto arrow_file_reader
+          = arrow::io::ReadableFile::Open(entry.path()).ValueUnsafe();
+
+        // Open Parquet file reader
+        std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+        ASSERT_TRUE(
+          parquet::arrow::OpenFile(
+            arrow_file_reader, arrow::default_memory_pool(), &arrow_reader)
+            .ok());
+
+        // Read entire file as a single Arrow table
+        std::shared_ptr<arrow::Table> table;
+        auto r = arrow_reader->ReadTable(&table);
+        ASSERT_TRUE(r.ok());
+
+        EXPECT_EQ(table->num_rows(), record_count * batch_count);
+        // Expect 4 columns for schemaless: offset, timestamp, key, value
+        EXPECT_EQ(table->num_columns(), 4);
+    }
+    // Expect this test to create exactly 1 file
+    EXPECT_EQ(file_count, 1);
 }

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -10,6 +10,7 @@
 #include "datalake/batching_parquet_writer.h"
 #include "datalake/record_multiplexer.h"
 #include "datalake/tests/test_data_writer.h"
+#include "model/fundamental.h"
 #include "model/tests/random_batch.h"
 #include "test_utils/tmp_dir.h"
 
@@ -23,6 +24,7 @@
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     int record_count = 10;
     int batch_count = 10;
+    int start_offset = 1005;
     auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
       false);
     datalake::record_multiplexer multiplexer(std::move(writer_factory));
@@ -30,6 +32,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
+    batch_spec.offset = model::offset{start_offset};
     ss::circular_buffer<model::record_batch> batches
       = model::test::make_random_batches(batch_spec).get();
 
@@ -43,8 +46,13 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
       = reader.consume(std::move(multiplexer), model::no_timeout).get();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(result.value().size(), 1);
-    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
+    ASSERT_EQ(result.value().files.size(), 1);
+    EXPECT_EQ(result.value().files[0].row_count, record_count * batch_count);
+    EXPECT_EQ(result.value().start_offset(), start_offset);
+    // Subtract one since offsets end at 0, and this is an inclusive range.
+    EXPECT_EQ(
+      result.value().last_offset(),
+      start_offset + record_count * batch_count - 1);
 }
 TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     int record_count = 10;
@@ -79,6 +87,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
 
     int record_count = 50;
     int batch_count = 20;
+    int start_offset = 1005;
 
     auto writer_factory
       = std::make_unique<datalake::batching_parquet_writer_factory>(
@@ -88,6 +97,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
+    batch_spec.offset = model::offset{start_offset};
     ss::circular_buffer<model::record_batch> batches
       = model::test::make_random_batches(batch_spec).get0();
 
@@ -101,8 +111,13 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
       = reader.consume(std::move(multiplexer), model::no_timeout).get0();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(result.value().size(), 1);
-    EXPECT_EQ(result.value()[0].row_count, record_count * batch_count);
+    ASSERT_EQ(result.value().files.size(), 1);
+    EXPECT_EQ(result.value().files[0].row_count, record_count * batch_count);
+    EXPECT_EQ(result.value().start_offset(), start_offset);
+    // Subtract one since offsets end at 0, and this is an inclusive range.
+    EXPECT_EQ(
+      result.value().last_offset(),
+      start_offset + record_count * batch_count - 1);
 
     // Open the resulting file and check that it has data in it with the
     // appropriate counts.

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,7 +52,7 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    ss::future<std::unique_ptr<data_writer>>
+    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override {
         co_return std::make_unique<test_data_writer>(
           std::move(schema), _return_error);

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,9 +52,9 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override {
-        co_return std::make_unique<test_data_writer>(
+        co_return ss::make_shared<test_data_writer>(
           std::move(schema), _return_error);
     }
 

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -29,22 +29,22 @@ public:
 
     ss::future<data_writer_error> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */) override {
-        _result.record_count++;
+        _result.row_count++;
         data_writer_error status
           = _return_error ? data_writer_error::parquet_conversion_error
                           : data_writer_error::ok;
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<result<data_writer_result, data_writer_error>>
+    ss::future<result<coordinator::data_file, data_writer_error>>
     finish() override {
         return ss::make_ready_future<
-          result<data_writer_result, data_writer_error>>(_result);
+          result<coordinator::data_file, data_writer_error>>(_result);
     }
 
 private:
     iceberg::struct_type _schema;
-    data_writer_result _result;
+    coordinator::data_file _result;
     bool _return_error;
 };
 class test_data_writer_factory : public data_writer_factory {

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,9 +52,9 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    std::unique_ptr<data_writer>
+    ss::future<std::unique_ptr<data_writer>>
     create_writer(iceberg::struct_type schema) override {
-        return std::make_unique<test_data_writer>(
+        co_return std::make_unique<test_data_writer>(
           std::move(schema), _return_error);
     }
 

--- a/ubsan_suppressions.txt
+++ b/ubsan_suppressions.txt
@@ -3,3 +3,4 @@ nonnull-attribute:aead.c
 alignment:crc32c_arm64.cc
 function:openssl/*.c
 function:openssl-fips/*.c
+alignment:arrow/util/ubsan.h


### PR DESCRIPTION
Adds a factory class for the batching_parquet_writer so it can be created by the multiplexer. This also improves error handling and logging in the data path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
