### PR TITLE
tests/setup: update ducktape ref

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@482b3f6ee066052871e3991eab1fa48a3cd241d4',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@78b65e1739580b2fa89db68a9285d8d478693962',
         'prometheus-client==0.9.0',
         'kafka-python==2.0.2',
         'crc32c==2.2',


### PR DESCRIPTION
Update ducktape ref that adds the ability to not fail when no test context was loaded. This is useful when ci is instructed to run a test that is skipped in `debug` mode. In such cases ducktape on debug builds fails with an exception raised by the ducktape framework `No tests to run`. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
