### PR TITLE
[v24.1.x] rpk: introduce license warnings messages

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -136,6 +136,7 @@ require (
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.25.0 // indirect
+	google.golang.org/genproto v0.0.0-20240116215550-a9fa1716bcac // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -358,6 +358,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/genproto v0.0.0-20240116215550-a9fa1716bcac h1:ZL/Teoy/ZGnzyrqK/Optxxp2pmVh+fmJ97slxSRyzUg=
+google.golang.org/genproto v0.0.0-20240116215550-a9fa1716bcac/go.mod h1:+Rvu7ElI+aLzyDQhpHMFMMltsD6m7nqpuWDd2CwJw3k=
 google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 h1:hjSy6tcFQZ171igDaN5QHOw2n6vx40juYbC/x67CEhc=
 google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:qpvKtACPCQhAdu3PyQgV4l3LMXZEtft7y8QcarRsp9I=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 h1:pPJltXNxVzT4pK9yD8vR9X75DaWYYmLGMsEvBfFQZzQ=

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -120,7 +121,7 @@ func getAuth(p *config.RpkProfile) (Auth, error) {
 
 // NewClient returns an AdminAPI client that talks to each of the addresses in
 // the rpk.admin_api section of the config.
-func NewClient(fs afero.Fs, p *config.RpkProfile, opts ...Opt) (*AdminAPI, error) {
+func NewClient(ctx context.Context, fs afero.Fs, p *config.RpkProfile, opts ...Opt) (*AdminAPI, error) {
 	a := &p.AdminAPI
 
 	addrs := a.Addresses
@@ -132,7 +133,15 @@ func NewClient(fs afero.Fs, p *config.RpkProfile, opts ...Opt) (*AdminAPI, error
 	if err != nil {
 		return nil, err
 	}
-	return newAdminAPI(addrs, auth, tc, p.FromCloud, opts...)
+
+	cl, err := newAdminAPI(addrs, auth, tc, p.FromCloud, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if msg := licenseFeatureChecks(ctx, fs, cl, p); msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+	return cl, nil
 }
 
 // NewHostClient returns an AdminAPI that talks to the given host, which is
@@ -657,4 +666,46 @@ func MaxRetries(r int) Opt {
 	return clientOpt{func(cl *pester.Client) {
 		cl.MaxRetries = r
 	}}
+}
+
+// licenseFeatureChecks checks if the user is talking to a cluster that has
+// enterprise features enabled without a license and returns a message with a
+// warning.
+func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *AdminAPI, p *config.RpkProfile) string {
+	var msg string
+	// We only do a check if:
+	//   1. LicenseCheck == nil: never checked before OR last check was in
+	//      violation. (we only save successful responses).
+	//   2. LicenseStatus was last checked more than 7 days ago.
+	if p.LicenseCheck == nil || p.LicenseCheck != nil && time.Unix(p.LicenseCheck.LastUpdate, 0).AddDate(0, 0, 7).Before(time.Now()) {
+		resp, err := cl.GetEnterpriseFeatures(ctx)
+		if err != nil {
+			zap.L().Sugar().Warnf("unable to check licensed enterprise features in the cluster: %v", err)
+			return ""
+		}
+		// We don't write a profile if the config doesn't exist.
+		y, exists := p.ActualConfig()
+		var licenseCheck *config.LicenseStatusCache
+		if resp.Violation {
+			var features []string
+			for _, f := range resp.Features {
+				if f.Enabled {
+					features = append(features, f.Name)
+				}
+			}
+			msg = fmt.Sprintf("A Redpanda Enterprise Edition license is required to use enterprise features: %v. For more information, see https://docs.redpanda.com/current/get-started/licenses.", features)
+		} else {
+			licenseCheck = &config.LicenseStatusCache{
+				LastUpdate: time.Now().Unix(),
+			}
+		}
+		if exists && y != nil {
+			actProfile := y.Profile(p.Name)
+			actProfile.LicenseCheck = licenseCheck
+			if err := y.Write(fs); err != nil {
+				zap.L().Sugar().Warnf("unable to save licensed enterprise features check cache to profile: %v", err)
+			}
+		}
+	}
+	return msg
 }

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -676,8 +676,8 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *AdminAPI, p *con
 	// We only do a check if:
 	//   1. LicenseCheck == nil: never checked before OR last check was in
 	//      violation. (we only save successful responses).
-	//   2. LicenseStatus was last checked more than 7 days ago.
-	if p.LicenseCheck == nil || p.LicenseCheck != nil && time.Unix(p.LicenseCheck.LastUpdate, 0).AddDate(0, 0, 7).Before(time.Now()) {
+	//   2. LicenseStatus was last checked more than 1 hour ago.
+	if p.LicenseCheck == nil || p.LicenseCheck != nil && time.Unix(p.LicenseCheck.LastUpdate, 0).Add(1*time.Hour).Before(time.Now()) {
 		resp, err := cl.GetEnterpriseFeatures(ctx)
 		if err != nil {
 			zap.L().Sugar().Warnf("unable to check licensed enterprise features in the cluster: %v", err)
@@ -693,7 +693,7 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *AdminAPI, p *con
 					features = append(features, f.Name)
 				}
 			}
-			msg = fmt.Sprintf("A Redpanda Enterprise Edition license is required to use enterprise features: %v. For more information, see https://docs.redpanda.com/current/get-started/licenses.", features)
+			msg = fmt.Sprintf("\nWARNING: The following Enterprise features are being used in your Redpanda cluster: %v. These features require a license. To get a license, contact us at https://www.redpanda.com/contact. For more information, see https://docs.redpanda.com/current/get-started/licenses/#redpanda-enterprise-edition\n", features)
 		} else {
 			licenseCheck = &config.LicenseStatusCache{
 				LastUpdate: time.Now().Unix(),

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -701,9 +701,11 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *AdminAPI, p *con
 		}
 		if exists && y != nil {
 			actProfile := y.Profile(p.Name)
-			actProfile.LicenseCheck = licenseCheck
-			if err := y.Write(fs); err != nil {
-				zap.L().Sugar().Warnf("unable to save licensed enterprise features check cache to profile: %v", err)
+			if actProfile != nil {
+				actProfile.LicenseCheck = licenseCheck
+				if err := y.Write(fs); err != nil {
+					zap.L().Sugar().Warnf("unable to save licensed enterprise features check cache to profile: %v", err)
+				}
 			}
 		}
 	}

--- a/src/go/rpk/pkg/adminapi/admin_test.go
+++ b/src/go/rpk/pkg/adminapi/admin_test.go
@@ -17,7 +17,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,6 +131,114 @@ func TestAdminAPI(t *testing.T) {
 	}
 }
 
+func Test_licenseFeatureChecks(t *testing.T) {
+	tests := []struct {
+		name         string
+		prof         *config.RpkProfile
+		responseCase string // See the mapLicenseResponses below.
+		expContain   string
+		withErr      bool
+		checkCache   func(t *testing.T, before int64, after int64)
+	}{
+		{
+			name:         "license ok, first time call",
+			prof:         &config.RpkProfile{},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name: "license ok, cache valid",
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// If the cache was valid, last update shouldn't have changed.
+				require.Equal(t, before, after)
+			},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name: "license ok, old cache",
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 15 days
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// Date should be updated.
+				afterT := time.Unix(after, 0)
+				require.True(t, time.Unix(before, 0).Before(afterT))
+			},
+			responseCase: "ok",
+			expContain:   "",
+		},
+		{
+			name:         "inViolation, first time call",
+			prof:         &config.RpkProfile{},
+			responseCase: "inViolation",
+			expContain:   "A Redpanda Enterprise Edition license is required",
+		},
+		{
+			name:         "inViolation, expired last check",
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}},
+			responseCase: "inViolation",
+			expContain:   "A Redpanda Enterprise Edition license is required t",
+		},
+		{
+			// Edge case when the license expires but the last check was less
+			// than 15 days ago.
+			name:         "inViolation, cache still valid",
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			responseCase: "inViolation",
+			// In this case, even if the license is in violation, rpk won't
+			// reach the Admin API because the last check was under 15 days.
+			checkCache: func(t *testing.T, before int64, after int64) {
+				// At this point we don't rewrite the last check, because still
+				// valid.
+				require.Equal(t, before, after)
+			},
+			expContain: "",
+		},
+		{
+			name:         "admin API errors, don't print",
+			prof:         &config.RpkProfile{},
+			withErr:      true,
+			responseCase: "failedRequest",
+			// If we fail to communicate with the cluster, or the request fails,
+			// then we just WARN the user of what happened but won't print to
+			// stdout.
+			expContain: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(licenseHandler(tt.responseCase))
+			defer ts.Close()
+			tt.prof.AdminAPI = config.RpkAdminAPI{Addresses: []string{ts.URL}}
+			fs := afero.NewMemMapFs()
+			loadedProfile := writeRpkProfileToFs(t, fs, tt.prof)
+			client, err := NewHostClient(fs, loadedProfile, "0")
+			require.NoError(t, err)
+			got := licenseFeatureChecks(context.Background(), fs, client, loadedProfile)
+			if tt.expContain == "" {
+				require.Empty(t, got)
+				if tt.withErr {
+					return
+				}
+				// If we get to this point, we need to make sure that the last
+				// update date was registered.
+				afterProf := loadProfile(t, fs)
+				require.NotEmpty(t, afterProf.LicenseCheck)
+				require.NotEmpty(t, afterProf.LicenseCheck.LastUpdate)
+				if tt.checkCache != nil {
+					tt.checkCache(t, tt.prof.LicenseCheck.LastUpdate, afterProf.LicenseCheck.LastUpdate)
+				}
+				return
+			}
+			require.Contains(t, got, tt.expContain)
+			// If we get to this point, then we shouldn't have the last
+			// update registered.
+			afterProf := loadProfile(t, fs)
+			require.Empty(t, afterProf.LicenseCheck)
+		})
+	}
+}
+
 func handlerForNode(
 	t *testing.T, nodeID int, tt reqsTest, calls *[]testCall, mutex *sync.Mutex,
 ) http.HandlerFunc {
@@ -221,4 +332,42 @@ func callsForNodeID(calls []testCall, nodeID int) []testCall {
 		}
 	}
 	return filtered
+}
+
+func writeRpkProfileToFs(t *testing.T, fs afero.Fs, p *config.RpkProfile) *config.RpkProfile {
+	p.Name = "test"
+	rpkyaml := config.RpkYaml{
+		CurrentProfile: "test",
+		Version:        6,
+		Profiles:       []config.RpkProfile{*p},
+	}
+	err := rpkyaml.Write(fs)
+	require.NoError(t, err)
+
+	return loadProfile(t, fs)
+}
+
+func loadProfile(t *testing.T, fs afero.Fs) *config.RpkProfile {
+	y, err := new(config.Params).Load(fs)
+	require.NoError(t, err)
+	return y.VirtualProfile()
+}
+
+type response struct {
+	status int
+	body   string
+}
+
+var mapLicenseResponses = map[string]response{
+	"ok":            {http.StatusOK, `{"license_status": "valid", "violation": false}`},
+	"inViolation":   {http.StatusOK, `{"license_status": "expired", "violation": true, "features": [{"name": "partition_auto_balancing_continuous", "enabled": true}]}`},
+	"failedRequest": {http.StatusBadRequest, ""},
+}
+
+func licenseHandler(respCase string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := mapLicenseResponses[respCase]
+		w.WriteHeader(resp.status)
+		w.Write([]byte(resp.body))
+	}
 }

--- a/src/go/rpk/pkg/adminapi/admin_test.go
+++ b/src/go/rpk/pkg/adminapi/admin_test.go
@@ -148,7 +148,7 @@ func Test_licenseFeatureChecks(t *testing.T) {
 		},
 		{
 			name: "license ok, cache valid",
-			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().Add(20 * time.Minute).Unix()}},
 			checkCache: func(t *testing.T, before int64, after int64) {
 				// If the cache was valid, last update shouldn't have changed.
 				require.Equal(t, before, after)
@@ -158,7 +158,7 @@ func Test_licenseFeatureChecks(t *testing.T) {
 		},
 		{
 			name: "license ok, old cache",
-			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 15 days
+			prof: &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}}, // Limit is 1 hour
 			checkCache: func(t *testing.T, before int64, after int64) {
 				// Date should be updated.
 				afterT := time.Unix(after, 0)
@@ -171,19 +171,19 @@ func Test_licenseFeatureChecks(t *testing.T) {
 			name:         "inViolation, first time call",
 			prof:         &config.RpkProfile{},
 			responseCase: "inViolation",
-			expContain:   "A Redpanda Enterprise Edition license is required",
+			expContain:   "These features require a license",
 		},
 		{
 			name:         "inViolation, expired last check",
 			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -20).Unix()}},
 			responseCase: "inViolation",
-			expContain:   "A Redpanda Enterprise Edition license is required t",
+			expContain:   "These features require a license",
 		},
 		{
 			// Edge case when the license expires but the last check was less
-			// than 15 days ago.
+			// than 1 hour ago.
 			name:         "inViolation, cache still valid",
-			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().AddDate(0, 0, -1).Unix()}},
+			prof:         &config.RpkProfile{LicenseCheck: &config.LicenseStatusCache{LastUpdate: time.Now().Add(30 * time.Minute).Unix()}},
 			responseCase: "inViolation",
 			// In this case, even if the license is in violation, rpk won't
 			// reach the Admin API because the last check was under 15 days.

--- a/src/go/rpk/pkg/adminapi/api_features.go
+++ b/src/go/rpk/pkg/adminapi/api_features.go
@@ -51,6 +51,38 @@ type LicenseProperties struct {
 	Checksum     string `json:"sha256"`
 }
 
+// LicenseStatus is an enum for different licensing states in a Redpanda cluster.
+type LicenseStatus string
+
+const (
+	// LicenseStatusValid represents a valid license.
+	LicenseStatusValid LicenseStatus = "valid"
+	// LicenseStatusExpired represents a valid, but already expired license.
+	LicenseStatusExpired LicenseStatus = "expired"
+	// LicenseStatusNotPresent means no license is installed.
+	LicenseStatusNotPresent LicenseStatus = "not_present"
+)
+
+// EnterpriseFeaturesResponse describes the response schema to a GET /v1/features/enterprise
+// request. This endpoint reports the license status and enterprise features in use.
+type EnterpriseFeaturesResponse struct {
+	// LicenseStatus describes the status of the Redpanda enterprise license.
+	LicenseStatus LicenseStatus `json:"license_status"`
+	// Violation indicates a license violation. It evaluates to true if LicenseStatus
+	// is not LicenseStatusValid and one or more enterprise features are enabled.
+	Violation bool `json:"violation"`
+	// Features is a list of enterprise features (name and whether in use).
+	Features []EnterpriseFeature `json:"features"`
+}
+
+// EnterpriseFeature is a Redpanda enterprise feature with its name, and whether it is in use.
+type EnterpriseFeature struct {
+	// Name of the enterprise feature. Follows snake case naming. For example: "audit_logging".
+	Name string `json:"name"`
+	// Enabled is true if the feature is in use.
+	Enabled bool `json:"enabled"`
+}
+
 // GetFeatures returns information about the available features.
 func (a *AdminAPI) GetFeatures(ctx context.Context) (FeaturesResponse, error) {
 	var features FeaturesResponse
@@ -60,6 +92,17 @@ func (a *AdminAPI) GetFeatures(ctx context.Context) (FeaturesResponse, error) {
 		"/v1/features",
 		nil,
 		&features)
+}
+
+// GetEnterpriseFeatures reports enterprise features in use as well as the license status.
+func (a *AdminAPI) GetEnterpriseFeatures(ctx context.Context) (EnterpriseFeaturesResponse, error) {
+	var response EnterpriseFeaturesResponse
+	return response, a.sendAny(
+		ctx,
+		http.MethodGet,
+		"/v1/features/enterprise",
+		nil,
+		&response)
 }
 
 func (a *AdminAPI) GetLicenseInfo(ctx context.Context) (License, error) {

--- a/src/go/rpk/pkg/cli/cloud/cloud.go
+++ b/src/go/rpk/pkg/cli/cloud/cloud.go
@@ -13,7 +13,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/auth"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/byoc"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/cluster"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/namespace"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cloud/resourcegroup"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -29,7 +29,7 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 		auth.NewCommand(fs, p),
 		byoc.NewCommand(fs, p, execFn),
 		cluster.NewCommand(fs, p),
-		namespace.NewCommand(fs, p),
+		resourcegroup.NewCommand(fs, p),
 		newLoginCommand(fs, p),
 		newLogoutCommand(fs, p),
 	)

--- a/src/go/rpk/pkg/cli/cloud/resourcegroup/resourcegroup.go
+++ b/src/go/rpk/pkg/cli/cloud/resourcegroup/resourcegroup.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package namespace
+package resourcegroup
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -17,12 +17,12 @@ import (
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:        "namespace",
-		Aliases:    []string{"ns"},
-		SuggestFor: []string{"namespaces"},
+		Use:        "resource-group",
+		Aliases:    []string{"namespace", "ns"},
+		SuggestFor: []string{"resource-group"},
 		Args:       cobra.ExactArgs(0),
 		Hidden:     true,
-		Short:      "Interact with Namespaces in Redpanda Cloud",
+		Short:      "Interact with resource groups in Redpanda Cloud",
 	}
 	cmd.AddCommand(
 		createCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/config/edit.go
+++ b/src/go/rpk/pkg/cli/cluster/config/edit.go
@@ -48,7 +48,7 @@ to edit all properties including these tunables.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -148,7 +148,7 @@ to include all properties including these low level tunables.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -37,7 +37,7 @@ output, use the 'edit' and 'export' commands respectively.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			currentConfig, err := client.Config(cmd.Context(), true)

--- a/src/go/rpk/pkg/cli/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cluster/config/import.go
@@ -305,7 +305,7 @@ from the YAML file, it is reset to its default value.  `,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the schema

--- a/src/go/rpk/pkg/cli/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cluster/config/lint.go
@@ -58,7 +58,7 @@ central configuration store (and via 'rpk cluster config edit').
 			p := cfg.VirtualProfile()
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			schema, err := client.ClusterConfigSchema(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -73,7 +73,7 @@ If an empty string is given as the value, the property is reset to its default.`
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			schema, err := client.ClusterConfigSchema(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -37,7 +37,7 @@ is offline.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// GET the status endpoint

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -43,7 +43,7 @@ following conditions are met:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// --exit-when-healthy only makes sense with --watch, so we enable

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -132,7 +132,6 @@ func printTextLicenseInfo(resp infoResponse) {
 		if *resp.Expired {
 			tw.Print("License expired:", *resp.Expired)
 		}
-		// need to defer as we flush the table below.
 		checkLicenseExpiry(resp.ExpiresUnix)
 	}
 	out.Section("LICENSE INFORMATION")

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -10,27 +10,35 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 type infoResponse struct {
-	Organization string `json:"organization" yaml:"organization"`
-	Type         string `json:"type" yaml:"type"`
-	Expires      string `json:"expires" yaml:"expires"`
-	ExpiresUnix  int64  `json:"expires_unix" yaml:"expires_unix"`
-	Checksum     string `json:"checksum_sha256,omitempty" yaml:"checksum_sha256,omitempty"`
-	Expired      bool   `json:"license_expired" yaml:"license_expired"`
+	LicenseStatus      string   `json:"license_status" yaml:"license_status"`
+	Organization       string   `json:"organization,omitempty" yaml:"organization,omitempty"`
+	Type               string   `json:"type,omitempty" yaml:"type,omitempty"`
+	Expires            string   `json:"expires,omitempty" yaml:"expires,omitempty"`
+	ExpiresUnix        int64    `json:"expires_unix,omitempty" yaml:"expires_unix,omitempty"`
+	Checksum           string   `json:"checksum_sha256,omitempty" yaml:"checksum_sha256,omitempty"`
+	Expired            *bool    `json:"license_expired,omitempty" yaml:"license_expired,omitempty"`
+	Violation          bool     `json:"license_violation" yaml:"license_violation"`
+	EnterpriseFeatures []string `json:"enterprise_features_in_use" yaml:"enterprise_features_in_use"`
 }
 
 func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "info",
-		Args:  cobra.ExactArgs(0),
-		Short: "Retrieve license information",
+		Use:     "info",
+		Aliases: []string{"status"},
+		Args:    cobra.ExactArgs(0),
+		Short:   "Retrieve license information",
 		Long: `Retrieve license information:
 
     Organization:    Organization the license was generated for.
     Type:            Type of license: free, enterprise, etc.
-    Expires:         Expiration date of the license
+    Expires:         Expiration date of the license.
+    License Status:  Status of the loaded license (valid, expired, not_present).
+    Violation:       Whether the cluster is using enterprise features without
+                     a valid license.
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
@@ -46,10 +54,12 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			info, err := cl.GetLicenseInfo(cmd.Context())
 			out.MaybeDie(err, "unable to retrieve license info: %v", err)
-			if !info.Loaded {
-				out.Die("this cluster is missing a license")
+
+			features, err := cl.GetEnterpriseFeatures(cmd.Context())
+			if err != nil {
+				zap.L().Sugar().Warnf("unable to retrieve enterprise features: %v; information will be incomplete; is Redpanda up to date?", err)
 			}
-			err = printLicenseInfo(f, info.Properties)
+			err = printLicenseInfo(f, info, &features)
 			out.MaybeDieErr(err)
 		},
 	}
@@ -57,17 +67,8 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return cmd
 }
 
-func printLicenseInfo(f config.OutFormatter, props adminapi.LicenseProperties) error {
-	ut := time.Unix(props.Expires, 0)
-	isExpired := ut.Before(time.Now())
-	resp := infoResponse{
-		Organization: props.Organization,
-		Type:         props.Type,
-		Expires:      ut.Format("Jan 2 2006"),
-		ExpiresUnix:  props.Expires,
-		Checksum:     props.Checksum,
-		Expired:      isExpired,
-	}
+func printLicenseInfo(f config.OutFormatter, license adminapi.License, features *adminapi.EnterpriseFeaturesResponse) error {
+	resp := buildInfoResponse(license, features)
 	if isText, _, formatted, err := f.Format(resp); !isText {
 		if err != nil {
 			return fmt.Errorf("unable to print license info in the required format %q: %v", f.Kind, err)
@@ -75,22 +76,74 @@ func printLicenseInfo(f config.OutFormatter, props adminapi.LicenseProperties) e
 		fmt.Println(formatted)
 		return nil
 	}
-
-	out.Section("LICENSE INFORMATION")
-	licenseFormat := `Organization:      %v
-Type:              %v
-Expires:           %v
-`
-	if isExpired {
-		licenseFormat += "License Expired:   true\n"
-	}
-	fmt.Printf(licenseFormat, resp.Organization, resp.Type, resp.Expires)
-
-	// Warn the user if the License is about to expire (<30 days left).
-	diff := time.Until(ut)
-	daysLeft := int(diff.Hours() / 24)
-	if daysLeft < 30 && daysLeft >= 0 {
-		fmt.Fprintln(os.Stderr, "warning: your license will expire soon")
-	}
+	printTextLicenseInfo(resp)
 	return nil
+}
+
+func buildInfoResponse(license adminapi.License, features *adminapi.EnterpriseFeaturesResponse) infoResponse {
+	var resp infoResponse
+	if license.Loaded {
+		resp = buildLicenseProperties(license)
+	}
+	if features != nil {
+		resp = buildFeatureViolations(resp, features)
+	}
+	return resp
+}
+
+func buildLicenseProperties(license adminapi.License) infoResponse {
+	ut := time.Unix(license.Properties.Expires, 0)
+	isExpired := ut.Before(time.Now())
+	return infoResponse{
+		Organization: license.Properties.Organization,
+		Type:         license.Properties.Type,
+		Expires:      ut.Format("Jan 2 2006"),
+		ExpiresUnix:  license.Properties.Expires,
+		Checksum:     license.Properties.Checksum,
+		Expired:      &isExpired,
+	}
+}
+
+func buildFeatureViolations(resp infoResponse, features *adminapi.EnterpriseFeaturesResponse) infoResponse {
+	resp.Violation = features.Violation
+	resp.LicenseStatus = string(features.LicenseStatus)
+	resp.EnterpriseFeatures = []string{}
+	for _, feat := range features.Features {
+		if feat.Enabled {
+			resp.EnterpriseFeatures = append(resp.EnterpriseFeatures, feat.Name)
+		}
+	}
+	return resp
+}
+
+func printTextLicenseInfo(resp infoResponse) {
+	tw := out.NewTable()
+	if resp.LicenseStatus != "" {
+		tw.Print("License status:", resp.LicenseStatus)
+		tw.Print("License violation:", resp.Violation)
+	}
+	if len(resp.EnterpriseFeatures) > 0 {
+		tw.Print("Enterprise features in use:", resp.EnterpriseFeatures)
+	}
+	if resp.Organization != "" {
+		tw.Print("Organization:", resp.Organization)
+		tw.Print("Type:", resp.Type)
+		tw.Print("Expires:", resp.Expires)
+		if *resp.Expired {
+			tw.Print("License expired:", *resp.Expired)
+		}
+		// need to defer as we flush the table below.
+		checkLicenseExpiry(resp.ExpiresUnix)
+	}
+	out.Section("LICENSE INFORMATION")
+	tw.Flush()
+}
+
+func checkLicenseExpiry(expiresUnix int64) {
+	ut := time.Unix(expiresUnix, 0)
+	daysLeft := int(time.Until(ut).Hours() / 24)
+
+	if daysLeft < 30 && !ut.Before(time.Now()) {
+		fmt.Fprintf(os.Stderr, "WARNING: your license will expire soon.\n\n")
+	}
 }

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -41,7 +41,7 @@ func newInfoCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			info, err := cl.GetLicenseInfo(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/license/set.go
+++ b/src/go/rpk/pkg/cli/cluster/license/set.go
@@ -45,7 +45,7 @@ default location '/etc/redpanda/redpanda.license'.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			var r io.Reader

--- a/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/disable.go
@@ -41,7 +41,7 @@ func newDisableCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			b, err := client.Broker(cmd.Context(), nodeID)

--- a/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
@@ -47,7 +47,7 @@ node exists that is already in maintenance mode then an error will be returned.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			b, err := client.Broker(cmd.Context(), nodeID)

--- a/src/go/rpk/pkg/cli/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/status.go
@@ -85,7 +85,7 @@ Notes:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			brokers, err := client.Brokers(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/balancer_run.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/balancer_run.go
@@ -54,7 +54,7 @@ To see more detailed movement status, monitor the progress using:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = cl.TriggerBalancer(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
@@ -62,7 +62,7 @@ func (m *movementCancelHandler) runMovementCancel(cmd *cobra.Command, _ []string
 	out.MaybeDie(err, "rpk unable to load config: %v", err)
 	config.CheckExitCloudAdmin(p)
 
-	cl, err := adminapi.NewClient(m.fs, p)
+	cl, err := adminapi.NewClient(cmd.Context(), m.fs, p)
 	out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 	var movements []adminapi.PartitionsMovementResult

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -94,7 +94,7 @@ List all in json format.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			var clusterPartitions []adminapi.ClusterPartition

--- a/src/go/rpk/pkg/cli/cluster/partitions/move.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move.go
@@ -56,7 +56,7 @@ func newMovePartitionReplicasCommand(fs afero.Fs, p *config.Params) *cobra.Comma
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			var (

--- a/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
@@ -46,7 +46,7 @@ func newPartitionMovementsStatusCommand(fs afero.Fs, p *config.Params) *cobra.Co
 				out.Die("specify at least one topic when --partition is used, exiting.")
 			}
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			response, err = cl.Reconfigurations(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/status.go
@@ -81,7 +81,7 @@ investigation. A few areas to investigate:
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			status, err := cl.GetPartitionStatus(cmd.Context())

--- a/src/go/rpk/pkg/cli/cluster/partitions/toggle.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/toggle.go
@@ -68,7 +68,7 @@ Enable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = runToggle(cmd.Context(), cl, all, topicArg, partitions, "enable")
@@ -143,7 +143,7 @@ Disable partition 1, and 2 of topic 'foo', and partition 5 of topic 'bar' in the
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = runToggle(cmd.Context(), cl, all, topicArg, partitions, "disable")

--- a/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
@@ -60,7 +60,7 @@ brokers automatically.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			if len(topicArg) > 0 { // foo -p 0:1

--- a/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
@@ -51,7 +51,7 @@ using the '--dry' flag.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			plan, err := cl.MajorityLostPartitions(cmd.Context(), nodes)

--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -68,7 +68,7 @@ command.`,
 			}
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Using cmd line args, assemble self_test_start_request body

--- a/src/go/rpk/pkg/cli/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/status.go
@@ -54,7 +54,7 @@ the jobs launched. Possible results are:
 			config.CheckExitCloudAdmin(p)
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Make HTTP GET request to any node requesting for status

--- a/src/go/rpk/pkg/cli/cluster/selftest/stop.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/stop.go
@@ -37,7 +37,7 @@ success when all jobs have been stopped or reports errors if broker timeouts hav
 			config.CheckExitCloudAdmin(p)
 
 			// Create new HTTP client for communication w/ admin server
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Make HTTP POST request to leader that stops all self tests on all nodes

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -41,7 +41,7 @@ recovery process until it's finished.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			ctx := cmd.Context()

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
@@ -33,7 +33,7 @@ archival bucket.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(fs, p)
+			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			status, err := client.PollAutomatedRecoveryStatus(cmd.Context())

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -275,7 +275,7 @@ func saveClusterAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, 
 				TLS:       p.AdminAPI.TLS,
 			},
 		}
-		cl, err := adminapi.NewClient(fs, p)
+		cl, err := adminapi.NewClient(ctx, fs, p)
 		if err != nil {
 			return fmt.Errorf("unable to initialize admin client: %v", err)
 		}
@@ -344,7 +344,7 @@ func saveSingleAdminAPICalls(ctx context.Context, ps *stepParams, fs afero.Fs, p
 					TLS:       p.AdminAPI.TLS,
 				},
 			}
-			cl, err := adminapi.NewClient(fs, p, adminapi.ClientTimeout(profilerWait+2*time.Second))
+			cl, err := adminapi.NewClient(ctx, fs, p, adminapi.ClientTimeout(profilerWait+2*time.Second))
 			if err != nil {
 				rerrs = multierror.Append(rerrs, fmt.Errorf("unable to initialize admin client for %q: %v", a, err))
 				continue

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -235,7 +235,7 @@ func runWithFlags(ctx context.Context, fs afero.Fs, p *config.RpkProfile, langFl
 }
 
 func createUser(ctx context.Context, fs afero.Fs, p *config.RpkProfile, user, pass string) error {
-	cl, err := adminapi.NewClient(fs, p)
+	cl, err := adminapi.NewClient(ctx, fs, p)
 	if err != nil {
 		return fmt.Errorf("unable to initialize admin client: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -478,12 +478,12 @@ func fromCloudCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.Resour
 		Name:      c.Name,
 		FromCloud: true,
 		CloudCluster: config.RpkCloudCluster{
-			Namespace:   rg.Name,
-			ClusterID:   c.Id,
-			ClusterName: c.Name,
-			AuthOrgID:   yAuth.OrgID,
-			AuthKind:    yAuth.Kind,
-			ClusterType: c.Type.String(),
+			ResourceGroup: rg.Name,
+			ClusterID:     c.Id,
+			ClusterName:   c.Name,
+			AuthOrgID:     yAuth.OrgID,
+			AuthKind:      yAuth.Kind,
+			ClusterType:   c.Type.String(),
 		},
 	}
 	if c.DataplaneApi != nil {
@@ -523,12 +523,12 @@ func fromVirtualCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.Reso
 			TLS:       new(config.TLS),
 		},
 		CloudCluster: config.RpkCloudCluster{
-			Namespace:   rg.Name,
-			ClusterID:   vc.ID,
-			ClusterName: vc.Name,
-			AuthOrgID:   yAuth.OrgID,
-			AuthKind:    yAuth.Kind,
-			ClusterType: publicapi.ServerlessClusterType, // Virtual clusters do not include a type in the response yet.
+			ResourceGroup: rg.Name,
+			ClusterID:     vc.ID,
+			ClusterName:   vc.Name,
+			AuthOrgID:     yAuth.OrgID,
+			AuthKind:      yAuth.Kind,
+			ClusterType:   publicapi.ServerlessClusterType, // Virtual clusters do not include a type in the response yet.
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	controlplanev1beta1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1beta1"
-	"connectrpc.com/connect"
+	controlplanev1beta2 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1beta2"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	container "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloudapi"
@@ -379,9 +379,7 @@ nameLookup:
 
 	vc, err := cl.VirtualCluster(ctx, clusterID)
 	if err != nil { // if we fail for a vcluster, we try again for a normal cluster
-		c, err := cpCl.Cluster.GetCluster(ctx, connect.NewRequest(&controlplanev1beta1.GetClusterRequest{
-			Id: clusterID,
-		}))
+		cluster, err := cpCl.ClusterForID(ctx, clusterID)
 		if err != nil {
 			// If the input cluster looks like an xid, we try
 			// parsing it as a cluster ID. If the xid lookup fails,
@@ -394,20 +392,20 @@ nameLookup:
 			}
 			return CloudClusterOutputs{}, fmt.Errorf("unable to request details for cluster %q: %w", clusterID, err)
 		}
-		ns, err := cl.NamespaceForID(ctx, c.Msg.NamespaceId)
+		if cluster.State != controlplanev1beta2.Cluster_STATE_READY {
+			return CloudClusterOutputs{}, fmt.Errorf("selected cluster %q is not ready for profile creation yet; you may run this command again once the cluster is running", clusterID)
+		}
+		rg, err := cpCl.ResourceGroupForID(ctx, cluster.GetResourceGroupId())
 		if err != nil {
 			return CloudClusterOutputs{}, err
 		}
-		if c.Msg.State != controlplanev1beta1.Cluster_STATE_READY {
-			return CloudClusterOutputs{}, fmt.Errorf("selected cluster %q is not ready for profile creation yet; you may run this command again once the cluster is running", clusterID)
-		}
-		return fromCloudCluster(yAuthVir, ns, c.Msg), nil
+		return fromCloudCluster(yAuthVir, rg, cluster), nil
 	}
-	ns, err := cl.NamespaceForID(ctx, vc.NamespaceUUID)
+	rg, err := cpCl.ResourceGroupForID(ctx, vc.NamespaceUUID)
 	if err != nil {
 		return CloudClusterOutputs{}, err
 	}
-	return fromVirtualCluster(yAuthVir, ns, vc), nil
+	return fromVirtualCluster(yAuthVir, rg, vc), nil
 }
 
 func clusterNameToID(ctx context.Context, cl *cloudapi.Client, name string) (string, error) {
@@ -475,12 +473,12 @@ func findNamedCluster(name string, nss []cloudapi.Namespace, vcs []cloudapi.Virt
 
 // fromCloudCluster returns an rpk profile from a cloud cluster, as well
 // as if the cluster requires mtls or sasl.
-func fromCloudCluster(yAuth *config.RpkCloudAuth, ns cloudapi.Namespace, c *controlplanev1beta1.Cluster) CloudClusterOutputs {
+func fromCloudCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.ResourceGroup, c *controlplanev1beta2.Cluster) CloudClusterOutputs {
 	p := config.RpkProfile{
 		Name:      c.Name,
 		FromCloud: true,
 		CloudCluster: config.RpkCloudCluster{
-			Namespace:   ns.Name,
+			Namespace:   rg.Name,
 			ClusterID:   c.Id,
 			ClusterName: c.Name,
 			AuthOrgID:   yAuth.OrgID,
@@ -500,16 +498,16 @@ func fromCloudCluster(yAuth *config.RpkCloudAuth, ns cloudapi.Namespace, c *cont
 		}
 	}
 	return CloudClusterOutputs{
-		Profile:       p,
-		NamespaceName: ns.Name,
-		ClusterName:   c.Name,
-		ClusterID:     c.Id,
-		MessageMTLS:   isMTLS,
-		MessageSASL:   true,
+		Profile:           p,
+		ResourceGroupName: rg.Name,
+		ClusterName:       c.Name,
+		ClusterID:         c.Id,
+		MessageMTLS:       isMTLS,
+		MessageSASL:       true,
 	}
 }
 
-func fromVirtualCluster(yAuth *config.RpkCloudAuth, ns cloudapi.Namespace, vc cloudapi.VirtualCluster) CloudClusterOutputs {
+func fromVirtualCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.ResourceGroup, vc cloudapi.VirtualCluster) CloudClusterOutputs {
 	p := config.RpkProfile{
 		Name:      vc.Name,
 		FromCloud: true,
@@ -525,7 +523,7 @@ func fromVirtualCluster(yAuth *config.RpkCloudAuth, ns cloudapi.Namespace, vc cl
 			TLS:       new(config.TLS),
 		},
 		CloudCluster: config.RpkCloudCluster{
-			Namespace:   ns.Name,
+			Namespace:   rg.Name,
 			ClusterID:   vc.ID,
 			ClusterName: vc.Name,
 			AuthOrgID:   yAuth.OrgID,
@@ -535,12 +533,12 @@ func fromVirtualCluster(yAuth *config.RpkCloudAuth, ns cloudapi.Namespace, vc cl
 	}
 
 	return CloudClusterOutputs{
-		Profile:       p,
-		NamespaceName: ns.Name,
-		ClusterName:   vc.Name,
-		ClusterID:     vc.ID,
-		MessageMTLS:   false, // we do not need to print any required message; we generate the config in full
-		MessageSASL:   false, // same
+		Profile:           p,
+		ResourceGroupName: rg.Name,
+		ClusterName:       vc.Name,
+		ClusterID:         vc.ID,
+		MessageMTLS:       false, // we do not need to print any required message; we generate the config in full
+		MessageSASL:       false, // same
 	}
 }
 
@@ -591,17 +589,17 @@ Consume messages from the %[1]s topic as a guide for your next steps:
 
 // CloudClusterOutputs contains outputs from a cloud based profile.
 type CloudClusterOutputs struct {
-	Profile       config.RpkProfile
-	NamespaceName string
-	ClusterID     string
-	ClusterName   string
-	MessageMTLS   bool
-	MessageSASL   bool
+	Profile           config.RpkProfile
+	ResourceGroupName string
+	ClusterID         string
+	ClusterName       string
+	MessageMTLS       bool
+	MessageSASL       bool
 }
 
-// Duplicates RpkCloudProfile.FullName (easier for now).
+// FullName Duplicates RpkCloudProfile.FullName (easier for now).
 func (o CloudClusterOutputs) FullName() string {
-	return fmt.Sprintf("%s/%s", o.NamespaceName, o.ClusterName)
+	return fmt.Sprintf("%s/%s", o.ResourceGroupName, o.ClusterName)
 }
 
 // PromptCloudClusterProfile returns a profile for the cluster selected by the
@@ -623,7 +621,7 @@ func PromptCloudClusterProfile(ctx context.Context, yAuth *config.RpkCloudAuth, 
 	if len(names) == 0 {
 		return CloudClusterOutputs{}, ErrNoCloudClusters
 	}
-	idx, err := out.PickIndex(names, "Which cloud namespace/cluster would you like to talk to?")
+	idx, err := out.PickIndex(names, "Which cloud resource-group/cluster would you like to talk to?")
 	if err != nil {
 		return CloudClusterOutputs{}, err
 	}
@@ -634,27 +632,25 @@ func PromptCloudClusterProfile(ctx context.Context, yAuth *config.RpkCloudAuth, 
 	// all information we need. We need to now directly request this
 	// cluster's information.
 	if selected.c != nil {
-		c, err := cpCl.Cluster.GetCluster(ctx, connect.NewRequest(&controlplanev1beta1.GetClusterRequest{
-			Id: selected.c.ID,
-		}))
-		if err != nil {
-			return CloudClusterOutputs{}, fmt.Errorf("unable to get cluster %q information: %w", selected.c.ID, err)
-		}
-		ns, err := cl.NamespaceForID(ctx, c.Msg.NamespaceId)
+		cluster, err := cpCl.ClusterForID(ctx, selected.c.ID)
 		if err != nil {
 			return CloudClusterOutputs{}, err
 		}
-		o = fromCloudCluster(yAuth, ns, c.Msg)
+		rg, err := cpCl.ResourceGroupForID(ctx, cluster.GetResourceGroupId())
+		if err != nil {
+			return CloudClusterOutputs{}, err
+		}
+		o = fromCloudCluster(yAuth, rg, cluster)
 	} else {
-		c, err := cl.VirtualCluster(ctx, selected.vc.ID)
+		vc, err := cl.VirtualCluster(ctx, selected.vc.ID)
 		if err != nil {
-			return CloudClusterOutputs{}, fmt.Errorf("unable to get cluster %q information: %w", c.ID, err)
+			return CloudClusterOutputs{}, fmt.Errorf("unable to get cluster %q information: %w", vc.ID, err)
 		}
-		ns, err := cl.NamespaceForID(ctx, c.NamespaceUUID)
+		rg, err := cpCl.ResourceGroupForID(ctx, vc.NamespaceUUID)
 		if err != nil {
 			return CloudClusterOutputs{}, err
 		}
-		o = fromVirtualCluster(yAuth, ns, c)
+		o = fromVirtualCluster(yAuth, rg, vc)
 	}
 	o.Profile.Description = fmt.Sprintf("%s %q", org.Name, selected.name)
 	return o, nil

--- a/src/go/rpk/pkg/cli/profile/print.go
+++ b/src/go/rpk/pkg/cli/profile/print.go
@@ -46,8 +46,11 @@ in the rpk.yaml file.
 			if p == nil {
 				out.Die("profile %s does not exist", args[0])
 			}
-			// We hide the license check.
+			// We hide the license check and the SASL password.
 			p.LicenseCheck = nil
+			if p.KafkaAPI.SASL != nil && p.KafkaAPI.SASL.Password != "" {
+				p.KafkaAPI.SASL.Password = "[REDACTED]"
+			}
 			m, err := yaml.Marshal(p)
 			out.MaybeDie(err, "unable to encode profile: %v", err)
 			fmt.Println(string(m))

--- a/src/go/rpk/pkg/cli/profile/print.go
+++ b/src/go/rpk/pkg/cli/profile/print.go
@@ -46,7 +46,8 @@ in the rpk.yaml file.
 			if p == nil {
 				out.Die("profile %s does not exist", args[0])
 			}
-
+			// We hide the license check.
+			p.LicenseCheck = nil
 			m, err := yaml.Marshal(p)
 			out.MaybeDie(err, "unable to encode profile: %v", err)
 			fmt.Println(string(m))

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -69,7 +69,7 @@ kafka/test/0
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			dbs, err := cl.DecommissionBrokerStatus(cmd.Context(), broker)

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission.go
@@ -42,7 +42,7 @@ cluster is unreachable), use the hidden --force flag.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			if !force {

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/list.go
@@ -43,7 +43,7 @@ NOTE: The UUID column is hidden when the cluster doesn't expose the UUID in the 
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			bs, err := cl.Brokers(cmd.Context())

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/recommission.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/recommission.go
@@ -38,7 +38,7 @@ the cluster leader handles the request.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			err = cl.RecommissionBroker(cmd.Context(), broker)

--- a/src/go/rpk/pkg/cli/security/role/assign.go
+++ b/src/go/rpk/pkg/cli/security/role/assign.go
@@ -48,7 +48,7 @@ Assign role "redpanda-admin" to users "red" and "panda"
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/role/create.go
+++ b/src/go/rpk/pkg/cli/security/role/create.go
@@ -41,7 +41,7 @@ flag in the 'rpk security acl create' command.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/role/delete.go
+++ b/src/go/rpk/pkg/cli/security/role/delete.go
@@ -41,7 +41,7 @@ The flag '--no-confirm' can be used to avoid the confirmation prompt.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			adm, err := kafka.NewAdmin(fs, p)

--- a/src/go/rpk/pkg/cli/security/role/describe.go
+++ b/src/go/rpk/pkg/cli/security/role/describe.go
@@ -76,7 +76,7 @@ Print only the ACL associated to the role 'red'
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			adm, err := kafka.NewAdmin(fs, p)

--- a/src/go/rpk/pkg/cli/security/role/list.go
+++ b/src/go/rpk/pkg/cli/security/role/list.go
@@ -51,7 +51,7 @@ List all roles with the prefix "agent-":
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			principalType, principal := parsePrincipal(principalFlag)

--- a/src/go/rpk/pkg/cli/security/role/unassign.go
+++ b/src/go/rpk/pkg/cli/security/role/unassign.go
@@ -48,7 +48,7 @@ Unassign role "redpanda-admin" from users "red" and "panda"
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 			roleName := args[0]

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -59,7 +59,7 @@ acl help text for more info.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Backwards compatibility: we favor the new user

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -39,7 +39,7 @@ delete any ACLs that may exist for this user.
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			// Backwards compat: we favor the new format (an

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -32,7 +32,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			users, err := cl.ListUsers(cmd.Context())

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -31,7 +31,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitNotServerlessAdmin(p)
 
-			cl, err := adminapi.NewClient(fs, p)
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			user := args[0]

--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -61,7 +61,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer cl.Close()
 
-			adminCl, err := adminapi.NewClient(fs, p)
+			adminCl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 			topic := args[0]

--- a/src/go/rpk/pkg/cli/transform/delete.go
+++ b/src/go/rpk/pkg/cli/transform/delete.go
@@ -33,7 +33,7 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitServerlessAdmin(p)
 
-			api, err := adminapi.NewClient(fs, p)
+			api, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 			functionName := args[0]
 

--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -125,7 +125,7 @@ The --var flag can be repeated to specify multiple variables like so:
 				})
 				out.MaybeDie(err, "unable to deploy transform to Cloud Cluster: %v", err)
 			} else {
-				api, err := adminapi.NewClient(fs, p)
+				api, err := adminapi.NewClient(cmd.Context(), fs, p)
 				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 				err = api.DeployWasmTransform(cmd.Context(), t, wasm)

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -91,7 +91,7 @@ The --detailed flag (-d) opts in to printing extra per-processor information.
 				out.MaybeDie(err, "unable to list transforms from Cloud: %v", err)
 				l = dataplaneToAdminTransformMetadata(res.Msg.Transforms)
 			} else {
-				api, err := adminapi.NewClient(fs, p)
+				api, err := adminapi.NewClient(cmd.Context(), fs, p)
 				out.MaybeDie(err, "unable to initialize admin api client: %v", err)
 
 				l, err = api.ListWasmTransforms(cmd.Context())

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -89,6 +89,7 @@ Admin API hosts via flags, profile, or environment variables.`,
 				return
 			}
 			cl, err := adminapi.NewClient(
+				cmd.Context(),
 				fs,
 				p,
 				adminapi.ClientTimeout(3*time.Second),

--- a/src/go/rpk/pkg/cloudapi/cloudapi.go
+++ b/src/go/rpk/pkg/cloudapi/cloudapi.go
@@ -124,22 +124,3 @@ type NamespacedCluster struct {
 	VCluster   VirtualCluster
 	IsVCluster bool
 }
-
-// FindNamespace finds a namespace by its ID, if it exists.
-func FindNamespace(nsID string, nss Namespaces) Namespace {
-	for _, ns := range nss {
-		if ns.ID == nsID {
-			return ns
-		}
-	}
-	return Namespace{}
-}
-
-// NamespaceForID lists all namespaces to find the namespace for the given ID.
-func (cl *Client) NamespaceForID(ctx context.Context, nsid string) (Namespace, error) {
-	nss, err := cl.Namespaces(ctx)
-	if err != nil {
-		return Namespace{}, fmt.Errorf("unable to request namespaces: %w", err)
-	}
-	return FindNamespace(nsid, nss), nil
-}

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -85,7 +85,7 @@ const (
 	xkindGlobal           // configuration for rpk.yaml globals
 )
 
-const currentRpkYAMLVersion = 5
+const currentRpkYAMLVersion = 6
 
 type xflag struct {
 	path        string

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -723,7 +723,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -815,7 +815,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -857,7 +857,7 @@ cloud_auth:
 		// * admin api is defaulted, using kafka broker ip
 		{
 			name: "rpk.yaml exists",
-			rpkYaml: `version: 5
+			rpkYaml: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -914,7 +914,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -975,7 +975,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			rpkYaml: `version: 5
+			rpkYaml: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1025,7 +1025,7 @@ rpk:
     tune_disk_irq: true
 `,
 
-			expVirtualRpk: `version: 5
+			expVirtualRpk: `version: 6
 globals:
     prompt: ""
     no_default_cluster: false

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -723,7 +723,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 4
+			expVirtualRpk: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false
@@ -815,7 +815,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			expVirtualRpk: `version: 4
+			expVirtualRpk: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false
@@ -857,7 +857,7 @@ cloud_auth:
 		// * admin api is defaulted, using kafka broker ip
 		{
 			name: "rpk.yaml exists",
-			rpkYaml: `version: 4
+			rpkYaml: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false
@@ -914,7 +914,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 4
+			expVirtualRpk: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false
@@ -975,7 +975,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			rpkYaml: `version: 4
+			rpkYaml: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1025,7 +1025,7 @@ rpk:
     tune_disk_irq: true
 `,
 
-			expVirtualRpk: `version: 4
+			expVirtualRpk: `version: 5
 globals:
     prompt: ""
     no_default_cluster: false

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -39,7 +39,7 @@ func defaultVirtualRpkYaml() (RpkYaml, error) {
 	path, _ := DefaultRpkYamlPath() // if err is non-nil, we fail in Write
 	y := RpkYaml{
 		fileLocation: path,
-		Version:      4,
+		Version:      5,
 		Profiles:     []RpkProfile{DefaultRpkProfile()},
 		CloudAuths:   []RpkCloudAuth{DefaultRpkCloudAuth()},
 	}
@@ -70,7 +70,7 @@ func DefaultRpkCloudAuth() RpkCloudAuth {
 
 func emptyVirtualRpkYaml() RpkYaml {
 	return RpkYaml{
-		Version: 4,
+		Version: 5,
 	}
 }
 
@@ -149,13 +149,14 @@ type (
 	}
 
 	RpkCloudCluster struct {
-		Namespace   string `json:"namespace" yaml:"namespace"`
-		ClusterID   string `json:"cluster_id" yaml:"cluster_id"`
-		ClusterName string `json:"cluster_name" yaml:"cluster_name"`
-		AuthOrgID   string `json:"auth_org_id" yaml:"auth_org_id"`
-		AuthKind    string `json:"auth_kind" yaml:"auth_kind"`
-		ClusterType string `json:"cluster_type" yaml:"cluster_type"`
-		ClusterURL  string `json:"cluster_url,omitempty" yaml:"cluster_url,omitempty"`
+		Namespace     string `json:"namespace" yaml:"namespace"`
+		ResourceGroup string `json:"resource_group" yaml:"resource_group"`
+		ClusterID     string `json:"cluster_id" yaml:"cluster_id"`
+		ClusterName   string `json:"cluster_name" yaml:"cluster_name"`
+		AuthOrgID     string `json:"auth_org_id" yaml:"auth_org_id"`
+		AuthKind      string `json:"auth_kind" yaml:"auth_kind"`
+		ClusterType   string `json:"cluster_type" yaml:"cluster_type"`
+		ClusterURL    string `json:"cluster_url,omitempty" yaml:"cluster_url,omitempty"`
 	}
 
 	// RpkCloudAuth is unique by name and org ID. We support multiple auths
@@ -413,9 +414,9 @@ func (y *RpkYaml) WriteAt(fs afero.Fs, path string) error {
 	return rpkos.ReplaceFile(fs, path, b, 0o644)
 }
 
-// FullName returns "namespace/cluster_name".
+// FullName returns "resource_group/cluster_name".
 func (c *RpkCloudCluster) FullName() string {
-	return fmt.Sprintf("%s/%s", c.Namespace, c.ClusterName)
+	return fmt.Sprintf("%s/%s", c.ResourceGroup, c.ClusterName)
 }
 
 // HasAuth returns if the cluster has the given auth.

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,7 +25,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v5sha = "74f0b320006aac52cb75af3d5c658f81decf3e40fe1e92f3eb1d59f5c47ab5f9" // 24-04-29
+		v5sha = "f3d394e88ba4a6a668d15b74208f32d71c82f8a0e9b6e6445defcdd64df1e37f" // 24-07-24
 	)
 
 	if shastr != v5sha {

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,11 +25,11 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v5sha = "f3d394e88ba4a6a668d15b74208f32d71c82f8a0e9b6e6445defcdd64df1e37f" // 24-07-24
+		expsha = "f3d394e88ba4a6a668d15b74208f32d71c82f8a0e9b6e6445defcdd64df1e37f" // 24-07-24
 	)
 
-	if shastr != v5sha {
-		t.Errorf("rpk.yaml type shape has changed (got sha %s != exp %s, if fields were reordered, update the valid v3 sha, otherwise bump the rpk.yaml version number", shastr, v5sha)
+	if shastr != expsha {
+		t.Errorf("rpk.yaml type shape has changed (got sha %s != exp %s, if fields were reordered, update the valid v3 sha, otherwise bump the rpk.yaml version number", shastr, expsha)
 		t.Errorf("current shape:\n%s\n", s)
 	}
 }

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,11 +25,11 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v4sha = "d40eea0724c6f7c876e5551c9b0a90d71d409c0426efbf6c06f3c25fef4b262e" // 24-04-15
+		v5sha = "74f0b320006aac52cb75af3d5c658f81decf3e40fe1e92f3eb1d59f5c47ab5f9" // 24-04-29
 	)
 
-	if shastr != v4sha {
-		t.Errorf("rpk.yaml type shape has changed (got sha %s != exp %s, if fields were reordered, update the valid v3 sha, otherwise bump the rpk.yaml version number", shastr, v4sha)
+	if shastr != v5sha {
+		t.Errorf("rpk.yaml type shape has changed (got sha %s != exp %s, if fields were reordered, update the valid v3 sha, otherwise bump the rpk.yaml version number", shastr, v5sha)
 		t.Errorf("current shape:\n%s\n", s)
 	}
 }

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -117,7 +117,7 @@ func TestLoadFlow(t *testing.T) {
 				hasClientID = true
 			}
 
-			expFile := fmt.Sprintf(`version: 5
+			expFile := fmt.Sprintf(`version: 6
 globals:
     prompt: ""
     no_default_cluster: false

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -117,7 +117,7 @@ func TestLoadFlow(t *testing.T) {
 				hasClientID = true
 			}
 
-			expFile := fmt.Sprintf(`version: 4
+			expFile := fmt.Sprintf(`version: 5
 globals:
     prompt: ""
     no_default_cluster: false

--- a/src/go/rpk/pkg/oauth/oauth.go
+++ b/src/go/rpk/pkg/oauth/oauth.go
@@ -68,7 +68,7 @@ func ClientCredentialFlow(ctx context.Context, cl Client, auth *config.RpkCloudA
 			return Token{}, false, fmt.Errorf("unable to validate your authorization token: %v", err)
 		}
 		if !expired {
-			fmt.Println("Your existing auth token is still valid, avoiding re-authentication.")
+			zap.L().Sugar().Debug("Your existing auth token is still valid, avoiding re-authentication.")
 			return Token{AccessToken: auth.AuthToken}, false, nil
 		}
 		fmt.Println("Your existing authorization token has expired.")
@@ -95,7 +95,7 @@ func DeviceFlow(ctx context.Context, cl Client, auth *config.RpkCloudAuth, noUI,
 			return Token{}, false, fmt.Errorf("unable to validate your authorization token: %v", err)
 		}
 		if !expired {
-			fmt.Println("Your existing auth token is still valid, avoiding re-authentication.")
+			zap.L().Sugar().Debug("Your existing auth token is still valid, avoiding re-authentication.")
 			return Token{AccessToken: auth.AuthToken}, false, nil
 		}
 		fmt.Println("Your existing authorization token has expired.")

--- a/src/go/rpk/pkg/publicapi/controlplane.go
+++ b/src/go/rpk/pkg/publicapi/controlplane.go
@@ -10,18 +10,22 @@
 package publicapi
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"time"
 
-	controlplanev1beta1connect "buf.build/gen/go/redpandadata/cloud/connectrpc/go/redpanda/api/controlplane/v1beta1/controlplanev1beta1connect"
+	controlplanev1beta2 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1beta2"
+
+	"buf.build/gen/go/redpandadata/cloud/connectrpc/go/redpanda/api/controlplane/v1beta2/controlplanev1beta2connect"
 	"connectrpc.com/connect"
 )
 
 // ControlPlaneClientSet holds the respective service clients to interact with
 // the control plane endpoints of the Public API.
 type ControlPlaneClientSet struct {
-	Namespace controlplanev1beta1connect.NamespaceServiceClient
-	Cluster   controlplanev1beta1connect.ClusterServiceClient
+	ResourceGroup controlplanev1beta2connect.ResourceGroupServiceClient
+	Cluster       controlplanev1beta2connect.ClusterServiceClient
 }
 
 // NewControlPlaneClientSet creates a Public API client set with the service
@@ -40,7 +44,39 @@ func NewControlPlaneClientSet(host, authToken string, opts ...connect.ClientOpti
 	httpCl := &http.Client{Timeout: 15 * time.Second}
 
 	return &ControlPlaneClientSet{
-		Namespace: controlplanev1beta1connect.NewNamespaceServiceClient(httpCl, host, opts...),
-		Cluster:   controlplanev1beta1connect.NewClusterServiceClient(httpCl, host, opts...),
+		ResourceGroup: controlplanev1beta2connect.NewResourceGroupServiceClient(httpCl, host, opts...),
+		Cluster:       controlplanev1beta2connect.NewClusterServiceClient(httpCl, host, opts...),
 	}, nil
+}
+
+// ResourceGroupForID gets the resource group for a given ID and handles the
+// error if the returned resource group is nil.
+func (cpCl *ControlPlaneClientSet) ResourceGroupForID(ctx context.Context, ID string) (*controlplanev1beta2.ResourceGroup, error) {
+	rg, err := cpCl.ResourceGroup.GetResourceGroup(ctx, connect.NewRequest(&controlplanev1beta2.GetResourceGroupRequest{
+		Id: ID,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("unable to request resource group with ID %q: %w", ID, err)
+	}
+	if rg.Msg.ResourceGroup == nil {
+		// This should not happen but the new API returns a pointer, and we
+		// need to make sure that a ResourceGroup is returned
+		return nil, fmt.Errorf("unable to request resource group with ID %q: resource group does not exist; please report this with Redpanda Support", ID)
+	}
+	return rg.Msg.ResourceGroup, nil
+}
+
+// ClusterForID gets the Cluster for a given ID and handles the error if the
+// returned cluster is nil.
+func (cpCl *ControlPlaneClientSet) ClusterForID(ctx context.Context, ID string) (*controlplanev1beta2.Cluster, error) {
+	c, err := cpCl.Cluster.GetCluster(ctx, connect.NewRequest(&controlplanev1beta2.GetClusterRequest{
+		Id: ID,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("unable to request cluster %q information: %w", ID, err)
+	}
+	if c.Msg.Cluster == nil {
+		return nil, fmt.Errorf("unable to find cluster %q; please report this bug to Redpanda Support", ID)
+	}
+	return c.Msg.Cluster, nil
 }

--- a/src/go/rpk/pkg/publicapi/transform.go
+++ b/src/go/rpk/pkg/publicapi/transform.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 
 	commonv1alpha1 "buf.build/gen/go/redpandadata/common/protocolbuffers/go/redpanda/api/common/v1alpha1"
-	dataplanev1alpha1connect "buf.build/gen/go/redpandadata/dataplane/connectrpc/go/redpanda/api/dataplane/v1alpha1/dataplanev1alpha1connect"
+	"buf.build/gen/go/redpandadata/dataplane/connectrpc/go/redpanda/api/dataplane/v1alpha1/dataplanev1alpha1connect"
 	v1alpha1 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1alpha1"
 	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -279,6 +279,9 @@ class RpkClusterTest(RedpandaTest):
             '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf',
             'expires_unix': 4813252273,
             'license_expired': False,
+            'license_status': 'valid',
+            'license_violation': False,
+            'enterprise_features_in_use': [],
         }
         result = json.loads(rp_license)
         assert expected_license == result, result


### PR DESCRIPTION
Manual backport of the license warning features, PRs https://github.com/redpanda-data/redpanda/pull/23472 and https://github.com/redpanda-data/redpanda/pull/23744

Had to be done manually as in v24.1.x We don't have the BUILD files or the migration to `common-go`. We also had to backport https://github.com/redpanda-data/redpanda/pull/18149 to bring the rpk.yaml version bump to this branch

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none

