### PR TITLE
[backport][v24.2.x] raft/state_machine: revisit synchronization around state_machine_base::apply #23811

### DIFF
--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -112,8 +112,9 @@ persisted_stm<T>::persisted_stm(
 }
 
 template<supported_stm_snapshot T>
-ss::future<> persisted_stm<T>::apply(const model::record_batch& b) {
-    return _apply_lock.with([this, &b] { return do_apply(b); });
+ss::future<> persisted_stm<T>::apply(
+  const model::record_batch& b, const ssx::semaphore_units&) {
+    return do_apply(b);
 }
 
 template<supported_stm_snapshot T>

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -112,6 +112,11 @@ persisted_stm<T>::persisted_stm(
 }
 
 template<supported_stm_snapshot T>
+ss::future<> persisted_stm<T>::apply(const model::record_batch& b) {
+    return _apply_lock.with([this, &b] { return do_apply(b); });
+}
+
+template<supported_stm_snapshot T>
 ss::future<std::optional<stm_snapshot>>
 persisted_stm<T>::load_local_snapshot() {
     return _snapshot_backend.load_snapshot();

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -123,7 +123,6 @@ persisted_stm<T>::load_local_snapshot() {
 }
 template<supported_stm_snapshot T>
 ss::future<> persisted_stm<T>::stop() {
-    _apply_lock.broken();
     co_await raft::state_machine_base::stop();
     co_await _gate.close();
 }

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -216,7 +216,9 @@ public:
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
-    ss::future<> apply(const model::record_batch&) final;
+    ss::future<> apply(
+      const model::record_batch&,
+      const ssx::semaphore_units& apply_units) final;
 
 protected:
     ss::future<> start() override;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -216,9 +216,7 @@ public:
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
-    ss::future<> apply(const model::record_batch& b) final {
-        return _apply_lock.with([this, &b] { return do_apply(b); });
-    }
+    ss::future<> apply(const model::record_batch&) final;
 
 protected:
     ss::future<> start() override;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -259,7 +259,6 @@ private:
     ss::future<> wait_for_snapshot_hydrated();
 
     ss::future<> do_write_local_snapshot();
-    mutex _apply_lock{"persisted_stm::apply_lock"};
     mutex _op_lock{"persisted_stm::op_lock"};
     std::vector<ss::lw_shared_ptr<expiring_promise<bool>>> _sync_waiters;
     ss::condition_variable _on_snapshot_hydrated;

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -16,6 +16,12 @@
 
 namespace raft {
 
+ss::future<> state_machine_base::apply(const model::record_batch& b) {
+    auto units = co_await _apply_lock.get_units();
+    co_await apply(b, units);
+    set_next(model::next_offset(b.last_offset()));
+}
+
 void state_machine_base::set_next(model::offset offset) {
     vassert(
       offset >= _next,

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -27,6 +27,7 @@ void state_machine_base::set_next(model::offset offset) {
 }
 
 ss::future<> state_machine_base::stop() {
+    _apply_lock.broken();
     _waiters.stop();
     co_return;
 }

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -16,6 +16,7 @@
 #include "model/record.h"
 #include "raft/fwd.h"
 #include "raft/offset_monitor.h"
+#include "utils/mutex.h"
 
 namespace raft {
 
@@ -95,6 +96,8 @@ protected:
 
     model::offset next() const { return _next; }
     void set_next(model::offset offset);
+
+    mutex _apply_lock{"state_machine_base::apply_lock"};
 
     friend class batch_applicator;
     friend class state_machine_manager;

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -43,6 +43,8 @@ public:
       = std::nullopt);
 
     /**
+     * Applies the batch and updates the next offset to be applied.
+     *
      * This function accepts a batch reference, an implementer may copy a batch
      * with `model::record_batch::copy()` method, the interface design is a
      * consequence of having single apply fiber for all state machines built on
@@ -50,7 +52,8 @@ public:
      * whole record is applied or not. When exception is thrown from apply
      * method it will be retried with the same record batch.
      */
-    virtual ss::future<> apply(const model::record_batch&) = 0;
+    ss::future<> apply(const model::record_batch&);
+
     /**
      * This function will be called every time a snapshot is applied in apply
      * fiber. Snapshot will contain only a data specific for this state machine
@@ -84,6 +87,15 @@ public:
     virtual ss::future<> remove_local_state() = 0;
 
 protected:
+    /**
+     * Must always be called under apply mutex scope and apply_units argument
+     * is in place to enforce that. It is const qualified to ensure the apply
+     * impelementors do not control their lifetime.
+     */
+    virtual ss::future<>
+    apply(const model::record_batch&, const ssx::semaphore_units& apply_units)
+      = 0;
+
     /**
      *  Lifecycle is managed by state_machine_manager
      */

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -140,7 +140,6 @@ batch_applicator::apply_to_stm(
         }
 
         co_await state.stm_entry->stm->apply(batch);
-        state.stm_entry->stm->set_next(model::next_offset(last_offset));
         co_return applied_successfully::yes;
     } catch (...) {
         vlog(

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -485,9 +485,17 @@ public:
         ASSERT_EQ_CORO(before, _last_stm_applied);
     }
 
+    ss::future<> validate_snapshot_on_latest_offset() {
+        ASSERT_EQ_CORO(_last_stm_applied, last_applied_offset());
+    }
+
     ss::future<stm_snapshot> take_local_snapshot(
       [[maybe_unused]] ssx::semaphore_units apply_units) override {
+        co_await validate_snapshot_on_latest_offset();
         auto applied_offset_before = _last_stm_applied;
+        co_await validate_applied_offsets(applied_offset_before);
+        // sleep a bit to ensure _last_applied_offset doesn't move
+        // as we are holding the units.
         co_await ss::sleep(2ms);
         co_await validate_applied_offsets(applied_offset_before);
         co_return stm_snapshot::create(

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -98,7 +98,8 @@ struct simple_kv : public raft::state_machine_base {
     ss::future<> start() override { return ss::now(); }
     ss::future<> stop() override { co_await raft::state_machine_base::stop(); };
 
-    ss::future<> apply(const model::record_batch& batch) override {
+    ss::future<> apply(
+      const model::record_batch& batch, const ssx::semaphore_units&) override {
         apply_to_state(batch, state);
         co_return;
     }


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-7943

This is related to recent work in https://github.com/redpanda-data/redpanda/commit/e2720105f1e1c377f47eb15bebe4a80f5c9ac825

This PR redoes synchronization around state_machine_base::apply(batch) so that racing snapshots (local snapshots) see a consistent state of the stm. The invariant that is currently violated without this synchronization is the following example.

Example:

```
* last_applied_offset = 10. [ initial state]

* state_machine_base::apply -- tries to apply offset 11

* persisted_stm::apply  -- grabs [persisted_stm::_apply_lock] for offset 11

* rm_stm::do_apply() -- successfully applies 11

** [scheduling points] control is still not back to state_machine_base::apply.. so set_next() is not called.. last_applied_offset  = 10

* racing take_local_snapshot() --  persisted_stm::do_write_local_snapshot() -- it can proceed with snapshotting because _apply_lock is no longer held.

* At this point .,,, rm_stm::take_local_snapshot(apply_lock_units)  is called with last_applied_offset ()= 10 .. when in fact the state of the stm corresponds to offset = 11
```

The invariant that is broken here is that the local snapshot sees an inconsistent state of the stm resulting in an off-by-one error in the snapshot offset. Snapshotting relies on the last_applied_offset() to compute snapshot offset  and in this case the last_applied_offset is not atomically updated along with actual apply.

This PR proposes to unify locking for the apply path into state_machine_base (from persisted_stm) and code paths that intend to see a consistent state of the stm must hold the lock so the apply doesn't interleave.


Adds a regression test that consistently reproduces this problem without the patch.

Fixes https://github.com/redpanda-data/redpanda/issues/23827

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
