### PR TITLE
raft/state_machine: revisit synchronization around state_machine_base::apply

### DIFF
--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -68,7 +68,7 @@ persisted_stm_base<BaseT, T>::persisted_stm_base(
 
 template<typename BaseT, supported_stm_snapshot T>
 ss::future<> persisted_stm_base<BaseT, T>::apply(const model::record_batch& b) {
-    return _apply_lock.with([this, &b] { return do_apply(b); });
+    return BaseT::_apply_lock.with([this, &b] { return do_apply(b); });
 }
 
 template<typename BaseT, supported_stm_snapshot T>
@@ -78,7 +78,6 @@ persisted_stm_base<BaseT, T>::load_local_snapshot() {
 }
 template<typename BaseT, supported_stm_snapshot T>
 ss::future<> persisted_stm_base<BaseT, T>::stop() {
-    _apply_lock.broken();
     co_await raft::state_machine_base::stop();
     co_await _gate.close();
 }
@@ -295,7 +294,7 @@ ss::future<> persisted_stm_base<BaseT, T>::wait_for_snapshot_hydrated() {
 
 template<typename BaseT, supported_stm_snapshot T>
 ss::future<> persisted_stm_base<BaseT, T>::do_write_local_snapshot() {
-    auto u = co_await _apply_lock.get_units();
+    auto u = co_await BaseT::_apply_lock.get_units();
     auto snapshot = co_await take_local_snapshot(std::move(u));
     auto offset = snapshot.header.offset;
 

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -67,8 +67,9 @@ persisted_stm_base<BaseT, T>::persisted_stm_base(
 }
 
 template<typename BaseT, supported_stm_snapshot T>
-ss::future<> persisted_stm_base<BaseT, T>::apply(const model::record_batch& b) {
-    return BaseT::_apply_lock.with([this, &b] { return do_apply(b); });
+ss::future<> persisted_stm_base<BaseT, T>::apply(
+  const model::record_batch& b, const ssx::semaphore_units&) {
+    return do_apply(b);
 }
 
 template<typename BaseT, supported_stm_snapshot T>

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -67,6 +67,11 @@ persisted_stm_base<BaseT, T>::persisted_stm_base(
 }
 
 template<typename BaseT, supported_stm_snapshot T>
+ss::future<> persisted_stm_base<BaseT, T>::apply(const model::record_batch& b) {
+    return _apply_lock.with([this, &b] { return do_apply(b); });
+}
+
+template<typename BaseT, supported_stm_snapshot T>
 ss::future<std::optional<stm_snapshot>>
 persisted_stm_base<BaseT, T>::load_local_snapshot() {
     return _snapshot_backend.load_snapshot();

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -209,7 +209,9 @@ public:
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> apply(
+      const model::record_batch&,
+      const ssx::semaphore_units& apply_units) final;
 
 protected:
     ss::future<> start() override;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -209,9 +209,7 @@ public:
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
-    ss::future<> apply(const model::record_batch& b) final {
-        return _apply_lock.with([this, &b] { return do_apply(b); });
-    }
+    ss::future<> apply(const model::record_batch&) final;
 
 protected:
     ss::future<> start() override;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -252,7 +252,6 @@ private:
     ss::future<> wait_for_snapshot_hydrated();
 
     ss::future<> do_write_local_snapshot();
-    mutex _apply_lock{"persisted_stm::apply_lock"};
     mutex _op_lock{"persisted_stm::op_lock"};
     std::vector<ss::lw_shared_ptr<expiring_promise<bool>>> _sync_waiters;
     ss::condition_variable _on_snapshot_hydrated;

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -16,6 +16,12 @@
 
 namespace raft {
 
+ss::future<> state_machine_base::apply(const model::record_batch& b) {
+    auto units = co_await _apply_lock.get_units();
+    co_await apply(b, units);
+    set_next(model::next_offset(b.last_offset()));
+}
+
 void state_machine_base::set_next(model::offset offset) {
     vassert(
       offset >= _next,

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -27,6 +27,7 @@ void state_machine_base::set_next(model::offset offset) {
 }
 
 ss::future<> state_machine_base::stop() {
+    _apply_lock.broken();
     _waiters.stop();
     co_return;
 }

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -45,6 +45,8 @@ public:
       = std::nullopt);
 
     /**
+     * Applies the batch and updates the next offset to be applied.
+     *
      * This function accepts a batch reference, an implementer may copy a batch
      * with `model::record_batch::copy()` method, the interface design is a
      * consequence of having single apply fiber for all state machines built on
@@ -52,7 +54,8 @@ public:
      * whole record is applied or not. When exception is thrown from apply
      * method it will be retried with the same record batch.
      */
-    virtual ss::future<> apply(const model::record_batch&) = 0;
+    ss::future<> apply(const model::record_batch&);
+
     /**
      * This function will be called every time a snapshot is applied in apply
      * fiber. Snapshot will contain only a data specific for this state machine
@@ -95,6 +98,15 @@ public:
     }
 
 protected:
+    /**
+     * Must always be called under apply mutex scope and apply_units argument
+     * is in place to enforce that. It is const qualified to ensure the apply
+     * impelementors do not control their lifetime.
+     */
+    virtual ss::future<>
+    apply(const model::record_batch&, const ssx::semaphore_units& apply_units)
+      = 0;
+
     /**
      *  Lifecycle is managed by state_machine_manager
      */

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -16,6 +16,7 @@
 #include "model/record.h"
 #include "raft/fwd.h"
 #include "raft/offset_monitor.h"
+#include "utils/mutex.h"
 
 namespace raft {
 using snapshot_at_offset_supported
@@ -106,6 +107,8 @@ protected:
 
     model::offset next() const { return _next; }
     void set_next(model::offset offset);
+
+    mutex _apply_lock{"state_machine_base::apply_lock"};
 
     friend class batch_applicator;
     friend class state_machine_manager;

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -140,7 +140,6 @@ batch_applicator::apply_to_stm(
         }
 
         co_await state.stm_entry->stm->apply(batch);
-        state.stm_entry->stm->set_next(model::next_offset(last_offset));
         co_return applied_successfully::yes;
     } catch (...) {
         vlog(

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -22,7 +22,9 @@ struct throwing_kv : public simple_kv {
     explicit throwing_kv(raft_node_instance& rn)
       : simple_kv(rn) {}
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch,
+      const ssx::semaphore_units& units) override {
         if (tests::random_bool()) {
             throw std::runtime_error("runtime error from throwing stm");
         }
@@ -32,7 +34,7 @@ struct throwing_kv : public simple_kv {
           "offset: {}",
           batch.header(),
           next());
-        co_await simple_kv::apply(batch);
+        co_await simple_kv::apply(batch, units);
         co_return;
     }
 
@@ -55,14 +57,16 @@ struct local_snapshot_stm : public simple_kv {
     explicit local_snapshot_stm(raft_node_instance& rn)
       : simple_kv(rn) {}
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch,
+      const ssx::semaphore_units& units) override {
         vassert(
           batch.base_offset() == next(),
           "batch {} base offset is not the next to apply, expected base "
           "offset: {}",
           batch.header(),
           next());
-        co_await simple_kv::apply(batch);
+        co_await simple_kv::apply(batch, units);
     }
 
     ss::future<> apply_raft_snapshot(const iobuf& buffer) override {
@@ -85,9 +89,11 @@ public:
     explicit slow_kv(raft_node_instance& rn)
       : simple_kv(rn) {}
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch,
+      const ssx::semaphore_units& apply_units) override {
         co_await ss::sleep(5ms);
-        co_return co_await simple_kv::apply(batch);
+        co_return co_await simple_kv::apply(batch, apply_units);
     }
 
     ss::future<> apply_raft_snapshot(const iobuf&) override {
@@ -104,13 +110,15 @@ public:
     explicit bg_only_kv(raft_node_instance& rn)
       : slow_kv(rn) {}
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch,
+      const ssx::semaphore_units& apply_units) override {
         if (_first_apply) {
             _first_apply = false;
             throw std::runtime_error("induced failure");
         }
         co_await ss::sleep(5ms);
-        co_return co_await slow_kv::apply(batch);
+        co_return co_await slow_kv::apply(batch, apply_units);
     }
 
 private:
@@ -434,7 +442,9 @@ struct controllable_throwing_kv : public simple_kv {
     explicit controllable_throwing_kv(raft_node_instance& rn)
       : simple_kv(rn) {}
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch,
+      const ssx::semaphore_units& apply_units) override {
         if (batch.last_offset() > _allow_apply) {
             throw std::runtime_error(fmt::format(
               "not allowed to apply batches with last offset greater than {}. "
@@ -448,7 +458,7 @@ struct controllable_throwing_kv : public simple_kv {
           "offset: {}",
           batch.header(),
           next());
-        co_await simple_kv::apply(batch);
+        co_await simple_kv::apply(batch, apply_units);
         co_return;
     }
 

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -100,7 +100,8 @@ struct simple_kv_base : public BaseT {
     ss::future<> start() override { return ss::now(); }
     ss::future<> stop() override { co_await BaseT::stop(); };
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch, const ssx::semaphore_units&) override {
         apply_to_state(batch, state);
         co_return;
     }


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-7943

This is related to recent work in https://github.com/redpanda-data/redpanda/commit/e2720105f1e1c377f47eb15bebe4a80f5c9ac825

This PR redoes synchronization around state_machine_base::apply(batch) so that racing snapshots (local snapshots) see a consistent state of the stm. The invariant that is currently violated without this synchronization is the following example.

Example:

```
* last_applied_offset = 10. [ initial state]

* state_machine_base::apply -- tries to apply offset 11

* persisted_stm::apply  -- grabs [persisted_stm::_apply_lock] for offset 11

* rm_stm::do_apply() -- successfully applies 11

** [scheduling points] control is still not back to state_machine_base::apply.. so set_next() is not called.. last_applied_offset  = 10

* racing take_local_snapshot() --  persisted_stm::do_write_local_snapshot() -- it can proceed with snapshotting because _apply_lock is no longer held.

* At this point .,,, rm_stm::take_local_snapshot(apply_lock_units)  is called with last_applied_offset ()= 10 .. when in fact the state of the stm corresponds to offset = 11
```

The invariant that is broken here is that the local snapshot sees an inconsistent state of the stm resulting in an off-by-one error in the snapshot offset. Snapshotting relies on the last_applied_offset() to compute snapshot offset  and in this case the last_applied_offset is not atomically updated along with actual apply.

This PR proposes to unify locking for the apply path into state_machine_base (from persisted_stm) and code paths that intend to see a consistent state of the stm must hold the lock so the apply doesn't interleave.


Adds a regression test that consistently reproduces this problem without the patch.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
