### PR TITLE
[WIP] Alternative for zero-copy foreign share iobufs

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -22,6 +22,7 @@
 #include "container/intrusive_list_helpers.h"
 
 #include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/sharded.hh>
 
 #include <cstddef>
 #include <iosfwd>
@@ -463,3 +464,4 @@ inline void iobuf::trim_back(size_t n) {
 }
 
 iobuf iobuf_copy(iobuf::iterator_consumer& in, size_t len);
+iobuf iobuf_make_foreign(ss::foreign_ptr<std::unique_ptr<iobuf>> orig);

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "bytes/iobuf.h"
 #include "cluster/rm_stm.h"
 #include "container/intrusive_list_helpers.h"
 #include "kafka/protocol/fetch.h"
@@ -312,11 +313,7 @@ struct read_result {
         return ss::visit(
           data,
           [](data_t& d) { return std::move(*d); },
-          [](foreign_data_t& d) {
-              auto ret = d->copy();
-              d.reset();
-              return ret;
-          });
+          [](foreign_data_t& d) { return iobuf_make_foreign(std::move(d)); });
     }
 
     variant_t data;

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -25,6 +25,7 @@
 #include "serde/rw/iobuf.h"
 #include "serde/rw/rw.h"
 
+#include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/optimized_optional.hh>
 
@@ -36,6 +37,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <memory>
 #include <numeric>
 #include <variant>
 #include <vector>
@@ -899,6 +901,13 @@ public:
                       header, std::move(records), tag_ctor_ng()};
                 });
           });
+    }
+
+    static model::record_batch make_foreign(record_batch&& r) {
+        auto r_records = iobuf_make_foreign(
+          ss::make_foreign(std::make_unique<iobuf>(std::move(r._records))));
+
+        return {r._header, std::move(r_records), r._compressed};
     }
 
 private:

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -164,7 +164,7 @@ replicate_batcher::do_cache_with_backpressure(
         if (b.header().ctx.owner_shard == ss::this_shard_id()) {
             data.push_back(std::move(b));
         } else {
-            data.push_back(b.copy());
+            data.push_back(model::record_batch::make_foreign(std::move(b)));
         }
     }
     auto i = ss::make_lw_shared<item>(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR is an alternative to atomically reference counting in https://github.com/redpanda-data/seastar/pull/149 to remove the need to copy data when moving iobufs across shards.

A few additional steps are needed to finalize this solution;
- https://github.com/redpanda-data/redpanda/pull/23263 will need to be modified to allow an iobuf to be "re-homed" once to a different shard when it has been made foreign. This PR is what will prevent accidental misuse of the iobuf that could result in segfaults.
- `foreign_data_t` and therefore the variant type could be removed from `record_batch_reader`
- It's possible to lazily transform iobuf/record_batch into their "foreign" variants to avoid the need to iterate over all io_fragments in either immediately. This could help performance if not all io_fragments are always accessed.
- Coarser grain deleters could be used to reduce the number of cross shard calls.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
