### PR TITLE
`cloud_storage`: add `initial_revision_id` to `topic_mount_manifest` path

### DIFF
--- a/src/v/cloud_storage/remote_path_provider.cc
+++ b/src/v/cloud_storage/remote_path_provider.cc
@@ -120,9 +120,10 @@ ss::sstring remote_path_provider::spillover_manifest_path(
 ss::sstring remote_path_provider::topic_mount_manifest_path(
   const topic_mount_manifest& manifest) const {
     return fmt::format(
-      "migration/{}/{}",
+      "migration/{}/{}/{}",
       manifest.get_source_label().cluster_uuid,
-      manifest.get_tp_ns().path());
+      manifest.get_tp_ns().path(),
+      manifest.get_revision_id());
 }
 
 ss::sstring remote_path_provider::segment_path(

--- a/src/v/cloud_storage/tests/remote_path_provider_test.cc
+++ b/src/v/cloud_storage/tests/remote_path_provider_test.cc
@@ -382,10 +382,10 @@ TEST_P(
 
 TEST(RemotePathProviderTest, TestTopicMountManifestPath) {
     remote_path_provider path_provider(test_label, std::nullopt);
-    topic_mount_manifest manifest(test_label, test_tp_ns);
+    topic_mount_manifest manifest(test_label, test_tp_ns, test_rev);
     EXPECT_STREQ(
       path_provider.topic_mount_manifest_path(manifest).c_str(),
-      "migration/deadbeef-0000-0000-0000-000000000000/kafka/tp");
+      "migration/deadbeef-0000-0000-0000-000000000000/kafka/tp/21");
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/cloud_storage/tests/topic_mount_handler_test.cc
+++ b/src/v/cloud_storage/tests/topic_mount_handler_test.cc
@@ -43,6 +43,7 @@ static const model::topic_namespace test_tp_ns_override{
 static ss::abort_source never_abort;
 static constexpr model::cloud_credentials_source config_file{
   model::cloud_credentials_source::config_file};
+static const model::initial_revision_id rev_id{123};
 
 static cluster::topic_configuration
 get_topic_configuration(cluster::topic_properties topic_props) {
@@ -99,10 +100,12 @@ TEST_P(TopicMountHandlerFixture, TestMountTopicManifestDoesNotExist) {
     auto handler = topic_mount_handler(bucket_name, remote.local());
 
     retry_chain_node rtc(never_abort, 10s, 20ms);
-    auto prepare_result = handler.prepare_mount_topic(topic_cfg, rtc).get();
+    auto prepare_result
+      = handler.prepare_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(
       prepare_result, topic_mount_result::mount_manifest_does_not_exist);
-    auto confirm_result = handler.confirm_mount_topic(topic_cfg, rtc).get();
+    auto confirm_result
+      = handler.confirm_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(
       confirm_result, topic_mount_result::mount_manifest_does_not_exist);
 }
@@ -119,8 +122,9 @@ TEST_P(TopicMountHandlerFixture, TestMountTopicManifestNotDeleted) {
                                   : test_tp_ns.path();
     const auto expected_label = remote_label_param ? test_uuid_str
                                                    : default_uuid_str;
-    const auto path = cloud_storage_clients::object_key{
-      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    const auto expected_rev_id = rev_id;
+    const auto path = cloud_storage_clients::object_key{fmt::format(
+      "migration/{}/{}/{}", expected_label, expected_tp_ns, expected_rev_id)};
     {
         auto result
           = remote.local()
@@ -159,9 +163,11 @@ TEST_P(TopicMountHandlerFixture, TestMountTopicManifestNotDeleted) {
 
     auto handler = topic_mount_handler(bucket_name, remote.local());
 
-    auto prepare_result = handler.prepare_mount_topic(topic_cfg, rtc).get();
+    auto prepare_result
+      = handler.prepare_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(prepare_result, topic_mount_result::mount_manifest_exists);
-    auto confirm_result = handler.confirm_mount_topic(topic_cfg, rtc).get();
+    auto confirm_result
+      = handler.confirm_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(confirm_result, topic_mount_result::mount_manifest_not_deleted);
 
     const auto exists_result
@@ -183,8 +189,9 @@ TEST_P(TopicMountHandlerFixture, TestMountTopicSuccess) {
                                   : test_tp_ns.path();
     const auto expected_label = remote_label_param ? test_uuid_str
                                                    : default_uuid_str;
-    const auto path = cloud_storage_clients::object_key{
-      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    const auto expected_rev_id = rev_id;
+    const auto path = cloud_storage_clients::object_key{fmt::format(
+      "migration/{}/{}/{}", expected_label, expected_tp_ns, expected_rev_id)};
     {
         auto result
           = remote.local()
@@ -207,9 +214,11 @@ TEST_P(TopicMountHandlerFixture, TestMountTopicSuccess) {
 
     auto handler = topic_mount_handler(bucket_name, remote.local());
 
-    auto prepare_result = handler.prepare_mount_topic(topic_cfg, rtc).get();
+    auto prepare_result
+      = handler.prepare_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(prepare_result, topic_mount_result::mount_manifest_exists);
-    auto confirm_result = handler.confirm_mount_topic(topic_cfg, rtc).get();
+    auto confirm_result
+      = handler.confirm_mount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(confirm_result, topic_mount_result::success);
 
     const auto exists_result
@@ -231,8 +240,9 @@ TEST_P(TopicMountHandlerFixture, TestUnmountTopicManifestNotCreated) {
                                   : test_tp_ns.path();
     const auto expected_label = remote_label_param ? test_uuid_str
                                                    : default_uuid_str;
-    const auto path = cloud_storage_clients::object_key{
-      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    const auto expected_rev_id = rev_id;
+    const auto path = cloud_storage_clients::object_key{fmt::format(
+      "migration/{}/{}/{}", expected_label, expected_tp_ns, expected_rev_id)};
 
     auto topic_props = cluster::topic_properties{};
     if (tp_ns_override_param) {
@@ -261,7 +271,7 @@ TEST_P(TopicMountHandlerFixture, TestUnmountTopicManifestNotCreated) {
 
     auto handler = topic_mount_handler(bucket_name, remote.local());
 
-    auto unmount_result = handler.unmount_topic(topic_cfg, rtc).get();
+    auto unmount_result = handler.unmount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(unmount_result, topic_unmount_result::mount_manifest_not_created);
 
     const auto exists_result
@@ -283,8 +293,9 @@ TEST_P(TopicMountHandlerFixture, TestUnmountTopicSuccess) {
                                   : test_tp_ns.path();
     const auto expected_label = remote_label_param ? test_uuid_str
                                                    : default_uuid_str;
-    const auto path = cloud_storage_clients::object_key{
-      fmt::format("migration/{}/{}", expected_label, expected_tp_ns)};
+    const auto expected_rev_id = rev_id;
+    const auto path = cloud_storage_clients::object_key{fmt::format(
+      "migration/{}/{}/{}", expected_label, expected_tp_ns, expected_rev_id)};
 
     auto topic_props = cluster::topic_properties{};
     if (tp_ns_override_param) {
@@ -297,7 +308,7 @@ TEST_P(TopicMountHandlerFixture, TestUnmountTopicSuccess) {
 
     auto handler = topic_mount_handler(bucket_name, remote.local());
 
-    auto unmount_result = handler.unmount_topic(topic_cfg, rtc).get();
+    auto unmount_result = handler.unmount_topic(topic_cfg, rev_id, rtc).get();
     ASSERT_EQ(unmount_result, topic_unmount_result::success);
 
     const auto exists_result

--- a/src/v/cloud_storage/tests/topic_mount_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_mount_manifest_test.cc
@@ -28,14 +28,15 @@ const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
 const remote_label test_label{test_uuid};
 const model::topic_namespace test_tp_ns{
   model::ns{"test_ns"}, model::topic{"test_tp"}};
+const model::initial_revision_id rev_id{123};
 
 TEST(topic_mount_manifest, manifest_type) {
-    topic_mount_manifest m(test_label, test_tp_ns);
+    topic_mount_manifest m(test_label, test_tp_ns, rev_id);
     ASSERT_TRUE(m.get_manifest_type() == manifest_type::topic_mount);
 }
 
 TEST(topic_mount_manifest, serde) {
-    topic_mount_manifest m(test_label, test_tp_ns);
+    topic_mount_manifest m(test_label, test_tp_ns, rev_id);
     auto serialized_manifest = m.serialize().get().stream;
 
     // Sanity check that the manifest contains the test label and
@@ -44,7 +45,7 @@ TEST(topic_mount_manifest, serde) {
     ASSERT_EQ(m.get_tp_ns(), test_tp_ns);
 
     topic_mount_manifest reconstructed_m(
-      remote_label{}, model::topic_namespace{});
+      remote_label{}, model::topic_namespace{}, model::initial_revision_id{});
 
     // Sanity check that the manifests differ.
     ASSERT_NE(reconstructed_m.get_source_label(), m.get_source_label());
@@ -58,6 +59,7 @@ TEST(topic_mount_manifest, serde) {
     // Manifests should be identical after deserialization.
     ASSERT_EQ(reconstructed_m.get_source_label(), m.get_source_label());
     ASSERT_EQ(reconstructed_m.get_tp_ns(), m.get_tp_ns());
+    ASSERT_EQ(reconstructed_m.get_revision_id(), m.get_revision_id());
     ASSERT_EQ(
       reconstructed_m.get_manifest_path(path_provider),
       m.get_manifest_path(path_provider));

--- a/src/v/cloud_storage/topic_mount_handler.cc
+++ b/src/v/cloud_storage/topic_mount_handler.cc
@@ -15,6 +15,8 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/topic_mount_manifest.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 
 namespace cloud_storage {
@@ -87,6 +89,7 @@ ss::future<topic_mount_result> topic_mount_handler::commit_mount(
 
 ss::future<topic_mount_result> topic_mount_handler::mount_topic(
   const cluster::topic_configuration& topic_cfg,
+  model::initial_revision_id rev,
   bool prepare_only,
   retry_chain_node& parent) {
     const auto remote_tp_ns = topic_cfg.remote_tp_ns();
@@ -97,7 +100,8 @@ ss::future<topic_mount_result> topic_mount_handler::mount_topic(
     const auto manifest = topic_mount_manifest(
       topic_cfg.properties.remote_label.value_or(
         remote_label{model::default_cluster_uuid}),
-      remote_tp_ns);
+      remote_tp_ns,
+      rev);
 
     const auto check_result = co_await check_mount(
       manifest, path_provider, parent);
@@ -129,7 +133,9 @@ ss::future<topic_mount_result> topic_mount_handler::mount_topic(
 }
 
 ss::future<topic_unmount_result> topic_mount_handler::unmount_topic(
-  const cluster::topic_configuration& topic_cfg, retry_chain_node& parent) {
+  const cluster::topic_configuration& topic_cfg,
+  model::initial_revision_id rev,
+  retry_chain_node& parent) {
     const auto remote_tp_ns = topic_cfg.remote_tp_ns();
     const auto path_provider = remote_path_provider(
       topic_cfg.properties.remote_label, remote_tp_ns);
@@ -138,7 +144,8 @@ ss::future<topic_unmount_result> topic_mount_handler::unmount_topic(
     const auto manifest = topic_mount_manifest(
       topic_cfg.properties.remote_label.value_or(
         remote_label{model::default_cluster_uuid}),
-      remote_tp_ns);
+      remote_tp_ns,
+      rev);
 
     // Upload manifest to cloud storage to mark it as mountable.
     const auto upload_result = co_await _remote.upload_manifest(
@@ -156,13 +163,17 @@ ss::future<topic_unmount_result> topic_mount_handler::unmount_topic(
 }
 
 ss::future<topic_mount_result> topic_mount_handler::prepare_mount_topic(
-  const cluster::topic_configuration& topic_cfg, retry_chain_node& parent) {
-    return mount_topic(topic_cfg, true, parent);
+  const cluster::topic_configuration& topic_cfg,
+  model::initial_revision_id rev,
+  retry_chain_node& parent) {
+    return mount_topic(topic_cfg, rev, true, parent);
 }
 
 ss::future<topic_mount_result> topic_mount_handler::confirm_mount_topic(
-  const cluster::topic_configuration& topic_cfg, retry_chain_node& parent) {
-    return mount_topic(topic_cfg, false, parent);
+  const cluster::topic_configuration& topic_cfg,
+  model::initial_revision_id rev,
+  retry_chain_node& parent) {
+    return mount_topic(topic_cfg, rev, false, parent);
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_mount_handler.h
+++ b/src/v/cloud_storage/topic_mount_handler.h
@@ -40,12 +40,16 @@ public:
     // Perform the first step of mounting process by checking the topic mount
     // manifest exists.
     ss::future<topic_mount_result> prepare_mount_topic(
-      const cluster::topic_configuration& topic_cfg, retry_chain_node& parent);
+      const cluster::topic_configuration& topic_cfg,
+      model::initial_revision_id rev,
+      retry_chain_node& parent);
 
     // Perform the second step of mounting process by deleting the topic mount
     // manifest.
     ss::future<topic_mount_result> confirm_mount_topic(
-      const cluster::topic_configuration& topic_cfg, retry_chain_node& parent);
+      const cluster::topic_configuration& topic_cfg,
+      model::initial_revision_id rev,
+      retry_chain_node& parent);
 
     // Perform the unmounting process by creating the topic mount manifest.
     // topic_cfg should be the recovered topic configuration from a topic
@@ -53,7 +57,9 @@ public:
     // the topic properties is used as the "source" label. Otherwise, the
     // default uuid (all zeros) is used.
     ss::future<topic_unmount_result> unmount_topic(
-      const cluster::topic_configuration& topic_cfg, retry_chain_node& parent);
+      const cluster::topic_configuration& topic_cfg,
+      model::initial_revision_id rev,
+      retry_chain_node& parent);
 
 private:
     // Perform the mounting process by deleting the topic mount manifest.
@@ -63,6 +69,7 @@ private:
     // default uuid (all zeros) is used.
     ss::future<topic_mount_result> mount_topic(
       const cluster::topic_configuration& topic_cfg,
+      model::initial_revision_id rev,
       bool prepare_only,
       retry_chain_node& parent);
 

--- a/src/v/cloud_storage/topic_mount_manifest.h
+++ b/src/v/cloud_storage/topic_mount_manifest.h
@@ -26,7 +26,9 @@ namespace cloud_storage {
 class topic_mount_manifest final : public base_manifest {
 public:
     topic_mount_manifest(
-      const remote_label& label, const model::topic_namespace& tp_ns);
+      const remote_label& label,
+      const model::topic_namespace& tp_ns,
+      model::initial_revision_id rev);
 
     ss::future<> update(ss::input_stream<char> is) override;
 
@@ -35,6 +37,8 @@ public:
     const remote_label& get_source_label() const { return _source_label; }
 
     const model::topic_namespace& get_tp_ns() const { return _tp_ns; }
+
+    model::initial_revision_id get_revision_id() const { return _rev; }
 
     /// Manifest object name in S3
     remote_manifest_path
@@ -49,5 +53,6 @@ private:
     // mounted/unmounted.
     remote_label _source_label;
     model::topic_namespace _tp_ns;
+    model::initial_revision_id _rev;
 };
 } // namespace cloud_storage


### PR DESCRIPTION
To disambiguate between topics with the same name during the mount process, the `initial_revision_id` is added to the `topic_mount_manifest` path (now of the form `migration/{uuid}/{namespace}/{topic}/{initial_revision_id}`) and relevant data structures.

Also, add a warning log line during the unmount process to warn of a collision between an existing topic mount manifest and one already in cloud storage.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
