### PR TITLE
net: Fix setting of TCP send/recv bufs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -171,7 +171,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "jyW/wSglDCRyw81cPNosb30rL/prqwEuWudG34WwL14=",
+        "bzlTransitiveDigest": "dH3wZYrazWinVB5iIibF9mMr7FS9fsNPdUJ1WaT33oE=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -358,9 +358,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "6451633c3a4c0422845f441994fe87d1f5a3caabf3e9d4abec733e47bfbed896",
-              "strip_prefix": "seastar-4a3406ce4071f0bc472233c4c669582ca527db89",
-              "url": "https://github.com/redpanda-data/seastar/archive/4a3406ce4071f0bc472233c4c669582ca527db89.tar.gz",
+              "sha256": "31b526bb8ddb445d624997bfd2f4f62919a9ddbfeb97ddbff71ea68a291ad211",
+              "strip_prefix": "seastar-7820b867bf659a1908e71e06f9b4d6bcea019c70",
+              "url": "https://github.com/redpanda-data/seastar/archive/7820b867bf659a1908e71e06f9b4d6bcea019c70.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:seastar-fortify-source.patch"
               ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,9 +167,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "6451633c3a4c0422845f441994fe87d1f5a3caabf3e9d4abec733e47bfbed896",
-        strip_prefix = "seastar-4a3406ce4071f0bc472233c4c669582ca527db89",
-        url = "https://github.com/redpanda-data/seastar/archive/4a3406ce4071f0bc472233c4c669582ca527db89.tar.gz",
+        sha256 = "31b526bb8ddb445d624997bfd2f4f62919a9ddbfeb97ddbff71ea68a291ad211",
+        strip_prefix = "seastar-7820b867bf659a1908e71e06f9b4d6bcea019c70",
+        url = "https://github.com/redpanda-data/seastar/archive/7820b867bf659a1908e71e06f9b4d6bcea019c70.tar.gz",
         patches = ["//bazel/thirdparty:seastar-fortify-source.patch"],
         patch_args = ["-p1"],
     )

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -89,6 +89,8 @@ void server::start() {
             if (cfg.listen_backlog.has_value()) {
                 lo.listen_backlog = cfg.listen_backlog.value();
             }
+            lo.so_rcvbuf = cfg.tcp_recv_buf;
+            lo.so_sndbuf = cfg.tcp_send_buf;
 
             if (!endpoint.credentials) {
                 ss = ss::engine().listen(endpoint.addr, lo);
@@ -227,21 +229,6 @@ ss::future<ss::stop_iteration> server::accept_finish(
               ar.remote_address);
             co_return ss::stop_iteration::no;
         }
-    }
-
-    // Apply socket buffer size settings
-    if (cfg.tcp_recv_buf.has_value()) {
-        // Explicitly store in an int to decouple the
-        // config type from the set_sockopt type.
-        int recv_buf = cfg.tcp_recv_buf.value();
-        ar.connection.set_sockopt(
-          SOL_SOCKET, SO_RCVBUF, &recv_buf, sizeof(recv_buf));
-    }
-
-    if (cfg.tcp_send_buf.has_value()) {
-        int send_buf = cfg.tcp_send_buf.value();
-        ar.connection.set_sockopt(
-          SOL_SOCKET, SO_SNDBUF, &send_buf, sizeof(send_buf));
     }
 
     if (_connection_rates) {


### PR DESCRIPTION
Setting of the TCP receive and send buffers needs to happen prior to
`listen`/`connect`.

However, on the server side we currently set it on the accepted socket.
This results in it only semi working. While the buffers do get sized
correctly it has no effect on the receive/send window which is the main
purpose.

We extended seastar to allow setting the buffers settings on the
listening socket. This patch makes use of that API.

Ref CORE-7753

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none


