### PR TITLE
[CORE-7803] Audit Log Manager: Refactoring - use `client::produce_record_batch` and reduce retries.

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -97,3 +97,28 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "record_batcher",
+    srcs = [
+        "logger.h",
+        "record_batcher.cc",
+    ],
+    hdrs = [
+        "record_batcher.h",
+    ],
+    implementation_deps = [
+        "//src/v/storage:record_batch_builder",
+        "//src/v/utils:human",
+        "//src/v/utils:truncating_logger",
+        "@abseil-cpp//absl/algorithm:container",
+    ],
+    include_prefix = "kafka/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -1,4 +1,15 @@
 v_cc_library(
+  NAME kc_record_batcher
+  HDRS
+    record_batcher.h
+  SRCS
+    record_batcher.cc
+  DEPS
+    v::model
+    v::storage
+)
+
+v_cc_library(
   NAME kafka_client
   SRCS
     assignment_plans.cc

--- a/src/v/kafka/client/record_batcher.cc
+++ b/src/v/kafka/client/record_batcher.cc
@@ -17,7 +17,7 @@
 #include "storage/record_batch_builder.h"
 #include "utils/human.h"
 
-namespace transform::logging {
+namespace kafka::client {
 
 namespace detail {
 class batcher_impl {
@@ -47,7 +47,7 @@ public:
         size_t record_size = record.size_bytes();
         if (record_size > max_records_bytes()) {
             vlog(
-              tlg_log.info,
+              kclog.info,
               "Dropped record: size exceeds configured batch max "
               "size: {} > {}",
               human::bytes{static_cast<double>(record_size)},
@@ -92,14 +92,14 @@ private:
                     - static_cast<int64_t>(batch.size_bytes());
         if (diff < 0) {
             vlog(
-              tlg_log.debug,
+              kclog.debug,
               "Underestimaged batch size {} - {} = {}",
               human::bytes{static_cast<double>(batch_size_bytes())},
               human::bytes{static_cast<double>(batch.size_bytes())},
               diff);
         } else {
             vlog(
-              tlg_log.trace,
+              kclog.trace,
               "Building record batch. Actual size: {} (estimated: {}, err:{})",
               human::bytes{static_cast<double>(batch.size_bytes())},
               human::bytes{static_cast<double>(batch_size_bytes())},
@@ -140,4 +140,4 @@ ss::chunked_fifo<model::record_batch> record_batcher::finish() {
     return _impl->finish();
 }
 
-} // namespace transform::logging
+} // namespace kafka::client

--- a/src/v/kafka/client/record_batcher.h
+++ b/src/v/kafka/client/record_batcher.h
@@ -11,9 +11,10 @@
 
 #pragma once
 
+#include "bytes/iobuf.h"
 #include "model/record.h"
 
-namespace transform::logging {
+namespace kafka::client {
 
 namespace detail {
 class batcher_impl;
@@ -59,4 +60,4 @@ public:
 private:
     std::unique_ptr<detail::batcher_impl> _impl;
 };
-} // namespace transform::logging
+} // namespace kafka::client

--- a/src/v/kafka/client/record_batcher.h
+++ b/src/v/kafka/client/record_batcher.h
@@ -14,6 +14,8 @@
 #include "bytes/iobuf.h"
 #include "model/record.h"
 
+#include <optional>
+
 namespace kafka::client {
 
 namespace detail {
@@ -40,10 +42,16 @@ public:
     record_batcher& operator=(record_batcher&&) = delete;
 
     /**
+     * Construct a batch from a single record
+     */
+    model::record_batch
+    make_batch_of_one(std::optional<iobuf> k, std::optional<iobuf> v);
+
+    /**
      * Add a record to the current batch, possibly rolling over to a
      * new batch if the serialized record would exceed batch_max_bytes.
      */
-    void append(iobuf k, iobuf v);
+    void append(std::optional<iobuf> k, std::optional<iobuf> v);
 
     /**
      * Return the total size in bytes of all record_batches, exclusive of any

--- a/src/v/kafka/client/record_batcher.h
+++ b/src/v/kafka/client/record_batcher.h
@@ -14,6 +14,8 @@
 #include "bytes/iobuf.h"
 #include "model/record.h"
 
+#include <seastar/util/log.hh>
+
 #include <optional>
 
 namespace kafka::client {
@@ -34,7 +36,8 @@ class batcher_impl;
 class record_batcher {
 public:
     record_batcher() = delete;
-    explicit record_batcher(size_t batch_max_bytes);
+    explicit record_batcher(
+      size_t batch_max_bytes, std::optional<ss::logger*> log = std::nullopt);
     ~record_batcher();
     record_batcher(const record_batcher&) = delete;
     record_batcher& operator=(const record_batcher&) = delete;

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -1,9 +1,15 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "utils",
+    srcs = [
+        "utils.cc",
+    ],
     hdrs = [
         "utils.h",
+    ],
+    implementation_deps = [
+        "//src/v/random:generators",
     ],
     include_prefix = "kafka/client/test",
     deps = [
@@ -98,5 +104,20 @@ redpanda_cc_btest(
         "@boost//:test",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "record_batcher_test",
+    timeout = "short",
+    srcs = ["record_batcher_test.cc"],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        ":utils",
+        "//src/v/base",
+        "//src/v/kafka/client:record_batcher",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -22,6 +22,29 @@ rp_test(
   LABELS kafka
 )
 
+v_cc_library(
+  NAME kc_test_utils
+  HDRS
+    utils.h
+  SRCS
+    utils.cc
+  DEPS
+    v::utils
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_kc_record_batcher
+  SOURCES
+    record_batcher_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::kc_record_batcher
+    v::kc_test_utils
+  LABELS kafka
+)
+
 rp_test(
   FIXTURE_TEST
   BINARY_NAME kafka_client

--- a/src/v/kafka/client/test/record_batcher_test.cc
+++ b/src/v/kafka/client/test/record_batcher_test.cc
@@ -10,12 +10,12 @@
  */
 
 #include "base/units.h"
-#include "transform/logging/record_batcher.h"
-#include "transform/logging/tests/utils.h"
+#include "kafka/client/record_batcher.h"
+#include "kafka/client/test/utils.h"
 
 #include <gtest/gtest.h>
 
-namespace transform::logging {
+namespace kafka::client {
 
 TEST(TransformLoggingRecordBatcherTest, TestMaxBytes) {
     constexpr size_t batch_max_bytes = 1_KiB;
@@ -64,4 +64,4 @@ TEST(TransformLoggingRecordBatcherTest, TestReuseBatcher) {
     }
 }
 
-} // namespace transform::logging
+} // namespace kafka::client

--- a/src/v/kafka/client/test/utils.cc
+++ b/src/v/kafka/client/test/utils.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/test/utils.h"
+
+#include "random/generators.h"
+
+namespace kafka::client::testing {
+
+iobuf random_length_iobuf(size_t data_max) {
+    assert(data_max > 0);
+    auto sz = random_generators::get_int(size_t{1}, data_max);
+    auto data = random_generators::gen_alphanum_string(sz);
+    iobuf b;
+    b.append(data.data(), data.size());
+    return b;
+}
+
+} // namespace kafka::client::testing

--- a/src/v/kafka/client/test/utils.h
+++ b/src/v/kafka/client/test/utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/iobuf.h"
 #include "reflection/adl.h"
 #include "storage/record_batch_builder.h"
 
@@ -22,3 +23,7 @@ inline model::record_batch make_batch(model::offset offset, size_t count) {
     }
     return std::move(builder).build();
 }
+
+namespace kafka::client::testing {
+iobuf random_length_iobuf(size_t data_max);
+} // namespace kafka::client::testing

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1838,7 +1838,11 @@ void application::wire_up_redpanda_services(
 
     syschecks::systemd_message("Creating auditing subsystem").get();
     construct_service(
-      audit_mgr, controller.get(), std::ref(*_audit_log_client_config))
+      audit_mgr,
+      node_id,
+      controller.get(),
+      std::ref(*_audit_log_client_config),
+      &metadata_cache)
       .get();
 
     syschecks::systemd_message("Creating metadata dissemination service").get();

--- a/src/v/security/audit/BUILD
+++ b/src/v/security/audit/BUILD
@@ -35,6 +35,10 @@ redpanda_cc_library(
         "schemas/utils.h",
         "types.h",
     ],
+    implementation_deps = [
+        "//src/v/kafka/client:record_batcher",
+        "@abseil-cpp//absl/algorithm:container",
+    ],
     include_prefix = "security/audit",
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/security/audit/CMakeLists.txt
+++ b/src/v/security/audit/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
     v::bytes
     v::utils
     v::config
+    v::cluster
 )
 
 add_subdirectory(schemas)

--- a/src/v/security/audit/CMakeLists.txt
+++ b/src/v/security/audit/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     v::utils
     v::config
     v::cluster
+    v::kc_record_batcher
 )
 
 add_subdirectory(schemas)

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -12,6 +12,7 @@
 
 #include "cluster/controller.h"
 #include "cluster/ephemeral_credential_frontend.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/security_frontend.h"
 #include "config/configuration.h"
 #include "kafka/client/client.h"
@@ -19,6 +20,7 @@
 #include "kafka/protocol/produce.h"
 #include "kafka/protocol/schemata/produce_response.h"
 #include "kafka/protocol/topic_properties.h"
+#include "model/fundamental.h"
 #include "model/namespace.h"
 #include "security/acl.h"
 #include "security/audit/client_probe.h"
@@ -674,7 +676,10 @@ bool audit_log_manager::recovery_mode_enabled() noexcept {
 }
 
 audit_log_manager::audit_log_manager(
-  cluster::controller* controller, kafka::client::configuration& client_config)
+  model::node_id self,
+  cluster::controller* controller,
+  kafka::client::configuration& client_config,
+  ss::sharded<cluster::metadata_cache>* metadata_cache)
   : _audit_enabled(config::shard_local_cfg().audit_enabled.bind())
   , _queue_drain_interval_ms(
       config::shard_local_cfg().audit_queue_drain_interval_ms.bind())
@@ -687,8 +692,10 @@ audit_log_manager::audit_log_manager(
   , _audit_excluded_principals_binding(
       config::shard_local_cfg().audit_excluded_principals.bind())
   , _queue_bytes_sem(_max_queue_size_bytes, "s/audit/buffer")
+  , _self(self)
   , _controller(controller)
-  , _config(client_config) {
+  , _config(client_config)
+  , _metadata_cache(metadata_cache) {
     if (ss::this_shard_id() == client_shard_id) {
         _sink = std::make_unique<audit_sink>(this, controller, client_config);
     }

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -10,6 +10,7 @@
 
 #include "security/audit/audit_log_manager.h"
 
+#include "base/outcome.h"
 #include "cluster/controller.h"
 #include "cluster/ephemeral_credential_frontend.h"
 #include "cluster/metadata_cache.h"
@@ -17,6 +18,7 @@
 #include "config/configuration.h"
 #include "kafka/client/client.h"
 #include "kafka/client/config_utils.h"
+#include "kafka/client/record_batcher.h"
 #include "kafka/protocol/produce.h"
 #include "kafka/protocol/schemata/produce_response.h"
 #include "kafka/protocol/topic_properties.h"
@@ -32,14 +34,25 @@
 #include "storage/parser_utils.h"
 #include "utils/retry.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+
+#include <absl/algorithm/container.h>
 
 #include <memory>
 #include <optional>
 
 namespace security::audit {
+
+namespace {
+struct partition_batch {
+    model::partition_id pid;
+    model::record_batch batch;
+    std::optional<ssx::semaphore_units> send_units{};
+};
+} // namespace
 
 static constexpr std::string_view subsystem_name = "Audit System";
 
@@ -88,10 +101,9 @@ public:
     /// kafka::config::produce_shutdown_delay_ms to complete
     ss::future<> shutdown();
 
-    /// Produces to the audit topic, internal partitioner assigns partitions
-    /// to the batches provided. Blocks if semaphore is exhausted.
-    ss::future<>
-    produce(std::vector<kafka::client::record_essence>, audit_probe&);
+    /// Produces to the audit topic partition specified with each batch.
+    /// Blocks if semaphore is exhausted.
+    ss::future<> produce(chunked_vector<partition_batch>, audit_probe&);
 
     /// Returns true if the configuration phase has completed which includes:
     /// - Connecting to the broker(s) w/ ephemeral creds
@@ -100,8 +112,8 @@ public:
     bool is_initialized() const { return _is_initialized; }
 
 private:
-    ss::future<> do_produce(
-      std::vector<kafka::client::record_essence> records, audit_probe& probe);
+    ss::future<>
+    do_produce(model::record_batch, model::partition_id, audit_probe&);
     ss::future<> update_status(kafka::error_code);
     ss::future<> update_status(kafka::produce_response);
     ss::future<> configure();
@@ -147,7 +159,7 @@ public:
     /// Produce to the audit topic within the context of the internal locks,
     /// ensuring toggling of the audit master switch happens in lock step with
     /// calls to produce()
-    ss::future<> produce(std::vector<kafka::client::record_essence> records);
+    ss::future<> produce(chunked_vector<partition_batch> records);
 
     /// Allocates and connects, or deallocates and shuts down the audit client
     void toggle(bool enabled);
@@ -247,9 +259,13 @@ ss::future<> audit_client::configure() {
         co_await create_internal_topic();
         co_await _client.connect();
 
-        /// Retries should be "infinite", to avoid dropping data, there is a
-        /// known issue within the client setting this value to size_t::max
-        _client.config().retries.set_value(10000);
+        /// To avoid dropping data, retries should be functionally infinite,
+        /// but we handle this logic at the produce call site. Individual
+        /// requests should fail after a few attempts, allowing the kafka
+        /// client to refresh its metadata on a subsequent request.
+        /// Explicitly set `client::config::retries` to its default value.
+        /// We might want to make this tunable at some point.
+        _client.config().retries.reset();
         vlog(adtlog.info, "Audit log client initialized");
     } catch (...) {
         vlog(
@@ -476,35 +492,60 @@ ss::future<> audit_client::shutdown() {
 }
 
 ss::future<> audit_client::produce(
-  std::vector<kafka::client::record_essence> records, audit_probe& probe) {
-    /// TODO: Produce with acks=1, atm -1 is hardcoded into client
-    const auto records_size = [](const auto& records) {
-        std::size_t size = 0;
-        for (const auto& r : records) {
-            if (r.value) {
-                /// auditing does not fill in any of the fields of the
-                /// record_essence other then the value member
-                size += r.value->size_bytes();
-            }
+  chunked_vector<partition_batch> records, audit_probe& probe) {
+    auto total_size = absl::c_accumulate(
+      records, size_t{0}, [](size_t acc, const partition_batch& b) {
+          return acc + b.batch.size_bytes();
+      });
+
+    vlog(
+      adtlog.trace,
+      "Producing {} batches, totaling {}B, wait for semaphore units...",
+      records.size(),
+      total_size);
+
+    auto reserved = co_await ss::get_units(_send_sem, total_size);
+
+    absl::c_for_each(records, [&reserved](partition_batch& pb) {
+        try {
+            pb.send_units.emplace(reserved.split(pb.batch.size_bytes()));
+        } catch (const std::invalid_argument& e) {
+            // NOTE(oren): we should never reach here because reserved should
+            // always begin with precisely the number of units needed for all
+            // input batches.
+            vassert(false, "Error getting units for batch: {}", e.what());
         }
-        return size;
-    };
+    });
+
+    // limit concurrency to the number of max-sized batches that the
+    // audit_client could handle. In the common case, the number of batches
+    // here should usually be 1-2, since the default per-shard queue limit
+    // is 1MiB, which is also the default for kafka_batch_max_bytes.
+    // TODO(oren): a configurabale ratio might be better
+    [[maybe_unused]] auto max_concurrency
+      = _max_buffer_size / config::shard_local_cfg().kafka_batch_max_bytes();
 
     try {
-        const auto size_bytes = records_size(records);
-        vlog(
-          adtlog.trace,
-          "Obtaining {} units from auditing semaphore",
-          size_bytes);
-        auto units = co_await ss::get_units(_send_sem, size_bytes);
         ssx::spawn_with_gate(
           _gate,
           [this,
            &probe,
-           units = std::move(units),
+           max_concurrency,
            records = std::move(records)]() mutable {
-              return do_produce(std::move(records), probe)
-                .finally([units = std::move(units)] {});
+              return ss::do_with(
+                std::move(records),
+                [this, &probe, max_concurrency](auto& records) mutable {
+                    return ss::max_concurrent_for_each(
+                      std::make_move_iterator(records.begin()),
+                      std::make_move_iterator(records.end()),
+                      max_concurrency,
+                      [this,
+                       &probe](partition_batch rec) mutable -> ss::future<> {
+                          return do_produce(
+                                   std::move(rec.batch), rec.pid, probe)
+                            .finally([units = std::move(rec.send_units)] {});
+                      });
+                });
           });
     } catch (const ss::broken_semaphore&) {
         vlog(
@@ -515,35 +556,34 @@ ss::future<> audit_client::produce(
 }
 
 ss::future<> audit_client::do_produce(
-  std::vector<kafka::client::record_essence> records, audit_probe& probe) {
-    const auto n_records = records.size();
-    kafka::produce_response r = co_await _client.produce_records(
-      model::kafka_audit_logging_topic, std::move(records));
-    bool errored = std::any_of(
-      r.data.responses.cbegin(),
-      r.data.responses.cend(),
-      [](const kafka::topic_produce_response& tp) {
-          return std::any_of(
-            tp.partitions.cbegin(),
-            tp.partitions.cend(),
-            [](const kafka::partition_produce_response& p) {
-                return p.error_code != kafka::error_code::none;
-            });
-      });
-    if (errored) {
-        if (_as.abort_requested()) {
-            vlog(
-              adtlog.warn,
-              "{} audit records dropped, shutting down",
-              n_records);
-        } else {
-            vlog(adtlog.error, "{} audit records dropped", n_records);
+  model::record_batch batch, model::partition_id pid, audit_probe& probe) {
+    // Effectively retry forever, but start a fresh request from batch data held
+    // in memory when each produce_record_batch's retries are exhausted. This
+    // way the kafka client should periodically refresh its internal metadata.
+    std::optional<kafka::error_code> ec;
+    while (!_as.abort_requested()) {
+        auto r = co_await _client.produce_record_batch(
+          model::topic_partition{model::kafka_audit_logging_topic, pid},
+          batch.copy());
+        ec.emplace(r.error_code);
+        co_await update_status(ec.value());
+        if (ec.value() == kafka::error_code::none) {
+            break;
         }
+    }
+
+    // report unknown server error if we aborted before making any attempt
+    if (auto errc = ec.value_or(kafka::error_code::unknown_server_error);
+        errc != kafka::error_code::none) {
+        vlog(
+          adtlog.warn,
+          "{} audit records dropped, shutting down. Last error: {}",
+          batch.record_count(),
+          errc);
         probe.audit_error();
     } else {
         probe.audit_event();
     }
-    co_return co_await update_status(std::move(r));
 }
 
 /// audit_sink
@@ -575,8 +615,7 @@ audit_sink::update_auth_status(auth_misconfigured_t auth_misconfigured) {
       });
 }
 
-ss::future<>
-audit_sink::produce(std::vector<kafka::client::record_essence> records) {
+ss::future<> audit_sink::produce(chunked_vector<partition_batch> records) {
     /// No locks/gates since the calls to this method are done in controlled
     /// context of other synchronization primitives
     vassert(_client, "produce() called on a null client");
@@ -593,8 +632,12 @@ ss::future<> audit_sink::publish_app_lifecycle_event(
     auto as_json = lifecycle_event->to_json();
     iobuf b;
     b.append(as_json.c_str(), as_json.size());
-    std::vector<kafka::client::record_essence> rs;
-    rs.push_back(kafka::client::record_essence{.value = std::move(b)});
+    auto batch
+      = kafka::client::
+          record_batcher{config::shard_local_cfg().kafka_batch_max_bytes(), &adtlog}
+            .make_batch_of_one(std::nullopt, std::move(b));
+    chunked_vector<partition_batch> rs;
+    rs.emplace_back(_audit_mgr->compute_partition_id(), std::move(batch));
     co_await produce(std::move(rs));
 }
 
@@ -847,6 +890,49 @@ bool audit_log_manager::report_redpanda_app_event(is_started app_started) {
         : application_lifecycle::activity_id::stop);
 }
 
+model::partition_id audit_log_manager::compute_partition_id() {
+    static thread_local model::partition_id _next_pid{0};
+
+    model::topic_namespace_view ns_tp{model::kafka_audit_logging_nt};
+    auto cfg = _metadata_cache->local().get_topic_cfg(ns_tp);
+    if (!cfg.has_value()) {
+        vlog(
+          adtlog.debug,
+          "{} missing from metadata cache, fall back to round-robin candidate "
+          "{}",
+          ns_tp,
+          _next_pid);
+        return _next_pid;
+    }
+    auto n_partitions = cfg.value().partition_count;
+    vassert(n_partitions >= 0, "Invalid partition count {}", n_partitions);
+
+    auto inc_pid = [n_partitions](model::partition_id pid, int32_t inc = 1) {
+        return model::partition_id{(pid + inc) % n_partitions};
+    };
+
+    const auto& partition_leaders
+      = _controller->get_partition_leaders().local();
+
+    std::optional<model::partition_id> pid;
+    for (auto i : boost::irange(n_partitions)) {
+        auto try_pid = inc_pid(_next_pid, i);
+        auto leader = partition_leaders.get_leader(ns_tp, try_pid);
+        if (!leader.has_value()) {
+            continue;
+        } else if (leader.value() == _self) {
+            vlog(adtlog.debug, "Node {} leads partition {}", _self, try_pid);
+            pid.emplace(try_pid);
+            break;
+        }
+    }
+
+    // NOTE(oren): sort of arbitrary. if we didn't find a locally led partition,
+    // then at least advance the round robin to the next PID in natural order
+    _next_pid = inc_pid(pid.value_or(_next_pid));
+    return pid.value_or(_next_pid);
+}
+
 ss::future<> audit_log_manager::drain() {
     if (_queue.empty()) {
         co_return;
@@ -857,8 +943,10 @@ ss::future<> audit_log_manager::drain() {
       "Attempting to drain {} audit events from sharded queue",
       _queue.size());
 
-    /// Combine all batched audit msgs into record_essences
-    std::vector<kafka::client::record_essence> essences;
+    /// Combine all queued audit msgs into record_batches
+    kafka::client::record_batcher batcher{
+      config::shard_local_cfg().kafka_batch_max_bytes(), &adtlog};
+
     auto records = std::exchange(_queue, underlying_t{});
     auto& records_seq = records.get<underlying_list>();
     while (!records_seq.empty()) {
@@ -867,10 +955,28 @@ ss::future<> audit_log_manager::drain() {
         auto as_json = audit_msg->to_json();
         iobuf b;
         b.append(as_json.c_str(), as_json.size());
-        essences.push_back(
-          kafka::client::record_essence{.value = std::move(b)});
-        co_await ss::maybe_yield();
+        batcher.append(std::nullopt, std::move(b));
+
+        co_await ss::coroutine::maybe_yield();
     }
+
+    auto batches = std::move(batcher).finish();
+
+    chunked_vector<partition_batch> p_batches;
+    p_batches.reserve(batches.size());
+
+    // attach a partition ID to each batch and call into the audit_sink
+
+    std::transform(
+      std::make_move_iterator(batches.begin()),
+      std::make_move_iterator(batches.end()),
+      std::back_inserter(p_batches),
+      [this](model::record_batch recs) {
+          return partition_batch{
+            .pid = compute_partition_id(),
+            .batch = std::move(recs),
+          };
+      });
 
     /// This call may block if the audit_clients semaphore is exhausted,
     /// this represents the amount of memory used within its kafka::client
@@ -879,7 +985,7 @@ ss::future<> audit_log_manager::drain() {
     /// capacity. When it hits capacity, enqueue_audit_event() will block.
     co_await container().invoke_on(
       client_shard_id,
-      [recs = std::move(essences)](audit_log_manager& mgr) mutable {
+      [recs = std::move(p_batches)](audit_log_manager& mgr) mutable {
           return mgr._sink->produce(std::move(recs));
       });
 }

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -63,7 +63,10 @@ public:
       = ss::bool_class<struct audit_event_permitted_tag>;
 
     audit_log_manager(
-      cluster::controller* controller, kafka::client::configuration&);
+      model::node_id self,
+      cluster::controller* controller,
+      kafka::client::configuration&,
+      ss::sharded<cluster::metadata_cache>*);
 
     audit_log_manager(const audit_log_manager&) = delete;
     audit_log_manager& operator=(const audit_log_manager&) = delete;
@@ -397,9 +400,12 @@ private:
     std::unique_ptr<audit_sink> _sink;
 
     /// Other references
+    model::node_id _self;
     cluster::controller* _controller;
     kafka::client::configuration& _config;
     std::unique_ptr<audit_probe> _probe;
+
+    ss::sharded<cluster::metadata_cache>* _metadata_cache;
 };
 
 } // namespace security::audit

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -228,6 +228,12 @@ private:
       const security::acl_principal&,
       const model::topic&) const;
 
+    /**
+     * Compute an output partition for some audit record batch by per-shard
+     * round-robin, biased toward partitions with a locally hosted leader.
+     */
+    model::partition_id compute_partition_id();
+
     ss::future<> drain();
     ss::future<> pause();
     ss::future<> resume();

--- a/src/v/transform/logging/BUILD
+++ b/src/v/transform/logging/BUILD
@@ -40,25 +40,6 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
-    name = "record_batcher",
-    srcs = ["record_batcher.cc"],
-    hdrs = ["record_batcher.h"],
-    implementation_deps = [
-        ":logger",
-        "//src/v/storage:record_batch_builder",
-        "//src/v/utils:human",
-        "@abseil-cpp//absl/algorithm:container",
-    ],
-    include_prefix = "transform/logging",
-    deps = [
-        "//src/v/base",
-        "//src/v/bytes:iobuf",
-        "//src/v/model",
-        "@seastar",
-    ],
-)
-
-redpanda_cc_library(
     name = "event",
     srcs = ["event.cc"],
     hdrs = ["event.h"],
@@ -94,13 +75,13 @@ redpanda_cc_library(
         ":event",
         ":logger",
         ":probes",
-        ":record_batcher",
         "//src/v/base",
         "//src/v/bytes:streambuf",
         "//src/v/cluster",
         "//src/v/config",
         "//src/v/hashing:murmur",
         "//src/v/json",
+        "//src/v/kafka/client:record_batcher",
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/random:time_jitter",

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -1,7 +1,6 @@
 v_cc_library(
   NAME transform_logging
   SRCS
-    record_batcher.cc
     event.cc
     log_manager.cc
     logger.cc
@@ -12,6 +11,7 @@ v_cc_library(
     v::cluster
     v::model
     v::transform_rpc
+    v::kc_record_batcher
 )
 
 add_subdirectory(tests)

--- a/src/v/transform/logging/rpc_client.cc
+++ b/src/v/transform/logging/rpc_client.cc
@@ -13,9 +13,9 @@
 
 #include "cluster/metadata_cache.h"
 #include "hashing/murmur.h"
+#include "kafka/client/record_batcher.h"
 #include "logger.h"
 #include "model/namespace.h"
-#include "record_batcher.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -41,7 +41,7 @@ rpc_client::write(model::partition_id pid, io::json_batches batches) {
     auto max_batch_size = cfg->properties.batch_max_bytes.value_or(
       config::shard_local_cfg().kafka_batch_max_bytes());
 
-    record_batcher batcher{max_batch_size};
+    kafka::client::record_batcher batcher{max_batch_size};
 
     while (!batches.empty()) {
         auto json_batch = std::move(batches.front());

--- a/src/v/transform/logging/rpc_client.cc
+++ b/src/v/transform/logging/rpc_client.cc
@@ -41,7 +41,7 @@ rpc_client::write(model::partition_id pid, io::json_batches batches) {
     auto max_batch_size = cfg->properties.batch_max_bytes.value_or(
       config::shard_local_cfg().kafka_batch_max_bytes());
 
-    kafka::client::record_batcher batcher{max_batch_size};
+    kafka::client::record_batcher batcher{max_batch_size, &tlg_log};
 
     while (!batches.empty()) {
         auto json_batch = std::move(batches.front());

--- a/src/v/transform/logging/tests/BUILD
+++ b/src/v/transform/logging/tests/BUILD
@@ -31,21 +31,6 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "record_batcher_test",
-    timeout = "short",
-    srcs = ["record_batcher_test.cc"],
-    cpu = 1,
-    memory = "128MiB",
-    deps = [
-        ":utils",
-        "//src/v/base",
-        "//src/v/test_utils:gtest",
-        "//src/v/transform/logging:record_batcher",
-        "@googletest//:gtest",
-    ],
-)
-
-redpanda_cc_gtest(
     name = "log_manager_test",
     timeout = "short",
     srcs = ["log_manager_test.cc"],

--- a/src/v/transform/logging/tests/CMakeLists.txt
+++ b/src/v/transform/logging/tests/CMakeLists.txt
@@ -15,9 +15,9 @@ rp_test(
   SOURCES
     model_test.cc
     log_manager_test.cc
-    record_batcher_test.cc
   LIBRARIES
     v::transform_logging
     v::transform_logging_test_utils
     v::gtest_main
+    v::kc_record_batcher
 )

--- a/src/v/transform/logging/tests/utils.cc
+++ b/src/v/transform/logging/tests/utils.cc
@@ -38,16 +38,4 @@ model::transform_name random_transform_name(size_t len) {
     return model::transform_name{random_generators::gen_alphanum_string(len)};
 }
 
-iobuf random_length_iobuf(size_t data_max) {
-    assert(data_max > 0);
-    std::random_device dev;
-    std::mt19937 rng(dev());
-    std::uniform_int_distribution<std::mt19937::result_type> dist(1, data_max);
-
-    auto data = random_generators::gen_alphanum_string(dist(rng));
-    iobuf b;
-    b.append(data.data(), data.size());
-    return b;
-}
-
 } // namespace transform::logging::testing

--- a/src/v/transform/logging/tests/utils.h
+++ b/src/v/transform/logging/tests/utils.h
@@ -24,6 +24,4 @@ std::string get_message_body(iobuf);
 
 model::transform_name random_transform_name(size_t len = 12);
 
-iobuf random_length_iobuf(size_t data_max);
-
 } // namespace transform::logging::testing


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

TODO:

- [x] better error handling
- [x] bazel stuff
- [ ] make a run at broker_error repro

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixes a bug where audit log manager would retry a bad request forever, causing buffers to fill up, blocking audit log appends and preventing authZ.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
