### PR TITLE
cluster: Implement sanctions on autobalancer features on invalid license

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -511,7 +511,6 @@ ss::future<> controller::start(
       std::ref(_tp_state),
       std::ref(_backend),
       config::shard_local_cfg().core_balancing_on_core_count_change.bind(),
-      config::shard_local_cfg().core_balancing_continuous.bind(),
       config::shard_local_cfg().core_balancing_debounce_timeout.bind(),
       config::shard_local_cfg().topic_partitions_per_shard.bind(),
       config::shard_local_cfg().topic_partitions_reserve_shard0.bind());

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -724,12 +724,12 @@ ss::future<> controller::start(
     co_await _partition_balancer.start_single(
       _raft0,
       std::ref(_stm),
+      std::ref(_feature_table),
       std::ref(_partition_balancer_state),
       std::ref(_hm_backend),
       std::ref(_partition_allocator),
       std::ref(_tp_frontend),
       std::ref(_members_frontend),
-      config::shard_local_cfg().partition_autobalancing_mode.bind(),
       config::shard_local_cfg()
         .partition_autobalancing_node_availability_timeout_sec.bind(),
       config::shard_local_cfg()

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -16,6 +16,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/types.h"
 #include "config/property.h"
+#include "features/enterprise_features.h"
 #include "model/fundamental.h"
 #include "raft/consensus.h"
 #include "utils/mutex.h"
@@ -35,12 +36,12 @@ public:
     partition_balancer_backend(
       consensus_ptr raft0,
       ss::sharded<controller_stm>&,
+      ss::sharded<features::feature_table>&,
       ss::sharded<partition_balancer_state>&,
       ss::sharded<health_monitor_backend>&,
       ss::sharded<partition_allocator>&,
       ss::sharded<topics_frontend>&,
       ss::sharded<members_frontend>&,
-      config::binding<model::partition_autobalancing_mode>&& mode,
       config::binding<std::chrono::seconds>&& availability_timeout,
       config::binding<unsigned>&& max_disk_usage_percent,
       config::binding<unsigned>&& storage_space_alert_free_threshold_percent,
@@ -91,13 +92,16 @@ private:
     consensus_ptr _raft0;
 
     controller_stm& _controller_stm;
+    features::feature_table& _feature_table;
     partition_balancer_state& _state;
     health_monitor_backend& _health_monitor;
     partition_allocator& _partition_allocator;
     topics_frontend& _topics_frontend;
     members_frontend& _members_frontend;
 
-    config::binding<model::partition_autobalancing_mode> _mode;
+    features::sanctioning_binding<
+      config::enum_property<model::partition_autobalancing_mode>>
+      _mode;
     config::binding<std::chrono::seconds> _availability_timeout;
     config::binding<unsigned> _max_disk_usage_percent;
     config::binding<unsigned> _storage_space_alert_free_threshold_percent;

--- a/src/v/cluster/shard_balancer.h
+++ b/src/v/cluster/shard_balancer.h
@@ -13,7 +13,9 @@
 
 #include "cluster/controller_backend.h"
 #include "cluster/shard_placement_table.h"
+#include "config/property.h"
 #include "container/chunked_hash_map.h"
+#include "features/enterprise_features.h"
 #include "random/simple_time_jitter.h"
 #include "ssx/event.h"
 #include "utils/mutex.h"
@@ -41,7 +43,6 @@ public:
       ss::sharded<topic_table>&,
       ss::sharded<controller_backend>&,
       config::binding<bool> balancing_on_core_count_change,
-      config::binding<bool> balancing_continuous,
       config::binding<std::chrono::milliseconds> debounce_timeout,
       config::binding<uint32_t> partitions_per_shard,
       config::binding<uint32_t> partitions_reserve_shard0);
@@ -116,7 +117,7 @@ private:
     model::node_id _self;
 
     config::binding<bool> _balancing_on_core_count_change;
-    config::binding<bool> _balancing_continuous;
+    features::sanctioning_binding<config::property<bool>> _balancing_continuous;
     config::binding<std::chrono::milliseconds> _debounce_timeout;
     simple_time_jitter<ss::lowres_clock> _debounce_jitter;
     config::binding<uint32_t> _partitions_per_shard;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -197,6 +197,10 @@ public:
         return std::nullopt;
     }
 
+    bool check_restricted(const T& value) const {
+        return do_check_restricted(value);
+    }
+
     void reset() override {
         auto v = default_value();
         update_value(std::move(v));
@@ -301,6 +305,11 @@ protected:
     const std::optional<legacy_default<value_type>> _legacy_default;
 
 private:
+    virtual bool do_check_restricted(const T&) const {
+        // Config properties are unrestricted by default
+        return false;
+    }
+
     validator _validator;
 
     friend class binding_base<value_type>;
@@ -1060,6 +1069,9 @@ public:
         assert_no_default_conflict();
     }
 
+    // Needed because the following override shadows the rest of the overloads
+    using P::check_restricted;
+
     /**
      * Decodes the given YAML node into the underlying property's value_type and
      * checks whether that value should be restricted to enterprise clusters
@@ -1067,7 +1079,7 @@ public:
      */
     std::optional<validation_error> check_restricted(YAML::Node n) const final {
         auto v = std::move(n.as<T>());
-        if (check_restricted(v)) {
+        if (do_check_restricted(v)) {
             return std::make_optional<validation_error>(
               P::name().data(),
               ssx::sformat(
@@ -1077,14 +1089,7 @@ public:
     }
 
 private:
-    void assert_no_default_conflict() const {
-        vassert(
-          !check_restricted(this->default_value()),
-          "Enterprise properties must not restrict the default value of the "
-          "underlying property!");
-    }
-
-    bool check_restricted(const T& setting) const {
+    bool do_check_restricted(const T& setting) const final {
         // depending on how the restriction was defined, construct an applicable
         // check function for bare instances of the underlying value type
         auto restriction_check = [this](const val_t& v) -> bool {
@@ -1111,6 +1116,13 @@ private:
         if constexpr (std::is_same_v<T, val_t>) {
             return restriction_check(setting);
         }
+    }
+
+    void assert_no_default_conflict() const {
+        vassert(
+          !do_check_restricted(this->default_value()),
+          "Enterprise properties must not restrict the default value of the "
+          "underlying property!");
     }
 
     restrict_variant_t _restriction;

--- a/src/v/config/tests/enterprise_property_test.cc
+++ b/src/v/config/tests/enterprise_property_test.cc
@@ -7,13 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "config/base_property.h"
 #include "config/config_store.h"
 #include "config/property.h"
 #include "config/types.h"
 
+#include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
 
+#include <concepts>
 #include <iostream>
 
 namespace config {
@@ -34,7 +37,7 @@ struct test_config : public config_store {
           true,
           "enterprise_bool",
           "An enterprise-only bool config",
-          meta{},
+          meta{.needs_restart = needs_restart::no},
           false,
           property<bool>::noop_validator,
           std::nullopt)
@@ -43,27 +46,28 @@ struct test_config : public config_store {
           std::vector<ss::sstring>{"bar"},
           "enterprise_str_enum",
           "An enterprise-only enum property",
-          meta{},
+          meta{.needs_restart = needs_restart::no},
           "foo",
           std::vector<ss::sstring>{"foo", "bar", "baz"})
       , enterprise_str_vec(
           *this,
           std::vector<ss::sstring>{"GSSAPI"},
           "enterprise_str_vec",
-          "An enterprise-only vector of strings")
+          "An enterprise-only vector of strings",
+          meta{.needs_restart = needs_restart::no})
       , enterprise_opt_int(
           *this,
           [](const int& v) -> bool { return v > 1000; },
           "enterprise_opt_int",
           "An enterprise-only optional int",
-          meta{},
+          meta{.needs_restart = needs_restart::no},
           0)
       , enterprise_enum(
           *this,
           std::vector<tls_version>{tls_version::v1_3},
           "enterprise_str_enum",
           "An enterprise-only enum property",
-          meta{},
+          meta{.needs_restart = needs_restart::no},
           tls_version::v1_1,
           std::vector<tls_version>{
             tls_version::v1_0,

--- a/src/v/features/BUILD
+++ b/src/v/features/BUILD
@@ -50,6 +50,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/config",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@boost//:range",
     ],

--- a/src/v/features/enterprise_features.h
+++ b/src/v/features/enterprise_features.h
@@ -11,6 +11,9 @@
 
 #pragma once
 
+#include "config/configuration.h"
+#include "config/property.h"
+
 #include <absl/container/flat_hash_set.h>
 #include <boost/range/iterator_range.hpp>
 
@@ -75,4 +78,60 @@ private:
     vtype _disabled;
 };
 
+template<config::detail::Property P>
+class sanctioning_binding {
+public:
+    using T = P::value_type;
+    explicit sanctioning_binding(config::enterprise<P>& prop)
+      : _prop(prop)
+      , _binding(_prop.bind()) {
+        update_sanctioned_state();
+        _binding.watch([this] { update_sanctioned_state(); });
+    }
+
+    config::binding<T>& binding() { return _binding; }
+    const config::binding<T>& binding() const { return _binding; }
+
+    std::pair<T, bool> operator()(bool should_sanction) const {
+        const auto& val = _binding();
+        if (should_sanction && _is_sanctioned) [[unlikely]] {
+            return std::make_pair(_prop.default_value(), true);
+        } else {
+            return std::make_pair(val, false);
+        }
+    }
+
+private:
+    config::enterprise<P>& _prop;
+    config::binding<T> _binding;
+    bool _is_sanctioned{false};
+
+    void update_sanctioned_state() {
+        _is_sanctioned = _prop.check_restricted(_binding());
+    }
+};
+
+namespace details {
+template<typename T>
+concept NonVoid = !std::is_void_v<T>;
+
+} // namespace details
+template<license_required_feature F>
+details::NonVoid auto make_sanctioning_binding() {
+    if constexpr (
+      F == license_required_feature::partition_auto_balancing_continuous) {
+        return sanctioning_binding(
+          config::shard_local_cfg().partition_autobalancing_mode);
+    }
+
+    if constexpr (F == license_required_feature::core_balancing_continuous) {
+        return sanctioning_binding(
+          config::shard_local_cfg().core_balancing_continuous);
+    }
+
+    if constexpr (F == license_required_feature::leadership_pinning) {
+        return sanctioning_binding(
+          config::shard_local_cfg().default_leaders_preference);
+    }
+}
 } // namespace features

--- a/src/v/features/tests/BUILD
+++ b/src/v/features/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "feature_table_test",
@@ -14,5 +14,19 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "enterprise_features_test",
+    timeout = "short",
+    srcs = [
+        "enterprise_features_test.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/features:enterprise_features",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/src/v/features/tests/CMakeLists.txt
+++ b/src/v/features/tests/CMakeLists.txt
@@ -10,3 +10,12 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::features
   LABELS features
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_enterprise_features
+  SOURCES enterprise_features_test.cc
+  LIBRARIES v::gtest_main v::enterprise_features v::config
+  LABELS enterprise_features
+)

--- a/src/v/features/tests/enterprise_features_test.cc
+++ b/src/v/features/tests/enterprise_features_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/base_property.h"
+#include "config/config_store.h"
+#include "config/property.h"
+#include "config/types.h"
+#include "features/enterprise_features.h"
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+
+namespace config {
+namespace {
+
+struct test_config : public config_store {
+    enterprise<property<bool>> enterprise_bool;
+    enterprise<enum_property<ss::sstring>> enterprise_str_enum;
+    enterprise<property<std::vector<ss::sstring>>> enterprise_str_vec;
+    enterprise<property<std::optional<int>>> enterprise_opt_int;
+    enterprise<enum_property<tls_version>> enterprise_enum;
+
+    using meta = base_property::metadata;
+
+    test_config()
+      : enterprise_bool(
+          *this,
+          true,
+          "enterprise_bool",
+          "An enterprise-only bool config",
+          meta{.needs_restart = needs_restart::no},
+          false,
+          property<bool>::noop_validator,
+          std::nullopt)
+      , enterprise_str_enum(
+          *this,
+          std::vector<ss::sstring>{"bar"},
+          "enterprise_str_enum",
+          "An enterprise-only enum property",
+          meta{.needs_restart = needs_restart::no},
+          "foo",
+          std::vector<ss::sstring>{"foo", "bar", "baz"})
+      , enterprise_str_vec(
+          *this,
+          std::vector<ss::sstring>{"GSSAPI"},
+          "enterprise_str_vec",
+          "An enterprise-only vector of strings",
+          meta{.needs_restart = needs_restart::no})
+      , enterprise_opt_int(
+          *this,
+          [](const int& v) -> bool { return v > 1000; },
+          "enterprise_opt_int",
+          "An enterprise-only optional int",
+          meta{.needs_restart = needs_restart::no},
+          0)
+      , enterprise_enum(
+          *this,
+          std::vector<tls_version>{tls_version::v1_3},
+          "enterprise_str_enum",
+          "An enterprise-only enum property",
+          meta{.needs_restart = needs_restart::no},
+          tls_version::v1_1,
+          std::vector<tls_version>{
+            tls_version::v1_0,
+            tls_version::v1_1,
+            tls_version::v1_2,
+            tls_version::v1_3}) {}
+};
+
+} // namespace
+} // namespace config
+
+namespace features {
+template<typename Property>
+struct EnterpriseFeatureTest : public ::testing::Test {
+    using value_type = typename Property::value_type;
+
+    struct test_values {
+        value_type default_value;
+        value_type allowed_value;
+        value_type restricted_value;
+    };
+
+    struct test_case {
+        config::enterprise<Property>* enterprise_conf;
+        test_values ts;
+    };
+
+    test_case get_test_case() {
+        if constexpr (std::same_as<Property, config::property<bool>>) {
+            return {
+              &cfg.enterprise_bool,
+              {.default_value = false,
+               .allowed_value = false,
+               .restricted_value = true}};
+        }
+        if constexpr (std::
+                        same_as<Property, config::enum_property<ss::sstring>>) {
+            return {
+              &cfg.enterprise_str_enum,
+              {.default_value = "foo",
+               .allowed_value = "baz",
+               .restricted_value = "bar"}};
+        }
+        if constexpr (std::same_as<
+                        Property,
+                        config::property<std::vector<ss::sstring>>>) {
+            return {
+              &cfg.enterprise_str_vec,
+              {.default_value{},
+               .allowed_value = {"OTHER"},
+               .restricted_value = {"GSSAPI", "OTHER"}}};
+        }
+        if constexpr (std::same_as<
+                        Property,
+                        config::property<std::optional<int>>>) {
+            return {
+              &cfg.enterprise_opt_int,
+              {.default_value{0}, .allowed_value{10}, .restricted_value{1010}}};
+        }
+        if constexpr (std::same_as<
+                        Property,
+                        config::enum_property<config::tls_version>>) {
+            return {
+              &cfg.enterprise_enum,
+              {.default_value = config::tls_version::v1_1,
+               .allowed_value = config::tls_version::v1_2,
+               .restricted_value = config::tls_version::v1_3}};
+        }
+    }
+
+    config::test_config cfg{};
+};
+
+using EnterprisePropertyTypes = ::testing::Types<
+  config::property<bool>,
+  config::enum_property<ss::sstring>,
+  config::property<std::vector<ss::sstring>>,
+  config::property<std::optional<int>>,
+  config::enum_property<config::tls_version>>;
+TYPED_TEST_SUITE(EnterpriseFeatureTest, EnterprisePropertyTypes);
+
+TYPED_TEST(EnterpriseFeatureTest, SanctionedValues) {
+    auto tc = this->get_test_case();
+    auto& enterprise_conf = *tc.enterprise_conf;
+    const auto [default_value, allowed_value, restricted_value] = tc.ts;
+
+    auto binded = sanctioning_binding{enterprise_conf};
+
+    // default value
+    EXPECT_EQ(enterprise_conf.value(), default_value);
+
+    EXPECT_EQ(binded(true), std::make_pair(default_value, false));
+    EXPECT_EQ(binded(false), std::make_pair(default_value, false));
+
+    // allowed value
+    enterprise_conf.set_value(allowed_value);
+
+    EXPECT_EQ(enterprise_conf.value(), allowed_value);
+
+    EXPECT_EQ(binded(true), std::make_pair(allowed_value, false));
+    EXPECT_EQ(binded(false), std::make_pair(allowed_value, false));
+
+    // sanctioned value
+    enterprise_conf.set_value(restricted_value);
+
+    EXPECT_EQ(enterprise_conf.value(), restricted_value);
+
+    EXPECT_EQ(binded(true), std::make_pair(default_value, true));
+    EXPECT_EQ(binded(false), std::make_pair(restricted_value, false));
+}
+
+} // namespace features

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
 from ducktape.utils.util import wait_until
 
 from rptest.services.cluster import cluster
@@ -17,6 +18,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.util import wait_until_result
+from ducktape.mark import matrix
 
 
 class ShardPlacementTest(PreallocNodesTest):
@@ -547,10 +549,17 @@ class ShardPlacementTest(PreallocNodesTest):
         self.stop_client_load()
 
     @cluster(num_nodes=6)
-    def test_node_join(self):
+    @matrix(disable_license=[True, False])
+    def test_node_join(self, disable_license):
         self.redpanda.add_extra_rp_conf({
             "core_balancing_continuous": True,
         })
+        if disable_license:
+            environment = dict(__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE='1')
+        else:
+            environment = dict()
+        self.redpanda.set_environment(environment)
+
         seed_nodes = self.redpanda.nodes[0:3]
         joiner_nodes = self.redpanda.nodes[3:]
         self.redpanda.start(nodes=seed_nodes)
@@ -584,7 +593,7 @@ class ShardPlacementTest(PreallocNodesTest):
 
             for topic in topics:
                 total_count = sum(
-                    len(replicas) for p, replicas in shard_map[topic].items())
+                    len(replicas) for _, replicas in shard_map[topic].items())
                 if total_count != n_partitions * 3:
                     return False
 
@@ -599,11 +608,16 @@ class ShardPlacementTest(PreallocNodesTest):
 
             return (True, shard_map)
 
-        shard_map_after_balance = wait_until_result(shard_rebalance_finished,
-                                                    timeout_sec=60,
-                                                    backoff_sec=2)
-        self.logger.info("shard rebalance finished")
-        self.print_shard_stats(shard_map_after_balance)
+        if disable_license:
+            time.sleep(60)
+            rebalanced = shard_rebalance_finished()
+            assert not rebalanced, f"continuous core balancing should not be active. Received {rebalanced}"
+        else:
+            shard_map_after_balance = wait_until_result(
+                shard_rebalance_finished, timeout_sec=60, backoff_sec=2)
+            self.logger.info("shard rebalance finished")
+            self.print_shard_stats(shard_map_after_balance)
+
         self.wait_shard_map_consistent_with_cluster_partitions(
             user_topics=topics, admin=admin)
 


### PR DESCRIPTION
Implements: [CORE-8014](https://redpandadata.atlassian.net/browse/CORE-8014)

Implement sanction(s) on partition autobalancer continuous mode. 
If there is no valid license and `partition_autobalancing_mode` is set to `continuous`, the setting will be ignored and it will revert to `node_add` behavior.

Implements: [CORE-8041](https://redpandadata.atlassian.net/browse/CORE-8041)

Implement sanction(s) on core balancing continuous property. 
If there is no valid license and `core_balancing_continuous` is set, the setting will be ignored.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[CORE-8014]: https://redpandadata.atlassian.net/browse/CORE-8014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-8041]: https://redpandadata.atlassian.net/browse/CORE-8041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ