### PR TITLE
parquet: dremel record shredding algorithm

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_library(
     name = "schema",
     srcs = [
         "flattened_schema.cc",
+        "schema.cc",
     ],
     hdrs = [
         "flattened_schema.h",

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -46,6 +46,9 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "value",
+    srcs = [
+        "value.cc",
+    ],
     hdrs = [
         "value.h",
     ],
@@ -54,8 +57,10 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
+        "//src/v/utils:base64",
         "//src/v/utils:uuid",
         "@abseil-cpp//absl/numeric:int128",
+        "@seastar",
     ],
 )
 

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -96,6 +96,7 @@ redpanda_cc_library(
         ":schema",
         ":value",
         "//src/v/base",
+        "@boost//:range",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -96,9 +96,6 @@ redpanda_cc_library(
         ":schema",
         ":value",
         "//src/v/base",
-        "//src/v/bytes:iobuf",
-        "//src/v/container:fragmented_vector",
-        "//src/v/utils:vint",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -82,3 +82,23 @@ redpanda_cc_library(
         "//src/v/utils:vint",
     ],
 )
+
+redpanda_cc_library(
+    name = "shredder",
+    srcs = [
+        "shredder.cc",
+    ],
+    hdrs = [
+        "shredder.h",
+    ],
+    include_prefix = "serde/parquet",
+    deps = [
+        ":schema",
+        ":value",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:fragmented_vector",
+        "//src/v/utils:vint",
+        "@seastar",
+    ],
+)

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -5,6 +5,9 @@ v_cc_library(
     metadata.cc
     encoding.cc
     flattened_schema.cc
+    value.cc
+    schema.cc
+    shredder.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/serde/parquet/README.md
+++ b/src/v/serde/parquet/README.md
@@ -5,6 +5,15 @@ Due to Redpanda's usage of Seastar off the shelf preexisting parquet libraries d
 our strict requirements, imposed by our userland task scheduler and virtual memory avoiding 
 allocator.
 
+### Record Shredding
+
+Parquet shreds records into a columnar format using the [same algorithm][twitter-parquet] as published in the [Dremel
+paper][dremel]. A very helpful step by step explainer of the algorithm can be found [here][random-useful-wiki].
+Our implmentation of this can be found in `shredder.cc`.
+
+[random-useful-wiki]: https://github.com/julienledem/redelm/wiki/The-striping-and-assembly-algorithms-from-the-Dremel-paper#step-by-step
+[twitter-parquet]: https://blog.x.com/engineering/en_us/a/2013/dremel-made-simple-with-parquet
+[dremel]: https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36632.pdf
 
 ### Metadata
 

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -20,7 +20,7 @@ namespace {
 
 indexed_schema_element transform(int32_t index, const schema_element& root) {
     indexed_schema_element out{
-      .column_index = index,
+      .index = index,
       .type = root.type,
       .repetition_type = root.repetition_type,
       .name = root.name,
@@ -84,9 +84,9 @@ auto fmt::formatter<serde::parquet::indexed_schema_element>::format(
   fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{column_index: {}, type: {}, repetition_type: {}, name: {}, "
+      "{{index: {}, type: {}, repetition_type: {}, name: {}, "
       "logical_type: {}, field_id: {}, children: [{}]}}",
-      e.column_index,
+      e.index,
       e.type.index(),
       static_cast<uint8_t>(e.repetition_type),
       e.name,

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/schema.h"
+
+#include <ranges>
+#include <variant>
+
+namespace serde::parquet {
+
+namespace {
+
+indexed_schema_element transform(int32_t index, const schema_element& root) {
+    indexed_schema_element out{
+      .column_index = index,
+      .type = root.type,
+      .repetition_type = root.repetition_type,
+      .name = root.name,
+      .field_id = root.field_id,
+      .logical_type = root.logical_type,
+    };
+    out.children.reserve(root.children.size());
+    return out;
+}
+
+} // namespace
+
+bool schema_element::is_leaf() const {
+    return !std::holds_alternative<std::monostate>(type);
+}
+
+bool indexed_schema_element::is_leaf() const {
+    return !std::holds_alternative<std::monostate>(type);
+}
+
+indexed_schema_element index_schema(const schema_element& root) {
+    int32_t index = 0;
+    indexed_schema_element indexed_root = transform(index++, root);
+    chunked_vector<std::pair<indexed_schema_element*, const schema_element*>>
+      to_visit;
+    to_visit.reserve(root.children.size());
+    for (const auto& child : std::ranges::reverse_view(root.children)) {
+        to_visit.emplace_back(&indexed_root, &child);
+    }
+    while (!to_visit.empty()) {
+        const auto [parent, popped] = to_visit.back();
+        to_visit.pop_back();
+        indexed_schema_element* indexed = &parent->children.emplace_back(
+          transform(index++, *popped));
+        for (const auto& child : std::ranges::reverse_view(popped->children)) {
+            to_visit.emplace_back(indexed, &child);
+        }
+    }
+    return indexed_root;
+}
+
+} // namespace serde::parquet
+
+auto fmt::formatter<serde::parquet::schema_element>::format(
+  const serde::parquet::schema_element& e,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{type: {}, repetition_type: {}, name: {}, logical_type: {}, field_id: "
+      "{}, children: [{}]}}",
+      e.type.index(),
+      static_cast<uint8_t>(e.repetition_type),
+      e.name,
+      e.logical_type.index(),
+      e.field_id.value_or(-1),
+      fmt::join(e.children, ", "));
+}
+
+auto fmt::formatter<serde::parquet::indexed_schema_element>::format(
+  const serde::parquet::indexed_schema_element& e,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{column_index: {}, type: {}, repetition_type: {}, name: {}, "
+      "logical_type: {}, field_id: {}, children: [{}]}}",
+      e.column_index,
+      e.type.index(),
+      static_cast<uint8_t>(e.repetition_type),
+      e.name,
+      e.logical_type.index(),
+      e.field_id.value_or(-1),
+      fmt::join(e.children, ", "));
+}

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -16,50 +16,22 @@
 
 namespace serde::parquet {
 
-namespace {
-
-indexed_schema_element transform(int32_t index, const schema_element& root) {
-    indexed_schema_element out{
-      .index = index,
-      .type = root.type,
-      .repetition_type = root.repetition_type,
-      .name = root.name,
-      .field_id = root.field_id,
-      .logical_type = root.logical_type,
-    };
-    out.children.reserve(root.children.size());
-    return out;
-}
-
-} // namespace
-
 bool schema_element::is_leaf() const {
     return !std::holds_alternative<std::monostate>(type);
 }
 
-bool indexed_schema_element::is_leaf() const {
-    return !std::holds_alternative<std::monostate>(type);
-}
-
-indexed_schema_element index_schema(const schema_element& root) {
-    int32_t index = 0;
-    indexed_schema_element indexed_root = transform(index++, root);
-    chunked_vector<std::pair<indexed_schema_element*, const schema_element*>>
-      to_visit;
-    to_visit.reserve(root.children.size());
-    for (const auto& child : std::ranges::reverse_view(root.children)) {
-        to_visit.emplace_back(&indexed_root, &child);
-    }
+void index_schema(schema_element& root) {
+    int32_t position = 0;
+    chunked_vector<schema_element*> to_visit;
+    to_visit.push_back(&root);
     while (!to_visit.empty()) {
-        const auto [parent, popped] = to_visit.back();
+        schema_element* popped = to_visit.back();
         to_visit.pop_back();
-        indexed_schema_element* indexed = &parent->children.emplace_back(
-          transform(index++, *popped));
-        for (const auto& child : std::ranges::reverse_view(popped->children)) {
-            to_visit.emplace_back(indexed, &child);
+        popped->position = position++;
+        for (auto& child : std::ranges::reverse_view(popped->children)) {
+            to_visit.push_back(&child);
         }
     }
-    return indexed_root;
 }
 
 } // namespace serde::parquet
@@ -69,24 +41,9 @@ auto fmt::formatter<serde::parquet::schema_element>::format(
   fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{type: {}, repetition_type: {}, name: {}, logical_type: {}, field_id: "
-      "{}, children: [{}]}}",
-      e.type.index(),
-      static_cast<uint8_t>(e.repetition_type),
-      e.name,
-      e.logical_type.index(),
-      e.field_id.value_or(-1),
-      fmt::join(e.children, ", "));
-}
-
-auto fmt::formatter<serde::parquet::indexed_schema_element>::format(
-  const serde::parquet::indexed_schema_element& e,
-  fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(
-      ctx.out(),
-      "{{index: {}, type: {}, repetition_type: {}, name: {}, "
-      "logical_type: {}, field_id: {}, children: [{}]}}",
-      e.index,
+      "{{position: {}, type: {}, repetition_type: {}, name: {}, logical_type: "
+      "{}, field_id: {}, children: [{}]}}",
+      e.position,
       e.type.index(),
       static_cast<uint8_t>(e.repetition_type),
       e.name,

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -298,7 +298,7 @@ struct schema_element {
  */
 struct indexed_schema_element {
     /** the overall index of the schema element within the schema. */
-    int32_t column_index;
+    int32_t index;
 
     /**
      * The physical encoding of the data. Left unset for intermediate nodes.

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -246,7 +246,7 @@ struct schema_element {
      * repetition of the field. The root of the schema does not have a
      * repetition_type. All other nodes must have one.
      *
-     * (this field is ignored on the schema root).
+     * This must be set to required on the schema root
      */
     field_repetition_type repetition_type;
 
@@ -309,7 +309,7 @@ struct indexed_schema_element {
      * repetition of the field. The root of the schema does not have a
      * repetition_type. All other nodes must have one.
      *
-     * (this field is ignored on the schema root).
+     * This must be set to required on the schema root.
      */
     field_repetition_type repetition_type;
 

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -75,13 +75,35 @@ enum class field_repetition_type : uint8_t {
 };
 
 /** Empty structs to use as logical type annotations */
-struct string_type {}; // allowed for BYTE_ARRAY, must be encoded with UTF-8
-struct uuid_type {};   // allowed for FIXED[16], must encoded raw UUID bytes
-struct map_type {};    // see LogicalTypes.md
-struct list_type {};   // see LogicalTypes.md
-struct enum_type {};   // allowed for BYTE_ARRAY, must be encoded with UTF-8
-struct date_type {};   // allowed for INT32
-struct f16_type {};    // allowed for FIXED[2], must encoded raw FLOAT16 bytes
+
+// allowed for BYTE_ARRAY, must be encoded with UTF-8
+struct string_type {
+    bool operator==(const string_type&) const = default;
+};
+// allowed for FIXED[16], must encoded raw UUID bytes
+struct uuid_type {
+    bool operator==(const uuid_type&) const = default;
+};
+// see LogicalTypes.md
+struct map_type {
+    bool operator==(const map_type&) const = default;
+};
+// see LogicalTypes.md
+struct list_type {
+    bool operator==(const list_type&) const = default;
+};
+// allowed for BYTE_ARRAY, must be encoded with UTF-8
+struct enum_type {
+    bool operator==(const enum_type&) const = default;
+};
+// allowed for INT32
+struct date_type {
+    bool operator==(const date_type&) const = default;
+};
+// allowed for FIXED[2], must encoded raw FLOAT16 bytes
+struct f16_type {
+    bool operator==(const f16_type&) const = default;
+};
 
 /**
  * Logical type to annotate a column that is always null.
@@ -90,7 +112,9 @@ struct f16_type {};    // allowed for FIXED[2], must encoded raw FLOAT16 bytes
  * null and the physical type can't be determined. This annotation signals
  * the case where the physical type was guessed from all null values.
  */
-struct null_type {}; // allowed for any physical type, only null values stored
+struct null_type {
+    bool operator==(const null_type&) const = default;
+}; // allowed for any physical type, only null values stored
 
 /**
  * Decimal logical type annotation
@@ -107,6 +131,7 @@ struct null_type {}; // allowed for any physical type, only null values stored
 struct decimal_type {
     int32_t scale;
     int32_t precision;
+    bool operator==(const decimal_type&) const = default;
 };
 
 /**
@@ -129,6 +154,7 @@ enum class time_unit : int8_t {
 struct timestamp_type {
     bool is_adjusted_to_utc;
     time_unit unit;
+    bool operator==(const timestamp_type&) const = default;
 };
 
 /**
@@ -139,6 +165,7 @@ struct timestamp_type {
 struct time_type {
     bool is_adjusted_to_utc;
     time_unit unit;
+    bool operator==(const time_type&) const = default;
 };
 
 /**
@@ -151,6 +178,7 @@ struct time_type {
 struct int_type {
     int8_t bit_width = 0;
     bool is_signed = false;
+    bool operator==(const int_type&) const = default;
 };
 
 /**
@@ -158,14 +186,18 @@ struct int_type {
  *
  * Allowed for physical types: BYTE_ARRAY
  */
-struct json_type {};
+struct json_type {
+    bool operator==(const json_type&) const = default;
+};
 
 /**
  * Embedded BSON logical type annotation
  *
  * Allowed for physical types: BYTE_ARRAY
  */
-struct bson_type {};
+struct bson_type {
+    bool operator==(const bson_type&) const = default;
+};
 
 /**
  * LogicalType annotations to replace ConvertedType.
@@ -258,6 +290,7 @@ struct schema_element {
 
     /** If this is a leaf in the schema.*/
     bool is_leaf() const;
+    bool operator==(const schema_element&) const = default;
 };
 
 /**
@@ -301,6 +334,8 @@ struct indexed_schema_element {
 
     /** If this is a leaf in the schema.*/
     bool is_leaf() const;
+
+    bool operator==(const indexed_schema_element&) const = default;
 };
 
 /**

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -238,6 +238,13 @@ using logical_type = std::variant<
  */
 struct schema_element {
     /**
+     * The overall index of the schema element within the schema.
+     *
+     * This is effectively an ID for the schema_element.
+     */
+    int32_t position = -1;
+
+    /**
      * The physical encoding of the data. Left unset for intermediate nodes.
      */
     physical_type type;
@@ -294,54 +301,9 @@ struct schema_element {
 };
 
 /**
- * A schema_element with it's index within the tree when flattened.
+ * Index the schema such that the position is known for each element.
  */
-struct indexed_schema_element {
-    /** the overall index of the schema element within the schema. */
-    int32_t index;
-
-    /**
-     * The physical encoding of the data. Left unset for intermediate nodes.
-     */
-    physical_type type;
-
-    /**
-     * repetition of the field. The root of the schema does not have a
-     * repetition_type. All other nodes must have one.
-     *
-     * This must be set to required on the schema root.
-     */
-    field_repetition_type repetition_type;
-
-    /** Name of the field in the schema. */
-    ss::sstring name;
-
-    /**
-     * Nested fields.
-     */
-    chunked_vector<indexed_schema_element> children;
-
-    /**
-     * When the original schema supports field ids, this will save the
-     * original field id in the parquet schema
-     */
-    std::optional<int32_t> field_id;
-
-    /**
-     * For leaf nodes, the logical type the physical bytes represent.
-     */
-    logical_type logical_type;
-
-    /** If this is a leaf in the schema.*/
-    bool is_leaf() const;
-
-    bool operator==(const indexed_schema_element&) const = default;
-};
-
-/**
- * Index the schema such that the column index is known for each element.
- */
-indexed_schema_element index_schema(const schema_element& root);
+void index_schema(schema_element& root);
 
 } // namespace serde::parquet
 
@@ -350,12 +312,4 @@ struct fmt::formatter<serde::parquet::schema_element>
   : fmt::formatter<std::string_view> {
     auto format(const serde::parquet::schema_element&, fmt::format_context& ctx)
       const -> decltype(ctx.out());
-};
-
-template<>
-struct fmt::formatter<serde::parquet::indexed_schema_element>
-  : fmt::formatter<std::string_view> {
-    auto format(
-      const serde::parquet::indexed_schema_element&,
-      fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/shredder.h"
+
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "src/v/serde/parquet/schema.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <stdexcept>
+
+namespace serde::parquet {
+
+namespace {
+
+struct traversal_levels {
+    uint8_t repetition_depth;
+    uint8_t repetition_level;
+    uint8_t definition_level;
+};
+
+void for_each_required_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    void(const indexed_schema_element&, traversal_levels, value)> cb) {
+    ss::visit(
+      std::move(val),
+      [&element, levels, cb](struct_value& fields) {
+          if (fields.size() != element.children.size()) {
+              throw std::runtime_error(fmt::format(
+                "schema/struct mismatch, schema had {} children, struct had {} "
+                "fields. At column {}",
+                element.children.size(),
+                fields.size(),
+                element.column_index));
+          }
+          // Levels don't change for require elements because they always have
+          // to be there so no additional bits need to be tracked (they'd be
+          // wasteful).
+          for (size_t i = 0; i < element.children.size(); ++i) {
+              struct_field& member = fields[i];
+              const indexed_schema_element& child = element.children[i];
+              cb(child, levels, std::move(member.field));
+          }
+      },
+      [&element](null_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected null value for required schema element {}",
+            element.name));
+      },
+      [&element](list_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected list value for non-repeated schema element {}",
+            element.name));
+      },
+      [&element](map_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected map value for non-repeated schema element {}",
+            element.name));
+      },
+      [&element](auto& v) {
+          throw std::runtime_error(fmt::format(
+            "unexpected leaf value for required schema element {}: {}",
+            element.name,
+            value(std::move(v))));
+      });
+}
+
+void for_each_optional_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    void(const indexed_schema_element&, traversal_levels, value)> cb) {
+    ss::visit(
+      std::move(val),
+      [&element, levels, cb](struct_value& fields) {
+          if (fields.size() != element.children.size()) {
+              throw std::runtime_error(fmt::format(
+                "schema/struct mismatch, schema had {} children, struct had {} "
+                "fields. At column {}",
+                element.children.size(),
+                fields.size(),
+                element.column_index));
+          }
+          traversal_levels child_levels = levels;
+          // Increment the definition level as this node in the hierarchy is
+          // defined.
+          ++child_levels.definition_level;
+          for (size_t i = 0; i < element.children.size(); ++i) {
+              struct_field& member = fields[i];
+              const indexed_schema_element& child = element.children[i];
+              cb(child, child_levels, std::move(member.field));
+          }
+      },
+      [&element, levels, cb](null_value& v) {
+          // If the value is `null`, we use the parent definition_level so that
+          // assembly can determine where the `null` started.
+          for (const auto& child : element.children) {
+              cb(child, levels, value(v));
+          }
+      },
+      [&element](list_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected list value for non-repeated schema element {}",
+            element.name));
+      },
+      [&element](map_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected map value for non-repeated schema element {}",
+            element.name));
+      },
+      [&element](auto& v) {
+          throw std::runtime_error(fmt::format(
+            "unexpected leaf value for optional schema element {}: {}",
+            element.name,
+            value(std::move(v))));
+      });
+}
+
+void for_each_repeated_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    void(const indexed_schema_element&, traversal_levels, value)> cb) {
+    ss::visit(
+      std::move(val),
+      [&element, levels, cb](null_value& v) {
+          for_each_optional_child(v, element, levels, cb);
+      },
+      [&element, levels, cb](list_value& list) {
+          // Empty lists are equivalent to a `null` value.
+          if (list.empty()) {
+              for_each_optional_child(null_value(), element, levels, cb);
+              return;
+          }
+          traversal_levels child_levels = levels;
+          // We are marking that there is a higher depth here we
+          // need to record, but the repetition_level is only set
+          // *when* we are repeating (so not for the first element).
+          ++child_levels.repetition_depth;
+          for (auto& member : list) {
+              for_each_optional_child(
+                std::move(member.element), element, child_levels, cb);
+              child_levels.repetition_level = child_levels.repetition_depth;
+          }
+      },
+      [&element](map_value&) {
+          throw std::runtime_error(
+            fmt::format("TODO(rockwood) handle maps: {}", element.name));
+      },
+      [&element](struct_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected struct value for repeated schema element {}",
+            element.name));
+      },
+      [&element](auto& v) {
+          throw std::runtime_error(fmt::format(
+            "unexpected leaf value for repeated schema element {}: {}",
+            element.name,
+            value(std::move(v))));
+      });
+}
+
+void for_each_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    void(const indexed_schema_element&, traversal_levels, value)> cb) {
+    switch (element.repetition_type) {
+    case field_repetition_type::required:
+        for_each_required_child(std::move(val), element, levels, cb);
+        break;
+    case field_repetition_type::optional:
+        for_each_optional_child(std::move(val), element, levels, cb);
+        break;
+    case field_repetition_type::repeated:
+        for_each_repeated_child(std::move(val), element, levels, cb);
+        break;
+    }
+}
+
+void emit_leaf(
+  const indexed_schema_element& element,
+  value val,
+  traversal_levels levels,
+  absl::FunctionRef<void(shredded_value)> cb) {
+    ss::visit(
+      std::move(val),
+      [cb, &element, levels](list_value& list) {
+          // Empty lists are treated as `null`
+          if (list.empty()) {
+              emit_leaf(element, null_value(), levels, cb);
+              return;
+          }
+          traversal_levels child_levels = levels;
+          // We are marking that there is a higher depth here we
+          // need to record, but the repetition_level is only set
+          // *when* we are repeating (so not for the first element).
+          ++child_levels.repetition_depth;
+          for (auto& member : list) {
+              emit_leaf(element, std::move(member.element), child_levels, cb);
+              child_levels.repetition_level = child_levels.repetition_depth;
+          }
+      },
+      [&element](map_value&) {
+          throw std::runtime_error(
+            fmt::format("TODO(rockwood) handle maps: {}", element.name));
+      },
+      [&element](struct_value&) {
+          throw std::runtime_error(fmt::format(
+            "unexpected struct value for leaf schema element {}",
+            element.name));
+      },
+      [cb, &element, levels](null_value& v) {
+          cb({
+            .column_index = element.column_index,
+            .val = v,
+            .rep_level = levels.repetition_level,
+            .def_level = levels.definition_level,
+          });
+      },
+      [cb, &element, levels](auto& v) {
+          traversal_levels leaf_levels = levels;
+          if (element.repetition_type != field_repetition_type::required) {
+              ++leaf_levels.definition_level;
+          }
+          cb({
+            .column_index = element.column_index,
+            .val = value(std::move(v)),
+            .rep_level = leaf_levels.repetition_level,
+            .def_level = leaf_levels.definition_level,
+          });
+      });
+}
+
+void shred_record(
+  const indexed_schema_element& element,
+  value val,
+  traversal_levels levels,
+  absl::FunctionRef<void(shredded_value)> cb) {
+    if (element.is_leaf()) {
+        emit_leaf(element, std::move(val), levels, cb);
+    } else {
+        for_each_child(
+          std::move(val),
+          element,
+          levels,
+          [cb](
+            const indexed_schema_element& element,
+            traversal_levels levels,
+            value val) { shred_record(element, std::move(val), levels, cb); });
+    }
+}
+
+} // namespace
+
+void shred_record(
+  const indexed_schema_element& root,
+  struct_value record,
+  absl::FunctionRef<void(shredded_value)> callback) {
+    shred_record(root, std::move(record), traversal_levels{}, callback);
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -255,6 +255,9 @@ void shred_record(
   const indexed_schema_element& root,
   struct_value record,
   absl::FunctionRef<void(shredded_value)> callback) {
+    if (root.repetition_type != field_repetition_type::required) {
+        throw std::runtime_error("schema root nodes must be required");
+    }
     shred_record(root, std::move(record), traversal_levels{}, callback);
 }
 

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -44,7 +44,7 @@ void for_each_required_child(
                 "fields. At column {}",
                 element.children.size(),
                 fields.size(),
-                element.column_index));
+                element.index));
           }
           // Levels don't change for require elements because they always have
           // to be there so no additional bits need to be tracked (they'd be
@@ -88,7 +88,7 @@ void for_each_optional_child(
                 "fields. At column {}",
                 element.children.size(),
                 fields.size(),
-                element.column_index));
+                element.index));
           }
           traversal_levels child_levels = levels;
           // Increment the definition level as this node in the hierarchy is
@@ -210,7 +210,7 @@ void emit_leaf(
       },
       [cb, &element, levels](null_value& v) {
           cb({
-            .column_index = element.column_index,
+            .schema_element_index = element.index,
             .val = v,
             .rep_level = levels.repetition_level,
             .def_level = levels.definition_level,
@@ -222,7 +222,7 @@ void emit_leaf(
               ++leaf_levels.definition_level;
           }
           cb({
-            .column_index = element.column_index,
+            .schema_element_index = element.index,
             .val = value(std::move(v)),
             .rep_level = leaf_levels.repetition_level,
             .def_level = leaf_levels.definition_level,

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -29,187 +29,226 @@ struct traversal_levels {
     uint8_t definition_level;
 };
 
-void for_each_required_child(
-  value val,
+ss::future<> process_required_struct(
+  // NOLINTNEXTLINE(*reference*)
   const indexed_schema_element& element,
   traversal_levels levels,
+  struct_value fields,
   absl::FunctionRef<
-    void(const indexed_schema_element&, traversal_levels, value)> cb) {
-    ss::visit(
-      std::move(val),
-      [&element, levels, cb](struct_value& fields) {
-          if (fields.size() != element.children.size()) {
-              throw std::runtime_error(fmt::format(
-                "schema/struct mismatch, schema had {} children, struct had {} "
-                "fields. At column {}",
-                element.children.size(),
-                fields.size(),
-                element.index));
-          }
-          // Levels don't change for require elements because they always have
-          // to be there so no additional bits need to be tracked (they'd be
-          // wasteful).
-          for (size_t i = 0; i < element.children.size(); ++i) {
-              struct_field& member = fields[i];
-              const indexed_schema_element& child = element.children[i];
-              cb(child, levels, std::move(member.field));
-          }
-      },
-      [&element](null_value&) {
-          throw std::runtime_error(fmt::format(
-            "unexpected null value for required schema element {}",
-            element.name));
-      },
-      [&element](repeated_value&) {
-          throw std::runtime_error(fmt::format(
-            "unexpected list value for non-repeated schema element {}",
-            element.name));
-      },
-      [&element](auto& v) {
-          throw std::runtime_error(fmt::format(
-            "unexpected leaf value for required schema element {}: {}",
-            element.name,
-            value(std::move(v))));
-      });
-}
-
-void for_each_optional_child(
-  value val,
-  const indexed_schema_element& element,
-  traversal_levels levels,
-  absl::FunctionRef<
-    void(const indexed_schema_element&, traversal_levels, value)> cb) {
-    ss::visit(
-      std::move(val),
-      [&element, levels, cb](struct_value& fields) {
-          if (fields.size() != element.children.size()) {
-              throw std::runtime_error(fmt::format(
-                "schema/struct mismatch, schema had {} children, struct had {} "
-                "fields. At column {}",
-                element.children.size(),
-                fields.size(),
-                element.index));
-          }
-          traversal_levels child_levels = levels;
-          // Increment the definition level as this node in the hierarchy is
-          // defined.
-          ++child_levels.definition_level;
-          for (size_t i = 0; i < element.children.size(); ++i) {
-              struct_field& member = fields[i];
-              const indexed_schema_element& child = element.children[i];
-              cb(child, child_levels, std::move(member.field));
-          }
-      },
-      [&element, levels, cb](null_value& v) {
-          // If the value is `null`, we use the parent definition_level so that
-          // assembly can determine where the `null` started.
-          for (const auto& child : element.children) {
-              cb(child, levels, value(v));
-          }
-      },
-      [&element](repeated_value&) {
-          throw std::runtime_error(fmt::format(
-            "unexpected list value for non-repeated schema element {}",
-            element.name));
-      },
-      [&element](auto& v) {
-          throw std::runtime_error(fmt::format(
-            "unexpected leaf value for optional schema element {}: {}",
-            element.name,
-            value(std::move(v))));
-      });
-}
-
-void for_each_repeated_child(
-  value val,
-  const indexed_schema_element& element,
-  traversal_levels levels,
-  absl::FunctionRef<
-    void(const indexed_schema_element&, traversal_levels, value)> cb) {
-    ss::visit(
-      std::move(val),
-      [&element, levels, cb](null_value& v) {
-          for_each_optional_child(v, element, levels, cb);
-      },
-      [&element, levels, cb](repeated_value& list) {
-          // Empty lists are equivalent to a `null` value.
-          if (list.empty()) {
-              for_each_optional_child(null_value(), element, levels, cb);
-              return;
-          }
-          traversal_levels child_levels = levels;
-          // We are marking that there is a higher depth here we
-          // need to record, but the repetition_level is only set
-          // *when* we are repeating (so not for the first element).
-          ++child_levels.repetition_depth;
-          for (auto& member : list) {
-              for_each_optional_child(
-                std::move(member.element), element, child_levels, cb);
-              child_levels.repetition_level = child_levels.repetition_depth;
-          }
-      },
-      [&element](struct_value&) {
-          throw std::runtime_error(fmt::format(
-            "unexpected struct value for repeated schema element {}",
-            element.name));
-      },
-      [&element](auto& v) {
-          throw std::runtime_error(fmt::format(
-            "unexpected leaf value for repeated schema element {}: {}",
-            element.name,
-            value(std::move(v))));
-      });
-}
-
-void for_each_child(
-  value val,
-  const indexed_schema_element& element,
-  traversal_levels levels,
-  absl::FunctionRef<
-    void(const indexed_schema_element&, traversal_levels, value)> cb) {
-    switch (element.repetition_type) {
-    case field_repetition_type::required:
-        for_each_required_child(std::move(val), element, levels, cb);
-        break;
-    case field_repetition_type::optional:
-        for_each_optional_child(std::move(val), element, levels, cb);
-        break;
-    case field_repetition_type::repeated:
-        for_each_repeated_child(std::move(val), element, levels, cb);
-        break;
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    if (fields.size() != element.children.size()) {
+        throw std::runtime_error(fmt::format(
+          "schema/struct mismatch, schema had {} children, struct had {} "
+          "fields. At column {}",
+          element.children.size(),
+          fields.size(),
+          element.index));
+    }
+    // Levels don't change for require elements because they always have
+    // to be there so no additional bits need to be tracked (they'd be
+    // wasteful).
+    for (size_t i = 0; i < element.children.size(); ++i) {
+        struct_field& member = fields[i];
+        const indexed_schema_element& child = element.children[i];
+        co_await cb(child, levels, std::move(member.field));
     }
 }
 
-void emit_leaf(
+ss::future<> for_each_required_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    return ss::visit(
+      std::move(val),
+      [&element, levels, cb](struct_value& fields) -> ss::future<> {
+          return process_required_struct(
+            element, levels, std::move(fields), cb);
+      },
+      [&element](null_value&) -> ss::future<> {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected null value for required schema element {}",
+            element.name)));
+      },
+      [&element](repeated_value&) -> ss::future<> {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected list value for non-repeated schema element {}",
+            element.name)));
+      },
+      [&element](auto& v) -> ss::future<> {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected leaf value for required schema element {}: {}",
+            element.name,
+            value(std::move(v)))));
+      });
+}
+
+ss::future<> process_optional_struct(
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  struct_value fields,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    // Increment the definition level as this node in the hierarchy is
+    // defined.
+    ++levels.definition_level;
+    return process_required_struct(element, levels, std::move(fields), cb);
+}
+
+ss::future<> process_null_optional(
+  // NOLINTNEXTLINE(*reference*)
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    // If the value is `null`, we use the parent definition_level so that
+    // assembly can determine where the `null` started.
+    for (const auto& child : element.children) {
+        co_await cb(child, levels, null_value());
+    }
+}
+
+ss::future<> for_each_optional_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    return ss::visit(
+      std::move(val),
+      [&element, levels, cb](struct_value& fields) -> ss::future<> {
+          return process_optional_struct(
+            element, levels, std::move(fields), cb);
+      },
+      [&element, levels, cb](null_value&) -> ss::future<> {
+          return process_null_optional(element, levels, cb);
+      },
+      [&element](repeated_value&) -> ss::future<> {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected list value for non-repeated schema element {}",
+            element.name)));
+      },
+      [&element](auto& v) -> ss::future<> {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected leaf value for optional schema element {}: {}",
+            element.name,
+            value(std::move(v)))));
+      });
+}
+
+ss::future<> process_repeated(
+  // NOLINTNEXTLINE(*reference*)
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  repeated_value list,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    // Empty lists are equivalent to a `null` value.
+    if (list.empty()) {
+        co_return co_await for_each_optional_child(
+          null_value(), element, levels, cb);
+    }
+    traversal_levels child_levels = levels;
+    // We are marking that there is a higher depth here we
+    // need to record, but the repetition_level is only set
+    // *when* we are repeating (so not for the first element).
+    ++child_levels.repetition_depth;
+    for (auto& member : list) {
+        co_await for_each_optional_child(
+          std::move(member.element), element, child_levels, cb);
+        child_levels.repetition_level = child_levels.repetition_depth;
+    }
+}
+
+ss::future<> for_each_repeated_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    return ss::visit(
+      std::move(val),
+      [&element, levels, cb](null_value& v) {
+          return for_each_optional_child(v, element, levels, cb);
+      },
+      [&element, levels, cb](repeated_value& list) {
+          return process_repeated(element, levels, std::move(list), cb);
+      },
+      [&element](struct_value&) {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected struct value for repeated schema element {}",
+            element.name)));
+      },
+      [&element](auto& v) {
+          return ss::make_exception_future(std::runtime_error(fmt::format(
+            "unexpected leaf value for repeated schema element {}: {}",
+            element.name,
+            value(std::move(v)))));
+      });
+}
+
+ss::future<> for_each_child(
+  value val,
+  const indexed_schema_element& element,
+  traversal_levels levels,
+  absl::FunctionRef<
+    ss::future<>(const indexed_schema_element&, traversal_levels, value)> cb) {
+    switch (element.repetition_type) {
+    case field_repetition_type::required:
+        return for_each_required_child(std::move(val), element, levels, cb);
+    case field_repetition_type::optional:
+        return for_each_optional_child(std::move(val), element, levels, cb);
+    case field_repetition_type::repeated:
+        return for_each_repeated_child(std::move(val), element, levels, cb);
+    }
+}
+
+ss::future<> emit_leaf(
   const indexed_schema_element& element,
   value val,
   traversal_levels levels,
-  absl::FunctionRef<void(shredded_value)> cb) {
-    ss::visit(
+  absl::FunctionRef<ss::future<>(shredded_value)> cb);
+
+ss::future<> process_repeated_leaf(
+  // NOLINTNEXTLINE(*reference*)
+  const indexed_schema_element& element,
+  repeated_value list,
+  traversal_levels levels,
+  absl::FunctionRef<ss::future<>(shredded_value)> cb) {
+    // Empty lists are treated as `null`
+    if (list.empty()) {
+        co_return co_await emit_leaf(element, null_value(), levels, cb);
+    }
+    traversal_levels child_levels = levels;
+    // We are marking that there is a higher depth here we
+    // need to record, but the repetition_level is only set
+    // *when* we are repeating (so not for the first element).
+    ++child_levels.repetition_depth;
+    for (auto& member : list) {
+        co_await emit_leaf(
+          element, std::move(member.element), child_levels, cb);
+        child_levels.repetition_level = child_levels.repetition_depth;
+    }
+}
+
+ss::future<> emit_leaf(
+  const indexed_schema_element& element,
+  value val,
+  traversal_levels levels,
+  absl::FunctionRef<ss::future<>(shredded_value)> cb) {
+    return ss::visit(
       std::move(val),
       [cb, &element, levels](repeated_value& list) {
-          // Empty lists are treated as `null`
-          if (list.empty()) {
-              emit_leaf(element, null_value(), levels, cb);
-              return;
-          }
-          traversal_levels child_levels = levels;
-          // We are marking that there is a higher depth here we
-          // need to record, but the repetition_level is only set
-          // *when* we are repeating (so not for the first element).
-          ++child_levels.repetition_depth;
-          for (auto& member : list) {
-              emit_leaf(element, std::move(member.element), child_levels, cb);
-              child_levels.repetition_level = child_levels.repetition_depth;
-          }
+          return process_repeated_leaf(element, std::move(list), levels, cb);
       },
       [&element](struct_value&) {
-          throw std::runtime_error(fmt::format(
+          return ss::make_exception_future(std::runtime_error(fmt::format(
             "unexpected struct value for leaf schema element {}",
-            element.name));
+            element.name)));
       },
       [cb, &element, levels](null_value& v) {
-          cb({
+          return cb({
             .schema_element_index = element.index,
             .val = v,
             .rep_level = levels.repetition_level,
@@ -221,7 +260,7 @@ void emit_leaf(
           if (element.repetition_type != field_repetition_type::required) {
               ++leaf_levels.definition_level;
           }
-          cb({
+          return cb({
             .schema_element_index = element.index,
             .val = value(std::move(v)),
             .rep_level = leaf_levels.repetition_level,
@@ -230,35 +269,36 @@ void emit_leaf(
       });
 }
 
-void shred_record(
+ss::future<> shred_record(
+  // NOLINTNEXTLINE(*reference*)
   const indexed_schema_element& element,
   value val,
   traversal_levels levels,
-  absl::FunctionRef<void(shredded_value)> cb) {
+  absl::FunctionRef<ss::future<>(shredded_value)> cb) {
     if (element.is_leaf()) {
-        emit_leaf(element, std::move(val), levels, cb);
-    } else {
-        for_each_child(
-          std::move(val),
-          element,
-          levels,
-          [cb](
-            const indexed_schema_element& element,
-            traversal_levels levels,
-            value val) { shred_record(element, std::move(val), levels, cb); });
+        co_return co_await emit_leaf(element, std::move(val), levels, cb);
     }
+    auto callback = [cb](
+                      const indexed_schema_element& element,
+                      traversal_levels levels,
+                      value val) {
+        return shred_record(element, std::move(val), levels, cb);
+    };
+    // NOTE: This takes an absl::FunctionRef, so make sure to keep the callback
+    // alive on the stack and use a coroutine for this method.
+    co_await for_each_child(std::move(val), element, levels, callback);
 }
 
 } // namespace
 
-void shred_record(
+ss::future<> shred_record(
   const indexed_schema_element& root,
   struct_value record,
-  absl::FunctionRef<void(shredded_value)> callback) {
+  absl::FunctionRef<ss::future<>(shredded_value)> callback) {
     if (root.repetition_type != field_repetition_type::required) {
         throw std::runtime_error("schema root nodes must be required");
     }
-    shred_record(root, std::move(record), traversal_levels{}, callback);
+    return shred_record(root, std::move(record), traversal_levels{}, callback);
 }
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -23,10 +23,19 @@ namespace serde::parquet {
 
 namespace {
 
+// A struct to track all the level related information we need during the tree
+// shredding traversal.
 struct traversal_levels {
-    uint8_t repetition_depth;
-    uint8_t repetition_level;
-    uint8_t definition_level;
+    uint8_t repetition_level = 0;
+    uint8_t definition_level = 0;
+    // repetition_depth is the current number of ancestor schema nodes in the
+    // schema tree that are set to be repeated. We track this seperately because
+    // repeated is only set for the additional values in the repeated node, so
+    // the first time we repeat we need to use the current repetition_level so
+    // that assembly knows at which level the repetition is starting at, but
+    // additional repetitions need to use the current repetition_depth as the
+    // repetition_level.
+    uint8_t repetition_depth = 0;
 };
 
 ss::future<> process_required_struct(

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -18,7 +18,7 @@ namespace serde::parquet {
 // (for determining list index) and definition level (for
 // determining where the null value in the hierarchy is).
 struct shredded_value {
-    int32_t column_index;
+    int32_t schema_element_index;
     value val;
     uint8_t rep_level;
     uint8_t def_level;

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+
+namespace serde::parquet {
+
+// A shredded value that has an assigned repetition level
+// (for determining list index) and definition level (for
+// determining where the null value in the hierarchy is).
+struct shredded_value {
+    int32_t column_index;
+    value val;
+    uint8_t rep_level;
+    uint8_t def_level;
+};
+
+// Preform the dremel record shredding algoritm on this struct,
+// emitting shredded_values as they are emitted.
+void shred_record(
+  const indexed_schema_element& root,
+  struct_value record,
+  absl::FunctionRef<void(shredded_value)> callback);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -21,7 +21,7 @@ namespace serde::parquet {
 // (for determining list index) and definition level (for
 // determining where the null value in the hierarchy is).
 struct shredded_value {
-    int32_t schema_element_index;
+    int32_t schema_element_position;
     value val;
     uint8_t rep_level;
     uint8_t def_level;
@@ -30,7 +30,7 @@ struct shredded_value {
 // Preform the dremel record shredding algoritm on this struct,
 // emitting shredded_values as they are emitted.
 ss::future<> shred_record(
-  const indexed_schema_element& root,
+  const schema_element& root,
   struct_value record,
   absl::FunctionRef<ss::future<>(shredded_value)> callback);
 

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -9,8 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
+#include "base/seastarx.h"
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
+
+#include <seastar/core/future.hh>
 
 namespace serde::parquet {
 
@@ -26,9 +29,9 @@ struct shredded_value {
 
 // Preform the dremel record shredding algoritm on this struct,
 // emitting shredded_values as they are emitted.
-void shred_record(
+ss::future<> shred_record(
   const indexed_schema_element& root,
   struct_value record,
-  absl::FunctionRef<void(shredded_value)> callback);
+  absl::FunctionRef<ss::future<>(shredded_value)> callback);
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -29,6 +29,10 @@ struct shredded_value {
 
 // Preform the dremel record shredding algoritm on this struct,
 // emitting shredded_values as they are emitted.
+//
+// NOTE: the caller is responsible for ensuring that the schema
+// element and the callback both live until the returned future
+// completes.
 ss::future<> shred_record(
   const schema_element& root,
   group_value record,

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -31,7 +31,7 @@ struct shredded_value {
 // emitting shredded_values as they are emitted.
 ss::future<> shred_record(
   const schema_element& root,
-  struct_value record,
+  group_value record,
   absl::FunctionRef<ss::future<>(shredded_value)> callback);
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -19,6 +19,24 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "shredder_test",
+    timeout = "short",
+    srcs = [
+        "shredder_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:shredder",
+        "//src/v/serde/parquet:value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_binary(
     name = "generate_metadata_binary",
     srcs = ["generate_metadata.cc"],

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -20,6 +20,22 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "schema_test",
+    timeout = "short",
+    srcs = [
+        "schema_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/serde/parquet:schema",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "shredder_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/schema_test.cc
+++ b/src/v/serde/parquet/tests/schema_test.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/schema.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+namespace {
+template<typename... Args>
+schema_element
+group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
+    chunked_vector<schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .children = std::move(children),
+    };
+}
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .logical_type = ltype,
+    };
+}
+
+template<typename... Args>
+indexed_schema_element indexed_group_node(
+  int32_t index,
+  ss::sstring name,
+  field_repetition_type rep_type,
+  Args... args) {
+    chunked_vector<indexed_schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .column_index = index,
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .children = std::move(children),
+    };
+}
+
+indexed_schema_element indexed_leaf_node(
+  int32_t index,
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .column_index = index,
+      .type = ptype,
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .logical_type = ltype,
+    };
+}
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+TEST(Schema, CanBeIndexed) {
+    using field_repetition_type::optional;
+    using field_repetition_type::repeated;
+    using field_repetition_type::required;
+    auto root = group_node(
+      "schema",
+      required,
+      group_node(
+        "persons",
+        optional,
+        group_node(
+          "persons_tuple",
+          repeated,
+          group_node(
+            "name",
+            required,
+            leaf_node("first_name", optional, byte_array_type(), string_type()),
+            leaf_node("last_name", required, byte_array_type(), string_type())),
+          leaf_node("id", optional, i32_type()),
+          leaf_node("email", required, byte_array_type(), string_type()),
+          group_node(
+            "phones",
+            repeated,
+            group_node(
+              "phones_tuple",
+              repeated,
+              leaf_node("number", optional, byte_array_type(), string_type()),
+              leaf_node("type", optional, byte_array_type(), enum_type()))))));
+    auto indexed = index_schema(root);
+    auto expected = indexed_group_node(
+      0,
+      "schema",
+      required,
+      indexed_group_node(
+        1,
+        "persons",
+        optional,
+        indexed_group_node(
+          2,
+          "persons_tuple",
+          repeated,
+          indexed_group_node(
+            3,
+            "name",
+            required,
+            indexed_leaf_node(
+              4, "first_name", optional, byte_array_type(), string_type()),
+            indexed_leaf_node(
+              5, "last_name", required, byte_array_type(), string_type())),
+          indexed_leaf_node(6, "id", optional, i32_type()),
+          indexed_leaf_node(
+            7, "email", required, byte_array_type(), string_type()),
+          indexed_group_node(
+            8,
+            "phones",
+            repeated,
+            indexed_group_node(
+              9,
+              "phones_tuple",
+              repeated,
+              indexed_leaf_node(
+                10, "number", optional, byte_array_type(), string_type()),
+              indexed_leaf_node(
+                11, "type", optional, byte_array_type(), enum_type()))))));
+    EXPECT_EQ(indexed, expected);
+}
+// NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/tests/schema_test.cc
+++ b/src/v/serde/parquet/tests/schema_test.cc
@@ -51,7 +51,7 @@ indexed_schema_element indexed_group_node(
     chunked_vector<indexed_schema_element> children;
     (children.push_back(std::move(args)), ...);
     return {
-      .column_index = index,
+      .index = index,
       .type = std::monostate{},
       .repetition_type = rep_type,
       .name = std::move(name),
@@ -66,7 +66,7 @@ indexed_schema_element indexed_leaf_node(
   physical_type ptype,
   logical_type ltype = logical_type{}) {
     return {
-      .column_index = index,
+      .index = index,
       .type = ptype,
       .repetition_type = rep_type,
       .name = std::move(name),

--- a/src/v/serde/parquet/tests/schema_test.cc
+++ b/src/v/serde/parquet/tests/schema_test.cc
@@ -43,15 +43,15 @@ schema_element leaf_node(
 }
 
 template<typename... Args>
-indexed_schema_element indexed_group_node(
+schema_element indexed_group_node(
   int32_t index,
   ss::sstring name,
   field_repetition_type rep_type,
   Args... args) {
-    chunked_vector<indexed_schema_element> children;
+    chunked_vector<schema_element> children;
     (children.push_back(std::move(args)), ...);
     return {
-      .index = index,
+      .position = index,
       .type = std::monostate{},
       .repetition_type = rep_type,
       .name = std::move(name),
@@ -59,14 +59,14 @@ indexed_schema_element indexed_group_node(
     };
 }
 
-indexed_schema_element indexed_leaf_node(
+schema_element indexed_leaf_node(
   int32_t index,
   ss::sstring name,
   field_repetition_type rep_type,
   physical_type ptype,
   logical_type ltype = logical_type{}) {
     return {
-      .index = index,
+      .position = index,
       .type = ptype,
       .repetition_type = rep_type,
       .name = std::move(name),
@@ -104,7 +104,7 @@ TEST(Schema, CanBeIndexed) {
               repeated,
               leaf_node("number", optional, byte_array_type(), string_type()),
               leaf_node("type", optional, byte_array_type(), enum_type()))))));
-    auto indexed = index_schema(root);
+    index_schema(root);
     auto expected = indexed_group_node(
       0,
       "schema",
@@ -140,6 +140,7 @@ TEST(Schema, CanBeIndexed) {
                 10, "number", optional, byte_array_type(), string_type()),
               indexed_leaf_node(
                 11, "type", optional, byte_array_type(), enum_type()))))));
-    EXPECT_EQ(indexed, expected);
+    EXPECT_EQ(root, expected)
+      << fmt::format("root={}\nexpected={}", root, expected);
 }
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -75,7 +75,7 @@ struct value_collector {
     }
 
     void operator()(shredded_value val) const {
-        auto it = column_mapping.find(val.column_index);
+        auto it = column_mapping.find(val.schema_element_index);
         ASSERT_NE(it, column_mapping.end()) << "invalid column index";
         columns[it->second].push_back(std::move(val));
     }

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "serde/parquet/shredder.h"
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+using namespace serde::parquet;
+
+namespace {
+template<typename... Args>
+schema_element
+group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
+    chunked_vector<schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .children = std::move(children),
+    };
+}
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .name = std::move(name),
+      .logical_type = ltype,
+    };
+}
+
+template<typename... Args>
+struct_value record(Args... field) {
+    chunked_vector<struct_field> fields;
+    (fields.push_back(struct_field{std::move(field)}), ...);
+    return fields;
+}
+
+template<typename... Args>
+list_value list(Args... field) {
+    chunked_vector<list_element> fields;
+    (fields.push_back(list_element{std::move(field)}), ...);
+    return fields;
+}
+
+struct value_collector {
+    explicit value_collector(const schema_element& root) {
+        int32_t col_index = 0;
+        root.for_each([this, &col_index](const schema_element& node) {
+            int32_t my_index = col_index++;
+            if (!node.is_leaf()) {
+                // Skip inner nodes.
+                return;
+            }
+            column_mapping[my_index] = columns.size();
+            columns.emplace_back();
+        });
+    }
+
+    void operator()(shredded_value val) const {
+        auto it = column_mapping.find(val.column_index);
+        ASSERT_NE(it, column_mapping.end()) << "invalid column index";
+        columns[it->second].push_back(std::move(val));
+    }
+
+    std::unordered_map<int32_t, size_t> column_mapping;
+    mutable chunked_vector<chunked_vector<shredded_value>> columns;
+};
+
+MATCHER_P3(IsVal, val, r, d, "") {
+    return fmt::format("{}", arg.val) == val && r == arg.rep_level
+           && d == arg.def_level;
+}
+
+} // namespace
+
+// NOLINTNEXTLINE(*internal-linkage*)
+void PrintTo(
+  const chunked_vector<chunked_vector<shredded_value>>& columns,
+  std::ostream* os) {
+    *os << "[\n";
+    for (const auto& column : columns) {
+        *os << "  [\n";
+        for (const auto& val : column) {
+            *os << fmt::format(
+              "    {{val: {}, r: {}, d: {}}}\n",
+              val.val,
+              val.rep_level,
+              val.def_level);
+        }
+        *os << "  ]\n";
+    }
+    *os << "]\n";
+}
+
+using testing::ElementsAre;
+
+// NOLINTBEGIN(*magic-number*)
+TEST(RecordShredding, ExampleFromDremelPaper) {
+    schema_element document_schema = group_node(
+      "Document",
+      field_repetition_type::required,
+      leaf_node("DocId", field_repetition_type::required, i64_type{}),
+      group_node(
+        "Links",
+        field_repetition_type::optional,
+        leaf_node("Forward", field_repetition_type::repeated, i64_type{}),
+        leaf_node("Backward", field_repetition_type::repeated, i64_type{})),
+      group_node(
+        "Name",
+        field_repetition_type::repeated,
+        group_node(
+          "Language",
+          field_repetition_type::repeated,
+          leaf_node(
+            "Code",
+            field_repetition_type::required,
+            byte_array_type{},
+            string_type{}),
+          leaf_node(
+            "Country",
+            field_repetition_type::optional,
+            byte_array_type{},
+            string_type{})),
+        leaf_node(
+          "Url",
+          field_repetition_type::optional,
+          byte_array_type{},
+          string_type{})));
+    struct_value r1 = record(
+      /*DocId*/ int64_value(10),
+      /*Links*/
+      record(
+        /*Forward*/ list(int64_value(20), int64_value(40), int64_value(60)),
+        /*Backward*/ list()),
+      list(
+        /*Name*/
+        record(
+          list(
+            /*Language*/
+            record(
+              /*Code*/
+              string_value(iobuf::from("en-us")),
+              /*Country*/
+              string_value(iobuf::from("us"))),
+            /*Language*/
+            record(string_value(iobuf::from("en")), null_value())),
+          /*Url*/
+          string_value(iobuf::from("http://A"))),
+        /*Name*/
+        record(
+          list(),
+          /*Url*/
+          string_value(iobuf::from("http://B"))),
+        /*Name*/
+        record(
+          list(
+            /*Language*/
+            record(
+              /*Code*/
+              string_value(iobuf::from("en-gb")),
+              /*Country*/
+              string_value(iobuf::from("gb")))),
+          /*Url*/
+          null_value())));
+    struct_value r2 = record(
+      /*DocId*/ int64_value(20),
+      /*Links*/
+      record(
+        /*Forward*/ list(int64_value(80)),
+        /*Backward*/ list(int64_value(10), int64_value(30))),
+      /*Name*/
+      list(record(
+        /*Language*/
+        list_value(),
+        /*Url*/
+        string_value(iobuf::from("http://C")))));
+    value_collector collector(document_schema);
+    auto indexed_schema = index_schema(document_schema);
+    shred_record(indexed_schema, std::move(r1), collector);
+    shred_record(indexed_schema, std::move(r2), collector);
+    EXPECT_THAT(
+      collector.columns,
+      ElementsAre(
+        // DocId
+        ElementsAre(IsVal("10", 0, 0), IsVal("20", 0, 0)),
+        // Links.Forward
+        ElementsAre(
+          IsVal("20", 0, 2),
+          IsVal("40", 1, 2),
+          IsVal("60", 1, 2),
+          IsVal("80", 0, 2)),
+        // Links.Backward
+        ElementsAre(IsVal("NULL", 0, 1), IsVal("10", 0, 2), IsVal("30", 1, 2)),
+        // Name.Language.Code
+        ElementsAre(
+          IsVal("en-us", 0, 2),
+          IsVal("en", 2, 2),
+          IsVal("NULL", 1, 1),
+          IsVal("en-gb", 1, 2),
+          IsVal("NULL", 0, 1)),
+        // Name.Language.Country
+        ElementsAre(
+          IsVal("us", 0, 3),
+          IsVal("NULL", 2, 2),
+          IsVal("NULL", 1, 1),
+          IsVal("gb", 1, 3),
+          IsVal("NULL", 0, 1)),
+        // Name.Url
+        ElementsAre(
+          IsVal("http://A", 0, 2),
+          IsVal("http://B", 1, 2),
+          IsVal("NULL", 1, 1),
+          IsVal("http://C", 0, 2))));
+}
+// NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -54,9 +54,9 @@ struct_value record(Args... field) {
 }
 
 template<typename... Args>
-list_value list(Args... field) {
-    chunked_vector<list_element> fields;
-    (fields.push_back(list_element{std::move(field)}), ...);
+repeated_value list(Args... field) {
+    chunked_vector<repeated_element> fields;
+    (fields.push_back(repeated_element{std::move(field)}), ...);
     return fields;
 }
 
@@ -189,7 +189,7 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
       /*Name*/
       list(record(
         /*Language*/
-        list_value(),
+        repeated_value(),
         /*Url*/
         string_value(iobuf::from("http://C")))));
     value_collector collector(document_schema);

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -411,4 +411,26 @@ TEST(RecordShredding, AddressBookExample) {
           IsVal("NULL", 0, 0))));
 }
 
+TEST(RecordShredding, RequiredGroupWrappedInOptionalGroup) {
+    schema_element schema = group_node(
+      "Root",
+      field_repetition_type::required,
+      group_node(
+        "optional",
+        field_repetition_type::optional,
+        group_node(
+          "required",
+          field_repetition_type::required,
+          leaf_node("leaf", field_repetition_type::required, i32_type()))));
+    group_value r1 = record(null_value());
+    group_value r2 = record(record(record(int32_value(42))));
+    index_schema(schema);
+    value_collector collector(schema);
+    shred_record(schema, std::move(r1), collector).get();
+    shred_record(schema, std::move(r2), collector).get();
+    EXPECT_THAT(
+      collector.columns,
+      ElementsAre(ElementsAre(IsVal("NULL", 0, 0), IsVal("42", 0, 1))));
+}
+
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/tests/value_test.cc
+++ b/src/v/serde/parquet/tests/value_test.cc
@@ -18,18 +18,11 @@
 using namespace serde::parquet;
 
 TEST(Value, Lists) {
-    chunked_vector<list_element> list;
+    chunked_vector<repeated_element> list;
     // It's not actually valid to have heterogenuous lists in parquet, but
     // our current encoding of the data structures isn't that strict.
     list.emplace_back(int32_value(2));
     list.emplace_back(boolean_value(true));
     value v = std::move(list);
-    EXPECT_TRUE(std::holds_alternative<chunked_vector<list_element>>(v));
-}
-
-TEST(Value, Maps) {
-    chunked_vector<map_entry> map;
-    map.emplace_back(int32_value(2), std::make_optional(boolean_value(true)));
-    value v = std::move(map);
-    EXPECT_TRUE(std::holds_alternative<chunked_vector<map_entry>>(v));
+    EXPECT_TRUE(std::holds_alternative<chunked_vector<repeated_element>>(v));
 }

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/value.h"
+
+#include "utils/base64.h"
+
+#include <seastar/util/variant_utils.hh>
+
+auto fmt::formatter<serde::parquet::value>::format(
+  const serde::parquet::value& val,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    using namespace serde::parquet;
+    return ss::visit(
+      val,
+      [&ctx](const null_value&) { return fmt::format_to(ctx.out(), "NULL"); },
+      [&ctx](const boolean_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const int32_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const int64_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const float32_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const float64_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const decimal_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const date_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const time_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const timestamp_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const string_value& v) {
+          ss::sstring raw;
+          for (const auto& e : v.val) {
+              raw.append(e.get(), e.size());
+          }
+          return fmt::format_to(ctx.out(), "{}", raw);
+      },
+      [&ctx](const uuid_value& v) {
+          return fmt::format_to(ctx.out(), "{}", v.val);
+      },
+      [&ctx](const byte_array_value& v) {
+          return fmt::format_to(ctx.out(), "{}", iobuf_to_base64(v.val));
+      },
+      [&ctx](const fixed_byte_array_value& v) {
+          return fmt::format_to(ctx.out(), "{}", iobuf_to_base64(v.val));
+      },
+      [&ctx](const struct_value& v) {
+          return fmt::format_to(ctx.out(), "({})", fmt::join(v, ", "));
+      },
+      [&ctx](const list_value& v) {
+          return fmt::format_to(ctx.out(), "[{}]", fmt::join(v, ", "));
+      },
+      [&ctx](const map_value& v) {
+          return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(v, ", "));
+      });
+}
+
+auto fmt::formatter<serde::parquet::struct_field>::format(
+  const serde::parquet::struct_field& f,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", f.field);
+}
+
+auto fmt::formatter<serde::parquet::list_element>::format(
+  const serde::parquet::list_element& e, fmt::format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", e.element);
+}
+
+auto fmt::formatter<serde::parquet::map_entry>::format(
+  const serde::parquet::map_entry& e, fmt::format_context& ctx) const
+  -> decltype(ctx.out()) {
+    if (e.val.has_value()) {
+        return fmt::format_to(ctx.out(), "{}: {}", e.key, e.val.value());
+    }
+    return fmt::format_to(ctx.out(), "{}", e.key);
+}

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -68,11 +68,8 @@ auto fmt::formatter<serde::parquet::value>::format(
       [&ctx](const struct_value& v) {
           return fmt::format_to(ctx.out(), "({})", fmt::join(v, ", "));
       },
-      [&ctx](const list_value& v) {
+      [&ctx](const repeated_value& v) {
           return fmt::format_to(ctx.out(), "[{}]", fmt::join(v, ", "));
-      },
-      [&ctx](const map_value& v) {
-          return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(v, ", "));
       });
 }
 
@@ -82,17 +79,8 @@ auto fmt::formatter<serde::parquet::struct_field>::format(
     return fmt::format_to(ctx.out(), "{}", f.field);
 }
 
-auto fmt::formatter<serde::parquet::list_element>::format(
-  const serde::parquet::list_element& e, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
+auto fmt::formatter<serde::parquet::repeated_element>::format(
+  const serde::parquet::repeated_element& e,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", e.element);
-}
-
-auto fmt::formatter<serde::parquet::map_entry>::format(
-  const serde::parquet::map_entry& e, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
-    if (e.val.has_value()) {
-        return fmt::format_to(ctx.out(), "{}: {}", e.key, e.val.value());
-    }
-    return fmt::format_to(ctx.out(), "{}", e.key);
 }

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -65,7 +65,7 @@ auto fmt::formatter<serde::parquet::value>::format(
       [&ctx](const fixed_byte_array_value& v) {
           return fmt::format_to(ctx.out(), "{}", iobuf_to_base64(v.val));
       },
-      [&ctx](const struct_value& v) {
+      [&ctx](const group_value& v) {
           return fmt::format_to(ctx.out(), "({})", fmt::join(v, ", "));
       },
       [&ctx](const repeated_value& v) {
@@ -73,8 +73,8 @@ auto fmt::formatter<serde::parquet::value>::format(
       });
 }
 
-auto fmt::formatter<serde::parquet::struct_field>::format(
-  const serde::parquet::struct_field& f,
+auto fmt::formatter<serde::parquet::group_member>::format(
+  const serde::parquet::group_member& f,
   fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", f.field);
 }

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -124,3 +124,33 @@ struct map_entry {
 };
 
 } // namespace serde::parquet
+
+template<>
+struct fmt::formatter<serde::parquet::value>
+  : fmt::formatter<std::string_view> {
+    auto format(const serde::parquet::value&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<serde::parquet::struct_field>
+  : fmt::formatter<std::string_view> {
+    auto format(const serde::parquet::struct_field&, fmt::format_context& ctx)
+      const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<serde::parquet::list_element>
+  : fmt::formatter<std::string_view> {
+    auto
+    format(const serde::parquet::list_element&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<serde::parquet::map_entry>
+  : fmt::formatter<std::string_view> {
+    auto
+    format(const serde::parquet::map_entry&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -78,6 +78,14 @@ struct fixed_byte_array_value {
 
 struct list_element;
 struct map_entry;
+struct struct_field;
+
+// The struct field ordering here matters - it must be the same as specified in
+// the schema.
+using struct_value = chunked_vector<struct_field>;
+
+using list_value = chunked_vector<list_element>;
+using map_value = chunked_vector<map_entry>;
 
 // Parquet proper actually supports a lot more types than this, but we only need
 // a few of them for iceberg.
@@ -96,8 +104,13 @@ using value = std::variant<
   uuid_value,
   byte_array_value,
   fixed_byte_array_value,
-  chunked_vector<list_element>,
-  chunked_vector<map_entry>>;
+  struct_value,
+  map_value,
+  list_value>;
+
+struct struct_field {
+    value field;
+};
 
 struct list_element {
     value element;

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -77,18 +77,19 @@ struct fixed_byte_array_value {
 };
 
 struct repeated_element;
-struct struct_field;
+struct group_member;
 
-// The struct field ordering here matters - it must be the same as specified in
+// The group member ordering here matters - it must be the same as specified in
 // the schema.
 //
-// This maps to any group node or non-leaf element in a schema.
-using struct_value = chunked_vector<struct_field>;
+// This maps to any "group node" (protobuf v2 naming) or non-leaf element in a
+// schema.
+using group_value = chunked_vector<group_member>;
 
 // Repeated values are what should wrap any repeated value in the schema,
-// it does *not* directly encode a logical list type value. See the parquet
-// spec on logical types for more information about how translate logical lists
-// into a parquet schema.
+// it does *not* directly encode a logical list type value (this is the same as
+// protocol buffer semantics). See the parquet spec on logical types for more
+// information about how translate logical lists into a parquet schema.
 using repeated_value = chunked_vector<repeated_element>;
 
 // Parquet proper actually supports a lot more types than this, but we only need
@@ -108,10 +109,10 @@ using value = std::variant<
   uuid_value,
   byte_array_value,
   fixed_byte_array_value,
-  struct_value,
+  group_value,
   repeated_value>;
 
-struct struct_field {
+struct group_member {
     value field;
 };
 
@@ -129,9 +130,9 @@ struct fmt::formatter<serde::parquet::value>
 };
 
 template<>
-struct fmt::formatter<serde::parquet::struct_field>
+struct fmt::formatter<serde::parquet::group_member>
   : fmt::formatter<std::string_view> {
-    auto format(const serde::parquet::struct_field&, fmt::format_context& ctx)
+    auto format(const serde::parquet::group_member&, fmt::format_context& ctx)
       const -> decltype(ctx.out());
 };
 


### PR DESCRIPTION
- **parquet/value: support struct types**
- **parquet/value: add formatter for values**
- **parquet/schema: add indexed schema element**
- **serde/parquet: record shredding algorithm implementation**


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
