### PR TITLE
bazel: backfill some cluster unit tests

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1,6 +1,67 @@
 load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
+    name = "randoms",
+    hdrs = [
+        "randoms.h",
+    ],
+    include_prefix = "cluster/tests",
+    deps = [
+        "//src/v/cluster",
+        "//src/v/model/tests:random",
+        "//src/v/storage/tests:random",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "topic_properties_generator",
+    hdrs = [
+        "topic_properties_generator.h",
+    ],
+    include_prefix = "cluster/tests",
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/model/tests:random",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "partition_allocator_fixture",
+    hdrs = [
+        "partition_allocator_fixture.h",
+    ],
+    include_prefix = "cluster/tests",
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "partition_balancer_planner_fixture",
+    hdrs = [
+        "partition_balancer_planner_fixture.h",
+    ],
+    include_prefix = "cluster/tests",
+    deps = [
+        ":utils",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "rm_stm_test_fixture",
+    hdrs = [
+        "rm_stm_test_fixture.h",
+    ],
+    include_prefix = "cluster/tests",
+    deps = [
+        "//src/v/cluster",
+        "//src/v/raft/tests:simple_raft_fixture",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "utils",
     hdrs = [
         "utils.h",
@@ -251,5 +312,235 @@ redpanda_cc_gtest(
         "//src/v/test_utils:random",
         "//src/v/utils:prefix_logger",
         "@seastar",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "partition_allocator_tests",
+    timeout = "short",
+    srcs = [
+        "partition_allocator_tests.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster/tests:partition_allocator_fixture",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft:fundamental",
+        "//src/v/random:fast_prng",
+        "//src/v/random:generators",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "partition_balancer_planner_test",
+    timeout = "short",
+    srcs = [
+        "partition_balancer_planner_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/cluster/tests:partition_balancer_planner_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:stable_iterator",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "simple_batch_builder_test",
+    timeout = "short",
+    srcs = [
+        "simple_batch_builder_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "cluster_utils_tests",
+    timeout = "short",
+    srcs = [
+        "cluster_utils_tests.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/storage/tests:kvstore_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:prefix_logger",
+        "//src/v/utils:unresolved_address",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "notification_latch_test",
+    timeout = "short",
+    srcs = [
+        "notification_latch_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster:offsets_lookup",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "commands_serialization_test",
+    timeout = "short",
+    srcs = [
+        "commands_serialization_test.cc",
+    ],
+    deps = [
+        ":utils",
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/cluster/tests:topic_table_fixture",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft:fundamental",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "topic_updates_dispatcher_test",
+    timeout = "short",
+    srcs = [
+        "topic_updates_dispatcher_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster/tests:topic_table_fixture",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "topic_table_partition_generator_test",
+    timeout = "short",
+    srcs = [
+        "topic_table_partition_generator_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/cluster/tests:topic_table_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "feature_barrier_test",
+    timeout = "short",
+    srcs = [
+        "feature_barrier_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "tm_coordinator_mapper_tests",
+    timeout = "short",
+    srcs = [
+        "tm_coordinator_mapper_tests.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "rm_stm_compatibility_test",
+    timeout = "short",
+    srcs = [
+        "rm_stm_compatibility_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "producer_state_tests",
+    timeout = "short",
+    srcs = [
+        "producer_state_tests.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "client_quota_store_test",
+    timeout = "short",
+    srcs = [
+        "client_quota_store_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:to_string",
+        "@boost//:algorithm",
+        "@boost//:range",
+        "@boost//:test",
+        "@fmt",
+        "@seastar//:testing",
     ],
 )

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -10,6 +10,7 @@
 #include "base/units.h"
 #include "cluster/commands.h"
 #include "cluster/simple_batch_builder.h"
+#include "cluster/tests/topic_table_fixture.h"
 #include "cluster/tests/utils.h"
 #include "cluster/types.h"
 #include "model/compression.h"
@@ -17,7 +18,6 @@
 #include "model/metadata.h"
 #include "raft/fundamental.h"
 #include "test_utils/fixture.h"
-#include "topic_table_fixture.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/chunked_fifo.hh>
@@ -27,7 +27,6 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/variant_utils.hh>
 
-#include <bits/stdint-intn.h>
 #include <boost/test/tools/old/interface.hpp>
 
 #include <vector>

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -194,7 +194,7 @@ FIXTURE_TEST(test_move_partition_replicass_command, cmd_test_fixture) {
 
     ss::visit(deser, [&cmd](cluster::move_partition_replicas_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key, cmd.key);
-        for (int i = 0; i < cmd.value.size(); ++i) {
+        for (size_t i = 0; i < cmd.value.size(); ++i) {
             BOOST_REQUIRE_EQUAL(c.value[i].node_id, cmd.value[i].node_id);
             BOOST_REQUIRE_EQUAL(c.value[i].shard, cmd.value[i].shard);
         }

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -11,8 +11,8 @@
 
 #include "base/seastarx.h"
 #include "cluster/logger.h"
+#include "cluster/tests/local_monitor_fixture.h"
 #include "config/configuration.h"
-#include "local_monitor_fixture.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/types.h"
 

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -583,7 +583,7 @@ void check_allocated_counts(
   const std::vector<size_t>& expected) {
     std::vector<size_t> counts;
     for (const auto& [id, node] : allocator.state().allocation_nodes()) {
-        BOOST_REQUIRE(id() == counts.size());
+        BOOST_REQUIRE(id() == static_cast<int>(counts.size()));
         counts.push_back(node->allocated_partitions());
     }
     logger.debug("allocated counts: {}, expected: {}", counts, expected);
@@ -595,7 +595,7 @@ void check_final_counts(
   const std::vector<size_t>& expected) {
     std::vector<size_t> counts;
     for (const auto& [id, node] : allocator.state().allocation_nodes()) {
-        BOOST_REQUIRE(id() == counts.size());
+        BOOST_REQUIRE(id() == static_cast<int>(counts.size()));
         counts.push_back(node->final_partitions());
     }
     logger.debug("final counts: {}, expected: {}", counts, expected);

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -219,7 +219,9 @@ struct partition_balancer_planner_fixture {
           replication_factor);
 
         ss::chunked_fifo<cluster::partition_assignment> assignments;
-        for (model::partition_id::type i = 0; i < static_cast<int>(partition_nodes.size()); ++i) {
+        for (model::partition_id::type i = 0;
+             i < static_cast<int>(partition_nodes.size());
+             ++i) {
             const auto& nodes = partition_nodes[i];
             BOOST_REQUIRE_EQUAL(nodes.size(), replication_factor);
             std::vector<model::broker_shard> replicas;

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -219,7 +219,7 @@ struct partition_balancer_planner_fixture {
           replication_factor);
 
         ss::chunked_fifo<cluster::partition_assignment> assignments;
-        for (model::partition_id::type i = 0; i < partition_nodes.size(); ++i) {
+        for (model::partition_id::type i = 0; i < static_cast<int>(partition_nodes.size()); ++i) {
             const auto& nodes = partition_nodes[i];
             BOOST_REQUIRE_EQUAL(nodes.size(), replication_factor);
             std::vector<model::broker_shard> replicas;
@@ -332,7 +332,7 @@ struct partition_balancer_planner_fixture {
     populate_node_status_table(std::set<size_t> unavailable_nodes = {}) {
         std::vector<cluster::node_status> status_updates;
         status_updates.reserve(last_node_idx + 1);
-        for (size_t i = 0; i < last_node_idx; ++i) {
+        for (int i = 0; i < last_node_idx; ++i) {
             auto last_seen = raft::clock_type::now();
             if (unavailable_nodes.contains(i)) {
                 last_seen = last_seen - node_unavailable_timeout;
@@ -358,7 +358,7 @@ struct partition_balancer_planner_fixture {
         for (const auto& topic : workers.table.local().topics_map()) {
             cluster::topic_status ts;
             ts.tp_ns = topic.second.get_configuration().tp_ns;
-            for (size_t i = 0;
+            for (int i = 0;
                  i < topic.second.get_configuration().partition_count;
                  ++i) {
                 cluster::partition_status ps;

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -9,9 +9,9 @@
 
 #include "base/vlog.h"
 #include "cluster/controller_snapshot.h"
+#include "cluster/data_migrated_resources.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/tests/partition_balancer_planner_fixture.h"
-#include "data_migrated_resources.h"
 #include "utils/stable_iterator_adaptor.h"
 
 #include <seastar/testing/thread_test_case.hh>

--- a/src/v/cluster/tests/producer_state_tests.cc
+++ b/src/v/cluster/tests/producer_state_tests.cc
@@ -99,7 +99,7 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
     const size_t num_producers = 10;
     std::vector<producer_ptr> producers;
     producers.reserve(num_producers);
-    for (int i = 0; i < num_producers; i++) {
+    for (unsigned i = 0; i < num_producers; i++) {
         producers.push_back(new_producer());
     }
     // Ensure all producers are registered and linked up
@@ -207,7 +207,7 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
     const size_t num_producers = 5;
     std::vector<producer_ptr> producers;
     producers.reserve(num_producers);
-    for (int i = 0; i < num_producers; i++) {
+    for (unsigned i = 0; i < num_producers; i++) {
         auto prod = new_producer();
         producers.push_back(prod);
     }
@@ -216,7 +216,7 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
     // run a function on each producer and ensure that is the
     // moved to the end of LRU list
     for (auto& producer : producers) {
-        producer->run_with_lock([](auto units) {}).get();
+        producer->run_with_lock([](auto) {}).get();
     }
 
     clean(producers);
@@ -225,17 +225,17 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
 
 FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
     create_producer_state_manager(10, 10);
-    int evicted_so_far = 0;
+    unsigned evicted_so_far = 0;
     std::vector<producer_ptr> producers;
     producers.reserve(default_max_producers);
-    for (int i = 0; i < default_max_producers; i++) {
+    for (unsigned i = 0; i < default_max_producers; i++) {
         producers.push_back(new_producer([&] { evicted_so_far++; }));
     }
     BOOST_REQUIRE_EQUAL(evicted_so_far, 0);
 
     // we are already at the limit, add a few more producers
     size_t extra_producers = 5;
-    for (int i = 0; i < extra_producers; i++) {
+    for (unsigned i = 0; i < extra_producers; i++) {
         producers.push_back(new_producer([&] { evicted_so_far++; }));
     }
 
@@ -248,7 +248,7 @@ FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
 
     // producers are evicted on an lru basis, so the prefix
     // set of producers should be evicted first.
-    for (int i = 0; i < producers.size(); i++) {
+    for (unsigned i = 0; i < producers.size(); i++) {
         BOOST_REQUIRE_EQUAL(i < extra_producers, producers[i]->is_evicted());
     }
 
@@ -285,7 +285,7 @@ FIXTURE_TEST(test_state_management_with_multiple_namespaces, test_fixture) {
     /**
      * Fill producer state manager with producers from one vcluster
      */
-    for (int i = 0; i < total_producers; ++i) {
+    for (unsigned i = 0; i < total_producers; ++i) {
         new_vcluster_producer(vcluster_1);
     }
     validate_producer_count(20);
@@ -334,7 +334,7 @@ FIXTURE_TEST(test_state_management_with_multiple_namespaces, test_fixture) {
     BOOST_REQUIRE_EXCEPTION(
       new_vcluster_producer(vcluster_5),
       cluster::cache_full_error,
-      [](const auto& ex) { return true; });
+      [](const auto&) { return true; });
 
     for (auto vp : producers) {
         manager().deregister_producer(*vp.producer, vp.vcluster);

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -170,7 +170,7 @@ FIXTURE_TEST(
     auto check_allocated_counts = [&](std::vector<size_t> expected) {
         std::vector<size_t> counts;
         for (const auto& [id, node] : allocation_nodes) {
-            BOOST_REQUIRE(id() == counts.size() + 1); // 1-based node ids
+            BOOST_REQUIRE(id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
             counts.push_back(node->allocated_partitions());
         }
         logger.debug("allocated counts: {}, expected: {}", counts, expected);
@@ -180,7 +180,7 @@ FIXTURE_TEST(
     auto check_final_counts = [&](std::vector<size_t> expected) {
         std::vector<size_t> counts;
         for (const auto& [id, node] : allocation_nodes) {
-            BOOST_REQUIRE(id() == counts.size() + 1); // 1-based node ids
+            BOOST_REQUIRE(id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
             counts.push_back(node->final_partitions());
         }
         logger.debug("final counts: {}, expected: {}", counts, expected);

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -170,7 +170,8 @@ FIXTURE_TEST(
     auto check_allocated_counts = [&](std::vector<size_t> expected) {
         std::vector<size_t> counts;
         for (const auto& [id, node] : allocation_nodes) {
-            BOOST_REQUIRE(id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
+            BOOST_REQUIRE(
+              id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
             counts.push_back(node->allocated_partitions());
         }
         logger.debug("allocated counts: {}, expected: {}", counts, expected);
@@ -180,7 +181,8 @@ FIXTURE_TEST(
     auto check_final_counts = [&](std::vector<size_t> expected) {
         std::vector<size_t> counts;
         for (const auto& [id, node] : allocation_nodes) {
-            BOOST_REQUIRE(id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
+            BOOST_REQUIRE(
+              id() == static_cast<int>(counts.size()) + 1); // 1-based node ids
             counts.push_back(node->final_partitions());
         }
         logger.debug("final counts: {}, expected: {}", counts, expected);

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -14,8 +14,6 @@
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <bits/stdint-uintn.h>
-
 #include <cstdint>
 using namespace std::chrono_literals;
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -6,12 +6,27 @@ redpanda_test_cc_library(
         "kvstore_fixture.h",
     ],
     include_prefix = "storage/tests",
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/config",
         "//src/v/features",
         "//src/v/random:generators",
         "//src/v/storage",
         "//src/v/test_utils:seastar_boost",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "random",
+    hdrs = [
+        "randoms.h",
+    ],
+    include_prefix = "storage/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/storage",
     ],
 )
 

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -18,6 +18,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/model",
+        "//src/v/storage",
         "@fmt",
         "@googletest//:gtest",
         "@seastar",
@@ -42,6 +43,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/model",
+        "//src/v/storage",
         "@seastar//:testing",
     ],
 )

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -9,6 +9,7 @@ redpanda_test_cc_library(
     hdrs = [
         "async.h",
         "gtest_utils.h",
+        "logs.h",
         "test.h",
         "test_macros.h",
     ],
@@ -32,6 +33,7 @@ redpanda_test_cc_library(
     hdrs = [
         "async.h",
         "fixture.h",
+        "logs.h",
         "test_macros.h",
         "tmp_dir.h",
     ],


### PR DESCRIPTION
Fixes: CORE-7412
Fixes: CORE-7448
Fixes: CORE-7450
Fixes: CORE-7456
Fixes: CORE-7426
Fixes: CORE-7458
Fixes: CORE-7459
Fixes: CORE-7416
Fixes: CORE-7440
Fixes: CORE-7415
Fixes: CORE-7455
Fixes: CORE-7443
Fixes: CORE-7441

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
