### PR TITLE
datalake/coordinator: add coordinator manager

### DIFF
--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -46,6 +46,7 @@ redpanda_cc_library(
         "//src/v/storage:record_batch_builder",
     ],
     include_prefix = "datalake/coordinator",
+    visibility = ["//visibility:public"],
     deps = [
         ":coordinator",
         ":state_update",
@@ -185,9 +186,12 @@ redpanda_cc_library(
     include_prefix = "datalake/coordinator",
     visibility = ["//visibility:public"],
     deps = [
+        ":coordinator",
+        ":coordinator_manager",
         ":generated_datalake_coordinator_rpc",
         ":model",
         ":stm",
+        ":translated_offset_range",
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/container:fragmented_vector",

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -33,6 +33,32 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "coordinator_manager",
+    srcs = [
+        "coordinator_manager.cc",
+    ],
+    hdrs = [
+        "coordinator_manager.h",
+    ],
+    implementation_deps = [
+        "//src/v/base",
+        "//src/v/datalake:logger",
+        "//src/v/storage:record_batch_builder",
+    ],
+    include_prefix = "datalake/coordinator",
+    deps = [
+        ":coordinator",
+        ":state_update",
+        ":stm",
+        "//src/v/cluster",
+        "//src/v/cluster:notification",
+        "//src/v/model",
+        "//src/v/raft",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "data_file",
     srcs = [
         "data_file.cc",

--- a/src/v/datalake/coordinator/CMakeLists.txt
+++ b/src/v/datalake/coordinator/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     NAME datalake_coordinator
     SRCS
         coordinator.cc
+        coordinator_manager.cc
         data_file.cc
         frontend.cc
         service.cc

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -36,6 +36,7 @@ public:
       model::topic_partition tp, chunked_vector<translated_offset_range>);
     ss::future<checked<std::optional<kafka::offset>, errc>>
     sync_get_last_added_offset(model::topic_partition tp);
+    void notify_leadership(std::optional<model::node_id>) {}
 
 private:
     checked<ss::gate::holder, errc> maybe_gate();

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -28,8 +28,8 @@ public:
         timedout,
         shutting_down,
     };
-    explicit coordinator(coordinator_stm& stm)
-      : stm_(stm) {}
+    explicit coordinator(ss::shared_ptr<coordinator_stm> stm)
+      : stm_(std::move(stm)) {}
 
     ss::future<> stop_and_wait();
     ss::future<checked<std::nullopt_t, errc>> sync_add_files(
@@ -41,7 +41,7 @@ public:
 private:
     checked<ss::gate::holder, errc> maybe_gate();
 
-    coordinator_stm& stm_;
+    ss::shared_ptr<coordinator_stm> stm_;
 
     ss::gate gate_;
     ss::abort_source as_;

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/coordinator/coordinator_manager.h"
+
+#include "cluster/partition_manager.h"
+#include "coordinator.h"
+#include "datalake/coordinator/state_machine.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+namespace datalake::coordinator {
+
+coordinator_manager::coordinator_manager(
+  model::node_id self,
+  ss::sharded<raft::group_manager>& gm,
+  ss::sharded<cluster::partition_manager>& pm)
+  : self_(self)
+  , gm_(gm.local())
+  , pm_(pm.local()) {}
+
+ss::future<> coordinator_manager::start() {
+    manage_notifications_ = pm_.register_manage_notification(
+      model::datalake_coordinator_nt.ns,
+      [this](ss::lw_shared_ptr<cluster::partition> p) { start_managing(*p); });
+    unmanage_notifications_ = pm_.register_unmanage_notification(
+      model::datalake_coordinator_nt.ns,
+      [this](model::topic_partition_view tp) {
+          if (tp.topic != model::datalake_coordinator_topic) {
+              return;
+          }
+          auto ntp = model::ntp{
+            model::datalake_coordinator_nt.ns,
+            model::datalake_coordinator_nt.tp,
+            tp.partition};
+          stop_managing(ntp);
+      });
+    leadership_notifications_ = gm_.register_leadership_notification(
+      [this](
+        raft::group_id group,
+        model::term_id term,
+        std::optional<model::node_id> leader_id) {
+          notify_leadership_change(group, term, leader_id);
+      });
+    return ss::now();
+}
+
+ss::future<> coordinator_manager::stop() {
+    if (manage_notifications_) {
+        pm_.unregister_manage_notification(*manage_notifications_);
+    }
+    if (unmanage_notifications_) {
+        pm_.unregister_unmanage_notification(*unmanage_notifications_);
+    }
+    if (leadership_notifications_) {
+        gm_.unregister_leadership_notification(*leadership_notifications_);
+    }
+    auto gate_close = gate_.close();
+    for (auto& [_, crd] : coordinators_) {
+        co_await crd->stop_and_wait();
+    }
+    co_await std::move(gate_close);
+}
+
+void coordinator_manager::start_managing(cluster::partition& p) {
+    if (gate_.is_closed()) {
+        return;
+    }
+    auto ntp = p.get_ntp_config().ntp();
+    if (
+      ntp.ns != model::datalake_coordinator_nt.ns
+      || ntp.tp.topic != model::datalake_coordinator_topic) {
+        return;
+    }
+    if (coordinators_.contains(ntp)) {
+        return;
+    }
+    auto stm = p.raft()->stm_manager()->get<coordinator_stm>();
+    if (stm == nullptr) {
+        return;
+    }
+    auto crd = ss::make_lw_shared<coordinator>(*stm);
+    if (p.is_leader()) {
+        crd->notify_leadership(self_);
+    }
+    coordinators_.emplace(ntp, std::move(crd));
+}
+
+void coordinator_manager::stop_managing(const model::ntp& ntp) {
+    if (gate_.is_closed()) {
+        // Cleanup should happen in class stop method.
+        return;
+    }
+    auto it = coordinators_.find(ntp);
+    if (it == coordinators_.end()) {
+        return;
+    }
+    auto crd = std::move(it->second);
+    coordinators_.erase(it);
+    ssx::background = crd->stop_and_wait().finally(
+      [c = crd, g = gate_.hold()] {});
+}
+
+ss::lw_shared_ptr<coordinator>
+coordinator_manager::get(const model::ntp& ntp) const {
+    if (gate_.is_closed()) {
+        return nullptr;
+    }
+    auto it = coordinators_.find(ntp);
+    if (it == coordinators_.end()) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+void coordinator_manager::notify_leadership_change(
+  raft::group_id group,
+  model::term_id,
+  std::optional<model::node_id> leader_id) {
+    if (gate_.is_closed()) {
+        return;
+    }
+    auto p = pm_.partition_for(group);
+    if (p == nullptr) {
+        return;
+    }
+    const auto& ntp = p->ntp();
+    auto crd = get(ntp);
+    if (crd == nullptr) {
+        return;
+    }
+    crd->notify_leadership(leader_id);
+}
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -86,7 +86,7 @@ void coordinator_manager::start_managing(cluster::partition& p) {
     if (stm == nullptr) {
         return;
     }
-    auto crd = ss::make_lw_shared<coordinator>(*stm);
+    auto crd = ss::make_lw_shared<coordinator>(std::move(stm));
     if (p.is_leader()) {
         crd->notify_leadership(self_);
     }

--- a/src/v/datalake/coordinator/coordinator_manager.h
+++ b/src/v/datalake/coordinator/coordinator_manager.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cluster/fwd.h"
+#include "cluster/notification.h"
+#include "datalake/coordinator/coordinator.h"
+#include "model/fundamental.h"
+#include "raft/fwd.h"
+#include "raft/notification.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+namespace datalake::coordinator {
+
+// Manages the lifecycle of datalake coordinators, each of which operate on a
+// single partition of the control topic.
+class coordinator_manager {
+public:
+    coordinator_manager(
+      model::node_id self,
+      ss::sharded<raft::group_manager>&,
+      ss::sharded<cluster::partition_manager>&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    ss::lw_shared_ptr<coordinator> get(const model::ntp&) const;
+
+private:
+    void start_managing(cluster::partition&);
+    void stop_managing(const model::ntp&);
+    void notify_leadership_change(
+      raft::group_id group,
+      model::term_id term,
+      std::optional<model::node_id> leader_id);
+
+    ss::gate gate_;
+    model::node_id self_;
+    raft::group_manager& gm_;
+    cluster::partition_manager& pm_;
+
+    std::optional<cluster::notification_id_type> manage_notifications_;
+    std::optional<cluster::notification_id_type> unmanage_notifications_;
+    std::optional<raft::group_manager_notification_id>
+      leadership_notifications_;
+
+    absl::btree_map<model::ntp, ss::lw_shared_ptr<coordinator>> coordinators_;
+};
+
+} // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/frontend.h
+++ b/src/v/datalake/coordinator/frontend.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "datalake/coordinator/rpc_service.h"
 #include "datalake/coordinator/types.h"
+#include "datalake/fwd.h"
 #include "model/namespace.h"
 #include "raft/fwd.h"
 #include "rpc/fwd.h"
@@ -34,6 +35,7 @@ public:
 
     frontend(
       model::node_id self,
+      ss::sharded<coordinator_manager>*,
       ss::sharded<raft::group_manager>*,
       ss::sharded<cluster::partition_manager>*,
       ss::sharded<cluster::topics_frontend>*,
@@ -89,6 +91,7 @@ private:
       ss::shard_id);
 
     model::node_id _self;
+    ss::sharded<coordinator_manager>* _coordinator_mgr;
     ss::sharded<raft::group_manager>* _group_mgr;
     ss::sharded<cluster::partition_manager>* _partition_mgr;
     ss::sharded<cluster::topics_frontend>* _topics_frontend;

--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -139,16 +139,6 @@ ss::future<iobuf> coordinator_stm::take_snapshot(model::offset) {
     co_return iobuf{};
 }
 
-ss::future<add_translated_data_files_reply>
-coordinator_stm::add_translated_data_file(add_translated_data_files_request) {
-    co_return add_translated_data_files_reply{coordinator_errc::ok};
-}
-
-ss::future<fetch_latest_data_file_reply>
-coordinator_stm::fetch_latest_data_file(fetch_latest_data_file_request) {
-    co_return fetch_latest_data_file_reply{coordinator_errc::ok};
-}
-
 bool stm_factory::is_applicable_for(const storage::ntp_config& config) const {
     const auto& ntp = config.ntp();
     return (ntp.ns == model::datalake_coordinator_nt.ns)

--- a/src/v/datalake/coordinator/state_machine.h
+++ b/src/v/datalake/coordinator/state_machine.h
@@ -45,12 +45,6 @@ public:
 
     const topics_state& state() const { return state_; }
 
-    // XXX: remove once there is a higher level coordinator abstraction.
-    ss::future<add_translated_data_files_reply>
-      add_translated_data_file(add_translated_data_files_request);
-    ss::future<fetch_latest_data_file_reply>
-      fetch_latest_data_file(fetch_latest_data_file_request);
-
 protected:
     ss::future<> do_apply(const model::record_batch&) override;
 

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -31,8 +31,8 @@ model::topic_partition tp(int t, int pid) {
       model::partition_id(pid));
 }
 struct coordinator_node {
-    explicit coordinator_node(coordinator_stm& stm)
-      : stm(stm)
+    explicit coordinator_node(ss::shared_ptr<coordinator_stm> stm)
+      : stm(*stm)
       , crd(stm) {}
 
     coordinator_stm& stm;
@@ -127,7 +127,7 @@ public:
             auto stm = builder.create_stm<coordinator_stm>(
               datalake::datalake_log, raft);
             node->start(std::move(builder)).get();
-            crds.at(id()) = std::make_unique<coordinator_node>(*stm);
+            crds.at(id()) = std::make_unique<coordinator_node>(std::move(stm));
         }
     }
     // Returns the coordinator on the current leader.

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -76,6 +76,9 @@ struct fetch_latest_data_file_reply
     fetch_latest_data_file_reply() = default;
     explicit fetch_latest_data_file_reply(coordinator_errc err)
       : errc(err) {}
+    explicit fetch_latest_data_file_reply(std::optional<kafka::offset> o)
+      : last_added_offset(o)
+      , errc(coordinator_errc::ok) {}
 
     // The offset of the latest data file added to the coordinator.
     std::optional<kafka::offset> last_added_offset;

--- a/src/v/datalake/fwd.h
+++ b/src/v/datalake/fwd.h
@@ -12,7 +12,8 @@
 
 namespace datalake {
 namespace coordinator {
+class coordinator_manager;
 class frontend;
-};
+}; // namespace coordinator
 class datalake_manager;
 } // namespace datalake

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -27,6 +27,7 @@ redpanda_cc_library(
         "//src/v/crypto",
         "//src/v/datalake:manager",
         "//src/v/datalake:types",
+        "//src/v/datalake/coordinator:coordinator_manager",
         "//src/v/datalake/coordinator:frontend",
         "//src/v/datalake/coordinator:stm",
         "//src/v/debug_bundle",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -86,6 +86,7 @@
 #include "config/seed_server.h"
 #include "config/types.h"
 #include "crypto/ossl_context_service.h"
+#include "datalake/coordinator/coordinator_manager.h"
 #include "datalake/coordinator/frontend.h"
 #include "datalake/coordinator/service.h"
 #include "datalake/coordinator/state_machine.h"
@@ -1418,8 +1419,15 @@ void application::wire_up_runtime_services(
     if (datalake_enabled()) {
         syschecks::systemd_message("Starting datalake services").get();
         construct_service(
+          _datalake_coordinator_mgr,
+          node_id,
+          std::ref(raft_group_manager),
+          std::ref(partition_manager))
+          .get();
+        construct_service(
           _datalake_coordinator_fe,
           node_id,
+          &_datalake_coordinator_mgr,
           &raft_group_manager,
           &partition_manager,
           &controller->get_topics_frontend(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -341,6 +341,8 @@ private:
     // Small helpers to execute one-time upgrade actions
     std::vector<std::unique_ptr<features::feature_migrator>> _migrators;
 
+    ss::sharded<datalake::coordinator::coordinator_manager>
+      _datalake_coordinator_mgr;
     ss::sharded<datalake::coordinator::frontend> _datalake_coordinator_fe;
     ss::sharded<datalake::datalake_manager> _datalake_manager;
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Adds a coordinator manager abstraction to instantiate coordinators and plugs it into the frontend, rather than having the frontend call directly into the STM directly.

Note for reviewers, the structure of the coordinator manager resembles the archiver_manager very closely, in all of its hooks into the partition manager.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
