### PR TITLE
[v24.2.x]: manual backport / introduce license warnings messages

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.59.1
-	github.com/redpanda-data/common-go/rpadmin v0.1.6
+	github.com/redpanda-data/common-go/rpadmin v0.1.7
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.4.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -208,8 +208,8 @@ github.com/prometheus/common v0.59.1 h1:LXb1quJHWm1P6wq/U824uxYi4Sg0oGvNeUm1z5dJ
 github.com/prometheus/common v0.59.1/go.mod h1:GpWM7dewqmVYcd7SmRaiWVe9SSqjf0UrwnYnpEZNuT0=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.6 h1:OpKO0h5unnZq8n1RJ3G6Hr8HT8ff/Ma0or5X1BNIMcM=
-github.com/redpanda-data/common-go/rpadmin v0.1.6/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
+github.com/redpanda-data/common-go/rpadmin v0.1.7 h1:zj3HiZuvAdOvOdi7oyTn4FYOPulO7BhvhLx9acOy810=
+github.com/redpanda-data/common-go/rpadmin v0.1.7/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/src/go/rpk/pkg/adminapi/admin_test.go
+++ b/src/go/rpk/pkg/adminapi/admin_test.go
@@ -1,0 +1,159 @@
+package adminapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_licenseFeatureChecks(t *testing.T) {
+	tests := []struct {
+		name         string
+		prof         *config.RpkProfile
+		responseCase string // See the mapLicenseResponses below.
+		expContain   string
+		withErr      bool
+		checkCache   func(t *testing.T, before int64, after int64)
+	}{
+		{
+			name:         "license ok, first time call",
+			prof:         &config.RpkProfile{},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name: "license ok, cache valid",
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// If the cache was valid, last update shouldn't have changed.
+				require.Equal(t, before, after)
+			},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name: "license ok, old cache",
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 15 days
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// Date should be updated.
+				afterT := time.Unix(after, 0)
+				require.True(t, time.Unix(before, 0).Before(afterT))
+			},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name:         "inViolation, first time call",
+			prof:         &config.RpkProfile{},
+			responseCase: "inViolation",
+			expContain:   "A Redpanda Enterprise Edition license is required",
+		},
+		{
+			name:         "inViolation, expired last check",
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}},
+			responseCase: "inViolation",
+			expContain:   "A Redpanda Enterprise Edition license is required t",
+		},
+		{
+			// Edge case when the license expires but the last check was less
+			// than 15 days ago.
+			name:         "inViolation, cache still valid",
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			responseCase: "inViolation",
+			// In this case, even if the license is in violation, rpk won't
+			// reach the Admin API because the last check was under 15 days.
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// At this point we don't rewrite the last check, because still
+				// valid.
+				require.Equal(t, before, after)
+			},
+			expContain: "",
+		},
+		{
+			name:         "admin API errors, don't print",
+			prof:         &config.RpkProfile{},
+			withErr:      true,
+			responseCase: "failedRequest",
+			// If we fail to communicate with the cluster, or the request fails,
+			// then we just WARN the user of what happened but won't print to
+			// stdout.
+			expContain: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(licenseHandler(tt.responseCase))
+			defer ts.Close()
+			tt.prof.AdminAPI = config.RpkAdminAPI{Addresses: []string{ts.URL}}
+			fs := afero.NewMemMapFs()
+			loadedProfile := writeRpkProfileToFs(t, fs, tt.prof)
+			client, err := NewHostClient(fs, loadedProfile, "0")
+			require.NoError(t, err)
+			got := licenseFeatureChecks(context.Background(), fs, client, loadedProfile)
+			if tt.expContain == "" {
+				require.Empty(t, got)
+				if tt.withErr {
+					return
+				}
+				// If we get to this point, we need to make sure that the last
+				// update date was registered.
+				afterProf := loadProfile(t, fs)
+				require.NotEmpty(t, afterProf.LicenseCheck)
+				require.NotEmpty(t, afterProf.LicenseCheck.LastUpdate)
+				if tt.checkCache != nil {
+					tt.checkCache(t, tt.prof.LicenseCheck.LastUpdate, afterProf.LicenseCheck.LastUpdate)
+				}
+				return
+			}
+			require.Contains(t, got, tt.expContain)
+			// If we get to this point, then we shouldn't have the last
+			// update registered.
+			afterProf := loadProfile(t, fs)
+			require.Empty(t, afterProf.LicenseCheck)
+		})
+	}
+}
+
+func writeRpkProfileToFs(t *testing.T, fs afero.Fs, p *config.RpkProfile) *config.RpkProfile {
+	p.Name = "test"
+	rpkyaml := config.RpkYaml{
+		CurrentProfile: "test",
+		Version:        6,
+		Profiles:       []config.RpkProfile{*p},
+	}
+	err := rpkyaml.Write(fs)
+	require.NoError(t, err)
+
+	return loadProfile(t, fs)
+}
+
+func loadProfile(t *testing.T, fs afero.Fs) *config.RpkProfile {
+	y, err := new(config.Params).Load(fs)
+	require.NoError(t, err)
+	return y.VirtualProfile()
+}
+
+type response struct {
+	status int
+	body   string
+}
+
+var mapLicenseResponses = map[string]response{
+	"ok":            {http.StatusOK, `{"license_status": "valid", "violation": false}`},
+	"inViolation":   {http.StatusOK, `{"license_status": "expired", "violation": true, "features": [{"name": "partition_auto_balancing_continuous", "enabled": true}]}`},
+	"failedRequest": {http.StatusBadRequest, ""},
+}
+
+func licenseHandler(respCase string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := mapLicenseResponses[respCase]
+		w.WriteHeader(resp.status)
+		w.Write([]byte(resp.body))
+	}
+}

--- a/src/go/rpk/pkg/cli/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cluster/config/edit.go
@@ -49,7 +49,7 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -149,7 +149,7 @@ to include all properties including these low level tunables.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -37,7 +37,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			currentConfig, err := client.Config(cmd.Context(), true)

--- a/src/go/rpk/pkg/cli/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cluster/config/import.go
@@ -306,7 +306,7 @@ from the YAML file, it is reset to its default value.  `,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cluster/config/lint.go
@@ -58,7 +58,7 @@ central configuration store (and via 'rpk cluster config edit').
 			p := cfg.VirtualProfile()
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			schema, err := client.ClusterConfigSchema(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -74,7 +74,7 @@ If an empty string is given as the value, the property is reset to its default.`
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			schema, err := client.ClusterConfigSchema(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -37,7 +37,7 @@ is offline.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the status endpoint

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -44,7 +44,7 @@ following conditions are met:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// --exit-when-healthy only makes sense with --watch, so we enable

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -42,7 +42,7 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			info, err := cl.GetLicenseInfo(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/license/set.go
+++ b/src/go/rpk/pkg/cli/cluster/license/set.go
@@ -45,7 +45,7 @@ default location '/etc/redpanda/redpanda.license'.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			var r io.Reader

--- a/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
@@ -42,7 +42,7 @@ func newDisableCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			b, err := client.Broker(cmd.Context(), nodeID)

--- a/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
@@ -48,7 +48,7 @@ node exists that is already in maintenance mode then an error will be returned.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			b, err := client.Broker(cmd.Context(), nodeID)

--- a/src/go/rpk/pkg/cli/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/status.go
@@ -87,7 +87,7 @@ Notes:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			brokers, err := client.Brokers(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/balancer_run.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/balancer_run.go
@@ -54,7 +54,7 @@ To see more detailed movement status, monitor the progress using:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = cl.TriggerBalancer(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
@@ -64,7 +64,7 @@ func (m *movementCancelHandler) runMovementCancel(cmd *cobra.Command, _ []string
 	out.MaybeDie(err, "rpk unable to load config: %v", err)
 	config.CheckExitCloudAdmin(p)
 
-	cl, err := adminapi.NewClient(m.fs, p)
+	cl, err := adminapi.NewClient(cmd.Context(), m.fs, p)
 	out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 	var movements []rpadmin.PartitionsMovementResult

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -100,7 +100,7 @@ List all in json format.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			var clusterPartitions []rpadmin.ClusterPartition

--- a/src/go/rpk/pkg/cli/cluster/partitions/move.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move.go
@@ -58,7 +58,7 @@ func newMovePartitionReplicasCommand(fs afero.Fs, p *config.Params) *cobra.Comma
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			newAssignmentList, coreAssignmentList, err := parseAssignments(cmd.Context(), cl, partitionsFlag, topics)

--- a/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
@@ -48,7 +48,7 @@ func newPartitionMovementsStatusCommand(fs afero.Fs, p *config.Params) *cobra.Co
 				out.Die("specify at least one topic when --partition is used, exiting.")
 			}
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			response, err = cl.Reconfigurations(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/status.go
@@ -83,7 +83,7 @@ investigation. A few areas to investigate:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			status, err := cl.GetPartitionStatus(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/toggle.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/toggle.go
@@ -70,7 +70,7 @@ Enable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = runToggle(cmd.Context(), cl, all, topicArg, partitions, "enable")
@@ -145,7 +145,7 @@ Disable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = runToggle(cmd.Context(), cl, all, topicArg, partitions, "disable")

--- a/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
@@ -63,7 +63,7 @@ brokers automatically.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			if len(topicArg) > 0 { // foo -p 0:1

--- a/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
@@ -53,7 +53,7 @@ using the '--dry' flag.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			plan, err := cl.MajorityLostPartitions(cmd.Context(), nodes)

--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -87,7 +87,7 @@ To view the test status, poll 'rpk cluster self-test status'. Once the tests end
 			}
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Using cmd line args, assemble self_test_start_request body

--- a/src/go/rpk/pkg/cli/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/status.go
@@ -72,7 +72,7 @@ If Tiered Storage is not enabled, the cloud storage tests won't run and a warnin
 			config.CheckExitCloudAdmin(p)
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Make HTTP GET request to any node requesting for status

--- a/src/go/rpk/pkg/cli/cluster/selftest/stop.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/stop.go
@@ -37,7 +37,7 @@ success when all jobs have been stopped or reports errors if broker timeouts hav
 			config.CheckExitCloudAdmin(p)
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Make HTTP POST request to leader that stops all self tests on all nodes

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -42,7 +42,7 @@ recovery process until it's finished.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			ctx := cmd.Context()

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
@@ -33,7 +33,7 @@ archival bucket.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			status, err := client.PollAutomatedRecoveryStatus(cmd.Context())

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -277,7 +277,7 @@ func saveClusterAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, 
 				TLS:       p.AdminAPI.TLS,
 			},
 		}
-		cl, err := adminapi.NewClient(fs, p)
+		cl, err := adminapi.NewClient(ctx, fs, p)
 		if err != nil {
 			return fmt.Errorf("unable to initialize admin client: %v", err)
 		}
@@ -346,7 +346,7 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, p
 					TLS:       p.AdminAPI.TLS,
 				},
 			}
-			cl, err := adminapi.NewClient(fs, p, rpadmin.ClientTimeout(profilerWait+2*time.Second))
+			cl, err := adminapi.NewClient(ctx, fs, p, rpadmin.ClientTimeout(profilerWait+2*time.Second))
 			if err != nil {
 				rerrs = multierror.Append(rerrs, fmt.Errorf("unable to initialize admin client for %q: %v", a, err))
 				continue

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -235,7 +235,7 @@ func runWithFlags(ctx context.Context, fs afero.Fs, p *config.RpkProfile, langFl
 }
 
 func createUser(ctx context.Context, fs afero.Fs, p *config.RpkProfile, user, pass string) error {
-	cl, err := adminapi.NewClient(fs, p)
+	cl, err := adminapi.NewClient(ctx, fs, p)
 	if err != nil {
 		return fmt.Errorf("unable to initialize admin client: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/profile/print.go
+++ b/src/go/rpk/pkg/cli/profile/print.go
@@ -46,7 +46,8 @@ in the rpk.yaml file.
 			if p == nil {
 				out.Die("profile %s does not exist", args[0])
 			}
-
+			// We hide the license check.
+			p.LicenseCheck = nil
 			m, err := yaml.Marshal(p)
 			out.MaybeDie(err, "unable to encode profile: %v", err)
 			fmt.Println(string(m))

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -71,7 +71,7 @@ kafka/test/0
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			dbs, err := cl.DecommissionBrokerStatus(cmd.Context(), broker)

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
@@ -44,7 +44,7 @@ cluster is unreachable), use the hidden --force flag.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			if !force {

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
@@ -20,7 +20,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			bs, err := cl.Brokers(cmd.Context())

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/recommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/recommission.go
@@ -38,7 +38,7 @@ the cluster leader handles the request.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = cl.RecommissionBroker(cmd.Context(), broker)

--- a/src/go/rpk/pkg/cli/security/role/assign.go
+++ b/src/go/rpk/pkg/cli/security/role/assign.go
@@ -48,7 +48,7 @@ Assign role "redpanda-admin" to users "red" and "panda"
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/role/create.go
+++ b/src/go/rpk/pkg/cli/security/role/create.go
@@ -41,7 +41,7 @@ flag in the 'rpk security acl create' command.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/role/delete.go
+++ b/src/go/rpk/pkg/cli/security/role/delete.go
@@ -41,7 +41,7 @@ The flag '--no-confirm' can be used to avoid the confirmation prompt.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			adm, err := kafka.NewAdmin(fs, p)

--- a/src/go/rpk/pkg/cli/security/role/describe.go
+++ b/src/go/rpk/pkg/cli/security/role/describe.go
@@ -78,7 +78,7 @@ Print only the ACL associated to the role 'red'
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			adm, err := kafka.NewAdmin(fs, p)

--- a/src/go/rpk/pkg/cli/security/role/list.go
+++ b/src/go/rpk/pkg/cli/security/role/list.go
@@ -51,7 +51,7 @@ List all roles with the prefix "agent-":
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			principalType, principal := parsePrincipal(principalFlag)

--- a/src/go/rpk/pkg/cli/security/role/unassign.go
+++ b/src/go/rpk/pkg/cli/security/role/unassign.go
@@ -48,7 +48,7 @@ Unassign role "redpanda-admin" from users "red" and "panda"
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -59,7 +59,7 @@ acl help text for more info.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Backwards compatibility: we favor the new user

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -39,7 +39,7 @@ delete any ACLs that may exist for this user.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Backwards compat: we favor the new format (an

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -32,7 +32,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			users, err := cl.ListUsers(cmd.Context())

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -31,7 +31,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			user := args[0]

--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -63,7 +63,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer cl.Close()
 
-			adminCl, err := adminapi.NewClient(fs, p)
+			adminCl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			topic := args[0]

--- a/src/go/rpk/pkg/cli/transform/delete.go
+++ b/src/go/rpk/pkg/cli/transform/delete.go
@@ -33,7 +33,7 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			api, err := adminapi.NewClient(fs, p)
+			api, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 			functionName := args[0]
 

--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -147,7 +147,7 @@ committed offset. Recall that this state is maintained until the transform is de
 				})
 				out.MaybeDie(err, "unable to deploy transform to Cloud Cluster: %v", err)
 			} else {
-				api, err := adminapi.NewClient(fs, p)
+				api, err := adminapi.NewClient(cmd.Context(), fs, p)
 				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 				err = api.DeployWasmTransform(cmd.Context(), t, wasm)

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -95,7 +95,7 @@ The --detailed flag (-d) opts in to printing extra per-processor information.
 				out.MaybeDie(err, "unable to list transforms from Cloud: %v", err)
 				l = dataplaneToAdminTransformMetadata(res.Msg.Transforms)
 			} else {
-				api, err := adminapi.NewClient(fs, p)
+				api, err := adminapi.NewClient(cmd.Context(), fs, p)
 				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 				l, err = api.ListWasmTransforms(cmd.Context())

--- a/src/go/rpk/pkg/cli/transform/meta.go
+++ b/src/go/rpk/pkg/cli/transform/meta.go
@@ -42,7 +42,7 @@ To resume a paused transform, use 'rpk transform resume'.
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
-			api, err := adminapi.NewClient(fs, p)
+			api, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 			functionName := args[0]
 			err = api.PauseTransform(cmd.Context(), functionName)
@@ -71,7 +71,7 @@ Subsequent 'rpk transform list' operations will show transform processors as
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
-			api, err := adminapi.NewClient(fs, p)
+			api, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 			functionName := args[0]
 			err = api.ResumeTransform(cmd.Context(), functionName)

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -91,6 +91,7 @@ Admin API hosts via flags, profile, or environment variables.`,
 				return
 			}
 			cl, err := adminapi.NewClient(
+				cmd.Context(),
 				fs,
 				p,
 				rpadmin.ClientTimeout(3*time.Second),

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -85,7 +85,7 @@ const (
 	xkindGlobal           // configuration for rpk.yaml globals
 )
 
-const currentRpkYAMLVersion = 5
+const currentRpkYAMLVersion = 6
 
 type xflag struct {
 	path        string

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -723,7 +723,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -815,7 +815,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -857,7 +857,7 @@ cloud_auth:
 		// * admin api is defaulted, using kafka broker ip
 		{
 			name: "rpk.yaml exists",
-			rpkYaml: `version: 5
+			rpkYaml: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -914,7 +914,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -975,7 +975,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			rpkYaml: `version: 5
+			rpkYaml: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1025,7 +1025,7 @@ rpk:
     tune_disk_irq: true
 `,
 
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,7 +25,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v5sha = "74f0b320006aac52cb75af3d5c658f81decf3e40fe1e92f3eb1d59f5c47ab5f9" // 24-04-29
+		v5sha = "f3d394e88ba4a6a668d15b74208f32d71c82f8a0e9b6e6445defcdd64df1e37f" // 24-07-24
 	)
 
 	if shastr != v5sha {

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -117,7 +117,7 @@ func TestLoadFlow(t *testing.T) {
 				hasClientID = true
 			}
 
-			expFile := fmt.Sprintf(`version: 5
+			expFile := fmt.Sprintf(`version: 6
 globals:
     prompt: ""
     no_default_cluster: false


### PR DESCRIPTION
Manual backport of commit 1f1e0cd779d794057621b8bf95a444d87c785d07, https://github.com/redpanda-data/redpanda/pull/23472

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* rpk will now warn you when you are running enterprise features without a license.
