### PR TITLE
rpk: small improvements prior v24.2

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -135,7 +135,7 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 			if noProfile {
 				// The current profile is seemingly pointing to a container cluster.
 				if p.Name == common.ContainerProfileName {
-					fmt.Printf("You are talking to a localhost 'rpk container' cluster (rpk profile name: %q)", p.Name)
+					fmt.Printf("You are talking to a localhost 'rpk container' cluster (rpk profile name: %q)\n", p.Name)
 					fmt.Println("To talk to a cloud cluster, use 'rpk cloud cluster select'.")
 					return
 				}

--- a/src/go/rpk/pkg/cli/connect/client.go
+++ b/src/go/rpk/pkg/cli/connect/client.go
@@ -16,9 +16,9 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
 )
 
 const pluginBaseURL = "https://rpk-plugins.redpanda.com"
@@ -75,13 +75,9 @@ type connectRepoClient struct {
 }
 
 func newRepoClient() (*connectRepoClient, error) {
-	timeout := 240 * time.Second
-	if t := os.Getenv("RPK_PLUGIN_DOWNLOAD_TIMEOUT"); t != "" {
-		duration, err := time.ParseDuration(t)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse RPK_PLUGIN_DOWNLOAD_TIMEOUT: %v", err)
-		}
-		timeout = duration
+	timeout, err := plugin.GetPluginDownloadTimeout()
+	if err != nil {
+		return nil, err
 	}
 	return &connectRepoClient{
 		cl: httpapi.NewClient(

--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -50,12 +50,10 @@ To print the schema, use the '--print-schema' flag.
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
-			var helpFormat any
-			helpFormat = []subjectSchema{}
-			if printSchema {
-				helpFormat = ""
+			if printSchema && f.Kind != "text" {
+				out.Die("--print-schema cannot be used along with --format %v", f.Kind)
 			}
-			if h, ok := f.Help(helpFormat); ok {
+			if h, ok := f.Help([]subjectSchema{}); ok {
 				out.Exit(h)
 			}
 			p, err := p.LoadVirtualProfile(fs)

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -60,7 +60,9 @@ This command prints the current rpk version and allows you to list the Redpanda
 version running on each node in your cluster.
 
 To list the Redpanda version of each node in your cluster you may pass the
-Admin API hosts via flags, profile, or environment variables.`,
+Admin API hosts using flags, profile, or environment variables.
+
+To get only the rpk version, use 'rpk --version'.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			rv := rpkVersion{
@@ -131,7 +133,9 @@ func printClusterVersions(rpv *redpandaVersions) {
 	if len(*rpv) == 0 {
 		fmt.Println(`  Unreachable, to debug, use the '-v' flag. To get the broker versions, pass the
   hosts via flags, profile, or environment variables:
-    rpk version -X admin.hosts=<host address>`)
+    rpk version -X admin.hosts=<host address>
+
+  To get only the rpk version, use 'rpk --version'.`)
 		return
 	}
 	for _, v := range *rpv {


### PR DESCRIPTION
This PR includes small bug fixes and improvements:

- a243704332a482ca2ca08162240d644bf6d51511 adds a missing newline on a login information message
- f8f0b5442d7ad6e0ab17278fad9627acde35b748 prevents using `--format` along with `--print-schema`. Previous behavior was to ignore the `--format` flag, which can lead to confusion.
- 18fbda92cae0de957e4e01638f083b45e50a2592 adds a pointer towards `rpk --version` in the `rpk version` help text, as this may be useful for users who only want the rpk version. (better discoverability)
- c40974399b6b2d32e6aced5b2de8fa4a7bcc7110 Increases the plugin download timeout to 300 and also adds support for `RPK_PLUGIN_DOWNLOAD_TIMEOUT` for the plugin download path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Improvements

* `rpk registry schema get` will now fail if is incorrectly invoked using the `--print-schema` and `--format` flag.