### PR TITLE
[CORE-7812] dt/metrics: Assert on presence of 'has_enterprise_features'

### DIFF
--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -148,7 +148,9 @@ class MetricsReporterTest(RedpandaTest):
         assert last['original_logical_version'] == features[
             'original_cluster_version']
         assert last['has_valid_license']
-        assert last['has_enterprise_features'] == False
+        # NOTE: value will vary depending on FIPS mode. we're confident that
+        # the source of the value is sound, so assert on presence instead.
+        assert 'has_enterprise_features' in last
         nodes_meta = last['nodes']
 
         assert len(last['nodes']) == len(self.redpanda.nodes)


### PR DESCRIPTION
Previous assertion (value == False) would always fail in FIPS/CDT mode. The machinery behind the calculation is sound and tested elsewhere, so rather than futz around with detecting the env, assert on the key's presence in metrics output.

Fixes CORE-7812

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
