### PR TITLE
rpk/transform/buildpack: upgrade tinygo

### DIFF
--- a/src/go/rpk/pkg/cli/transform/buildpack/BUILD
+++ b/src/go/rpk/pkg/cli/transform/buildpack/BUILD
@@ -18,7 +18,10 @@ go_library(
 go_test(
     name = "buildpack_test",
     size = "small",
-    srcs = ["download_test.go"],
+    srcs = [
+        "download_test.go",
+        "url_test.go",
+    ],
     embed = [":buildpack"],
     deps = [
         "//src/go/rpk/pkg/testfs",

--- a/src/go/rpk/pkg/cli/transform/buildpack/url_test.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/url_test.go
@@ -1,0 +1,21 @@
+/*
+* Copyright 2024 Redpanda Data, Inc.
+*
+* Use of this software is governed by the Business Source License
+* included in the file licenses/BSL.md
+*
+* As of the Change Date specified in that file, in accordance with
+* the Business Source License, use of this software will be governed
+* by the Apache License, Version 2.0
+ */
+
+package buildpack
+
+import "testing"
+
+func TestURLIsValidTemplate(t *testing.T) {
+	// Just ensure these functions don't panic
+	// as the templates are valid.
+	t.Log(Tinygo.URL())
+	t.Log(JavaScript.URL())
+}


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes


### Improvements

* Upgrade data transforms tinygo compiler to version 0.34.0

