### PR TITLE
[CORE-7827] dt/rpk_cluster: Add some slop for license metrics tests

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -225,7 +225,12 @@ class RpkClusterTest(RedpandaTest):
 
         internal_val = get_metrics_value(MetricsEndpoint.METRICS)
         public_val = get_metrics_value(MetricsEndpoint.PUBLIC_METRICS)
-        assert internal_val == public_val, f"Mismatch: {internal_val} != {public_val}"
+        # generous slop. only a very large difference here would suggest a
+        # logic error on the backend (e.g. approaching a calendar day).
+        threshold_s = 30
+        assert abs(
+            internal_val - public_val
+        ) <= threshold_s, f"Mismatch: abs({internal_val} - {public_val}) > {threshold_s}"
         return internal_val
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
Fixes a flaky assertion that the enterprise_license_expiry_sec metric gives the same value on internal and public endpoints.

Since these values are calculated remotely, we can't make that guarantee, so this commit adds an extremely generous 30s of slop and asserts on the difference.

Fixes CORE-7827

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
