### PR TITLE
datalake: Avro schema resolution for record components

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -30,6 +30,19 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "schema_identifier",
+    hdrs = [
+        "schema_identifier.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/pandaproxy",
+        "//src/v/serde",
+    ],
+)
+
+redpanda_cc_library(
     name = "schema_protobuf",
     srcs = [
         "schema_protobuf.cc",

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -271,3 +271,31 @@ redpanda_cc_library(
         "//src/v/pandaproxy",
     ],
 )
+
+redpanda_cc_library(
+    name = "record_schema_resolver",
+    srcs = [
+        "record_schema_resolver.cc",
+    ],
+    hdrs = [
+        "record_schema_resolver.h",
+    ],
+    implementation_deps = [
+        ":conversion_outcome",
+        ":logger",
+        ":schema_registry",
+        "//src/v/iceberg:avro_utils",
+        "//src/v/iceberg:schema_avro",
+        "//src/v/pandaproxy",
+        "//src/v/schema:registry",
+        "@avro",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":schema_identifier",
+        "//src/v/base",
+        "//src/v/iceberg:datatypes",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -243,3 +243,18 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "schema_registry",
+    srcs = ["schema_registry.cc"],
+    hdrs = ["schema_registry.h"],
+    implementation_deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/pandaproxy",
+    ],
+)

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/record_schema_resolver.h"
+
+#include "base/vlog.h"
+#include "datalake/logger.h"
+#include "datalake/schema_identifier.h"
+#include "datalake/schema_registry.h"
+#include "iceberg/schema_avro.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "schema/registry.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+#include <exception>
+
+namespace datalake {
+
+namespace {
+
+namespace ppsr = pandaproxy::schema_registry;
+struct schema_translating_visitor {
+    schema_translating_visitor(iobuf b, ppsr::schema_id id)
+      : buf_no_id(std::move(b))
+      , id(id) {}
+    // Buffer without the schema ID.
+    iobuf buf_no_id;
+    ppsr::schema_id id;
+
+    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    operator()(const ppsr::avro_schema_definition& avro_def) {
+        const auto& avro_schema = avro_def();
+        try {
+            // TODO: we should use Avro value conversion instead of this
+            // Iceberg-specific code.
+            auto type = iceberg::type_from_avro(
+              avro_schema.root(), iceberg::with_field_ids::no);
+            co_return type_and_buf{
+              .type = resolved_type{
+                .schema = avro_schema,
+                .id = { .schema_id = id, .protobuf_offsets = std::nullopt, },
+                .type = std::move(type),
+                .type_name = avro_schema.root()->name().fullname(),
+              },
+              .parsable_buf = std::move(buf_no_id),
+            };
+        } catch (...) {
+            vlog(
+              datalake_log.error,
+              "Avro schema translation failed: {}",
+              std::current_exception());
+            co_return record_schema_resolver::errc::translation_error;
+        }
+    }
+    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    operator()(const ppsr::protobuf_schema_definition&) {
+        // XXX: a subsequent PR will add protobuf support.
+        co_return type_and_buf::make_raw_binary(std::move(buf_no_id));
+    }
+    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    operator()(const ppsr::json_schema_definition&) {
+        co_return type_and_buf::make_raw_binary(std::move(buf_no_id));
+    }
+};
+
+} // namespace
+
+type_and_buf type_and_buf::make_raw_binary(iobuf b) {
+    return type_and_buf{
+      .type = std::nullopt,
+      .parsable_buf = std::move(b),
+    };
+}
+
+ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+record_schema_resolver::resolve_buf_type(iobuf b) const {
+    schema_message_data schema_id_res;
+    try {
+        // NOTE: Kafka's serialization protocol relies on a magic byte to
+        // indicate if we have a schema. This has room for false positives, and
+        // we can't say for sure if an error is the result of the record not
+        // having a schema. Just translate to binary.
+        auto res = get_value_schema_id(b);
+        if (res.has_error()) {
+            vlog(
+              datalake_log.trace,
+              "Error parsing schema ID; using binary type: {}",
+              res.error());
+            co_return type_and_buf::make_raw_binary(std::move(b));
+        }
+        schema_id_res = std::move(res.value());
+    } catch (...) {
+        vlog(
+          datalake_log.trace,
+          "Error parsing schema ID; using binary type: {}",
+          std::current_exception());
+        co_return type_and_buf::make_raw_binary(std::move(b));
+    }
+    auto schema_id = schema_id_res.schema_id;
+    auto buf_no_id = std::move(schema_id_res.shared_message_data);
+
+    // TODO: It'd be nice to cache these -- translation interval instills a
+    // natural limit to concurrency so a cache wouldn't grow huge.
+    auto schema_fut = co_await ss::coroutine::as_future(
+      sr_.get_valid_schema(schema_id));
+    if (schema_fut.failed()) {
+        vlog(
+          datalake_log.warn,
+          "Error getting schema from registry: {}",
+          schema_fut.get_exception());
+        // TODO: make schema::registry tell us whether the issue was transient.
+        co_return errc::registry_error;
+    }
+    auto resolved_schema = std::move(schema_fut.get());
+    co_return co_await resolved_schema.visit(
+      schema_translating_visitor{std::move(buf_no_id), schema_id});
+}
+
+} // namespace datalake

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "datalake/schema_identifier.h"
+#include "iceberg/datatypes.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/future.hh>
+
+namespace schema {
+class registry;
+} // namespace schema
+
+namespace datalake {
+
+// Represents an object that can be converted into an Iceberg schema.
+// NOTE: these aren't exactly just the schemas from the registry: Protobuf
+// schemas are FileDescriptors in the registry rather than Descriptors, and
+// require additional information to get the Descriptors.
+using resolved_schema
+  = std::variant<std::reference_wrapper<const avro::ValidSchema>>;
+
+struct resolved_type {
+    // The resolved schema that corresponds to the type.
+    resolved_schema schema;
+    schema_identifier id;
+
+    // The schema (and offsets, for protobuf), translated into an
+    // Iceberg-compatible type. Note, the field IDs may not necessarily
+    // correspond to their final IDs in the catalog.
+    iceberg::field_type type;
+    ss::sstring type_name;
+};
+
+struct type_and_buf {
+    std::optional<resolved_type> type;
+
+    // Part of a record field (key or value) that conforms to the given Iceberg
+    // field type.
+    iobuf parsable_buf;
+
+    // Constructs a type that indicates that the record didn't have a schema or
+    // there was an issue trying to parse the schema, in which case we need to
+    // fall back to representing the value as a binary blob column.
+    static type_and_buf make_raw_binary(iobuf buf);
+};
+
+class record_schema_resolver {
+public:
+    enum class errc {
+        registry_error,
+        translation_error,
+    };
+    explicit record_schema_resolver(schema::registry& sr)
+      : sr_(sr) {}
+
+    ss::future<checked<type_and_buf, errc>> resolve_buf_type(iobuf b) const;
+
+private:
+    schema::registry& sr_;
+};
+
+} // namespace datalake

--- a/src/v/datalake/schema_identifier.h
+++ b/src/v/datalake/schema_identifier.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "pandaproxy/schema_registry/types.h"
+#include "serde/rw/envelope.h"
+
+#include <optional>
+
+namespace datalake {
+
+// Uniquely identifies the structure of a record component schema as it exists
+// in the schema registry.
+struct schema_identifier
+  : serde::
+      envelope<schema_identifier, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    auto serde_fields() { return std::tie(schema_id, protobuf_offsets); }
+
+    pandaproxy::schema_registry::schema_id schema_id;
+    std::optional<std::vector<int32_t>> protobuf_offsets;
+};
+
+// The components required to build the Iceberg schema of a record.
+struct record_schema_components
+  : serde::envelope<
+      record_schema_components,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    auto serde_fields() { return std::tie(key_identifier, val_identifier); }
+
+    std::optional<schema_identifier> key_identifier;
+    std::optional<schema_identifier> val_identifier;
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -124,3 +124,23 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "record_schema_resolver_test",
+    timeout = "short",
+    srcs = [
+        "record_schema_resolver_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/datalake:logger",
+        "//src/v/datalake:record_schema_resolver",
+        "//src/v/iceberg:datatypes",
+        "//src/v/pandaproxy",
+        "//src/v/schema:registry",
+        "//src/v/schema/tests:fake_registry",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "bytes/bytes.h"
+#include "datalake/logger.h"
+#include "datalake/record_schema_resolver.h"
+#include "iceberg/datatypes.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "schema/tests/fake_registry.h"
+
+#include <gtest/gtest.h>
+
+#include <exception>
+#include <variant>
+
+using namespace pandaproxy::schema_registry;
+using namespace datalake;
+using namespace iceberg;
+
+namespace {
+constexpr std::string_view avro_record_schema = R"({
+  "type": "record",
+  "name": "LongList",
+  "fields" : [
+    {"name": "value", "type": "long"},
+    {"type": "int", "name": "next", "metadata" : "two"}
+  ]
+})";
+iobuf generate_dummy_body() { return iobuf::from("blob"); }
+
+// Checks that the given resolved buffer has no schema, and just returns a
+// single binary column that matches the input iobuf.
+void check_no_schema(const type_and_buf& resolved, const iobuf& expected) {
+    EXPECT_FALSE(resolved.type.has_value());
+
+    // The value should match the expected buf.
+    ASSERT_EQ(resolved.parsable_buf, expected);
+}
+} // namespace
+
+class RecordSchemaResolverTest : public ::testing::Test {
+public:
+    RecordSchemaResolverTest()
+      : sr(std::make_unique<schema::fake_registry>()) {}
+
+    void SetUp() override {
+        auto avro_schema_id = sr
+                                ->create_schema(unparsed_schema{
+                                  subject{"foo"},
+                                  unparsed_schema_definition{
+                                    avro_record_schema, schema_type::avro}})
+                                .get();
+        ASSERT_EQ(1, avro_schema_id());
+    }
+    std::unique_ptr<schema::fake_registry> sr;
+};
+
+TEST_F(RecordSchemaResolverTest, TestAvroSchemaHappyPath) {
+    // Kakfa magic byte + schema ID.
+    iobuf buf;
+    buf.append("\0\0\0\0\1", 5);
+    buf.append(generate_dummy_body());
+
+    auto resolver = record_schema_resolver(*sr);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    auto& resolved_buf = res.value();
+    ASSERT_TRUE(resolved_buf.type.has_value());
+    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
+    EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+
+    // Check that the resolved schema looks correct. Note, the field IDs are
+    // unimportant since they are assigned outside of the resolver -- it's just
+    // important the data's structure looks good.
+    const auto expected_type = field_type{[] {
+        auto expected_struct = struct_type{};
+        expected_struct.fields.emplace_back(
+          nested_field::create(0, "value", field_required::yes, long_type{}));
+        expected_struct.fields.emplace_back(
+          nested_field::create(0, "next", field_required::yes, int_type{}));
+        return expected_struct;
+    }()};
+    EXPECT_EQ(resolved_buf.type->type, expected_type);
+}
+
+TEST_F(RecordSchemaResolverTest, TestMissingMagic) {
+    iobuf buf;
+    // Write body but no magic.
+    buf.append(generate_dummy_body());
+    auto resolver = record_schema_resolver(*sr);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    const auto& resolved_buf = res.value();
+    ASSERT_NO_FATAL_FAILURE(check_no_schema(resolved_buf, buf));
+}
+
+TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
+    iobuf buf;
+    buf.append("\0\0\0\0\1", 5);
+    buf.append(generate_dummy_body());
+    sr->set_inject_failures(
+      std::make_exception_ptr(std::runtime_error("injected")));
+
+    auto resolver = record_schema_resolver(*sr);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_TRUE(res.has_error());
+    ASSERT_EQ(res.error(), record_schema_resolver::errc::registry_error);
+
+    // We can try again when there are no injected errors and there should be
+    // no issue.
+    sr->set_inject_failures(nullptr);
+    res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    auto& resolved_buf = res.value();
+    ASSERT_TRUE(resolved_buf.type.has_value());
+    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
+    EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+}

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -42,6 +42,7 @@ redpanda_cc_library(
         "avro_utils.h",
     ],
     include_prefix = "iceberg",
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
@@ -533,6 +534,7 @@ redpanda_cc_library(
         "schema_avro.h",
     ],
     include_prefix = "iceberg",
+    visibility = ["//visibility:public"],
     deps = [
         ":datatypes",
         "@avro",
@@ -954,6 +956,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf_parser",
     ],
     include_prefix = "iceberg",
+    visibility = ["//visibility:public"],
     deps = [
         ":datatypes",
         ":values",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -539,6 +539,7 @@ redpanda_cc_library(
         ":datatypes",
         "@avro",
         "@fmt",
+        "@seastar",
     ],
 )
 

--- a/src/v/iceberg/schema_avro.h
+++ b/src/v/iceberg/schema_avro.h
@@ -10,6 +10,8 @@
 
 #include "iceberg/datatypes.h"
 
+#include <seastar/util/bool_class.hh>
+
 #include <avro/CustomAttributes.hh>
 #include <avro/LogicalType.hh>
 #include <avro/Schema.hh>
@@ -27,6 +29,8 @@ avro::Schema struct_type_to_avro(const struct_type&, std::string_view name);
 // attributes).
 nested_field_ptr
 child_field_from_avro(const avro::NodePtr& parent, size_t child_idx);
-field_type type_from_avro(const avro::NodePtr&);
+using with_field_ids = ss::bool_class<struct field_id_tag>;
+field_type type_from_avro(
+  const avro::NodePtr&, with_field_ids with_ids = with_field_ids::yes);
 
 } // namespace iceberg

--- a/src/v/pandaproxy/BUILD
+++ b/src/v/pandaproxy/BUILD
@@ -206,6 +206,7 @@ redpanda_cc_library(
         "schema_registry/requests/get_subject_versions_version.h",
         "schema_registry/requests/mode.h",
         "schema_registry/requests/post_subject_versions.h",
+        "schema_registry/schema_getter.h",
         "schema_registry/schema_id_cache.h",
         "schema_registry/seq_writer.h",
         "schema_registry/service.h",

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -20,6 +20,7 @@
 #include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "strings/string_switch.h"
@@ -544,7 +545,7 @@ private:
 };
 
 ss::future<collected_schema> collect_schema(
-  sharded_store& store,
+  schema_getter& store,
   collected_schema collected,
   ss::sstring name,
   canonical_schema schema) {
@@ -561,7 +562,7 @@ ss::future<collected_schema> collect_schema(
 }
 
 ss::future<avro_schema_definition>
-make_avro_schema_definition(sharded_store& store, canonical_schema schema) {
+make_avro_schema_definition(schema_getter& store, canonical_schema schema) {
     std::optional<avro::Exception> ex;
     try {
         auto name = schema.sub()();

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -18,7 +18,7 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<avro_schema_definition>
-make_avro_schema_definition(sharded_store& store, canonical_schema schema);
+make_avro_schema_definition(schema_getter& store, canonical_schema schema);
 
 result<canonical_schema_definition>
 sanitize_avro_schema_definition(unparsed_schema_definition def);

--- a/src/v/pandaproxy/schema_registry/fwd.h
+++ b/src/v/pandaproxy/schema_registry/fwd.h
@@ -17,6 +17,7 @@ class api;
 struct configuration;
 class schema_id_cache;
 class schema_id_validation_probe;
+class schema_getter;
 class seq_writer;
 class service;
 class sharded_store;

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -2378,7 +2378,7 @@ result<id_to_schema_pointer> collect_bundled_schema_and_fix_refs(
 } // namespace
 
 ss::future<json_schema_definition>
-make_json_schema_definition(sharded_store&, canonical_schema schema) {
+make_json_schema_definition(schema_getter&, canonical_schema schema) {
     auto doc
       = parse_json(schema.def().shared_raw()()).value(); // throws on error
     std::string_view name = schema.sub()();

--- a/src/v/pandaproxy/schema_registry/json.h
+++ b/src/v/pandaproxy/schema_registry/json.h
@@ -17,7 +17,7 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<json_schema_definition>
-make_json_schema_definition(sharded_store& store, canonical_schema schema);
+make_json_schema_definition(schema_getter& store, canonical_schema schema);
 
 ss::future<canonical_schema> make_canonical_json_schema(
   sharded_store& store, unparsed_schema def, normalize norm = normalize::no);

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -341,7 +341,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 /// Recursively import references into the DescriptorPool, building the
 /// files on stack unwind.
 ss::future<const pb::FileDescriptor*> build_file_with_refs(
-  pb::DescriptorPool& dp, sharded_store& store, canonical_schema schema) {
+  pb::DescriptorPool& dp, schema_getter& store, canonical_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         if (dp.FindFileByName(ref.name)) {
             continue;
@@ -361,7 +361,7 @@ ss::future<const pb::FileDescriptor*> build_file_with_refs(
 ///\brief Import a schema in the DescriptorPool and return the
 /// FileDescriptor.
 ss::future<const pb::FileDescriptor*> import_schema(
-  pb::DescriptorPool& dp, sharded_store& store, canonical_schema schema) {
+  pb::DescriptorPool& dp, schema_getter& store, canonical_schema schema) {
     try {
         co_return co_await build_file_with_refs(dp, store, schema.share());
     } catch (const exception& e) {
@@ -461,7 +461,7 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
 }
 
 ss::future<protobuf_schema_definition>
-make_protobuf_schema_definition(sharded_store& store, canonical_schema schema) {
+make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     auto refs = schema.def().refs();
     impl->fd = co_await import_schema(impl->_dp, store, std::move(schema));

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -17,7 +17,7 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<protobuf_schema_definition>
-make_protobuf_schema_definition(sharded_store& store, canonical_schema schema);
+make_protobuf_schema_definition(schema_getter& store, canonical_schema schema);
 
 ss::future<canonical_schema_definition>
 validate_protobuf_schema(sharded_store& store, canonical_schema schema);

--- a/src/v/pandaproxy/schema_registry/schema_getter.h
+++ b/src/v/pandaproxy/schema_registry/schema_getter.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "container/fragmented_vector.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/future.hh>
+
+namespace pandaproxy::schema_registry {
+
+class schema_getter {
+public:
+    virtual ss::future<subject_schema> get_subject_schema(
+      subject sub,
+      std::optional<schema_version> version,
+      include_deleted inc_dec)
+      = 0;
+    virtual ss::future<canonical_schema_definition>
+    get_schema_definition(schema_id id) = 0;
+    virtual ~schema_getter() = default;
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "container/fragmented_vector.h"
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/core/sharded.hh>
@@ -22,8 +23,9 @@ class store;
 
 ///\brief Dispatch requests to shards based on a a hash of the
 /// subject or schema_id
-class sharded_store {
+class sharded_store final : public schema_getter {
 public:
+    ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
 
@@ -69,7 +71,8 @@ public:
       canonical_schema schema, include_deleted inc_del = include_deleted::no);
 
     ///\brief Return a schema definition by id.
-    ss::future<canonical_schema_definition> get_schema_definition(schema_id id);
+    ss::future<canonical_schema_definition>
+    get_schema_definition(schema_id id) override;
 
     ///\brief Return a list of subject-versions for the shema id.
     ss::future<chunked_vector<subject_version>>
@@ -83,7 +86,7 @@ public:
     ss::future<subject_schema> get_subject_schema(
       subject sub,
       std::optional<schema_version> version,
-      include_deleted inc_dec);
+      include_deleted inc_dec) final;
 
     ///\brief Return a list of subjects.
     ss::future<chunked_vector<subject>> get_subjects(

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "pandaproxy/schema_registry/fwd.h"
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "pandaproxy/schema_registry/types.h"
 
 namespace schema {
@@ -38,6 +39,12 @@ public:
     virtual ~registry() = default;
 
     virtual bool is_enabled() const = 0;
+
+    virtual ss::future<pandaproxy::schema_registry::schema_getter*>
+    getter() const = 0;
+
+    ss::future<pandaproxy::schema_registry::valid_schema>
+    get_valid_schema(pandaproxy::schema_registry::schema_id schema_id) const;
 
     virtual ss::future<pandaproxy::schema_registry::canonical_schema_definition>
       get_schema_definition(pandaproxy::schema_registry::schema_id) const = 0;

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -22,19 +22,12 @@ namespace ppsr = pandaproxy::schema_registry;
 
 } // namespace
 
-ss::future<ppsr::canonical_schema_definition>
-schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
-    for (const auto& s : _schemas) {
-        if (s.id == id) {
-            co_return s.schema.def().share();
-        }
-    }
-    throw std::runtime_error("unknown schema id");
-}
-ss::future<ppsr::subject_schema> schema::fake_registry::get_subject_schema(
-  ppsr::subject sub, std::optional<ppsr::schema_version> version) const {
+ss::future<ppsr::subject_schema> schema::fake_store::get_subject_schema(
+  ppsr::subject sub,
+  std::optional<ppsr::schema_version> version,
+  ppsr::include_deleted) {
     std::optional<ppsr::subject_schema> found;
-    for (const auto& s : _schemas) {
+    for (const auto& s : schemas) {
         if (s.schema.sub() != sub) {
             continue;
         }
@@ -48,16 +41,37 @@ ss::future<ppsr::subject_schema> schema::fake_registry::get_subject_schema(
     }
     co_return std::move(found).value();
 }
+
+ss::future<ppsr::canonical_schema_definition>
+schema::fake_store::get_schema_definition(ppsr::schema_id id) {
+    for (const auto& s : schemas) {
+        if (s.id == id) {
+            co_return s.schema.def().share();
+        }
+    }
+    throw std::runtime_error("unknown schema id");
+}
+ss::future<ppsr::canonical_schema_definition>
+schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
+    return _store.get_schema_definition(id);
+}
+ss::future<ppsr::subject_schema> schema::fake_registry::get_subject_schema(
+  ppsr::subject sub, std::optional<ppsr::schema_version> version) const {
+    return _store.get_subject_schema(sub, version, ppsr::include_deleted::no);
+}
+ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
+    co_return &_store;
+}
 ss::future<ppsr::schema_id>
 schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
     // This is wrong, but simple for our testing.
-    for (const auto& s : _schemas) {
+    for (const auto& s : _store.schemas) {
         if (s.schema.def().raw()() == unparsed.def().raw()()) {
             co_return s.id;
         }
     }
     auto version = ppsr::schema_version(0);
-    for (const auto& s : _schemas) {
+    for (const auto& s : _store.schemas) {
         if (s.schema.sub() == unparsed.sub()) {
             version = std::max(version, s.version);
         }
@@ -65,7 +79,7 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
     // TODO: validate references too
     auto [sub, unparsed_def] = std::move(unparsed).destructure();
     auto [def, type, refs] = std::move(unparsed_def).destructure();
-    _schemas.push_back({
+    _store.schemas.push_back({
       .schema = ppsr::canonical_schema(
         std::move(sub),
         ppsr::canonical_schema_definition(
@@ -73,11 +87,11 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
           type,
           std::move(refs))),
       .version = version + 1,
-      .id = ppsr::schema_id(int32_t(_schemas.size() + 1)),
+      .id = ppsr::schema_id(int32_t(_store.schemas.size() + 1)),
       .deleted = ppsr::is_deleted::no,
     });
-    co_return _schemas.back().id;
+    co_return _store.schemas.back().id;
 }
 const std::vector<ppsr::subject_schema>& schema::fake_registry::get_all() {
-    return _schemas;
+    return _store.schemas;
 }

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -51,19 +51,30 @@ schema::fake_store::get_schema_definition(ppsr::schema_id id) {
     }
     throw std::runtime_error("unknown schema id");
 }
+
+void schema::fake_registry::maybe_throw_injected_failure() const {
+    if (_injected_failure) {
+        std::rethrow_exception(_injected_failure);
+    }
+}
+
 ss::future<ppsr::canonical_schema_definition>
 schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
+    maybe_throw_injected_failure();
     return _store.get_schema_definition(id);
 }
 ss::future<ppsr::subject_schema> schema::fake_registry::get_subject_schema(
   ppsr::subject sub, std::optional<ppsr::schema_version> version) const {
+    maybe_throw_injected_failure();
     return _store.get_subject_schema(sub, version, ppsr::include_deleted::no);
 }
 ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
+    maybe_throw_injected_failure();
     co_return &_store;
 }
 ss::future<ppsr::schema_id>
 schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
+    maybe_throw_injected_failure();
     // This is wrong, but simple for our testing.
     for (const auto& s : _store.schemas) {
         if (s.schema.def().raw()() == unparsed.def().raw()()) {
@@ -93,5 +104,6 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
     co_return _store.schemas.back().id;
 }
 const std::vector<ppsr::subject_schema>& schema::fake_registry::get_all() {
+    maybe_throw_injected_failure();
     return _store.schemas;
 }

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -10,11 +10,24 @@
  */
 #pragma once
 
+#include "pandaproxy/schema_registry/schema_getter.h"
 #include "schema/registry.h"
 
 #include <seastar/core/future.hh>
 
 namespace schema {
+
+struct fake_store : public pandaproxy::schema_registry::schema_getter {
+public:
+    ss::future<pandaproxy::schema_registry::subject_schema> get_subject_schema(
+      pandaproxy::schema_registry::subject sub,
+      std::optional<pandaproxy::schema_registry::schema_version> version,
+      pandaproxy::schema_registry::include_deleted inc_dec) final;
+    ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    get_schema_definition(pandaproxy::schema_registry::schema_id id) final;
+
+    std::vector<pandaproxy::schema_registry::subject_schema> schemas;
+};
 
 // This is a fake schema registry for testing. Schemas are maintained in local
 // memory only, not replicated or persisted to stable storage.
@@ -22,6 +35,8 @@ class fake_registry : public schema::registry {
 public:
     bool is_enabled() const override { return true; };
 
+    ss::future<pandaproxy::schema_registry::schema_getter*>
+    getter() const override;
     ss::future<pandaproxy::schema_registry::canonical_schema_definition>
     get_schema_definition(
       pandaproxy::schema_registry::schema_id id) const override;
@@ -37,6 +52,6 @@ public:
     const std::vector<pandaproxy::schema_registry::subject_schema>& get_all();
 
 private:
-    std::vector<pandaproxy::schema_registry::subject_schema> _schemas;
+    mutable fake_store _store;
 };
 } // namespace schema

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -51,7 +51,14 @@ public:
 
     const std::vector<pandaproxy::schema_registry::subject_schema>& get_all();
 
+    void set_inject_failures(const std::exception_ptr& injected) {
+        _injected_failure = injected;
+    }
+
 private:
+    void maybe_throw_injected_failure() const;
+
+    std::exception_ptr _injected_failure;
     mutable fake_store _store;
 };
 } // namespace schema


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Introduces the record_schema_resolver, which takes an iobuf component of a record (e.g. a key or value), parses any schema-related bytes, and returns the translated schema, if any. If there is no schema, or there is a deterministic error, the input buffer in its entirety is returned from the resolver as a binary field.

This only adds this code for Avro schemas. Protobuf will come in a following PR, and the behavior for JSON is to just return the binary value.

This PR also introduces a schema identifier, which are the Kafka components that uniquely identify the Parquet structure (i.e. the schema ID and optional protobuf offsets). This identifier will be passed to the coordinator and it will be the coordinator's job to re-resolve the schema and register it with the catalog. This identifier is a return value of the resolver.

Along the way, this PR also makes a small update to the schema registry to allow us to reuse some code in tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
