### PR TITLE
clang-tidy: make WarningsAsErrors match cmake clang tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange'
-WarningsAsErrors: ''
+WarningsAsErrors: 'cppcoreguidelines-avoid-capturing-lambda-coroutines,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move'
 HeaderFilterRegex: '^(?!external/.*).*'
 FormatStyle:    file
 CheckOptions:

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+# Increment to trigger bazel build in CI: 0
+
 load("@gazelle//:def.bzl", "gazelle", "gazelle_test")
 
 # gazelle:prefix github.com/redpanda-data/redpanda

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -15,6 +15,7 @@ if(REDPANDA_RUN_CLANG_TIDY)
     if(NOT CLANG_TIDY_COMMAND)
         message(FATAL_ERROR "Could not find clang-tidy program")
     endif()
+    # IMPORTANT: Sync these with `WarningsAsErrors` field in `.clang-tidy`!
     set(clang_tidy_checks
         -*
         cppcoreguidelines-avoid-capturing-lambda-coroutines

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -17,6 +17,7 @@ if(REDPANDA_RUN_CLANG_TIDY)
     endif()
     set(clang_tidy_checks
         -*
+        cppcoreguidelines-avoid-capturing-lambda-coroutines
         bugprone-use-after-move
         bugprone-assert-side-effect
         bugprone-assignment-in-if-condition

--- a/src/v/base/seastarx.h
+++ b/src/v/base/seastarx.h
@@ -15,4 +15,5 @@
 
 namespace seastar {} // namespace seastar
 
+// NOLINTNEXTLINE(misc-unused-alias-decls)
 namespace ss = seastar;

--- a/src/v/cloud_topics/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/batcher/tests/aggregator_test.cc
@@ -121,11 +121,10 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
     // Checks situation when the aggregator is destroyed with staging write
     // requests but one write request is destroyed before the aggregator.
     constexpr static auto timeout = 10s;
-    auto chunk = get_random_serialized_chunk(10, 10);
     cloud_topics::details::write_request<ss::manual_clock> request(
       model::controller_ntp,
       cloud_topics::details::batcher_req_index(0),
-      std::move(chunk),
+      get_random_serialized_chunk(10, 10),
       timeout);
     auto fut = request.response.get_future();
 
@@ -133,7 +132,7 @@ TEST(AggregatorTest, SingleRequestDtorWithLostRequestStaged) {
         cloud_topics::details::write_request<ss::manual_clock> tmp_request(
           model::controller_ntp,
           cloud_topics::details::batcher_req_index(1),
-          std::move(chunk),
+          get_random_serialized_chunk(10, 10),
           timeout);
         cloud_topics::details::aggregator<ss::manual_clock> aggregator;
         aggregator.add(request);


### PR DESCRIPTION
Will it fly?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
