### PR TITLE
`config`: add `log_compaction_pause_use_sliding_window`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1069,6 +1069,15 @@ configuration::configuration()
       "Use sliding window compaction.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       true)
+  , log_compaction_pause_use_sliding_window(
+      *this,
+      "log_compaction_pause_use_sliding_window",
+      "Pause use of sliding window compaction. This should only be toggled "
+      "to `true` when it is desired to force adjacent segment compaction. The "
+      "memory reserved by `storage_compaction_key_map_memory` is not freed "
+      "when this is set to `true`.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , log_compaction_adjacent_merge_self_compaction_count(
       *this,
       "log_compaction_adjacent_merge_self_compaction_count",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -260,6 +260,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> max_compaction_lag_ms;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
+    property<bool> log_compaction_pause_use_sliding_window;
     property<std::optional<size_t>>
       log_compaction_adjacent_merge_self_compaction_count;
     // same as retention.size in kafka - TODO: size not implemented

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1371,9 +1371,12 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
-    if (
-      !config::shard_local_cfg().log_compaction_use_sliding_window()
-      || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0)) {
+    auto use_adjacent_merge
+      = !config::shard_local_cfg().log_compaction_use_sliding_window()
+        || config::shard_local_cfg().log_compaction_pause_use_sliding_window()
+        || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0);
+
+    if (use_adjacent_merge) {
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);
     }

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -523,9 +523,13 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
     """
     def __init__(self, test_context):
         self.test_context = test_context
-        # Start with sliding window compaction disabled.
+
+        # Start with sliding window compaction set per the starting_config argument.
+        use_sliding_window_starting_config = self.test_context.injected_args[
+            'starting_config']
         self.extra_rp_conf = {
-            'log_compaction_use_sliding_window': False,
+            'log_compaction_use_sliding_window':
+            use_sliding_window_starting_config,
             'log_compaction_interval_ms': 100,
             'log_segment_size': 2 * 1024**2,  # 2 MiB
             'compacted_log_segment_size': 1024**2,  # 1 MiB
@@ -538,34 +542,52 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
         self._rpk_client = RpkTool(self.redpanda)
 
     @cluster(num_nodes=2)
-    def test_enable_sliding_window(self):
-        # Redpanda was started with log_compaction_use_sliding_window=false.
-        # Set it to true, thereby leaving the memory reservation for compaction at 0.
+    @matrix(starting_config=[False, True])
+    def test_toggle_sliding_window(self, starting_config):
+        next_sliding_window_config = not starting_config
+        # If Redpanda was started with log_compaction_use_sliding_window=false and
+        # we set it to true, the memory reservation for compaction will be left at 0.
         self._rpk_client.cluster_config_set(
-            "log_compaction_use_sliding_window", True)
+            "log_compaction_use_sliding_window", next_sliding_window_config)
 
         topic_spec = TopicSpec(cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+                               min_cleanable_dirty_ratio=0.0,
                                replication_factor=1)
         self.client().create_topic(topic_spec)
 
-        # Produce a small amount of segments and wait
-        producer = KgoVerifierProducer(context=self.test_context,
-                                       redpanda=self.redpanda,
-                                       topic=topic_spec.name,
-                                       msg_size=1024,
-                                       msg_count=10000)
+        # The number of times log_compaction_use_sliding_window will be flipped on/off.
+        self.prev_num_compacted_segments = 0
+        num_rounds = 5
+        for i in range(0, num_rounds):
+            # Produce a small amount of segments and wait
+            producer = KgoVerifierProducer(context=self.test_context,
+                                           redpanda=self.redpanda,
+                                           topic=topic_spec.name,
+                                           msg_size=1024,
+                                           msg_count=10000)
 
-        producer.start()
-        producer.wait(timeout_sec=180)
+            producer.start()
+            producer.wait(timeout_sec=180)
 
-        def seen_compacted_segments():
-            return self.redpanda.metric_sum(
-                metric_name="vectorized_storage_log_compacted_segment_total",
-                metrics_endpoint=MetricsEndpoint.METRICS,
-                topic=topic_spec.name,
-                expect_metric=True) > 0
+            def seen_compacted_segments():
+                num_compacted_segments = self.redpanda.metric_sum(
+                    metric_name=
+                    "vectorized_storage_log_compacted_segment_total",
+                    metrics_endpoint=MetricsEndpoint.METRICS,
+                    topic=topic_spec.name,
+                    expect_metric=True)
+                ret = num_compacted_segments > self.prev_num_compacted_segments
+                self.prev_num_compacted_segments = num_compacted_segments
+                return ret
 
-        wait_until(seen_compacted_segments,
-                   timeout_sec=60,
-                   backoff_sec=1,
-                   err_msg=f"Did not see any compacted segments.")
+            wait_until(seen_compacted_segments,
+                       timeout_sec=60,
+                       backoff_sec=1,
+                       err_msg=f"Did not see any compacted segments.")
+
+            producer.free()
+
+            next_sliding_window_config = not next_sliding_window_config
+            self._rpk_client.cluster_config_set(
+                "log_compaction_use_sliding_window",
+                next_sliding_window_config)


### PR DESCRIPTION
We have seen in incidents that it can be useful to disable sliding window compaction for a period of time, in order to allow adjacent segment compaction to kick in instead.

Unfortunately, `log_compaction_use_sliding_window` is marked as `needs_restart::yes`, due to the fact memory is only allocated at start-up if it is enabled.

To deal with the common case in which we start `redpanda` with `log_compaction_use_sliding_window=true`, and wish to disable sliding window compaction for a period of time without forcing a cluster restart (usually by cloud operators), add a new cluster config `log_compaction_pause_use_sliding_window`, which doesn't require a restart and can be used to temporarily disable sliding window compaction.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
