### PR TITLE
Fix reader cache misses

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -407,6 +407,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
+        "//src/v/strings:static_str",
         "//src/v/strings:string_switch",
         "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:directory_walker",

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -79,6 +79,20 @@ std::vector<model::record_batch> make_ghost_batches(
 
 } // anonymous namespace
 
+template<>
+struct fmt::formatter<storage::log_reader> : fmt::formatter<std::string_view> {
+    auto format(const storage::log_reader& r, auto& ctx) const {
+        auto str = fmt::format(
+          "{{eos: {}, lb: {}, lsd: {}, config: {}}}",
+          r.is_end_of_stream(),
+          r._last_base,
+          r._load_slice_depth,
+          r._config);
+
+        return fmt::formatter<std::string_view>::format(str, ctx);
+    }
+};
+
 namespace storage {
 using records_t = ss::circular_buffer<model::record_batch>;
 

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -541,6 +541,19 @@ std::optional<log_reader::private_flags> log_reader::get_flags() const {
       .was_cached = _was_cached};
 };
 
+void log_reader::reset_config(log_reader_config cfg) {
+    _config = cfg;
+    _iterator.next_seg = _iterator.current_reader_seg;
+    _expected_next = _config.fill_gaps
+                       ? std::make_optional<model::offset>(_config.start_offset)
+                       : std::nullopt;
+
+    _last_base = {};
+
+    // reset_config is only called in the context of a reader cache hit
+    _was_cached = true;
+};
+
 static inline bool is_finished_offset(segment_set& s, model::offset o) {
     if (s.empty()) {
         return true;

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -516,6 +516,15 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
     }
 }
 
+std::optional<log_reader::private_flags> log_reader::get_flags() const {
+    return private_flags{
+      .is_reusable = is_reusable(),
+      // log_reader objects which are cached are contained inside a reader_cache
+      // entry object which overrides this to return true (if we had a cache
+      // hit)
+      .was_cached = _was_cached};
+};
+
 static inline bool is_finished_offset(segment_set& s, model::offset o) {
     if (s.empty()) {
         return true;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -173,17 +173,7 @@ public:
      *
      * Resetting a reader also sets its "was cached" attribute to true.
      */
-    void reset_config(log_reader_config cfg) {
-        _config = cfg;
-        _iterator.next_seg = _iterator.current_reader_seg;
-        _expected_next = _config.fill_gaps ? std::make_optional<model::offset>(
-                                               _config.start_offset)
-                                           : std::nullopt;
-        _last_base = {};
-
-        // reset_config is only called in the context of a reader cache hit
-        _was_cached = true;
-    };
+    void reset_config(log_reader_config cfg);
 
     /**
      * Return next read request lower bound. i.e. lowest offset that can be read

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "bytes/iobuf.h"
-#include "model/limits.h"
 #include "model/record_batch_reader.h"
 #include "storage/lock_manager.h"
 #include "storage/offset_translator_state.h"

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -130,6 +130,8 @@ private:
 };
 
 class log_reader final : public model::record_batch_reader::impl {
+    friend struct fmt::formatter<log_reader>;
+
 public:
     using data_t = model::record_batch_reader::data_t;
     using foreign_data_t = model::record_batch_reader::foreign_data_t;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -179,6 +179,8 @@ public:
         _expected_next = _config.fill_gaps ? std::make_optional<model::offset>(
                                                _config.start_offset)
                                            : std::nullopt;
+        _last_base = {};
+
         // reset_config is only called in the context of a reader cache hit
         _was_cached = true;
     };

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -16,6 +16,7 @@
 #include "ssx/future-util.h"
 #include "storage/logger.h"
 #include "storage/types.h"
+#include "strings/static_str.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
@@ -135,7 +136,7 @@ readers_cache::get_reader(const log_reader_config& cfg) {
     /**
      * dispose unused readers in background
      */
-    dispose_in_background(std::move(to_evict));
+    dispose_in_background(std::move(to_evict), "evicted in get_reader");
     if (it == _readers.end()) {
         _probe.cache_miss();
         vlog(stlog.trace, "{} - reader cache miss for: {}", _ntp, cfg);
@@ -289,33 +290,38 @@ readers_cache::~readers_cache() {
       "readers cache have to be closed before destorying");
 }
 
+void readers_cache::remove_entry(entry* e, static_str reason) {
+    vlog(
+      stlog.trace,
+      "{} - removing reader (reason: {}): [{},{}] lower_bound: {}",
+      _ntp,
+      reason,
+      e->reader->lease_range_base_offset(),
+      e->reader->lease_range_end_offset(),
+      e->reader->next_read_lower_bound());
+    _probe.reader_evicted();
+    delete e; // NOLINT(cppcoreguidelines-owning-memory)
+}
+
 ss::future<> readers_cache::dispose_entries(
-  uncounted_intrusive_list<entry, &entry::_hook> entries) {
+  uncounted_intrusive_list<entry, &entry::_hook> entries, static_str reason) {
     for (auto& e : entries) {
         co_await e.reader->finally();
     }
 
-    entries.clear_and_dispose([this](entry* e) {
-        vlog(
-          stlog.trace,
-          "{} - removing reader: [{},{}] lower_bound: {}",
-          _ntp,
-          e->reader->lease_range_base_offset(),
-          e->reader->lease_range_end_offset(),
-          e->reader->next_read_lower_bound());
-        _probe.reader_evicted();
-        delete e; // NOLINT
-    });
+    entries.clear_and_dispose(
+      [this, reason](entry* e) { remove_entry(e, reason); });
 }
 
 void readers_cache::dispose_in_background(
-  uncounted_intrusive_list<entry, &entry::_hook> entries) {
-    ssx::spawn_with_gate(_gate, [this, entries = std::move(entries)]() mutable {
-        return dispose_entries(std::move(entries));
-    });
+  uncounted_intrusive_list<entry, &entry::_hook> entries, static_str reason) {
+    ssx::spawn_with_gate(
+      _gate, [this, entries = std::move(entries), reason]() mutable {
+          return dispose_entries(std::move(entries), reason);
+      });
 }
 
-void readers_cache::dispose_in_background(entry* e) {
+void readers_cache::dispose_in_background(entry* e, static_str reason) {
     if (_gate.is_closed()) {
         /**
          * since gate is closed and we failed to call finally on the reader we
@@ -329,18 +335,9 @@ void readers_cache::dispose_in_background(entry* e) {
          */
         _readers.push_back(*e);
     } else {
-        ssx::spawn_with_gate(_gate, [this, e] {
-            return e->reader->finally().finally([this, e] {
-                vlog(
-                  stlog.trace,
-                  "{} - removing reader: [{},{}] lower_bound: {}",
-                  _ntp,
-                  e->reader->lease_range_base_offset(),
-                  e->reader->lease_range_end_offset(),
-                  e->reader->next_read_lower_bound());
-                _probe.reader_evicted();
-                delete e; // NOLINT
-            });
+        ssx::spawn_with_gate(_gate, [this, e, reason] {
+            return e->reader->finally().finally(
+              [this, e, reason] { remove_entry(e, reason); });
         });
     }
 }
@@ -371,7 +368,7 @@ void readers_cache::maybe_evict_size() {
     _readers.pop_front_and_dispose(
       [&to_evict](entry* e) { to_evict.push_back(*e); });
 
-    dispose_in_background(std::move(to_evict));
+    dispose_in_background(std::move(to_evict), "maybe_evict_size");
 }
 
 readers_cache::stats readers_cache::get_stats() const {

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -16,7 +16,6 @@
 #include "ssx/future-util.h"
 #include "storage/logger.h"
 #include "storage/types.h"
-#include "utils/mutex.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -271,6 +271,10 @@ readers_cache::entry::make_cached_reader(readers_cache* cache) {
             return _underlying->do_load_slice(tout);
         }
 
+        virtual std::optional<private_flags> get_flags() const final {
+            return _underlying->get_flags();
+        }
+
         ss::future<> finally() noexcept final { return ss::now(); }
 
         void print(std::ostream& o) final { return _underlying->print(o); };

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -36,7 +36,6 @@
 #include "test_utils/async.h"
 #include "test_utils/tmp_dir.h"
 #include "utils/directory_walker.h"
-#include "utils/to_string.h"
 
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/loop.hh>

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -24,6 +24,7 @@
 #include "reflection/adl.h"
 #include "storage/batch_cache.h"
 #include "storage/log_manager.h"
+#include "storage/log_reader.h"
 #include "storage/ntp_config.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_utils.h"
@@ -52,7 +53,6 @@
 #include <iterator>
 #include <numeric>
 #include <optional>
-#include <stdexcept>
 #include <vector>
 
 static ss::logger e2e_test_log("storage_e2e_test");
@@ -887,6 +887,11 @@ FIXTURE_TEST(test_eviction_notification, storage_test_fixture) {
       compacted_lstats.start_offset,
       lstats_before.dirty_offset + model::offset(1));
 };
+
+/**
+ * Appends batch_count batches which have exactly batch_sz bytes when
+ * serialized, with each batch having 1 record.
+ */
 ss::future<storage::append_result> append_exactly(
   ss::shared_ptr<storage::log> log,
   size_t batch_count,
@@ -1925,6 +1930,7 @@ FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
         BOOST_REQUIRE(locks.size() == segments.size());
     }
 }
+
 FIXTURE_TEST(reader_reusability_test_parser_header, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.cache = storage::with_cache::no;
@@ -3819,6 +3825,137 @@ struct batch_size_accumulator {
     bool end_of_stream() const { return false; }
     size_t* size_bytes;
 };
+
+using private_flags = model::record_batch_reader::private_flags;
+
+namespace model {
+struct record_batch_reader_accessor {
+    static storage::log_reader* get_impl(model::record_batch_reader& r) {
+        auto impl = r._impl.get();
+        BOOST_REQUIRE(impl != nullptr);
+        auto impl_log_reader = dynamic_cast<storage::log_reader*>(impl);
+        BOOST_REQUIRE_MESSAGE(impl_log_reader, "impl was not a log_reader");
+        return impl_log_reader;
+    }
+
+    static private_flags get_flags(model::record_batch_reader& r) {
+        auto flags = r._impl->get_flags();
+        BOOST_REQUIRE_MESSAGE(flags.has_value(), "private flags unset");
+        return *flags;
+    };
+};
+} // namespace model
+
+FIXTURE_TEST(reader_reusability_max_bytes, storage_test_fixture) {
+    constexpr size_t total_log_bytes = 1_MiB;
+
+    auto cfg = default_log_config(test_dir);
+    cfg.cache = storage::with_cache::no;
+    cfg.max_segment_size = config::mock_binding<size_t>(2_MiB);
+    storage::ntp_config::default_overrides overrides;
+    storage::log_manager mgr = make_log_manager(cfg);
+    info("config: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    int log_num = 0;
+
+    auto test_case = [&](
+                       size_t bytes_per_batch,
+                       size_t reader_max_bytes,
+                       bool second_read_reusable = true) {
+        BOOST_TEST_CONTEXT(fmt::format(
+          "bytes_per_batch={}, reader_max_bytes={}",
+          bytes_per_batch,
+          reader_max_bytes)) {
+            auto ntp = model::ntp(
+              "default", fmt::format("test-{}", log_num++), 0);
+            auto log
+              = mgr
+                  .manage(storage::ntp_config(
+                    ntp,
+                    mgr.config().base_dir,
+                    std::make_unique<storage::ntp_config::default_overrides>(
+                      overrides)))
+                  .get();
+
+            append_exactly(
+              log, total_log_bytes / bytes_per_batch, bytes_per_batch)
+              .get();
+            log->flush().get();
+
+            storage::log_reader_config reader_cfg(
+              model::offset(0),
+              model::model_limits<model::offset>::max(),
+              0,
+              reader_max_bytes,
+              ss::default_priority_class(),
+              std::nullopt,
+              std::nullopt,
+              std::nullopt);
+
+            reader_cfg.skip_batch_cache = true;
+
+            auto read_one = [&](
+                              std::string_view label,
+                              bool expected_reusable,
+                              bool expected_cached) {
+                auto reader = log->make_reader(reader_cfg).get();
+                auto finalize = ss::defer([&] {
+                    model::consume_reader_to_memory(
+                      std::move(reader), model::no_timeout)
+                      .get();
+                });
+
+                auto summary
+                  = reader
+                      .consume(batch_summary_accumulator{}, model::no_timeout)
+                      .get();
+
+                auto flags = model::record_batch_reader_accessor::get_flags(
+                  reader);
+
+                BOOST_TEST_CONTEXT(fmt::format("label={}", label)) {
+                    BOOST_CHECK_EQUAL(flags.is_reusable, expected_reusable);
+                    BOOST_CHECK_EQUAL(flags.was_cached, expected_cached);
+                }
+
+                return summary;
+            };
+
+            // Do the first read, we don't expect the reader to come from cache
+            // as this is the first read from this ntp.
+            auto summary = read_one("first", true, false);
+
+            reader_cfg.start_offset = summary.summaries.back().last
+                                      + model::offset(1);
+
+            read_one("second", second_read_reusable, true);
+        }
+    };
+
+    // 128_KiB is special because it is the default storage_read_buffer_size
+    for (auto offset0 : {-1, 0, 1}) {
+        for (auto offset1 : {-1, 0, 1}) {
+            test_case(128_KiB + offset0, 128_KiB + offset1);
+        }
+    }
+
+    // any size that can fit 3 times into the total_log_size should have the
+    // reader should be reusable since we hit the bytes limit on the reader
+    // config rather than exhausting the reader
+    auto sizes = std::vector<size_t>{1000, 10000, 200000};
+    // test all combinations of the above sizes for both bytes per batch and
+    // reader max bytes
+    for (auto bytes_per_batch : sizes) {
+        for (auto reader_max_bytes : sizes) {
+            test_case(bytes_per_batch, reader_max_bytes);
+        }
+    }
+
+    // if we can only fit 2 batches in the log, the reader will be exhausted
+    // after the second reader, so should be !is_resusable
+    test_case(400000, 300000, false);
+}
 
 FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
 #ifdef NDEBUG

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -449,6 +449,11 @@ struct log_reader_config {
     friend std::ostream& operator<<(std::ostream& o, const log_reader_config&);
 };
 
+// Empty, invalid reader config which is sometimes useful as a placeholder
+// since log_reader_config doesn't have a default constructor.
+static const log_reader_config empty_reader_config{
+  {}, {}, ss::default_priority_class()};
+
 struct gc_config {
     gc_config(model::timestamp upper, std::optional<size_t> max_bytes_in_log)
       : eviction_time(upper)


### PR DESCRIPTION
During benchmarking it was observed that the number of disk reads was 2x the expected amount from the fetch throughput, with the difference explained by "dropped readahead" (i.e., the readahead that seastar does on disk-backed ss::input_stream). We use the "readers cache" to try to capture this readahead but it was failing to be hit in this case.

There were two underlying bugs:

 - Inside the log reader loop when the last iteration finishes without increasing the start offset (which is common, up to 100% chance, for large batches, due to the way the interaction with the slice boundary works) we close the iterator without trying to re-use it. This is a bug in the ordering of re-use checks.
 - When we reset the reader on a cache hit, we fail to reset the "_last_base" member, which causes an immediate spurious closing of the iterator.
 
Both of these fail to trigger test failures because the primary impact is a performance one, not a functional one.

Fixes CORE-7865.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Fixed a case where fetch readers were not cached, even though they were eligible, which resulted in read amplification of up to 2x for some workloads in cases where the fetch misses in the batch cache but hits in the raft log.  
