### PR TITLE
raft: move broker_v0 definition into raft subsystem

### DIFF
--- a/src/v/model/adl_serde.cc
+++ b/src/v/model/adl_serde.cc
@@ -128,26 +128,6 @@ model::broker adl<model::broker>::from(iobuf_parser& in) {
     return model::broker{id, std::move(kafka_adrs), rpc_adrs, rack, etc_props};
 }
 
-void adl<model::internal::broker_v0>::to(
-  iobuf& out, model::internal::broker_v0&& r) {
-    adl<model::node_id>{}.to(out, r.id);
-    adl<net::unresolved_address>{}.to(out, r.kafka_address);
-    adl<net::unresolved_address>{}.to(out, r.rpc_address);
-    adl<std::optional<model::rack_id>>{}.to(out, r.rack);
-    adl<model::broker_properties>{}.to(out, r.properties);
-}
-
-model::internal::broker_v0
-adl<model::internal::broker_v0>::from(iobuf_parser& in) {
-    auto id = adl<model::node_id>{}.from(in);
-    auto kafka_adrs = adl<net::unresolved_address>{}.from(in);
-    auto rpc_adrs = adl<net::unresolved_address>{}.from(in);
-    auto rack = adl<std::optional<model::rack_id>>{}.from(in);
-    auto etc_props = adl<model::broker_properties>{}.from(in);
-    return model::internal::broker_v0{
-      id, kafka_adrs, rpc_adrs, rack, etc_props};
-}
-
 void adl<model::record>::to(iobuf& ref, model::record&& record) {
     reflection::serialize(
       ref,

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -89,12 +89,6 @@ struct adl<model::broker> {
     model::broker from(iobuf_parser& in);
 };
 
-template<>
-struct adl<model::internal::broker_v0> {
-    void to(iobuf& out, model::internal::broker_v0&& r);
-    model::internal::broker_v0 from(iobuf_parser& in);
-};
-
 // TODO: optimize this transmition with varints
 template<>
 struct adl<model::record> {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -574,25 +574,6 @@ std::optional<write_caching_mode>
 std::ostream& operator<<(std::ostream&, write_caching_mode);
 std::istream& operator>>(std::istream&, write_caching_mode&);
 
-namespace internal {
-/*
- * Old version for use in backwards compatibility serialization /
- * deserialization helpers.
- */
-struct broker_v0 {
-    model::node_id id;
-    net::unresolved_address kafka_address;
-    net::unresolved_address rpc_address;
-    std::optional<rack_id> rack;
-    model::broker_properties properties;
-
-    model::broker to_v3() const {
-        return model::broker(id, kafka_address, rpc_address, rack, properties);
-    }
-};
-
-} // namespace internal
-
 enum class recovery_validation_mode : std::uint16_t {
     // ensure that either the manifest is in TS or that no manifest is present.
     // download issues will fail the validation

--- a/src/v/raft/BUILD
+++ b/src/v/raft/BUILD
@@ -1,6 +1,8 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 load("//src/v/rpc:compiler.bzl", "redpanda_cc_rpc_library")
 
+package(default_visibility = ["//src/v/raft:__subpackages__"])
+
 redpanda_cc_rpc_library(
     name = "raft_rpc",
     src = "raftgen.json",
@@ -18,6 +20,19 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/model",
         "//src/v/utils:named_type",
+    ],
+)
+
+redpanda_cc_library(
+    name = "broker_compat",
+    hdrs = [
+        "broker_compat.h",
+    ],
+    include_prefix = "raft",
+    deps = [
+        "//src/v/model",
+        "//src/v/reflection:adl",
+        "//src/v/utils:unresolved_address",
     ],
 )
 
@@ -99,6 +114,7 @@ redpanda_cc_library(
     include_prefix = "raft",
     visibility = ["//visibility:public"],
     deps = [
+        ":broker_compat",
         ":fundamental",
         ":raft_rpc",
         "//src/v/base",

--- a/src/v/raft/broker_compat.h
+++ b/src/v/raft/broker_compat.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/adl_serde.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "reflection/adl.h"
+#include "utils/unresolved_address.h"
+
+namespace model::internal {
+/*
+ * Old version for use in backwards compatibility serialization /
+ * deserialization helpers.
+ */
+struct broker_v0 {
+    model::node_id id;
+    net::unresolved_address kafka_address;
+    net::unresolved_address rpc_address;
+    std::optional<rack_id> rack;
+    model::broker_properties properties;
+
+    model::broker to_v3() const {
+        return model::broker(id, kafka_address, rpc_address, rack, properties);
+    }
+};
+
+} // namespace model::internal
+
+namespace reflection {
+
+template<>
+struct adl<model::internal::broker_v0> {
+    void to(iobuf& out, model::internal::broker_v0&& r) {
+        adl<model::node_id>{}.to(out, r.id);
+        adl<net::unresolved_address>{}.to(out, r.kafka_address);
+        adl<net::unresolved_address>{}.to(out, r.rpc_address);
+        adl<std::optional<model::rack_id>>{}.to(out, r.rack);
+        adl<model::broker_properties>{}.to(out, r.properties);
+    }
+
+    model::internal::broker_v0 from(iobuf_parser& in) {
+        auto id = adl<model::node_id>{}.from(in);
+        auto kafka_adrs = adl<net::unresolved_address>{}.from(in);
+        auto rpc_adrs = adl<net::unresolved_address>{}.from(in);
+        auto rack = adl<std::optional<model::rack_id>>{}.from(in);
+        auto etc_props = adl<model::broker_properties>{}.from(in);
+        return model::internal::broker_v0{
+          id, kafka_adrs, rpc_adrs, rack, etc_props};
+    }
+};
+
+} // namespace reflection

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -13,6 +13,7 @@
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "raft/broker_compat.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
 #include "serde/rw/rw.h"

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -12,6 +12,7 @@
 #include "model/metadata.h"
 #include "model/tests/random_batch.h"
 #include "model/tests/randoms.h"
+#include "raft/broker_compat.h"
 #include "raft/consensus_utils.h"
 #include "raft/group_configuration.h"
 #include "random/generators.h"


### PR DESCRIPTION
The broker_v0 is used for serialization compat. This commit moves its definition into raft which is the only user of the type, rather than storing it in one of the most used headers in the tree.

broker_v0 may actually not be needed any longer, but that will require a different type of analysis.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
