### PR TITLE
cloud_topics: add cloud topics topic property

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -481,6 +481,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       false,
       std::nullopt,
+      false,
     };
 
     auto random_initial_revision_id

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -29,7 +29,7 @@ ss::logger lg("reconciler");
  */
 bool is_cloud_partition(
   const ss::lw_shared_ptr<cluster::partition>& partition) {
-    return partition->ntp().tp.topic().ends_with("_ct");
+    return partition->get_ntp_config().cloud_topic_enabled();
 }
 } // namespace
 

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -56,6 +56,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .flush_ms = properties.flush_ms,
             .flush_bytes = properties.flush_bytes,
             .iceberg_enabled = properties.iceberg_enabled,
+            .cloud_topic_enabled = properties.cloud_topic_enabled,
           });
     }
     return {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -97,33 +97,35 @@ bool topic_properties::is_compacted() const {
 }
 
 bool topic_properties::has_overrides() const {
-    const auto overrides = cleanup_policy_bitflags || compaction_strategy || segment_size
-           || retention_bytes.is_engaged() || retention_duration.is_engaged()
-           || recovery.has_value() || shadow_indexing.has_value()
-           || read_replica.has_value()
-           || remote_topic_namespace_override.has_value()
-           || batch_max_bytes.has_value()
-           || retention_local_target_bytes.is_engaged()
-           || retention_local_target_ms.is_engaged()
-           || remote_delete != storage::ntp_config::default_remote_delete
-           || segment_ms.is_engaged()
-           || record_key_schema_id_validation.has_value()
-           || record_key_schema_id_validation_compat.has_value()
-           || record_key_subject_name_strategy.has_value()
-           || record_key_subject_name_strategy_compat.has_value()
-           || record_value_schema_id_validation.has_value()
-           || record_value_schema_id_validation_compat.has_value()
-           || record_value_subject_name_strategy.has_value()
-           || record_value_subject_name_strategy_compat.has_value()
-           || initial_retention_local_target_bytes.is_engaged()
-           || initial_retention_local_target_ms.is_engaged()
-           || write_caching.has_value() || flush_ms.has_value()
-           || flush_bytes.has_value() || remote_label.has_value()
-           || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
-           || leaders_preference.has_value();
+    const auto overrides
+      = cleanup_policy_bitflags || compaction_strategy || segment_size
+        || retention_bytes.is_engaged() || retention_duration.is_engaged()
+        || recovery.has_value() || shadow_indexing.has_value()
+        || read_replica.has_value()
+        || remote_topic_namespace_override.has_value()
+        || batch_max_bytes.has_value()
+        || retention_local_target_bytes.is_engaged()
+        || retention_local_target_ms.is_engaged()
+        || remote_delete != storage::ntp_config::default_remote_delete
+        || segment_ms.is_engaged()
+        || record_key_schema_id_validation.has_value()
+        || record_key_schema_id_validation_compat.has_value()
+        || record_key_subject_name_strategy.has_value()
+        || record_key_subject_name_strategy_compat.has_value()
+        || record_value_schema_id_validation.has_value()
+        || record_value_schema_id_validation_compat.has_value()
+        || record_value_subject_name_strategy.has_value()
+        || record_value_subject_name_strategy_compat.has_value()
+        || initial_retention_local_target_bytes.is_engaged()
+        || initial_retention_local_target_ms.is_engaged()
+        || write_caching.has_value() || flush_ms.has_value()
+        || flush_bytes.has_value() || remote_label.has_value()
+        || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
+        || leaders_preference.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
-        return overrides || (cloud_topic_enabled != storage::ntp_config::default_cloud_topic_enabled);
+        return overrides
+               || (cloud_topic_enabled != storage::ntp_config::default_cloud_topic_enabled);
     }
 
     return overrides;

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "flush_ms: {}, "
       "flush_bytes: {}, "
       "remote_label: {}, iceberg_enabled: {}, "
-      "leaders_preference: {}}}",
+      "leaders_preference: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -77,6 +77,13 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.iceberg_enabled,
       properties.leaders_preference);
 
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        fmt::print(
+          o, ", cloud_topic_enabled: {}", properties.cloud_topic_enabled);
+    }
+
+    o << "}";
+
     return o;
 }
 
@@ -90,7 +97,7 @@ bool topic_properties::is_compacted() const {
 }
 
 bool topic_properties::has_overrides() const {
-    return cleanup_policy_bitflags || compaction_strategy || segment_size
+    const auto overrides = cleanup_policy_bitflags || compaction_strategy || segment_size
            || retention_bytes.is_engaged() || retention_duration.is_engaged()
            || recovery.has_value() || shadow_indexing.has_value()
            || read_replica.has_value()
@@ -114,6 +121,12 @@ bool topic_properties::has_overrides() const {
            || flush_bytes.has_value() || remote_label.has_value()
            || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
            || leaders_preference.has_value();
+
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        return overrides || (cloud_topic_enabled != storage::ntp_config::default_cloud_topic_enabled);
+    }
+
+    return overrides;
 }
 
 bool topic_properties::requires_remote_erase() const {
@@ -147,6 +160,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.flush_ms = flush_ms;
     ret.flush_bytes = flush_bytes;
     ret.iceberg_enabled = iceberg_enabled;
+    ret.cloud_topic_enabled = cloud_topic_enabled;
     return ret;
 }
 
@@ -236,7 +250,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       false,
-      std::nullopt};
+      std::nullopt,
+      false};
 }
 
 } // namespace reflection

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -73,7 +73,8 @@ struct topic_properties
       std::optional<std::chrono::milliseconds> flush_ms,
       std::optional<size_t> flush_bytes,
       bool iceberg_enabled,
-      std::optional<config::leaders_preference> leaders_preference)
+      std::optional<config::leaders_preference> leaders_preference,
+      bool cloud_topic_enabled)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -112,7 +113,8 @@ struct topic_properties
       , flush_ms(flush_ms)
       , flush_bytes(flush_bytes)
       , iceberg_enabled(iceberg_enabled)
-      , leaders_preference(std::move(leaders_preference)) {}
+      , leaders_preference(std::move(leaders_preference))
+      , cloud_topic_enabled(cloud_topic_enabled) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -183,6 +185,8 @@ struct topic_properties
 
     std::optional<config::leaders_preference> leaders_preference;
 
+    bool cloud_topic_enabled{storage::ntp_config::default_cloud_topic_enabled};
+
     bool is_compacted() const;
     bool has_overrides() const;
     bool requires_remote_erase() const;
@@ -226,7 +230,8 @@ struct topic_properties
           remote_label,
           remote_topic_namespace_override,
           iceberg_enabled,
-          leaders_preference);
+          leaders_preference,
+          cloud_topic_enabled);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -424,6 +424,19 @@ errc topics_frontend::validate_topic_configuration(
         return errc::topic_invalid_config;
     }
 
+    // the only way that cloud topics can be enabled on a topic is if the cloud
+    // topics development feature is also enabled.
+    if (!config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (assignable_config.cfg.properties.cloud_topic_enabled) {
+            vlog(
+              clusterlog.error,
+              "Cloud topic flag on {} is set but development feature is "
+              "disabled",
+              assignable_config.cfg.tp_ns);
+            return errc::topic_invalid_config;
+        }
+    }
+
     return errc::success;
 }
 

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -651,7 +651,8 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_optional(
             [] { return random_generators::get_int<size_t>(); }),
           false,
-          std::nullopt};
+          std::nullopt,
+          false};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -341,6 +341,14 @@ create_topic_properties_update(
                   config::leaders_preference::parse);
                 continue;
             }
+            if (cfg.name == topic_property_cloud_topic_enabled) {
+                if (config::shard_local_cfg()
+                      .development_enable_cloud_topics()) {
+                    throw validation_error(
+                      "Cloud topics property cannot be changed");
+                }
+                throw validation_error("Cloud topics is not enabled");
+            }
 
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -761,6 +761,25 @@ config_response_container_t make_topic_configs(
           [](const bool& b) { return b ? "true" : "false"; });
     }
 
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (config_property_requested(
+              config_keys, topic_property_cloud_topic_enabled)) {
+            add_topic_config<bool>(
+              result,
+              topic_property_cloud_topic_enabled,
+              false,
+              topic_property_cloud_topic_enabled,
+              override_if_not_default(
+                std::make_optional<bool>(topic_properties.cloud_topic_enabled),
+                false),
+              include_synonyms,
+              maybe_make_documentation(
+                include_documentation,
+                "Cloud topic enabled on this topic if ture."),
+              [](const bool& b) { return b ? "true" : "false"; });
+        }
+    }
+
     constexpr std::string_view key_validation
       = "Enable validation of the schema id for keys on a record";
     constexpr std::string_view val_validation

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -38,45 +38,47 @@
 
 namespace kafka {
 
-static constexpr auto supported_configs = std::to_array(
-  {topic_property_compression,
-   topic_property_cleanup_policy,
-   topic_property_timestamp_type,
-   topic_property_segment_size,
-   topic_property_compaction_strategy,
-   topic_property_retention_bytes,
-   topic_property_retention_duration,
-   topic_property_recovery,
-   topic_property_remote_write,
-   topic_property_remote_read,
-   topic_property_remote_delete,
-   topic_property_read_replica,
-   topic_property_max_message_bytes,
-   topic_property_retention_local_target_bytes,
-   topic_property_retention_local_target_ms,
-   topic_property_segment_ms,
-   topic_property_record_key_schema_id_validation,
-   topic_property_record_key_schema_id_validation_compat,
-   topic_property_record_key_subject_name_strategy,
-   topic_property_record_key_subject_name_strategy_compat,
-   topic_property_record_value_schema_id_validation,
-   topic_property_record_value_schema_id_validation_compat,
-   topic_property_record_value_subject_name_strategy,
-   topic_property_record_value_subject_name_strategy_compat,
-   topic_property_initial_retention_local_target_bytes,
-   topic_property_initial_retention_local_target_ms,
-   topic_property_write_caching,
-   topic_property_flush_ms,
-   topic_property_flush_bytes,
-   topic_property_iceberg_enabled,
-   topic_property_leaders_preference});
-
+namespace {
 bool is_supported(std::string_view name) {
+    static constexpr auto supported_configs = std::to_array(
+      {topic_property_compression,
+       topic_property_cleanup_policy,
+       topic_property_timestamp_type,
+       topic_property_segment_size,
+       topic_property_compaction_strategy,
+       topic_property_retention_bytes,
+       topic_property_retention_duration,
+       topic_property_recovery,
+       topic_property_remote_write,
+       topic_property_remote_read,
+       topic_property_remote_delete,
+       topic_property_read_replica,
+       topic_property_max_message_bytes,
+       topic_property_retention_local_target_bytes,
+       topic_property_retention_local_target_ms,
+       topic_property_segment_ms,
+       topic_property_record_key_schema_id_validation,
+       topic_property_record_key_schema_id_validation_compat,
+       topic_property_record_key_subject_name_strategy,
+       topic_property_record_key_subject_name_strategy_compat,
+       topic_property_record_value_schema_id_validation,
+       topic_property_record_value_schema_id_validation_compat,
+       topic_property_record_value_subject_name_strategy,
+       topic_property_record_value_subject_name_strategy_compat,
+       topic_property_initial_retention_local_target_bytes,
+       topic_property_initial_retention_local_target_ms,
+       topic_property_write_caching,
+       topic_property_flush_ms,
+       topic_property_flush_bytes,
+       topic_property_iceberg_enabled,
+       topic_property_leaders_preference});
+
     return std::any_of(
       supported_configs.begin(),
       supported_configs.end(),
       [name](std::string_view p) { return name == p; });
 }
+} // namespace
 
 using validators = make_validator_types<
   creatable_topic,

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -73,10 +73,25 @@ bool is_supported(std::string_view name) {
        topic_property_iceberg_enabled,
        topic_property_leaders_preference});
 
-    return std::any_of(
-      supported_configs.begin(),
-      supported_configs.end(),
-      [name](std::string_view p) { return name == p; });
+    if (std::any_of(
+          supported_configs.begin(),
+          supported_configs.end(),
+          [name](std::string_view p) { return name == p; })) {
+        return true;
+    }
+
+    /*
+     * check development features below. if a development feature is not
+     * enabled, the system should behave as if the feature does not exist.
+     */
+
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (name == topic_property_cloud_topic_enabled) {
+            return true;
+        }
+    }
+
+    return false;
 }
 } // namespace
 
@@ -97,7 +112,8 @@ using validators = make_validator_types<
   replication_factor_must_be_greater_or_equal_to_minimum,
   vcluster_id_validator,
   write_caching_configs_validator,
-  iceberg_config_validator>;
+  iceberg_config_validator,
+  cloud_topic_config_validator>;
 
 static void
 append_topic_configs(request_context& ctx, create_topics_response& response) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -353,6 +353,14 @@ create_topic_properties_update(
                   config::leaders_preference::parse);
                 continue;
             }
+            if (cfg.name == topic_property_cloud_topic_enabled) {
+                if (config::shard_local_cfg()
+                      .development_enable_cloud_topics()) {
+                    throw validation_error(
+                      "Cloud topics property cannot be changed");
+                }
+                throw validation_error("Cloud topics is not enabled");
+            }
 
         } catch (const validation_error& e) {
             vlog(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -274,6 +274,12 @@ to_cluster_type(const creatable_topic& t) {
           p, kafka::config_resource_operation::set);
     }
 
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        cfg.properties.cloud_topic_enabled
+          = get_bool_value(config_entries, topic_property_cloud_topic_enabled)
+              .value_or(storage::ntp_config::default_cloud_topic_enabled);
+    }
+
     /// Final topic_property not decoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -99,6 +99,9 @@ inline constexpr std::string_view topic_property_iceberg_enabled
 inline constexpr std::string_view topic_property_leaders_preference
   = "redpanda.leaders.preference";
 
+inline constexpr std::string_view topic_property_cloud_topic_enabled
+  = "redpanda.cloud_topic.enabled";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -34,6 +34,7 @@ public:
     static constexpr bool default_remote_delete{true};
     static constexpr bool legacy_remote_delete{false};
     static constexpr bool default_iceberg_enabled{false};
+    static constexpr bool default_cloud_topic_enabled{false};
 
     static constexpr std::chrono::milliseconds read_replica_retention{3600000};
 
@@ -78,6 +79,7 @@ public:
         std::optional<std::chrono::milliseconds> flush_ms;
         std::optional<size_t> flush_bytes;
         bool iceberg_enabled{default_iceberg_enabled};
+        bool cloud_topic_enabled{default_cloud_topic_enabled};
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
@@ -307,6 +309,14 @@ public:
         }
         return _overrides ? _overrides->iceberg_enabled
                           : default_iceberg_enabled;
+    }
+
+    bool cloud_topic_enabled() const {
+        if (!config::shard_local_cfg().development_enable_cloud_topics()) {
+            return false;
+        }
+        return _overrides ? _overrides->cloud_topic_enabled
+                          : default_cloud_topic_enabled;
     }
 
 private:

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -114,7 +114,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
-      "flush_bytes: {} iceberg_enabled: {}}}",
+      "flush_bytes: {} iceberg_enabled: {}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -131,6 +131,12 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.flush_ms,
       v.flush_bytes,
       v.iceberg_enabled);
+
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        fmt::print(o, ", cloud_topic_enabled: {}", v.cloud_topic_enabled);
+    }
+
+    o << "}";
 
     return o;
 }

--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -13,15 +13,33 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import SISettings, CloudStorageType
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 
 
 class CloudTopicsTest(RedpandaTest):
-    topics = (TopicSpec(name="cloud_topics_test_ct", partition_count=5), )
-
     def __init__(self, test_context):
         super(CloudTopicsTest,
               self).__init__(test_context=test_context,
                              si_settings=SISettings(test_context=test_context))
+
+    def __create_initial_topics(self):
+        """
+        Create initial initial test topics with cloud topic enabled. This needs
+        to be done after development feature support has been enabled, and nodes
+        have been restarted so that development services start at bootup.
+        """
+        self.redpanda.enable_development_feature_support()
+        self.redpanda.set_cluster_config(
+            values={
+                "development_enable_cloud_topics": True,
+            })
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        rpk = RpkTool(self.redpanda)
+        for spec in self.topics:
+            rpk.create_topic(spec.name,
+                             spec.partition_count,
+                             spec.replication_factor,
+                             config={"redpanda.cloud_topic.enabled": "true"})
 
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=[CloudStorageType.S3])
@@ -35,13 +53,8 @@ class CloudTopicsTest(RedpandaTest):
             kafka_tools.produce(self.topic, 100, 1, batch_size=10)
             return count_l1_objects()
 
-        # enable cloud topics feature
-        self.redpanda.enable_development_feature_support()
-        self.redpanda.set_cluster_config(
-            values={
-                "development_enable_cloud_topics": True,
-            })
-        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.topics = (TopicSpec(partition_count=5), )
+        self.__create_initial_topics()
 
         wait_until(lambda: produce_and_count() >= 5,
                    backoff_sec=12,

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -140,6 +140,7 @@ def read_topic_properties_serde(rdr: Reader, version):
         topic_properties |= {
             'iceberg_enabled': rdr.read_bool(),
             'leaders_preference': rdr.read_optional(read_leaders_preference),
+            'cloud_topic_enabled': rdr.read_bool(),
         }
 
     return topic_properties


### PR DESCRIPTION
Adds a new `redpanda.cloud_topic.enable` topic property.

This topic is protected by the `development_enable_cloud_topics` development configuration option. That is, it needs to be turned on in order for this topic property to be active.

The one caveat is that we do reserve a bit on the wire (topic_properties serialization) for this flag which defaults to false.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

