### PR TITLE
Disabling large_messages_test

### DIFF
--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -291,6 +291,7 @@ class LargeMessagesTest(RedpandaTest):
         sent_samples, sent_bytes = _get_samples(sent_metric_name)
         return read_bytes, sent_bytes
 
+    @ignore
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @parametrize(message_size_mib=1)
     @parametrize(message_size_mib=2)


### PR DESCRIPTION
Disabling large messages test based on Slack conversation:
https://redpandadata.slack.com/archives/C07HL3GJ282/p1729625039588029?thread_ts=1729623975.439799&cid=C07HL3GJ282

Jira: https://redpandadata.atlassian.net/browse/DEVPROD-2066


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
