### PR TITLE
bazel: add sudo dependency

### DIFF
--- a/bazel/install-deps.sh
+++ b/bazel/install-deps.sh
@@ -36,6 +36,7 @@ deb_deps=(
   ragel
   valgrind
   xfslibs-dev
+  sudo
 )
 
 fedora_deps=(
@@ -50,6 +51,7 @@ fedora_deps=(
   valgrind-devel
   xfsprogs-devel
   xorg-x11-util-macros
+  sudo
 )
 
 case "$ID" in


### PR DESCRIPTION
Adding `sudo` dependency

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

