### PR TITLE
Iceberg data writer cleanup

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -18,6 +18,7 @@ v_cc_library(
     arrow_translator.cc
     datalake_manager.cc
     batching_parquet_writer.cc
+    data_writer_interface.cc
     parquet_writer.cc
     record_multiplexer.cc
     schema_registry.cc

--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/data_writer_interface.h"
+
+#include <fmt/core.h>
+namespace datalake {
+std::string data_writer_error_category::message(int ev) const {
+    switch (static_cast<data_writer_error>(ev)) {
+    case data_writer_error::ok:
+        return "Ok";
+    case data_writer_error::parquet_conversion_error:
+        return "Parquet Conversion Error";
+    case data_writer_error::file_io_error:
+        return "File IO Error";
+    case data_writer_error::no_data:
+        return "No data";
+    }
+}
+std::ostream& operator<<(std::ostream& o, const local_file_metadata& f_meta) {
+    fmt::print(
+      o,
+      "{{relative_path: {}, size_bytes: {}, row_count: {}}}",
+      f_meta.path,
+      f_meta.size_bytes,
+      f_meta.row_count);
+    return o;
+}
+} // namespace datalake

--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -24,13 +24,15 @@ std::string data_writer_error_category::message(int ev) const {
         return "No data";
     }
 }
+
 std::ostream& operator<<(std::ostream& o, const local_file_metadata& f_meta) {
     fmt::print(
       o,
-      "{{relative_path: {}, size_bytes: {}, row_count: {}}}",
+      "{{relative_path: {}, size_bytes: {}, row_count: {}, hour: {}}}",
       f_meta.path,
       f_meta.size_bytes,
-      f_meta.row_count);
+      f_meta.row_count,
+      f_meta.hour);
     return o;
 }
 } // namespace datalake

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -51,18 +51,28 @@ inline std::error_code make_error_code(data_writer_error e) noexcept {
 
 class data_writer {
 public:
+    data_writer() = default;
+    data_writer(const data_writer&) = delete;
+    data_writer(data_writer&&) = default;
+    data_writer& operator=(const data_writer&) = delete;
+    data_writer& operator=(data_writer&&) = delete;
+
     virtual ~data_writer() = default;
 
     virtual ss::future<data_writer_error> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
 
-    virtual ss::future<result<coordinator::data_file, data_writer_error>>
-    finish() = 0;
+    virtual ss::future<result<local_data_file, data_writer_error>> finish() = 0;
 };
 
 class data_writer_factory {
 public:
+    data_writer_factory() = default;
+    data_writer_factory(const data_writer_factory&) = delete;
+    data_writer_factory(data_writer_factory&&) = default;
+    data_writer_factory& operator=(const data_writer_factory&) = delete;
+    data_writer_factory& operator=(data_writer_factory&&) = default;
     virtual ~data_writer_factory() = default;
 
     virtual ss::future<result<ss::shared_ptr<data_writer>, data_writer_error>>

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -32,20 +32,9 @@ enum class data_writer_error {
 };
 
 struct data_writer_error_category : std::error_category {
-    const char* name() const noexcept override { return "Data Writer Error"; }
+    const char* name() const noexcept final { return "Data Writer Error"; }
 
-    std::string message(int ev) const override {
-        switch (static_cast<data_writer_error>(ev)) {
-        case data_writer_error::ok:
-            return "Ok";
-        case data_writer_error::parquet_conversion_error:
-            return "Parquet Conversion Error";
-        case data_writer_error::file_io_error:
-            return "File IO Error";
-        case data_writer_error::no_data:
-            return "No data";
-        }
-    }
+    std::string message(int ev) const final;
 
     static const std::error_category& error_category() {
         static data_writer_error_category e;

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -16,6 +16,14 @@
 #include <cstddef>
 
 namespace datalake {
+/**
+ * Definitions of local and remote paths, as the name indicates the local path
+ * is always pointing to the location on local disk wheras the remote path is a
+ * path of the object in the object store.
+ */
+using local_path = named_type<std::filesystem::path, struct local_path_tag>;
+using remote_path = named_type<std::filesystem::path, struct remote_path_tag>;
+
 enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -24,6 +24,20 @@ namespace datalake {
 using local_path = named_type<std::filesystem::path, struct local_path_tag>;
 using remote_path = named_type<std::filesystem::path, struct remote_path_tag>;
 
+/**
+ * Simple type describing local parquet file metadata with its path and basic
+ * statistics
+ */
+struct local_file_metadata {
+    local_path path;
+    size_t row_count = 0;
+    size_t size_bytes = 0;
+    int hour = 0;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const local_file_metadata& r);
+};
+
 enum class data_writer_error {
     ok = 0,
     parquet_conversion_error,

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -10,14 +10,10 @@
 #pragma once
 
 #include "base/outcome.h"
-#include "coordinator/data_file.h"
-#include "datalake/schemaless_translator.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
-#include "serde/envelope.h"
 
 #include <cstddef>
-#include <memory>
 
 namespace datalake {
 enum class data_writer_error {

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -74,7 +74,8 @@ public:
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
 
-    virtual ss::future<result<local_data_file, data_writer_error>> finish() = 0;
+    virtual ss::future<result<local_file_metadata, data_writer_error>>
+    finish() = 0;
 };
 
 class data_writer_factory {

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -94,7 +94,15 @@ record_multiplexer::end_of_stream() {
         }
         auto result_files = co_await _writer->finish();
         if (result_files.has_value()) {
-            _result.value().files.push_back(result_files.value());
+            auto local_file = result_files.value();
+            // TODO: upload files to cloud here, and fill necessary details
+            coordinator::data_file remote_file{
+              .remote_path = "",
+              .row_count = local_file.row_count,
+              .file_size_bytes = local_file.size_bytes,
+              .hour = local_file.hour,
+            };
+            _result.value().files.push_back(remote_file);
             co_return std::move(_result.value());
         } else {
             co_return result_files.error();

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -91,7 +91,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
 
     auto writer_factory
       = std::make_unique<datalake::batching_parquet_writer_factory>(
-        tmp_dir.get_path(), "data", 100, 10000);
+        datalake::local_path(tmp_dir.get_path()), "data", 100, 10000);
     datalake::record_multiplexer multiplexer(std::move(writer_factory));
 
     model::test::record_batch_spec batch_spec;

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -36,15 +36,15 @@ public:
         return ss::make_ready_future<data_writer_error>(status);
     }
 
-    ss::future<result<coordinator::data_file, data_writer_error>>
+    ss::future<result<local_file_metadata, data_writer_error>>
     finish() override {
         return ss::make_ready_future<
-          result<coordinator::data_file, data_writer_error>>(_result);
+          result<local_file_metadata, data_writer_error>>(_result);
     }
 
 private:
     iceberg::struct_type _schema;
-    coordinator::data_file _result;
+    local_file_metadata _result;
     bool _return_error;
 };
 class test_data_writer_factory : public data_writer_factory {


### PR DESCRIPTION
Cleaned up `datalake` writer interface. The change include introduction of remote and local path types definitions and returning `local_file_metadata` from the writer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 