### PR TITLE
CORE-7870 dt: ignore OIDC background errors in license tests

### DIFF
--- a/tests/rptest/tests/enterprise_features_license_test.py
+++ b/tests/rptest/tests/enterprise_features_license_test.py
@@ -66,6 +66,12 @@ SKIP_FEATURES = [
 
 
 class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
+    OIDC_UPDATE_FAILURE_LOGS = [
+        # Example: security - oidc_service.cc:232 - Error updating jwks: security::exception (Invalid jwks: Invalid response from jwks_uri: https://auth.prd.cloud.redpanda.com:443/.well-known/jwks.json)"
+        "Error updating jwks",
+        "Error updating metadata",
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
@@ -148,6 +154,8 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
             self.redpanda.set_cluster_config(
                 {'sasl_mechanisms': ['SCRAM', 'GSSAPI']})
         elif feature == Feature.oidc:
+            # Note: the default OIDC server is flaky in CI, so use `OIDC_UPDATE_FAILURE_LOGS`
+            # to ignore the related error logs in the background updater.
             self.redpanda.set_cluster_config(
                 {'sasl_mechanisms': ['SCRAM', 'OAUTHBEARER']})
         elif feature == Feature.schema_id_validation:
@@ -194,7 +202,7 @@ class EnterpriseFeaturesTest(EnterpriseFeaturesTestBase):
             assert False, f"Unexpected feature={feature}"
 
     @skip_fips_mode
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=OIDC_UPDATE_FAILURE_LOGS)
     @matrix(feature=[f for f in Feature if f not in SKIP_FEATURES],
             install_license=[
                 True,


### PR DESCRIPTION
The default OIDC server is flaky in CI, so ignore the related error logs in the background updater using `OIDC_UPDATE_FAILURE_LOGS`.

Alternatively, we could create a local `KeyCloak` OIDC Authorization Server which would be reliably available locally, but it's not simple to configure, so it's simpler to ignore the error logs for the purpose of these tests.

Fixes https://redpandadata.atlassian.net/browse/CORE-7870

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
