### PR TITLE
transform-sdk/go/tests: remove -quiet flag

### DIFF
--- a/src/transform-sdk/go/transform/internal/testdata/CMakeLists.txt
+++ b/src/transform-sdk/go/transform/internal/testdata/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 function(add_wasm_transform NAME)
   find_program(TINYGO_BIN "tinygo")
   set(wasm_output "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.wasm")
-  set(tinygo_cmd ${TINYGO_BIN} build -o ${wasm_output} -quiet -target wasi -scheduler none "${NAME}/transform.go")
+  set(tinygo_cmd ${TINYGO_BIN} build -o ${wasm_output} -target wasi -scheduler none "${NAME}/transform.go")
   set(gopath ${CMAKE_CURRENT_BINARY_DIR}/${NAME})
   add_custom_command(OUTPUT ${wasm_output}
                      COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/retry.py


### PR DESCRIPTION
This was only added for custom logging we put in tinygo, but we will remove that now that we're using upstream tinygo and not a fork.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
