### PR TITLE
tests/scripts: make script work in FIPS env

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -92,7 +92,8 @@ def safe_listdir(p: Path) -> list[Path]:
 
 
 def md5_for_bytes(calculate_md5: bool, data: bytes) -> str:
-    return hashlib.md5(data).hexdigest() if calculate_md5 else ''
+    return hashlib.md5(
+        data, usedforsecurity=False).hexdigest() if calculate_md5 else ''
 
 
 def md5_for_filename(calculate_md5: bool, file: Path) -> str:


### PR DESCRIPTION
This script has been failing when executed in a FIPS environment. This script makes use of python's `hashlib` library. As explained in https://docs.python.org/3/library/hashlib.html#hash-algorithms:

> All hashlib constructors take a keyword-only argument `usedforsecurity` with default value `True`. A false value allows the use of insecure and blocked hashing algorithms in restricted environments. `False` indicates that the hashing algorithm is not used in a security context, e.g. as a non-cryptographic one-way compression function.

I think the above applies in this context but folks more familiar with Redpanda's FIPS mode should confirm.

fixes https://redpandadata.atlassian.net/browse/DEVPROD-2041

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
