### PR TITLE
`cluster`: alter log line in `maybe_download_log()`

### DIFF
--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -210,7 +210,18 @@ ss::future<log_recovery_result> partition_downloader::maybe_download_log() {
         //
         // The only possible solution here is to discard the exception and
         // continue with normal partition creation process.
-        vlog(_ctxlog.error, "Error during log recovery: {}", err);
+        //
+        // This may or may not indicate a failed log recovery - if new
+        // partitions have been added to a topic post recovery, this warning can
+        // be safely ignored.
+        //
+        // TODO: add partition aware mechanism to avoid triggering this log line
+        // for partitions created post recovery that do not need to attempt
+        // download_log().
+        vlog(
+          _ctxlog.warn,
+          "Warning encountered for a partition with log recovery enabled: {}.",
+          err);
     } catch (...) {
         // We can get here in case of transient download error.
         // The controller will retry recovery after some time.


### PR DESCRIPTION
Currently, topics with recovery enabled will always have their `remote_topic_properties` and `recovery_enabled` flags set in `topic_properties`. As a result, post topic recovery, partitions added to the topic will still attempt to go through the log recovery process.

This would trigger an `ERROR` level log line, despite the fact it is expected that the partition should not have any data to recover from.

Reduce the log level to `WARN` for now- this can still indicate an error during log recovery.

Future work should add more sophisticated topic recovery improvements which discern partitions that need recovery vs freshly created partitions (which shouldn't reach `maybe_download_log()`), in which case this could again be raised back to `ERROR`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
