### PR TITLE
dt: revert unignoring some flaky ducktape tests

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -21,6 +21,7 @@ from rptest.services.redpanda import SaslCredentials, SecurityConfig, MetricsEnd
 from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.util import wait_until_result
 from ducktape.errors import TimeoutError
+from ducktape.mark import ignore
 
 # How much memory to assign to redpanda per partition. Redpanda will be started
 # with MIB_PER_PARTITION * PARTITIONS_PER_SHARD * CORE_COUNT memory
@@ -301,6 +302,7 @@ class AuditLogTest(RedpandaTest):
             # to me able to assert on other properties of the test run.
             return make_result_set(t1, repeater)
 
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/16199
     @cluster(num_nodes=5)
     def test_audit_log(self):
         """

--- a/tests/rptest/scale_tests/many_clients_test.py
+++ b/tests/rptest/scale_tests/many_clients_test.py
@@ -15,7 +15,7 @@ from rptest.services.cluster import cluster
 from rptest.services.rpk_consumer import RpkConsumer
 
 from rptest.services.producer_swarm import ProducerSwarm
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 
 
 class CompactionMode(str, enum.Enum):
@@ -76,6 +76,7 @@ class ManyClientsTest(RedpandaTest):
         self._test_many_clients(compaction_mode=CompactionMode.REALISTIC)
 
     @cluster(num_nodes=7)
+    @ignore
     def test_many_clients_pathological_compaction(self):
         self._test_many_clients(compaction_mode=CompactionMode.PATHOLOGICAL)
 

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from keycloak import KeycloakOpenID
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
@@ -724,6 +724,7 @@ class AuditLogTestsAppLifecycle(AuditLogTestBase):
                     True), lambda record_count: record_count == 3,
             "Single redpanda start event per node")
 
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/16198
     @skip_fips_mode
     @cluster(num_nodes=5)
     def test_drain_on_audit_disabled(self):

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -29,7 +29,7 @@ from ducktape.tests.test import TestContext
 from rptest.clients.types import TopicSpec
 from rptest.tests.e2e_finjector import Finjector
 from rptest.clients.rpk import RpkTool, RpkException
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from contextlib import nullcontext
 import requests
 import re
@@ -687,6 +687,7 @@ class DataMigrationsApiTest(RedpandaTest):
         self.cancel(migration_id, topic_name)
         self.assert_no_topics()
 
+    @ignore
     @cluster(num_nodes=4, log_allow_list=MIGRATION_LOG_ALLOW_LIST)
     @matrix(transfer_leadership=[True, False],
             params=generate_tmptpdi_params())

--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -81,6 +81,7 @@ class LibrdkafkaTest(RedpandaTest):
                                                  "default_topic_partitions": 4
                                              })
 
+    @ignore  # https://github.com/redpanda-data/redpanda/issues/7148
     @cluster(num_nodes=4)
     @matrix(test_num=tests_to_run())
     @skip_debug_mode

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -10,6 +10,7 @@
 import os
 from time import sleep
 
+from ducktape.mark import ignore
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
@@ -71,6 +72,7 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
         super(RedpandaFIPSStartupTest,
               self).__init__(test_context=test_context)
 
+    @ignore  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_startup(self):
         """
@@ -122,6 +124,7 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
             metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
             expected_mode=RedpandaServiceBase.FIPSMode.permissive)
 
+    @ignore  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_non_homogenous(self):
         """
@@ -253,6 +256,7 @@ class RedpandaFIPSStartupLicenseTest(RedpandaFIPSStartupTestBase):
             f"Overriding default license log annoy interval to: {self.LICENSE_CHECK_INTERVAL_SEC}s"
         )
 
+    @ignore  # https://redpandadata.atlassian.net/browse/CORE-4283
     @cluster(num_nodes=3)
     def test_fips_license_nag(self):
         wait_until(self._license_nag_is_set,


### PR DESCRIPTION
These tests were unignored in a previous PR because they were thought to be no longer flaky based on testing. However, they still seem to be flaky, making CI red. Let's revert unignoring them to return to the status quo before the PR.

Partially reverts 3ee9ae6b5308353f2e8cf2051c759caede0665fb

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
