### PR TITLE
CORE-8106 dt: Removed calls to install_license

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2874,11 +2874,6 @@ class RedpandaService(RedpandaServiceBase):
                                          request_timeout_ms=30000,
                                          api_version_auto_timeout_ms=3000)
 
-        if in_fips_environment():
-            # We may have dropped the data directory of the node before the start,
-            # so install the license even when this is not the first start.
-            self.install_license()
-
     def write_crl_file(self, node: ClusterNode, ca: tls.CertificateAuthority):
         self.logger.info(
             f"Writing Redpanda node tls ca CRL file: {RedpandaService.TLS_CA_CRL_FILE}"

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -19,7 +19,6 @@ from rptest.clients.rpk import RpkTool, ClusterAuthorizationError, RpkException,
 from rptest.services.redpanda import SecurityConfig, TLSProvider
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.services import tls
-from rptest.utils.mode_checks import skip_fips_mode
 from typing import Optional
 from enum import Enum
 
@@ -541,7 +540,6 @@ class AccessControlListTestUpgrade(AccessControlListTest):
 
     # Test that a cluster configured with enable_sasl can be upgraded
     # from v22.1.x, and still have sasl enabled. See PR 5292.
-    @skip_fips_mode
     @cluster(num_nodes=3,
              log_allow_list=[
                  r'rpc - .* The TLS connection was non-properly terminated.*'

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -380,8 +380,7 @@ class AlterConfigMixedNodeTest(EndToEndTest):
         self.start_redpanda(
             num_nodes=num_nodes,
             si_settings=SISettings(test_context=self.test_context),
-            install_opts=install_opts,
-            license_required=True)
+            install_opts=install_opts)
 
         rpk = RpkTool(self.redpanda)
         # KCL is used to direct AlterConfig and DescribeConfigs requests to specific brokers.

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -85,8 +85,7 @@ class EndToEndTest(Test):
                        environment=None,
                        install_opts: Optional[InstallOptions] = None,
                        new_bootstrap=False,
-                       max_num_seeds=3,
-                       license_required=False):
+                       max_num_seeds=3):
         if si_settings is not None:
             self.si_settings = si_settings
 
@@ -130,9 +129,6 @@ class EndToEndTest(Test):
         self.redpanda.start(nodes=started_nodes,
                             auto_assign_node_id=new_bootstrap,
                             omit_seeds_on_idx_one=not new_bootstrap)
-        if license_required:
-            # Install an enterprise license before the upgrade
-            self.redpanda.install_license()
         if version_to_install and install_opts.num_to_upgrade > 0:
             # Perform the upgrade rather than starting each node on the
             # appropriate version. Redpanda may not start up if starting a new

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -1017,9 +1017,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         test_mixed_versions = num_to_upgrade > 0
         install_opts = InstallOptions(
             install_previous_version=test_mixed_versions)
-        self.start_redpanda(num_nodes=3,
-                            install_opts=install_opts,
-                            license_required=True)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         spec = TopicSpec(name="topic",
                          partition_count=partitions,
@@ -1067,9 +1065,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         test_mixed_versions = num_to_upgrade > 0
         install_opts = InstallOptions(
             install_previous_version=test_mixed_versions)
-        self.start_redpanda(num_nodes=3,
-                            install_opts=install_opts,
-                            license_required=True)
+        self.start_redpanda(num_nodes=3, install_opts=install_opts)
 
         spec = TopicSpec(name="topic",
                          partition_count=partitions,

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -19,7 +19,6 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.admin import Admin
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
-from rptest.utils.mode_checks import skip_fips_mode
 
 LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
     # raft - [follower: {id: {1}, revision: {9}}] [group_id:1, {kafka/topic-xyeyqcbyxi/0}] - recovery_stm.cc:422 - recovery append entries error: rpc::errc::exponential_backoff
@@ -186,7 +185,6 @@ class PrefixTruncateRecoveryUpgradeTest(PrefixTruncateRecoveryTestBase):
                                          self.initial_version)
         super(PrefixTruncateRecoveryUpgradeTest, self).setUp()
 
-    @skip_fips_mode
     @cluster(num_nodes=3,
              log_allow_list=LOG_ALLOW_LIST +
              MixedVersionWorkloadRunner.ALLOWED_LOGS)

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -158,23 +158,11 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                    self.previous_version)
 
             self.redpanda.set_seed_servers(self.nodes_with_prev_version)
-
-            # Installing a license is required for version upgrades with enterprise features
-            # We need to install it before the new nodes try to join the cluster, so install
-            # it after the old nodes are started but before the new ones are starting
-            self.redpanda.start(nodes=self.redpanda.nodes[:with_prev_version],
-                                auto_assign_node_id=True,
-                                omit_seeds_on_idx_one=False)
-            self.redpanda.install_license()
-            self.redpanda.start(nodes=self.redpanda.nodes[with_prev_version:],
-                                auto_assign_node_id=True,
+            self.redpanda.start(auto_assign_node_id=True,
                                 omit_seeds_on_idx_one=False)
         else:
             self.redpanda.start(auto_assign_node_id=True,
                                 omit_seeds_on_idx_one=False)
-
-            # Installing a license is required for version upgrades with enterprise features
-            self.redpanda.install_license()
 
         self.redpanda.await_feature('membership_change_controller_cmds',
                                     'active',

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -496,8 +496,7 @@ class ReadReplicasUpgradeTest(EndToEndTest):
         install_opts = InstallOptions(install_previous_version=True)
         self.start_redpanda(3,
                             si_settings=self.si_settings,
-                            install_opts=install_opts,
-                            license_required=True)
+                            install_opts=install_opts)
         spec = TopicSpec(name=self.topic_name,
                          partition_count=partition_count,
                          replication_factor=3)
@@ -523,7 +522,6 @@ class ReadReplicasUpgradeTest(EndToEndTest):
         self.second_cluster._installer.install(self.second_cluster.nodes,
                                                previous_version)
         self.second_cluster.start(start_si=True)
-        self.second_cluster.install_license()
         create_read_replica_topic(self.second_cluster, self.topic_name,
                                   self.si_settings.cloud_storage_bucket)
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -151,13 +151,12 @@ class RedpandaTest(RedpandaTestBase):
         return versions
 
     def upgrade_through_versions(
-            self,
-            versions_in: list[RedpandaVersion],
-            already_running: bool = False,
-            auto_assign_node_id: bool = False,
-            mid_upgrade_check: Callable[[Mapping[Any, RedpandaVersion]],
-                                        None] = lambda x: None,
-            license_required: bool = False):
+        self,
+        versions_in: list[RedpandaVersion],
+        already_running: bool = False,
+        auto_assign_node_id: bool = False,
+        mid_upgrade_check: Callable[[Mapping[Any, RedpandaVersion]],
+                                    None] = lambda x: None):
         """
         Step the cluster through all the versions in `versions`, at each stage
         yielding the version of the cluster.
@@ -252,10 +251,6 @@ class RedpandaTest(RedpandaTestBase):
                 self.logger.info(
                     f"Upgrading to {current_version}, skipping maintenance mode"
                 )
-
-            # Installing a license is required for version upgrades with enterprise features
-            if license_required:
-                self.redpanda.install_license()
 
             # restarts the nodes in two batches, to run mid_upgrade_check with a mixed-version cluster
             rp_nodes: list[Any] = self.redpanda.nodes

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -19,7 +19,6 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, MetricSamples, Metr
 from rptest.util import expect_exception, get_cluster_license, get_second_cluster_license
 from ducktape.utils.util import wait_until
 from rptest.util import wait_until_result
-from rptest.utils.mode_checks import skip_fips_mode
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
@@ -234,7 +233,6 @@ class RpkClusterTest(RedpandaTest):
         ) <= threshold_s, f"Mismatch: abs({internal_val} - {public_val}) > {threshold_s}"
         return internal_val
 
-    @skip_fips_mode
     @cluster(num_nodes=3)
     def test_upload_and_query_cluster_license_rpk(self):
         """

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -282,8 +282,7 @@ class SelfTestTest(EndToEndTest):
         self.start_redpanda(
             num_nodes=num_nodes,
             si_settings=SISettings(test_context=self.test_context),
-            install_opts=install_opts,
-            license_required=True)
+            install_opts=install_opts)
 
         # Attempt to run with a possibly unknown "cloud" test.
         # The controller, which is of a lower version than the other nodes in the cluster,

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -413,7 +413,6 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         This ensures that rollbacks remain possible.
         """
         self.install_and_start()
-        self.redpanda.install_license()
 
         initial_version = Version(
             self.redpanda.get_version(self.redpanda.nodes[0]))

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -27,7 +27,7 @@ from rptest.util import (
     produce_until_segments,
     wait_until_segments,
 )
-from rptest.utils.mode_checks import skip_fips_mode, in_fips_environment
+from rptest.utils.mode_checks import skip_fips_mode
 from rptest.utils.si_utils import BucketView
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
@@ -145,7 +145,6 @@ class UpgradeBackToBackTest(PreallocNodesTest):
     topics = (TopicSpec(partition_count=3, replication_factor=3), )
 
     oldest_version = (21, 11)
-    fips_oldest_version = (22, 2)
 
     def __init__(self, test_context):
         if self.debug_mode:
@@ -198,11 +197,7 @@ class UpgradeBackToBackTest(PreallocNodesTest):
             return
 
         else:
-            # For FIPS, start with a version that supports installing an enterprise license.
-            # This is to allow upgrading to 24.3.x and beyond which has enterprise license enforcement on upgrade.
-            oldest_v = self.oldest_version if not in_fips_environment() \
-                else self.fips_oldest_version
-            self.versions = self.load_version_range(oldest_v)
+            self.versions = self.load_version_range(self.oldest_version)
 
     def install_next(self):
         v = self.versions.pop(0)

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -280,8 +280,7 @@ class RedpandaUpgradeTest(PreallocNodesTest):
         for current_version in self.upgrade_through_versions(
                 self.upgrade_steps,
                 already_running=False,
-                mid_upgrade_check=mid_upgrade_check,
-                license_required=True):
+                mid_upgrade_check=mid_upgrade_check):
             current_version = expand_version(self.installer, current_version)
             # setup workload that could start at current_version
             for w in self.adapted_workloads:

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -38,7 +38,7 @@ from rptest.services.admin import Admin
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.clients.rpk import RpkTool, AclList
 
-from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class TransactionsMixin:
@@ -1422,7 +1422,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.check_consume(2)
 
-    @skip_fips_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def upgrade_coordinator_test(self):
         def get_tx_coordinator():
@@ -1434,7 +1433,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
 
         self.do_upgrade_with_tx(get_tx_coordinator)
 
-    @skip_fips_mode
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def upgrade_topic_test(self):
         topic_name = self.topics[0].name


### PR DESCRIPTION
Now that Redpanda comes with a built-in evaluation period, there is no need to attempt to install a license to run these tests.  This reduces developer effort because they no longer will need to download a sample license and configure it on their system in order to run these ducktape tests locally.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
