### PR TITLE
datalake: add catalog schema manager

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -1,6 +1,31 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "catalog_schema_manager",
+    srcs = [
+        "catalog_schema_manager.cc",
+    ],
+    hdrs = [
+        "catalog_schema_manager.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        ":table_definition",
+        "//src/v/base",
+        "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/iceberg:transaction",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/iceberg:catalog",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:table_identifier",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "conversion_outcome",
     srcs = [
     ],

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -31,6 +31,7 @@ v_cc_library(
   SRCS
     arrow_translator.cc
     batching_parquet_writer.cc
+    catalog_schema_manager.cc
     data_writer_interface.cc
     parquet_writer.cc
     record_multiplexer.cc

--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/catalog_schema_manager.h"
+
+#include "base/vlog.h"
+#include "datalake/logger.h"
+#include "datalake/table_definition.h"
+#include "iceberg/field_collecting_visitor.h"
+#include "iceberg/table_identifier.h"
+#include "iceberg/transaction.h"
+
+namespace datalake {
+
+namespace {
+catalog_schema_manager::errc log_and_convert_catalog_err(
+  iceberg::catalog::errc e, std::string_view log_msg) {
+    switch (e) {
+    case iceberg::catalog::errc::shutting_down:
+        vlog(datalake_log.debug, "{}: {}", log_msg, e);
+        return catalog_schema_manager::errc::shutting_down;
+    case iceberg::catalog::errc::timedout:
+    case iceberg::catalog::errc::not_found:
+    case iceberg::catalog::errc::io_error:
+    case iceberg::catalog::errc::unexpected_state:
+    case iceberg::catalog::errc::already_exists:
+        vlog(datalake_log.warn, "{}: {}", log_msg, e);
+        return catalog_schema_manager::errc::failed;
+    }
+}
+enum class fill_errc {
+    // There is a mismatch in a field's type, name, or required.
+    mismatch,
+    // We couldn't fill all the columns, but the ones we could all matched.
+    incomplete,
+};
+// Performs a simultaneous, depth-first iteration through fields of the two
+// schemas, filling dest's field IDs with those from the source. Returns
+// successfully if all the field IDs in the destination type are filled.
+checked<std::nullopt_t, fill_errc>
+fill_field_ids(iceberg::struct_type& dest, const iceberg::struct_type& source) {
+    using namespace iceberg;
+    chunked_vector<nested_field*> dest_stack;
+    dest_stack.reserve(dest.fields.size());
+    for (auto& f : std::ranges::reverse_view(dest.fields)) {
+        dest_stack.emplace_back(f.get());
+    }
+    chunked_vector<nested_field*> source_stack;
+    source_stack.reserve(source.fields.size());
+    for (auto& f : std::ranges::reverse_view(source.fields)) {
+        source_stack.emplace_back(f.get());
+    }
+    while (!source_stack.empty() && !dest_stack.empty()) {
+        auto* dst = dest_stack.back();
+        auto* src = source_stack.back();
+        if (
+          dst->name != src->name || dst->required != src->required
+          || dst->type.index() != src->type.index()) {
+            return fill_errc::mismatch;
+        }
+        dst->id = src->id;
+        dest_stack.pop_back();
+        source_stack.pop_back();
+        std::visit(reverse_field_collecting_visitor(dest_stack), dst->type);
+        std::visit(reverse_field_collecting_visitor(source_stack), src->type);
+    }
+    if (!dest_stack.empty()) {
+        // There are more fields to fill.
+        return fill_errc::incomplete;
+    }
+    // We successfully filled all the fields in the destination.
+    return std::nullopt;
+}
+} // namespace
+
+ss::future<checked<std::nullopt_t, catalog_schema_manager::errc>>
+catalog_schema_manager::get_registered_ids(
+  const model::topic& topic, iceberg::struct_type& dest_type) {
+    auto table_id = table_id_for_topic(topic);
+    auto load_res = co_await catalog_.load_or_create_table(
+      table_id, dest_type, hour_partition_spec());
+    if (load_res.has_error()) {
+        co_return log_and_convert_catalog_err(
+          load_res.error(), fmt::format("Error loading table {}", table_id));
+    }
+    auto get_res = get_ids_from_table_meta(
+      table_id, load_res.value(), dest_type);
+    if (get_res.has_error()) {
+        co_return get_res.error();
+    }
+    if (get_res.value()) {
+        // Success! We got all the field IDs.
+        co_return std::nullopt;
+    }
+    // The current table schema is a prefix of the desired schema. Add the
+    // schema to the table.
+    iceberg::transaction txn(std::move(load_res.value()));
+    auto update_res = co_await txn.set_schema(iceberg::schema{
+      .schema_struct = dest_type.copy(),
+      .schema_id = iceberg::schema::unassigned_id,
+      .identifier_field_ids = {},
+    });
+    if (update_res.has_error()) {
+        auto msg = fmt::format(
+          "Failed trying to apply schema update to table {}: {}",
+          table_id,
+          update_res.error());
+        switch (update_res.error()) {
+        case iceberg::action::errc::shutting_down:
+            vlog(datalake_log.debug, "{}", msg);
+            co_return errc::shutting_down;
+        case iceberg::action::errc::io_failed:
+        case iceberg::action::errc::unexpected_state:
+            vlog(datalake_log.warn, "{}", msg);
+            co_return errc::failed;
+        }
+    }
+    auto commit_res = co_await catalog_.commit_txn(table_id, std::move(txn));
+    if (commit_res.has_error()) {
+        co_return log_and_convert_catalog_err(
+          commit_res.error(),
+          fmt::format(
+            "Error while committing schema update to table {}", table_id));
+    }
+    load_res = co_await catalog_.load_table(table_id);
+    if (load_res.has_error()) {
+        co_return log_and_convert_catalog_err(
+          load_res.error(),
+          fmt::format(
+            "Error while reloading table {} after schema update", table_id));
+    }
+    get_res = get_ids_from_table_meta(table_id, load_res.value(), dest_type);
+    if (get_res.has_error()) {
+        co_return get_res.error();
+    }
+    if (!get_res.value()) {
+        vlog(
+          datalake_log.warn,
+          "Failed to fill field IDs after adding schema to table {}",
+          table_id);
+        co_return errc::failed;
+    }
+    // Success! We got all the field IDs.
+    co_return std::nullopt;
+}
+
+checked<bool, catalog_schema_manager::errc>
+catalog_schema_manager::get_ids_from_table_meta(
+  const iceberg::table_identifier& table_id,
+  const iceberg::table_metadata& table_meta,
+  iceberg::struct_type& dest_type) {
+    auto schema_iter = std::ranges::find(
+      table_meta.schemas,
+      table_meta.current_schema_id,
+      &iceberg::schema::schema_id);
+    if (schema_iter == table_meta.schemas.end()) {
+        vlog(
+          datalake_log.error,
+          "Cannot find current schema {} in table {}",
+          table_meta.current_schema_id,
+          table_id);
+        return errc::failed;
+    }
+    auto fill_res = fill_field_ids(dest_type, schema_iter->schema_struct);
+    if (fill_res.has_error()) {
+        switch (fill_res.error()) {
+        case fill_errc::mismatch:
+            vlog(datalake_log.warn, "Type mismatch with table {}", table_id);
+            return errc::not_supported;
+        case fill_errc::incomplete:
+            return false;
+        }
+    }
+    return true;
+}
+
+iceberg::table_identifier
+catalog_schema_manager::table_id_for_topic(const model::topic& t) const {
+    return iceberg::table_identifier{
+      // TODO: namespace as a topic property? Keep it in the table metadata?
+      .ns = {"redpanda"},
+      .table = t,
+    };
+}
+
+} // namespace datalake

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/catalog.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/table_identifier.h"
+
+namespace datalake {
+
+// Manages interactions with the catalog when reconciling the current schema of
+// a given table. This is where Redpanda should make decisions about schema
+// evolution.
+class catalog_schema_manager {
+public:
+    enum class errc {
+        // The requested operation is not supported (e.g. unsupported schema
+        // evolution).
+        not_supported,
+        // The operation failed because of a subsystem failure.
+        failed,
+        // The system is shutting down.
+        shutting_down,
+    };
+    explicit catalog_schema_manager(iceberg::catalog& catalog)
+      : catalog_(catalog) {}
+
+    // Loads the table metadata for the given topic and fills the field IDs of
+    // the given type with those in the current schema.
+    //
+    // If the table's current schema doesn't include all of the fields (e.g. we
+    // are going from the schemaless schema to a schema containing user
+    // fields), the table's schema is updated to the desired type, and then the
+    // fill is attempted again.
+    ss::future<checked<std::nullopt_t, errc>>
+    get_registered_ids(const model::topic&, iceberg::struct_type& desired_type);
+
+private:
+    iceberg::table_identifier table_id_for_topic(const model::topic& t) const;
+
+    // Attempts to fill the field ids in the given type with those from the
+    // current schema of the given table metadata.
+    //
+    // Returns true if successful, false if the fill is incomplete because the
+    // table schema does not have all the necessary fields. The latter is a
+    // signal that the caller needs to add the schema to the table.
+    checked<bool, errc> get_ids_from_table_meta(
+      const iceberg::table_identifier&,
+      const iceberg::table_metadata&,
+      iceberg::struct_type&);
+
+    iceberg::catalog& catalog_;
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -81,6 +81,27 @@ redpanda_test_cc_library(
 )
 
 redpanda_cc_gtest(
+    name = "catalog_schema_manager_test",
+    timeout = "short",
+    srcs = [
+        "catalog_schema_manager_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage/tests:s3_imposter_gtest",
+        "//src/v/datalake:catalog_schema_manager",
+        "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/iceberg:filesystem_catalog",
+        "//src/v/iceberg:table_identifier",
+        "//src/v/iceberg/tests:test_schemas",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "datalake_protobuf_test",
     timeout = "short",
     srcs = [

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -62,6 +62,23 @@ rp_test(
 )
 
 rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME catalog_schema_manager
+  SOURCES catalog_schema_manager_test.cc
+  LIBRARIES
+    Boost::iostreams
+    v::cloud_io_utils
+    v::datalake_writer
+    v::iceberg
+    v::iceberg_test_utils
+    v::gtest_main
+    v::s3_imposter
+  LABELS datalake
+  ARGS "-- -c 1"
+)
+
+rp_test(
   FIXTURE_TEST
   GTEST
   BINARY_NAME translator_test

--- a/src/v/datalake/tests/catalog_schema_manager_test.cc
+++ b/src/v/datalake/tests/catalog_schema_manager_test.cc
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "datalake/catalog_schema_manager.h"
+#include "iceberg/field_collecting_visitor.h"
+#include "iceberg/filesystem_catalog.h"
+#include "iceberg/table_identifier.h"
+#include "iceberg/tests/test_schemas.h"
+
+#include <gtest/gtest.h>
+
+using namespace datalake;
+using namespace iceberg;
+
+namespace {
+const auto table_ident = table_identifier{.ns = {"redpanda"}, .table = "foo"};
+} // namespace
+
+class CatalogSchemaManagerTest
+  : public s3_imposter_fixture
+  , public ::testing::Test {
+public:
+    static constexpr std::string_view base_location{"test"};
+    CatalogSchemaManagerTest()
+      : sr(cloud_io::scoped_remote::create(10, conf))
+      , catalog(remote(), bucket_name, ss::sstring(base_location))
+      , schema_mgr(catalog) {
+        set_expectations_and_listen({});
+    }
+    cloud_io::remote& remote() { return sr->remote.local(); }
+
+    void reset_field_ids(struct_type& type) {
+        chunked_vector<nested_field*> to_visit;
+        for (auto& f : std::ranges::reverse_view(type.fields)) {
+            to_visit.emplace_back(f.get());
+        }
+        while (!to_visit.empty()) {
+            auto* f = to_visit.back();
+            f->id = nested_field::id_t{0};
+            to_visit.pop_back();
+            std::visit(reverse_field_collecting_visitor{to_visit}, f->type);
+        }
+    }
+
+    void create_nested_table() {
+        create_table(std::get<struct_type>(test_nested_schema_type()));
+    }
+
+    void create_table(const struct_type& type) {
+        schema s{
+          .schema_struct = type.copy(),
+          .schema_id = schema::id_t{1},
+          .identifier_field_ids{},
+        };
+        auto create_res
+          = catalog.create_table(table_ident, s, partition_spec{}).get();
+        ASSERT_FALSE(create_res.has_error());
+    }
+
+    ss::future<std::optional<schema>>
+    load_table_schema(const table_identifier& table_ident) {
+        auto load_res = catalog.load_table(table_ident).get();
+        if (!load_res.has_value()) {
+            co_return std::nullopt;
+        }
+        auto& table = load_res.value();
+        EXPECT_NE(table.current_schema_id, schema::unassigned_id);
+        auto schema_it = std::ranges::find(
+          table.schemas, table.current_schema_id, &schema::schema_id);
+        if (schema_it == table.schemas.end()) {
+            co_return std::nullopt;
+        }
+        co_return std::move(*schema_it);
+    }
+
+    std::unique_ptr<cloud_io::scoped_remote> sr;
+    filesystem_catalog catalog;
+    catalog_schema_manager schema_mgr;
+};
+
+TEST_F(CatalogSchemaManagerTest, TestCreateTable) {
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+
+    // Trying to fill the field IDs requires querying the catalog, which will
+    // result in the table being created.
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+
+    auto table_ident = table_identifier{.ns = {"redpanda"}, .table = "foo"};
+    auto schema = load_table_schema(table_ident).get();
+    ASSERT_TRUE(schema.has_value());
+    EXPECT_EQ(type, schema->schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestFillFromExistingTable) {
+    create_nested_table();
+    auto schema = load_table_schema(table_ident).get();
+    ASSERT_TRUE(schema.has_value());
+
+    // Even if the table already exists, we should be able to fill fields IDs
+    // without trouble.
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+    EXPECT_EQ(type, schema.value().schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestFillSubset) {
+    create_nested_table();
+    auto schema = load_table_schema(table_ident).get();
+    ASSERT_TRUE(schema.has_value());
+
+    // Remove a field from the set that we want to fill.
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    type.fields.pop_back();
+
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+
+    schema.value().schema_struct.fields.pop_back();
+    EXPECT_EQ(type, schema.value().schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestFillNestedSubset) {
+    create_nested_table();
+    auto schema = load_table_schema(table_ident).get();
+    ASSERT_TRUE(schema.has_value());
+
+    // Remove a subfield from the set that we want to fill.
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    std::get<struct_type>(type.fields.back()->type).fields.pop_back();
+
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+
+    std::get<struct_type>(schema.value().schema_struct.fields.back()->type)
+      .fields.pop_back();
+    EXPECT_EQ(type, schema.value().schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestFillSuperset) {
+    create_nested_table();
+
+    // Add a couple nested fields to the desired type.
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    for (size_t i = 0; i < 2; ++i) {
+        struct_type nested;
+        for (size_t j = 0; j < 10; ++j) {
+            nested.fields.emplace_back(nested_field::create(
+              0,
+              fmt::format("inner-{}", j),
+              field_required::no,
+              boolean_type{}));
+        }
+        type.fields.emplace_back(nested_field::create(
+          0,
+          fmt::format("nested-{}", i),
+          field_required::no,
+          std::move(nested)));
+    }
+
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+
+    // Check the resulting schema.
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    EXPECT_EQ(39, s.highest_field_id());
+
+    // Sanity check: the field IDs should match what is in the catalog.
+    auto loaded_table = load_table_schema(table_ident).get();
+    ASSERT_TRUE(loaded_table.has_value());
+    ASSERT_EQ(loaded_table.value().schema_struct, s.schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestFillSupersetSubtype) {
+    create_nested_table();
+
+    // Add a couple fields to a subfield of the desired type.
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    for (size_t i = 0; i < 2; ++i) {
+        std::get<struct_type>(type.fields.back()->type)
+          .fields.emplace_back(nested_field::create(
+            0,
+            fmt::format("extra-nested-{}", i),
+            field_required::no,
+            int_type{}));
+    }
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_FALSE(res.has_error());
+
+    // Check the resulting schema.
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {},
+    };
+    EXPECT_EQ(19, s.highest_field_id());
+
+    // Sanity check: the field IDs should match what is in the catalog.
+    auto loaded_table = load_table_schema(table_ident).get();
+    ASSERT_TRUE(loaded_table.has_value());
+    ASSERT_EQ(loaded_table.value().schema_struct, s.schema_struct);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestOptionalMismatch) {
+    struct_type type;
+    type.fields.emplace_back(
+      nested_field::create(0, "required", field_required::yes, int_type{}));
+    type.fields.emplace_back(
+      nested_field::create(0, "optional", field_required::no, int_type{}));
+    create_table(type);
+
+    // Make the destinations both optional.
+    type.fields[0]->required = field_required::no;
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_TRUE(res.has_error());
+    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+
+    // Make the destinations both required.
+    type.fields[0]->required = field_required::yes;
+    type.fields[1]->required = field_required::yes;
+    res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_TRUE(res.has_error());
+    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+}
+
+TEST_F(CatalogSchemaManagerTest, TestTypeMismatch) {
+    create_nested_table();
+
+    auto type = std::get<struct_type>(test_nested_schema_type());
+    reset_field_ids(type);
+    std::swap(type.fields.front(), type.fields.back());
+
+    auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
+    ASSERT_TRUE(res.has_error());
+    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+}


### PR DESCRIPTION
Adds a new component the catalog_schema_manager to get field IDs from the Iceberg catalog, potentially registering a new schema if there are missing fields in the catalog.

This will be the place we can make decisions about schema evolution. As is, the implemented policy is that as long as fields are added to the end of the table, the schema can be added. This is so that we can support going from the default schema to the default schema + user defined columns, but has the effect of also letting us support schema evolution in a limited form.

In the short term, for simplicity, I expect this to live along side the datalake workers, where each worker will call into the schema manager when constructing a parquet writer with a given schema to get the correct field IDs. Longer term, for scale, perhaps this ought to live in the coordinator and workers may interact with it via RPC.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
