### PR TITLE
gha: fix pip install on python actions

### DIFF
--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -25,7 +25,10 @@ jobs:
       - name: install dependencies
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
-        run: pip install -r ${SCRIPT_DIR}/requirements.txt
+        run: |
+          python3 -mvenv /tmp/venv/jira
+          source /tmp/venv/jira/bin/activate
+          pip install -r ${SCRIPT_DIR}/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - uses: aws-actions/configure-aws-credentials@v4
@@ -49,4 +52,4 @@ jobs:
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name) }}
           ISSUE_STATE: ${{ github.event.issue.state }}
           EVENT_NAME: ${{ github.event.action }}
-        run: python ${SCRIPT_DIR}/jira_helper.py ISSUE --verbose -p CORE
+        run: /tmp/venv/jira/bin/python ${SCRIPT_DIR}/jira_helper.py ISSUE --verbose -p CORE

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install yapf
-        run: pip install yapf==0.40.1
+        run: |
+          python3 -mvenv /tmp/venv/yapf
+          source /tmp/venv/yapf/bin/activate
+          pip install yapf==0.40.1
       - name: Run yapf
-        run: find . -type f -name '*.py' | xargs -n8 yapf -d
+        run: |
+          python3 -mvenv /tmp/env/yapf
+          source /tmp/venv/yapf/bin/activate
+          find . -type f -name '*.py' | xargs -n8 yapf -d

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Publish
         working-directory: src/transform-sdk/rust
         run: |
+          python3 -mvenv /tmp/venv/publish
+          source /tmp/venv/publish/bin/activate
           pip install tomlkit
           ./scripts/publish.py --version ${{github.ref_name}}
         env:


### PR DESCRIPTION
The new `ubuntu-latest` complains when system-wide `pip` is invoked.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none
