### PR TITLE
redpanda: hide kafka server implementation from application.cc

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -56,6 +56,7 @@ v_cc_library(
     server/group_metadata.cc
     server/group_tx_tracker_stm.cc
     server/logger.cc
+    server/app.cc
  DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -1,6 +1,15 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "qdc_monitor_config",
+    hdrs = [
+        "queue_depth_monitor_config.h",
+    ],
+    include_prefix = "kafka/server",
+    visibility = ["//visibility:public"],
+)
+
+redpanda_cc_library(
     name = "server",
     srcs = [
         "client_quota_translator.cc",
@@ -148,6 +157,7 @@ redpanda_cc_library(
     include_prefix = "kafka/server",
     visibility = ["//visibility:public"],
     deps = [
+        ":qdc_monitor_config",
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -329,3 +329,22 @@ redpanda_cc_library(
         "//src/v/kafka/protocol",
     ],
 )
+
+redpanda_cc_library(
+    name = "app",
+    srcs = [
+        "app.cc",
+    ],
+    hdrs = [
+        "app.h",
+    ],
+    implementation_deps = [
+        ":server",
+    ],
+    include_prefix = "kafka/server",
+    visibility = ["//src/v/redpanda:__pkg__"],
+    deps = [
+        ":qdc_monitor_config",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/server/app.cc
+++ b/src/v/kafka/server/app.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/app.h"
+
+#include "kafka/server/server.h"
+
+#include <memory>
+
+namespace kafka {
+
+seastar::future<> server_app::init(
+  seastar::sharded<net::server_configuration>* conf,
+  seastar::smp_service_group smp,
+  seastar::scheduling_group sched,
+  seastar::sharded<cluster::metadata_cache>& mdc,
+  seastar::sharded<cluster::topics_frontend>& tf,
+  seastar::sharded<cluster::config_frontend>& cf,
+  seastar::sharded<features::feature_table>& ft,
+  seastar::sharded<cluster::client_quota::frontend>& cqf,
+  seastar::sharded<cluster::client_quota::store>& cqs,
+  seastar::sharded<quota_manager>& qm,
+  seastar::sharded<snc_quota_manager>& snc_mgr,
+  seastar::sharded<kafka::group_router>& gr,
+  seastar::sharded<kafka::usage_manager>& um,
+  seastar::sharded<cluster::shard_table>& st,
+  seastar::sharded<cluster::partition_manager>& pm,
+  seastar::sharded<cluster::id_allocator_frontend>& idaf,
+  seastar::sharded<security::credential_store>& cs,
+  seastar::sharded<security::authorizer>& auth,
+  seastar::sharded<security::audit::audit_log_manager>& audit,
+  seastar::sharded<security::oidc::service>& oidc,
+  seastar::sharded<cluster::security_frontend>& sec,
+  seastar::sharded<cluster::controller_api>& ctrl,
+  seastar::sharded<cluster::tx_gateway_frontend>& tx,
+  std::optional<qdc_monitor_config> qdc,
+  ssx::singleton_thread_worker& worker,
+  const std::unique_ptr<pandaproxy::schema_registry::api>& pp) {
+    return _server.start(
+      conf,
+      smp,
+      sched,
+      std::ref(mdc),
+      std::ref(tf),
+      std::ref(cf),
+      std::ref(ft),
+      std::ref(cqf),
+      std::ref(cqs),
+      std::ref(qm),
+      std::ref(snc_mgr),
+      std::ref(gr),
+      std::ref(um),
+      std::ref(st),
+      std::ref(pm),
+      std::ref(idaf),
+      std::ref(cs),
+      std::ref(auth),
+      std::ref(audit),
+      std::ref(oidc),
+      std::ref(sec),
+      std::ref(ctrl),
+      std::ref(tx),
+      qdc,
+      std::ref(worker),
+      std::ref(pp));
+}
+
+server_app::~server_app() = default;
+
+seastar::future<> server_app::start() {
+    return _server.invoke_on_all(&net::server::start);
+}
+
+seastar::future<> server_app::shutdown_input() {
+    return _server.invoke_on_all(&net::server::shutdown_input);
+}
+
+seastar::future<> server_app::wait_for_shutdown() {
+    return _server.invoke_on_all(&net::server::wait_for_shutdown);
+}
+
+seastar::future<> server_app::stop() { return _server.stop(); }
+
+} // namespace kafka

--- a/src/v/kafka/server/app.h
+++ b/src/v/kafka/server/app.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "kafka/server/queue_depth_monitor_config.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+#include <memory>
+
+namespace cluster {
+class metadata_cache;
+class topics_frontend;
+class config_frontend;
+class shard_table;
+class partition_manager;
+class id_allocator_frontend;
+class security_frontend;
+class controller_api;
+class tx_gateway_frontend;
+namespace client_quota {
+class frontend;
+class store;
+} // namespace client_quota
+} // namespace cluster
+
+namespace security {
+class credential_store;
+class authorizer;
+namespace audit {
+class audit_log_manager;
+}
+namespace oidc {
+class service;
+}
+} // namespace security
+
+namespace pandaproxy::schema_registry {
+class api;
+}
+
+namespace ssx {
+class singleton_thread_worker;
+}
+
+namespace net {
+struct server_configuration;
+}
+
+namespace features {
+class feature_table;
+}
+
+namespace kafka {
+
+class server;
+class quota_manager;
+class snc_quota_manager;
+class group_router;
+class usage_manager;
+
+class server_app {
+public:
+    server_app() = default;
+    server_app(const server_app&) = delete;
+    server_app& operator=(const server_app&) = delete;
+    server_app(server_app&&) noexcept = delete;
+    server_app& operator=(server_app&&) noexcept = delete;
+    ~server_app();
+
+    seastar::future<> init(
+      seastar::sharded<net::server_configuration>*,
+      seastar::smp_service_group,
+      seastar::scheduling_group,
+      seastar::sharded<cluster::metadata_cache>&,
+      seastar::sharded<cluster::topics_frontend>&,
+      seastar::sharded<cluster::config_frontend>&,
+      seastar::sharded<features::feature_table>&,
+      seastar::sharded<cluster::client_quota::frontend>&,
+      seastar::sharded<cluster::client_quota::store>&,
+      seastar::sharded<quota_manager>&,
+      seastar::sharded<snc_quota_manager>&,
+      seastar::sharded<kafka::group_router>&,
+      seastar::sharded<kafka::usage_manager>&,
+      seastar::sharded<cluster::shard_table>&,
+      seastar::sharded<cluster::partition_manager>&,
+      seastar::sharded<cluster::id_allocator_frontend>&,
+      seastar::sharded<security::credential_store>&,
+      seastar::sharded<security::authorizer>&,
+      seastar::sharded<security::audit::audit_log_manager>&,
+      seastar::sharded<security::oidc::service>&,
+      seastar::sharded<cluster::security_frontend>&,
+      seastar::sharded<cluster::controller_api>&,
+      seastar::sharded<cluster::tx_gateway_frontend>&,
+      std::optional<qdc_monitor_config>,
+      ssx::singleton_thread_worker&,
+      const std::unique_ptr<pandaproxy::schema_registry::api>&);
+
+    seastar::future<> start();
+    seastar::future<> shutdown_input();
+    seastar::future<> wait_for_shutdown();
+    seastar::future<> stop();
+
+    seastar::sharded<server>& ref() { return _server; }
+    server& local() { return _server.local(); }
+
+private:
+    seastar::sharded<server> _server;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/queue_depth_monitor.h
+++ b/src/v/kafka/server/queue_depth_monitor.h
@@ -11,23 +11,12 @@
 #pragma once
 #include "base/vlog.h"
 #include "kafka/server/logger.h"
+#include "kafka/server/queue_depth_monitor_config.h"
 #include "utils/queue_depth_control.h"
 
 namespace kafka {
 
 struct qdc_monitor {
-    struct config {
-        double latency_alpha;
-        std::chrono::milliseconds max_latency;
-        size_t window_count;
-        std::chrono::milliseconds window_size;
-        double depth_alpha;
-        size_t idle_depth;
-        size_t min_depth;
-        size_t max_depth;
-        std::chrono::milliseconds depth_update_freq;
-    };
-
     exponential_moving_average<std::chrono::steady_clock::duration> ema;
     queue_depth_control qdc;
     ss::timer<ss::lowres_clock> timer;
@@ -38,7 +27,7 @@ struct qdc_monitor {
      * isn't really a perfect value here. its purpose is to bootstrap the
      * algorithm and is irrelevant after a full time window has elapsed.
      */
-    explicit qdc_monitor(const config& cfg)
+    explicit qdc_monitor(const qdc_monitor_config& cfg)
       : ema(cfg.latency_alpha, cfg.max_latency / 2, cfg.window_count)
       , qdc(
           cfg.max_latency,

--- a/src/v/kafka/server/queue_depth_monitor_config.h
+++ b/src/v/kafka/server/queue_depth_monitor_config.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <chrono>
+
+namespace kafka {
+
+struct qdc_monitor_config {
+    double latency_alpha;
+    std::chrono::milliseconds max_latency;
+    size_t window_count;
+    std::chrono::milliseconds window_size;
+    double depth_alpha;
+    size_t idle_depth;
+    size_t min_depth;
+    size_t max_depth;
+    std::chrono::milliseconds depth_update_freq;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -136,7 +136,7 @@ server::server(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
-  std::optional<qdc_monitor::config> qdc_config,
+  std::optional<qdc_monitor_config> qdc_config,
   ssx::singleton_thread_worker& tw,
   const std::unique_ptr<pandaproxy::schema_registry::api>& sr) noexcept
   : net::server(cfg, klog)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -24,6 +24,7 @@
 #include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/latency_probe.h"
 #include "kafka/server/queue_depth_monitor.h"
+#include "kafka/server/queue_depth_monitor_config.h"
 #include "kafka/server/read_distribution_probe.h"
 #include "kafka/server/sasl_probe.h"
 #include "metrics/metrics.h"
@@ -75,7 +76,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
-      std::optional<qdc_monitor::config>,
+      std::optional<qdc_monitor_config>,
       ssx::singleton_thread_worker&,
       const std::unique_ptr<pandaproxy::schema_registry::api>&) noexcept;
 

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "//src/v/finjector",
         "//src/v/kafka/client",
         "//src/v/kafka/server",
+        "//src/v/kafka/server:qdc_monitor_config",
         "//src/v/metrics",
         "//src/v/migrations",
         "//src/v/model",

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "//src/v/finjector",
         "//src/v/kafka/client",
         "//src/v/kafka/server",
+        "//src/v/kafka/server:app",
         "//src/v/kafka/server:qdc_monitor_config",
         "//src/v/metrics",
         "//src/v/migrations",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -103,7 +103,6 @@
 #include "kafka/server/queue_depth_monitor_config.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/rm_group_frontend.h"
-#include "kafka/server/server.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "kafka/server/usage_manager.h"
 #include "metrics/prometheus_sanitize.h"
@@ -280,8 +279,8 @@ application::~application() {
 void application::shutdown() {
     storage.invoke_on_all(&storage::api::stop_cluster_uuid_waiters).get();
     // Stop accepting new requests.
-    if (_kafka_server.local_is_initialized()) {
-        _kafka_server.invoke_on_all(&net::server::shutdown_input).get();
+    if (_kafka_server.ref().local_is_initialized()) {
+        _kafka_server.shutdown_input().get();
     }
     if (_rpc.local_is_initialized()) {
         _rpc.invoke_on_all(&rpc::rpc_server::shutdown_input).get();
@@ -353,8 +352,8 @@ void application::shutdown() {
 
     // Wait for all requests to finish before destructing services that may be
     // used by pending requests.
-    if (_kafka_server.local_is_initialized()) {
-        _kafka_server.invoke_on_all(&net::server::wait_for_shutdown).get();
+    if (_kafka_server.ref().local_is_initialized()) {
+        _kafka_server.wait_for_shutdown().get();
         _kafka_server.stop().get();
     }
     if (_kafka_conn_quotas.local_is_initialized()) {
@@ -1175,7 +1174,7 @@ void application::configure_admin_server() {
       &_transform_service,
       std::ref(audit_mgr),
       std::ref(_tx_manager_migrator),
-      std::ref(_kafka_server),
+      std::ref(_kafka_server.ref()),
       std::ref(tx_gateway_frontend),
       std::ref(_debug_bundle_service))
       .get();
@@ -2304,7 +2303,7 @@ void application::wire_up_redpanda_services(
     syschecks::systemd_message("Starting kafka RPC {}", kafka_cfg.local())
       .get();
     _kafka_server
-      .start(
+      .init(
         &kafka_cfg,
         smp_service_groups.kafka_smp_sg(),
         sched_groups.fetch_sg(),
@@ -3230,7 +3229,7 @@ void application::start_kafka(
         cvar.wait().get();
     }
 
-    _kafka_server.invoke_on_all(&net::server::start).get();
+    _kafka_server.start().get();
     vlog(
       _log.info,
       "Started Kafka API server listening at {}",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -100,7 +100,7 @@
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
 #include "kafka/server/group_tx_tracker_stm.h"
-#include "kafka/server/queue_depth_monitor.h"
+#include "kafka/server/queue_depth_monitor_config.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/rm_group_frontend.h"
 #include "kafka/server/server.h"
@@ -2286,9 +2286,9 @@ void application::wire_up_redpanda_services(
           });
       })
       .get();
-    std::optional<kafka::qdc_monitor::config> qdc_config;
+    std::optional<kafka::qdc_monitor_config> qdc_config;
     if (config::shard_local_cfg().kafka_qdc_enable()) {
-        qdc_config = kafka::qdc_monitor::config{
+        qdc_config = kafka::qdc_monitor_config{
           .latency_alpha = config::shard_local_cfg().kafka_qdc_latency_alpha(),
           .max_latency = config::shard_local_cfg().kafka_qdc_max_latency_ms(),
           .window_count = config::shard_local_cfg().kafka_qdc_window_count(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -34,6 +34,7 @@
 #include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
+#include "kafka/server/app.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "metrics/aggregate_metrics_watcher.h"
@@ -184,7 +185,7 @@ public:
     std::unique_ptr<ssx::singleton_thread_worker> thread_worker;
 
     ss::sharded<crypto::ossl_context_service> ossl_context_service;
-    ss::sharded<kafka::server> _kafka_server;
+    kafka::server_app _kafka_server;
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<experimental::cloud_topics::reconciler::app> _reconciler;


### PR DESCRIPTION
redpanda: hide kafka server implementation from application.cc

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
