### PR TITLE
r/consensus_utils: use chunked vector when extracting configurations

### DIFF
--- a/src/v/raft/configuration_bootstrap_state.h
+++ b/src/v/raft/configuration_bootstrap_state.h
@@ -35,10 +35,10 @@ public:
     model::term_id term() const { return _term; }
     model::offset prev_log_index() const { return _prev_log_index; }
     model::term_id prev_log_term() const { return _prev_log_term; }
-    const std::vector<raft::offset_configuration>& configurations() const {
+    const chunked_vector<raft::offset_configuration>& configurations() const {
         return _configurations;
     }
-    std::vector<raft::offset_configuration> release_configurations() && {
+    chunked_vector<raft::offset_configuration> release_configurations() && {
         return std::move(_configurations);
     }
     void set_term(model::term_id t) { _term = t; }
@@ -76,7 +76,7 @@ private:
     model::term_id _term{0};
     model::offset _prev_log_index{0};
     model::term_id _prev_log_term{0};
-    std::vector<raft::offset_configuration> _configurations;
+    chunked_vector<raft::offset_configuration> _configurations;
 
     // we need to keep track of what we have processed in case we re-reprocess a
     // multiple segments

--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -169,8 +169,8 @@ void configuration_manager::add_configuration(
     }
 }
 
-ss::future<>
-configuration_manager::add(std::vector<offset_configuration> configurations) {
+ss::future<> configuration_manager::add(
+  chunked_vector<offset_configuration> configurations) {
     return _lock.with([this,
                        configurations = std::move(configurations)]() mutable {
         for (auto& co : configurations) {

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -92,7 +92,7 @@ public:
     /**
      * Add all configurations
      */
-    ss::future<> add(std::vector<offset_configuration>);
+    ss::future<> add(chunked_vector<offset_configuration>);
 
     /**
      * Get the configuration that is valid for given offset. This method return

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2835,7 +2835,7 @@ ss::future<storage::append_result> consensus::disk_append(
              consumer(_log->make_appender(cfg)),
              cfg.timeout)
       .then([this, should_update_last_quorum_idx](
-              std::tuple<ret_t, std::vector<offset_configuration>> t) {
+              std::tuple<ret_t, chunked_vector<offset_configuration>> t) {
           auto& [ret, configurations] = t;
           _pending_flush_bytes += ret.byte_size;
           if (should_update_last_quorum_idx) {

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -168,7 +168,7 @@ auto for_each_ref_extract_configuration(
 
         ReferenceConsumer wrapped;
         model::offset next_offset;
-        std::vector<offset_configuration> configurations;
+        chunked_vector<offset_configuration> configurations;
     };
 
     return std::move(rdr).for_each_ref(


### PR DESCRIPTION
When extracting configurations from a range of batches the configuration vector may grow pretty large. Replaced `std::vector` with `chunked_vector` to prevent large allocations.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- fixed large allocation in Raft implementation 