### PR TITLE
rpk: Add License violations to `rpk cluster info`

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -160,9 +160,11 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *rpadmin.AdminAPI
 		}
 		if exists && y != nil {
 			actProfile := y.Profile(p.Name)
-			actProfile.LicenseCheck = licenseCheck
-			if err := y.Write(fs); err != nil {
-				zap.L().Sugar().Warnf("unable to save licensed enterprise features check cache to profile: %v", err)
+			if actProfile != nil {
+				actProfile.LicenseCheck = licenseCheck
+				if err := y.Write(fs); err != nil {
+					zap.L().Sugar().Warnf("unable to save licensed enterprise features check cache to profile: %v", err)
+				}
 			}
 		}
 	}

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -135,8 +135,8 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *rpadmin.AdminAPI
 	// We only do a check if:
 	//   1. LicenseCheck == nil: never checked before OR last check was in
 	//      violation. (we only save successful responses).
-	//   2. LicenseStatus was last checked more than 7 days ago.
-	if p.LicenseCheck == nil || p.LicenseCheck != nil && time.Unix(p.LicenseCheck.LastUpdate, 0).AddDate(0, 0, 7).Before(time.Now()) {
+	//   2. LicenseStatus was last checked more than 1 hour ago.
+	if p.LicenseCheck == nil || p.LicenseCheck != nil && time.Unix(p.LicenseCheck.LastUpdate, 0).Add(1*time.Hour).Before(time.Now()) {
 		resp, err := cl.GetEnterpriseFeatures(ctx)
 		if err != nil {
 			zap.L().Sugar().Warnf("unable to check licensed enterprise features in the cluster: %v", err)
@@ -152,7 +152,7 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *rpadmin.AdminAPI
 					features = append(features, f.Name)
 				}
 			}
-			msg = fmt.Sprintf("A Redpanda Enterprise Edition license is required to use enterprise features: %v. For more information, see https://docs.redpanda.com/current/get-started/licenses.", features)
+			msg = fmt.Sprintf("\nWARNING: The following Enterprise features are being used in your Redpanda cluster: %v. These features require a license. To get a license, contact us at https://www.redpanda.com/contact. For more information, see https://docs.redpanda.com/current/get-started/licenses/#redpanda-enterprise-edition\n", features)
 		} else {
 			licenseCheck = &config.LicenseStatusCache{
 				LastUpdate: time.Now().Unix(),

--- a/src/go/rpk/pkg/adminapi/admin_test.go
+++ b/src/go/rpk/pkg/adminapi/admin_test.go
@@ -29,7 +29,7 @@ func Test_licenseFeatureChecks(t *testing.T) {
 		},
 		{
 			name: "license ok, cache valid",
-			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().Add(20 * time.Minute).Unix()}},
 			checkCache: func(t *testing.T, before int64, after int64) {
 				// If the cache was valid, last update shouldn't have changed.
 				require.Equal(t, before, after)
@@ -39,7 +39,7 @@ func Test_licenseFeatureChecks(t *testing.T) {
 		},
 		{
 			name: "license ok, old cache",
-			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 15 days
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 1 hour
 			checkCache: func(t *testing.T, before int64, after int64) {
 				// Date should be updated.
 				afterT := time.Unix(after, 0)
@@ -52,19 +52,19 @@ func Test_licenseFeatureChecks(t *testing.T) {
 			name:         "inViolation, first time call",
 			prof:         &config.RpkProfile{},
 			responseCase: "inViolation",
-			expContain:   "A Redpanda Enterprise Edition license is required",
+			expContain:   "These features require a license",
 		},
 		{
 			name:         "inViolation, expired last check",
 			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}},
 			responseCase: "inViolation",
-			expContain:   "A Redpanda Enterprise Edition license is required t",
+			expContain:   "These features require a license",
 		},
 		{
 			// Edge case when the license expires but the last check was less
-			// than 15 days ago.
+			// than 1 hour ago.
 			name:         "inViolation, cache still valid",
-			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().Add(30 * time.Minute).Unix()}},
 			responseCase: "inViolation",
 			// In this case, even if the license is in violation, rpk won't
 			// reach the Admin API because the last check was under 15 days.

--- a/src/go/rpk/pkg/cli/cluster/license/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/license/BUILD
@@ -16,5 +16,6 @@ go_library(
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -133,7 +133,6 @@ func printTextLicenseInfo(resp infoResponse) {
 		if *resp.Expired {
 			tw.Print("License expired:", *resp.Expired)
 		}
-		// need to defer as we flush the table below.
 		checkLicenseExpiry(resp.ExpiresUnix)
 	}
 	out.Section("LICENSE INFORMATION")

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -11,27 +11,35 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 type infoResponse struct {
-	Organization string `json:"organization" yaml:"organization"`
-	Type         string `json:"type" yaml:"type"`
-	Expires      string `json:"expires" yaml:"expires"`
-	ExpiresUnix  int64  `json:"expires_unix" yaml:"expires_unix"`
-	Checksum     string `json:"checksum_sha256,omitempty" yaml:"checksum_sha256,omitempty"`
-	Expired      bool   `json:"license_expired" yaml:"license_expired"`
+	LicenseStatus      string   `json:"license_status" yaml:"license_status"`
+	Organization       string   `json:"organization,omitempty" yaml:"organization,omitempty"`
+	Type               string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Expires            string   `json:"expires,omitempty" yaml:"expires,omitempty"`
+	ExpiresUnix        int64    `json:"expires_unix,omitempty" yaml:"expires_unix,omitempty"`
+	Checksum           string   `json:"checksum_sha256,omitempty" yaml:"checksum_sha256,omitempty"`
+	Expired            *bool    `json:"license_expired,omitempty" yaml:"license_expired,omitempty"`
+	Violation          bool     `json:"license_violation" yaml:"license_violation"`
+	EnterpriseFeatures []string `json:"enterprise_features_in_use" yaml:"enterprise_features_in_use"`
 }
 
 func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "info",
-		Args:  cobra.ExactArgs(0),
-		Short: "Retrieve license information",
+		Use:     "info",
+		Aliases: []string{"status"},
+		Args:    cobra.ExactArgs(0),
+		Short:   "Retrieve license information",
 		Long: `Retrieve license information:
 
     Organization:    Organization the license was generated for.
     Type:            Type of license: free, enterprise, etc.
-    Expires:         Expiration date of the license
+    Expires:         Expiration date of the license.
+    License Status:  Status of the loaded license (valid, expired, not_present).
+    Violation:       Whether the cluster is using enterprise features without
+                     a valid license.
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
@@ -47,10 +55,12 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			info, err := cl.GetLicenseInfo(cmd.Context())
 			out.MaybeDie(err, "unable to retrieve license info: %v", err)
-			if !info.Loaded {
-				out.Die("this cluster is missing a license")
+
+			features, err := cl.GetEnterpriseFeatures(cmd.Context())
+			if err != nil {
+				zap.L().Sugar().Warnf("unable to retrieve enterprise features: %v; information will be incomplete; is Redpanda up to date?", err)
 			}
-			err = printLicenseInfo(f, info.Properties)
+			err = printLicenseInfo(f, info, &features)
 			out.MaybeDieErr(err)
 		},
 	}
@@ -58,17 +68,8 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return cmd
 }
 
-func printLicenseInfo(f config.OutFormatter, props rpadmin.LicenseProperties) error {
-	ut := time.Unix(props.Expires, 0)
-	isExpired := ut.Before(time.Now())
-	resp := infoResponse{
-		Organization: props.Organization,
-		Type:         props.Type,
-		Expires:      ut.Format("Jan 2 2006"),
-		ExpiresUnix:  props.Expires,
-		Checksum:     props.Checksum,
-		Expired:      isExpired,
-	}
+func printLicenseInfo(f config.OutFormatter, license rpadmin.License, features *rpadmin.EnterpriseFeaturesResponse) error {
+	resp := buildInfoResponse(license, features)
 	if isText, _, formatted, err := f.Format(resp); !isText {
 		if err != nil {
 			return fmt.Errorf("unable to print license info in the required format %q: %v", f.Kind, err)
@@ -76,22 +77,74 @@ func printLicenseInfo(f config.OutFormatter, props rpadmin.LicenseProperties) er
 		fmt.Println(formatted)
 		return nil
 	}
-
-	out.Section("LICENSE INFORMATION")
-	licenseFormat := `Organization:      %v
-Type:              %v
-Expires:           %v
-`
-	if isExpired {
-		licenseFormat += "License Expired:   true\n"
-	}
-	fmt.Printf(licenseFormat, resp.Organization, resp.Type, resp.Expires)
-
-	// Warn the user if the License is about to expire (<30 days left).
-	diff := time.Until(ut)
-	daysLeft := int(diff.Hours() / 24)
-	if daysLeft < 30 && daysLeft >= 0 {
-		fmt.Fprintln(os.Stderr, "warning: your license will expire soon")
-	}
+	printTextLicenseInfo(resp)
 	return nil
+}
+
+func buildInfoResponse(license rpadmin.License, features *rpadmin.EnterpriseFeaturesResponse) infoResponse {
+	var resp infoResponse
+	if license.Loaded {
+		resp = buildLicenseProperties(license)
+	}
+	if features != nil {
+		resp = buildFeatureViolations(resp, features)
+	}
+	return resp
+}
+
+func buildLicenseProperties(license rpadmin.License) infoResponse {
+	ut := time.Unix(license.Properties.Expires, 0)
+	isExpired := ut.Before(time.Now())
+	return infoResponse{
+		Organization: license.Properties.Organization,
+		Type:         license.Properties.Type,
+		Expires:      ut.Format("Jan 2 2006"),
+		ExpiresUnix:  license.Properties.Expires,
+		Checksum:     license.Properties.Checksum,
+		Expired:      &isExpired,
+	}
+}
+
+func buildFeatureViolations(resp infoResponse, features *rpadmin.EnterpriseFeaturesResponse) infoResponse {
+	resp.Violation = features.Violation
+	resp.LicenseStatus = string(features.LicenseStatus)
+	resp.EnterpriseFeatures = []string{}
+	for _, feat := range features.Features {
+		if feat.Enabled {
+			resp.EnterpriseFeatures = append(resp.EnterpriseFeatures, feat.Name)
+		}
+	}
+	return resp
+}
+
+func printTextLicenseInfo(resp infoResponse) {
+	tw := out.NewTable()
+	if resp.LicenseStatus != "" {
+		tw.Print("License status:", resp.LicenseStatus)
+		tw.Print("License violation:", resp.Violation)
+	}
+	if len(resp.EnterpriseFeatures) > 0 {
+		tw.Print("Enterprise features in use:", resp.EnterpriseFeatures)
+	}
+	if resp.Organization != "" {
+		tw.Print("Organization:", resp.Organization)
+		tw.Print("Type:", resp.Type)
+		tw.Print("Expires:", resp.Expires)
+		if *resp.Expired {
+			tw.Print("License expired:", *resp.Expired)
+		}
+		// need to defer as we flush the table below.
+		checkLicenseExpiry(resp.ExpiresUnix)
+	}
+	out.Section("LICENSE INFORMATION")
+	tw.Flush()
+}
+
+func checkLicenseExpiry(expiresUnix int64) {
+	ut := time.Unix(expiresUnix, 0)
+	daysLeft := int(time.Until(ut).Hours() / 24)
+
+	if daysLeft < 30 && !ut.Before(time.Now()) {
+		fmt.Fprintf(os.Stderr, "WARNING: your license will expire soon.\n\n")
+	}
 }

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -279,6 +279,9 @@ class RpkClusterTest(RedpandaTest):
             '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf',
             'expires_unix': 4813252273,
             'license_expired': False,
+            'license_status': 'valid',
+            'license_violation': False,
+            'enterprise_features_in_use': [],
         }
         result = json.loads(rp_license)
         assert expected_license == result, result


### PR DESCRIPTION
This PR adds the output of `/v1/features/enterprise` to `rpk cluster license info`. It also changes the warning message and the cache to be invalidated after 1 hour:

### Examples
**License loaded:**
```
WARNING: your license will expire soon.

LICENSE INFORMATION
===================
License status:              valid
License violation:           false
Enterprise features in use:  [partition_auto_balancing_continuous]
Organization:                Devex
Type:                        enterprise
Expires:                     Oct 11 2024
```
**No License, Violation:**
```
LICENSE INFORMATION
===================
License status:              not_present
License violation:           true
Enterprise features in use:  [partition_auto_balancing_continuous]
```
**No License, No Violation:**
```
LICENSE INFORMATION
===================
License status:          not_present
License violation:       false
```

**Expired License with new warning message**
```
WARNING: The following Enterprise features are being used in your Redpanda cluster: [partition_auto_balancing_continuous]. These features require a license. To get a license, contact us at https://www.redpanda.com/contact. For more information, see https://docs.redpanda.com/current/get-started/licenses/#redpanda-enterprise-edition

LICENSE INFORMATION
===================
License status:              expired
License violation:           true
Enterprise features in use:  [partition_auto_balancing_continuous]
Organization:                Devex
Type:                        enterprise
Expires:                     Oct 11 2024
License expired:             true
```

**JSON format**
```
{"license_status":"valid","organization":"Devex","type":"enterprise","expires":"Oct 17 2024","expires_unix":1729190366,"checksum_sha256":"382c69f94cbdebcab3da32c69f94cbdebcab62152c69f94cbdebcc213ac4c08","license_expired":false,"license_violation":false,"enterprise_features_in_use":["partition_auto_balancing_continuous"]}
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* rpk cluster license info: now includes more information about your license status and possible violations.