### PR TITLE
Migrations distinct error codes

### DIFF
--- a/src/v/cluster/data_migration_frontend.cc
+++ b/src/v/cluster/data_migration_frontend.cc
@@ -262,7 +262,7 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
      */
     if (migrations_table::is_empty_migration(migration)) {
         vlog(dm_log.warn, "data migration can not be empty.");
-        co_return make_error_code(errc::data_migration_invalid_resources);
+        co_return make_error_code(errc::data_migration_invalid_definition);
     }
 
     auto v_err = _table.local().validate_migrated_resources(migration);
@@ -273,7 +273,7 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
           "data migration {} validation error - {}",
           migration,
           v_err.value());
-        co_return make_error_code(errc::data_migration_invalid_resources);
+        co_return v_err->ec();
     }
 
     auto id = _table.local().get_next_id();

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -94,6 +94,8 @@ enum class errc : int16_t {
     data_migration_not_exists,
     data_migration_already_exists,
     data_migration_invalid_resources,
+    data_migration_invalid_definition,
+    data_migrations_disabled,
     resource_is_being_migrated,
     invalid_target_node_id,
 };
@@ -278,8 +280,11 @@ struct errc_category final : public std::error_category {
         case errc::data_migration_already_exists:
             return "Data migration with requested id already exists";
         case errc::data_migration_invalid_resources:
-            return "Data migration contains resources that does not exists or "
-                   "are already being migrated";
+            return "Data migration contains resources that are not eligible";
+        case errc::data_migration_invalid_definition:
+            return "Data migration definition contains errors";
+        case errc::data_migrations_disabled:
+            return "Data migrations are disabled for this cluster";
         case errc::resource_is_being_migrated:
             return "Requested operation can not be executed as the resource is "
                    "undergoing data migration";

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -176,6 +176,10 @@ std::ostream& operator<<(std::ostream& o, cluster::errc err) {
         return o << "cluster::errc::data_migration_already_exists";
     case errc::data_migration_invalid_resources:
         return o << "cluster::errc::data_migration_invalid_resources";
+    case errc::data_migration_invalid_definition:
+        return o << "cluster::errc::data_migration_invalid_definition";
+    case errc::data_migrations_disabled:
+        return o << "cluster::errc::data_migrations_disabled";
     case errc::resource_is_being_migrated:
         return o << "cluster::errc::resource_is_being_migrated";
     case errc::invalid_target_node_id:

--- a/src/v/cluster/tests/data_migration_table_test.cc
+++ b/src/v/cluster/tests/data_migration_table_test.cc
@@ -510,7 +510,7 @@ TEST_F_CORO(data_migration_table_fixture, test_resource_validation) {
      */
     auto r = co_await try_create_migration(odm.copy());
     EXPECT_TRUE(r.has_error());
-    EXPECT_EQ(r.error(), cluster::errc::data_migration_invalid_resources);
+    EXPECT_EQ(r.error(), cluster::errc::topic_not_exists);
 
     // create topics, retry migration creation
     co_await populate_topic_table_with_topics(odm.topics);
@@ -536,7 +536,7 @@ TEST_F_CORO(data_migration_table_fixture, test_resource_validation) {
      */
     r = co_await try_create_migration(invalid_idm.copy());
     EXPECT_TRUE(r.has_error());
-    EXPECT_EQ(r.error(), cluster::errc::data_migration_invalid_resources);
+    EXPECT_EQ(r.error(), cluster::errc::topic_already_exists);
     // valid idm should be created
     r = co_await try_create_migration(idm_with_alias.copy());
     EXPECT_TRUE(r.has_value());

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -114,6 +114,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::data_migration_already_exists:
     case cluster::errc::data_migration_not_exists:
     case cluster::errc::data_migration_invalid_resources:
+    case cluster::errc::data_migration_invalid_definition:
+    case cluster::errc::data_migrations_disabled:
     case cluster::errc::invalid_target_node_id:
         break;
     }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1102,6 +1102,8 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::invalid_data_migration_state:
         case cluster::errc::data_migration_already_exists:
         case cluster::errc::data_migration_invalid_resources:
+        case cluster::errc::data_migration_invalid_definition:
+        case cluster::errc::data_migrations_disabled:
             throw ss::httpd::bad_request_exception(
               fmt::format("{}", ec.message()));
         case cluster::errc::data_migration_not_exists:


### PR DESCRIPTION
Make migration creation admin API endpoint respond with more distinct errors.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
