### PR TITLE
`kafka`: fix typo for `alter_broker_configuration()`

### DIFF
--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -411,7 +411,7 @@ inline std::string_view map_config_name(std::string_view input) {
       .default_match(input);
 }
 
-static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuartion(
+static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
   request_context& ctx, chunked_vector<req_resource_t> resources) {
     chunked_vector<resp_resource_t> responses;
     responses.reserve(resources.size());
@@ -582,7 +582,7 @@ ss::future<response_ptr> incremental_alter_configs_handler::handle(
     futures.push_back(alter_topic_configuration(
       ctx, std::move(groupped.topic_changes), request.data.validate_only));
     futures.push_back(
-      alter_broker_configuartion(ctx, std::move(groupped.broker_changes)));
+      alter_broker_configuration(ctx, std::move(groupped.broker_changes)));
 
     auto ret = co_await ss::when_all_succeed(futures.begin(), futures.end());
     // include authorization errors


### PR DESCRIPTION
:) 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
