### PR TITLE
[CORE-8029] - RBAC Sanctions

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1583,6 +1583,11 @@ ss::future<response_ptr> create_acls_handler::handle(
               auto ec = map_topic_error_code(results[i]);
               response.data.results.push_back(
                 creatable_acl_result{.error_code = ec});
+              if (results[i] == cluster::errc::feature_disabled) {
+                  response.data.results.back().error_message.emplace(
+                    "An enterprise license is required to create "
+                    "Role-bound ACLs");
+              }
           },
           [&response](creatable_acl_result r) {
               response.data.results.push_back(std::move(r));

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -397,6 +397,7 @@ void admin_server::register_security_routes() {
     register_route<superuser>(
       ss::httpd::security_json::create_role,
       request_handler_fn{[this](auto req, auto reply) {
+          check_license();
           return create_role_handler(std::move(req), std::move(reply));
       }});
 

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -436,6 +436,7 @@ void admin_server::register_security_routes() {
       ss::httpd::security_json::update_role_members,
       [this]([[maybe_unused]] std::unique_ptr<ss::http::request> req)
         -> ss::future<ss::json::json_return_type> {
+          check_license();
           return update_role_members_handler(std::move(req));
       });
 }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1727,6 +1727,14 @@ void config_multi_property_validation(
 }
 } // namespace
 
+void admin_server::check_license() const {
+    if (_controller->get_feature_table().local().should_sanction()) {
+        throw ss::httpd::base_exception(
+          "Enterprise License Required",
+          ss::http::reply::status_type::forbidden);
+    }
+}
+
 void admin_server::register_cluster_config_routes() {
     register_route<superuser>(
       ss::httpd::cluster_config_json::get_cluster_config_status,

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -191,6 +191,8 @@ private:
         return auth_state;
     }
 
+    void check_license() const;
+
     void log_exception(
       const ss::sstring& url,
       const request_auth_result& auth_state,

--- a/tests/rptest/tests/enterprise_features_license_test.py
+++ b/tests/rptest/tests/enterprise_features_license_test.py
@@ -216,14 +216,12 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
 
         has_license = not disable_trial or install_license
 
-        # RBAC isn't controlled by cluster config and so is not subject to
-        # sanction/restriction pending CORE-8029
-        expect_rejected = not has_license and not (feature == Feature.rbac)
+        expect_rejected = not has_license
 
         if expect_rejected:
             with expect_exception(
-                    requests.exceptions.HTTPError,
-                    lambda e: FEATURE_DEPENDENT_CONFIG[
+                    requests.exceptions.HTTPError, \
+                    lambda e: e.response.status_code == 403 or FEATURE_DEPENDENT_CONFIG[
                         feature] in e.response.json().keys()):
                 self.try_enable_feature(feature)
         else:


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR implements enterprise sanctions on the Core RBAC feature. This includes sanctioning (i.e. preventing users from):
- creating new roles (Admin API)
- adding/removing members from existing roles (Admin API)
- Adding Role-based ACLs (Kafka API)
- ~Deleting Role-based ACLs (Kafka API)~
   - ~Error reporting on the security frontend tends to be "all or nothing", so we match that here - if _any_ filter in a DeleteAcls request matches a Role-bound ACL, the whole request must be rejected.~
   - ~At some point in the future, we may want to consider something more granular - e.g. requests that fail partially or are rejected only partially, but that would (I think) require revisiting error reporting code beyond the scope of this PR.~
   - DeleteACLs sanctions were dropped from the requirements

Functionality not affected by sanctions:
- Role deletion
- Role-ACL deletion
- The application of Role-based ACLs to incoming requests (i.e. Role-based AuthZ)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
