### PR TITLE
[CORE-8075] debug_bundle: Don't return excess on 204 no_content

### DIFF
--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -59,10 +59,10 @@ as_json_doc(ss::http::request* req) {
 template<typename T>
 std::unique_ptr<ss::http::reply> make_json_body(
   ss::http::reply::status_type status,
-  const T& t,
+  T&& t,
   std::unique_ptr<ss::http::reply> rep) {
     rep->set_status(status);
-    rep->write_body("json", ss::json::stream_object(t));
+    rep->write_body("json", ss::json::stream_object(std::forward<T>(t)));
     return rep;
 }
 
@@ -259,10 +259,8 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::delete_debug_bundle(
         co_return make_error_body(res.assume_error(), std::move(rep));
     }
 
-    co_return make_json_body(
-      ss::http::reply::status_type::no_content,
-      ss::json::json_void{},
-      std::move(rep));
+    rep->set_status(ss::http::reply::status_type::no_content);
+    co_return rep;
 }
 
 namespace {
@@ -326,8 +324,6 @@ admin_server::delete_debug_bundle_file(
         co_return make_error_body(del_res.assume_error(), std::move(rep));
     }
 
-    co_return make_json_body(
-      ss::http::reply::status_type::no_content,
-      ss::json::json_void{},
-      std::move(rep));
+    rep->set_status(ss::http::reply::status_type::no_content);
+    co_return rep;
 }

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -146,6 +146,7 @@ class DebugBundleTestBase(RedpandaTest):
         if cancel_after_start:
             res = admin.delete_debug_bundle(job_id=job_id, node=node)
             assert res.status_code == requests.codes.no_content, f"Failed to cancel debug bundle: {res.json()}"
+            assert len(res.content) == 0, f"Response not empty: {res.content}"
 
         expected_status = 'error' if cancel_after_start else 'success'
 
@@ -304,7 +305,7 @@ class DebugBundleTest(DebugBundleTestBase):
         # Delete the debug bundle file
         res = self.admin.delete_debug_bundle_file(filename=filename, node=node)
         assert res.status_code == requests.codes.no_content, res.json()
-        assert res.headers['Content-Type'] == 'application/json', res.json()
+        assert len(res.content) == 0, f"Response not empty: {res.content}"
         assert not node.account.exists(file)
 
         # Get the non-existant debug bundle


### PR DESCRIPTION
Due to a feature in streaming a body, seastar adds "\r\n\r\n" before streaming nothing, which is incorrect:

Request:
```
DELETE /v1/debug/bundle/37be2e14-c3d6-461a-927f-3a2a2afe4da8 HTTP/1.1
Host: 127.0.0.1:10644
```

Response:
```
2024/10/28 13:08:10 Unsolicited response received on idle HTTP channel starting with "0\r\n\r\n"; err=<nil>
HTTP/1.1 204 No Content
Transfer-Encoding: chunked
Content-Type: application/json
Date: Mon, 28 Oct 2024 20:08:09 GMT
Server: Seastar httpd

0
```

Instead of streaming a `json_void`, just return an empty response.

Note: The added test doesn't fail with the old code; I couldn't find a way to coerce python to detect it with `requests` or `http.client`.

Additionally, I took the opportunity to avoid a copy when streaming bodies.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
