### PR TITLE
tests: bump to `0.11.x-redpanda` without ok-to-fail reporting

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@78b65e1739580b2fa89db68a9285d8d478693962',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@0b128ce0aaa1815db9880fb171a4f90cf7b74e43',
         'prometheus-client==0.9.0',
         'kafka-python==2.0.2',
         'crc32c==2.2',


### PR DESCRIPTION
Bump ducktape version to one that is based on 0.11.x but doesn't have `OPASS`/`OFAIL` reporting.

fixes https://redpandadata.atlassian.net/browse/DEVPROD-2121

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
