### PR TITLE
CORE-6977 dt: relax noncogent crl test log whitelist

### DIFF
--- a/tests/rptest/tests/crl_test.py
+++ b/tests/rptest/tests/crl_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
 import socket
 import tempfile
 import json
@@ -274,7 +275,9 @@ class CertificateRevocationTest(RedpandaTest):
                    backoff_sec=0.2,
                    err_msg="Cluster did not become unhealthy")
 
-    @cluster(num_nodes=3)
+    # Ignore all logs since we can expect a variety of errors with noncogent certs, eg:
+    # kafka - server.cc:159 - Error[applying protocol] remote address: 172.31.37.188:59640 - seastar::timed_out_error (timedout)
+    @cluster(num_nodes=3, log_allow_list=[re.compile(".*")])
     def test_noncogent(self):
         node = self.redpanda.nodes[0]
         self.rpk.list_schemas()


### PR DESCRIPTION
Ignores all error log lines for this test since a range of errors can happen across various layers in the brokers when we install a noncogent CRL and cause this test to be flaky in CI.

Fixes https://redpandadata.atlassian.net/browse/CORE-6977
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
