### PR TITLE
AVRO to Iceberg schema conversion for datalake

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -326,3 +326,22 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "schema_avro",
+    srcs = [
+        "schema_avro.cc",
+    ],
+    hdrs = [
+        "schema_avro.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":conversion_outcome",
+        "//src/v/iceberg:datatypes",
+        "@avro",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -37,6 +37,7 @@ v_cc_library(
     record_multiplexer.cc
     schema_registry.cc
     schemaless_translator.cc
+    schema_avro.cc
     schema_protobuf.cc
     partitioning_writer.cc
     protobuf_utils.cc

--- a/src/v/datalake/schema_avro.cc
+++ b/src/v/datalake/schema_avro.cc
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/schema_avro.h"
+
+#include <seastar/util/defer.hh>
+
+#include <avro/Schema.hh>
+namespace datalake {
+
+namespace {
+static constexpr size_t max_schema_depth = 100;
+struct state {
+    chunked_vector<avro::NodePtr> type_hierarchy;
+    iceberg::nested_field::id_t last_field_id{0};
+
+    iceberg::nested_field::id_t next_field_id() { return last_field_id++; }
+};
+
+conversion_outcome<std::optional<iceberg::field_type>>
+field_type_from_avro(const avro::NodePtr& node, state& state);
+
+conversion_outcome<iceberg::struct_type>
+struct_from_avro_record(const avro::NodePtr& node, state& state) {
+    iceberg::struct_type ret;
+    ret.fields.reserve(node->leaves());
+    for (size_t i = 0; i < node->leaves(); ++i) {
+        auto leaf = node->leafAt(i);
+
+        auto result = field_type_from_avro(leaf, state);
+        if (result.has_error()) {
+            return result.error();
+        }
+
+        auto field = std::move(result.value());
+        if (field.has_value()) {
+            ret.fields.push_back(iceberg::nested_field::create(
+              state.next_field_id(),
+              node->nameAt(i),
+              iceberg::field_required::yes,
+              std::move(field.value())));
+        }
+    }
+    return ret;
+}
+
+iceberg::decimal_type create_decimal(const avro::NodePtr& node) {
+    return iceberg::decimal_type{
+      .precision = static_cast<uint32_t>(node->logicalType().precision()),
+      .scale = static_cast<uint32_t>(node->logicalType().scale())};
+}
+
+bool is_recursive_type(const state& state, const avro::NodePtr& node) {
+    for (auto& n : state.type_hierarchy) {
+        if (node == n) {
+            return true;
+        }
+    }
+    return false;
+}
+
+conversion_outcome<std::optional<iceberg::field_type>>
+inner_field_type_from_avro(const avro::NodePtr& node, state& state) {
+    if (is_recursive_type(state, node)) {
+        return schema_conversion_exception(
+          fmt::format("Unsupported recursive type: {}", *node));
+    }
+    if (state.type_hierarchy.size() >= max_schema_depth) {
+        return schema_conversion_exception(
+          fmt::format("Max nesting depth of {} reached", max_schema_depth));
+    }
+
+    state.type_hierarchy.push_back(node);
+    auto deferred_pop = ss::defer(
+      [&state] { state.type_hierarchy.pop_back(); });
+
+    switch (node->type()) {
+    case avro::AVRO_STRING:
+        if (node->logicalType().type() == avro::LogicalType::UUID) {
+            return iceberg::uuid_type{};
+        }
+
+        return iceberg::string_type{};
+    case avro::AVRO_BYTES:
+        if (node->logicalType().type() == avro::LogicalType::DECIMAL) {
+            return create_decimal(node);
+        }
+        return iceberg::binary_type{};
+    case avro::AVRO_INT: {
+        auto lt = node->logicalType().type();
+        if (lt == avro::LogicalType::DATE) {
+            return iceberg::date_type{};
+        }
+        if (lt == avro::LogicalType::TIME_MILLIS) {
+            return iceberg::time_type{};
+        }
+        return iceberg::int_type{};
+    }
+    case avro::AVRO_LONG: {
+        auto lt = node->logicalType().type();
+        if (lt == avro::LogicalType::TIME_MICROS) {
+            return iceberg::time_type{};
+        }
+        if (
+          lt == avro::LogicalType::TIMESTAMP_MILLIS
+          || lt == avro::LogicalType::TIMESTAMP_MICROS) {
+            return iceberg::timestamp_type{};
+        }
+        return iceberg::long_type{};
+    }
+    case avro::AVRO_FLOAT:
+        return iceberg::float_type{};
+    case avro::AVRO_DOUBLE:
+        return iceberg::double_type{};
+    case avro::AVRO_BOOL:
+        return iceberg::boolean_type{};
+    case avro::AVRO_NULL:
+        return std::nullopt;
+    case avro::AVRO_RECORD: {
+        auto struct_result = struct_from_avro_record(node, state);
+        if (struct_result.has_error()) {
+            return struct_result.error();
+        }
+        return std::make_optional<iceberg::field_type>(
+          std::move(struct_result.value()));
+    }
+    case avro::AVRO_ENUM:
+        return iceberg::int_type{};
+    case avro::AVRO_ARRAY: {
+        if (node->leaves() != 1) {
+            return schema_conversion_exception(fmt::format(
+              "Invalid number of leaves {} in AVRO_ARRAY, expected to have "
+              "only 1 leaf",
+              node->leaves()));
+        }
+        auto array_id = state.next_field_id();
+        auto element_type = node->leafAt(0);
+        auto field_res = field_type_from_avro(element_type, state);
+        if (field_res.has_error()) {
+            return field_res.error();
+        }
+        if (!field_res.value().has_value()) {
+            return schema_conversion_exception(
+              fmt::format("Unsupported type of AVRO_NULL as an array element"));
+        }
+        return iceberg::list_type::create(
+          array_id,
+          iceberg::field_required::yes,
+          std::move(*field_res.value()));
+    }
+    case avro::AVRO_MAP: {
+        if (node->leaves() != 2) {
+            return schema_conversion_exception(fmt::format(
+              "Invalid number of leaves {} in AVRO_MAP, expected to have "
+              "exactly 2 leaves",
+              node->leaves()));
+        }
+
+        if (node->leafAt(0)->type() != avro::AVRO_STRING) {
+            return schema_conversion_exception(fmt::format(
+              "AVRO_MAP is expected to be a string. Current key type: {}",
+              node->leafAt(0)->type()));
+        }
+        auto value_t_result = field_type_from_avro(node->leafAt(1), state);
+        if (value_t_result.has_error()) {
+            return value_t_result.error();
+        }
+        if (!value_t_result.value().has_value()) {
+            return schema_conversion_exception(
+              fmt::format("Unsupported type of AVRO_NULL as a map value"));
+        }
+
+        return iceberg::map_type::create(
+          state.next_field_id(),
+          iceberg::string_type{},
+          state.next_field_id(),
+          iceberg::field_required::yes,
+          std::move(*value_t_result.value()));
+    }
+    case avro::AVRO_UNION: {
+        // Avro union is flattened as a struct with fields that are not
+        // required, only one of the fields will be present at a time.
+        iceberg::struct_type ret;
+        ret.fields.reserve(node->leaves());
+        for (size_t i = 0; i < node->leaves(); ++i) {
+            auto leaf = node->leafAt(i);
+            auto result = field_type_from_avro(leaf, state);
+            if (result.has_error()) {
+                return result.error();
+            }
+            auto field = std::move(result.value());
+            if (field.has_value()) {
+                ret.fields.push_back(iceberg::nested_field::create(
+                  state.next_field_id(),
+                  // union struct fields name are represented as
+                  // <union_name>_<leaf_idx>
+                  fmt::format("union_opt_{}", i),
+                  // union struct fields are not required
+                  iceberg::field_required::no,
+                  std::move(field.value())));
+            }
+        }
+        return ret;
+    }
+
+    case avro::AVRO_FIXED:
+        if (node->logicalType().type() == avro::LogicalType::DECIMAL) {
+            return create_decimal(node);
+        }
+        return iceberg::fixed_type{node->fixedSize()};
+    case avro::AVRO_SYMBOLIC:
+        /**
+         * Avro schema symbolic type is indicating that the current node is of
+         * type already present in a schema f.e.:
+         * {
+         *     "name": "nestedrecord",
+         *     "type": {
+         *         "type": "record",
+         *         "name": "Nested",
+         *         "fields": [
+         *             {
+         *                 "name": "inval1",
+         *                 "type": "double"
+         *             }
+         *         ]
+         *     }
+         * },
+         * {
+         *     "name": "mymap",
+         *     "type": {
+         *         "type": "map",
+         *         "values": "Nested"
+         *     }
+         * }
+         *
+         * The `mymap` value type will be a symbolic type pointing to Nested.
+         *
+         * For iceberg schema we flatten the representation and the same
+         * stucture will be repeated every time it occur in schema DAG.
+         */
+        return field_type_from_avro(::avro::resolveSymbol(node), state);
+    case avro::AVRO_UNKNOWN:
+        return schema_conversion_exception(
+          "Conversion of unknown avro type is not supported");
+    }
+}
+
+conversion_outcome<std::optional<iceberg::field_type>>
+field_type_from_avro(const avro::NodePtr& node, state& state) {
+    try {
+        return inner_field_type_from_avro(node, state);
+    } catch (...) {
+        return schema_conversion_exception(fmt::format(
+          "exception thrown while converting AVRO {} schema of type {} to "
+          "iceberg - {}",
+          *node,
+          node->type(),
+          std::current_exception()));
+    }
+}
+
+} // namespace
+
+conversion_outcome<iceberg::struct_type>
+type_to_iceberg(const avro::NodePtr& node) {
+    state s;
+
+    // schema root is not a record
+    if (node->type() != avro::AVRO_RECORD) {
+        auto id = s.next_field_id();
+        iceberg::struct_type ret;
+        auto result = field_type_from_avro(node, s);
+        if (result.has_error()) {
+            return result.error();
+        }
+        auto field = std::move(result.value());
+        if (!field.has_value()) {
+            return schema_conversion_exception(
+              "AVRO_NULL is not supported top level type");
+        }
+
+        ret.fields.push_back(iceberg::nested_field::create(
+          id,
+          node->hasName() ? node->name().fullname() : "root",
+          iceberg::field_required::yes,
+          std::move(field.value())));
+        return ret;
+    }
+
+    // schema root is a record
+    return struct_from_avro_record(node, s);
+}
+
+} // namespace datalake

--- a/src/v/datalake/schema_avro.h
+++ b/src/v/datalake/schema_avro.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/conversion_outcome.h"
+#include "iceberg/datatypes.h"
+
+#include <avro/Node.hh>
+
+namespace datalake {
+
+/**
+ * Converts given AVRO schema to iceberg struct type. If a top level avro type
+ * is different than avro record the method will return a struct type with
+ * single filed being a top level type.
+ *
+ * Most important limitations/assumptions:
+ *
+ *  - do not support recursive types
+ *
+ *  - avro unions are 'flattened' as a structure with optional fields out of
+ *    which only one or none are present (i case ther is a field with null type)
+ *
+ *  - all fields are required by default (avro always sets a default in binary
+ *    representation)
+ *
+ *  - duration logical type is ignored
+ *
+ *  - avro null type is ignored and not represented in iceberg schema
+ *
+ *  - different flavours of timestamp and time types are all represented by the
+ *    same iceberg type, conversion will be done when parsing avro value
+ */
+conversion_outcome<iceberg::struct_type> type_to_iceberg(const avro::NodePtr&);
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -182,3 +182,21 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "datalake_avro_tests",
+    timeout = "short",
+    srcs = [
+        "datalake_avro_tests.cc",
+    ],
+    deps = [
+        "//src/v/datalake:schema_avro",
+        "//src/v/datalake:values_protobuf",
+        "//src/v/iceberg:datatypes",
+        "//src/v/test_utils:gtest",
+        "@avro",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -159,3 +159,18 @@ rp_test(
   LABELS storage
   ARGS "-- -c 1"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  USE_CWD
+  BINARY_NAME datalake_avro
+  SOURCES 
+    datalake_avro_tests.cc
+  LIBRARIES
+    v::gtest_main
+    v::datalake_writer
+    v::iceberg_test_utils
+  LABELS datalake
+  ARGS "-- -c 1"
+)

--- a/src/v/datalake/tests/datalake_avro_tests.cc
+++ b/src/v/datalake/tests/datalake_avro_tests.cc
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/schema_avro.h"
+#include "gtest/gtest.h"
+#include "iceberg/datatypes.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <avro/Compiler.hh>
+#include <avro/ValidSchema.hh>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace testing;
+static constexpr auto tl_string = R"J({"type": "string"})J";
+static constexpr auto tl_int = R"J({"type": "int"})J";
+static constexpr auto tl_long = R"J({"type": "long"})J";
+static constexpr auto tl_double = R"J({"type": "double"})J";
+static constexpr auto tl_array = R"J({ "type" : "array", "items" : "int" })J";
+
+static constexpr auto tl_map = R"J({"type": "map","values": {"type":"int"}})J";
+static constexpr auto tl_union = R"J([ "int" , "long" , "float" ])J";
+avro::NodePtr load_json_schema(std::string_view sch) {
+    return avro::compileJsonSchemaFromString(std::string(sch)).root();
+}
+
+struct TypeEqMatcher : MatcherInterface<const iceberg::field_type&> {
+    explicit TypeEqMatcher(const iceberg::field_type& ft)
+      : ft(ft) {}
+    bool MatchAndExplain(
+      const iceberg::field_type& x, MatchResultListener*) const final {
+        return ft == x;
+    }
+    void DescribeTo(::std::ostream* os) const final {
+        *os << " is equal to " << ft;
+    }
+
+    const iceberg::field_type& ft;
+};
+
+auto TypeEq(const iceberg::field_type& ft) {
+    return Matcher<const iceberg::field_type&>(new TypeEqMatcher(ft));
+}
+
+auto match_field(
+  int id, const ss::sstring& name, const iceberg::field_type& ft) {
+    return Pointee(AllOf(
+      Field(&iceberg::nested_field::id, Eq(id)),
+      Field(&iceberg::nested_field::name, Eq(name)),
+      Field(&iceberg::nested_field::type, TypeEq(ft))));
+}
+
+TEST(AvroSchema, TestNonRecordSchema) {
+    std::vector<std::tuple<ss::sstring, std::string_view, iceberg::field_type>>
+      tl_type_expectations;
+
+    tl_type_expectations.emplace_back(
+      "root", tl_string, iceberg::string_type{});
+    tl_type_expectations.emplace_back("root", tl_int, iceberg::int_type{});
+    tl_type_expectations.emplace_back(
+
+      "root", tl_double, iceberg::double_type{});
+    tl_type_expectations.emplace_back("root", tl_long, iceberg::long_type{});
+    tl_type_expectations.emplace_back(
+
+      "root",
+      tl_array,
+      iceberg::list_type::create(
+        1, iceberg::field_required::yes, iceberg::int_type{}));
+    tl_type_expectations.emplace_back(
+      "root",
+      tl_map,
+      iceberg::map_type::create(
+        1,
+        iceberg::string_type{},
+        2,
+        iceberg::field_required::yes,
+        iceberg::int_type{}));
+
+    iceberg::struct_type union_st;
+    union_st.fields.push_back(iceberg::nested_field::create(
+      1, "union_opt_0", iceberg::field_required::no, iceberg::int_type{}));
+    union_st.fields.push_back(iceberg::nested_field::create(
+      2, "union_opt_1", iceberg::field_required::no, iceberg::long_type{}));
+    union_st.fields.push_back(iceberg::nested_field::create(
+      3, "union_opt_2", iceberg::field_required::no, iceberg::float_type{}));
+
+    tl_type_expectations.emplace_back("root", tl_union, std::move(union_st));
+
+    for (auto& [name, schema, type] : tl_type_expectations) {
+        auto root = load_json_schema(schema);
+        auto iceberg_struct_res = datalake::type_to_iceberg(root);
+
+        ASSERT_TRUE(iceberg_struct_res.has_value());
+
+        ASSERT_THAT(
+          iceberg_struct_res.value().fields,
+          testing::ElementsAre(match_field(0, name, type)));
+    }
+}
+
+constexpr auto big_record = R"J(
+{
+    "type": "record",
+    "doc": "Top level Doc.",
+    "name": "RootRecord",
+    "fields": [
+        {
+            "name": "mylong",
+            "doc": "mylong field doc.",
+            "type": "long"
+        },
+        {
+            "name": "nestedrecord",
+            "type": {
+                "type": "record",
+                "name": "Nested",
+                "fields": [
+                    {
+                        "name": "inval1",
+                        "type": "double"
+                    },
+                    {
+                        "name": "inval2",
+                        "type": "string"
+                    },
+                    {
+                        "name": "inval3",
+                        "type": "int"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "mymap",
+            "type": {
+                "type": "map",
+                "values": "int"
+            }
+        },
+        {
+            "name": "recordmap",
+            "type": {
+                "type": "map",
+                "values": "Nested"
+            }
+        },
+        {
+            "name": "myarray",
+            "type": {
+                "type": "array",
+                "items": "double"
+            }
+        },
+        {
+            "name": "myenum",
+            "type": {
+                "type": "enum",
+                "name": "ExampleEnum",
+                "symbols": [
+                    "zero",
+                    "one",
+                    "two",
+                    "three"
+                ]
+            }
+        },
+        {
+            "name": "myunion",
+            "type": [
+                "null",
+                {
+                    "type": "map",
+                    "values": "int"
+                },
+                "float"
+            ]
+        },
+        {
+            "name": "anotherunion",
+            "type": [
+                "bytes",
+                "null"
+            ]
+        },
+        {
+            "name": "mybool",
+            "type": "boolean"
+        },
+        {
+            "name": "anothernested",
+            "type": "Nested"
+        },
+        {
+            "name": "myfixed",
+            "type": {
+                "type": "fixed",
+                "size": 16,
+                "name": "md5"
+            }
+        },
+        {
+            "name": "anotherint",
+            "type": "int"
+        },
+        {
+            "name": "bytes",
+            "type": "bytes"
+        },
+		        {
+            "name": "null",
+            "type": "null"
+        }
+    ]
+}
+)J";
+
+iceberg::struct_type nested_record(int initial_id) {
+    iceberg::struct_type st;
+    int i = initial_id;
+    st.fields.push_back(iceberg::nested_field::create(
+      i++, "inval1", iceberg::field_required::yes, iceberg::double_type{}));
+    st.fields.push_back(iceberg::nested_field::create(
+      i++, "inval2", iceberg::field_required::yes, iceberg::string_type{}));
+    st.fields.push_back(iceberg::nested_field::create(
+      i++, "inval3", iceberg::field_required::yes, iceberg::int_type{}));
+    return st;
+}
+
+AssertionResult field_matches(
+  const iceberg::nested_field_ptr& field,
+  int id,
+  const ss::sstring& name,
+  const iceberg::field_type& ft) {
+    if (field->id != id || field->name != name || field->type != ft) {
+        return AssertionFailure() << fmt::format(
+                 "\nexpected: (id: {}, name: {}, type: {})\n"
+                 "actual  : (id: {}, name: {}, type: {})",
+                 id,
+                 name,
+                 ft,
+                 field->id,
+                 field->name,
+                 field->type);
+    }
+    return AssertionSuccess();
+}
+
+TEST(AvroSchema, TestRecordType) {
+    auto root = load_json_schema(big_record);
+    auto iceberg_struct_res = datalake::type_to_iceberg(root);
+
+    ASSERT_TRUE(iceberg_struct_res.has_value());
+    auto struct_t = std::move(iceberg_struct_res.value());
+    ASSERT_EQ(struct_t.fields.size(), 13);
+
+    ASSERT_TRUE(
+      field_matches(struct_t.fields[0], 0, "mylong", iceberg::long_type{}));
+
+    ASSERT_TRUE(
+      field_matches(struct_t.fields[1], 4, "nestedrecord", nested_record(1)));
+
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[2],
+      7,
+      "mymap",
+      iceberg::map_type::create(
+        5,
+        iceberg::string_type{},
+        6,
+        iceberg::field_required::yes,
+        iceberg::int_type{})));
+
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[3],
+      13,
+      "recordmap",
+      iceberg::map_type::create(
+        11,
+        iceberg::string_type{},
+        12,
+        iceberg::field_required::yes,
+        nested_record(8))));
+
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[4],
+      15,
+      "myarray",
+      iceberg::list_type::create(
+        14, iceberg::field_required::yes, iceberg::double_type{})));
+    ASSERT_TRUE(
+      field_matches(struct_t.fields[5], 16, "myenum", iceberg::int_type{}));
+
+    iceberg::struct_type union_struct;
+    // starts from union_1 as the union_0 is null type which is not represented
+    // here
+    union_struct.fields.push_back(iceberg::nested_field::create(
+      19,
+      "union_opt_1",
+      iceberg::field_required::no,
+      iceberg::map_type::create(
+        17,
+        iceberg::string_type{},
+        18,
+        iceberg::field_required::yes,
+        iceberg::int_type{})));
+    union_struct.fields.push_back(iceberg::nested_field::create(
+      20, "union_opt_2", iceberg::field_required::no, iceberg::float_type{}));
+
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[6], 21, "myunion", std::move(union_struct)));
+    iceberg::struct_type another_union_struct;
+
+    another_union_struct.fields.push_back(iceberg::nested_field::create(
+      22, "union_opt_0", iceberg::field_required::no, iceberg::binary_type{}));
+
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[7], 23, "anotherunion", std::move(another_union_struct)));
+
+    ASSERT_TRUE(
+      field_matches(struct_t.fields[8], 24, "mybool", iceberg::boolean_type{}));
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[9], 28, "anothernested", nested_record(25)));
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[10], 29, "myfixed", iceberg::fixed_type{.length = 16}));
+    ASSERT_TRUE(field_matches(
+      struct_t.fields[11], 30, "anotherint", iceberg::int_type{}));
+    ASSERT_TRUE(
+      field_matches(struct_t.fields[12], 31, "bytes", iceberg::binary_type{}));
+    // There is a NULL type in schema, but it is skiped when translating to
+    // iceberg
+}
+
+constexpr auto tree_node = R"J(
+{
+  "name": "Node",
+  "type": "record",
+  "fields": [
+    {
+      "name": "payload",
+      "type": "int",
+      "default": 0
+    },
+    {
+      "name": "edges",
+      "type": {
+        "type": "map",
+        "values": "Node"
+      }
+    }
+  ]
+}
+)J";
+
+TEST(AvroSchema, TestRecursiveType) {
+    auto root = load_json_schema(tree_node);
+    auto iceberg_struct_res = datalake::type_to_iceberg(root);
+
+    ASSERT_TRUE(iceberg_struct_res.has_error());
+}
+
+// R"({"type":"int","logicalType":"time-millis"})",
+// R"({"type":"long","logicalType":"time-micros"})",
+// R"({"type":"long","logicalType":"timestamp-millis"})",
+// R"({"type":"long","logicalType":"timestamp-micros"})",
+// R"({"type":"fixed","name":"test","size":12,"logicalType":"duration"})",
+// R"({"type":"string","logicalType":"uuid"})",
+
+constexpr auto logical_types = R"J(
+{
+    "name": "LogicalTypesRecord",
+    "type": "record",
+    "fields": [
+        {
+            "name": "uuid_string",
+            "type": {
+                "type": "string",
+                "logicalType": "uuid"
+            }
+        },
+        {
+            "name": "date_int",
+            "type": {
+                "type": "int",
+                "logicalType": "date"
+            }
+        },
+        {
+            "name": "bytes_decimal",
+            "type": {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 38,
+                "scale": 9
+            }
+        },
+        {
+            "name": "fixed_decimal",
+            "type": {
+                "name": "fixed_16",
+                "size": 16,
+                "type": "fixed",
+                "logicalType": "decimal",
+                "precision": 20,
+                "scale": 9
+            }
+        },
+        {
+            "name": "int_time_ms",
+            "type": {
+                "type": "int",
+                "logicalType": "time-millis"
+            }
+        },
+        {
+            "name": "long_time_micro",
+            "type": {
+                "type": "long",
+                "logicalType": "time-micros"
+            }
+        },
+        {
+            "name": "long_ts_ms",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            }
+        },
+        {
+            "name": "long_ts_micro",
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-micros"
+            }
+        },
+        {
+            "name": "duration_fixed",
+            "type": {
+                "type": "fixed",
+                "name": "fixed_12",
+                "size": 12,
+                "logicalType": "duration"
+            }
+        }
+    ]
+}
+)J";
+
+TEST(AvroSchema, TestLogicalTypes) {
+    auto root = load_json_schema(logical_types);
+    auto iceberg_struct_res = datalake::type_to_iceberg(root);
+
+    ASSERT_FALSE(iceberg_struct_res.has_error());
+    auto struct_t = std::move(iceberg_struct_res.value());
+    ASSERT_EQ(struct_t.fields.size(), 9);
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[0], 0, "uuid_string", iceberg::uuid_type{}));
+    EXPECT_TRUE(
+      field_matches(struct_t.fields[1], 1, "date_int", iceberg::date_type{}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[2],
+      2,
+      "bytes_decimal",
+      iceberg::decimal_type{.precision = 38, .scale = 9}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[3],
+      3,
+      "fixed_decimal",
+      iceberg::decimal_type{.precision = 20, .scale = 9}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[4], 4, "int_time_ms", iceberg::time_type{}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[5], 5, "long_time_micro", iceberg::time_type{}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[6], 6, "long_ts_ms", iceberg::timestamp_type{}));
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[7], 7, "long_ts_micro", iceberg::timestamp_type{}));
+    // Duration logical type is not intrepreted in as a separate iceberg type
+    EXPECT_TRUE(field_matches(
+      struct_t.fields[8], 8, "duration_fixed", iceberg::fixed_type{12}));
+}

--- a/src/v/iceberg/datatypes.h
+++ b/src/v/iceberg/datatypes.h
@@ -132,6 +132,7 @@ struct nested_field {
     nested_field_ptr copy() const;
 
     friend bool operator==(const nested_field& lhs, const nested_field& rhs);
+    friend std::ostream& operator<<(std::ostream&, const nested_field&);
 };
 
 } // namespace iceberg

--- a/src/v/iceberg/tests/datatypes_test.cc
+++ b/src/v/iceberg/tests/datatypes_test.cc
@@ -200,15 +200,15 @@ TEST(DatatypeTest, TestList) {
     ASSERT_TRUE(std::holds_alternative<list_type>(t1));
     ASSERT_TRUE(std::get<list_type>(t1).element_field == nullptr);
     ASSERT_NE(t1_move, t1);
-    ASSERT_EQ("list", fmt::format("{}", t1));
+    ASSERT_EQ("list<null>", fmt::format("{}", t1));
     // NOLINTEND(bugprone-use-after-move)
 
     ASSERT_EQ(t1_move, t1_dup);
-    ASSERT_EQ("list", fmt::format("{}", t2));
-    ASSERT_EQ("list", fmt::format("{}", t3));
-    ASSERT_EQ("list", fmt::format("{}", t4));
-    ASSERT_EQ("list", fmt::format("{}", t1_dup));
-    ASSERT_EQ("list", fmt::format("{}", t1_move));
+    ASSERT_EQ("list<boolean>", fmt::format("{}", t2));
+    ASSERT_EQ("list<boolean>", fmt::format("{}", t3));
+    ASSERT_EQ("list<string>", fmt::format("{}", t4));
+    ASSERT_EQ("list<boolean>", fmt::format("{}", t1_dup));
+    ASSERT_EQ("list<boolean>", fmt::format("{}", t1_move));
 }
 TEST(DatatypeTest, TestMap) {
     auto t1 = field_type{map_type::create(
@@ -238,15 +238,15 @@ TEST(DatatypeTest, TestMap) {
     ASSERT_TRUE(std::get<map_type>(t1).key_field == nullptr);
     ASSERT_TRUE(std::get<map_type>(t1).value_field == nullptr);
     ASSERT_NE(t1_move, t1);
-    ASSERT_EQ("map", fmt::format("{}", t1));
+    ASSERT_EQ("map<null,null>", fmt::format("{}", t1));
     // NOLINTEND(bugprone-use-after-move)
 
     ASSERT_EQ(t1_move, t1_dup);
-    ASSERT_EQ("map", fmt::format("{}", t2));
-    ASSERT_EQ("map", fmt::format("{}", t3));
-    ASSERT_EQ("map", fmt::format("{}", t4));
-    ASSERT_EQ("map", fmt::format("{}", t1_dup));
-    ASSERT_EQ("map", fmt::format("{}", t1_move));
+    ASSERT_EQ("map<string,string>", fmt::format("{}", t2));
+    ASSERT_EQ("map<boolean,string>", fmt::format("{}", t3));
+    ASSERT_EQ("map<string,string>", fmt::format("{}", t4));
+    ASSERT_EQ("map<string,string>", fmt::format("{}", t1_dup));
+    ASSERT_EQ("map<string,string>", fmt::format("{}", t1_move));
 
     // Regression test that would cause previous impl to crash if both types
     // are the same but keys are null.
@@ -284,16 +284,21 @@ TEST(DatatypeTest, TestStruct) {
     ASSERT_TRUE(std::holds_alternative<struct_type>(t1));
     ASSERT_TRUE(std::get<struct_type>(t1).fields.empty());
     ASSERT_NE(t1_move, t1);
-    ASSERT_EQ("struct", fmt::format("{}", t1));
+    ASSERT_EQ("struct[]", fmt::format("{}", t1));
     // NOLINTEND(bugprone-use-after-move)
 
     ASSERT_EQ(t1_move, t1_dup);
-    ASSERT_EQ("struct", fmt::format("{}", t2));
-    ASSERT_EQ("struct", fmt::format("{}", t3));
-    ASSERT_EQ("struct", fmt::format("{}", t4));
-    ASSERT_EQ("struct", fmt::format("{}", t5));
-    ASSERT_EQ("struct", fmt::format("{}", t1_dup));
-    ASSERT_EQ("struct", fmt::format("{}", t1_move));
+    ASSERT_EQ("struct[foo<string>]", fmt::format("{}", t2));
+    ASSERT_EQ("struct[food<string>]", fmt::format("{}", t3));
+    ASSERT_EQ("struct[foo<string>]", fmt::format("{}", t4));
+    ASSERT_EQ("struct[foo<boolean>]", fmt::format("{}", t5));
+    ASSERT_EQ("struct[foo<string>]", fmt::format("{}", t1_dup));
+    ASSERT_EQ("struct[foo<string>]", fmt::format("{}", t1_move));
+    // struct with two fields
+    auto t6 = struct_single(0, "foo", field_required::yes, boolean_type{});
+    std::get<struct_type>(t6).fields.push_back(
+      nested_field::create(2, "bar", field_required::yes, int_type{}));
+    ASSERT_EQ("struct[foo<boolean>, bar<int>]", fmt::to_string(t6));
 }
 
 TEST(DatatypeTest, TestBasicCopy) {


### PR DESCRIPTION
Added conversion of AVRO to Iceberg schema.  

If a top level AVRO type is different than AVRO record the method will return a struct type with single filed being a top level type.

 Most important limitations/assumptions:

- do not support recursive types

- avro maps are interpreted as list of key-value pairs

- avro unions are 'flattened' as a structure with optional fields out of
  which only one or none are present (i case ther is a field with null type)

- all fields are required by default (avro always sets a default in binary
  representation)

- duration logical type is ignored

- avro null type is ignored and not represented in iceberg schema

- different flavours of timestamp and time types are all represented by the
  same iceberg type, conversion will be done when parsing avro value

Useful links: 
[AVRO Spec](https://avro.apache.org/docs/1.11.1/specification/) 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
