### PR TITLE
raft: const wait and wait_no_throw

### DIFF
--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -501,7 +501,7 @@ template<typename BaseT, supported_stm_snapshot T>
 ss::future<bool> persisted_stm_base<BaseT, T>::wait_no_throw(
   model::offset offset,
   model::timeout_clock::time_point deadline,
-  std::optional<std::reference_wrapper<ss::abort_source>> as) noexcept {
+  std::optional<std::reference_wrapper<ss::abort_source>> as) const noexcept {
     return BaseT::wait(offset, deadline, as)
       .then([] { return true; })
       .handle_exception_type([](const ss::abort_requested_exception&) {

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -203,7 +203,7 @@ public:
       model::offset offset,
       model::timeout_clock::time_point,
       std::optional<std::reference_wrapper<ss::abort_source>>
-      = std::nullopt) noexcept;
+      = std::nullopt) const noexcept;
 
     model::offset max_collectible_offset() override;
     ss::future<fragmented_vector<model::tx_range>>

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -41,7 +41,7 @@ ss::future<> state_machine_base::stop() {
 ss::future<> state_machine_base::wait(
   model::offset offset,
   model::timeout_clock::time_point timeout,
-  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+  std::optional<std::reference_wrapper<ss::abort_source>> as) const {
     co_await _waiters.wait(offset, timeout, as);
 }
 

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -42,7 +42,7 @@ public:
       model::offset,
       model::timeout_clock::time_point,
       std::optional<std::reference_wrapper<ss::abort_source>> as
-      = std::nullopt);
+      = std::nullopt) const;
 
     /**
      * Applies the batch and updates the next offset to be applied.
@@ -126,7 +126,7 @@ protected:
     friend class state_machine_manager;
 
 private:
-    offset_monitor _waiters;
+    mutable offset_monitor _waiters;
     model::offset _next{0};
 };
 


### PR DESCRIPTION
Allow to wait for offsets to be applied using a const reference to state machine. I have a use-case in another PR where where I want to enforce read-only access to STM state to prevent accidental direct state mutation rather than via consensus::replicate but I need to wait for results to be applied.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
