### PR TITLE
sr/avro: fix missing default compat check for null

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -171,7 +171,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "Lbym0V8QC5CgB4Ja6cI2QZLO4RHkHXMREUETEHvWCkc=",
+        "bzlTransitiveDigest": "jW+tM9iA4DepR7H7FTqasQ5ZWZGDc/fZxWq8LIPz0RM=",
         "usagesDigest": "bsXDsdl5Gq0iZDf6R9bhf3oHUM35HAGF1usXoFeQrF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -378,9 +378,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:avro.BUILD",
-              "sha256": "f1a7d13b28ce5cc8812f26c705a6ea27b8bc63554d82d556c63b437da0338cf1",
-              "strip_prefix": "avro-e54bf712fce903652f3eab7a6c16264ac5d17285",
-              "url": "https://github.com/redpanda-data/avro/archive/e54bf712fce903652f3eab7a6c16264ac5d17285.tar.gz",
+              "sha256": "3f6f1e32225b94f3bd70822b7e819c61b30570417308ae7a9d7661d8016be99e",
+              "strip_prefix": "avro-98d753c48cf3a22b52adc688ea3ca53550d0630c",
+              "url": "https://github.com/pgellert/avro/archive/98d753c48cf3a22b52adc688ea3ca53550d0630c.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:avro-snappy-includes.patch"
               ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -23,9 +23,9 @@ def data_dependency():
     http_archive(
         name = "avro",
         build_file = "//bazel/thirdparty:avro.BUILD",
-        sha256 = "f1a7d13b28ce5cc8812f26c705a6ea27b8bc63554d82d556c63b437da0338cf1",
-        strip_prefix = "avro-e54bf712fce903652f3eab7a6c16264ac5d17285",
-        url = "https://github.com/redpanda-data/avro/archive/e54bf712fce903652f3eab7a6c16264ac5d17285.tar.gz",
+        sha256 = "3f6f1e32225b94f3bd70822b7e819c61b30570417308ae7a9d7661d8016be99e",
+        strip_prefix = "avro-98d753c48cf3a22b52adc688ea3ca53550d0630c",
+        url = "https://github.com/pgellert/avro/archive/98d753c48cf3a22b52adc688ea3ca53550d0630c.tar.gz",
         patches = ["//bazel/thirdparty:avro-snappy-includes.patch"],
         patch_args = ["-p1"],
     )

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -115,18 +115,29 @@ avro_compatibility_result check_compatible(
                       *reader.leafAt(int(r_idx)),
                       *writer.leafAt(int(w_idx)),
                       fields_p / std::to_string(r_idx) / "type"));
-                } else if (
-                  reader.defaultValueAt(int(r_idx)).type() == avro::AVRO_NULL) {
-                    // if the reader's record schema has a field with no default
-                    // value, and writer's schema does not have a field with the
-                    // same name, an error is signalled.
+                } else {
+                    // if the reader's record schema has a field with no
+                    // default value, and writer's schema does not have a
+                    // field with the same name, an error is signalled.
 
-                    // For union, the default must correspond to the first type.
-                    // The default may be null.
+                    // For union, the default must correspond to the first
+                    // type. The default may be null.
                     const auto& r_leaf = reader.leafAt(int(r_idx));
-                    if (
-                      r_leaf->type() != avro::Type::AVRO_UNION
-                      || r_leaf->leafAt(0)->type() != avro::Type::AVRO_NULL) {
+                    const auto& r_def = reader.defaultValueAt(int(r_idx));
+
+                    auto missing_valid_default = [&]() {
+                        if (!r_def) {
+                            return true;
+                        }
+
+                        auto expected_type = (r_leaf->type()
+                                              == avro::Type::AVRO_UNION)
+                                               ? r_leaf->leafAt(0)->type()
+                                               : r_leaf->type();
+                        return expected_type != r_def->type();
+                    }();
+
+                    if (missing_valid_default) {
                         compat_result.emplace<avro_incompatibility>(
                           fields_p / std::to_string(r_idx),
                           avro_incompatibility::Type::
@@ -139,7 +150,7 @@ avro_compatibility_result check_compatible(
             // if the writer's symbol is not present in the reader's enum and
             // the reader has a default value, then that value is used,
             // otherwise an error is signalled.
-            if (reader.defaultValueAt(0).type() == avro::AVRO_NULL) {
+            if (!reader.defaultValueAt(0)) {
                 std::vector<std::string_view> missing;
                 for (size_t w_idx = 0; w_idx < writer.names(); ++w_idx) {
                     size_t r_idx{0};

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -543,6 +543,50 @@ const auto compat_data = std::to_array<compat_test_case>({
     .writer=schema_old,
     .expected=backward_expected,
   },
+  {
+    .reader=R"({
+        "type": "record",
+        "name": "car",
+        "fields": [
+            {
+                "name": "color",
+                "type": ["string", "null"]
+            }
+        ]
+    })",
+    .writer=R"({
+        "type": "record",
+        "name": "car",
+        "fields": []
+    })",
+    .expected={
+      {"/fields/0",
+       incompatibility::Type::reader_field_missing_default_value,
+       "color"},
+    },
+  },
+  {
+    .reader=R"({
+      "type": "record",
+      "name": "car",
+      "fields": [
+          {
+              "name": "color",
+              "type": "null"
+          }
+      ]
+  })",
+    .writer=R"({
+      "type": "record",
+      "name": "car",
+      "fields": []
+  })",
+  .expected={
+      {"/fields/0",
+       incompatibility::Type::reader_field_missing_default_value,
+       "color"},
+    },
+  },
 });
 
 std::string format_set(const absl::flat_hash_set<ss::sstring>& d) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -325,9 +325,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_alias_resolution_stopgap) {
 
 namespace {
 
-const auto schema_old = pps::sanitize_avro_schema_definition(
-                          {
-                            R"({
+const auto schema_old = R"({
     "type": "record",
     "name": "myrecord",
     "fields": [
@@ -392,13 +390,9 @@ const auto schema_old = pps::sanitize_avro_schema_definition(
             }
         }
     ]
-})",
-                            pps::schema_type::avro})
-                          .value();
+})";
 
-const auto schema_new = pps::sanitize_avro_schema_definition(
-                          {
-                            R"({
+const auto schema_new = R"({
     "type": "record",
     "name": "myrecord",
     "fields": [
@@ -464,9 +458,7 @@ const auto schema_new = pps::sanitize_avro_schema_definition(
             }
         }
     ]
-})",
-                            pps::schema_type::avro})
-                          .value();
+})";
 
 using incompatibility = pps::avro_incompatibility;
 
@@ -534,16 +526,22 @@ const absl::flat_hash_set<incompatibility> backward_expected{
    "expected: someEnum1 (alias resolution is not yet fully supported)"},
 };
 
-const auto compat_data = std::to_array<compat_test_data<incompatibility>>({
+struct compat_test_case {
+    std::string reader;
+    std::string writer;
+    absl::flat_hash_set<incompatibility> expected;
+};
+
+const auto compat_data = std::to_array<compat_test_case>({
   {
-    schema_old.share(),
-    schema_new.share(),
-    forward_expected,
+    .reader=schema_old,
+    .writer=schema_new,
+    .expected=forward_expected,
   },
   {
-    schema_new.share(),
-    schema_old.share(),
-    backward_expected,
+    .reader=schema_new,
+    .writer=schema_old,
+    .expected=backward_expected,
   },
 });
 
@@ -555,13 +553,26 @@ std::string format_set(const absl::flat_hash_set<ss::sstring>& d) {
 
 SEASTAR_THREAD_TEST_CASE(test_avro_compat_messages) {
     for (const auto& cd : compat_data) {
-        auto compat = check_compatible_verbose(cd.reader, cd.writer);
+        auto compat = check_compatible_verbose(
+          pps::sanitize_avro_schema_definition(
+            {cd.reader, pps::schema_type::avro})
+            .value(),
+          pps::sanitize_avro_schema_definition(
+            {cd.writer, pps::schema_type::avro})
+            .value());
+
+        pps::raw_compatibility_result raw;
+        absl::c_for_each(cd.expected, [&raw](auto e) {
+            raw.emplace<incompatibility>(std::move(e));
+        });
+        auto exp_compat = std::move(raw)(pps::verbose::yes);
+
         absl::flat_hash_set<ss::sstring> errs{
           compat.messages.begin(), compat.messages.end()};
         absl::flat_hash_set<ss::sstring> expected{
-          cd.expected.messages.begin(), cd.expected.messages.end()};
+          exp_compat.messages.begin(), exp_compat.messages.end()};
 
-        BOOST_CHECK(!compat.is_compat);
+        BOOST_CHECK_EQUAL(compat.is_compat, exp_compat.is_compat);
         BOOST_CHECK_EQUAL(errs.size(), expected.size());
         BOOST_REQUIRE_MESSAGE(
           errs == expected,

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -550,6 +550,28 @@ const auto compat_data = std::to_array<compat_test_case>({
         "fields": [
             {
                 "name": "color",
+                "type": ["null", "string"]
+            }
+        ]
+    })",
+    .writer=R"({
+        "type": "record",
+        "name": "car",
+        "fields": []
+    })",
+    .expected={
+      {"/fields/0",
+       incompatibility::Type::reader_field_missing_default_value,
+       "color"},
+    },
+  },
+  {
+    .reader=R"({
+        "type": "record",
+        "name": "car",
+        "fields": [
+            {
+                "name": "color",
                 "type": ["string", "null"]
             }
         ]
@@ -564,6 +586,25 @@ const auto compat_data = std::to_array<compat_test_case>({
        incompatibility::Type::reader_field_missing_default_value,
        "color"},
     },
+  },
+  {
+    .reader=R"({
+    "type": "record",
+    "name": "car",
+    "fields": [
+        {
+            "name": "color",
+            "type": "null",
+            "default": null
+        }
+    ]
+})",
+    .writer=R"({
+    "type": "record",
+    "name": "car",
+    "fields": []
+})",
+    .expected = {},
   },
   {
     .reader=R"({


### PR DESCRIPTION
This fixes two related bugs in the avro compatibility checks where our
implementation was too lenient for the check
`reader_field_missing_default_value`.

In Avro, a record field may declare a null default (`"default": null`)
which is different from not declaring a default (no `"default"`). The
first case means that by default the reader will set the field to `null`
unless the field was set by the writer. The second case means that the
writer must declare the field, otherwise the data is invalid for the
reader.

https://avro.apache.org/docs/1.11.1/specification/#schema-record

However, the C++ avro implementation used a null object to represent
even missing fields, which meant that the redpanda schema registry
implementation could not tell the difference between a missing field and
a null field. (See the associated avro fix PR).

This meant that we incorrectly didn't detect when the reader schema had
a new record field without a default value and always thought that a
`null` default value is present. This surfaced as a bug for `"null"` and
`["null", ...]` (union) types but it was constrained to these two types
because the default-value-vs-field type mismatch check caught this as an
incompatibility otherwise.

Depends on: https://github.com/redpanda-data/avro/pull/313
Fixes https://redpandadata.atlassian.net/browse/CORE-1796
Fixes https://github.com/redpanda-data/redpanda/issues/16649

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

### Bug Fixes

* Schema Registry: fixes a bug in the Avro compatibility check `reader_field_missing_default_value` where it was too lenient for missing default values of null-able types.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
