### PR TITLE
cluster: Implement sanctions on pin leadership features on invalid license

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -687,7 +687,6 @@ ss::future<> controller::start(
       config::shard_local_cfg().leader_balancer_node_mute_timeout.bind(),
       config::shard_local_cfg().leader_balancer_transfer_limit_per_shard.bind(),
       config::shard_local_cfg().enable_rack_awareness.bind(),
-      config::shard_local_cfg().default_leaders_preference.bind(),
       config::shard_local_cfg().metadata_dissemination_interval_ms(),
       _raft0);
     co_await _leader_balancer->start();

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -17,6 +17,8 @@
 #include "cluster/scheduling/leader_balancer_strategy.h"
 #include "cluster/scheduling/leader_balancer_types.h"
 #include "cluster/types.h"
+#include "config/property.h"
+#include "features/enterprise_features.h"
 #include "raft/notification.h"
 
 #include <seastar/core/gate.hh>
@@ -90,7 +92,6 @@ public:
       config::binding<std::chrono::milliseconds>&&,
       config::binding<size_t>&&,
       config::binding<bool> enable_rack_awareness,
-      config::binding<config::leaders_preference>,
       std::chrono::milliseconds metadata_dissemination_interval,
       consensus_ptr);
 
@@ -199,7 +200,8 @@ private:
     config::binding<size_t> _transfer_limit_per_shard;
 
     config::binding<bool> _enable_rack_awareness;
-    config::binding<config::leaders_preference> _default_preference;
+    features::sanctioning_binding<config::property<config::leaders_preference>>
+      _default_preference;
 
     std::chrono::milliseconds _metadata_dissemination_interval;
 


### PR DESCRIPTION
Implements: [CORE-8042](https://redpandadata.atlassian.net/browse/CORE-8042) - Sanctions 18,19

Implement sanction(s) on leadership pinning properties when there is no valid license:
- If either the cluster config `default_leaders_preference` or a topic property `redpanda.leaders.preference` are set, the settings will be ignored.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[CORE-8042]: https://redpandadata.atlassian.net/browse/CORE-8042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ