### PR TITLE
model: move boundary type into storage layer

### DIFF
--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -235,15 +235,6 @@ operator-(model::offset r, kafka::offset k) {
     return model::offset_delta{r() - k()};
 }
 
-/// \brief offset boundary type
-///
-/// indicate whether or not the offset that encodes the end of the offset
-/// range belongs to the offset range
-enum class boundary_type {
-    exclusive,
-    inclusive,
-};
-
 /// \brief cast to model::offset
 ///
 /// The purpose of this function is to mark every place where we converting

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1888,7 +1888,7 @@ struct batch_size_accumulator {
         //                  target---v
         //     |++++++++++++++[+++++++]X          |
         //
-        if (boundary == model::boundary_type::inclusive) {
+        if (boundary == boundary_type::inclusive) {
             if (b.last_offset() > target) {
                 co_return ss::stop_iteration::yes;
             }
@@ -1908,7 +1908,7 @@ struct batch_size_accumulator {
 
     size_t* result_size_bytes{nullptr};
     model::offset target;
-    model::boundary_type boundary;
+    boundary_type boundary;
 };
 } // namespace details
 
@@ -1916,7 +1916,7 @@ ss::future<size_t> disk_log_impl::get_file_offset(
   ss::lw_shared_ptr<segment> s,
   std::optional<segment_index::entry> maybe_index_entry,
   model::offset target,
-  model::boundary_type boundary,
+  boundary_type boundary,
   ss::io_priority_class priority) {
     auto index_entry = maybe_index_entry.value_or(segment_index::entry{
       .offset = s->offsets().get_base_offset(),
@@ -2042,7 +2042,7 @@ disk_log_impl::offset_range_size(
       segments.front(),
       ix_left,
       first,
-      model::boundary_type::exclusive,
+      boundary_type::exclusive,
       io_priority);
 
     // Right subscan
@@ -2066,7 +2066,7 @@ disk_log_impl::offset_range_size(
       segments.back(),
       ix_right,
       last,
-      model::boundary_type::inclusive,
+      boundary_type::inclusive,
       io_priority);
 
     // compute size
@@ -2202,7 +2202,7 @@ disk_log_impl::offset_range_size(
           first_segment,
           ix_res,
           first,
-          model::boundary_type::exclusive,
+          boundary_type::exclusive,
           io_priority);
     } else {
         // We expect to find first offset inside the first segment.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2039,11 +2039,7 @@ disk_log_impl::offset_range_size(
           segments.front()->offsets());
     }
     auto left_scan_bytes = co_await get_file_offset(
-      segments.front(),
-      ix_left,
-      first,
-      boundary_type::exclusive,
-      io_priority);
+      segments.front(), ix_left, first, boundary_type::exclusive, io_priority);
 
     // Right subscan
     auto ix_right = segments.back()->index().find_nearest(last);
@@ -2063,11 +2059,7 @@ disk_log_impl::offset_range_size(
           segments.back()->offsets());
     }
     auto right_scan_bytes = co_await get_file_offset(
-      segments.back(),
-      ix_right,
-      last,
-      boundary_type::inclusive,
-      io_priority);
+      segments.back(), ix_right, last, boundary_type::inclusive, io_priority);
 
     // compute size
     size_t total_size = 0;
@@ -2199,11 +2191,7 @@ disk_log_impl::offset_range_size(
         auto ix_res = first_segment->index().find_nearest(first);
 
         first_segment_file_pos = co_await get_file_offset(
-          first_segment,
-          ix_res,
-          first,
-          boundary_type::exclusive,
-          io_priority);
+          first_segment, ix_res, first, boundary_type::exclusive, io_priority);
     } else {
         // We expect to find first offset inside the first segment.
         // If this is not the case the log was likely truncated concurrently.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -33,6 +33,15 @@
 
 namespace storage {
 
+/// \brief offset boundary type
+///
+/// indicate whether or not the offset that encodes the end of the offset
+/// range belongs to the offset range
+enum class boundary_type {
+    exclusive,
+    inclusive,
+};
+
 class disk_log_impl final : public log {
 public:
     using failure_probes = storage::log_failure_probes;
@@ -246,7 +255,7 @@ private:
       ss::lw_shared_ptr<segment> s,
       std::optional<segment_index::entry> index_entry,
       model::offset target,
-      model::boundary_type boundary,
+      boundary_type boundary,
       ss::io_priority_class priority);
 
     ss::future<model::record_batch_reader>


### PR DESCRIPTION
Storage is the only place that it used, so it's a bit hard to say that it's a fundamental aspect.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

