### PR TITLE
CORE-8032 Audit log sanctioning

### DIFF
--- a/src/v/base/vlog.h
+++ b/src/v/base/vlog.h
@@ -25,3 +25,11 @@
 // NOLINTNEXTLINE
 #define vlogl(logger, level, fmt, args...)                                     \
     fmt_with_ctx_level(logger, level, fmt, ##args)
+
+// NOLINTNEXTLINE
+#define fmt_with_ctx_level_and_rate(logger, level, rate, fmt, args...)         \
+    logger.log(level, rate, "{} - " fmt, vlog::file_line::current(), ##args)
+
+// NOLINTNEXTLINE
+#define vloglr(logger, level, rate, fmt, args...)                              \
+    fmt_with_ctx_level_and_rate(logger, level, rate, fmt, ##args)


### PR DESCRIPTION
When audit logging is enabled and the license has expired or is absent,
then any attempt to fetch data from the audit log will be denied.

Note that Redpanda will continue to produce data to the audit log even
when the license has expired so customers will be able to see their
historical audit data once a valid license is set.

Fixes https://redpandadata.atlassian.net/browse/CORE-8032

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
