### PR TITLE
rpk: fill schema registry information in cloud profiles

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -497,6 +497,13 @@ func fromCloudCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.Resour
 			isMTLS = mtls.Enabled
 		}
 	}
+	if c.SchemaRegistry != nil {
+		p.SR.Addresses = []string{c.SchemaRegistry.Url}
+		p.SR.TLS = new(config.TLS)
+		if mtls := c.SchemaRegistry.Mtls; !isMTLS && mtls != nil {
+			isMTLS = mtls.Enabled
+		}
+	}
 	return CloudClusterOutputs{
 		Profile:           p,
 		ResourceGroupName: rg.Name,
@@ -520,6 +527,10 @@ func fromVirtualCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.Reso
 		},
 		AdminAPI: config.RpkAdminAPI{
 			Addresses: []string{vc.Status.Listeners.ConsoleURL},
+			TLS:       new(config.TLS),
+		},
+		SR: config.RpkSchemaRegistryAPI{
+			Addresses: vc.Status.Listeners.SchemaRegistryURL,
 			TLS:       new(config.TLS),
 		},
 		CloudCluster: config.RpkCloudCluster{

--- a/src/go/rpk/pkg/cloudapi/api_virtual_cluster.go
+++ b/src/go/rpk/pkg/cloudapi/api_virtual_cluster.go
@@ -30,8 +30,9 @@ type (
 
 		Status struct {
 			Listeners struct {
-				ConsoleURL    string   `json:"consoleUrl"`
-				SeedAddresses []string `json:"seedAddress"`
+				ConsoleURL        string   `json:"consoleUrl"`
+				SeedAddresses     []string `json:"seedAddress"`
+				SchemaRegistryURL []string `json:"schemaRegistryUrl,omitempty"`
 			} `json:"listeners"`
 		} `json:"status"`
 	}


### PR DESCRIPTION
This is available in all of our cloud deployments.

**Example:**
```
$ rpk cloud cluster select                                
? Which cloud resource-group/cluster would you like to talk to? rogger/test-sr
Updated profile "rpk-cloud" to talk to cloud cluster "rogger/test-sr".

Cluster test-sr
  Web UI: https://cloud.redpanda.com/clusters/foo/overview
  Redpanda Seed Brokers: [foo.any.us-east-1.mpx.prd.cloud.redpanda.com:9092]

$ rpk profile print                                       
name: rpk-cloud
description: Redpanda Production "rogger/test-sr"
prompt: ""
from_cloud: true
cloud_cluster:
    resource_group: rogger
    cluster_id: bar
    cluster_name: test-sr
    auth_org_id: baz
    auth_kind: sso
    cluster_type: TYPE_SERVERLESS
...
schema_registry:
    addresses:
        - https://foo.registry.us-east-1.mpx.prd.cloud.redpanda.com
    tls: {}

```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
