### PR TITLE
[CORE-7997] Suppress enterprise configs when license is missing or expired

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -137,6 +137,14 @@ public:
      * to this property.
      */
     virtual std::optional<validation_error> validate(YAML::Node) const = 0;
+
+    /**
+     * Check whether a proposed new value is restricted before it has been
+     * assigned. Rejection logic should be accounted for at the call site.
+     */
+    virtual std::optional<validation_error>
+      check_restricted(YAML::Node) const = 0;
+
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1472,11 +1472,15 @@ configuration::configuration()
       false)
   , sasl_mechanisms(
       *this,
+      std::vector<ss::sstring>{"GSSAPI", "OAUTHBEARER"},
       "sasl_mechanisms",
       "A list of supported SASL mechanisms. Accepted values: `SCRAM`, "
       "`GSSAPI`, `OAUTHBEARER`.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      {"SCRAM"},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
+      std::vector<ss::sstring>{"SCRAM"},
       validate_sasl_mechanisms)
   , sasl_kerberos_config(
       *this,
@@ -1720,11 +1724,15 @@ configuration::configuration()
       true)
   , audit_enabled(
       *this,
+      true, /* restricted values */
       "audit_enabled",
       "Enables or disables audit logging. When you set this to true, Redpanda "
       "checks for an existing topic named `_redpanda.audit_log`. If none is "
       "found, Redpanda automatically creates one for you.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
       false)
   , audit_log_num_partitions(
       *this,
@@ -1813,10 +1821,14 @@ configuration::configuration()
       {})
   , cloud_storage_enabled(
       *this,
+      true,
       "cloud_storage_enabled",
       "Enable object storage. Must be set to `true` to use Tiered Storage or "
       "Remote Read Replicas.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::yes,
+        .visibility = visibility::user,
+      },
       false)
   , cloud_storage_enable_remote_read(
       *this,
@@ -2965,6 +2977,7 @@ configuration::configuration()
 
   , partition_autobalancing_mode(
       *this,
+      model::partition_autobalancing_mode::continuous,
       "partition_autobalancing_mode",
       "Mode of partition balancing for a cluster. * `node_add`: partition "
       "balancing happens when a node is added. * `continuous`: partition "
@@ -2976,11 +2989,13 @@ configuration::configuration()
       "`partition_autobalancing_max_disk_usage_percent` properties. * `off`: "
       "partition balancing is disabled. This option is not recommended for "
       "production clusters.",
-      {.needs_restart = needs_restart::no,
-       .example = "node_add",
-       .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::no,
+        .example = "node_add",
+        .visibility = visibility::user,
+      },
       model::partition_autobalancing_mode::node_add,
-      {
+      std::vector<model::partition_autobalancing_mode>{
         model::partition_autobalancing_mode::off,
         model::partition_autobalancing_mode::node_add,
         model::partition_autobalancing_mode::continuous,
@@ -3086,12 +3101,18 @@ configuration::configuration()
       {.min = 1, .max = 2048})
   , default_leaders_preference(
       *this,
+      [](const config::leaders_preference& v) {
+          return v != config::leaders_preference{};
+      },
       "default_leaders_preference",
       "Default settings for preferred location of topic partition leaders. "
       "It can be either \"none\" (no preference), "
       "or \"racks:<rack1>,<rack2>,...\" (prefer brokers with rack id from the "
       "list).",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
       config::leaders_preference{})
   , core_balancing_on_core_count_change(
       *this,
@@ -3103,10 +3124,14 @@ configuration::configuration()
       true)
   , core_balancing_continuous(
       *this,
+      true,
       "core_balancing_continuous",
       "If set to `true`, move partitions between cores in runtime to maintain "
       "balanced partition distribution.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
       false)
   , core_balancing_debounce_timeout(
       *this,
@@ -3495,6 +3520,10 @@ configuration::configuration()
       300s)
   , enable_schema_id_validation(
       *this,
+      std::vector<pandaproxy::schema_registry::schema_id_validation_mode>{
+        pandaproxy::schema_registry::schema_id_validation_mode::compat,
+        pandaproxy::schema_registry::schema_id_validation_mode::redpanda,
+      },
       "enable_schema_id_validation",
       "Mode to enable server-side schema ID validation. Accepted Values: * "
       "`none`: Schema validation is disabled (no schema ID checks are done). "
@@ -3502,11 +3531,15 @@ configuration::configuration()
       "validation is enabled. Only Redpanda topic properties are accepted. * "
       "`compat`: Schema validation is enabled. Both Redpanda and compatible "
       "topic properties are accepted.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
       pandaproxy::schema_registry::schema_id_validation_mode::none,
-      {pandaproxy::schema_registry::schema_id_validation_mode::none,
-       pandaproxy::schema_registry::schema_id_validation_mode::redpanda,
-       pandaproxy::schema_registry::schema_id_validation_mode::compat})
+      std::vector<pandaproxy::schema_registry::schema_id_validation_mode>{
+        pandaproxy::schema_registry::schema_id_validation_mode::none,
+        pandaproxy::schema_registry::schema_id_validation_mode::redpanda,
+        pandaproxy::schema_registry::schema_id_validation_mode::compat})
   , kafka_schema_id_validation_cache_capacity(
       *this,
       "kafka_schema_id_validation_cache_capacity",
@@ -3641,11 +3674,15 @@ configuration::configuration()
       1h)
   , http_authentication(
       *this,
+      "OIDC",
       "http_authentication",
       "A list of supported HTTP authentication mechanisms. Accepted Values: "
       "`BASIC`, `OIDC`",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      {"BASIC"},
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
+      std::vector<ss::sstring>{"BASIC"},
       validate_http_authn_mechanisms)
   , enable_mpx_extensions(
       *this,
@@ -3682,6 +3719,7 @@ configuration::configuration()
        tls_version::v1_3})
   , iceberg_enabled(
       *this,
+      true,
       "iceberg_enabled",
       "Enables the translation of topic data into Iceberg tables. Setting "
       "iceberg_enabled to true activates the feature at the cluster level, but "
@@ -3689,7 +3727,10 @@ configuration::configuration()
       "property to true to use it. If iceberg_enabled is set to false, the "
       "feature is disabled for all topics in the cluster, overriding any "
       "topic-level settings.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      meta{
+        .needs_restart = needs_restart::yes,
+        .visibility = visibility::user,
+      },
       false)
   , iceberg_translation_interval_ms_default(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -107,6 +107,7 @@ private:
 };
 
 struct configuration final : public config_store {
+    using meta = base_property::metadata;
     constexpr static auto target_produce_quota_byte_rate_default
       = 0; // disabled
 
@@ -320,7 +321,7 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
-    property<std::vector<ss::sstring>> sasl_mechanisms;
+    enterprise<property<std::vector<ss::sstring>>> sasl_mechanisms;
     property<ss::sstring> sasl_kerberos_config;
     property<ss::sstring> sasl_kerberos_keytab;
     property<ss::sstring> sasl_kerberos_principal;
@@ -361,7 +362,7 @@ struct configuration final : public config_store {
     property<bool> kafka_enable_describe_log_dirs_remote_storage;
 
     // Audit logging
-    property<bool> audit_enabled;
+    enterprise<property<bool>> audit_enabled;
     property<int32_t> audit_log_num_partitions;
     property<std::optional<int16_t>> audit_log_replication_factor;
     property<size_t> audit_client_max_buffer_size;
@@ -372,7 +373,7 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> audit_excluded_principals;
 
     // Archival storage
-    property<bool> cloud_storage_enabled;
+    enterprise<property<bool>> cloud_storage_enabled;
     property<bool> cloud_storage_enable_remote_read;
     property<bool> cloud_storage_enable_remote_write;
     property<bool> cloud_storage_disable_archiver_manager;
@@ -560,7 +561,7 @@ struct configuration final : public config_store {
     deprecated_property full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 
-    enum_property<model::partition_autobalancing_mode>
+    enterprise<enum_property<model::partition_autobalancing_mode>>
       partition_autobalancing_mode;
     property<std::chrono::seconds>
       partition_autobalancing_node_availability_timeout_sec;
@@ -579,10 +580,10 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;
     bounded_property<size_t> leader_balancer_transfer_limit_per_shard;
-    property<config::leaders_preference> default_leaders_preference;
+    enterprise<property<config::leaders_preference>> default_leaders_preference;
 
     property<bool> core_balancing_on_core_count_change;
-    property<bool> core_balancing_continuous;
+    enterprise<property<bool>> core_balancing_continuous;
     property<std::chrono::milliseconds> core_balancing_debounce_timeout;
 
     property<int> internal_topic_replication_factor;
@@ -655,7 +656,8 @@ struct configuration final : public config_store {
     property<std::chrono::seconds> legacy_unsafe_log_warning_interval_sec;
 
     // schema id validation
-    enum_property<pandaproxy::schema_registry::schema_id_validation_mode>
+    enterprise<
+      enum_property<pandaproxy::schema_registry::schema_id_validation_mode>>
       enable_schema_id_validation;
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
@@ -682,7 +684,7 @@ struct configuration final : public config_store {
     property<std::chrono::seconds> oidc_keys_refresh_interval;
 
     // HTTP Authentication
-    property<std::vector<ss::sstring>> http_authentication;
+    enterprise<property<std::vector<ss::sstring>>> http_authentication;
 
     // MPX
     property<bool> enable_mpx_extensions;
@@ -694,7 +696,7 @@ struct configuration final : public config_store {
     enum_property<tls_version> tls_min_version;
 
     // datalake configurations
-    property<bool> iceberg_enabled;
+    enterprise<property<bool>> iceberg_enabled;
     bounded_property<std::chrono::milliseconds>
       iceberg_translation_interval_ms_default;
     bounded_property<std::chrono::milliseconds>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -854,10 +854,8 @@ public:
           meta,
           def,
           [this](T new_value) -> std::optional<ss::sstring> {
-              auto found = std::find_if(
-                _values.begin(), _values.end(), [&new_value](const T& v) {
-                    return v == new_value;
-                });
+              auto found = std::ranges::find_if(
+                _values, [&new_value](const T& v) { return v == new_value; });
               if (found == _values.end()) {
                   return help_text();
               } else {

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -12,7 +12,8 @@ set(srcs
     validator_tests.cc
     throughput_control_group_test.cc
     node_override_test.cc
-    leaders_preference_test.cc)
+    leaders_preference_test.cc
+  )
 
 rp_test(
   UNIT_TEST
@@ -20,4 +21,14 @@ rp_test(
   SOURCES ${srcs}
   LIBRARIES v::seastar_testing_main v::config
   LABELS config
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_enterprise_property
+  SOURCES  enterprise_property_test.cc
+  LIBRARIES
+    v::config
+    v::gtest_main
 )

--- a/src/v/config/tests/enterprise_property_test.cc
+++ b/src/v/config/tests/enterprise_property_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/config_store.h"
+#include "config/property.h"
+#include "config/types.h"
+
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+
+#include <iostream>
+
+namespace config {
+namespace {
+
+struct test_config : public config_store {
+    enterprise<property<bool>> enterprise_bool;
+    enterprise<enum_property<ss::sstring>> enterprise_str_enum;
+    enterprise<property<std::vector<ss::sstring>>> enterprise_str_vec;
+    enterprise<property<std::optional<int>>> enterprise_opt_int;
+    enterprise<enum_property<tls_version>> enterprise_enum;
+
+    using meta = base_property::metadata;
+
+    test_config()
+      : enterprise_bool(
+          *this,
+          true,
+          "enterprise_bool",
+          "An enterprise-only bool config",
+          meta{},
+          false,
+          property<bool>::noop_validator,
+          std::nullopt)
+      , enterprise_str_enum(
+          *this,
+          std::vector<ss::sstring>{"bar"},
+          "enterprise_str_enum",
+          "An enterprise-only enum property",
+          meta{},
+          "foo",
+          std::vector<ss::sstring>{"foo", "bar", "baz"})
+      , enterprise_str_vec(
+          *this,
+          std::vector<ss::sstring>{"GSSAPI"},
+          "enterprise_str_vec",
+          "An enterprise-only vector of strings")
+      , enterprise_opt_int(
+          *this,
+          [](const int& v) -> bool { return v > 1000; },
+          "enterprise_opt_int",
+          "An enterprise-only optional int",
+          meta{},
+          0)
+      , enterprise_enum(
+          *this,
+          std::vector<tls_version>{tls_version::v1_3},
+          "enterprise_str_enum",
+          "An enterprise-only enum property",
+          meta{},
+          tls_version::v1_1,
+          std::vector<tls_version>{
+            tls_version::v1_0,
+            tls_version::v1_1,
+            tls_version::v1_2,
+            tls_version::v1_3}) {}
+};
+
+} // namespace
+
+TEST(EnterprisePropertyTest, TestRestriction) {
+    using N = YAML::Node;
+    test_config cfg;
+
+    EXPECT_FALSE(cfg.enterprise_bool.check_restricted(N(false)));
+    EXPECT_TRUE(cfg.enterprise_bool.check_restricted(N(true)));
+
+    EXPECT_FALSE(cfg.enterprise_str_enum.check_restricted(N("foo")));
+    EXPECT_TRUE(cfg.enterprise_str_enum.check_restricted(N("bar")));
+
+    EXPECT_FALSE(cfg.enterprise_str_vec.check_restricted(
+      N(std::vector<ss::sstring>{"foo", "bar", "baz"})));
+    EXPECT_TRUE(cfg.enterprise_str_vec.check_restricted(
+      N(std::vector<ss::sstring>{"foo", "bar", "baz", "GSSAPI"})));
+
+    EXPECT_FALSE(cfg.enterprise_opt_int.check_restricted(N(10)));
+    EXPECT_TRUE(cfg.enterprise_opt_int.check_restricted(N(10000)));
+
+    EXPECT_FALSE(cfg.enterprise_enum.check_restricted(N(tls_version::v1_0)));
+    EXPECT_TRUE(cfg.enterprise_enum.check_restricted(N(tls_version::v1_3)));
+}
+
+TEST(EnterprisePropertyTest, TestTypeName) {
+    test_config cfg;
+    EXPECT_EQ(cfg.enterprise_bool.type_name(), "boolean");
+    EXPECT_EQ(cfg.enterprise_str_enum.type_name(), "string");
+    EXPECT_EQ(cfg.enterprise_str_vec.type_name(), "string");
+    EXPECT_EQ(cfg.enterprise_opt_int.type_name(), "integer");
+    EXPECT_EQ(cfg.enterprise_enum.type_name(), "string");
+}
+
+} // namespace config

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -168,8 +168,6 @@ class RedpandaKerberosLicenseTest(RedpandaKerberosTestBase):
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
             f'{self.LICENSE_CHECK_INTERVAL_SEC}',
-            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
-            True
         })
 
     def _has_license_nag(self):
@@ -197,6 +195,15 @@ class RedpandaKerberosLicenseTest(RedpandaKerberosTestBase):
         self.logger.debug("Setting cluster config")
         self.redpanda.set_cluster_config(
             {"sasl_mechanisms": ["GSSAPI", "SCRAM"]})
+
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': '1'})
+        self.redpanda.stop()
+        self.redpanda.start(clean_nodes=False)
+
+        wait_until(self._license_nag_is_set,
+                   timeout_sec=30,
+                   err_msg="Failed to set license nag internal")
 
         self.logger.debug("Waiting for license nag")
         wait_until(self._has_license_nag,

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -610,8 +610,6 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
             f'{self.LICENSE_CHECK_INTERVAL_SEC}',
-            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
-            True
         })
 
     def _has_license_nag(self):
@@ -640,6 +638,15 @@ class OIDCLicenseTest(RedpandaOIDCTestBase):
 
         self.logger.debug("Setting cluster config")
         self.redpanda.set_cluster_config(authn_config)
+
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': '1'})
+
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
+                                            use_maintenance_mode=False)
+        wait_until(self._license_nag_is_set,
+                   timeout_sec=30,
+                   err_msg="Failed to set license nag internal")
 
         self.logger.debug("Waiting for license nag")
         wait_until(self._has_license_nag,

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3841,8 +3841,6 @@ class SchemaRegistryLicenseTest(RedpandaTest):
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
             f'{self.LICENSE_CHECK_INTERVAL_SEC}',
-            '__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE':
-            True
         })
 
     def _has_license_nag(self):
@@ -3871,6 +3869,15 @@ class SchemaRegistryLicenseTest(RedpandaTest):
 
         self.logger.debug("Setting cluster config")
         self.redpanda.set_cluster_config({"enable_schema_id_validation": mode})
+
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': '1'})
+        self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
+                                            use_maintenance_mode=False)
+
+        wait_until(self._license_nag_is_set,
+                   timeout_sec=30,
+                   err_msg="Failed to set license nag internal")
 
         self.logger.debug("Waiting for license nag")
         wait_until(self._has_license_nag,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

### Pros

- small change to make a property "enterprise only"
   - add the wrapper template and update constructor call w/ restricted values
- change isolated to property _definition_, use as normal throughout codebase
- enforcement is effectively optional from the compiler's perspective
   - and the logic to perform it can be isolated to admin
- works for arbitrary types (arrays, optionals, subclasses of `property` etc) and can be extended to others incl support for "custom" check for aggregates or whatever

### Cons

- Looks bizarre 🙃 
- slightly un-ergonomic to construct. 
   - variadic template prevents type deduction on initializer lists, so containers and aggregates need to be  explicit at the call site
- arguably the information encoded here feels a bit unnatural as a property of a `config::property`.

### TODO

- [ ] tests tests tests
- [ ] rebase on Gellert's PR and test test test

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
