### PR TITLE
cloud_topics: Remove record batch reader layout interface

### DIFF
--- a/src/v/cloud_topics/batcher/batcher.cc
+++ b/src/v/cloud_topics/batcher/batcher.cc
@@ -302,11 +302,11 @@ template<class Clock>
 ss::future<result<model::record_batch_reader>>
 batcher<Clock>::write_and_debounce(
   model::ntp ntp,
-  model::record_batch_reader r,
+  model::record_batch_reader reader,
   std::chrono::milliseconds timeout) {
     auto h = _gate.hold();
     auto index = _index++;
-    auto layout = maybe_get_data_layout(r);
+    auto layout = maybe_get_data_layout(reader);
     if (!layout.has_value()) {
         // We expect to get in-memory record batch reader here so
         // we will be able to estimate the size.
@@ -317,7 +317,7 @@ batcher<Clock>::write_and_debounce(
     // promise can be set by any fiber that uploaded the
     // data from the write request.
     auto data_chunk = co_await details::serialize_in_memory_record_batch_reader(
-      std::move(r));
+      std::move(reader));
     _current_size += data_chunk.payload.size_bytes();
     details::write_request<Clock> request(
       std::move(ntp), index, std::move(data_chunk), timeout);

--- a/src/v/cloud_topics/batcher/batcher.cc
+++ b/src/v/cloud_topics/batcher/batcher.cc
@@ -306,12 +306,6 @@ batcher<Clock>::write_and_debounce(
   std::chrono::milliseconds timeout) {
     auto h = _gate.hold();
     auto index = _index++;
-    auto layout = maybe_get_data_layout(reader);
-    if (!layout.has_value()) {
-        // We expect to get in-memory record batch reader here so
-        // we will be able to estimate the size.
-        co_return errc::timeout;
-    }
     // The write request is stored on the stack of the
     // fiber until the 'response' promise is set. The
     // promise can be set by any fiber that uploaded the

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -29,11 +29,6 @@ using data_t = record_batch_reader::data_t;
 using foreign_data_t = record_batch_reader::foreign_data_t;
 using storage_t = record_batch_reader::storage_t;
 
-std::optional<reader_data_layout>
-maybe_get_data_layout(const model::record_batch_reader& reader) {
-    return reader._impl->maybe_get_data_layout();
-}
-
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
 record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
     class foreign_reader final : public record_batch_reader::impl {
@@ -79,42 +74,11 @@ record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
             });
         }
 
-        std::optional<reader_data_layout>
-        maybe_get_data_layout() const override {
-            return _ptr->maybe_get_data_layout();
-        }
-
     private:
         ss::foreign_ptr<std::unique_ptr<record_batch_reader::impl>> _ptr;
     };
     auto frn = std::make_unique<foreign_reader>(std::move(r).release());
     return record_batch_reader(std::move(frn));
-}
-
-inline reader_data_layout make_data_layout(const storage_t& data) {
-    auto layout = ss::visit(
-      data,
-      [](const data_t& d) {
-          reader_data_layout layout{
-            .total_payload_size = 0,
-            .num_headers = d.size(),
-          };
-          for (const auto& b : d) {
-              layout.total_payload_size += b.data().size_bytes();
-          }
-          return layout;
-      },
-      [](const foreign_data_t& d) {
-          reader_data_layout layout{
-            .total_payload_size = 0,
-            .num_headers = d.buffer->size(),
-          };
-          for (const auto& b : *d.buffer) {
-              layout.total_payload_size += b.data().size_bytes();
-          }
-          return layout;
-      });
-    return layout;
 }
 
 record_batch_reader make_memory_record_batch_reader(storage_t batches) {
@@ -138,11 +102,6 @@ record_batch_reader make_memory_record_batch_reader(storage_t batches) {
               [](const data_t& d) { return d.size(); },
               [](const foreign_data_t& d) { return d.buffer->size(); });
             fmt::print(os, "memory reader {} batches", size);
-        }
-
-        std::optional<reader_data_layout>
-        maybe_get_data_layout() const override {
-            return make_data_layout(_batches);
         }
 
     protected:
@@ -243,17 +202,6 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
               os,
               "fragmented memory reader {} batches of batches",
               _data.size());
-        }
-
-        std::optional<reader_data_layout>
-        maybe_get_data_layout() const override {
-            reader_data_layout layout{};
-            for (const auto& d : _data) {
-                auto l = make_data_layout(d);
-                layout.num_headers += l.num_headers;
-                layout.total_payload_size += l.total_payload_size;
-            }
-            return layout;
         }
 
     protected:

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -44,17 +44,6 @@ concept ReferenceBatchReaderConsumer = requires(
     c.end_of_stream();
 };
 
-// Describes the layout of the data returned by the reader.
-// The reader operates on batches/records so in some cases
-// we may know the layout in advance or are able to calculate
-// it.
-struct reader_data_layout {
-    // sum of all record batch payloads
-    size_t total_payload_size;
-    // number of record batch headers
-    size_t num_headers;
-};
-
 class record_batch_reader final {
 public:
     using data_t = ss::circular_buffer<model::record_batch>;
@@ -64,9 +53,6 @@ public:
     };
     using storage_t = std::variant<data_t, foreign_data_t>;
 
-    friend std::optional<reader_data_layout>
-    maybe_get_data_layout(const model::record_batch_reader& reader);
-
     class impl {
     public:
         impl() noexcept = default;
@@ -75,12 +61,6 @@ public:
         impl(const impl& o) = delete;
         impl& operator=(const impl& o) = delete;
         virtual ~impl() noexcept = default;
-
-        /// Get data layout object that can be used to calculate serialized size
-        virtual std::optional<reader_data_layout>
-        maybe_get_data_layout() const {
-            return std::nullopt;
-        }
 
         virtual bool is_end_of_stream() const = 0;
 
@@ -322,9 +302,6 @@ private:
     friend std::ostream&
     operator<<(std::ostream& os, const record_batch_reader& r);
 };
-
-std::optional<reader_data_layout>
-maybe_get_data_layout(const model::record_batch_reader& reader);
 
 template<typename Impl, typename... Args>
 record_batch_reader make_record_batch_reader(Args&&... args) {


### PR DESCRIPTION
Remove record batch reader layout interface. More examples of implementations being able to expose their layout should be accumulated before adding a generic interface.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
