### PR TITLE
[v24.2.x] [DEVEX-36] rpk: change expiry check for free_trial

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/hamba/avro/v2 v2.25.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/kr/text v0.2.0
 	github.com/lestrrat-go/jwx v1.2.30
 	github.com/linkedin/goavro/v2 v2.13.0
 	github.com/lorenzosaino/go-sysctl v0.3.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -43,6 +43,7 @@ github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kr/text"
+	mTerm "github.com/moby/term"
+
 	"go.uber.org/zap"
 
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -177,6 +180,10 @@ func licenseFeatureChecks(ctx context.Context, fs afero.Fs, cl *rpadmin.AdminAPI
 				}
 			}
 		}
+	}
+	if ws, err := mTerm.GetWinsize(0); err == nil {
+		// text.Wrap removes the newline from the text. We add it back.
+		msg = "\n" + text.Wrap(msg, int(ws.Width)) + "\n"
 	}
 	return msg
 }

--- a/src/go/rpk/pkg/cli/cluster/license/info.go
+++ b/src/go/rpk/pkg/cli/cluster/license/info.go
@@ -3,6 +3,7 @@ package license
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -133,17 +134,21 @@ func printTextLicenseInfo(resp infoResponse) {
 		if *resp.Expired {
 			tw.Print("License expired:", *resp.Expired)
 		}
-		checkLicenseExpiry(resp.ExpiresUnix)
+		checkLicenseExpiry(resp.ExpiresUnix, resp.Type)
 	}
 	out.Section("LICENSE INFORMATION")
 	tw.Flush()
 }
 
-func checkLicenseExpiry(expiresUnix int64) {
+func checkLicenseExpiry(expiresUnix int64, licenseType string) {
 	ut := time.Unix(expiresUnix, 0)
 	daysLeft := int(time.Until(ut).Hours() / 24)
 
-	if daysLeft < 30 && !ut.Before(time.Now()) {
+	dayThreshold := 30
+	if strings.EqualFold(licenseType, "free_trial") {
+		dayThreshold = 15
+	}
+	if daysLeft < dayThreshold && !ut.Before(time.Now()) {
 		fmt.Fprintf(os.Stderr, "WARNING: your license will expire soon.\n\n")
 	}
 }


### PR DESCRIPTION
Manual Backport of https://github.com/redpanda-data/redpanda/pull/23951

The difference is the BUILD files.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


* none
