### PR TITLE
schema_registry: Add metrics

### DIFF
--- a/src/v/pandaproxy/probe.cc
+++ b/src/v/pandaproxy/probe.cc
@@ -50,7 +50,7 @@ void probe::setup_metrics() {
             return _request_metrics.hist().internal_histogram_logform();
         })},
       {},
-      {sm::shard_label, operation_label});
+      {sm::shard_label});
 }
 
 void probe::setup_public_metrics() {


### PR DESCRIPTION
Added metrics (prefixed with `[vectorized|redpanda]_schema_registry_cache_`):
| Metric | Type | Description | Labels | Aggregation labels |
| -- | -- | -- | -- | -- |
| `schema_count` | gauge | The number of schemas in the store | `shard` | `shard` |
| `schema_memory_bytes` | gauge | The memory usage of schemas in the store | `shard` | `shard` |
| `subject_count` | gauge | The number of subjects in the store | `shard`, `deleted` | `shard` |
| `subject_version_count` | gauge | The number of versions for each subject in the store | `shard`, `subject`, `deleted` |`shard` |

Modified metrics (prefixed with `vectorized_pandaproxy`):
| Metric | Type | Description | Labels | Aggregation labels |
| -- | -- | -- | -- | -- |
| `request_latency` | histogram | Request latency | `shard`, `operation` | `shard` |

This was modified to not aggregate `operation` when `aggregate_metrics = true`.  This increases the count of metrics by about 1000 when `aggregate_metrics` is true and 1000/shard when `aggregate_metrics` is false. This is a similar number to `vectorized_kafka_handler_latency`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Improvements

* Schema Registry: Add Some metrics for resource usage taken by in-memory schemas 