### PR TITLE
libpciaccess: quiet deprecated API warnings

### DIFF
--- a/bazel/thirdparty/libpciaccess.BUILD
+++ b/bazel/thirdparty/libpciaccess.BUILD
@@ -58,6 +58,7 @@ cc_library(
         # Quiet some build warnings
         "-Wno-unused-result",
         "-Wno-tautological-constant-out-of-range-compare",
+        "-Wno-deprecated-declarations",
     ],
     # This is only consumed by a make library that produces a static library,
     # so this library only needs to produce a static library. Doing this means


### PR DESCRIPTION
libpciaccess: quiet deprecated API warnings

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
