### PR TITLE
rpk: Add format to `rpk topic list`

### DIFF
--- a/src/go/rpk/Makefile
+++ b/src/go/rpk/Makefile
@@ -14,9 +14,11 @@ GOFUMPTCMD=gofumpt
 ifeq ($(shell uname),Darwin)
     BAZELCMD := bazelisk
     BAZEL_GAZELLE_CMD := run --config system-clang //:gazelle
+    GOFUMPT_OS_CMD := $(shell find . -type f -name '*.go' -print0 | xargs -0 -n 1 $(GOFUMPTCMD) -w)
 else
 	BAZELCMD := bazel
     BAZEL_GAZELLE_CMD := run //:gazelle
+    GOFUMPT_OS_CMD := 	$(shell find -type f -name '*.go' | xargs -n1 $(GOFUMPTCMD) -w)
 endif
 
 GOOS ?= $(shell go env GOOS)
@@ -59,7 +61,7 @@ install_gofumpt:
 
 run_gofumpt:
 	@echo "running gofumpt"
-	$(shell find -type f -name '*.go' | xargs -n1 $(GOFUMPTCMD) -w)
+	$(GOFUMPT_OS_CMD)
 
 install_golangci_lint:
 	@echo "installing golangci-lint"

--- a/src/go/rpk/pkg/cli/topic/BUILD
+++ b/src/go/rpk/pkg/cli/topic/BUILD
@@ -20,7 +20,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/go/rpk/pkg/adminapi",
-        "//src/go/rpk/pkg/cli/cluster",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/kafka",
         "//src/go/rpk/pkg/out",
@@ -48,15 +47,18 @@ go_test(
     srcs = [
         "consume_test.go",
         "describe_test.go",
+        "list_test.go",
         "trim_test.go",
         "utils_test.go",
     ],
     embed = [":topic"],
     deps = [
+        "//src/go/rpk/pkg/config",
         "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//require",
         "@com_github_twmb_franz_go//pkg/kerr",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@com_github_twmb_franz_go_pkg_kmsg//:kmsg",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/src/go/rpk/pkg/cli/topic/list.go
+++ b/src/go/rpk/pkg/cli/topic/list.go
@@ -11,13 +11,16 @@ package topic
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
 
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
 )
 
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -55,6 +58,17 @@ information.
 			// We forbid deleting internal topics (redpanda
 			// actually does not expose these currently), so we
 			// make -r and -i incompatible.
+
+			f := p.Formatter
+			if detailed {
+				if h, ok := f.Help([]detailedListTopic{}); ok {
+					out.Exit(h)
+				}
+			} else {
+				if h, ok := f.Help([]summarizedList{}); ok {
+					out.Exit(h)
+				}
+			}
 			if internal && re {
 				out.Exit("cannot list with internal topics and list by regular expression")
 			}
@@ -73,12 +87,165 @@ information.
 
 			listed, err := adm.ListTopicsWithInternal(context.Background(), topics...)
 			out.MaybeDie(err, "unable to request metadata: %v", err)
-			cluster.PrintTopics(listed, internal, detailed)
+
+			if detailed {
+				printDetailedListView(f, detailedListView(internal, listed), os.Stdout)
+			} else {
+				printSummarizedListView(f, summarizedListView(internal, listed), os.Stdout)
+			}
+			out.MaybeDie(err, "unable to summarize metadata: %v", err)
 		},
 	}
 
+	p.InstallFormatFlag(cmd)
 	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "Print per-partition information for topics")
 	cmd.Flags().BoolVarP(&internal, "internal", "i", false, "Print internal topics")
 	cmd.Flags().BoolVarP(&re, "regex", "r", false, "Parse topics as regex; list any topic that matches any input topic expression")
 	return cmd
+}
+
+type summarizedList struct {
+	Name       string `json:"name" yaml:"name"`
+	Partitions int    `json:"partitions" yaml:"partitions"`
+	Replicas   int    `json:"replicas" yaml:"replicas"`
+}
+
+func summarizedListView(internal bool, topics kadm.TopicDetails) (resp []summarizedList) {
+	resp = make([]summarizedList, 0, len(topics))
+	for _, topic := range topics.Sorted() {
+		if !internal && topic.IsInternal {
+			continue
+		}
+		s := summarizedList{
+			Name:       topic.Topic,
+			Partitions: len(topic.Partitions),
+			Replicas:   topic.Partitions.NumReplicas(),
+		}
+		resp = append(resp, s)
+	}
+	return
+}
+
+func printSummarizedListView(f config.OutFormatter, topics []summarizedList, w io.Writer) {
+	if isText, _, t, err := f.Format(topics); !isText {
+		out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
+		fmt.Fprintln(w, t)
+		return
+	}
+
+	tw := out.NewTableTo(w, "NAME", "PARTITIONS", "REPLICAS")
+	defer tw.Flush()
+	for _, topic := range topics {
+		tw.Print(topic.Name, topic.Partitions, topic.Replicas)
+	}
+}
+
+type detailedListTopic struct {
+	Name          string                  `json:"name" yaml:"name"`
+	Partitions    int                     `json:"partitions" yaml:"partitions"`
+	Replicas      int                     `json:"replicas" yaml:"replicas"`
+	PartitionList []detailedListPartition `json:"partition_list" yaml:"partition_list"`
+	isOffline     bool
+	isInternal    bool
+	isEpoch       bool
+	isLoadErr     bool
+}
+
+type detailedListPartition struct {
+	Partition       int32   `json:"partition" yaml:"partition"`
+	Leader          int32   `json:"leader" yaml:"leader"`
+	Epoch           int32   `json:"epoch,omitempty" yaml:"epoch"`
+	Replicas        []int32 `json:"replicas" yaml:"replicas"`
+	OfflineReplicas []int32 `json:"offline_replicas" yaml:"offline_replicas"`
+	LoadError       string  `json:"load_error" yaml:"load_error"`
+}
+
+func detailedListView(internal bool, topics kadm.TopicDetails) (resp []detailedListTopic) {
+	resp = make([]detailedListTopic, 0, len(topics))
+	for _, topic := range topics.Sorted() {
+		if !internal && topic.IsInternal {
+			continue
+		}
+		d := detailedListTopic{
+			Name:       topic.Topic,
+			Partitions: len(topic.Partitions),
+			isInternal: topic.IsInternal,
+		}
+		if len(topic.Partitions) > 0 {
+			d.Replicas = topic.Partitions.NumReplicas()
+			d.PartitionList = make([]detailedListPartition, len(topic.Partitions))
+		}
+
+		for k, p := range topic.Partitions.Sorted() {
+			d.PartitionList[k].Partition = p.Partition
+			d.PartitionList[k].Replicas = int32s(p.Replicas).sort()
+			d.PartitionList[k].Leader = p.Leader
+			if p.LeaderEpoch != -1 {
+				d.isEpoch = true
+				d.PartitionList[k].Epoch = p.LeaderEpoch
+			}
+			if len(p.OfflineReplicas) > 0 {
+				d.isOffline = true
+				d.PartitionList[k].OfflineReplicas = int32s(p.OfflineReplicas).sort()
+			}
+			if p.Err != nil {
+				d.isLoadErr = true
+				d.PartitionList[k].LoadError = p.Err.Error()
+			}
+		}
+		resp = append(resp, d)
+	}
+	return
+}
+
+func printDetailedListView(f config.OutFormatter, topics []detailedListTopic, w io.Writer) {
+	if isText, _, t, err := f.Format(topics); !isText {
+		out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
+		fmt.Fprintln(w, t)
+		return
+	}
+
+	for i, topic := range topics {
+		var topicName string
+		if topic.isInternal {
+			topicName = fmt.Sprintf("%s (internal)", topic.Name)
+		} else {
+			topicName = topic.Name
+		}
+		fmt.Fprintf(w, "%s, %d partitions, %d replicas\n", topicName, topic.Partitions, topic.Replicas)
+		headers := []string{"", "partition", "leader"}
+		if topic.isEpoch {
+			headers = append(headers, "epoch")
+		}
+		headers = append(headers, "replicas")
+		if topic.isOffline {
+			headers = append(headers, "offline_replicas")
+		}
+		if topic.isLoadErr {
+			headers = append(headers, "load_error")
+		}
+		printPartitionTable(w, headers, topic, topic.PartitionList)
+		if i != len(topics)-1 {
+			fmt.Fprintf(w, "\n")
+		}
+	}
+}
+
+func printPartitionTable(w io.Writer, headers []string, topic detailedListTopic, partitions []detailedListPartition) {
+	tw := out.NewTableTo(w, headers...)
+	defer tw.Flush()
+	for _, p := range partitions {
+		part := []any{"", p.Partition, p.Leader}
+		if topic.isEpoch {
+			part = append(part, p.Epoch)
+		}
+		part = append(part, p.Replicas)
+		if topic.isOffline {
+			part = append(part, p.OfflineReplicas)
+		}
+		if topic.isLoadErr {
+			part = append(part, p.LoadError)
+		}
+		tw.Print(part...)
+	}
 }

--- a/src/go/rpk/pkg/cli/topic/list_test.go
+++ b/src/go/rpk/pkg/cli/topic/list_test.go
@@ -1,0 +1,193 @@
+package topic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"gopkg.in/yaml.v3"
+)
+
+func setupTestTopics() kadm.TopicDetails {
+	return kadm.TopicDetails{
+		"test-topic": {
+			Topic:      "test-topic",
+			IsInternal: false,
+			Partitions: kadm.PartitionDetails{
+				0: {
+					Partition:   0,
+					Leader:      1,
+					LeaderEpoch: 5,
+					Replicas:    []int32{1, 2, 3},
+					ISR:         []int32{1, 2, 3},
+				},
+				1: {
+					Partition:       1,
+					Leader:          2,
+					LeaderEpoch:     3,
+					Replicas:        []int32{1, 2, 3},
+					ISR:             []int32{2, 3},
+					OfflineReplicas: []int32{1},
+				},
+			},
+		},
+		"internal-topic": {
+			Topic:      "internal-topic",
+			IsInternal: true,
+			Partitions: kadm.PartitionDetails{
+				0: {
+					Partition:   0,
+					Leader:      1,
+					LeaderEpoch: 1,
+					Replicas:    []int32{1},
+					ISR:         []int32{1},
+				},
+			},
+		},
+	}
+}
+
+type testCase struct {
+	Kind   string
+	Output string
+}
+
+func JSON(t *testing.T, o any) testCase {
+	expected, err := json.Marshal(o)
+	require.NoError(t, err)
+	return testCase{Kind: "json", Output: string(expected) + "\n"}
+}
+
+func YAML(t *testing.T, o any) testCase {
+	expected, err := yaml.Marshal(o)
+	require.NoError(t, err)
+	return testCase{Kind: "yaml", Output: string(expected) + "\n"}
+}
+
+func Text(s string) testCase {
+	return testCase{Kind: "text", Output: s}
+}
+
+func TestSummarizedListView(t *testing.T) {
+	topics := setupTestTopics()
+	s := summarizedListView(false, topics)
+
+	cases := []testCase{
+		Text(`NAME        PARTITIONS  REPLICAS
+test-topic  2           3
+`),
+		JSON(t, s),
+		YAML(t, s),
+	}
+
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printSummarizedListView(f, s, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}
+
+func TestDetailedListView(t *testing.T) {
+	topics := setupTestTopics()
+	d := detailedListView(false, topics)
+
+	cases := []testCase{
+		Text(`test-topic, 2 partitions, 3 replicas
+      PARTITION  LEADER  EPOCH  REPLICAS  OFFLINE_REPLICAS
+      0          1       5      [1 2 3]   []
+      1          2       3      [1 2 3]   [1]
+`),
+		JSON(t, d),
+		YAML(t, d),
+	}
+
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printDetailedListView(f, d, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}
+
+func TestSummarizedListViewWithInternal(t *testing.T) {
+	topics := setupTestTopics()
+	s := summarizedListView(true, topics)
+
+	cases := []testCase{
+		Text(`NAME            PARTITIONS  REPLICAS
+internal-topic  1           1
+test-topic      2           3
+`),
+		JSON(t, s),
+		YAML(t, s),
+	}
+
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printSummarizedListView(f, s, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}
+
+func TestDetailedListViewWithInternal(t *testing.T) {
+	topics := setupTestTopics()
+	d := detailedListView(true, topics)
+
+	cases := []testCase{
+		Text(`internal-topic (internal), 1 partitions, 1 replicas
+      PARTITION  LEADER  EPOCH  REPLICAS
+      0          1       1      [1]
+
+test-topic, 2 partitions, 3 replicas
+      PARTITION  LEADER  EPOCH  REPLICAS  OFFLINE_REPLICAS
+      0          1       5      [1 2 3]   []
+      1          2       3      [1 2 3]   [1]
+`),
+		JSON(t, d),
+		YAML(t, d),
+	}
+
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printDetailedListView(f, d, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}
+
+func TestEmptyTopicList(t *testing.T) {
+	emptyTopics := kadm.TopicDetails{}
+	s := summarizedListView(false, emptyTopics)
+	d := detailedListView(false, emptyTopics)
+
+	for _, format := range []string{"text", "json", "yaml"} {
+		f := config.OutFormatter{Kind: format}
+		b := &strings.Builder{}
+
+		printSummarizedListView(f, s, b)
+		switch format {
+		case "text":
+			require.Equal(t, "NAME  PARTITIONS  REPLICAS\n", b.String())
+		case "json":
+			require.Equal(t, "[]\n", b.String())
+		case "yaml":
+			require.Equal(t, "[]\n\n", b.String())
+		}
+
+		b.Reset()
+		printDetailedListView(f, d, b)
+		switch format {
+		case "text":
+			require.Empty(t, b.String())
+		case "json":
+			require.Equal(t, "[]\n", b.String())
+		case "yaml":
+			require.Equal(t, "[]\n\n", b.String())
+		}
+	}
+}


### PR DESCRIPTION
Adds --format to topic list

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
### Improvements

* rpk: add `--format` JSON/YAML support to `rpk topic list`.
