### PR TITLE
[v24.1.x] rpk: brokers list exposing Host/Port/Rack/UUID

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_broker.go
+++ b/src/go/rpk/pkg/adminapi/api_broker.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	brokersEndpoint = "/v1/brokers"
-	brokerEndpoint  = "/v1/brokers/%d"
+	brokersEndpoint     = "/v1/brokers"
+	brokerEndpoint      = "/v1/brokers/%d"
+	brokerUuidsEndpoint = "/v1/broker_uuids"
 )
 
 type MaintenanceStatus struct {
@@ -43,12 +44,15 @@ const (
 
 // Broker is the information returned from the Redpanda admin broker endpoints.
 type Broker struct {
-	NodeID           int                `json:"node_id"`
-	NumCores         int                `json:"num_cores"`
-	MembershipStatus MembershipStatus   `json:"membership_status"`
-	IsAlive          *bool              `json:"is_alive"`
-	Version          string             `json:"version"`
-	Maintenance      *MaintenanceStatus `json:"maintenance_status"`
+	NodeID             int                `json:"node_id"`
+	NumCores           int                `json:"num_cores"`
+	Rack               string             `json:"rack"`
+	InternalRPCAddress string             `json:"internal_rpc_address"`
+	InternalRPCPort    int                `json:"internal_rpc_port"`
+	MembershipStatus   MembershipStatus   `json:"membership_status"`
+	IsAlive            *bool              `json:"is_alive"`
+	Version            string             `json:"version"`
+	Maintenance        *MaintenanceStatus `json:"maintenance_status"`
 }
 
 type DecommissionPartitions struct {
@@ -59,6 +63,12 @@ type DecommissionPartitions struct {
 	BytesLeftToMove int                  `json:"bytes_left_to_move"`
 	BytesMoved      int                  `json:"bytes_moved"`
 	PartitionSize   int                  `json:"partition_size"`
+}
+
+// BrokerUuids is information that shows the mapping of node ID to node UUID.
+type BrokerUuids struct {
+	NodeID int    `json:"node_id"`
+	UUID   string `json:"uuid"`
 }
 
 type DecommissionMovingTo struct {
@@ -168,4 +178,10 @@ func (a *AdminAPI) MaintenanceStatus(ctx context.Context) (MaintenanceStatus, er
 func (a *AdminAPI) CancelNodePartitionsMovement(ctx context.Context, node int) ([]PartitionsMovementResult, error) {
 	var response []PartitionsMovementResult
 	return response, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%s/%d/cancel_partition_moves", brokersEndpoint, node), nil, &response)
+}
+
+// GetBrokerUuids retrieves the mapping of node ID to node UUID.
+func (a *AdminAPI) GetBrokerUuids(ctx context.Context) ([]BrokerUuids, error) {
+	var response []BrokerUuids
+	return response, a.sendAny(ctx, http.MethodGet, brokerUuidsEndpoint, nil, &response)
 }

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
@@ -1,19 +1,43 @@
 package brokers
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/redpanda"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	return &cobra.Command{
+	var decom bool
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List the brokers in your cluster",
-		Args:    cobra.ExactArgs(0),
+		Long: `List the brokers in your cluster.
+
+This command lists all brokers in the cluster, active and inactive, unless they have been decommissioned.
+Using the "--include-decommissioned" flag, it lists decommissioned brokers with associated UUIDs too.
+
+The output table contains the following columns:
+
+ID               Node ID, an exclusive identifier for a broker
+HOST             Internal RPC address for communication between brokers
+PORT             Internal RPC port for communication between brokers
+RACK             Assigned rack ID
+CORES            Number of cores (shards) on a broker
+MEMBERSHIP       Whether a broker is decommissioned or not
+IS-ALIVE         Whether a broker is alive or offline
+VERSION          Broker version
+UUID (Optional)  Additional exclusive identifier for a broker
+
+NOTE: The UUID column is hidden when the cluster doesn't expose the UUID in the Admin API, or the API call fails to retrieve UUIDs.
+`,
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
@@ -25,27 +49,82 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			bs, err := cl.Brokers(cmd.Context())
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
-			headers := []string{"Node-ID", "Num-Cores", "Membership-Status"}
+			headers := []string{"ID", "Host", "Port", "Rack", "Cores", "Membership", "Is-Alive", "Version"}
 
 			args := func(b *adminapi.Broker) []interface{} {
-				ret := []interface{}{b.NodeID, b.NumCores, b.MembershipStatus}
+				version, _ := redpanda.VersionFromString(b.Version)
+				ret := []interface{}{b.NodeID, b.InternalRPCAddress, b.InternalRPCPort, formatOutput(b.Rack), b.NumCores, b.MembershipStatus, *b.IsAlive, formatOutput(version.String())}
 				return ret
 			}
-			for _, b := range bs {
-				if b.IsAlive != nil {
-					headers = append(headers, "Is-Alive", "Broker-Version")
-					orig := args
-					args = func(b *adminapi.Broker) []interface{} {
-						return append(orig(b), *b.IsAlive, b.Version)
-					}
-					break
+
+			idUUIDMapping, err := cl.GetBrokerUuids(cmd.Context())
+			if err != nil {
+				fmt.Printf("unable to retrieve node UUIDs: %v", err)
+			}
+			if idUUIDMapping != nil {
+				headers = append(headers, "UUID")
+				org := args
+				args = func(b *adminapi.Broker) []interface{} {
+					return append(org(b), mapUUID(b.NodeID, idUUIDMapping))
 				}
 			}
+
 			tw := out.NewTable(headers...)
 			defer tw.Flush()
 			for _, b := range bs {
 				tw.Print(args(&b)...)
 			}
+
+			if decom && idUUIDMapping != nil {
+				decomNodes := extractDecomNodes(bs, idUUIDMapping)
+				for _, b := range decomNodes {
+					tw.Print(b.NodeID, "-", "-", "-", "-", "-", "-", "-", b.UUID)
+				}
+			}
 		},
 	}
+	cmd.Flags().BoolVarP(&decom, "include-decommissioned", "d", false, "If true, include decommissioned brokers")
+	return cmd
+}
+
+// mapUUID returns a UUID from "mapping" which node ID maps to "nodeID".
+func mapUUID(nodeID int, mapping []adminapi.BrokerUuids) string {
+	var UUIDs []string
+	for _, node := range mapping {
+		if nodeID == node.NodeID {
+			UUIDs = append(UUIDs, node.UUID)
+		}
+	}
+	if len(UUIDs) == 0 {
+		return "-"
+	}
+	return strings.Join(UUIDs, ", ")
+}
+
+// extractDecomNodes compares and returns nodes in brokerUUIDs (with UUIDs) not in brokers.
+func extractDecomNodes(brokers []adminapi.Broker, brokerUUIDs []adminapi.BrokerUuids) []adminapi.BrokerUuids {
+	activeNodeMap := make(map[int]bool)
+
+	for _, br := range brokers {
+		activeNodeMap[br.NodeID] = true
+	}
+
+	var decomNodes []adminapi.BrokerUuids
+	for _, bu := range brokerUUIDs {
+		if !activeNodeMap[bu.NodeID] {
+			decomNodes = append(decomNodes, adminapi.BrokerUuids{
+				NodeID: bu.NodeID,
+				UUID:   bu.UUID,
+			})
+		}
+	}
+
+	return decomNodes
+}
+
+func formatOutput(s string) string {
+	if s == "" || s == "0.0.0" {
+		return "-"
+	}
+	return s
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23595

(cherry picked from commit 08e30aa37df43bca951a66f6f31ad8bafa517119)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* rpk: `redpanda admin brokers list` exposes Host/Port/Rack/UUID additionally
