### PR TITLE
gha: improve backport instructions

### DIFF
--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -16,10 +16,9 @@ fi
 
 additional_body=""
 if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
-  additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
+  additional_body="This issue was created as a placeholder because the original PR's commit(s) could not be automatically cherry-picked."
 
-  local_user=$(gh api user --jq .login)
-  local_branch="$local_user/backport-$PR_NUMBER-$BACKPORT_BRANCH-$((RANDOM % 1000))"
+  local_branch="manual-backport-$PR_NUMBER-$BACKPORT_BRANCH-$((RANDOM % 1000))"
 
   additional_body="$additional_body
   Here are the commands to execute:


### PR DESCRIPTION
jira: [DEVPROD-2219]

Change from using branch name like `vbotbuildovich/backport-23614-v24.1.x-917` to
branch name like `manual-backport-23614-v24.1.x-917` to avoid confusion in branch name and remove `/` from branch name.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[DEVPROD-2219]: https://redpandadata.atlassian.net/browse/DEVPROD-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ