### PR TITLE
datalake: cloud uploader

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     arrow_translator.cc
     datalake_manager.cc
     batching_parquet_writer.cc
+    cloud_uploader.cc
     parquet_writer.cc
     record_multiplexer.cc
     schema_registry.cc
@@ -18,6 +19,7 @@ v_cc_library(
     protobuf_utils.cc
     values_protobuf.cc
   DEPS
+    v::cloud_io
     v::datalake_coordinator
     v::storage
     Seastar::seastar

--- a/src/v/datalake/batching_parquet_writer.h
+++ b/src/v/datalake/batching_parquet_writer.h
@@ -44,14 +44,13 @@ public:
       size_t row_count_threshold,
       size_t byte_count_threshold);
 
-    ss::future<data_writer_error>
-    initialize(std::filesystem::path output_file_path);
+    ss::future<data_writer_error> initialize(
+      std::filesystem::path base_path, std::filesystem::path output_file_path);
 
     ss::future<data_writer_error>
     add_data_struct(iceberg::struct_value data, int64_t approx_size) override;
 
-    ss::future<result<coordinator::data_file, data_writer_error>>
-    finish() override;
+    ss::future<result<local_data_file, data_writer_error>> finish() override;
 
     // Close the file handle, delete any temporary data and clean up any other
     // state.
@@ -71,10 +70,9 @@ private:
     size_t _byte_count = 0;
 
     // Output
-    std::filesystem::path _output_file_path;
     ss::file _output_file;
     ss::output_stream<char> _output_stream;
-    coordinator::data_file _result;
+    local_data_file _result;
 };
 
 class batching_parquet_writer_factory : public data_writer_factory {

--- a/src/v/datalake/cloud_uploader.cc
+++ b/src/v/datalake/cloud_uploader.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/cloud_uploader.h"
+
+#include "base/outcome.h"
+#include "base/seastarx.h"
+#include "cloud_io/remote.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/types.h"
+#include "data_file.h"
+#include "datalake/data_writer_interface.h"
+#include "datalake/logger.h"
+#include "model/fundamental.h"
+#include "storage/segment_reader.h"
+#include "utils/lazy_abort_source.h"
+#include "utils/retry_chain_node.h"
+#include "utils/stream_provider.h"
+
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+
+#include <exception>
+
+namespace datalake {
+
+namespace {
+struct one_time_stream_provider : public stream_provider {
+    explicit one_time_stream_provider(ss::input_stream<char> s)
+      : _st(std::move(s)) {}
+    ss::input_stream<char> take_stream() override {
+        auto tmp = std::exchange(_st, std::nullopt);
+        return std::move(tmp.value());
+    }
+    ss::future<> close() override {
+        if (_st.has_value()) {
+            return _st->close().then([this] { _st = std::nullopt; });
+        }
+        return ss::now();
+    }
+    std::optional<ss::input_stream<char>> _st;
+};
+
+} // namespace
+
+// Modeled after cloud_storage::remote::upload_controller_snapshot
+ss::future<result<coordinator::data_file, data_writer_error>>
+cloud_uploader::upload_data_file(
+  coordinator::data_file local_file,
+  std::filesystem::path remote_filename,
+  retry_chain_node& rtc_parent,
+  lazy_abort_source& lazy_abort_source) {
+    std::filesystem::path remote_path = (_remote_directory / remote_filename);
+    ss::sstring remote_uri = fmt::format(
+      "s3://{}/{}", _bucket(), remote_path.string());
+    vlog(
+      datalake_log.info,
+      "Uploading {} to {}",
+      local_file.remote_path,
+      remote_uri);
+
+    ss::file file;
+    try {
+        file = co_await ss::open_file_dma(
+          local_file.remote_path, ss::open_flags::ro);
+    } catch (...) {
+        vlog(
+          datalake_log.error,
+          "Failed to open file for upload {}: {}",
+          local_file.remote_path,
+          std::current_exception());
+        co_return data_writer_error::file_io_error;
+    }
+    auto reset_stream = [&file] {
+        using provider_t = std::unique_ptr<stream_provider>;
+        ss::file_input_stream_options opts;
+        return ss::make_ready_future<provider_t>(
+          std::make_unique<one_time_stream_provider>(
+            ss::make_file_input_stream(file, opts)));
+    };
+
+    auto upload_result = co_await _cloud_io.upload_stream(
+      {
+        .bucket = _bucket,
+        .key = cloud_storage_clients::object_key(remote_path),
+        .parent_rtc = rtc_parent,
+      },
+      local_file.file_size_bytes,
+      reset_stream,
+      lazy_abort_source,
+      "datalake parquet upload",
+      std::nullopt);
+
+    if (upload_result == cloud_storage::upload_result::success) {
+        coordinator::data_file remote_file{
+          .remote_path = remote_uri,
+          .row_count = local_file.row_count,
+          .file_size_bytes = local_file.file_size_bytes,
+          .hour = local_file.hour,
+        };
+        co_return remote_file;
+    } else {
+        vlog(datalake_log.error, "Failed to upload: {}", upload_result);
+        co_return data_writer_error::cloud_io_error;
+    }
+}
+} // namespace datalake

--- a/src/v/datalake/cloud_uploader.cc
+++ b/src/v/datalake/cloud_uploader.cc
@@ -52,7 +52,7 @@ struct one_time_stream_provider : public stream_provider {
 // Modeled after cloud_storage::remote::upload_controller_snapshot
 ss::future<result<coordinator::data_file, data_writer_error>>
 cloud_uploader::upload_data_file(
-  coordinator::data_file local_file,
+  datalake::local_data_file local_file,
   std::filesystem::path remote_filename,
   retry_chain_node& rtc_parent,
   lazy_abort_source& lazy_abort_source) {
@@ -62,18 +62,18 @@ cloud_uploader::upload_data_file(
     vlog(
       datalake_log.info,
       "Uploading {} to {}",
-      local_file.remote_path,
+      local_file.local_path(),
       remote_uri);
 
     ss::file file;
     try {
         file = co_await ss::open_file_dma(
-          local_file.remote_path, ss::open_flags::ro);
+          local_file.local_path().string(), ss::open_flags::ro);
     } catch (...) {
         vlog(
           datalake_log.error,
           "Failed to open file for upload {}: {}",
-          local_file.remote_path,
+          local_file.local_path(),
           std::current_exception());
         co_return data_writer_error::file_io_error;
     }

--- a/src/v/datalake/cloud_uploader.h
+++ b/src/v/datalake/cloud_uploader.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_io/remote.h"
+#include "cloud_storage/types.h"
+#include "datalake/coordinator/data_file.h"
+#include "datalake/data_writer_interface.h"
+
+#include <memory>
+namespace datalake {
+class cloud_uploader {
+public:
+    cloud_uploader(
+      cloud_io::remote& io,
+      cloud_storage_clients::bucket_name bucket,
+      std::filesystem::path remote_directory)
+      : _cloud_io{io}
+      , _bucket{std::move(bucket)}
+      , _remote_directory{std::move(remote_directory)} {}
+
+    ss::future<result<coordinator::data_file, data_writer_error>>
+    upload_data_file(
+      coordinator::data_file local_file,
+      std::filesystem::path remote_filename,
+      retry_chain_node& rtc_parent,
+      lazy_abort_source& lazy_abort_source);
+
+private:
+    cloud_io::remote& _cloud_io;
+    cloud_storage_clients::bucket_name _bucket;
+    std::filesystem::path _remote_directory;
+};
+} // namespace datalake

--- a/src/v/datalake/cloud_uploader.h
+++ b/src/v/datalake/cloud_uploader.h
@@ -27,7 +27,7 @@ public:
 
     ss::future<result<coordinator::data_file, data_writer_error>>
     upload_data_file(
-      coordinator::data_file local_file,
+      datalake::local_data_file local_file,
       std::filesystem::path remote_filename,
       retry_chain_node& rtc_parent,
       lazy_abort_source& lazy_abort_source);

--- a/src/v/datalake/cloud_uploader.h
+++ b/src/v/datalake/cloud_uploader.h
@@ -47,5 +47,11 @@ private:
     cloud_io::remote& _cloud_io;
     cloud_storage_clients::bucket_name _bucket;
     std::filesystem::path _remote_directory;
+
+    ss::future<>
+    cleanup_local_files(chunked_vector<local_data_file> local_files);
+    ss::future<> cleanup_remote_files(
+      chunked_vector<coordinator::data_file> remote_files,
+      retry_chain_node& rtc_parent);
 };
 } // namespace datalake

--- a/src/v/datalake/cloud_uploader.h
+++ b/src/v/datalake/cloud_uploader.h
@@ -32,6 +32,17 @@ public:
       retry_chain_node& rtc_parent,
       lazy_abort_source& lazy_abort_source);
 
+    // Upload multiple data files.
+    // so that, in case of error, we know which files failed to upload.
+    // On success all files are uploaded and local files are removed.
+    // On failure, all files are removed.
+    ss::future<
+      result<chunked_vector<coordinator::data_file>, data_writer_error>>
+    upload_multiple(
+      chunked_vector<local_data_file> local_files,
+      retry_chain_node& rtc_parent,
+      lazy_abort_source& lazy_abort_source);
+
 private:
     cloud_io::remote& _cloud_io;
     cloud_storage_clients::bucket_name _bucket;

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -25,6 +25,7 @@ enum class data_writer_error {
     parquet_conversion_error,
     file_io_error,
     no_data,
+    cloud_io_error,
 };
 
 struct data_writer_error_category : std::error_category {
@@ -40,6 +41,8 @@ struct data_writer_error_category : std::error_category {
             return "File IO Error";
         case data_writer_error::no_data:
             return "No data";
+        case data_writer_error::cloud_io_error:
+            return "Cloud IO error";
         }
     }
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -53,7 +53,7 @@ struct local_data_file {
         return o;
     }
 
-    std::filesystem::path local_path() { return base_path / file_path; }
+    std::filesystem::path local_path() const { return base_path / file_path; }
 };
 
 struct data_writer_error_category : std::error_category {

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -46,6 +46,21 @@ rp_test(
   ARGS "-- -c 1"
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  USE_CWD
+  BINARY_NAME datalake_cloud_uploader
+  SOURCES cloud_uploader_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::cloud_io_utils
+    v::datalake
+    v::s3_imposter
+  LABELS datalake
+  ARGS "-- -c 1"
+)
+
 set(PROTO_FILES
   testdata/person.proto
   testdata/complex.proto

--- a/src/v/datalake/tests/batching_parquet_writer_test.cc
+++ b/src/v/datalake/tests/batching_parquet_writer_test.cc
@@ -26,13 +26,14 @@ namespace datalake {
 
 TEST(BatchingParquetWriterTest, WritesParquetFiles) {
     temporary_dir tmp_dir("batching_parquet_writer");
-    std::filesystem::path file_path = tmp_dir.get_path() / "test_file.parquet";
+    std::filesystem::path file_path = "test_file.parquet";
+    std::filesystem::path full_path = tmp_dir.get_path() / file_path;
     int num_rows = 1000;
 
     datalake::batching_parquet_writer writer(
       test_schema(iceberg::field_required::no), 500, 1000000);
 
-    writer.initialize(file_path).get0();
+    writer.initialize(tmp_dir.get_path(), file_path).get0();
 
     for (int i = 0; i < num_rows; i++) {
         auto data = iceberg::tests::make_struct_value(
@@ -44,13 +45,13 @@ TEST(BatchingParquetWriterTest, WritesParquetFiles) {
 
     auto result = writer.finish().get0();
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value().remote_path, file_path);
+    EXPECT_EQ(result.value().local_path(), full_path);
     EXPECT_EQ(result.value().row_count, num_rows);
-    auto true_file_size = std::filesystem::file_size(file_path);
+    auto true_file_size = std::filesystem::file_size(full_path);
     EXPECT_EQ(result.value().file_size_bytes, true_file_size);
 
     // Read the file and check the contents
-    auto reader = arrow::io::ReadableFile::Open(file_path).ValueUnsafe();
+    auto reader = arrow::io::ReadableFile::Open(full_path).ValueUnsafe();
 
     // Open Parquet file reader
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
@@ -69,13 +70,13 @@ TEST(BatchingParquetWriterTest, WritesParquetFiles) {
 
 TEST(BatchingParquetWriterTest, DeletesFileOnAbort) {
     temporary_dir tmp_dir("batching_parquet_writer");
-    std::filesystem::path file_path = tmp_dir.get_path() / "test_file.parquet";
+    std::filesystem::path file_path = "test_file.parquet";
     int num_rows = 1000;
 
     datalake::batching_parquet_writer writer(
       test_schema(iceberg::field_required::no), 500, 1000000);
 
-    writer.initialize(file_path).get0();
+    writer.initialize(tmp_dir.get_path(), file_path).get0();
 
     for (int i = 0; i < num_rows; i++) {
         auto data = iceberg::tests::make_struct_value(

--- a/src/v/datalake/tests/cloud_uploader_test.cc
+++ b/src/v/datalake/tests/cloud_uploader_test.cc
@@ -39,9 +39,9 @@ TEST_F(DatalakeCloudUploaderTest, UploadsData) {
 
     // Write out a test file
     temporary_dir tmp_dir("datalake_cloud_uploader_test");
-    std::filesystem::path file_path = tmp_dir.get_path() / "test_file";
+    std::string file_name = "test_file";
     std::string contents = "Hello world!";
-    std::ofstream ofile(file_path);
+    std::ofstream ofile(tmp_dir.get_path() / file_name);
     ofile << contents;
     ofile.close();
 
@@ -54,8 +54,9 @@ TEST_F(DatalakeCloudUploaderTest, UploadsData) {
     retry_chain_node retry(never_abort, 10s, 1s);
     lazy_abort_source always_continue{[]() { return std::nullopt; }};
 
-    datalake::coordinator::data_file local_file{
-      .remote_path = file_path.c_str(),
+    datalake::local_data_file local_file{
+      .base_path = tmp_dir.get_path().c_str(),
+      .file_path = file_name,
       .row_count = 1,
       .file_size_bytes = contents.size(),
     };
@@ -91,8 +92,9 @@ TEST_F(DatalakeCloudUploaderTest, HandlesMissingFiles) {
     retry_chain_node retry(never_abort, 10s, 1s);
     lazy_abort_source always_continue{[]() { return std::nullopt; }};
 
-    datalake::coordinator::data_file local_file{
-      .remote_path = file_path.c_str(),
+    datalake::local_data_file local_file{
+      .base_path = tmp_dir.get_path(),
+      .file_path = "test_file",
       .row_count = 1,
       .file_size_bytes = 100,
     };

--- a/src/v/datalake/tests/cloud_uploader_test.cc
+++ b/src/v/datalake/tests/cloud_uploader_test.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "data_file.h"
+#include "datalake/cloud_uploader.h"
+#include "datalake/data_writer_interface.h"
+#include "model/fundamental.h"
+#include "test_utils/tmp_dir.h"
+#include "utils/lazy_abort_source.h"
+#include "utils/retry_chain_node.h"
+
+#include <gtest/gtest.h>
+
+class DatalakeCloudUploaderTest
+  : public s3_imposter_fixture
+  , public ::testing::Test {
+public:
+    DatalakeCloudUploaderTest()
+      : sr(cloud_io::scoped_remote::create(/*pool_size=*/10, conf)) {
+        set_expectations_and_listen({});
+    }
+
+    auto& remote() { return sr->remote.local(); }
+
+    std::unique_ptr<cloud_io::scoped_remote> sr;
+};
+
+TEST_F(DatalakeCloudUploaderTest, UploadsData) {
+    using namespace std::chrono_literals;
+
+    // Write out a test file
+    temporary_dir tmp_dir("datalake_cloud_uploader_test");
+    std::filesystem::path file_path = tmp_dir.get_path() / "test_file";
+    std::string contents = "Hello world!";
+    std::ofstream ofile(file_path);
+    ofile << contents;
+    ofile.close();
+
+    // Upload it
+    datalake::cloud_uploader uploader(
+      remote(),
+      cloud_storage_clients::bucket_name{"test-bucket"},
+      "remote_test/remote_directory");
+    ss::abort_source never_abort;
+    retry_chain_node retry(never_abort, 10s, 1s);
+    lazy_abort_source always_continue{[]() { return std::nullopt; }};
+
+    datalake::coordinator::data_file local_file{
+      .remote_path = file_path.c_str(),
+      .row_count = 1,
+      .file_size_bytes = contents.size(),
+    };
+
+    auto cloud_result
+      = uploader
+          .upload_data_file(
+            local_file, "remote_test_file", retry, always_continue)
+          .get0();
+
+    EXPECT_TRUE(cloud_result.has_value());
+    EXPECT_EQ(
+      cloud_result.value().remote_path,
+      "s3://test-bucket/remote_test/remote_directory/remote_test_file");
+    EXPECT_EQ(cloud_result.value().file_size_bytes, local_file.file_size_bytes);
+    EXPECT_EQ(cloud_result.value().row_count, local_file.row_count);
+}
+
+TEST_F(DatalakeCloudUploaderTest, HandlesMissingFiles) {
+    using namespace std::chrono_literals;
+
+    // Don't write out a test file
+    temporary_dir tmp_dir("datalake_cloud_uploader_test");
+    std::filesystem::path file_path = tmp_dir.get_path() / "test_file";
+
+    // Upload it
+    datalake::cloud_uploader uploader(
+      remote(),
+      cloud_storage_clients::bucket_name{"test-bucket"},
+
+      "test/directory");
+    ss::abort_source never_abort;
+    retry_chain_node retry(never_abort, 10s, 1s);
+    lazy_abort_source always_continue{[]() { return std::nullopt; }};
+
+    datalake::coordinator::data_file local_file{
+      .remote_path = file_path.c_str(),
+      .row_count = 1,
+      .file_size_bytes = 100,
+    };
+
+    auto cloud_result
+      = uploader
+          .upload_data_file(
+            local_file, "remote_test_file", retry, always_continue)
+          .get0();
+
+    EXPECT_TRUE(cloud_result.has_error());
+}

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -36,15 +36,14 @@ public:
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<result<coordinator::data_file, data_writer_error>>
-    finish() override {
+    ss::future<result<local_data_file, data_writer_error>> finish() override {
         return ss::make_ready_future<
-          result<coordinator::data_file, data_writer_error>>(_result);
+          result<local_data_file, data_writer_error>>(_result);
     }
 
 private:
     iceberg::struct_type _schema;
-    coordinator::data_file _result;
+    local_data_file _result;
     bool _return_error;
 };
 class test_data_writer_factory : public data_writer_factory {


### PR DESCRIPTION
Adds a cloud_uploader that uploads local parquet files to s3.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none