### PR TITLE
tests/ducktape: tighten property consistency check

### DIFF
--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -406,10 +406,13 @@ class AlterConfigMixedNodeTest(EndToEndTest):
                 props = set()
                 for line in desc.split('\n'):
                     line = line.rstrip()
+                    # normalize spaces/tabs from outputs across nodes
+                    line = " ".join(line.split())
                     if 'redpanda.remote.read' in line:
                         props.add(line)
                     elif 'redpanda.remote.write' in line:
                         props.add(line)
+                self.logger.debug(f"{props}")
                 assert len(props) == 2
                 node_props.append(props)
             return all(p == node_props[0] for p in node_props)


### PR DESCRIPTION
In a mixed mode cluster the describe output from different nodes could be formatted differently depending on property string lenghts. The current check does not factor that in. Example.

```
redpanda.remote.delete                    true        DEFAULT_CONFIG
redpanda.remote.read                      true        DEFAULT_CONFIG
redpanda.remote.write                     true        DEFAULT_CONFIG
```

and

```
redpanda.remote.delete                true        DEFAULT_CONFIG
redpanda.remote.read                  true        DEFAULT_CONFIG
redpanda.remote.write                 true        DEFAULT_CONFIG
```

are treated as unequal. Normalize the output before comparison.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
