### PR TITLE
[v24.2.x] dt/audit: Added missing skip_fips_mode

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -40,6 +40,7 @@ from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception, wait_until, wait_until_result
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.rpk_config import read_redpanda_cfg
 from rptest.utils.schema_registry_utils import Mode, get_subjects, put_mode
 from urllib.parse import urlparse
@@ -1756,6 +1757,7 @@ class AuditLogTestInvalidConfigMTLS(AuditLogTestInvalidConfigBase):
               self).__init__(test_context=test_context,
                              security=self._security_config)
 
+    @skip_fips_mode
     @cluster(
         num_nodes=4,
         log_allow_list=[


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23804
