### PR TITLE
goreleaser: rm publish brews

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -117,39 +117,5 @@ release:
     - rpk-zip
   draft: true
   discussion_category_name: Releases
-brews:
-  - name: redpanda
-    homepage: "https://redpanda.com"
-    description: "Redpanda CLI & toolbox"
-    repository:
-      owner: redpanda-data
-      name: homebrew-tap
-    folder: Formula
-    skip_upload: auto
-    ids:
-      - rpk-zip
-    extra_install: |
-      generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
-    caveats: |
-        Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
-        utility. The rpk commands let you configure, manage, and tune
-        Redpanda clusters. They also let you manage topics, groups,
-        and access control lists (ACLs).
-        Start a three-node docker cluster locally:
-
-            rpk container start -n 3
-
-        Interact with the cluster using commands like:
-
-            rpk topic list
-
-        When done, stop and delete the docker cluster:
-
-            rpk container purge
-
-        For more examples and guides, visit: https://docs.redpanda.com
-    commit_author:
-      name: vbotbuildovich
-      email: vbot@redpanda.com
 announce:
   skip: "true"


### PR DESCRIPTION
jira: [DEVPROD-996]

Move the homebrew tap formula update out of goreleaser because goreleaser needs to maintain state between release stages that make it difficult to coordinate with our draft release process. Plus, the `goreleaser release --prepare` is a pro-only feature.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

* none

[DEVPROD-996]: https://redpandadata.atlassian.net/browse/DEVPROD-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ