### PR TITLE
Fix an oversized alloc in cluster_config schema endpoint

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -171,7 +171,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "Lbym0V8QC5CgB4Ja6cI2QZLO4RHkHXMREUETEHvWCkc=",
+        "bzlTransitiveDigest": "msutg4GYJql2xCaEjuA/wNiTJxwUfXKpxHGAEtRs9qM=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -312,9 +312,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "948e5f8ad769114a4721c81d5829f675ac51482e4a9a106d57ab313104308666",
-              "strip_prefix": "seastar-4350d7960ec5ac8a1cf9274316c8f1ab1896d24e",
-              "url": "https://github.com/redpanda-data/seastar/archive/4350d7960ec5ac8a1cf9274316c8f1ab1896d24e.tar.gz",
+              "sha256": "6451633c3a4c0422845f441994fe87d1f5a3caabf3e9d4abec733e47bfbed896",
+              "strip_prefix": "seastar-4a3406ce4071f0bc472233c4c669582ca527db89",
+              "url": "https://github.com/redpanda-data/seastar/archive/4a3406ce4071f0bc472233c4c669582ca527db89.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:seastar-fortify-source.patch"
               ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,9 +167,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "948e5f8ad769114a4721c81d5829f675ac51482e4a9a106d57ab313104308666",
-        strip_prefix = "seastar-4350d7960ec5ac8a1cf9274316c8f1ab1896d24e",
-        url = "https://github.com/redpanda-data/seastar/archive/4350d7960ec5ac8a1cf9274316c8f1ab1896d24e.tar.gz",
+        sha256 = "6451633c3a4c0422845f441994fe87d1f5a3caabf3e9d4abec733e47bfbed896",
+        strip_prefix = "seastar-4a3406ce4071f0bc472233c4c669582ca527db89",
+        url = "https://github.com/redpanda-data/seastar/archive/4a3406ce4071f0bc472233c4c669582ca527db89.tar.gz",
         patches = ["//bazel/thirdparty:seastar-fortify-source.patch"],
         patch_args = ["-p1"],
     )

--- a/src/v/redpanda/admin/cluster_config_schema_util.cc
+++ b/src/v/redpanda/admin/cluster_config_schema_util.cc
@@ -12,6 +12,8 @@
 
 #include "redpanda/admin/api-doc/cluster_config.json.hh"
 
+#include <seastar/json/json_elements.hh>
+
 // This is factored out to make it a separate binary that can generate schema
 // without bringing up a redpanda cluster. Down stream tools can make use of
 // this for config generation.
@@ -81,5 +83,5 @@ util::generate_json_schema(const config::configuration& conf) {
 
     std::map<ss::sstring, property_map> response = {
       {ss::sstring("properties"), std::move(properties)}};
-    return ss::json::json_return_type(std::move(response));
+    return ss::json::stream_object(std::move(response));
 }


### PR DESCRIPTION
After some fixes to the seastar json encoder we can now use
`ss::json::stream_object` avoiding oversized allocs that get triggered by using
plain `ss::json::json_return_type`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


