### PR TITLE
ducktape/java: download java22 for  arm64 arch correctly

### DIFF
--- a/tests/docker/ducktape-deps/java-dev-tools
+++ b/tests/docker/ducktape-deps/java-dev-tools
@@ -21,11 +21,11 @@ ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH)
 architecture=""
 case $ARCH in
     amd64) architecture="x64" ;;
-    aarch64) architecture="aarch64";;
+    arm64) architecture="aarch64";;
 esac
 
 if [ -z "${architecture}" ]; then
-  echo "Unable to determine arch to download JDK22, exiting."
+  echo "Unable to determine arch to download JDK22 for ${architecture}, exiting."
   exit 1
 fi
 


### PR DESCRIPTION
It appears debian packaging prefers arm64 over aarch64 naming. Fix the check accordingly.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
