### PR TITLE
datalake/arrow: added parquet field_id metadata when writing data files

### DIFF
--- a/src/v/datalake/tests/parquet_writer_test.cc
+++ b/src/v/datalake/tests/parquet_writer_test.cc
@@ -53,10 +53,10 @@ TEST(ParquetWriter, CreatesValidParquetData) {
 
     // The last write is long. This is probably Parquet footer information.
     auto serialized = writer.close_and_take_iobuf();
-    EXPECT_NEAR(serialized.size_bytes(), 21000, 1000);
+    EXPECT_NEAR(serialized.size_bytes(), 22000, 1000);
     full_result.append_fragments(std::move(serialized));
 
-    EXPECT_NEAR(full_result.size_bytes(), 55000, 1000);
+    EXPECT_NEAR(full_result.size_bytes(), 57000, 1000);
 
     // Check that the data is a valid parquet file. Convert the iobuf to a
     // single buffer then import that into an arrow::io::BufferReader


### PR DESCRIPTION
According to Iceberg specification the `PARQUET:field_id` metadata value is used to find columns using the id of a field in Iceberg schema. Added missing metadata to parquet files written by
`datalake::arrow_translator`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none