### PR TITLE
test_utils: throw on gtest assert

### DIFF
--- a/src/v/test_utils/CMakeLists.txt
+++ b/src/v/test_utils/CMakeLists.txt
@@ -6,12 +6,19 @@ v_cc_library(
 find_package(GTest)
 
 v_cc_library(
+  NAME gtest_utils
+  SRCS
+    gtest_utils.cc
+  DEPS Seastar::seastar Seastar::seastar_testing GTest::gtest GTest::gmock v::bytes_random
+)
+
+v_cc_library(
   NAME gtest_main
   SRCS
     gtest_main.cc
-    gtest_utils.cc
     runfiles.cc
-  DEPS Seastar::seastar Seastar::seastar_testing GTest::gtest GTest::gmock v::bytes_random)
+  DEPS v_gtest_utils)
+
 
 add_subdirectory(go/kreq-gen)
 add_subdirectory(tests)

--- a/src/v/test_utils/gtest_utils.cc
+++ b/src/v/test_utils/gtest_utils.cc
@@ -26,6 +26,13 @@ void rp_test_listener::OnTestIterationStart(
     gtest_iteration = iteration;
 }
 
+void rp_test_listener::OnTestPartResult(
+  const ::testing::TestPartResult& result) {
+    if (result.type() == testing::TestPartResult::kFatalFailure) {
+        throw testing::AssertionException(result);
+    }
+}
+
 ss::sstring get_test_directory() {
     const auto* test_info
       = ::testing::UnitTest::GetInstance()->current_test_info();

--- a/src/v/test_utils/gtest_utils.h
+++ b/src/v/test_utils/gtest_utils.h
@@ -21,6 +21,8 @@
 class rp_test_listener : public ::testing::EmptyTestEventListener {
     void
     OnTestIterationStart(const ::testing::UnitTest&, int iteration) override;
+
+    void OnTestPartResult(const ::testing::TestPartResult& result) override;
 };
 
 // Returns a pathname that may be used for the currently running test.

--- a/src/v/test_utils/tests/CMakeLists.txt
+++ b/src/v/test_utils/tests/CMakeLists.txt
@@ -4,3 +4,12 @@ rp_test(
   BINARY_NAME gtest_test
   SOURCES gtest_test.cc
   LIBRARIES v::gtest_main)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_listener
+  SOURCES
+    gtest_listener_test.cc
+  LIBRARIES v_gtest_utils GTest::gtest
+)

--- a/src/v/test_utils/tests/gtest_listener_test.cc
+++ b/src/v/test_utils/tests/gtest_listener_test.cc
@@ -1,0 +1,50 @@
+#include "gtest/gtest.h"
+#include "test_utils/gtest_utils.h"
+
+#include <gtest/gtest.h>
+
+/// Helper function to print and error message and exit with code 1.
+/// We can't use gtest assertions because the way test is set up is meant to
+/// fail and we hide that failure.
+void fail_test(const std::string_view msg) {
+    std::cout << testing::internal::GetCapturedStdout() << std::endl;
+    fmt::print("FAILURE: {}\n", msg);
+    exit(1);
+}
+
+void helper_asserts_false() {
+    ASSERT_FALSE(true) << "Expected failure. Aye aye!";
+}
+
+TEST(AssertInHelper, AssertInHelperThrows) {
+    try {
+        helper_asserts_false();
+        fail_test("Expected exception to be thrown above and this line to not "
+                  "be executed.");
+    } catch (const testing::AssertionException& e) {
+        if (strstr(e.what(), "Expected failure. Aye aye!") == nullptr) {
+            fail_test(
+              "Expected message to contain 'Expected failure. Aye aye!'");
+        }
+        throw;
+    }
+}
+
+/// In this test we want to check that the listener intercepts asserts and
+/// throws exception resulting in not just test failure but test termination.
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new rp_test_listener());
+
+    // Hide stdout to avoid confusing users.
+    testing::internal::CaptureStdout();
+
+    int result = RUN_ALL_TESTS();
+    if (result == 0) {
+        fail_test("Expected the test to fail but it passed.");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR tries to address feedback given by Travis Downs

> My biggest gripe about gtest is that its assertion macros are by
> default much less useful than everyone else's because you can't use them
> outside of the test method itself (e.g., in a function called by the
> test method) without jumping through a bunch of error-prone hoops. In
> addition to just being annoying writing new tests, it makes sort of
> "rote" migration of boost tests more difficult because assertions that
> break this rule are common. Not all of the issues are caught at compile
> time either, assertions in void-returning methods will compile but not
> stop the test so you may get a different set of errors or a crash,
> ultimately after conversion.

https://google.github.io/googletest/advanced.html#asserting-on-subroutines-with-an-exception
https://github.com/google/googletest/commit/092d0885332316ca679ac77e0f8fe1f5c368fb4f

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
