### PR TITLE
iceberg/manifest_entry: fixed manifest entry avro serialization

### DIFF
--- a/src/v/iceberg/manifest_entry_type.cc
+++ b/src/v/iceberg/manifest_entry_type.cc
@@ -47,12 +47,6 @@ struct_type data_file_type(partition_key_type partition_type) {
       map_type::create(
         121, int_type(), 122, field_required::yes, long_type())));
     r2_type.fields.emplace_back(nested_field::create(
-      111,
-      "distinct_counts",
-      field_required::no,
-      map_type::create(
-        123, int_type(), 124, field_required::yes, long_type())));
-    r2_type.fields.emplace_back(nested_field::create(
       137,
       "nan_value_counts",
       field_required::no,

--- a/src/v/iceberg/manifest_entry_values.cc
+++ b/src/v/iceberg/manifest_entry_values.cc
@@ -174,16 +174,25 @@ std::unique_ptr<struct_value> data_file_to_value(const data_file& file) {
       long_value(static_cast<int64_t>(file.file_size_bytes)));
 
     // TODO: serialize the rest of the optional fields.
+    // column_sizes
     ret->fields.emplace_back(std::nullopt);
+    // value_counts
     ret->fields.emplace_back(std::nullopt);
+    // null_value_counts
     ret->fields.emplace_back(std::nullopt);
+    // nan_value_counts
     ret->fields.emplace_back(std::nullopt);
+    // lower_bounds
     ret->fields.emplace_back(std::nullopt);
+    // upper_bounds
     ret->fields.emplace_back(std::nullopt);
+    // key_metadata
     ret->fields.emplace_back(std::nullopt);
+    // split_offsets
     ret->fields.emplace_back(std::nullopt);
+    // equality_ids
     ret->fields.emplace_back(std::nullopt);
-    ret->fields.emplace_back(std::nullopt);
+    // sort_order_id
     ret->fields.emplace_back(std::nullopt);
     return ret;
 }


### PR DESCRIPTION
The `distinct_count` is not part of iceberg manifest_entry schema definition. Having the field in Redpanda iceberg manifest entry definition lead to issues when querying iceberg metadata with pyicebrg library.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none