### PR TITLE
cluster: Fix leadership pinning minor reporting bug

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -228,12 +228,16 @@ feature_manager::report_enterprise_features() const {
       = n_roles >= 2
         || (n_roles == 1 && !_role_store.local().contains(security::default_role));
     auto leadership_pinning_enabled = [&cfg, this]() {
-        if (cfg.default_leaders_preference() != config::leaders_preference{}) {
+        const config::leaders_preference no_leaders_preference{};
+        if (cfg.default_leaders_preference() != no_leaders_preference) {
             return true;
         }
         for (const auto& topic : _topic_table.local().topics_map()) {
-            if (topic.second.get_configuration()
-                  .properties.leaders_preference) {
+            const auto leaders_preference
+              = topic.second.get_configuration().properties.leaders_preference;
+            if (
+              leaders_preference.has_value()
+              && leaders_preference.value() != no_leaders_preference) {
                 return true;
             }
         }


### PR DESCRIPTION
When reporting which features are enabled, for leadership pinning, the "default_leaders_preference" config property and each topic's "redpanda.leaders.preference" property were checked. However, for the latter, it was only checked whether the optional had a value and not what that value actually is.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
