### PR TITLE
[CORE-7957] tests: wait for license information comparisons

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -257,17 +257,6 @@ class RpkClusterTest(RedpandaTest):
             output = self._rpk.license_set(tf.name)
             assert "Successfully uploaded license" in output
 
-        def obtain_license():
-            lic = self._rpk.license_info()
-            return (lic != "{}", lic)
-
-        rp_license = wait_until_result(
-            obtain_license,
-            timeout_sec=10,
-            backoff_sec=1,
-            retry_on_exc=True,
-            err_msg="unable to retrieve license information")
-
         wait_until(
             lambda: self._get_license_expiry() > 0,
             timeout_sec=10,
@@ -288,8 +277,19 @@ class RpkClusterTest(RedpandaTest):
             'license_violation': False,
             'enterprise_features_in_use': [],
         }
-        result = json.loads(rp_license)
-        assert expected_license == result, result
+
+        def compare_license():
+            license = self._rpk.license_info()
+            if license is None or license == "{}":
+                return False
+            return json.loads(license) == expected_license
+
+        wait_until(
+            compare_license,
+            timeout_sec=10,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg="unable to retrieve and compare license information")
 
         # Assert that a second put takes license
         license = get_second_cluster_license()


### PR DESCRIPTION
/v1/features/enterprise does not redirect the
request to the leader, so the handler reads
directly from the local controller. The state
may not be synchronized, so it's better to retry.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
