### PR TITLE
bazel: enable seastar debug flags in non release build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,9 @@ build --sandbox_default_allow_network=false
 # leaking into the build.
 build --incompatible_strict_action_env
 
+# Add stack guards by default for better debugging, we disable them in release builds
+build --@seastar//:stack_guards=True
+
 # =================================
 # Sanitizer
 # =================================
@@ -85,6 +88,7 @@ build:release --compilation_mode opt
 build:release --config=secure
 build:release --copt -mllvm --copt -inline-threshold=2500
 build:release --linkopt=-flto
+build:release --@seastar//:stack_guards=False
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh
 

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -579,6 +579,11 @@ cc_library(
     ],
     local_defines = [
         "SEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT",
+        # This is nested in a `#ifdef SEASTAR_ASAN_ENABLED` so it's safe
+        # to always enable this as it will only have effect if ASAN is
+        # is enabled for the build.
+        # NOTE: SEASTAR_ASAN_ENABLED is auto detected - it's not set here
+        "SEASTAR_HAVE_ASAN_FIBER_SUPPORT",
     ] + select({
         ":use_debug_allocations": ["SEASTAR_DEBUG_ALLOCATIONS"],
         "//conditions:default": [],

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -18,7 +18,7 @@ bool_flag(
 
 bool_flag(
     name = "heap_profiling",
-    build_setting_default = False,
+    build_setting_default = True,
 )
 
 # "Enable the compile-time {fmt} check when formatting logging messages" ON


### PR DESCRIPTION
As discussed in Slack: https://redpandadata.slack.com/archives/C04B8659KGR/p1729095422516709

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
