### PR TITLE
metrics: Add list of enterprise features to call-home POST

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -275,6 +275,8 @@ metrics_reporter::build_metrics_snapshot() {
                                  && !license.value().is_expired();
     snapshot.has_enterprise_features = feature_report.any();
 
+    snapshot.enterprise_features.emplace(std::move(feature_report));
+
     co_return snapshot;
 }
 
@@ -554,6 +556,15 @@ void rjson_serialize(
 
     w.Key("has_enterprise_features");
     w.Bool(snapshot.has_enterprise_features);
+
+    if (snapshot.enterprise_features.has_value()) {
+        w.Key("enterprise_features");
+        w.StartArray();
+        for (const auto& f : snapshot.enterprise_features.value().enabled()) {
+            w.String(fmt::format("{}", f));
+        }
+        w.EndArray();
+    }
 
     w.EndObject();
 }

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/plugin_table.h"
 #include "cluster/types.h"
+#include "features/enterprise_features.h"
 #include "features/fwd.h"
 #include "http/client.h"
 #include "model/metadata.h"
@@ -82,6 +83,8 @@ public:
 
         bool has_enterprise_features{false};
         bool has_valid_license{false};
+
+        std::optional<features::enterprise_feature_report> enterprise_features;
     };
     static constexpr ss::shard_id shard = 0;
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -137,6 +137,7 @@ class MetricsReporterTest(RedpandaTest):
         # license violation status should not change across requests
         assert_fields_are_the_same(metadata, 'has_valid_license')
         assert_fields_are_the_same(metadata, 'has_enterprise_features')
+        assert_fields_are_the_same(metadata, 'enterprise_features')
         # get the last report
         last = metadata.pop()
         assert last['topic_count'] == total_topics
@@ -151,6 +152,8 @@ class MetricsReporterTest(RedpandaTest):
         # NOTE: value will vary depending on FIPS mode. we're confident that
         # the source of the value is sound, so assert on presence instead.
         assert 'has_enterprise_features' in last
+        assert 'enterprise_features' in last
+        assert type(last['enterprise_features']) == list
         nodes_meta = last['nodes']
 
         assert len(last['nodes']) == len(self.redpanda.nodes)


### PR DESCRIPTION
Flat list of feature names, only those which are currently enabled

Fixes: CORE-8138

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
