### PR TITLE
[v24.2.x] c/tx_gateway: fixed missing set outcome value after tx is committed

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1832,6 +1832,9 @@ tx_gateway_frontend::handle_commit_tx(
           "[tx_id={}] transaction is {} already committed",
           tx.id,
           tx);
+        if (!outcome->available()) {
+            outcome->set_value(tx::errc::none);
+        }
         co_return tx::errc::none;
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23734
