### PR TITLE
cluster: fix log message formatting

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -357,7 +357,7 @@ void feature_manager::verify_enterprise_license() {
       "enterprise_features=[{}], license_missing_or_expired={}{}",
       _feature_table.local().get_active_version(),
       _feature_table.local().get_latest_logical_version(),
-      enterprise_features.enabled(),
+      fmt::join(enterprise_features.enabled(), ", "),
       license_missing_or_expired,
       fallback_license ? " (detected fallback license)" : "");
 

--- a/src/v/features/enterprise_features.h
+++ b/src/v/features/enterprise_features.h
@@ -40,13 +40,12 @@ std::ostream& operator<<(std::ostream&, license_required_feature);
  */
 class enterprise_feature_report {
     using vtype = absl::flat_hash_set<license_required_feature>;
-    using range = boost::iterator_range<vtype::const_iterator>;
 
 public:
     void set(license_required_feature feat, bool enabled);
     bool test(license_required_feature);
-    range enabled() const { return _enabled; }
-    range disabled() const { return _disabled; }
+    const vtype& enabled() const { return _enabled; }
+    const vtype& disabled() const { return _disabled; }
 
     // This method returns true if there are any feature(s) enabled that require
     // the enterprise license.  Currently the following features require a


### PR DESCRIPTION
Ensure that the listed enterprise features are delimited by a comma and that it is not easy to format the collection of enterprise features incorrectly.

This is effectively another round of the same change as https://github.com/redpanda-data/redpanda/pull/23640/commits/b2012c3504e391f690887f4abe75d5e5a81e9ce5, but there this third log line was missed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
