### PR TITLE
bazel: Don't build openssl tests

### DIFF
--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -45,6 +45,7 @@ configure_make(
     configure_command = "Configure",
     configure_options = [
         "--libdir=lib",
+        "no-tests",
     ] + select({
         ":debug_mode": ["--debug"],
         ":release_mode": ["--release"],


### PR DESCRIPTION
Don't build openssl tests. These are just a waste of time as we don't need them.

FIPS build is kept as is for FIPS compliance.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


