### PR TITLE
Datalake: Translated offset Range

### DIFF
--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -210,7 +210,7 @@ batching_parquet_writer_factory::batching_parquet_writer_factory(
   , _row_count_threshold{row_count_threshold}
   , _byte_count_treshold{byte_count_threshold} {}
 
-ss::future<std::unique_ptr<data_writer>>
+ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
 batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
     auto ret = std::make_unique<batching_parquet_writer>(
       std::move(schema), _row_count_threshold, _byte_count_treshold);
@@ -218,9 +218,7 @@ batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
     std::filesystem::path file_path = _local_directory / filename;
     auto err = co_await ret->initialize(file_path);
     if (err != data_writer_error::ok) {
-        // FIXME: This method should return a result and let the multiplexer
-        // deal with it appropriately
-        co_return nullptr;
+        co_return err;
     }
     co_return ret;
 }

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -106,7 +106,7 @@ ss::future<data_writer_error> batching_parquet_writer::add_data_struct(
     co_return data_writer_error::ok;
 }
 
-ss::future<result<data_writer_result, data_writer_error>>
+ss::future<result<data_file_result, data_writer_error>>
 batching_parquet_writer::finish() {
     auto write_result = co_await write_row_group();
     if (write_result != data_writer_error::ok) {

--- a/src/v/datalake/batching_parquet_writer.cc
+++ b/src/v/datalake/batching_parquet_writer.cc
@@ -210,9 +210,9 @@ batching_parquet_writer_factory::batching_parquet_writer_factory(
   , _row_count_threshold{row_count_threshold}
   , _byte_count_treshold{byte_count_threshold} {}
 
-ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
 batching_parquet_writer_factory::create_writer(iceberg::struct_type schema) {
-    auto ret = std::make_unique<batching_parquet_writer>(
+    auto ret = ss::make_shared<batching_parquet_writer>(
       std::move(schema), _row_count_threshold, _byte_count_treshold);
     std::string filename = fmt::format("{}.parquet", uuid_t::create());
     std::filesystem::path file_path = _local_directory / filename;

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -21,6 +21,7 @@
 #include <base/seastarx.h>
 
 #include <filesystem>
+#include <memory>
 
 namespace datalake {
 // batching_parquet_writer ties together the low-level components for iceberg to
@@ -73,6 +74,22 @@ private:
     ss::file _output_file;
     ss::output_stream<char> _output_stream;
     data_writer_result _result;
+};
+
+class batching_parquet_writer_factory : public data_writer_factory {
+public:
+    batching_parquet_writer_factory(
+      std::filesystem::path local_directory,
+      size_t row_count_threshold,
+      size_t byte_count_threshold);
+
+    ss::future<std::unique_ptr<data_writer>>
+    create_writer(iceberg::struct_type schema) override;
+
+private:
+    std::filesystem::path _local_directory;
+    size_t _row_count_threshold;
+    size_t _byte_count_treshold;
 };
 
 } // namespace datalake

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -50,7 +50,7 @@ public:
     ss::future<data_writer_error>
     add_data_struct(iceberg::struct_value data, int64_t approx_size) override;
 
-    ss::future<result<data_writer_result, data_writer_error>> finish() override;
+    ss::future<result<data_file_result, data_writer_error>> finish() override;
 
     // Close the file handle, delete any temporary data and clean up any other
     // state.
@@ -73,7 +73,7 @@ private:
     std::filesystem::path _output_file_path;
     ss::file _output_file;
     ss::output_stream<char> _output_stream;
-    data_writer_result _result;
+    data_file_result _result;
 };
 
 class batching_parquet_writer_factory : public data_writer_factory {

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -83,7 +83,7 @@ public:
       size_t row_count_threshold,
       size_t byte_count_threshold);
 
-    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override;
 
 private:

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -83,7 +83,7 @@ public:
       size_t row_count_threshold,
       size_t byte_count_threshold);
 
-    ss::future<std::unique_ptr<data_writer>>
+    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override;
 
 private:

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -31,7 +31,7 @@ struct translated_data_file_entry
     // translation
     model::term_id translator_term;
 
-    data_writer_result translation_result;
+    data_file_result translation_result;
 
     auto serde_fields() {
         return std::tie(

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -25,9 +25,9 @@ enum class data_writer_error {
     file_io_error,
 };
 
-struct data_writer_result
+struct data_file_result
   : serde::envelope<
-      data_writer_result,
+      data_file_result,
       serde::version<0>,
       serde::compat_version<0>> {
     ss::sstring file_path = "";
@@ -69,7 +69,7 @@ public:
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
 
-    virtual ss::future<result<data_writer_result, data_writer_error>>
+    virtual ss::future<result<data_file_result, data_writer_error>>
     finish() = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -23,18 +23,30 @@ enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,
     file_io_error,
+    no_data,
 };
 
 struct data_file_result
-  : serde::envelope<
-      data_file_result,
-      serde::version<0>,
-      serde::compat_version<0>> {
+  : serde::
+      envelope<data_file_result, serde::version<0>, serde::compat_version<0>> {
     ss::sstring file_path = "";
     size_t record_count = 0;
     size_t file_size_bytes = 0;
 
-    auto serde_fields() { return std::tie(record_count); }
+    // TODO: add kafka schema id
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const data_file_result& r) {
+        // TODO: do we have a preferred format for printing structures?
+        o << "data_file_result{file_path:" << r.file_path
+          << " record_count:" << r.record_count
+          << " file_size_bytes: " << r.file_size_bytes << " }";
+        return o;
+    }
+
+    auto serde_fields() {
+        return std::tie(file_path, record_count, file_size_bytes);
+    }
 };
 
 struct data_writer_error_category : std::error_category {
@@ -48,6 +60,8 @@ struct data_writer_error_category : std::error_category {
             return "Parquet Conversion Error";
         case data_writer_error::file_io_error:
             return "File IO Error";
+        case data_writer_error::no_data:
+            return "No data";
         }
     }
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -77,7 +77,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    virtual ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -78,7 +78,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual std::unique_ptr<data_writer>
+    virtual ss::future<std::unique_ptr<data_writer>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -23,7 +23,6 @@ enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,
     file_io_error,
-
 };
 
 struct data_writer_result
@@ -78,7 +77,7 @@ class data_writer_factory {
 public:
     virtual ~data_writer_factory() = default;
 
-    virtual ss::future<std::unique_ptr<data_writer>>
+    virtual ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
       create_writer(iceberg::struct_type /* schema */) = 0;
 };
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -96,13 +96,12 @@ ss::future<data_writer&> record_multiplexer::get_writer() {
     if (!_writer) {
         auto& translator = get_translator();
         auto schema = translator.get_schema();
-        _writer = co_await _writer_factory->create_writer(std::move(schema));
-        if (!_writer) {
-            // FIXME: modify create_writer to return a result and check that
-            // here. This method should also return a result. That is coming in
-            // one of the next commits. For now throw & catch.
+        auto writer_result = co_await _writer_factory->create_writer(std::move(schema));
+        if (!writer_result.has_value()) {
+            // FIXME: handle this error correctly
             throw std::runtime_error("Could not create data writer");
         }
+        _writer = std::move(writer_result.value());
     }
     co_return *_writer;
 }

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -69,14 +69,14 @@ record_multiplexer::operator()(model::record_batch batch) {
     co_return ss::stop_iteration::no;
 }
 
-ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
+ss::future<result<chunked_vector<data_file_result>, data_writer_error>>
 record_multiplexer::end_of_stream() {
     if (_writer_status != data_writer_error::ok) {
         co_return _writer_status;
     }
     // TODO: once we have multiple _writers this should be a loop
     if (_writer) {
-        chunked_vector<data_writer_result> ret;
+        chunked_vector<data_file_result> ret;
         auto res = co_await _writer->finish();
         if (res.has_value()) {
             ret.push_back(res.value());
@@ -85,7 +85,7 @@ record_multiplexer::end_of_stream() {
             co_return res.error();
         }
     } else {
-        co_return chunked_vector<data_writer_result>{};
+        co_return chunked_vector<data_file_result>{};
     }
 }
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -46,6 +46,19 @@ record_multiplexer::operator()(model::record_batch batch) {
                          + record.offset_delta();
         int64_t estimated_size = key.size_bytes() + val.size_bytes() + 16;
 
+        // TODO: we want to ensure we're using an offset translating reader so
+        // that these will be Kafka offsets, not Raft offsets.
+        if (!_result.has_value()) {
+            _result = translated_offset_range{};
+            _result.value().start_offset = kafka::offset(offset);
+        }
+        if (offset < _result.value().start_offset()) {
+            _result.value().start_offset = kafka::offset(offset);
+        }
+        if (offset > _result.value().start_offset()) {
+            _result.value().last_offset = kafka::offset(offset);
+        }
+
         // Translate the record
         auto& translator = get_translator();
         iceberg::struct_value data = translator.translate_event(
@@ -69,23 +82,25 @@ record_multiplexer::operator()(model::record_batch batch) {
     co_return ss::stop_iteration::no;
 }
 
-ss::future<result<chunked_vector<data_file_result>, data_writer_error>>
+ss::future<result<translated_offset_range, data_writer_error>>
 record_multiplexer::end_of_stream() {
     if (_writer_status != data_writer_error::ok) {
         co_return _writer_status;
     }
     // TODO: once we have multiple _writers this should be a loop
     if (_writer) {
-        chunked_vector<data_file_result> ret;
-        auto res = co_await _writer->finish();
-        if (res.has_value()) {
-            ret.push_back(res.value());
-            co_return ret;
+        if (!_result.has_value()) {
+            co_return data_writer_error::no_data;
+        }
+        auto result_files = co_await _writer->finish();
+        if (result_files.has_value()) {
+            _result.value().files.push_back(result_files.value());
+            co_return std::move(_result.value());
         } else {
-            co_return res.error();
+            co_return result_files.error();
         }
     } else {
-        co_return chunked_vector<data_file_result>{};
+        co_return data_writer_error::no_data;
     }
 }
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -52,13 +52,14 @@ record_multiplexer::operator()(model::record_batch batch) {
           std::move(key), std::move(val), timestamp, offset);
         // Send it to the writer
 
-        try {
-            auto& writer = co_await get_writer();
-            _writer_status = co_await writer.add_data_struct(
-              std::move(data), estimated_size);
-        } catch (const std::runtime_error& err) {
-            datalake_log.error("Failed to add data to writer");
+        auto writer_result = co_await get_writer();
+        if (!writer_result.has_value()) {
+            _writer_status = writer_result.error();
+            co_return ss::stop_iteration::yes;
         }
+        auto writer = std::move(writer_result.value());
+        _writer_status = co_await writer->add_data_struct(
+          std::move(data), estimated_size);
         if (_writer_status != data_writer_error::ok) {
             // If a write fails, the writer is left in an indeterminate state,
             // we cannot continue in this case.
@@ -92,17 +93,19 @@ schemaless_translator& record_multiplexer::get_translator() {
     return _translator;
 }
 
-ss::future<data_writer&> record_multiplexer::get_writer() {
+ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
+record_multiplexer::get_writer() {
     if (!_writer) {
         auto& translator = get_translator();
         auto schema = translator.get_schema();
-        auto writer_result = co_await _writer_factory->create_writer(std::move(schema));
+        auto writer_result = co_await _writer_factory->create_writer(
+          std::move(schema));
         if (!writer_result.has_value()) {
-            // FIXME: handle this error correctly
-            throw std::runtime_error("Could not create data writer");
+            co_return writer_result.error();
         }
-        _writer = std::move(writer_result.value());
+        _writer = writer_result.value();
+        co_return _writer;
     }
-    co_return *_writer;
+    co_return _writer;
 }
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -47,7 +47,7 @@ public:
 
 private:
     schemaless_translator& get_translator();
-    data_writer& get_writer();
+    ss::future<data_writer&> get_writer();
 
     // TODO: in a future PR this will be a map of translators keyed by schema_id
     schemaless_translator _translator;

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -47,14 +47,15 @@ public:
 
 private:
     schemaless_translator& get_translator();
-    ss::future<data_writer&> get_writer();
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
+    get_writer();
 
     // TODO: in a future PR this will be a map of translators keyed by schema_id
     schemaless_translator _translator;
     std::unique_ptr<data_writer_factory> _writer_factory;
 
     // TODO: similarly this will be a map keyed by schema_id
-    std::unique_ptr<data_writer> _writer;
+    ss::shared_ptr<data_writer> _writer;
 
     data_writer_error _writer_status = data_writer_error::ok;
 };

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -42,7 +42,7 @@ public:
     explicit record_multiplexer(
       std::unique_ptr<data_writer_factory> writer_factory);
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
-    ss::future<result<chunked_vector<data_writer_result>, data_writer_error>>
+    ss::future<result<chunked_vector<data_file_result>, data_writer_error>>
     end_of_stream();
 
 private:

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -7,11 +7,18 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+#include "datalake/batching_parquet_writer.h"
 #include "datalake/record_multiplexer.h"
 #include "datalake/tests/test_data_writer.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/tmp_dir.h"
 
+#include <arrow/io/file.h>
+#include <arrow/table.h>
 #include <gtest/gtest.h>
+#include <parquet/arrow/reader.h>
+
+#include <filesystem>
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     int record_count = 10;
@@ -61,4 +68,67 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     ASSERT_TRUE(res.has_error());
     EXPECT_EQ(
       res.error(), datalake::data_writer_error::parquet_conversion_error);
+}
+
+TEST(DatalakeMultiplexerTest, WritesDataFiles) {
+    // Almost an integration test:
+    // Stitch together as many parts of the data path as is reasonable in a
+    // single test and make sure we can go from Kafka log to Parquet files on
+    // disk.
+    temporary_dir tmp_dir("datalake_multiplexer_test");
+
+    int record_count = 50;
+    int batch_count = 20;
+
+    auto writer_factory
+      = std::make_unique<datalake::batching_parquet_writer_factory>(
+        tmp_dir.get_path(), 100, 10000);
+    datalake::record_multiplexer multiplexer(std::move(writer_factory));
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    ss::circular_buffer<model::record_batch> batches
+      = model::test::make_random_batches(batch_spec).get0();
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+
+    auto result
+      = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 1);
+    EXPECT_EQ(result.value()[0].record_count, record_count * batch_count);
+
+    // Open the resulting file and check that it has data in it with the
+    // appropriate counts.
+    int file_count = 0;
+    for (const auto& entry :
+         std::filesystem::directory_iterator(tmp_dir.get_path())) {
+        file_count++;
+        auto arrow_file_reader
+          = arrow::io::ReadableFile::Open(entry.path()).ValueUnsafe();
+
+        // Open Parquet file reader
+        std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+        ASSERT_TRUE(
+          parquet::arrow::OpenFile(
+            arrow_file_reader, arrow::default_memory_pool(), &arrow_reader)
+            .ok());
+
+        // Read entire file as a single Arrow table
+        std::shared_ptr<arrow::Table> table;
+        auto r = arrow_reader->ReadTable(&table);
+        ASSERT_TRUE(r.ok());
+
+        EXPECT_EQ(table->num_rows(), record_count * batch_count);
+        // Expect 4 columns for schemaless: offset, timestamp, key, value
+        EXPECT_EQ(table->num_columns(), 4);
+    }
+    // Expect this test to create exactly 1 file
+    EXPECT_EQ(file_count, 1);
 }

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -36,15 +36,15 @@ public:
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<result<data_writer_result, data_writer_error>>
+    ss::future<result<data_file_result, data_writer_error>>
     finish() override {
         return ss::make_ready_future<
-          result<data_writer_result, data_writer_error>>(_result);
+          result<data_file_result, data_writer_error>>(_result);
     }
 
 private:
     iceberg::struct_type _schema;
-    data_writer_result _result;
+    data_file_result _result;
     bool _return_error;
 };
 class test_data_writer_factory : public data_writer_factory {

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,7 +52,7 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    ss::future<std::unique_ptr<data_writer>>
+    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override {
         co_return std::make_unique<test_data_writer>(
           std::move(schema), _return_error);

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,9 +52,9 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    ss::future<result<std::unique_ptr<data_writer>, data_writer_error>>
+    ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>
     create_writer(iceberg::struct_type schema) override {
-        co_return std::make_unique<test_data_writer>(
+        co_return ss::make_shared<test_data_writer>(
           std::move(schema), _return_error);
     }
 

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -36,8 +36,7 @@ public:
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<result<data_file_result, data_writer_error>>
-    finish() override {
+    ss::future<result<data_file_result, data_writer_error>> finish() override {
         return ss::make_ready_future<
           result<data_file_result, data_writer_error>>(_result);
     }

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -52,9 +52,9 @@ public:
     explicit test_data_writer_factory(bool return_error)
       : _return_error{return_error} {}
 
-    std::unique_ptr<data_writer>
+    ss::future<std::unique_ptr<data_writer>>
     create_writer(iceberg::struct_type schema) override {
-        return std::make_unique<test_data_writer>(
+        co_return std::make_unique<test_data_writer>(
           std::move(schema), _return_error);
     }
 


### PR DESCRIPTION
This adds a new structure, translated_offset_range, to store a range of Kafka offsets translated into Parquet, as well as the paths to the resulting Parquet files. It modifies record_multiplexer to use this as the return type when consuming a log.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none