### PR TITLE
CORE-7935: admin: Removed status check in get_debug_bundle_job_id

### DIFF
--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -274,22 +274,6 @@ debug_bundle::result<debug_bundle::job_id_t> get_debug_bundle_job_id(
         return std::move(status_res).assume_error();
     }
 
-    switch (status_res.assume_value().status) {
-    case debug_bundle::debug_bundle_status::running:
-        return debug_bundle::error_info{
-          debug_bundle::error_code::debug_bundle_process_running,
-          "Process still running"};
-    case debug_bundle::debug_bundle_status::error:
-        return debug_bundle::error_info{
-          debug_bundle::error_code::internal_error, "Process errored out"};
-    case debug_bundle::debug_bundle_status::expired:
-        return debug_bundle::error_info{
-          debug_bundle::error_code::debug_bundle_expired,
-          "Debug bundle expired"};
-    case debug_bundle::debug_bundle_status::success:
-        break;
-    }
-
     if (status_res.assume_value().file_name != filename) {
         return debug_bundle::error_info{
           debug_bundle::error_code::job_id_not_recognized, "File Not Found"};


### PR DESCRIPTION
The status check is the admin server is unnecessary.  Allow the service to report any errors based on the request it received.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None