### PR TITLE
datalake: plumb schema management into datalake worker

### DIFF
--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -23,6 +23,7 @@ v_cc_library(
     v::cluster
     v::raft
     v::storage
+    v::schema
     Seastar::seastar
 )
 
@@ -54,6 +55,7 @@ v_cc_library(
     v::pandaproxy_schema_registry
     v::schema
     v::storage
+    v::schema
     Seastar::seastar
     Arrow::arrow_shared
     Parquet::parquet_shared

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -18,6 +18,7 @@
 #include "datalake/fwd.h"
 #include "datalake/translation/partition_translator.h"
 #include "features/fwd.h"
+#include "pandaproxy/schema_registry/fwd.h"
 #include "raft/fundamental.h"
 #include "raft/fwd.h"
 #include "ssx/semaphore.h"
@@ -29,7 +30,13 @@
 
 namespace cloud_io {
 class remote;
-}
+} // namespace cloud_io
+namespace iceberg {
+class catalog;
+} // namespace iceberg
+namespace schema {
+class registry;
+} // namespace schema
 
 namespace datalake {
 
@@ -50,10 +57,13 @@ public:
       ss::sharded<features::feature_table>*,
       ss::sharded<coordinator::frontend>*,
       ss::sharded<cloud_io::remote>*,
+      std::unique_ptr<iceberg::catalog>,
+      pandaproxy::schema_registry::api* schema_registry,
       ss::sharded<ss::abort_source>*,
       cloud_storage_clients::bucket_name,
       ss::scheduling_group sg,
       size_t memory_limit);
+    ~datalake_manager();
 
     ss::future<> start();
     ss::future<> stop();
@@ -76,6 +86,10 @@ private:
     ss::sharded<features::feature_table>* _features;
     ss::sharded<coordinator::frontend>* _coordinator_frontend;
     std::unique_ptr<datalake::cloud_data_io> _cloud_data_io;
+    std::unique_ptr<schema::registry> _schema_registry;
+    std::unique_ptr<iceberg::catalog> _catalog;
+    std::unique_ptr<datalake::schema_manager> _schema_mgr;
+    std::unique_ptr<datalake::type_resolver> _type_resolver;
     ss::sharded<ss::abort_source>* _as;
     ss::scheduling_group _sg;
     ss::gate _gate;

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -69,6 +69,8 @@ public:
       ss::sharded<coordinator::frontend>* frontend,
       ss::sharded<features::feature_table>* features,
       std::unique_ptr<datalake::cloud_data_io>* cloud_io,
+      schema_manager* schema_mgr,
+      type_resolver* type_resolver,
       std::chrono::milliseconds translation_interval,
       ss::scheduling_group sg,
       size_t reader_max_bytes,
@@ -109,6 +111,8 @@ private:
     ss::sharded<coordinator::frontend>* _frontend;
     ss::sharded<features::feature_table>* _features;
     std::unique_ptr<datalake::cloud_data_io>* _cloud_io;
+    schema_manager* _schema_mgr;
+    type_resolver* _type_resolver;
     std::unique_ptr<kafka::partition_proxy> _partition_proxy;
     using jitter_t
       = simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -235,7 +235,10 @@ private:
     void
     wire_up_runtime_services(model::node_id node_id, ::stop_signal& app_signal);
     void configure_admin_server();
-    void wire_up_redpanda_services(model::node_id, ::stop_signal& app_signal);
+    void wire_up_redpanda_services(
+      model::node_id,
+      ::stop_signal& app_signal,
+      std::optional<cloud_storage_clients::bucket_name>& bucket_name);
 
     void load_feature_table_snapshot();
 

--- a/tests/rptest/services/spark_service.py
+++ b/tests/rptest/services/spark_service.py
@@ -32,7 +32,8 @@ class SparkService(Service, QueryEngineBase):
         --conf spark.sql.catalog.redpanda-iceberg-catalog.type=rest \
         --conf spark.sql.catalog.redpanda-iceberg-catalog.uri={catalog} \
         --conf spark.sql.catalog.redpanda-iceberg-catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
-        --conf spark.sql.catalog.redpanda-iceberg-catalog.s3.endpoint={s3}
+        --conf spark.sql.catalog.redpanda-iceberg-catalog.s3.endpoint={s3} \
+        --conf spark.sql.catalog.redpanda-iceberg-catalog.cache-enabled=false
     """
 
     def __init__(self, ctx, iceberg_catalog_rest_uri: str, si: SISettings):

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -125,10 +125,11 @@ class DatalakeServices():
         table_name = f"redpanda.{topic}"
 
         def translation_done():
-            return all([
-                engine.count_table(table_name) == msg_count
-                for engine in self.query_engines
-            ])
+            counts = dict(
+                map(lambda e: (e.engine_name(), e.count_table(table_name)),
+                    self.query_engines))
+            self.redpanda.logger.debug(f"Current counts: {counts}")
+            return all([c == msg_count for _, c in counts.items()])
 
         wait_until(
             translation_done,

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -8,11 +8,14 @@
 # by the Apache License, Version 2.0
 
 from typing import Any
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, TopicSpec
 from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from ducktape.utils.util import wait_until
 from rptest.services.redpanda import RedpandaService
+from rptest.services.spark_service import SparkService
+from rptest.services.trino_service import TrinoService
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.query_engine_factory import get_query_engine_by_type
 
@@ -42,7 +45,7 @@ class DatalakeServices():
         self.included_query_engines = include_query_engines
         # To be populated later once we have the URI of the catalog
         # available
-        self.query_engines = []
+        self.query_engines: list[Service] = []
 
     def setUp(self):
         self.catalog_service.start()
@@ -64,6 +67,22 @@ class DatalakeServices():
 
     def __exit__(self, *args, **kwargs):
         self.tearDown()
+
+    def trino(self) -> TrinoService:
+        trino = self.service(QueryEngineType.TRINO)
+        assert trino, "Missing Trino service"
+        return trino
+
+    def spark(self) -> SparkService:
+        spark = self.service(QueryEngineType.SPARK)
+        assert spark, "Missing Spark service"
+        return spark
+
+    def service(self, engine_type: QueryEngineType):
+        for e in self.query_engines:
+            if e.engine_name() == engine_type:
+                return e
+        return None
 
     def create_iceberg_enabled_topic(self,
                                      name,

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -44,7 +44,7 @@ class QueryEngineBase(ABC):
 
     def run_query_fetch_all(self, query):
         with self.run_query(query) as cursor:
-            cursor.fetchall()
+            return cursor.fetchall()
 
     def count_table(self, table) -> int:
         query = f"select count(*) from {table}"


### PR DESCRIPTION
Plumbs the schema registry and an Iceberg catalog to the datalake manager so they can be used by translation tasks to resolve schemas and register them with Iceberg.

It's noteworthy that the workers now own another instance of the Iceberg catalog (in addition to the coordinators owning one). Longer term we may want to have workers RPC out to coordinators and have all catalog communication happen on coordinators.

Also adds some updates to ducktape to exercise the new schema registration with Trino and Spark.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
