### PR TITLE
CORE-7936 dt: fix fips CI hang on md5 usage

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -92,7 +92,8 @@ def safe_listdir(p: Path) -> list[Path]:
 
 
 def md5_for_bytes(calculate_md5: bool, data: bytes) -> str:
-    return hashlib.md5(data).hexdigest() if calculate_md5 else ''
+    return hashlib.md5(
+        data, usedforsecurity=False).hexdigest() if calculate_md5 else ''
 
 
 def md5_for_filename(calculate_md5: bool, file: Path) -> str:


### PR DESCRIPTION
Using MD5 is not allowed in FIPS mode and so the default python installation on a FIPS-enabled host prevents using MD5 without explicitly marking it as `usedforsecurity=False`.

This has caused the nightly FIPS CI build to hang when the `compute_storage.py` script is attempting to run md5.

This tries to fix the hanging test by marking the md5 usage with `usedforsecurity=False`.

Fixes https://redpandadata.atlassian.net/browse/CORE-7936

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
