### PR TITLE
offline_log_viewer: allow reading newer versions of envelopes

### DIFF
--- a/tools/offline_log_viewer/kafka.py
+++ b/tools/offline_log_viewer/kafka.py
@@ -44,7 +44,7 @@ def read_cloud_storage_segment_meta(rdr):
             o["metadata_size_hint"] = 0
         return o
 
-    return rdr.read_envelope(spec, max_version=3)
+    return rdr.read_envelope(spec, reader_version=3)
 
 
 def get_control_record_type(key):
@@ -70,7 +70,7 @@ def decode_archival_metadata_command(kr, vr):
                 o['is_validated'] = False
             return o
 
-        return vr.read_envelope(spec, max_version=1)
+        return vr.read_envelope(spec, reader_version=1)
 
     elif key == ArchivalMetadataCommand.mark_clean:
         return dict(offset=vr.read_int64())

--- a/tools/offline_log_viewer/model.py
+++ b/tools/offline_log_viewer/model.py
@@ -120,7 +120,7 @@ def read_broker(rdr: Reader):
     br['rpc_address'] = rdr.read_envelope(read_unresolved_address)
     br['rack'] = rdr.read_optional(lambda r: r.read_string())
     br['properties'] = rdr.read_envelope(type_read=read_broker_properties,
-                                         max_version=1)
+                                         reader_version=1)
     return br
 
 
@@ -160,7 +160,7 @@ def decode_configuration_update(rdr: Reader, version: int):
 
 
 def read_configuration_update_serde(rdr: Reader):
-    return rdr.read_envelope(decode_configuration_update, max_version=1)
+    return rdr.read_envelope(decode_configuration_update, reader_version=1)
 
 
 def read_raft_config(rdr):
@@ -177,7 +177,7 @@ def read_raft_config(rdr):
             "revision":
             rdr.read_int64()
         },
-                                 max_version=6)
+                                 reader_version=6)
 
     else:
         cfg['version'] = rdr.read_int8()

--- a/tools/offline_log_viewer/reader.py
+++ b/tools/offline_log_viewer/reader.py
@@ -127,32 +127,56 @@ class Reader:
             ret[key] = val
         return ret
 
-    def read_envelope(self, type_read=None, max_version=0):
+    def read_envelope(self, type_read=None, reader_version=0):
         header = self.read_bytes(SERDE_ENVELOPE_SIZE)
         envelope = SerdeEnvelope(*struct.unpack(SERDE_ENVELOPE_FORMAT, header))
-        return self.read_envelope_inner(envelope, type_read, max_version)
+        return self.read_envelope_inner(envelope, type_read, reader_version)
 
-    def read_checksum_envelope(self, type_read=None, max_version=0):
+    def read_checksum_envelope(self, type_read=None, reader_version=0):
         header = self.read_bytes(SERDE_CHECKSUM_ENVELOPE_SIZE)
         envelope = SerdeChecksumEnvelope(
             *struct.unpack(SERDE_CHECKSUM_ENVELOPE_FORMAT, header))
-        return self.read_envelope_inner(envelope, type_read, max_version)
+        return self.read_envelope_inner(envelope, type_read, reader_version)
 
-    def read_envelope_inner(self, envelope, type_read, max_version):
+    def read_envelope_inner(self, envelope, type_read, reader_version):
+        bytes_left_in_envelope = envelope.size
+        envelope_start_pos = self.stream.tell()
+
         if type_read is not None:
-            if envelope.version <= max_version:
+            # This is technical debt. We are currently assuming that all
+            # type_read methods were written to handle the original envelope
+            # declarations. If their compat_version is greater than 0, it
+            # means that they do contain breaking changes.
+            #
+            # We should extend the interface to allow reading different compat
+            # versions of the envelope in some way.
+            if envelope.compat_version == 0:
+                if envelope.version > reader_version:
+                    logger.warning(
+                        f"Reading {type_read=} envelope with version {envelope.version},"
+                        f" but max compat version is {reader_version}."
+                        f" The output is likely to be incomplete.")
+
                 v = type_read(self, envelope.version)
+
+                # Skip the rest of the envelope.
+                bytes_left_in_envelope -= self.stream.tell(
+                ) - envelope_start_pos
+                self.stream.read(bytes_left_in_envelope)
+
                 if not self.include_envelope:
                     return v
                 else:
                     return {'envelope': envelope} | v
             else:
+                # Skip the the envelope.
+                self.stream.read(bytes_left_in_envelope)
                 logger.error(
-                    f"can't decode {envelope.version=}, check {type_read=} or {max_version=}"
+                    f"can't decode {envelope.version=}, check {envelope.compat_version=} > {reader_version=} for {type_read=}"
                 )
                 return {
                     'error': {
-                        'max_supported_version': max_version,
+                        'reader_version': reader_version,
                         'envelope': envelope
                     }
                 }

--- a/tools/offline_log_viewer/topic_manifest.py
+++ b/tools/offline_log_viewer/topic_manifest.py
@@ -36,7 +36,7 @@ def to_tristate_json(key: str,
 def decode_topic_manifest(path: str) -> dict[str, Any]:
     return Reader(open(path, "rb")).read_envelope(
         lambda rdr, _: {
-            'cfg': rdr.read_envelope(read_topic_config, max_version=2),
+            'cfg': rdr.read_envelope(read_topic_config, reader_version=2),
             'initial_revision': rdr.read_int64()
         })
 


### PR DESCRIPTION
Before this commit offline log viewer would refuse reading envelopes if their version was higher than max_version. That is an overly restrictive constraint. Our envelopes are designed to be forward and backwards compatible so in most of the cases an older implementation of the log viewer should be able to read newer versions of the envelopes just fine.

This commit implements that. Instead of putting a constraint on version we constrain only compat_version like regular redpanda deserialization would do.

Additional changes include issuing a warning if offline log viewer compat version is lower than envelope version. This means that offline log viewer will be able to decode only a subset of the envelope.

And obviously added code to skip over data that can't be read by the offline log viewer.

Breaking changes in the envelopes are introduced by bumping compat version. In that case offline log viewer will refuse the decoding as expected.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
