### PR TITLE
`cloud_storage`: support conditional operations

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -60,6 +60,9 @@ redpanda_cc_library(
     ],
     include_prefix = "cloud_io",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_storage_clients",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/cloud_io/io_result.cc
+++ b/src/v/cloud_io/io_result.cc
@@ -25,6 +25,9 @@ std::ostream& operator<<(std::ostream& o, const download_result& r) {
     case download_result::failed:
         o << "{failed}";
         break;
+    case download_result::precondition_failed:
+        o << "{precondition_failed}";
+        break;
     };
     return o;
 }
@@ -42,6 +45,9 @@ std::ostream& operator<<(std::ostream& o, const upload_result& r) {
         break;
     case upload_result::cancelled:
         o << "{cancelled}";
+        break;
+    case upload_result::precondition_failed:
+        o << "{precondition_failed}";
         break;
     };
     return o;

--- a/src/v/cloud_io/io_result.h
+++ b/src/v/cloud_io/io_result.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "cloud_storage_clients/client.h"
+
 #include <cstdint>
 #include <iostream>
 
@@ -29,5 +31,7 @@ enum class [[nodiscard]] upload_result : int32_t {
 };
 std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);
+
+using list_result = cloud_storage_clients::client::list_result;
 
 } // namespace cloud_io

--- a/src/v/cloud_io/io_result.h
+++ b/src/v/cloud_io/io_result.h
@@ -21,6 +21,7 @@ enum class [[nodiscard]] download_result : int32_t {
     notfound,
     timedout,
     failed,
+    precondition_failed
 };
 
 enum class [[nodiscard]] upload_result : int32_t {
@@ -28,6 +29,7 @@ enum class [[nodiscard]] upload_result : int32_t {
     timedout,
     failed,
     cancelled,
+    precondition_failed
 };
 std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1107,6 +1107,10 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
 
         if (res) {
             transfer_details.on_success();
+            // Set the ETag in the upload request, if the pointer exists.
+            if (upload_request.etag) {
+                *upload_request.etag = std::move(res.value().etag);
+            }
             co_return upload_result::success;
         }
 

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -41,6 +41,7 @@ struct basic_upload_request {
     std::string_view display_str;
     iobuf payload;
     bool accept_no_content_response{false};
+    cloud_storage_clients::header_map_t headers;
 };
 using upload_request = basic_upload_request<ss::lowres_clock>;
 
@@ -50,6 +51,7 @@ struct basic_download_request {
     std::string_view display_str;
     iobuf& payload;
     bool expect_missing{false};
+    cloud_storage_clients::header_map_t headers;
 };
 using download_request = basic_download_request<ss::lowres_clock>;
 using remote_path = named_type<ss::sstring, struct remote_path_tag>;

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -42,6 +42,7 @@ struct basic_upload_request {
     iobuf payload;
     bool accept_no_content_response{false};
     cloud_storage_clients::header_map_t headers;
+    ss::sstring* etag{nullptr};
 };
 using upload_request = basic_upload_request<ss::lowres_clock>;
 

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -95,7 +95,8 @@ public:
       const cloud_storage_clients::bucket_name& bucket,
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent,
-      std::string_view object_type)
+      std::string_view object_type,
+      cloud_storage_clients::header_map_t headers = {})
       = 0;
 
     /// \brief Upload small objects to bucket. Suitable for uploading simple
@@ -182,7 +183,8 @@ public:
       const cloud_storage_clients::bucket_name& bucket,
       const cloud_storage_clients::object_key& path,
       retry_chain_node& parent,
-      std::string_view object_type) override;
+      std::string_view object_type,
+      cloud_storage_clients::header_map_t headers = {}) override;
 
     /// \brief Delete object from S3
     ///

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -54,10 +54,6 @@ struct basic_download_request {
 using download_request = basic_download_request<ss::lowres_clock>;
 using remote_path = named_type<ss::sstring, struct remote_path_tag>;
 
-using list_result = result<
-  cloud_storage_clients::client::list_bucket_result,
-  cloud_storage_clients::error_outcome>;
-
 /// Functor that attempts to consume the input stream. If the connection
 /// is broken during the download the functor is responsible for he cleanup.
 /// The functor should be reenterable since it can be called many times.

--- a/src/v/cloud_storage/download_exception.cc
+++ b/src/v/cloud_storage/download_exception.cc
@@ -33,6 +33,8 @@ const char* download_exception::what() const noexcept {
         return "TimedOut";
     case download_result::success:
         vassert(false, "Successful result can't be used as an error");
+    case download_result::precondition_failed:
+        return "PreconditionFailed";
     }
     __builtin_unreachable();
 }

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -13,6 +13,7 @@
 #include "cloud_storage/inventory/inv_consumer.h"
 #include "cloud_storage/inventory/report_parser.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/types.h"
 
 #include <gmock/gmock.h>
 
@@ -31,7 +32,7 @@ public:
       (cloud_storage::download_request),
       (override));
     MOCK_METHOD(
-      ss::future<cloud_storage::cloud_storage_api::list_result>,
+      ss::future<cloud_storage::list_result>,
       list_objects,
       (const cloud_storage_clients::bucket_name&,
        retry_chain_node&,

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -11,6 +11,7 @@
 #include "cloud_storage/inventory/aws_ops.h"
 #include "cloud_storage/inventory/inv_ops.h"
 #include "cloud_storage/inventory/tests/common.h"
+#include "cloud_storage/types.h"
 
 namespace cst = cloud_storage;
 namespace csi = cst::inventory;
@@ -58,8 +59,7 @@ void setup_and_validate_list_call(
         t::Eq(std::nullopt)))
       .Times(1)
       .WillOnce(
-        t::Return(ss::make_ready_future<cst::cloud_storage_api::list_result>(
-          std::move(result))));
+        t::Return(ss::make_ready_future<cst::list_result>(std::move(result))));
 }
 
 TEST(FindLatestReport, NoReportsExist) {

--- a/src/v/cloud_storage/inventory/tests/inv_svc_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/inv_svc_tests.cc
@@ -124,7 +124,7 @@ validate_create_inv_req_failure(cst::upload_request r) {
     co_return cst::upload_result::failed;
 }
 
-ss::future<cst::cloud_storage_api::list_result> validate_list_objs(
+ss::future<cst::list_result> validate_list_objs(
   const cloud_storage_clients::bucket_name&,
   retry_chain_node&,
   std::optional<cloud_storage_clients::object_key> pre,
@@ -367,8 +367,7 @@ TEST(Service, OlderReportIsSkipped) {
       .Times(1)
       .WillRepeatedly(validate_check_inv_exists_success);
 
-    auto list_return_old_date =
-      []() -> ss::future<csi::MockRemote::list_result> {
+    auto list_return_old_date = []() -> ss::future<cst::list_result> {
         co_return cloud_storage_clients::client::list_bucket_result{
           .common_prefixes = {
             fmt::format(

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -463,6 +463,7 @@ remote::download_object(download_request download_request) {
       .transfer_details = std::move(details),
       .display_str = to_string(download_request.type),
       .payload = download_request.payload,
+      .headers = std::move(download_request.headers.headers),
     });
 }
 
@@ -550,12 +551,12 @@ ss::future<upload_result> remote::upload_object(upload_request req) {
         details.on_req_cb = make_notify_cb(
           api_activity_type::object_upload, details.parent_rtc);
     }
-    return io().upload_object({
-      .transfer_details = std::move(details),
-      .display_str = to_string(req.type),
-      .payload = std::move(req.payload),
-      .accept_no_content_response = false,
-    });
+    return io().upload_object(
+      {.transfer_details = std::move(details),
+       .display_str = to_string(req.type),
+       .payload = std::move(req.payload),
+       .accept_no_content_response = false,
+       .headers = std::move(req.headers.headers)});
 }
 
 ss::future<api_activity_notification>

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -526,7 +526,7 @@ remote::delete_objects<std::deque<cloud_storage_clients::object_key>>(
   std::deque<cloud_storage_clients::object_key> keys,
   retry_chain_node& parent);
 
-ss::future<remote::list_result> remote::list_objects(
+ss::future<list_result> remote::list_objects(
   const cloud_storage_clients::bucket_name& bucket,
   retry_chain_node& parent,
   std::optional<cloud_storage_clients::object_key> prefix,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -556,7 +556,8 @@ ss::future<upload_result> remote::upload_object(upload_request req) {
        .display_str = to_string(req.type),
        .payload = std::move(req.payload),
        .accept_no_content_response = false,
-       .headers = std::move(req.headers.headers)});
+       .headers = std::move(req.headers.headers),
+       .etag = req.etag});
 }
 
 ss::future<api_activity_notification>

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -66,10 +66,6 @@ struct api_activity_notification {
 // references/pointers to this interface instead of remote to enable testing.
 class cloud_storage_api {
 public:
-    using list_result = result<
-      cloud_storage_clients::client::list_bucket_result,
-      cloud_storage_clients::error_outcome>;
-
     /// Functor that attempts to consume the input stream. If the connection
     /// is broken during the download the functor is responsible for he cleanup.
     /// The functor should be reenterable since it can be called many times.

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -215,12 +215,16 @@ public:
     /// \param bucket is a bucket name
     /// \param manifest is a manifest to upload
     /// \param key is the remote object name
+    /// \param upload_if_not_exists If true, a conditional write to cloud
+    /// storage will be issued. If an existing manifest exists, this put request
+    /// will fail with a precondition_failed return value.
     /// \return future that returns success code
     ss::future<upload_result> upload_manifest(
       const cloud_storage_clients::bucket_name& bucket,
       const base_manifest& manifest,
       const remote_manifest_path& key,
-      retry_chain_node& parent);
+      retry_chain_node& parent,
+      bool upload_if_not_exists = false);
 
     /// \brief Upload segment to S3
     ///

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -424,11 +424,21 @@ enum class existence_check_type { object, segment, manifest };
 std::ostream& operator<<(std::ostream&, existence_check_type);
 
 class remote_probe;
+
+struct request_headers {
+    void add_header(boost::beast::http::field field, ss::sstring value) {
+        headers.insert_or_assign(field, std::move(value));
+    }
+
+    cloud_storage_clients::header_map_t headers;
+};
+
 struct upload_request {
     cloud_io::transfer_details transfer_details;
     upload_type type;
     iobuf payload;
     bool accept_no_content_response{false};
+    request_headers headers;
 };
 
 struct download_request {
@@ -436,6 +446,7 @@ struct download_request {
     download_type type;
     iobuf& payload;
     bool expect_missing{false};
+    request_headers headers;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -36,6 +36,7 @@ namespace cloud_storage {
 
 using upload_result = cloud_io::upload_result;
 using download_result = cloud_io::download_result;
+using list_result = cloud_io::list_result;
 
 using remote_metrics_disabled
   = ss::bool_class<struct remote_metrics_disabled_tag>;

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -449,6 +449,7 @@ struct upload_request {
     iobuf payload;
     bool accept_no_content_response{false};
     request_headers headers;
+    ss::sstring* etag{nullptr};
 
     // Sets the `If-None-Match` header in the HTTP request with the provided
     // ETag. This header is useful for guaranteeing atomic uploads to cloud

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
         "//src/v/utils:retry_chain_node",
         "//src/v/utils:stop_signal",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@boost//:beast",
         "@boost//:lexical_cast",
         "@boost//:property_tree",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -549,6 +549,18 @@ ss::future<result<T, error_outcome>> abs_client::send_request(
               key);
             outcome = error_outcome::operation_not_supported;
             _probe->register_failure(err.code());
+        } else if (err.code() == abs_error_code::precondition_failed) {
+            // We support preconditions for cloud requests. If a request
+            // fails due to a precondition header, it
+            // should be handled differently than a regular `fail` outcome (as
+            // it may be expected).
+            vlog(
+              abs_log.debug,
+              "ConditionNotMet response received for key {}",
+              key);
+            outcome = error_outcome::precondition_failed;
+            // TODO(willem): add a _precondition_failed counter to client probe
+            // and register failures?
         } else {
             vlog(
               abs_log.error,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -175,7 +175,7 @@ public:
     /// \param body is an input_stream that can be used to read body
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the upload is completed
-    ss::future<result<no_response, error_outcome>> put_object(
+    ss::future<result<put_object_result, error_outcome>> put_object(
       const bucket_name& name,
       const object_key& key,
       size_t payload_size,
@@ -266,7 +266,7 @@ private:
       std::optional<http_byte_range> byte_range = std::nullopt,
       header_map_t headers = {});
 
-    ss::future<> do_put_object(
+    ss::future<put_object_result> do_put_object(
       const bucket_name& name,
       const object_key& key,
       size_t payload_size,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -37,7 +37,8 @@ public:
     result<http::client::request_header> make_put_blob_request(
       const bucket_name& name,
       const object_key& key,
-      size_t payload_size_bytes);
+      size_t payload_size_bytes,
+      header_map_t headers = {});
 
     /// \brief Create a 'Get Blob' request header
     ///
@@ -47,7 +48,8 @@ public:
     result<http::client::request_header> make_get_blob_request(
       const bucket_name& name,
       const object_key& key,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {});
 
     /// \brief Create a 'Get Blob Metadata' request header
     ///
@@ -55,7 +57,9 @@ public:
     /// \param key is a blob name
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_get_blob_metadata_request(
-      const bucket_name& name, const object_key& key);
+      const bucket_name& name,
+      const object_key& key,
+      header_map_t headers = {});
 
     /// \brief Create a 'Delete Blob' request header
     ///
@@ -150,7 +154,8 @@ public:
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt) override;
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {}) override;
 
     /// Send Get Blob Metadata request.
     /// \param name is a container name
@@ -160,7 +165,8 @@ public:
     ss::future<result<head_object_result, error_outcome>> head_object(
       const bucket_name& name,
       const object_key& key,
-      ss::lowres_clock::duration timeout) override;
+      ss::lowres_clock::duration timeout,
+      header_map_t headers = {}) override;
 
     /// Put blob to ABS container.
     /// \param name is a container name
@@ -175,7 +181,8 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false) override;
+      bool accept_no_content = false,
+      header_map_t headers = {}) override;
 
     /// Send List Blobs request
     /// \param name is a container name
@@ -256,7 +263,8 @@ private:
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {});
 
     ss::future<> do_put_object(
       const bucket_name& name,
@@ -264,12 +272,14 @@ private:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false);
+      bool accept_no_content = false,
+      header_map_t headers = {});
 
     ss::future<head_object_result> do_head_object(
       const bucket_name& name,
       const object_key& key,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      header_map_t headers = {});
 
     ss::future<> do_delete_object(
       const bucket_name& name,

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -49,6 +49,7 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match(
             "OperationNotSupportedOnDirectory",
             abs_error_code::operation_not_supported_on_directory)
+          .match("ConditionNotMet", abs_error_code::precondition_failed)
           .default_match(abs_error_code::_unknown);
 
     return i;

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -41,7 +41,8 @@ enum class abs_error_code {
     container_not_found,
     directory_not_empty,
     path_not_found,
-    operation_not_supported_on_directory
+    operation_not_supported_on_directory,
+    precondition_failed
 };
 
 /// Operators to use with lexical_cast

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -53,7 +53,8 @@ public:
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt)
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {})
       = 0;
 
     struct head_object_result {
@@ -70,7 +71,8 @@ public:
     virtual ss::future<result<head_object_result, error_outcome>> head_object(
       const bucket_name& name,
       const object_key& key,
-      ss::lowres_clock::duration timeout)
+      ss::lowres_clock::duration timeout,
+      header_map_t headers = {})
       = 0;
 
     /// Upload object to cloud storage
@@ -88,7 +90,8 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false)
+      bool accept_no_content = false,
+      header_map_t headers = {})
       = 0;
 
     struct list_bucket_item {

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -105,6 +105,8 @@ public:
         std::vector<ss::sstring> common_prefixes;
     };
 
+    using list_result = result<list_bucket_result, error_outcome>;
+
     /// A predicate to allow list_objects to collect items selectively, saving
     /// memory. This cannot be ss::noncopyable_function because remote needs to
     /// copy this object for calls in a loop.
@@ -122,7 +124,7 @@ public:
     /// \param collect_item_if if present, only items passing this predicate are
     /// collected.
     /// \return future that becomes ready when the request is completed
-    virtual ss::future<result<list_bucket_result, error_outcome>> list_objects(
+    virtual ss::future<list_result> list_objects(
       const bucket_name& name,
       std::optional<object_key> prefix = std::nullopt,
       std::optional<object_key> start_after = std::nullopt,

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -75,6 +75,10 @@ public:
       header_map_t headers = {})
       = 0;
 
+    struct put_object_result {
+        ss::sstring etag;
+    };
+
     /// Upload object to cloud storage
     ///
     /// \param name is a bucket name
@@ -84,7 +88,7 @@ public:
     /// \param timeout is a timeout of the operation
     /// \param accept_no_content accepts a 204 response as valid
     /// \return future that becomes ready when the upload is completed
-    virtual ss::future<result<no_response, error_outcome>> put_object(
+    virtual ss::future<result<put_object_result, error_outcome>> put_object(
       const bucket_name& name,
       const object_key& key,
       size_t payload_size,

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -472,11 +472,12 @@ ss::future<ResultT> parse_head_error_response(
             msg = ss::sstring(hdr.reason().data(), hdr.reason().size());
         }
         boost::string_view rid;
-        if (hdr.find(aws_header_names::x_amz_request_id) != hdr.end()) {
-            rid = hdr.at(aws_header_names::x_amz_request_id);
-        } else if (
-          hdr.find(aws_header_names::x_guploader_uploadid) != hdr.end()) {
-            rid = hdr.at(aws_header_names::x_guploader_uploadid);
+        if (auto it = hdr.find(aws_header_names::x_amz_request_id);
+            it != hdr.end()) {
+            rid = it->value();
+        } else if (auto it = hdr.find(aws_header_names::x_guploader_uploadid);
+                   it != hdr.end()) {
+            rid = it->value();
         }
         rest_error_response err(
           code, msg, ss::sstring(rid.data(), rid.size()), key().native());

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -51,7 +51,8 @@ public:
     result<http::client::request_header> make_unsigned_put_object_request(
       const bucket_name& name,
       const object_key& key,
-      size_t payload_size_bytes);
+      size_t payload_size_bytes,
+      header_map_t headers = {});
 
     /// \brief Create a 'GetObject' request header
     ///
@@ -62,15 +63,18 @@ public:
     result<http::client::request_header> make_get_object_request(
       const bucket_name& name,
       const object_key& key,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {});
 
     /// \brief Create a 'HeadObject' request header
     ///
     /// \param name is a bucket that has the object
     /// \param key is an object name
     /// \return initialized and signed http header or error
-    result<http::client::request_header>
-    make_head_object_request(const bucket_name& name, const object_key& key);
+    result<http::client::request_header> make_head_object_request(
+      const bucket_name& name,
+      const object_key& key,
+      header_map_t headers = {});
 
     /// \brief Create a 'DeleteObject' request header
     ///
@@ -156,7 +160,8 @@ public:
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt) override;
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {}) override;
 
     /// HeadObject request.
     /// \param name is a bucket name
@@ -165,7 +170,8 @@ public:
     ss::future<result<head_object_result, error_outcome>> head_object(
       const bucket_name& name,
       const object_key& key,
-      ss::lowres_clock::duration timeout) override;
+      ss::lowres_clock::duration timeout,
+      header_map_t headers = {}) override;
 
     /// Put object to S3 bucket.
     /// \param name is a bucket name
@@ -179,7 +185,8 @@ public:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false) override;
+      bool accept_no_content = false,
+      header_map_t headers = {}) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
       const bucket_name& name,
@@ -205,14 +212,16 @@ private:
     ss::future<head_object_result> do_head_object(
       const bucket_name& name,
       const object_key& key,
-      ss::lowres_clock::duration timeout);
+      ss::lowres_clock::duration timeout,
+      header_map_t headers = {});
 
     ss::future<http::client::response_stream_ref> do_get_object(
       const bucket_name& name,
       const object_key& key,
       ss::lowres_clock::duration timeout,
       bool expect_no_such_key = false,
-      std::optional<http_byte_range> byte_range = std::nullopt);
+      std::optional<http_byte_range> byte_range = std::nullopt,
+      header_map_t headers = {});
 
     ss::future<> do_put_object(
       const bucket_name& name,
@@ -220,7 +229,8 @@ private:
       size_t payload_size,
       ss::input_stream<char> body,
       ss::lowres_clock::duration timeout,
-      bool accept_no_content = false);
+      bool accept_no_content = false,
+      header_map_t headers = {});
 
     ss::future<list_bucket_result> do_list_objects_v2(
       const bucket_name& name,

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -179,7 +179,7 @@ public:
     /// \param payload_size is a size of the object in bytes
     /// \param body is an input_stream that can be used to read body
     /// \return future that becomes ready when the upload is completed
-    ss::future<result<no_response, error_outcome>> put_object(
+    ss::future<result<put_object_result, error_outcome>> put_object(
       const bucket_name& name,
       const object_key& key,
       size_t payload_size,
@@ -223,7 +223,7 @@ private:
       std::optional<http_byte_range> byte_range = std::nullopt,
       header_map_t headers = {});
 
-    ss::future<> do_put_object(
+    ss::future<put_object_result> do_put_object(
       const bucket_name& name,
       const object_key& key,
       size_t payload_size,

--- a/src/v/cloud_storage_clients/s3_error.cc
+++ b/src/v/cloud_storage_clients/s3_error.cc
@@ -45,6 +45,9 @@ std::ostream& operator<<(std::ostream& o, s3_error_code code) {
     case s3_error_code::bucket_not_empty:
         o << "BucketNotEmpty";
         break;
+    case s3_error_code::conditional_request_conflict:
+        o << "ConditionalRequestConflict";
+        break;
     case s3_error_code::credentials_not_supported:
         o << "CredentialsNotSupported";
         break;
@@ -308,6 +311,7 @@ static const std::map<ss::sstring, s3_error_code> known_aws_error_codes = {
   {"BucketAlreadyExists", s3_error_code::bucket_already_exists},
   {"BucketAlreadyOwnedByYou", s3_error_code::bucket_already_owned_by_you},
   {"BucketNotEmpty", s3_error_code::bucket_not_empty},
+  {"ConditionalRequestConflict", s3_error_code::conditional_request_conflict},
   {"CredentialsNotSupported", s3_error_code::credentials_not_supported},
   {"CrossLocationLoggingProhibited",
    s3_error_code::cross_location_logging_prohibited},

--- a/src/v/cloud_storage_clients/s3_error.h
+++ b/src/v/cloud_storage_clients/s3_error.h
@@ -35,6 +35,7 @@ enum class s3_error_code {
     bucket_already_exists,
     bucket_already_owned_by_you,
     bucket_not_empty,
+    conditional_request_conflict,
     credentials_not_supported,
     cross_location_logging_prohibited,
     entity_too_small,

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -16,6 +16,9 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <boost/beast/http/field.hpp>
+
 #include <filesystem>
 #include <iostream>
 #include <system_error>
@@ -27,6 +30,9 @@ using object_key = named_type<std::filesystem::path, struct s3_object_key>;
 using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
 using ca_trust_file
   = named_type<std::filesystem::path, struct s3_ca_trust_file>;
+
+using header_map_t
+  = absl::flat_hash_map<boost::beast::http::field, ss::sstring>;
 
 enum class error_outcome {
     /// Error condition that can be retried

--- a/src/v/cloud_topics/batcher/batcher.cc
+++ b/src/v/cloud_topics/batcher/batcher.cc
@@ -11,6 +11,7 @@
 #include "cloud_topics/batcher/batcher.h"
 
 #include "base/unreachable.h"
+#include "cloud_io/io_result.h"
 #include "cloud_io/remote.h"
 #include "cloud_topics/batcher/aggregator.h"
 #include "cloud_topics/batcher/serializer.h"
@@ -151,6 +152,8 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
         case cloud_io::upload_result::timedout:
             err = errc::timeout;
             break;
+        case cloud_io::upload_result::precondition_failed:
+            [[fallthrough]];
         case cloud_io::upload_result::failed:
             err = errc::upload_failure;
         }

--- a/src/v/cloud_topics/batcher/tests/remote_mock.h
+++ b/src/v/cloud_topics/batcher/tests/remote_mock.h
@@ -47,7 +47,8 @@ public:
       (const cloud_storage_clients::bucket_name&,
        const cloud_storage_clients::object_key&,
        basic_retry_chain_node<ss::manual_clock>&,
-       std::string_view),
+       std::string_view,
+       cloud_storage_clients::header_map_t),
       (override));
 
     MOCK_METHOD(

--- a/src/v/cloud_topics/reader/placeholder_extent.cc
+++ b/src/v/cloud_topics/reader/placeholder_extent.cc
@@ -30,6 +30,8 @@ struct errc_converter<cloud_io::download_result, errc> {
         switch (r) {
         case cloud_io::download_result::notfound:
             return errc::download_not_found;
+        case cloud_io::download_result::precondition_failed:
+            [[fallthrough]];
         case cloud_io::download_result::failed:
             return errc::download_failure;
         case cloud_io::download_result::timedout:

--- a/src/v/cloud_topics/reader/tests/mocks.h
+++ b/src/v/cloud_topics/reader/tests/mocks.h
@@ -54,7 +54,8 @@ public:
       (const cloud_storage_clients::bucket_name&,
        const cloud_storage_clients::object_key&,
        retry_chain_node&,
-       std::string_view),
+       std::string_view,
+       cloud_storage_clients::header_map_t),
       (override));
 
     MOCK_METHOD(

--- a/src/v/cluster/archival/archiver_operations_impl.cc
+++ b/src/v/cluster/archival/archiver_operations_impl.cc
@@ -525,6 +525,8 @@ public:
                 co_return error_outcome::shutting_down;
             case upload_result::timedout:
                 co_return error_outcome::timed_out;
+            case upload_result::precondition_failed:
+                [[fallthrough]];
             case upload_result::failed:
                 co_return error_outcome::unexpected_failure;
             case upload_result::success:

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -270,6 +270,8 @@ ss::future<cloudcheck::verify_upload_result> cloudcheck::verify_upload(
             [[fallthrough]];
         case cloud_storage::upload_result::failed:
             [[fallthrough]];
+        case cloud_storage::upload_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::upload_result::cancelled:
             result.error = "Failed to upload to cloud storage.";
             break;
@@ -346,6 +348,8 @@ ss::future<cloudcheck::verify_head_result> cloudcheck::verify_head(
             [[fallthrough]];
         case cloud_storage::download_result::failed:
             [[fallthrough]];
+        case cloud_storage::download_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::download_result::notfound:
             result.error = "Failed to download from cloud storage.";
             break;
@@ -396,6 +400,8 @@ ss::future<cloudcheck::verify_download_result> cloudcheck::verify_download(
             [[fallthrough]];
         case cloud_storage::download_result::failed:
             [[fallthrough]];
+        case cloud_storage::download_result::precondition_failed:
+            [[fallthrough]];
         case cloud_storage::download_result::notfound:
             result.error = "Failed to download from cloud storage.";
             break;
@@ -430,6 +436,8 @@ ss::future<cloudcheck::verify_delete_result> cloudcheck::verify_delete(
         case cloud_storage::upload_result::timedout:
             [[fallthrough]];
         case cloud_storage::upload_result::failed:
+            [[fallthrough]];
+        case cloud_storage::upload_result::precondition_failed:
             [[fallthrough]];
         case cloud_storage::upload_result::cancelled:
             result.error = "Failed to delete from cloud storage.";
@@ -473,6 +481,8 @@ ss::future<cloudcheck::verify_deletes_result> cloudcheck::verify_deletes(
         case cloud_storage::upload_result::timedout:
             [[fallthrough]];
         case cloud_storage::upload_result::failed:
+            [[fallthrough]];
+        case cloud_storage::upload_result::precondition_failed:
             [[fallthrough]];
         case cloud_storage::upload_result::cancelled:
             result.error = "Failed to delete from cloud storage.";

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -296,7 +296,7 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
 
     try {
         auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
-        const cloud_storage::remote::list_result object_list
+        const cloud_storage::list_result object_list
           = co_await _cloud_storage_api.local().list_objects(
             bucket, rtc, prefix, std::nullopt, std::nullopt, max_keys);
 

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -93,7 +93,7 @@ private:
       const iobuf& payload);
 
     struct verify_list_result {
-        cloud_storage::remote::list_result list_result;
+        cloud_storage::list_result list_result;
         self_test_result test_result;
     };
 

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -142,6 +142,12 @@ private:
       cloud_storage_clients::bucket_name bucket,
       size_t num_objects = num_default_objects);
 
+    // Verify that conditional requests (both Put: write operation, using the
+    // `If-None-Match` header and Get: read operation, using the `If-Match`
+    // header) to cloud storage work.
+    ss::future<verify_upload_result>
+    verify_conditional_puts_and_gets(cloud_storage_clients::bucket_name bucket);
+
 private:
     static constexpr size_t num_default_objects = 5;
     bool _cancelled{false};

--- a/src/v/datalake/cloud_data_io.cc
+++ b/src/v/datalake/cloud_data_io.cc
@@ -47,6 +47,7 @@ map_upload_result(cloud_io::upload_result result) {
         return std::nullopt;
     case cloud_io::upload_result::timedout:
         return cloud_data_io::errc::cloud_op_timeout;
+    case cloud_io::upload_result::precondition_failed:
     case cloud_io::upload_result::failed:
     case cloud_io::upload_result::cancelled:
         return cloud_data_io::errc::cloud_op_error;

--- a/src/v/iceberg/metadata_io.h
+++ b/src/v/iceberg/metadata_io.h
@@ -11,6 +11,7 @@
 #include "base/outcome.h"
 #include "base/vlog.h"
 #include "bytes/iobuf.h"
+#include "cloud_io/io_result.h"
 #include "cloud_io/provider.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/types.h"
@@ -112,6 +113,9 @@ protected:
         case notfound:
             // Not found is not a retriable error.
             [[fallthrough]];
+        case precondition_failed:
+            // Precondition failed is not a retriable error.
+            [[fallthrough]];
         case failed:
             co_return errc::failed;
         }
@@ -163,6 +167,8 @@ protected:
             co_return uploaded_size_bytes;
         case cancelled:
             co_return errc::shutting_down;
+        case precondition_failed:
+            [[fallthrough]];
         case failed:
             co_return errc::failed;
         case timedout:
@@ -201,6 +207,8 @@ protected:
             co_return true;
         case timedout:
             co_return errc::timedout;
+        case precondition_failed:
+            [[fallthrough]];
         case notfound:
             co_return false;
         case failed:

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - -f
       - http://localhost:9000/minio/health/live
       timeout: 20s
-    image: minio/minio:RELEASE.2023-01-25T00-19-54Z
+    image: minio/minio:RELEASE.2024-09-13T20-26-02Z
     networks:
       redpanda-test:
         ipv4_address: 192.168.215.125

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -83,14 +83,13 @@ class SelfTestTest(EndToEndTest):
 
         cloud_results = [r for r in reports if r['test_type'] == 'cloud']
 
-        read_tests = ['List', 'Head', 'Get']
-        write_tests = ['Put', 'Delete', 'Plural Delete']
+        cloudcheck_tests = [
+            'List', 'Head', 'Get', 'Put', 'Delete', 'Plural Delete',
+            'Conditional Puts and Gets'
+        ]
 
-        num_expected_cloud_storage_read_tests = num_nodes * len(read_tests)
-        num_expected_cloud_storage_write_tests = num_nodes * len(write_tests)
-        assert len(
-            cloud_results
-        ) == num_expected_cloud_storage_write_tests + num_expected_cloud_storage_read_tests
+        num_expected_cloud_storage_tests = num_nodes * len(cloudcheck_tests)
+        assert len(cloud_results) == num_expected_cloud_storage_tests
 
         # Ensure no other result sets exist
         assert len(disk_results) + len(network_results) + len(


### PR DESCRIPTION
This PR does two notable things:

1. The addition of `request_headers` as a field for the `cloud_storage::download_request` and `cloud_storage::upload_request` structs, allowing users to add header/value pairs in a `header_map_t` to requests made to cloud storage
2. Error handling for preconditional failures at all layers of the cloud storage stack, from the `client` layer, up to the `cloud_storage::remote` layer, and finally the `cloud_io::remote` layer.

For background, conditional headers are supported in all of S3, ABS, and GCS:

https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html
https://learn.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations#write-operations
https://cloud.google.com/storage/docs/request-preconditions

By specifying certain headers (e.g `If-Match`, `If-None-Match`) in requests made to these providers, we can prevent certain race-y situations such as competing topic mount manifest uploads.

This PR plumbs the `header_map_t` through a few (but not all) of the functions in the remote api.

Also in this PR is a commit to bump the MinIO version used in ducktape testing, [as conditional operations require a more up-to-date version](https://github.com/minio/minio/discussions/20318).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
