### PR TITLE
datalake/protobuf: fallback to strings for uint64_t

### DIFF
--- a/src/v/datalake/tests/testdata/complex.proto
+++ b/src/v/datalake/tests/testdata/complex.proto
@@ -35,3 +35,13 @@ message TopLevel {
     }
     NestedLevelOne nested_level_one = 1;
 }
+
+message StructWithUnsignedInt {
+    int64 valid = 1;
+    uint64 invalid = 2;
+}
+
+message StructWithUnsignedFixed {
+    int64 valid = 1;
+    fixed64 invalid = 2;
+}

--- a/src/v/datalake/tests/testdata/not_supported.proto
+++ b/src/v/datalake/tests/testdata/not_supported.proto
@@ -1,13 +1,4 @@
 syntax = "proto3";
-message StructWithUnsignedInt {
-    int64 valid = 1;
-    uint64 invalid = 2;
-}
-
-message StructWithUnsignedFixed {
-    int64 valid = 1;
-    fixed64 invalid = 2;
-}
 
 message RecursiveMessage {
     int32 field = 1;


### PR DESCRIPTION
This is a better experience for users than not being able to support
their schema at all.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
