### PR TITLE
iceberg: serialize path style URIs in metadata

### DIFF
--- a/src/v/iceberg/manifest_io.h
+++ b/src/v/iceberg/manifest_io.h
@@ -36,13 +36,29 @@ public:
 
     ss::future<checked<manifest, metadata_io::errc>> download_manifest(
       const manifest_path& path, const partition_key_type& pk_type);
+    ss::future<checked<manifest, metadata_io::errc>> download_manifest_uri(
+      const ss::sstring& uri, const partition_key_type& pk_type);
+
     ss::future<checked<manifest_list, metadata_io::errc>>
     download_manifest_list(const manifest_list_path& path);
+    ss::future<checked<manifest_list, metadata_io::errc>>
+    download_manifest_list_uri(const ss::sstring& uri);
 
     ss::future<checked<size_t, metadata_io::errc>>
     upload_manifest(const manifest_path& path, const manifest&);
     ss::future<checked<size_t, metadata_io::errc>>
     upload_manifest_list(const manifest_list_path& path, const manifest_list&);
+
+    ss::sstring to_uri(const std::filesystem::path& p) const;
+
+private:
+    // TODO: make URIs less fragile with an explicit type?
+    // E.g. s3://bucket/
+    ss::sstring uri_base() const;
+
+    // E.g. s3://bucket/path/to/file => path/to/file
+    // Leaves the path as is if it doesn't match the expected URI base.
+    std::filesystem::path from_uri(const ss::sstring& s) const;
 };
 
 } // namespace iceberg

--- a/src/v/iceberg/metadata_io.h
+++ b/src/v/iceberg/metadata_io.h
@@ -179,7 +179,7 @@ protected:
         }
     }
 
-private:
+protected:
     cloud_io::remote& io_;
     const cloud_storage_clients::bucket_name bucket_;
 };

--- a/src/v/iceberg/metadata_query.cc
+++ b/src/v/iceberg/metadata_query.cc
@@ -186,8 +186,8 @@ do_execute_query(
             collector.collect(s);
             continue;
         }
-        auto m_list_result = co_await io.download_manifest_list(
-          manifest_list_path{s.manifest_list_path});
+        auto m_list_result = co_await io.download_manifest_list_uri(
+          s.manifest_list_path);
 
         if (m_list_result.has_error()) {
             vlog(
@@ -217,9 +217,8 @@ do_execute_query(
             if (pk_result.has_error()) {
                 co_return pk_result.error();
             }
-            auto m_result = co_await io.download_manifest(
-              manifest_path(manifest_file.manifest_path),
-              std::move(pk_result.value()));
+            auto m_result = co_await io.download_manifest_uri(
+              manifest_file.manifest_path, std::move(pk_result.value()));
 
             if (m_result.has_error()) {
                 vlog(

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -125,9 +125,8 @@ TEST_F(MergeAppendActionTest, TestMergeByCount) {
 
         auto latest_mlist_path
           = table.snapshots.value().back().manifest_list_path;
-        auto latest_mlist = io.download_manifest_list(
-                                manifest_list_path{latest_mlist_path})
-                              .get();
+        auto latest_mlist
+          = io.download_manifest_list_uri(latest_mlist_path).get();
         ASSERT_TRUE(latest_mlist.has_value());
         ASSERT_EQ(latest_mlist.value().files.size(), expected_manifests);
     }
@@ -144,8 +143,7 @@ TEST_F(MergeAppendActionTest, TestMergeByCount) {
 
     // Validate that the latest snapshot indeed contains a single manifest.
     auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
-    auto latest_mlist
-      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+    auto latest_mlist = io.download_manifest_list_uri(latest_mlist_path).get();
     ASSERT_TRUE(latest_mlist.has_value());
     ASSERT_EQ(latest_mlist.value().files.size(), 1);
     const auto& merged_mfile = latest_mlist.value().files[0];
@@ -186,9 +184,8 @@ TEST_F(MergeAppendActionTest, TestMergeByBytes) {
 
         auto latest_mlist_path
           = table.snapshots.value().back().manifest_list_path;
-        auto latest_mlist = io.download_manifest_list(
-                                manifest_list_path{latest_mlist_path})
-                              .get();
+        auto latest_mlist
+          = io.download_manifest_list_uri(latest_mlist_path).get();
         ASSERT_TRUE(latest_mlist.has_value());
         ASSERT_EQ(latest_mlist.value().files.size(), expected_manifests);
     }
@@ -207,8 +204,7 @@ TEST_F(MergeAppendActionTest, TestMergeByBytes) {
     // - the one containing 8 merged 1MB paths
     // - the two we added that weren't merged
     auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
-    auto latest_mlist
-      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+    auto latest_mlist = io.download_manifest_list_uri(latest_mlist_path).get();
     ASSERT_TRUE(latest_mlist.has_value());
     ASSERT_EQ(latest_mlist.value().files.size(), 3);
 
@@ -296,9 +292,8 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
         // manifest (no merge yet).
         auto latest_mlist_path
           = table.snapshots.value().back().manifest_list_path;
-        auto latest_mlist_res = io.download_manifest_list(
-                                    manifest_list_path{latest_mlist_path})
-                                  .get();
+        auto latest_mlist_res
+          = io.download_manifest_list_uri(latest_mlist_path).get();
         ASSERT_TRUE(latest_mlist_res.has_value());
         ASSERT_EQ(expected_manifests, latest_mlist_res.value().files.size());
 
@@ -325,7 +320,7 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
     ASSERT_FALSE(res.has_error()) << res.error();
     auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
     auto latest_mlist_res
-      = io.download_manifest_list(manifest_list_path{latest_mlist_path}).get();
+      = io.download_manifest_list_uri(latest_mlist_path).get();
     ASSERT_TRUE(latest_mlist_res.has_value());
     ASSERT_EQ(1, latest_mlist_res.value().files.size());
 

--- a/src/v/iceberg/tests/metadata_query_test.cc
+++ b/src/v/iceberg/tests/metadata_query_test.cc
@@ -114,8 +114,8 @@ public:
         chunked_vector<iceberg::manifest_file> files;
 
         for (auto& s : *table.snapshots) {
-            auto m_list = co_await io.download_manifest_list(
-              manifest_list_path(s.manifest_list_path));
+            auto m_list = co_await io.download_manifest_list_uri(
+              s.manifest_list_path);
             for (auto& f : m_list.assume_value().files) {
                 if (!paths.contains(f.manifest_path)) {
                     paths.emplace(f.manifest_path);
@@ -136,8 +136,8 @@ public:
         chunked_vector<iceberg::manifest> manifests;
         auto files = co_await collect_all_manifest_files(table);
         for (auto& f : files) {
-            auto m = co_await io.download_manifest(
-              manifest_path(f.manifest_path), make_partition_key_type(table));
+            auto m = co_await io.download_manifest_uri(
+              f.manifest_path, make_partition_key_type(table));
             manifests.push_back(std::move(m.assume_value()));
         }
         co_return manifests;


### PR DESCRIPTION
In general, Iceberg tables use a configurable path style. This is just a first step towards that: as is, the raw object locations in the metadata aren't readable by systems like Spark.

Updates manifest_io and its callers to use path style URIs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
