### PR TITLE
CORE-7996 Trial: build in an evaluation period license

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -205,8 +205,10 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     });
 
     // Sanity check we have a different cluster.
-    ASSERT_TRUE(
-      !app.controller->get_feature_table().local().get_license().has_value());
+    ASSERT_TRUE(!app.controller->get_feature_table()
+                   .local()
+                   .get_configured_license()
+                   .has_value());
     ASSERT_NE(
       1, config::shard_local_cfg().log_segment_size_jitter_percent.value());
     ASSERT_TRUE(!app.controller->get_credential_store().local().contains(
@@ -249,7 +251,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     auto validate_post_recovery = [&] {
         ASSERT_TRUE(app.controller->get_feature_table()
                       .local()
-                      .get_license()
+                      .get_configured_license()
                       .has_value());
         ASSERT_EQ(
           1, config::shard_local_cfg().log_segment_size_jitter_percent.value());

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -63,7 +63,7 @@ controller_snapshot_reconciler::get_actions(
 
     controller_actions actions;
     const auto& snap_license = snap.features.snap.license;
-    auto existing_license = _feature_table.get_license();
+    auto existing_license = _feature_table.get_configured_license();
     if (
       cur_stage < recovery_stage::recovered_license && !existing_license
       && snap_license.has_value()) {

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -46,12 +46,12 @@ public:
     template<typename... Args>
     controller_stm(
       limiter_configuration limiter_conf,
-      const ss::sharded<features::feature_table>& feature_table,
+      ss::sharded<features::feature_table>& feature_table,
       config::binding<std::chrono::seconds>&& snapshot_max_age,
       Args&&... stm_args)
       : mux_state_machine(std::forward<Args>(stm_args)...)
       , _limiter(std::move(limiter_conf))
-      , _feature_table(feature_table.local())
+      , _feature_table(feature_table)
       , _snapshot_max_age(std::move(snapshot_max_age))
       , _snapshot_debounce_timer([this] { snapshot_timer_callback(); }) {}
 
@@ -91,7 +91,7 @@ private:
 
 private:
     controller_log_limiter _limiter;
-    const features::feature_table& _feature_table;
+    ss::sharded<features::feature_table>& _feature_table;
     config::binding<std::chrono::seconds> _snapshot_max_age;
 
     metrics_reporter_cluster_info _metrics_reporter_cluster_info;

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -298,8 +298,7 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
     if (_feature_table.local().is_active(features::feature::license)) {
         auto enterprise_features = report_enterprise_features();
         if (enterprise_features.any()) {
-            const auto& license
-              = _feature_table.local().get_configured_license();
+            const auto& license = _feature_table.local().get_license();
             if (!license || license->is_expired()) {
                 vlog(
                   clusterlog.warn,

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -298,7 +298,8 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
     if (_feature_table.local().is_active(features::feature::license)) {
         auto enterprise_features = report_enterprise_features();
         if (enterprise_features.any()) {
-            const auto& license = _feature_table.local().get_license();
+            const auto& license
+              = _feature_table.local().get_configured_license();
             if (!license || license->is_expired()) {
                 vlog(
                   clusterlog.warn,
@@ -329,7 +330,7 @@ void feature_manager::verify_enterprise_license() {
         return;
     }
 
-    const auto& license = _feature_table.local().get_license();
+    const auto& license = _feature_table.local().get_configured_license();
     std::optional<security::license> fallback_license = std::nullopt;
     auto fallback_license_str = std::getenv(
       "REDPANDA_FALLBACK_ENTERPRISE_LICENSE");

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -330,7 +330,7 @@ void feature_manager::verify_enterprise_license() {
         return;
     }
 
-    const auto& license = _feature_table.local().get_configured_license();
+    const auto& license = _feature_table.local().get_license();
     std::optional<security::license> fallback_license = std::nullopt;
     auto fallback_license_str = std::getenv(
       "REDPANDA_FALLBACK_ENTERPRISE_LICENSE");

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -287,7 +287,7 @@ public:
             sm::make_gauge(
               "enterprise_license_expiry_sec",
               [&ft = _parent]() {
-                  return calculate_expiry_metric(ft.get_configured_license());
+                  return calculate_expiry_metric(ft.get_license());
               },
               sm::description("Number of seconds remaining until the "
                               "Enterprise license expires"))

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -17,9 +17,12 @@
 #include "features/logger.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
+#include "model/timestamp.h"
+#include "security/license.h"
 #include "version/version.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/shard_id.hh>
 
 #include <chrono>
 #include <memory>
@@ -284,7 +287,7 @@ public:
             sm::make_gauge(
               "enterprise_license_expiry_sec",
               [&ft = _parent]() {
-                  return calculate_expiry_metric(ft.get_license());
+                  return calculate_expiry_metric(ft.get_configured_license());
               },
               sm::description("Number of seconds remaining until the "
                               "Enterprise license expires"))
@@ -296,6 +299,30 @@ public:
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };
+
+namespace {
+
+security::license
+make_builtin_trial_license(security::license::clock::time_point start_time) {
+    auto expiry_time = start_time + std::chrono::days{45};
+    auto expiry = std::chrono::duration_cast<std::chrono::seconds>(
+      expiry_time.time_since_epoch());
+
+    if (std::getenv("__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE") != nullptr) {
+        // For testing, use an expired trial license
+        expiry = 0s;
+    }
+
+    return security::license{
+      .format_version = 0,
+      .type = security::license_type::free_trial,
+      .organization = "Redpanda Built-In Evaluation Period",
+      .expiry = expiry,
+      .checksum = "",
+    };
+}
+
+} // namespace
 
 feature_table::feature_table() {
     // Intentionally undocumented environment variable, only for use
@@ -686,9 +713,28 @@ void feature_table::set_license(security::license license) {
     _license = std::move(license);
 }
 
+void feature_table::set_builtin_trial_license(
+  model::timestamp cluster_creation_timestamp) {
+    _builtin_trial_license = make_builtin_trial_license(
+      model::to_time_point(cluster_creation_timestamp));
+
+    if (ss::this_shard_id() == 0) {
+        vlog(
+          featureslog.debug,
+          "Initialized builtin trial license expirying at "
+          "{}",
+          _builtin_trial_license->expiry);
+    }
+}
+
 void feature_table::revoke_license() { _license = std::nullopt; }
 
 const std::optional<security::license>& feature_table::get_license() const {
+    return _license ? _license : _builtin_trial_license;
+}
+
+const std::optional<security::license>&
+feature_table::get_configured_license() const {
     return _license;
 }
 

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -738,6 +738,18 @@ feature_table::get_configured_license() const {
     return _license;
 }
 
+bool feature_table::should_sanction() const {
+    if (_license) {
+        return _license->is_expired();
+    } else if (_builtin_trial_license) {
+        return _builtin_trial_license->is_expired();
+    }
+
+    // We are yet to initialize _builtin_trial_license on cluster creation, be
+    // permissive in the meantime
+    return false;
+}
+
 void feature_table::testing_activate_all() {
     for (auto& s : _feature_state) {
         if (

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -26,6 +26,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 
 // The feature table is closely related to cluster and uses many types from it
 using namespace cluster;
@@ -717,6 +718,7 @@ void feature_table::set_builtin_trial_license(
   model::timestamp cluster_creation_timestamp) {
     _builtin_trial_license = make_builtin_trial_license(
       model::to_time_point(cluster_creation_timestamp));
+    _builtin_trial_license_initialized = true;
 
     if (ss::this_shard_id() == 0) {
         vlog(
@@ -727,7 +729,10 @@ void feature_table::set_builtin_trial_license(
     }
 }
 
-void feature_table::revoke_license() { _license = std::nullopt; }
+void feature_table::revoke_license() {
+    _license = std::nullopt;
+    _builtin_trial_license = std::nullopt;
+}
 
 const std::optional<security::license>& feature_table::get_license() const {
     return _license ? _license : _builtin_trial_license;
@@ -745,9 +750,9 @@ bool feature_table::should_sanction() const {
         return _builtin_trial_license->is_expired();
     }
 
-    // We are yet to initialize _builtin_trial_license on cluster creation, be
-    // permissive in the meantime
-    return false;
+    // While we are yet to initialize _builtin_trial_license on cluster
+    // creation, be permissive
+    return _builtin_trial_license_initialized;
 }
 
 void feature_table::testing_activate_all() {

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -585,9 +585,16 @@ public:
 
     void set_license(security::license license);
 
+    /// Sets the builtin trial license based on the cluster creation time
+    void set_builtin_trial_license(model::timestamp cluster_creation_timestamp);
+
     void revoke_license();
 
     const std::optional<security::license>& get_license() const;
+
+    /// Returns the user-configured license without falling back to the
+    /// evaluation period license
+    const std::optional<security::license>& get_configured_license() const;
 
     /**
      * For use in unit tests: activate all features that would
@@ -719,6 +726,9 @@ private:
 
     // Currently loaded redpanda license details
     std::optional<security::license> _license;
+
+    // Built in trial license to fall back to if there is no license set
+    std::optional<security::license> _builtin_trial_license;
 
     model::offset _applied_offset{};
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -739,6 +739,10 @@ private:
     // Built in trial license to fall back to if there is no license set
     std::optional<security::license> _builtin_trial_license;
 
+    // Whether _builtin_trial_license has ever been initialized
+    // Used for implementing revoking the trial license for testing
+    bool _builtin_trial_license_initialized{false};
+
     model::offset _applied_offset{};
 
     // feature_manager is a friend so that they can initialize

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -590,11 +590,20 @@ public:
 
     void revoke_license();
 
+    /// Returns the user-configured license or if not set, a built in trial
+    /// license. The built in trial license is initialized async on cluster
+    /// bootstrap and during startup on subsequent starts, so consider using
+    /// `should_sanction` instead for a general, permissive check on whether
+    /// to act on a missing valid license.
     const std::optional<security::license>& get_license() const;
 
     /// Returns the user-configured license without falling back to the
     /// evaluation period license
     const std::optional<security::license>& get_configured_license() const;
+
+    /// Whether to act on an expired license or evaluation period by restricting
+    /// enterprise feature usage
+    bool should_sanction() const;
 
     /**
      * For use in unit tests: activate all features that would

--- a/src/v/features/feature_table_snapshot.cc
+++ b/src/v/features/feature_table_snapshot.cc
@@ -23,7 +23,7 @@ feature_table_snapshot feature_table_snapshot::from(const feature_table& ft) {
     fts.states.reserve(feature_schema.size());
 
     fts.version = ft.get_active_version();
-    fts.license = ft.get_license();
+    fts.license = ft.get_configured_license();
     for (const auto& state : ft._feature_state) {
         auto& name = state.spec.name;
         fts.states.push_back(feature_state_snapshot{

--- a/src/v/features/tests/BUILD
+++ b/src/v/features/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_btest(
     deps = [
         "//src/v/cluster:features",
         "//src/v/features",
+        "//src/v/model",
         "//src/v/security:license",
         "//src/v/test_utils:seastar_boost",
         "@seastar",

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -354,18 +354,22 @@ FIXTURE_TEST(feature_table_trial_license_test, feature_table_fixture) {
     expired_license.expiry = 0s;
 
     BOOST_CHECK_EQUAL(ft.get_license().has_value(), false);
+    BOOST_CHECK_EQUAL(ft.should_sanction(), false);
 
     ft.set_builtin_trial_license(model::timestamp::now());
     BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
     BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), false);
+    BOOST_CHECK_EQUAL(ft.should_sanction(), false);
 
     ft.set_license(expired_license);
     BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
     BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), true);
+    BOOST_CHECK_EQUAL(ft.should_sanction(), true);
 
     ft.set_license(license);
     BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
     BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), false);
+    BOOST_CHECK_EQUAL(ft.should_sanction(), false);
 }
 
 SEASTAR_THREAD_TEST_CASE(feature_table_probe_expiry_metric_test) {

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -370,6 +370,10 @@ FIXTURE_TEST(feature_table_trial_license_test, feature_table_fixture) {
     BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
     BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), false);
     BOOST_CHECK_EQUAL(ft.should_sanction(), false);
+
+    ft.revoke_license();
+    BOOST_CHECK_EQUAL(ft.get_license().has_value(), false);
+    BOOST_CHECK_EQUAL(ft.should_sanction(), true);
 }
 
 SEASTAR_THREAD_TEST_CASE(feature_table_probe_expiry_metric_test) {

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -12,6 +12,7 @@
 #include "cluster/feature_update_action.h"
 #include "features/feature_table.h"
 #include "features/feature_table_snapshot.h"
+#include "model/timestamp.h"
 #include "security/license.h"
 #include "test_utils/fixture.h"
 
@@ -334,6 +335,37 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
     BOOST_CHECK(
       ft.get_state(feature::test_alpha).get_state()
       == feature_state::state::active);
+}
+
+FIXTURE_TEST(feature_table_trial_license_test, feature_table_fixture) {
+    const char* sample_valid_license = std::getenv("REDPANDA_SAMPLE_LICENSE");
+    if (sample_valid_license == nullptr) {
+        const char* is_on_ci = std::getenv("CI");
+        BOOST_TEST_REQUIRE(
+          !is_on_ci,
+          "Expecting the REDPANDA_SAMPLE_LICENSE env var in the CI "
+          "enviornment");
+        return;
+    }
+    const ss::sstring license_str{sample_valid_license};
+    const auto license = security::make_license(license_str);
+
+    auto expired_license = license;
+    expired_license.expiry = 0s;
+
+    BOOST_CHECK_EQUAL(ft.get_license().has_value(), false);
+
+    ft.set_builtin_trial_license(model::timestamp::now());
+    BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
+    BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), false);
+
+    ft.set_license(expired_license);
+    BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
+    BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), true);
+
+    ft.set_license(license);
+    BOOST_CHECK_EQUAL(ft.get_license().has_value(), true);
+    BOOST_CHECK_EQUAL(ft.get_license()->is_expired(), false);
 }
 
 SEASTAR_THREAD_TEST_CASE(feature_table_probe_expiry_metric_test) {

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -96,6 +96,10 @@ inline timestamp_clock::duration duration_since_epoch(timestamp ts) {
       std::chrono::milliseconds{ts.value()});
 }
 
+inline timestamp_clock::time_point to_time_point(timestamp ts) {
+    return timestamp_clock::time_point(std::chrono::milliseconds(ts.value()));
+}
+
 inline timestamp to_timestamp(timestamp_clock::time_point ts) {
     return timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
                        ts.time_since_epoch())

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2252,7 +2252,7 @@ admin_server::put_license_handler(std::unique_ptr<ss::http::request> req) {
               fmt::format("License is expired: {}", license));
         }
         const auto& ft = _controller->get_feature_table().local();
-        const auto& loaded_license = ft.get_configured_license();
+        const auto& loaded_license = ft.get_license();
         if (loaded_license && (*loaded_license == license)) {
             /// Loaded license is idential to license in request, do
             /// nothing and return 200(OK)
@@ -2291,7 +2291,7 @@ admin_server::get_enterprise_handler(std::unique_ptr<ss::http::request>) {
       enterprise_response_license_status;
 
     const auto& license
-      = _controller->get_feature_table().local().get_configured_license();
+      = _controller->get_feature_table().local().get_license();
     auto license_status = [&license]() {
         auto present = license.has_value();
         auto exp = present && license.value().is_expired();
@@ -2407,7 +2407,7 @@ void admin_server::register_features_routes() {
           ss::httpd::features_json::license_response res;
           res.loaded = false;
           const auto& ft = _controller->get_feature_table().local();
-          const auto& license = ft.get_configured_license();
+          const auto& license = ft.get_license();
           if (license) {
               res.loaded = true;
               ss::httpd::features_json::license_contents lc;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2252,7 +2252,7 @@ admin_server::put_license_handler(std::unique_ptr<ss::http::request> req) {
               fmt::format("License is expired: {}", license));
         }
         const auto& ft = _controller->get_feature_table().local();
-        const auto& loaded_license = ft.get_license();
+        const auto& loaded_license = ft.get_configured_license();
         if (loaded_license && (*loaded_license == license)) {
             /// Loaded license is idential to license in request, do
             /// nothing and return 200(OK)
@@ -2291,7 +2291,7 @@ admin_server::get_enterprise_handler(std::unique_ptr<ss::http::request>) {
       enterprise_response_license_status;
 
     const auto& license
-      = _controller->get_feature_table().local().get_license();
+      = _controller->get_feature_table().local().get_configured_license();
     auto license_status = [&license]() {
         auto present = license.has_value();
         auto exp = present && license.value().is_expired();
@@ -2407,7 +2407,7 @@ void admin_server::register_features_routes() {
           ss::httpd::features_json::license_response res;
           res.loaded = false;
           const auto& ft = _controller->get_feature_table().local();
-          const auto& license = ft.get_license();
+          const auto& license = ft.get_configured_license();
           if (license) {
               res.loaded = true;
               ss::httpd::features_json::license_contents lc;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -904,6 +904,25 @@ class Admin:
                              node=node,
                              timeout=timeout).json()
 
+    @staticmethod
+    def is_sample_license(resp) -> bool:
+        """
+        Returns true if the given response to a `get_license` request returned the same license as the sample license
+        configured in `sample_license` ("REDPANDA_SAMPLE_LICENSE" env var). Returns false for the built in evaluation
+        period license and the second sample license 'REDPANDA_SECOND_SAMPLE_LICENSE'.
+        """
+        # NOTE: the initial implementation of the get license endpoint (before v22.3) didn't return the sha256.
+        # We could remove those old tests, but it's simpler to use the type and the org to detect the installed
+        # license instead.
+
+        # REDPANDA_SAMPLE_LICENSE: {'loaded': True, 'license': {'format_version': 0, 'org': 'redpanda-testing', 'type': 'enterprise', 'expires': 4813252273, 'sha256': '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf'}}
+        # REDPANDA_SECOND_SAMPLE_LICENSE: {'loaded': True, 'license': {'format_version': 0, 'org': 'redpanda-testing-2', 'type': 'enterprise', 'expires': 4827156118, 'sha256': '54240716865c1196fa6bd0ebb31821ab69160a3ed312b13bc810c17c9ec8852c'}}
+        # Evaluation Period: {'loaded': True, 'license': {'format_version': 0, 'org': 'Redpanda Built-In Evaluation Period', 'type': 'free_trial', 'expires': 1733992567, 'sha256': ''}}
+
+        return resp is not None and resp.get('license', None) is not None \
+                and resp['license']['type'] == 'enterprise' \
+                and resp['license']['org'] == 'redpanda-testing'
+
     def put_license(self, license):
         return self._request("PUT", "features/license", data=license)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5350,7 +5350,7 @@ class RedpandaService(RedpandaServiceBase):
         def license_observable():
             for node in self.started_nodes():
                 license = self._admin.get_license(node)
-                if license is None or license['loaded'] is not True:
+                if not self._admin.is_sample_license(license):
                     return False
             return True
 

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -229,11 +229,13 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         assert self.admin.put_license(license).status_code == 200
 
-        def obtain_license():
+        def obtain_configured_license():
             lic = self.admin.get_license()
-            return (lic is not None and lic['loaded'] is True, lic)
+            return (self.admin.is_sample_license(lic), lic)
 
-        resp = wait_until_result(obtain_license, timeout_sec=5, backoff_sec=1)
+        resp = wait_until_result(obtain_configured_license,
+                                 timeout_sec=5,
+                                 backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
 

--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -46,8 +46,10 @@ class LicenseEnforcementTest(RedpandaTest):
     )
     def test_license_enforcement(self, clean_node_before_recovery,
                                  clean_node_after_recovery):
-        installer = self.redpanda._installer
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
 
+        installer = self.redpanda._installer
         prev_version = installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
         latest_version = installer.head_version()
@@ -106,8 +108,10 @@ class LicenseEnforcementTest(RedpandaTest):
     @cluster(num_nodes=5, log_allow_list=LOG_ALLOW_LIST)
     @matrix(clean_node_before_upgrade=[False, True])
     def test_escape_hatch_license_variable(self, clean_node_before_upgrade):
-        installer = self.redpanda._installer
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
 
+        installer = self.redpanda._installer
         prev_version = installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
         latest_version = installer.head_version()

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -62,7 +62,7 @@ class UpgradeMigratingLicenseVersion(RedpandaTest):
         # Attempt to read license written by older version
         def license_loaded_ok():
             license = self.admin.get_license()
-            return license is not None and license['loaded'] is True
+            return self.admin.is_sample_license(license)
 
         wait_until(license_loaded_ok,
                    timeout_sec=30,

--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -629,7 +629,9 @@ class RBACLicenseTest(RBACTestBase):
         super().__init__(test_ctx, **kwargs)
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
 
     def _has_license_nag(self):

--- a/tests/rptest/tests/rbac_upgrade_test.py
+++ b/tests/rptest/tests/rbac_upgrade_test.py
@@ -29,7 +29,9 @@ class UpgradeMigrationCreatingDefaultRole(RedpandaTest):
         super().__init__(test_ctx, **kwargs)
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
         self.installer = self.redpanda._installer
         self.admin = Admin(self.redpanda)

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -167,7 +167,9 @@ class RedpandaKerberosLicenseTest(RedpandaKerberosTestBase):
                              **kwargs)
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
 
     def _has_license_nag(self):

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -609,7 +609,9 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
                                               **kwargs)
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
 
     def _has_license_nag(self):

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -244,7 +244,9 @@ class RedpandaFIPSStartupLicenseTest(RedpandaFIPSStartupTestBase):
 
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
 
     def _has_license_nag(self) -> bool:

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -245,11 +245,15 @@ class RpkClusterTest(RedpandaTest):
                 "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
             return
 
-        wait_until(lambda: self._get_license_expiry() == -1,
-                   timeout_sec=10,
-                   backoff_sec=1,
-                   retry_on_exc=True,
-                   err_msg="Unset license should return a -1 expiry")
+        evaluation_period = 3888000  # 45 days
+        wait_until(
+            lambda: self._get_license_expiry() <= evaluation_period,
+            timeout_sec=10,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg=
+            "Without a license we should observe the built in evaluation period trial license"
+        )
 
         with tempfile.NamedTemporaryFile() as tf:
             tf.write(bytes(license, 'UTF-8'))
@@ -258,7 +262,7 @@ class RpkClusterTest(RedpandaTest):
             assert "Successfully uploaded license" in output
 
         wait_until(
-            lambda: self._get_license_expiry() > 0,
+            lambda: self._get_license_expiry() > evaluation_period,
             timeout_sec=10,
             backoff_sec=1,
             retry_on_exc=True,

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3840,7 +3840,9 @@ class SchemaRegistryLicenseTest(RedpandaTest):
                              **kwargs)
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
-            f'{self.LICENSE_CHECK_INTERVAL_SEC}'
+            f'{self.LICENSE_CHECK_INTERVAL_SEC}',
+            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
+            True
         })
 
     def _has_license_nag(self):


### PR DESCRIPTION
Create a builtin fallback license that allows customers to trial
Enterprise features for a trial period starting at cluster creation.

Fixes https://redpandadata.atlassian.net/browse/CORE-7996

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
### Features

* After the cluster is first formed, a trial license is automatically loaded to provide an evaluation period of enterprise features.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
