### PR TITLE
tx/group: ignore replay requests if producer/tx is not found

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1749,70 +1749,7 @@ void group::insert_ongoing_tx(
 ss::future<cluster::commit_group_tx_reply>
 group::commit_tx(cluster::commit_group_tx_request r) {
     vlog(_ctx_txlog.trace, "processing commit_tx request: {}", r);
-    if (_partition->term() != _term) {
-        vlog(
-          _ctx_txlog.warn,
-          "commit_tx request: {} failed - leadership_changed, expected term: "
-          "{}, current_term: {}",
-          r,
-          _term,
-          _partition->term());
-        co_return make_commit_tx_reply(cluster::tx::errc::stale);
-    }
-
-    auto it = _producers.find(r.pid.get_id());
-    if (it == _producers.end()) {
-        vlog(
-          _ctx_txlog.warn,
-          "commit_tx request: {} failed - producer not found",
-          r);
-        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
-    }
-    auto& producer = it->second;
-    if (r.pid.get_epoch() != producer.epoch) {
-        vlog(
-          _ctx_txlog.warn,
-          "commit_tx request: {} failed - fenced, stored producer epoch: {}",
-          r,
-          producer.epoch);
-        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
-    }
-
-    if (producer.transaction == nullptr) {
-        vlog(
-          _ctx_txlog.trace,
-          "commit_tx request: {} - can not find ongoing transaction, it was "
-          "most likely already committed",
-          r);
-        co_return make_commit_tx_reply(cluster::tx::errc::none);
-    }
-    auto& producer_tx = *producer.transaction;
-    if (producer_tx.tx_seq > r.tx_seq) {
-        // rare situation:
-        //   * tm_stm begins (tx_seq+1)
-        //   * request on this group passes but then tm_stm fails and forgets
-        //   about this tx
-        //   * during recovery tm_stm recommits previous tx (tx_seq)
-        // existence of {pid, tx_seq+1} implies {pid, tx_seq} is committed
-        vlog(
-          _ctx_txlog.trace,
-          "Already commited pid: {} tx_seq: {} - a higher tx_seq: {} was "
-          "observed",
-          r.pid,
-          r.tx_seq,
-          producer_tx.tx_seq);
-        co_return make_commit_tx_reply(cluster::tx::errc::none);
-    }
-    if (producer_tx.tx_seq != r.tx_seq) {
-        vlog(
-          _ctx_txlog.warn,
-          "commit_tx request: {} failed - tx_seq mismatch. Expected seq: {}",
-          r,
-          producer_tx.tx_seq);
-        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
-    }
-
-    co_return co_await do_commit(r.group_id, r.pid);
+    co_return co_await do_commit(r.group_id, r.pid, r.tx_seq);
 }
 
 cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx::errc ec) {
@@ -2982,16 +2919,80 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
     co_return make_abort_tx_reply(cluster::tx::errc::none);
 }
 
-ss::future<cluster::commit_group_tx_reply>
-group::do_commit(kafka::group_id group_id, model::producer_identity pid) {
-    auto it = _producers.find(pid.get_id());
-    if (it == _producers.end() || it->second.transaction == nullptr) {
-        // Impossible situation
+ss::future<cluster::commit_group_tx_reply> group::do_commit(
+  kafka::group_id group_id,
+  model::producer_identity pid,
+  model::tx_seq sequence) {
+    vlog(
+      _ctx_txlog.trace,
+      "processing do_commit_tx request: pid: {}",
+      group_id,
+      pid);
+    if (_partition->term() != _term) {
         vlog(
-          _ctx_txlog.error,
-          "Unable to find an ongoing transaction for producer: {}",
+          _ctx_txlog.warn,
+          "do_commit_tx request: pid: {} failed - "
+          "leadership_changed, expected term: "
+          "{}, current_term: {}",
+          pid,
+          _term,
+          _partition->term());
+        co_return make_commit_tx_reply(cluster::tx::errc::stale);
+    }
+    auto it = _producers.find(pid.get_id());
+    if (it == _producers.end()) {
+        vlog(
+          _ctx_txlog.warn,
+          "do_commit_tx request: {} failed - producer not found",
           pid);
-        co_return make_commit_tx_reply(cluster::tx::errc::unknown_server_error);
+        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
+    }
+    auto& producer = it->second;
+    if (pid.get_epoch() != producer.epoch) {
+        vlog(
+          _ctx_txlog.warn,
+          "do_commit_tx request: pid: {} failed - fenced, stored "
+          "producer epoch: {}",
+          pid,
+          producer.epoch);
+        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
+    }
+
+    if (producer.transaction == nullptr) {
+        vlog(
+          _ctx_txlog.trace,
+          "do_commit_tx request: producer: {} - can not find "
+          "ongoing transaction, it was "
+          "most likely already committed",
+          pid);
+        co_return make_commit_tx_reply(cluster::tx::errc::none);
+    }
+    auto& producer_tx = *producer.transaction;
+    if (producer_tx.tx_seq > sequence) {
+        // rare situation:
+        //   * tm_stm begins (tx_seq+1)
+        //   * request on this group passes but then tm_stm fails and forgets
+        //   about this tx
+        //   * during recovery tm_stm recommits previous tx (tx_seq)
+        // existence of {pid, tx_seq+1} implies {pid, tx_seq} is committed
+        vlog(
+          _ctx_txlog.trace,
+          "Already commited pid: {} tx_seq: {} - a higher tx_seq: {} was "
+          "observed",
+          pid,
+          sequence,
+          producer_tx.tx_seq);
+        co_return make_commit_tx_reply(cluster::tx::errc::none);
+    }
+    if (producer_tx.tx_seq != sequence) {
+        vlog(
+          _ctx_txlog.warn,
+          "commit_tx request: pid: {}, sequence: {} failed - tx_seq mismatch. "
+          "Expected seq: {}",
+          pid,
+          sequence,
+          producer_tx.tx_seq);
+        co_return make_commit_tx_reply(cluster::tx::errc::request_rejected);
     }
     auto& ongoing_tx = *it->second.transaction;
     // It is fix for https://github.com/redpanda-data/redpanda/issues/5163.
@@ -3188,6 +3189,7 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
       pid,
       producer_tx.tx_seq,
       producer_tx.coordinator_partition);
+    auto tx_seq = producer_tx.tx_seq;
     auto r = co_await _tx_frontend.local().route_globally(
       cluster::try_abort_request(
         producer_tx.coordinator_partition,
@@ -3206,7 +3208,7 @@ group::do_try_abort_old_tx(model::producer_identity pid) {
       r.aborted);
 
     if (r.commited) {
-        auto res = co_await do_commit(_id, pid);
+        auto res = co_await do_commit(_id, pid, tx_seq);
         if (res.ec != cluster::tx::errc::none) {
             vlog(
               _ctxlog.warn,

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1888,74 +1888,7 @@ group::begin_tx(cluster::begin_group_tx_request r) {
 
 ss::future<cluster::abort_group_tx_reply>
 group::abort_tx(cluster::abort_group_tx_request r) {
-    // doesn't make sense to fence off an abort because transaction
-    // manager has already decided to abort and acked to a client
     vlog(_ctxlog.trace, "processing abort_tx request: {}", r);
-    if (_partition->term() != _term) {
-        vlog(
-          _ctxlog.debug,
-          "abort_tx request: {} failed - leadership changed, expected term: "
-          "{}, current term: {}",
-          r,
-          _term,
-          _partition->term());
-        co_return make_abort_tx_reply(cluster::tx::errc::stale);
-    }
-
-    auto it = _producers.find(r.pid.get_id());
-    if (it == _producers.end()) {
-        vlog(
-          _ctx_txlog.warn,
-          "abort_tx request: {} failed - producer not found",
-          r);
-        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
-    }
-    auto& producer = it->second;
-    if (r.pid.get_epoch() != producer.epoch) {
-        vlog(
-          _ctx_txlog.warn,
-          "abort_tx request: {} failed - fence epoch mismatch. Fence epoch: {}",
-          r.pid,
-          producer.epoch);
-        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
-    }
-
-    if (producer.transaction == nullptr) {
-        vlog(
-          _ctx_txlog.trace,
-          "unable to find transaction for {}, probably already aborted",
-          r.pid);
-        co_return make_abort_tx_reply(cluster::tx::errc::none);
-    }
-    auto& producer_tx = *producer.transaction;
-    if (producer_tx.tx_seq > r.tx_seq) {
-        // rare situation:
-        //   * tm_stm begins (tx_seq+1)
-        //   * request on this group passes but then tm_stm fails and forgets
-        //   about this tx
-        //   * during recovery tm_stm reaborts previous tx (tx_seq)
-        // existence of {pid, tx_seq+1} implies {pid, tx_seq} is aborted
-        vlog(
-          _ctx_txlog.trace,
-          "producer transaction {} already aborted, ongoing tx sequence: {}, "
-          "request tx sequence: {}",
-          r.pid,
-          producer_tx.tx_seq,
-          r.tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::none);
-    }
-
-    if (producer_tx.tx_seq != r.tx_seq) {
-        vlog(
-          _ctx_txlog.warn,
-          "abort_tx request: {} failed - tx sequence mismatch. Ongoing tx "
-          "sequence: {}, request tx sequence: {}",
-          r.pid,
-          producer_tx.tx_seq,
-          r.tx_seq);
-        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
-    }
-
     co_return co_await do_abort(r.group_id, r.pid, r.tx_seq);
 }
 
@@ -2885,6 +2818,78 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
   kafka::group_id group_id,
   model::producer_identity pid,
   model::tx_seq tx_seq) {
+    vlog(
+      _ctxlog.trace,
+      "processing do_abort_tx request: producer: {}, sequence: {}",
+      group_id,
+      pid,
+      tx_seq);
+    if (_partition->term() != _term) {
+        vlog(
+          _ctxlog.debug,
+          "do_abort_tx request: failed - leadership changed, expected term: "
+          "{}, current term: {}, pid: {}, sequence: {}",
+          _term,
+          _partition->term(),
+          pid,
+          tx_seq);
+        co_return make_abort_tx_reply(cluster::tx::errc::stale);
+    }
+    auto it = _producers.find(pid.get_id());
+    if (it == _producers.end()) {
+        vlog(
+          _ctx_txlog.warn,
+          "do_abort_tx request: failed - producer {} not found, sequence: {}",
+          pid,
+          tx_seq);
+        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
+    }
+    auto& producer = it->second;
+    if (pid.get_epoch() != producer.epoch) {
+        vlog(
+          _ctx_txlog.warn,
+          "do_abort_tx request: {} failed - fence epoch mismatch. Fence epoch: "
+          "{}",
+          pid,
+          producer.epoch);
+        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
+    }
+
+    if (producer.transaction == nullptr) {
+        vlog(
+          _ctx_txlog.trace,
+          "unable to find transaction for {}, probably already aborted",
+          pid);
+        co_return make_abort_tx_reply(cluster::tx::errc::none);
+    }
+    auto& producer_tx = *producer.transaction;
+    if (producer_tx.tx_seq > tx_seq) {
+        // rare situation:
+        //   * tm_stm begins (tx_seq+1)
+        //   * request on this group passes but then tm_stm fails and forgets
+        //   about this tx
+        //   * during recovery tm_stm reaborts previous tx (tx_seq)
+        // existence of {pid, tx_seq+1} implies {pid, tx_seq} is aborted
+        vlog(
+          _ctx_txlog.trace,
+          "producer transaction {} already aborted, ongoing tx sequence: {}, "
+          "request tx sequence: {}",
+          pid,
+          producer_tx.tx_seq,
+          tx_seq);
+        co_return make_abort_tx_reply(cluster::tx::errc::none);
+    }
+
+    if (producer_tx.tx_seq != tx_seq) {
+        vlog(
+          _ctx_txlog.warn,
+          "do_abort_tx request: {} failed - tx sequence mismatch. Ongoing tx "
+          "sequence: {}, request tx sequence: {}",
+          pid,
+          producer_tx.tx_seq,
+          tx_seq);
+        co_return make_abort_tx_reply(cluster::tx::errc::request_rejected);
+    }
     auto tx = group_tx::abort_metadata{.group_id = group_id, .tx_seq = tx_seq};
 
     auto batch = make_tx_batch(
@@ -2912,7 +2917,7 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
         }
         co_return map_tx_replication_error(result.error());
     }
-    auto it = _producers.find(pid.get_id());
+    it = _producers.find(pid.get_id());
     if (it != _producers.end()) {
         it->second.transaction.reset();
     }

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -861,8 +861,10 @@ private:
       model::producer_identity pid,
       model::tx_seq tx_seq);
 
-    ss::future<cluster::commit_group_tx_reply>
-    do_commit(kafka::group_id group_id, model::producer_identity pid);
+    ss::future<cluster::commit_group_tx_reply> do_commit(
+      kafka::group_id group_id,
+      model::producer_identity pid,
+      model::tx_seq sequence);
 
     void start_abort_timer() {
         _auto_abort_timer.set_callback([this] { abort_old_txes(); });


### PR DESCRIPTION
If a producer/transaction is not found, we assume it is replay request
from the coordinator to roll forward/back the transaction and return success.
This is valid because the the current request to commit/abort confirms that the
coordinator sees a corresponding commit/abort respectively in its's log, so the
original request that cleaned up the state should have been the same
too. One particular sequence of events where this is possible is as follows.

- Coordinator - Attempting to commit -- it got a timeout but the group commit actually made it to replica 1
- group leadership changed from replica 1 to replica 2
- replica 2 has a compacted state of the log
- replica 2 recovers and _producers is empty
- replica 2 now rejects the commit request

Note: compaction cleans up the producer ids in group topic, so the
resulting log after compaction cannot load up the producer ids resulting
in a pid not found.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
