### PR TITLE
Add static_str utility class

### DIFF
--- a/src/v/strings/BUILD
+++ b/src/v/strings/BUILD
@@ -24,3 +24,15 @@ redpanda_cc_library(
     include_prefix = "strings",
     visibility = ["//visibility:public"],
 )
+
+redpanda_cc_library(
+    name = "static_str",
+    hdrs = [
+        "static_str.h",
+    ],
+    include_prefix = "strings",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@fmt",
+    ],
+)

--- a/src/v/strings/static_str.h
+++ b/src/v/strings/static_str.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include <fmt/format.h>
+
+#include <string_view>
+
+#pragma once
+
+/**
+ * @brief A wrapper around a compile-time constant string.
+ *
+ * A static_str wraps an compile-time constant string, and is intended to be
+ * used at runtime as a guarantee that a string has static lifetime. Such string
+ * have trivial and cheap copy operations, since we just copy pointers (or
+ * views) to the underlying string.
+ */
+class static_str {
+public:
+    /**
+     * @brief Create a static_str based on a compile-time string literal.
+     *
+     * The use of consteval prevents passing anything other than compile-time
+     * values, which necessarily have static lifetime.
+     */
+    consteval static_str(const char* str) // NOLINT(hicpp-explicit-conversions)
+      : _data{str} {}
+
+    /**
+     * @brief Create a static_str based on a compile-time string literal.
+     *
+     * The use of consteval prevents passing anything other than compile-time
+     * values, which necessarily have static lifetime.
+     */
+    explicit consteval static_str(std::string_view str)
+      : _data{str} {}
+
+    constexpr auto operator<=>(const static_str& rhs) const = default;
+
+    /**
+     * @brief Return the static_str as a string_view.
+     */
+    constexpr operator std::string_view() const { return _data; } // NOLINT
+
+private:
+    // We could validly store the underlying string as a const char* or
+    // std::string_view, while offering the same API. We choose the string_view
+    // approach because storing the size speeds up several common operations.
+    // The pointer approach wins for size and the cost of copying, which is also
+    // common on the fast path.
+    //
+    // Should this not be the right tradeoff for some specific use case it is
+    // easy to define the other variant simply by changing the storage type.
+    //
+    // Comparison of generated assembly for a few interesting cases:
+    // string_view based: https://godbolt.org/z/Pzq9d93qj
+    // pointer based    : https://godbolt.org/z/azd8a3xT5
+
+    // the underlying string_view
+    std::string_view _data;
+};
+
+template<>
+struct fmt::formatter<static_str> : public formatter<std::string_view> {
+    constexpr auto format(static_str s, fmt::format_context& ctx) const {
+        return formatter<std::string_view>::format(s, ctx);
+    }
+};

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -5,10 +5,12 @@ redpanda_cc_btest_no_seastar(
     timeout = "short",
     srcs = [
         "constexpr_string_switch.cc",
+        "static_str_test.cc",
         "string_switch_test.cc",
         "utf8_control_chars.cc",
     ],
     deps = [
+        "//src/v/strings:static_str",
         "//src/v/strings:string_switch",
         "//src/v/strings:utf8",
     ],

--- a/src/v/strings/tests/CMakeLists.txt
+++ b/src/v/strings/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   BINARY_NAME strings
   SOURCES
     constexpr_string_switch.cc
+    static_str_test.cc
     string_switch_test.cc
     utf8_control_chars.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/strings/tests/constexpr_string_switch.cc
+++ b/src/v/strings/tests/constexpr_string_switch.cc
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#define BOOST_TEST_MODULE utils
+#define BOOST_TEST_MODULE strings
 
 #include "strings/string_switch.h"
 

--- a/src/v/strings/tests/static_str_test.cc
+++ b/src/v/strings/tests/static_str_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "strings/static_str.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <fmt/core.h>
+
+#include <string_view>
+
+// for boost test
+std::ostream& operator<<(std::ostream& o, const static_str& s) {
+    return o << (std::string_view)s;
+}
+
+using namespace std::string_view_literals;
+
+static constexpr std::string_view abc_sv = "abc";
+
+namespace static_tests {
+constexpr static_str abc = "abc";
+constexpr static_str abc2 = "abc";
+constexpr static_str abc3{"abc"sv};
+constexpr static_str abd = "abd";
+
+static_assert(abc == abc); // NOLINT(misc-redundant-expression)
+static_assert(abc == abc2);
+static_assert(abc == abc3);
+static_assert(abc != abd);
+static_assert(abc < abd);
+
+static_assert(abc == "abc"sv);
+static_assert(abc != "ccc"sv);
+
+static_assert(abc <= "abc"sv);
+static_assert(!(abc <= "abb"sv));
+
+// check that prefix does not compare equal
+static_assert(static_str{abc_sv} != static_str{abc_sv.substr(0, 2)});
+
+constexpr auto zero_term_abc = std::array{'a', 'b', 'c', '\0'};
+static_assert(static_str{zero_term_abc.data()} == "abc"sv);
+
+// // the following must not compile:
+//
+// // init from a constexpr non-null-terminated string
+// constexpr auto no_zero_term_abc = std::array{'a', 'b', 'c'};
+// static_assert(static_str{no_zero_term_abc.data()} == "abc"sv);
+
+// // init with non-constexpr string
+// const auto non_constexpr_str = "abc";
+// static_assert(static_str{non_constexpr_str} == "abc"sv);
+
+} // namespace static_tests
+
+BOOST_AUTO_TEST_CASE(static_str_compare) {
+    static_str abc = "abc";
+    static_str abc2 = "abc";
+    static_str abd = "abd";
+
+    BOOST_CHECK(abc == abc);
+    BOOST_CHECK(abc == abc2);
+    BOOST_CHECK(abc != abd);
+    BOOST_CHECK(abc < abd);
+
+    BOOST_CHECK(abc == "abc"sv);
+    BOOST_CHECK(abc != "ccc"sv);
+
+    BOOST_CHECK(abc <= "abc"sv);
+    BOOST_CHECK(!(abc <= "abb"sv));
+
+    BOOST_CHECK(abc == static_tests::abc);
+    BOOST_CHECK(abc <= static_tests::abc);
+    BOOST_CHECK(abc < static_tests::abd);
+}
+
+BOOST_AUTO_TEST_CASE(static_str_prefix) {
+    static_str abc{abc_sv};
+    static_str ab{abc_sv.substr(0, 2)};
+
+    BOOST_REQUIRE_EQUAL(abc, "abc"sv);
+    BOOST_REQUIRE_EQUAL(ab, "ab"sv);
+
+    BOOST_REQUIRE_NE(ab, abc);
+}
+
+BOOST_AUTO_TEST_CASE(static_str_format) {
+    using namespace static_tests;
+
+    BOOST_REQUIRE_EQUAL(fmt::format("{}", abc), "abc");
+    BOOST_REQUIRE_EQUAL(fmt::format("{:>4}", abc), " abc");
+    BOOST_REQUIRE_EQUAL(fmt::format("{:<4}", abc), "abc ");
+}


### PR DESCRIPTION
static_str wraps a constant string with known static ("indefinite")
lifetime. This useful because constructing and passing such strings from
character constants is very cheap: just a single "copy" of a
pointer-sized value, which can often even be elided. This opens the door
to using this in hot paths where an allocating string might raise
performance concerns.

In a subsequent series, this is used to enhance logging on the reader
cache path.

Relates to CORE-7865.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

