### PR TITLE
ct: add an application hook for cloud topics reconciler

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -54,3 +54,21 @@ redpanda_cc_library(
         "//src/v/utils:uuid",
     ],
 )
+
+redpanda_cc_library(
+    name = "app",
+    srcs = [
+        "app.cc",
+    ],
+    hdrs = [
+        "app.h",
+    ],
+    implementation_deps = [
+        "//src/v/cloud_topics/reconciler",
+    ],
+    include_prefix = "cloud_topics",
+    visibility = ["//src/v/redpanda:__pkg__"],
+    deps = [
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/CMakeLists.txt
+++ b/src/v/cloud_topics/CMakeLists.txt
@@ -7,6 +7,15 @@ v_cc_library(
   DEPS
     v::model
     v::serde
+    v::cloud_topics_reconciler
+)
+
+v_cc_library(
+  NAME cloud_topics_app
+  SRCS
+    app.cc
+  DEPS
+    v::cloud_topics
 )
 
 add_subdirectory(reconciler)

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cloud_topics/app.h"
+
+#include "cloud_topics/reconciler/reconciler.h"
+
+namespace experimental::cloud_topics::reconciler {
+
+app::app(
+  seastar::sharded<cluster::partition_manager>* partition_manager,
+  seastar::sharded<cloud_io::remote>* remote)
+  : _reconciler(std::make_unique<reconciler>(partition_manager, remote)) {}
+
+app::~app() = default;
+
+seastar::future<> app::start() { return _reconciler->start(); }
+
+seastar::future<> app::stop() { return _reconciler->stop(); }
+
+} // namespace experimental::cloud_topics::reconciler

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+#include <memory>
+
+namespace cluster {
+class partition_manager;
+}
+
+namespace cloud_io {
+class remote;
+}
+
+namespace experimental::cloud_topics::reconciler {
+
+class reconciler;
+
+class app {
+public:
+    app(
+      seastar::sharded<cluster::partition_manager>*,
+      seastar::sharded<cloud_io::remote>*);
+
+    app(const app&) = delete;
+    app& operator=(const app&) = delete;
+    app(app&&) noexcept = delete;
+    app& operator=(app&&) noexcept = delete;
+    ~app();
+
+    seastar::future<> start();
+    seastar::future<> stop();
+
+private:
+    std::unique_ptr<reconciler> _reconciler;
+};
+
+} // namespace experimental::cloud_topics::reconciler

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -19,7 +19,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage",
         "//src/v/cloud_storage_clients",
-        "//src/v/cloud_topics/reconciler",
+        "//src/v/cloud_topics:app",
         "//src/v/cluster",
         "//src/v/cluster:cloud_metadata_offsets_recovery_router",
         "//src/v/cluster:cloud_metadata_offsets_recovery_service",

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -80,7 +80,7 @@ v_cc_library(
     v::transform
     v::version 
     v::wasm
-    v::cloud_topics_reconciler
+    v::cloud_topics_app
   )
 
 add_subdirectory(tests)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -3173,10 +3173,7 @@ void application::start_runtime_services(
     space_manager->start().get();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
-        _reconciler
-          .invoke_on_all(
-            &experimental::cloud_topics::reconciler::reconciler::start)
-          .get();
+        _reconciler.invoke_on_all([](auto& app) { return app.start(); }).get();
     }
 }
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -14,7 +14,7 @@
 #include "base/seastarx.h"
 #include "cloud_storage/fwd.h"
 #include "cloud_storage_clients/client_pool.h"
-#include "cloud_topics/reconciler/reconciler.h"
+#include "cloud_topics/app.h"
 #include "cluster/archival/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
@@ -187,7 +187,7 @@ public:
     ss::sharded<kafka::server> _kafka_server;
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
-    ss::sharded<experimental::cloud_topics::reconciler::reconciler> _reconciler;
+    ss::sharded<experimental::cloud_topics::reconciler::app> _reconciler;
 
     const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
         return _schema_registry;


### PR DESCRIPTION
Hide cloud topics service implementation using pimpl pattern so that less code is exposed into application.{h,cc}.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

