### PR TITLE
CORE-7831 dt/license: fix flaky license enforcement test

### DIFF
--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -65,7 +65,8 @@ class LicenseEnforcementTest(RedpandaTest):
                                  err_msg="The cluster hasn't stabilized")
 
         self.logger.info(f"Enabling an enterprise feature")
-        self.rpk.create_role("XYZ")
+        self.redpanda.set_cluster_config(
+            {"partition_autobalancing_mode": "continuous"})
 
         first_upgraded = self.redpanda.nodes[0]
         self.logger.info(
@@ -124,7 +125,8 @@ class LicenseEnforcementTest(RedpandaTest):
                                  err_msg="The cluster hasn't stabilized")
 
         self.logger.info(f"Enabling an enterprise feature")
-        self.rpk.create_role("XYZ")
+        self.redpanda.set_cluster_config(
+            {"partition_autobalancing_mode": "continuous"})
 
         first_upgraded = self.redpanda.nodes[0]
         self.logger.info(


### PR DESCRIPTION
The role creation was racing with the node restart. If the target node is restarted before it observes the new role, it won't crash on startup like we would expect it to.

To fix this, we want to ensure that the enabled enterprise feature is observable on all nodes before the restart. We could implement this with roles, but it is simpler to switch to a different enterprise feature and using `redpanda.set_cluster_config`, which implements all-node-observability under the hood.

Fixes https://redpandadata.atlassian.net/browse/CORE-7831
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
