### PR TITLE
Fixed intermittently failing `AvroParserTest.TestIncorrectSchema`

### DIFF
--- a/src/v/serde/avro/parser.cc
+++ b/src/v/serde/avro/parser.cc
@@ -51,6 +51,14 @@ public:
         }
         case ::avro::AVRO_INT: {
             auto [value, _] = _parser.read_varlong();
+            using limits_t = std::numeric_limits<int32_t>;
+            if (value < limits_t::min() || value > limits_t::max()) {
+                throw std::invalid_argument(fmt::format(
+                  "Value {} is outside of avro int limits: [{},{}]",
+                  value,
+                  limits_t::min(),
+                  limits_t::max()));
+            }
             co_return std::make_unique<parsed::message>(
               parsed::primitive(static_cast<int32_t>(value)));
         }


### PR DESCRIPTION
The test that used incorrect schema to parse a buffer serialized with
avro library, sometimes failed as the parsing didn't throw an error.
Changed the test to check if the behavior of `serde::parser` is the same
as the `::avro::GenericReader`. The test now validates that the outcome
of both parsers is the same.

Additionally added validation of `AVRO_INT` range when decoding its varlong encoded value.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none