### PR TITLE
datalake/stm: fixed translation of of range error

### DIFF
--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -255,7 +255,7 @@ frontend::add_translated_data_files_locally(
   ss::shard_id shard) {
     co_return co_await _coordinator_mgr->invoke_on(
       shard,
-      [&coordinator_partition,
+      [coordinator_partition,
        req = std::move(request)](coordinator_manager& mgr) mutable {
           return add_files(mgr, coordinator_partition, std::move(req));
       });
@@ -277,7 +277,7 @@ frontend::fetch_latest_data_file_locally(
   ss::shard_id shard) {
     co_return co_await _coordinator_mgr->invoke_on(
       shard,
-      [&coordinator_partition,
+      [coordinator_partition,
        req = std::move(request)](coordinator_manager& mgr) mutable {
           auto partition = mgr.get(coordinator_partition);
           if (!partition) {

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -113,6 +113,10 @@ model::offset translation_stm::max_collectible_offset() {
     if (!_raft->log_config().iceberg_enabled()) {
         return model::offset::max();
     }
+    // if offset is not initialized, do not attempt translation.
+    if (_highest_translated_offset == kafka::offset{}) {
+        return model::offset{};
+    }
     return _raft->log()->to_log_offset(
       kafka::offset_cast(_highest_translated_offset));
 }


### PR DESCRIPTION
When last translated offset is not updated an offset translation can not be performed as the requested offset is out of translation range. Fixed the problem by returning `model::offset{}` when last translated offset wasn't yet updated.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none