### PR TITLE
datalake: write multiple files from record_multiplexer

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -329,6 +329,38 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "record_translator",
+    srcs = [
+        "record_translator.cc",
+    ],
+    hdrs = [
+        "record_translator.h",
+    ],
+    implementation_deps = [
+        ":conversion_outcome",
+        ":logger",
+        ":schema_registry",
+        ":table_definition",
+        ":values_protobuf",
+        "//src/v/iceberg:avro_utils",
+        "//src/v/iceberg:values",
+        "//src/v/iceberg:values_avro",
+        "@avro",
+        "@protobuf",
+        "@seastar",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":record_schema_resolver",
+        ":schema_identifier",
+        "//src/v/base",
+        "//src/v/iceberg:datatypes",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
     name = "schema_avro",
     srcs = [
         "schema_avro.cc",

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -300,6 +300,35 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "record_multiplexer",
+    srcs = [
+        "record_multiplexer.cc",
+    ],
+    hdrs = [
+        "record_multiplexer.h",
+    ],
+    implementation_deps = [
+        ":catalog_schema_manager",
+        ":conversion_outcome",
+        ":logger",
+        ":record_schema_resolver",
+        ":record_translator",
+        "//src/v/base",
+        "//src/v/storage:parser_utils",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":partitioning_writer",
+        ":schema_identifier",
+        ":writer",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "record_schema_resolver",
     srcs = [
         "record_schema_resolver.cc",

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -13,6 +13,7 @@ redpanda_cc_library(
         ":table_definition",
         "//src/v/base",
         "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/iceberg:schema",
         "//src/v/iceberg:transaction",
     ],
     include_prefix = "datalake",

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -36,6 +36,7 @@ v_cc_library(
     parquet_writer.cc
     record_multiplexer.cc
     record_schema_resolver.cc
+    record_translator.cc
     schema_registry.cc
     schemaless_translator.cc
     schema_avro.cc

--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -79,6 +79,16 @@ fill_field_ids(iceberg::struct_type& dest, const iceberg::struct_type& source) {
 }
 } // namespace
 
+std::ostream& operator<<(std::ostream& o, const schema_manager::errc& e) {
+    switch (e) {
+    case schema_manager::errc::not_supported:
+        return o << "schema_manager::errc::not_supported";
+    case schema_manager::errc::failed:
+        return o << "schema_manager::errc::failed";
+    case schema_manager::errc::shutting_down:
+        return o << "schema_manager::errc::shutting_down";
+    }
+}
 ss::future<checked<std::nullopt_t, schema_manager::errc>>
 simple_schema_manager::get_registered_ids(
   const model::topic&, iceberg::struct_type& desired_type) {

--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -19,19 +19,19 @@
 namespace datalake {
 
 namespace {
-catalog_schema_manager::errc log_and_convert_catalog_err(
+schema_manager::errc log_and_convert_catalog_err(
   iceberg::catalog::errc e, std::string_view log_msg) {
     switch (e) {
     case iceberg::catalog::errc::shutting_down:
         vlog(datalake_log.debug, "{}: {}", log_msg, e);
-        return catalog_schema_manager::errc::shutting_down;
+        return schema_manager::errc::shutting_down;
     case iceberg::catalog::errc::timedout:
     case iceberg::catalog::errc::not_found:
     case iceberg::catalog::errc::io_error:
     case iceberg::catalog::errc::unexpected_state:
     case iceberg::catalog::errc::already_exists:
         vlog(datalake_log.warn, "{}: {}", log_msg, e);
-        return catalog_schema_manager::errc::failed;
+        return schema_manager::errc::failed;
     }
 }
 enum class fill_errc {
@@ -79,7 +79,20 @@ fill_field_ids(iceberg::struct_type& dest, const iceberg::struct_type& source) {
 }
 } // namespace
 
-ss::future<checked<std::nullopt_t, catalog_schema_manager::errc>>
+ss::future<checked<std::nullopt_t, schema_manager::errc>>
+simple_schema_manager::get_registered_ids(
+  const model::topic&, iceberg::struct_type& desired_type) {
+    iceberg::schema s{
+      .schema_struct = std::move(desired_type),
+      .schema_id = {},
+      .identifier_field_ids = {},
+    };
+    s.assign_fresh_ids();
+    desired_type = std::move(s.schema_struct);
+    co_return std::nullopt;
+}
+
+ss::future<checked<std::nullopt_t, schema_manager::errc>>
 catalog_schema_manager::get_registered_ids(
   const model::topic& topic, iceberg::struct_type& dest_type) {
     auto table_id = table_id_for_topic(topic);
@@ -150,7 +163,7 @@ catalog_schema_manager::get_registered_ids(
     co_return std::nullopt;
 }
 
-checked<bool, catalog_schema_manager::errc>
+checked<bool, schema_manager::errc>
 catalog_schema_manager::get_ids_from_table_meta(
   const iceberg::table_identifier& table_id,
   const iceberg::table_metadata& table_meta,

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -26,6 +26,8 @@ public:
         // The system is shutting down.
         shutting_down,
     };
+    friend std::ostream& operator<<(std::ostream&, const errc&);
+
     virtual ss::future<checked<std::nullopt_t, errc>>
     get_registered_ids(const model::topic&, iceberg::struct_type& desired_type)
       = 0;

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -15,10 +15,7 @@
 
 namespace datalake {
 
-// Manages interactions with the catalog when reconciling the current schema of
-// a given table. This is where Redpanda should make decisions about schema
-// evolution.
-class catalog_schema_manager {
+class schema_manager {
 public:
     enum class errc {
         // The requested operation is not supported (e.g. unsupported schema
@@ -29,6 +26,25 @@ public:
         // The system is shutting down.
         shutting_down,
     };
+    virtual ss::future<checked<std::nullopt_t, errc>>
+    get_registered_ids(const model::topic&, iceberg::struct_type& desired_type)
+      = 0;
+    virtual ~schema_manager() = default;
+};
+
+class simple_schema_manager : public schema_manager {
+public:
+    ss::future<checked<std::nullopt_t, schema_manager::errc>>
+    get_registered_ids(
+      const model::topic&, iceberg::struct_type& desired_type) override;
+    ~simple_schema_manager() override = default;
+};
+
+// Manages interactions with the catalog when reconciling the current schema of
+// a given table. This is where Redpanda should make decisions about schema
+// evolution.
+class catalog_schema_manager : public schema_manager {
+public:
     explicit catalog_schema_manager(iceberg::catalog& catalog)
       : catalog_(catalog) {}
 
@@ -39,8 +55,9 @@ public:
     // are going from the schemaless schema to a schema containing user
     // fields), the table's schema is updated to the desired type, and then the
     // fill is attempted again.
-    ss::future<checked<std::nullopt_t, errc>>
-    get_registered_ids(const model::topic&, iceberg::struct_type& desired_type);
+    ss::future<checked<std::nullopt_t, schema_manager::errc>>
+    get_registered_ids(
+      const model::topic&, iceberg::struct_type& desired_type) override;
 
 private:
     iceberg::table_identifier table_id_for_topic(const model::topic& t) const;

--- a/src/v/datalake/fwd.h
+++ b/src/v/datalake/fwd.h
@@ -12,6 +12,7 @@
 
 namespace datalake {
 struct data_writer_result;
+class schema_manager;
 namespace coordinator {
 class coordinator_manager;
 class frontend;

--- a/src/v/datalake/fwd.h
+++ b/src/v/datalake/fwd.h
@@ -13,6 +13,7 @@
 namespace datalake {
 struct data_writer_result;
 class schema_manager;
+class type_resolver;
 namespace coordinator {
 class coordinator_manager;
 class frontend;

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -38,7 +38,7 @@ struct schema_translating_visitor {
     iobuf buf_no_id;
     ppsr::schema_id id;
 
-    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    ss::future<checked<type_and_buf, type_resolver::errc>>
     operator()(const ppsr::avro_schema_definition& avro_def) {
         const auto& avro_schema = avro_def();
         try {
@@ -60,23 +60,23 @@ struct schema_translating_visitor {
               datalake_log.error,
               "Avro schema translation failed: {}",
               std::current_exception());
-            co_return record_schema_resolver::errc::translation_error;
+            co_return type_resolver::errc::translation_error;
         }
     }
-    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    ss::future<checked<type_and_buf, type_resolver::errc>>
     operator()(const ppsr::protobuf_schema_definition& pb_def) {
         const google::protobuf::Descriptor* d;
         proto_offsets_message_data offsets;
         try {
             auto offsets_res = get_proto_offsets(buf_no_id);
             if (offsets_res.has_error()) {
-                co_return record_schema_resolver::errc::bad_input;
+                co_return type_resolver::errc::bad_input;
             }
             offsets = std::move(offsets_res.value());
             // TODO: maybe there's another caching opportunity here.
             auto d_res = descriptor(pb_def, offsets.protobuf_offsets);
             if (d_res.has_error()) {
-                co_return record_schema_resolver::errc::bad_input;
+                co_return type_resolver::errc::bad_input;
             }
             d = &d_res.value().get();
         } catch (...) {
@@ -84,7 +84,7 @@ struct schema_translating_visitor {
               datalake_log.error,
               "Error getting protobuf offsets from buffer: {}",
               std::current_exception());
-            co_return record_schema_resolver::errc::bad_input;
+            co_return type_resolver::errc::bad_input;
         }
         try {
             auto type = type_to_iceberg(*d).value();
@@ -102,10 +102,10 @@ struct schema_translating_visitor {
               datalake_log.error,
               "Protobuf schema translation failed: {}",
               std::current_exception());
-            co_return record_schema_resolver::errc::translation_error;
+            co_return type_resolver::errc::translation_error;
         }
     }
-    ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+    ss::future<checked<type_and_buf, type_resolver::errc>>
     operator()(const ppsr::json_schema_definition&) {
         co_return type_and_buf::make_raw_binary(std::move(buf_no_id));
     }
@@ -120,7 +120,12 @@ type_and_buf type_and_buf::make_raw_binary(iobuf b) {
     };
 }
 
-ss::future<checked<type_and_buf, record_schema_resolver::errc>>
+ss::future<checked<type_and_buf, type_resolver::errc>>
+binary_type_resolver::resolve_buf_type(iobuf b) const {
+    co_return type_and_buf::make_raw_binary(std::move(b));
+}
+
+ss::future<checked<type_and_buf, type_resolver::errc>>
 record_schema_resolver::resolve_buf_type(iobuf b) const {
     schema_message_data schema_id_res;
     try {

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -113,6 +113,17 @@ struct schema_translating_visitor {
 
 } // namespace
 
+std::ostream& operator<<(std::ostream& o, const type_resolver::errc& e) {
+    switch (e) {
+    case type_resolver::errc::registry_error:
+        return o << "type_resolver::errc::registry_error";
+    case type_resolver::errc::translation_error:
+        return o << "type_resolver::errc::translation_error";
+    case type_resolver::errc::bad_input:
+        return o << "type_resolver::errc::bad_input";
+    }
+}
+
 type_and_buf type_and_buf::make_raw_binary(iobuf b) {
     return type_and_buf{
       .type = std::nullopt,

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -59,17 +59,33 @@ struct type_and_buf {
     static type_and_buf make_raw_binary(iobuf buf);
 };
 
-class record_schema_resolver {
+class type_resolver {
 public:
     enum class errc {
         registry_error,
         translation_error,
         bad_input,
     };
+    virtual ss::future<checked<type_and_buf, errc>>
+    resolve_buf_type(iobuf b) const = 0;
+    virtual ~type_resolver() = default;
+};
+
+class binary_type_resolver : public type_resolver {
+public:
+    ss::future<checked<type_and_buf, type_resolver::errc>>
+    resolve_buf_type(iobuf b) const override;
+    ~binary_type_resolver() override = default;
+};
+
+class record_schema_resolver : public type_resolver {
+public:
     explicit record_schema_resolver(schema::registry& sr)
       : sr_(sr) {}
 
-    ss::future<checked<type_and_buf, errc>> resolve_buf_type(iobuf b) const;
+    ss::future<checked<type_and_buf, type_resolver::errc>>
+    resolve_buf_type(iobuf b) const override;
+    ~record_schema_resolver() override = default;
 
 private:
     schema::registry& sr_;

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -66,6 +66,7 @@ public:
         translation_error,
         bad_input,
     };
+    friend std::ostream& operator<<(std::ostream&, const errc&);
     virtual ss::future<checked<type_and_buf, errc>>
     resolve_buf_type(iobuf b) const = 0;
     virtual ~type_resolver() = default;

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/record_translator.h"
+
+#include "base/vlog.h"
+#include "datalake/conversion_outcome.h"
+#include "datalake/logger.h"
+#include "datalake/table_definition.h"
+#include "datalake/values_protobuf.h"
+#include "iceberg/avro_utils.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+#include "iceberg/values_avro.h"
+
+#include <avro/Generic.hh>
+#include <avro/GenericDatum.hh>
+
+namespace datalake {
+
+namespace {
+
+struct value_translating_visitor {
+    // Buffer ready to be parsed, e.g. no schema ID or protobuf offsets.
+    iobuf parsable_buf;
+    const iceberg::field_type& type;
+
+    ss::future<optional_value_outcome>
+    operator()(const google::protobuf::Descriptor& d) {
+        return deserialize_protobuf(std::move(parsable_buf), d);
+    }
+    ss::future<optional_value_outcome> operator()(const avro::ValidSchema& s) {
+        avro::GenericDatum d(s);
+        try {
+            auto in = std::make_unique<iceberg::avro_iobuf_istream>(
+              std::move(parsable_buf));
+            auto decoder = avro::validatingDecoder(s, avro::binaryDecoder());
+            decoder->init(*in);
+            avro::decode(*decoder, d);
+        } catch (...) {
+            co_return value_conversion_exception(fmt::format(
+              "Error reading Avro buffer: {}", std::current_exception()));
+        }
+        co_return iceberg::val_from_avro(d, type, iceberg::field_required::yes);
+    }
+};
+
+} // namespace
+
+record_type
+record_translator::build_type(std::optional<resolved_type> val_type) {
+    auto ret_type = schemaless_struct_type();
+    std::optional<schema_identifier> val_id;
+    if (val_type.has_value()) {
+        // Add the extra user-defined fields.
+        ret_type.fields.emplace_back(iceberg::nested_field::create(
+          0,
+          val_type->type_name,
+          iceberg::field_required::no,
+          std::move(val_type->type)));
+        val_id = std::move(val_type->id);
+    }
+    return record_type{
+      .comps = record_schema_components{
+          .key_identifier = std::nullopt,
+          .val_identifier = std::move(val_id),
+      },
+      .type = std::move(ret_type),
+    };
+}
+
+ss::future<checked<iceberg::struct_value, record_translator::errc>>
+record_translator::translate_data(
+  kafka::offset o,
+  iobuf key,
+  const std::optional<resolved_type>& val_type,
+  iobuf parsable_val,
+  model::timestamp ts) {
+    auto ret_data = iceberg::struct_value{};
+    ret_data.fields.emplace_back(iceberg::long_value(o));
+    // NOTE: Kafka uses milliseconds, Iceberg uses microseconds.
+    ret_data.fields.emplace_back(iceberg::timestamp_value(ts.value() * 1000));
+    ret_data.fields.emplace_back(iceberg::binary_value{std::move(key)});
+    if (val_type.has_value()) {
+        // Fill in the internal value field.
+        ret_data.fields.emplace_back(std::nullopt);
+
+        auto translated_val = co_await std::visit(
+          value_translating_visitor{std::move(parsable_val), val_type->type},
+          val_type->schema);
+        if (translated_val.has_error()) {
+            vlog(
+              datalake_log.error,
+              "Error converting buffer: {}",
+              translated_val.error());
+            // TODO: metric for data translation errors.
+            // Either needs to drop the data or send it to a dead-letter queue.
+            co_return errc::translation_error;
+        }
+        ret_data.fields.emplace_back(std::move(translated_val.value()));
+    } else {
+        ret_data.fields.emplace_back(
+          iceberg::binary_value{std::move(parsable_val)});
+    }
+    co_return ret_data;
+}
+
+} // namespace datalake

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -53,6 +53,13 @@ struct value_translating_visitor {
 
 } // namespace
 
+std::ostream& operator<<(std::ostream& o, const record_translator::errc& e) {
+    switch (e) {
+    case record_translator::errc::translation_error:
+        return o << "record_translator::errc::translation_error";
+    }
+}
+
 record_type
 record_translator::build_type(std::optional<resolved_type> val_type) {
     auto ret_type = schemaless_struct_type();

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -30,6 +30,7 @@ public:
     enum class errc {
         translation_error,
     };
+    friend std::ostream& operator<<(std::ostream&, const errc&);
     static record_type build_type(std::optional<resolved_type> val_type);
     static ss::future<checked<iceberg::struct_value, errc>> translate_data(
       kafka::offset o,

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "datalake/record_schema_resolver.h"
+#include "datalake/schema_identifier.h"
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/future.hh>
+
+namespace datalake {
+
+struct record_type {
+    record_schema_components comps;
+    iceberg::struct_type type;
+};
+
+class record_translator {
+public:
+    enum class errc {
+        translation_error,
+    };
+    static record_type build_type(std::optional<resolved_type> val_type);
+    static ss::future<checked<iceberg::struct_value, errc>> translate_data(
+      kafka::offset o,
+      iobuf key,
+      const std::optional<resolved_type>& val_type,
+      iobuf parsable_val,
+      model::timestamp ts);
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -51,6 +51,20 @@ cc_proto_library(
     deps = [":proto2_proto"],
 )
 
+redpanda_test_cc_library(
+    name = "catalog_and_registry_fixture",
+    hdrs = ["catalog_and_registry_fixture.h"],
+    include_prefix = "datalake/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/cloud_storage/tests:s3_imposter_gtest",
+        "//src/v/iceberg:filesystem_catalog",
+        "//src/v/schema/tests:fake_registry",
+    ],
+)
+
 #TODO: this wrapper can be removed when we completely remove cmake tests support
 redpanda_test_cc_library(
     name = "proto_definitions_wrapper",

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -67,6 +67,33 @@ redpanda_test_cc_library(
 )
 
 redpanda_test_cc_library(
+    name = "record_generator",
+    srcs = [
+        "record_generator.cc",
+    ],
+    hdrs = [
+        "record_generator.h",
+    ],
+    implementation_deps = [
+        "//src/v/schema:registry",
+        "//src/v/serde/avro/tests:data_generator",
+        "@avro",
+    ],
+    include_prefix = "datalake/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:fragmented_vector",
+        "//src/v/model",
+        "//src/v/pandaproxy",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/utils:named_type",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "test_data_writer",
     hdrs = [
         "test_data_writer.h",

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -188,6 +188,33 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "record_multiplexer_test",
+    timeout = "short",
+    srcs = [
+        "record_multiplexer_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":catalog_and_registry_fixture",
+        ":record_generator",
+        ":test_data_writer",
+        "//src/v/datalake:catalog_schema_manager",
+        "//src/v/datalake:record_multiplexer",
+        "//src/v/datalake:record_schema_resolver",
+        "//src/v/datalake:table_definition",
+        "//src/v/iceberg:filesystem_catalog",
+        "//src/v/model",
+        "//src/v/pandaproxy",
+        "//src/v/schema:registry",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
+        "@avro",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "record_schema_resolver_test",
     timeout = "short",
     srcs = [

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -22,12 +22,13 @@ rp_test(
   BINARY_NAME gtest_record_multiplexer
   SOURCES gtest_record_multiplexer_test.cc
   LIBRARIES
-    v::application
-    v::features
-    v::gtest_main
-    v::kafka_test_utils
+    v::cloud_io_utils
     v::datalake_writer
+    v::datalake_test_utils
+    v::gtest_main
     v::model_test_utils
+    v::schema
+    v::s3_imposter
   LABELS datalake
   ARGS "-- -c 1"
 )

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     Seastar::seastar
     v::avro_test_utils
     v::schema
+    v::schema_test_fixture
     v::storage
 )
 
@@ -70,9 +71,13 @@ rp_test(
 rp_test(
   UNIT_TEST
   GTEST
-  BINARY_NAME translation_task
-  SOURCES translation_task_test.cc
+  BINARY_NAME datalake_cloud
+  SOURCES
+    record_multiplexer_test.cc
+    translation_task_test.cc
   LIBRARIES
+    Boost::iostreams
+    v::datalake_test_utils
     v::gtest_main
     v::datalake_writer
     v::cloud_io_utils

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -1,4 +1,19 @@
+find_package(Avro REQUIRED)
 set(testdata_dir "${CMAKE_CURRENT_SOURCE_DIR}/testdata")
+
+v_cc_library(
+  NAME datalake_test_utils
+  HDRS
+    record_generator.h
+  SRCS
+    record_generator.cc
+  DEPS
+    Avro::avro
+    Seastar::seastar
+    v::avro_test_utils
+    v::schema
+    v::storage
+)
 
 rp_test(
   UNIT_TEST

--- a/src/v/datalake/tests/catalog_and_registry_fixture.h
+++ b/src/v/datalake/tests/catalog_and_registry_fixture.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/scoped_remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "iceberg/filesystem_catalog.h"
+#include "schema/tests/fake_registry.h"
+
+namespace datalake::tests {
+
+// Test fixture that contains a functioning schema::registry and
+// iceberg::catalog. This can be used to exercise schema resolution without
+// heavier weight dependencies (e.g. REST catalog, PandaProxy).
+class catalog_and_registry_fixture : public s3_imposter_fixture {
+public:
+    static constexpr std::string_view base_location{"test"};
+    catalog_and_registry_fixture()
+      : scoped_remote(cloud_io::scoped_remote::create(10, conf))
+      , catalog(
+          scoped_remote->remote.local(),
+          bucket_name,
+          ss::sstring(base_location)) {
+        set_expectations_and_listen({});
+    }
+    std::unique_ptr<cloud_io::scoped_remote> scoped_remote;
+    schema::fake_registry registry;
+    iceberg::filesystem_catalog catalog;
+};
+} // namespace datalake::tests

--- a/src/v/datalake/tests/catalog_schema_manager_test.cc
+++ b/src/v/datalake/tests/catalog_schema_manager_test.cc
@@ -233,14 +233,14 @@ TEST_F(CatalogSchemaManagerTest, TestOptionalMismatch) {
     type.fields[0]->required = field_required::no;
     auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
     ASSERT_TRUE(res.has_error());
-    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+    EXPECT_EQ(res.error(), schema_manager::errc::not_supported);
 
     // Make the destinations both required.
     type.fields[0]->required = field_required::yes;
     type.fields[1]->required = field_required::yes;
     res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
     ASSERT_TRUE(res.has_error());
-    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+    EXPECT_EQ(res.error(), schema_manager::errc::not_supported);
 }
 
 TEST_F(CatalogSchemaManagerTest, TestTypeMismatch) {
@@ -252,5 +252,5 @@ TEST_F(CatalogSchemaManagerTest, TestTypeMismatch) {
 
     auto res = schema_mgr.get_registered_ids(model::topic{"foo"}, type).get();
     ASSERT_TRUE(res.has_error());
-    EXPECT_EQ(res.error(), catalog_schema_manager::errc::not_supported);
+    EXPECT_EQ(res.error(), schema_manager::errc::not_supported);
 }

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -12,9 +12,14 @@
 #include "datalake/catalog_schema_manager.h"
 #include "datalake/record_multiplexer.h"
 #include "datalake/record_schema_resolver.h"
+#include "datalake/tests/catalog_and_registry_fixture.h"
+#include "datalake/tests/record_generator.h"
 #include "datalake/tests/test_data_writer.h"
+#include "iceberg/filesystem_catalog.h"
 #include "model/fundamental.h"
+#include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
+#include "storage/record_batch_builder.h"
 #include "test_utils/tmp_dir.h"
 
 #include <arrow/io/file.h>
@@ -28,7 +33,8 @@ using namespace datalake;
 namespace {
 simple_schema_manager simple_schema_mgr;
 binary_type_resolver bin_resolver;
-const auto ntp = model::ntp{};
+const model::ntp
+  ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 } // namespace
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
@@ -161,4 +167,122 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     }
     // Expect this test to create exactly 1 file
     EXPECT_EQ(file_count, 1);
+}
+
+namespace {
+constexpr std::string_view avro_schema = R"({
+    "type": "record",
+    "name": "RootRecord",
+    "fields": [
+        { "name": "mylong", "doc": "mylong field doc.", "type": "long" },
+        {
+            "name": "nestedrecord",
+            "type": {
+                "type": "record",
+                "name": "Nested",
+                "fields": [
+                    { "name": "inval1", "type": "double" },
+                    { "name": "inval2", "type": "string" },
+                    { "name": "inval3", "type": "int" }
+                ]
+            }
+        },
+        { "name": "myarray", "type": { "type": "array", "items": "double" } },
+        { "name": "mybool", "type": "boolean" },
+        { "name": "myfixed", "type": { "type": "fixed", "size": 16, "name": "md5" } },
+        { "name": "anotherint", "type": "int" },
+        { "name": "bytes", "type": "bytes" }
+    ]
+})";
+} // namespace
+
+class RecordMultiplexerParquetTest
+  : public tests::catalog_and_registry_fixture
+  , public ::testing::Test {
+public:
+    RecordMultiplexerParquetTest()
+      : schema_mgr(catalog)
+      , type_resolver(registry) {}
+    catalog_schema_manager schema_mgr;
+    record_schema_resolver type_resolver;
+};
+
+TEST_F(RecordMultiplexerParquetTest, TestSimple) {
+    tests::record_generator gen(&registry);
+    auto reg_res = gen.register_avro_schema("schema", avro_schema).get();
+    EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
+    ss::circular_buffer<model::record_batch> batches;
+    model::offset o{0};
+    const auto start_offset = o;
+    const size_t num_hrs = 3;
+    const size_t batches_per_hr = 4;
+    const size_t records_per_batch = 4;
+    auto start_ts = model::timestamp::now();
+    constexpr auto ms_per_hr = 1000 * 3600;
+    for (size_t h = 0; h < num_hrs; ++h) {
+        // Split batches across the hours.
+        auto h_ts = model::timestamp{
+          start_ts.value() + ms_per_hr * static_cast<long>(h)};
+        for (size_t b = 0; b < batches_per_hr; ++b) {
+            storage::record_batch_builder batch_builder(
+              model::record_batch_type::raft_data, model::offset{o});
+            batch_builder.set_timestamp(h_ts);
+
+            // Add some records per batch.
+            for (size_t r = 0; r < records_per_batch; ++r) {
+                auto add_res = gen
+                                 .add_random_avro_record(
+                                   batch_builder, "schema", std::nullopt)
+                                 .get();
+                ASSERT_FALSE(add_res.has_error());
+                ++o;
+            }
+            batches.emplace_back(std::move(batch_builder).build());
+        }
+    }
+    auto reader = model::make_memory_record_batch_reader(std::move(batches));
+
+    temporary_dir tmp_dir("datalake_multiplexer_test");
+    auto writer_factory
+      = std::make_unique<datalake::batching_parquet_writer_factory>(
+        datalake::local_path(tmp_dir.get_path()), "data", 100, 10000);
+    record_multiplexer mux(
+      ntp, std::move(writer_factory), schema_mgr, type_resolver);
+    auto res = reader.consume(std::move(mux), model::no_timeout).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    EXPECT_EQ(res.value().start_offset(), start_offset());
+
+    const auto num_records = num_hrs * batches_per_hr * records_per_batch;
+    EXPECT_EQ(res.value().last_offset(), start_offset() + num_records - 1);
+    int file_count = 0;
+    for (const auto& entry :
+         std::filesystem::directory_iterator(tmp_dir.get_path())) {
+        file_count++;
+        auto arrow_file_reader
+          = arrow::io::ReadableFile::Open(entry.path()).ValueUnsafe();
+        std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+        ASSERT_TRUE(
+          parquet::arrow::OpenFile(
+            arrow_file_reader, arrow::default_memory_pool(), &arrow_reader)
+            .ok());
+
+        // Read entire file as a single Arrow table
+        std::shared_ptr<arrow::Table> table;
+        auto r = arrow_reader->ReadTable(&table);
+        ASSERT_TRUE(r.ok());
+
+        // Records should be split across hours.
+        EXPECT_EQ(table->num_rows(), num_records / num_hrs);
+
+        // Default columns + a nested struct.
+        EXPECT_EQ(table->num_columns(), 5);
+        auto expected_type = R"(redpanda_offset: int64 not null
+redpanda_timestamp: timestamp[us] not null
+redpanda_key: binary
+redpanda_value: binary
+RootRecord: struct<mylong: int64 not null, nestedrecord: struct<inval1: double not null, inval2: string not null, inval3: int32 not null> not null, myarray: list<element: double not null> not null, mybool: bool not null, myfixed: fixed_size_binary[16] not null, anotherint: int32 not null, bytes: binary not null>)";
+        EXPECT_EQ(expected_type, table->schema()->ToString());
+    }
+    // Expect this test to create exactly 1 file
+    EXPECT_EQ(file_count, num_hrs);
 }

--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/tests/record_generator.h"
+
+#include "schema/registry.h"
+#include "serde/avro/tests/data_generator.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+#include <avro/Encoder.hh>
+#include <avro/Generic.hh>
+#include <avro/Specific.hh>
+#include <avro/Stream.hh>
+
+namespace datalake::tests {
+
+ss::future<checked<std::nullopt_t, record_generator::error>>
+record_generator::register_avro_schema(
+  std::string_view name, std::string_view schema) {
+    using namespace pandaproxy::schema_registry;
+    auto id = co_await ss::coroutine::as_future(
+      _sr->create_schema(unparsed_schema{
+        subject{"foo"},
+        unparsed_schema_definition{schema, schema_type::avro}}));
+    if (id.failed()) {
+        co_return error{fmt::format(
+          "Error creating schema {}: {}", name, id.get_exception())};
+    }
+    auto [_, added] = _id_by_name.emplace(name, id.get());
+    if (!added) {
+        co_return error{fmt::format("Failed to add schema {} to map", name)};
+    }
+    co_return std::nullopt;
+}
+
+ss::future<checked<std::nullopt_t, record_generator::error>>
+record_generator::add_random_avro_record(
+  storage::record_batch_builder& b,
+  std::string_view name,
+  std::optional<iobuf> key) {
+    using namespace pandaproxy::schema_registry;
+    auto it = _id_by_name.find(name);
+    if (it == _id_by_name.end()) {
+        co_return error{fmt::format("Schema {} is missing", name)};
+    }
+    auto schema_id = it->second;
+    auto schema_def = co_await _sr->get_valid_schema(schema_id);
+    if (schema_def.type() != schema_type::avro) {
+        co_return error{
+          fmt::format("Schema {} has wrong type: {}", name, schema_def.type())};
+    }
+    iobuf val;
+    val.append("\0", 1);
+    int32_t encoded_id = ss::cpu_to_be(schema_id());
+    val.append((const uint8_t*)(&encoded_id), 4);
+
+    avro::NodePtr node_ptr;
+    struct visitor {
+    public:
+        explicit visitor(avro::NodePtr& ptr)
+          : node_ptr(ptr) {}
+        avro::NodePtr& node_ptr;
+        void operator()(const avro_schema_definition& avro_def) {
+            node_ptr = avro_def().root();
+        }
+        void operator()(const protobuf_schema_definition&) {}
+        void operator()(const json_schema_definition&) {}
+    };
+    schema_def.visit(visitor(node_ptr));
+    if (!node_ptr) {
+        co_return error{
+          fmt::format("Schema {} didn't resolve Avro node", name)};
+    }
+    testing::generator_state gs;
+    auto datum = generate_datum(node_ptr, gs, 10);
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    avro::EncoderPtr e = avro::binaryEncoder();
+    e->init(*out);
+    avro::encode(*e, datum);
+    auto snap = avro::snapshot(*out);
+    iobuf data_buf;
+    data_buf.append(snap->data(), snap->size());
+    val.append(std::move(data_buf));
+
+    b.add_raw_kv(std::move(key), std::move(val));
+    co_return std::nullopt;
+}
+
+} // namespace datalake::tests

--- a/src/v/datalake/tests/record_generator.h
+++ b/src/v/datalake/tests/record_generator.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "container/chunked_hash_map.h"
+#include "model/record.h"
+#include "model/timestamp.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "storage/record_batch_builder.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/future.hh>
+
+namespace schema {
+class registry;
+} // namespace schema
+
+namespace datalake::tests {
+
+class record_generator {
+public:
+    explicit record_generator(schema::registry* sr)
+      : _sr(sr) {}
+    using error = named_type<ss::sstring, struct error_tag>;
+
+    // Registers the given schema with the given name.
+    ss::future<checked<std::nullopt_t, error>>
+    register_avro_schema(std::string_view name, std::string_view schema);
+
+    // Adds a record of the given schema to the builder.
+    ss::future<checked<std::nullopt_t, error>> add_random_avro_record(
+      storage::record_batch_builder&,
+      std::string_view schema_name,
+      std::optional<iobuf> key);
+
+private:
+    chunked_hash_map<std::string_view, pandaproxy::schema_registry::schema_id>
+      _id_by_name;
+    schema::registry* _sr;
+};
+
+} // namespace datalake::tests

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/catalog_schema_manager.h"
+#include "datalake/record_multiplexer.h"
+#include "datalake/record_schema_resolver.h"
+#include "datalake/table_definition.h"
+#include "datalake/tests/catalog_and_registry_fixture.h"
+#include "datalake/tests/record_generator.h"
+#include "datalake/tests/test_data_writer.h"
+#include "iceberg/filesystem_catalog.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/circular_buffer.hh>
+
+#include <avro/Compiler.hh>
+#include <gtest/gtest.h>
+
+using namespace datalake;
+
+namespace {
+const model::ntp
+  ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
+// v1: struct field with one field.
+constexpr std::string_view avro_schema_v1_str = R"({
+    "type": "record",
+    "name": "RootRecord",
+    "fields": [ { "name": "mylong", "doc": "mylong field doc.", "type": "long" } ]
+})";
+// v2: v1 schema + several others in the struct.
+constexpr std::string_view avro_schema_v2_str = R"({
+    "type": "record",
+    "name": "RootRecord",
+    "fields": [
+        { "name": "mylong", "doc": "mylong field doc.", "type": "long" },
+        {
+            "name": "nestedrecord",
+            "type": {
+                "type": "record",
+                "name": "Nested",
+                "fields": [
+                    { "name": "inval1", "type": "double" },
+                    { "name": "inval2", "type": "string" },
+                    { "name": "inval3", "type": "int" }
+                ]
+            }
+        },
+        { "name": "myarray", "type": { "type": "array", "items": "double" } },
+        { "name": "mybool", "type": "boolean" },
+        { "name": "myfixed", "type": { "type": "fixed", "size": 16, "name": "md5" } },
+        { "name": "anotherint", "type": "int" },
+        { "name": "bytes", "type": "bytes" }
+    ]
+})";
+} // namespace
+
+struct records_param {
+    size_t records_per_batch;
+    size_t batches_per_hr;
+    size_t hrs;
+
+    size_t num_records() const { return records_per_hr() * hrs; }
+    size_t records_per_hr() const { return records_per_batch * batches_per_hr; }
+};
+
+class RecordMultiplexerTest
+  : public datalake::tests::catalog_and_registry_fixture
+  , public ::testing::TestWithParam<records_param> {
+public:
+    RecordMultiplexerTest()
+      : schema_mgr(catalog)
+      , type_resolver(registry) {}
+
+    // Runs the multiplexer on records generated with cb() based on the test
+    // parameters.
+    std::optional<record_multiplexer::write_result> mux(
+      model::offset o,
+      const std::function<void(storage::record_batch_builder&)>& cb) {
+        auto start_offset = o;
+        ss::circular_buffer<model::record_batch> batches;
+        const auto start_ts = model::timestamp::now();
+        constexpr auto ms_per_hr = 1000 * 3600;
+        for (size_t h = 0; h < GetParam().hrs; ++h) {
+            // Split batches across the hours.
+            auto h_ts = model::timestamp{
+              start_ts.value() + ms_per_hr * static_cast<long>(h)};
+            for (size_t b = 0; b < GetParam().batches_per_hr; ++b) {
+                storage::record_batch_builder batch_builder(
+                  model::record_batch_type::raft_data, model::offset{o});
+                batch_builder.set_timestamp(h_ts);
+
+                // Add some records per batch.
+                for (size_t r = 0; r < GetParam().records_per_batch; ++r) {
+                    cb(batch_builder);
+                    ++o;
+                }
+                batches.emplace_back(std::move(batch_builder).build());
+            }
+        }
+        auto reader = model::make_memory_record_batch_reader(
+          std::move(batches));
+        record_multiplexer mux(
+          ntp,
+          std::make_unique<test_data_writer_factory>(false),
+          schema_mgr,
+          type_resolver);
+        auto res = reader.consume(std::move(mux), model::no_timeout).get();
+        EXPECT_FALSE(res.has_error()) << res.error();
+        if (res.has_error()) {
+            return std::nullopt;
+        }
+        EXPECT_EQ(res.value().start_offset(), start_offset());
+        EXPECT_EQ(
+          res.value().last_offset(),
+          start_offset() + GetParam().num_records() - 1);
+        return std::move(res.value());
+    }
+
+    // Returns the current schema.
+    std::optional<iceberg::schema> get_current_schema() {
+        auto load_res
+          = catalog.load_table(iceberg::table_identifier{{"redpanda"}, "t"})
+              .get();
+        EXPECT_FALSE(load_res.has_error()) << load_res.error();
+        if (load_res.has_error()) {
+            return std::nullopt;
+        }
+        auto& table = load_res.value();
+        auto it = std::ranges::find(
+          table.schemas, table.current_schema_id, &iceberg::schema::schema_id);
+        EXPECT_FALSE(it == table.schemas.end());
+        if (it == table.schemas.end()) {
+            return std::nullopt;
+        }
+        return std::move(*it);
+    }
+
+    catalog_schema_manager schema_mgr;
+    record_schema_resolver type_resolver;
+};
+
+TEST_P(RecordMultiplexerTest, TestNoSchema) {
+    auto start_offset = model::offset{0};
+    auto res = mux(start_offset, [](storage::record_batch_builder& b) {
+        b.add_raw_kv(std::nullopt, iobuf::from("foobar"));
+    });
+    ASSERT_TRUE(res.has_value());
+    const auto& write_res = res.value();
+    EXPECT_EQ(write_res.data_files.size(), GetParam().hrs);
+
+    std::unordered_set<int> hrs;
+    for (auto& f : write_res.data_files) {
+        hrs.emplace(f.hour);
+        EXPECT_EQ(f.row_count, GetParam().records_per_hr());
+    }
+    EXPECT_EQ(hrs.size(), GetParam().hrs);
+    auto schema = get_current_schema();
+    ASSERT_TRUE(schema.has_value());
+    EXPECT_EQ(schema->schema_struct, schemaless_struct_type());
+}
+
+TEST_P(RecordMultiplexerTest, TestSimpleAvroRecords) {
+    tests::record_generator gen(&registry);
+    auto reg_res
+      = gen.register_avro_schema("avro_v1", avro_schema_v1_str).get();
+    EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
+
+    // Add Avro records.
+    auto start_offset = model::offset{0};
+    auto res = mux(start_offset, [&gen](storage::record_batch_builder& b) {
+        auto res = gen.add_random_avro_record(b, "avro_v1", std::nullopt).get();
+        ASSERT_FALSE(res.has_error());
+    });
+    ASSERT_TRUE(res.has_value());
+    const auto& write_res = res.value();
+    EXPECT_EQ(write_res.data_files.size(), GetParam().hrs);
+
+    std::unordered_set<int> hrs;
+    for (auto& f : write_res.data_files) {
+        hrs.emplace(f.hour);
+        EXPECT_EQ(f.row_count, GetParam().records_per_hr());
+    }
+    EXPECT_EQ(hrs.size(), GetParam().hrs);
+
+    // 4 default columns + RootRecord + mylong
+    auto schema = get_current_schema();
+    EXPECT_EQ(schema->highest_field_id(), 6);
+}
+
+TEST_P(RecordMultiplexerTest, TestAvroRecordsMultipleSchemas) {
+    tests::record_generator gen(&registry);
+    auto reg_res
+      = gen.register_avro_schema("avro_v1", avro_schema_v1_str).get();
+    EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
+    reg_res = gen.register_avro_schema("avro_v2", avro_schema_v2_str).get();
+    EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
+
+    auto start_offset = model::offset{0};
+    int i = 0;
+    auto res = mux(start_offset, [&gen, &i](storage::record_batch_builder& b) {
+        auto res = gen
+                     .add_random_avro_record(
+                       b, (++i % 2) ? "avro_v1" : "avro_v2", std::nullopt)
+                     .get();
+        ASSERT_FALSE(res.has_error());
+    });
+    ASSERT_TRUE(res.has_value());
+    const auto& write_res = res.value();
+
+    // There should be twice as many files as normal, since we have twice the
+    // schemas.
+    EXPECT_EQ(write_res.data_files.size(), 2 * GetParam().hrs);
+
+    std::unordered_set<int> hrs;
+    for (auto& f : write_res.data_files) {
+        hrs.emplace(f.hour);
+        // Each file should have half the records as normal, since we have
+        // twice the files.
+        EXPECT_EQ(f.row_count, GetParam().records_per_hr() / 2);
+    }
+    EXPECT_EQ(hrs.size(), GetParam().hrs);
+    auto schema = get_current_schema();
+    EXPECT_EQ(schema->highest_field_id(), 16);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  RecordsArgs,
+  RecordMultiplexerTest,
+  ::testing::Values(
+    records_param{
+      .records_per_batch = 10,
+      .batches_per_hr = 2,
+      .hrs = 1,
+    },
+    records_param{
+      .records_per_batch = 4,
+      .batches_per_hr = 4,
+      .hrs = 4,
+    }),
+  [](const auto& info) {
+      const auto& p = info.param;
+      return fmt::format(
+        "rpb{}_bph{}_h{}", p.records_per_batch, p.batches_per_hr, p.hrs);
+  });

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -235,7 +235,7 @@ TEST_F(RecordSchemaResolverTest, TestProtobufSchemaBadOffsets) {
     auto resolver = record_schema_resolver(*sr);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_TRUE(res.has_error());
-    ASSERT_EQ(res.error(), record_schema_resolver::errc::bad_input);
+    ASSERT_EQ(res.error(), type_resolver::errc::bad_input);
 }
 
 TEST_F(RecordSchemaResolverTest, TestMissingMagic) {
@@ -259,7 +259,7 @@ TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
     auto resolver = record_schema_resolver(*sr);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_TRUE(res.has_error());
-    ASSERT_EQ(res.error(), record_schema_resolver::errc::registry_error);
+    ASSERT_EQ(res.error(), type_resolver::errc::registry_error);
 
     // We can try again when there are no injected errors and there should be
     // no issue.

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -13,11 +13,13 @@
 #include "cluster/archival/types.h"
 #include "cluster/partition.h"
 #include "datalake/batching_parquet_writer.h"
+#include "datalake/catalog_schema_manager.h"
 #include "datalake/coordinator/frontend.h"
 #include "datalake/coordinator/translated_offset_range.h"
 #include "datalake/data_writer_interface.h"
 #include "datalake/logger.h"
 #include "datalake/record_multiplexer.h"
+#include "datalake/record_schema_resolver.h"
 #include "datalake/translation/state_machine.h"
 #include "datalake/translation_task.h"
 #include "kafka/utils/txn_reader.h"
@@ -27,7 +29,14 @@
 
 #include <seastar/coroutine/as_future.hh>
 
+namespace datalake::translation {
+
 namespace {
+
+// TODO: configure these with topic configs, maybe make them be owned by the
+// datalake manager
+auto schema_mgr = std::make_unique<simple_schema_manager>();
+auto schema_resolver = std::make_unique<binary_type_resolver>();
 
 // A simple utility to conditionally retry with backoff on failures.
 static constexpr std::chrono::milliseconds initial_backoff{300};
@@ -73,8 +82,6 @@ ss::futurize_t<FuncRet> retry_with_backoff(
 }
 
 } // namespace
-
-namespace datalake::translation {
 
 static constexpr std::chrono::milliseconds translation_jitter{500};
 constexpr ::model::timeout_clock::duration wait_timeout = 5s;
@@ -177,7 +184,7 @@ partition_translator::do_translation_for_range(
       "", // todo(iceberg): generate a prefix with offset information
       max_rows_per_row_group,
       max_bytes_per_row_group);
-    auto task = translation_task{**_cloud_io};
+    auto task = translation_task{**_cloud_io, *schema_mgr, *schema_resolver};
     const auto& ntp = _partition->ntp();
     auto remote_path_prefix = remote_path{
       fmt::format("{}/{}/{}", iceberg_file_path_prefix, ntp.path(), _term)};
@@ -186,6 +193,7 @@ partition_translator::do_translation_for_range(
                               : std::make_optional("translator stopping");
     }};
     auto result = co_await task.translate(
+      ntp,
       std::move(writer_factory),
       std::move(rdr),
       remote_path_prefix,

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -25,7 +25,10 @@ namespace datalake {
  */
 class translation_task {
 public:
-    explicit translation_task(cloud_data_io& uploader);
+    explicit translation_task(
+      cloud_data_io& uploader,
+      schema_manager& schema_mgr,
+      type_resolver& type_resolver);
     enum class errc {
         file_io_error,
         cloud_io_error,
@@ -36,6 +39,7 @@ public:
      * stopped and a root retry chain node.
      */
     ss::future<checked<coordinator::translated_offset_range, errc>> translate(
+      const model::ntp& ntp,
       std::unique_ptr<data_writer_factory> writer_factory,
       model::record_batch_reader reader,
       const remote_path& remote_path_prefix,
@@ -59,5 +63,7 @@ private:
 
     static constexpr std::chrono::milliseconds _read_timeout{30000};
     cloud_data_io* _cloud_io;
+    schema_manager* _schema_mgr;
+    type_resolver* _type_resolver;
 };
 } // namespace datalake


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR fulfills the record_multiplexer's destiny in writing data across multiple files. There are two dimension on which we will write multiple files:
- by Iceberg partition key (the hour of the record timestamp)
- by the record value's schema, as resolved by the
  record_schema_resolver

The former is already encapsulated entirely within partitioning_writer, so the record_multiplexer just needs to maintain a collection thereof.

A couple of companions have joined to help the record_multiplexer in its journey: the schema manager, to register new schemas and fetch field IDs; and the type resolver, to determine the schema from a given record.  These will likely be owned by the datalake manager, and for now, have stub implementations where needed.

A follow-up change will plumb the schema registry and Iceberg catalog in so we can use the real implementations.

Some tests are added:
- with a dummy writer, to exercise the different aspects of multiplexing (by partition and by schema)
- with a parquet writer, to exercise translation of data alongside the schema translation

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
