### PR TITLE
cloud_storage: follow ups to https://github.com/redpanda-data/redpanda/pull/23748

### DIFF
--- a/src/v/cloud_io/basic_cache_service_api.h
+++ b/src/v/cloud_io/basic_cache_service_api.h
@@ -27,10 +27,10 @@
 
 namespace cloud_io {
 
-static constexpr size_t default_write_buffer_size = 128_KiB;
-static constexpr unsigned default_write_behind = 10;
-static constexpr size_t default_read_buffer_size = 128_KiB;
-static constexpr unsigned default_read_ahead = 10;
+inline constexpr size_t default_write_buffer_size = 128_KiB;
+inline constexpr unsigned default_write_behind = 10;
+inline constexpr size_t default_read_buffer_size = 128_KiB;
+inline constexpr unsigned default_read_ahead = 10;
 
 struct [[nodiscard]] cache_item {
     ss::file body;

--- a/src/v/cloud_io/basic_cache_service_api.h
+++ b/src/v/cloud_io/basic_cache_service_api.h
@@ -34,7 +34,7 @@ struct [[nodiscard]] cache_item {
     size_t size;
 };
 
-struct [[nodiscard]] cache_item_str {
+struct [[nodiscard]] cache_item_stream {
     ss::input_stream<char> body;
     size_t size;
 };
@@ -108,7 +108,7 @@ public:
     /// \param key is a cache key
     /// \param read_buffer_size is a read buffer size for the iostream
     /// \param readahead number of pages that can be read asynchronously
-    virtual ss::future<std::optional<cache_item_str>> get(
+    virtual ss::future<std::optional<cache_item_stream>> get(
       std::filesystem::path key,
       ss::io_priority_class io_priority,
       size_t read_buffer_size = default_read_buffer_size,

--- a/src/v/cloud_io/basic_cache_service_api.h
+++ b/src/v/cloud_io/basic_cache_service_api.h
@@ -20,10 +20,7 @@
 #include <seastar/core/lowres_clock.hh>
 
 #include <filesystem>
-#include <iterator>
 #include <optional>
-#include <set>
-#include <string_view>
 
 namespace cloud_io {
 

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1137,7 +1137,7 @@ ss::future<std::optional<cache_item>> cache::get(std::filesystem::path key) {
     co_return std::move(result);
 }
 
-ss::future<std::optional<cloud_io::cache_item_str>> cache::get(
+ss::future<std::optional<cloud_io::cache_item_stream>> cache::get(
   std::filesystem::path key,
   ss::io_priority_class io_priority,
   size_t read_buffer_size,
@@ -1153,7 +1153,7 @@ ss::future<std::optional<cloud_io::cache_item_str>> cache::get(
     options.io_priority_class = io_priority;
     auto stream = ss::make_file_input_stream(
       std::move(get_res->body), 0, std::move(options));
-    co_return cloud_io::cache_item_str{
+    co_return cloud_io::cache_item_stream{
       .body = std::move(stream),
       .size = get_res->size,
     };

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -86,7 +86,7 @@ public:
     /// \param key is a cache key
     ss::future<std::optional<cache_item>> get(std::filesystem::path key);
 
-    ss::future<std::optional<cloud_io::cache_item_str>> get(
+    ss::future<std::optional<cloud_io::cache_item_stream>> get(
       std::filesystem::path key,
       ss::io_priority_class io_priority,
       size_t read_buffer_size = cloud_io::default_read_buffer_size,

--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -238,3 +238,27 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_btest(
+    name = "cache_test",
+    timeout = "short",
+    srcs = [
+        "cache_test.cc",
+        "cache_test_fixture.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_storage",
+        "//src/v/config",
+        "//src/v/random:generators",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:file_io",
+        "//src/v/utils:human",
+        "@boost//:filesystem",
+        "@boost//:test",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -350,7 +350,7 @@ SEASTAR_THREAD_TEST_CASE(test_access_time_tracker) {
         cm.add(names[i], timestamps[i], i);
     }
 
-    for (int i = 0; i < 10; i++) {
+    for (unsigned i = 0; i < 10; i++) {
         auto ts = cm.get(names[i]);
         BOOST_REQUIRE(ts.has_value());
         BOOST_REQUIRE(ts->time_point() == timestamps[i]);
@@ -416,7 +416,7 @@ SEASTAR_THREAD_TEST_CASE(test_access_time_tracker_serializer) {
 
     auto out = serde_roundtrip(in);
 
-    for (int i = 0; i < timestamps.size(); i++) {
+    for (unsigned i = 0; i < timestamps.size(); i++) {
         auto ts = out.get(names[i]);
         BOOST_REQUIRE(ts.has_value());
         BOOST_REQUIRE(ts->time_point() == timestamps[i]);
@@ -693,7 +693,7 @@ FIXTURE_TEST(test_background_maybe_trim, cache_test_fixture) {
       write_buf.data(), write_buf.size());
     size_t num_objects = 100;
     std::vector<std::filesystem::path> object_keys;
-    for (int i = 0; i < num_objects; i++) {
+    for (unsigned i = 0; i < num_objects; i++) {
         object_keys.emplace_back(fmt::format("test_{}.log.1", i));
         std::ofstream segment{CACHE_DIR / object_keys.back()};
         segment.write(

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -9,14 +9,12 @@
  */
 
 #include "base/units.h"
-#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
 #include "cache_test_fixture.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_service.h"
 #include "random/generators.h"
-#include "ssx/sformat.h"
 #include "test_utils/fixture.h"
 #include "test_utils/scoped_config.h"
 #include "utils/file_io.h"
@@ -64,6 +62,22 @@ FIXTURE_TEST(get_after_put, cache_test_fixture) {
       std::string_view(read_buf.get(), read_buf.size()), data_string);
     BOOST_CHECK(!stream.read().get().get());
     stream.close().get();
+}
+
+FIXTURE_TEST(stremaing_get_after_put, cache_test_fixture) {
+    auto data_string = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string, KEY);
+
+    auto stream
+      = sharded_cache.local().get(KEY, seastar::default_priority_class()).get();
+    BOOST_REQUIRE(stream);
+    BOOST_CHECK_EQUAL(stream->size, data_string.length());
+
+    auto read_buf = stream->body.read_exactly(data_string.length()).get();
+    BOOST_CHECK_EQUAL(
+      std::string_view(read_buf.get(), read_buf.size()), data_string);
+    BOOST_CHECK(!stream->body.read().get().get());
+    stream->body.close().get();
 }
 
 FIXTURE_TEST(put_rewrites_file, cache_test_fixture) {

--- a/src/v/cloud_topics/reader/tests/mocks.h
+++ b/src/v/cloud_topics/reader/tests/mocks.h
@@ -119,7 +119,7 @@ public:
 class cache_mock : public cloud_io::basic_cache_service_api<ss::lowres_clock> {
 public:
     MOCK_METHOD(
-      ss::future<std::optional<cloud_io::cache_item_str>>,
+      ss::future<std::optional<cloud_io::cache_item_stream>>,
       get,
       (std::filesystem::path key,
        ss::io_priority_class io_priority,
@@ -181,9 +181,10 @@ public:
     }
 
     void expect_get(
-      std::filesystem::path p, std::optional<cloud_io::cache_item_str> item) {
+      std::filesystem::path p,
+      std::optional<cloud_io::cache_item_stream> item) {
         auto fut
-          = ss::make_ready_future<std::optional<cloud_io::cache_item_str>>(
+          = ss::make_ready_future<std::optional<cloud_io::cache_item_stream>>(
             std::move(item));
         EXPECT_CALL(*this, get(p, ::testing::_, ::testing::_, ::testing::_))
           .Times(1)
@@ -191,9 +192,8 @@ public:
     }
 
     void expect_get_throws(std::filesystem::path p, std::exception_ptr e) {
-        auto fut
-          = ss::make_exception_future<std::optional<cloud_io::cache_item_str>>(
-            e);
+        auto fut = ss::make_exception_future<
+          std::optional<cloud_io::cache_item_stream>>(e);
         EXPECT_CALL(*this, get(p, ::testing::_, ::testing::_, ::testing::_))
           .Times(1)
           .WillOnce(::testing::Return(std::move(fut)));

--- a/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.cc
+++ b/src/v/cloud_topics/reader/tests/placeholder_extent_fixture.cc
@@ -190,7 +190,7 @@ void placeholder_extent_fixture::produce_placeholders(
                 continue;
             };
 
-            cloud_io::cache_item_str s{
+            cloud_io::cache_item_stream s{
               .body = make_iobuf_input_stream(kv.second.copy()),
               .size = sz,
             };


### PR DESCRIPTION
cloud_storage: follow ups to https://github.com/redpanda-data/redpanda/pull/23748

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

