### PR TITLE
bazel: quiet some 3rd party build warnings

### DIFF
--- a/bazel/thirdparty/libpciaccess.BUILD
+++ b/bazel/thirdparty/libpciaccess.BUILD
@@ -27,7 +27,6 @@ cc_library(
         "include/pciaccess.h",
     ],
     copts = [
-        "-Wno-unused-result",
         "-Wpointer-arith",
         "-Wmissing-declarations",
         "-Wformat=2",
@@ -55,6 +54,10 @@ cc_library(
         "-Werror=write-strings",
         "-Werror=address",
         "-Werror=int-to-pointer-cast",
+
+        # Quiet some build warnings
+        "-Wno-unused-result",
+        "-Wno-tautological-constant-out-of-range-compare",
     ],
     # This is only consumed by a make library that produces a static library,
     # so this library only needs to produce a static library. Doing this means

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -547,6 +547,8 @@ cc_library(
         "include/seastar/websocket/server.hh",
     ],
     copts = [
+        "-Wno-unused-variable",
+        "-Wno-unused-result",
         "-Wno-unused-but-set-variable",
     ] + select({
         ":use_stack_guards": ["-fstack-clash-protection"],


### PR DESCRIPTION
- **bazel: quiet some warnings in seastar**
- **bazel: quiet some build warnings in libpciaccess**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
