### PR TITLE
datalake/tests: enable parametrizing datalake tests across query engines / catalog modes

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -7,23 +7,40 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 from rptest.services.cluster import cluster
-from rptest.tests.datalake.datalake_services import DatalakeServicesBase
+from rptest.services.redpanda import SISettings
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from ducktape.mark import matrix
 
 
-class DatalakeE2ETests(DatalakeServicesBase):
+class DatalakeE2ETests(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):
-        super(DatalakeE2ETests, self).__init__(test_ctx,
-                                               num_brokers=1,
-                                               *args,
-                                               **kwargs)
+        super(DatalakeE2ETests,
+              self).__init__(test_ctx,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context=test_ctx),
+                             extra_rp_conf={
+                                 "iceberg_enabled": "true",
+                                 "iceberg_catalog_commit_interval_ms": 5000
+                             },
+                             *args,
+                             **kwargs)
+        self.test_ctx = test_ctx
         self.topic_name = "test"
 
-    @cluster(num_nodes=5)
-    def test_e2e_basic(self):
+    @cluster(num_nodes=4)
+    @matrix(query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
+            filesystem_catalog_mode=[True])
+    def test_e2e_basic(self, query_engine, filesystem_catalog_mode):
         # Create a topic
         # Produce some events
         # Ensure they end up in datalake
         count = 100
-        self.create_iceberg_enabled_topic(self.topic_name)
-        self.produce_to_topic(self.topic_name, 1024, count)
-        self.wait_for_translation(self.topic_name, msg_count=count)
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              include_query_engines=[query_engine]) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name)
+            dl.produce_to_topic(self.topic_name, 1024, count)
+            dl.wait_for_translation(self.topic_name, msg_count=count)

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -9,43 +9,43 @@
 
 from typing import Any
 from rptest.clients.rpk import RpkTool, TopicSpec
-from rptest.tests.datalake.iceberg_rest_catalog import IcebergRESTCatalogTest
+from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from ducktape.utils.util import wait_until
+from rptest.services.redpanda import RedpandaService
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.query_engine_factory import get_query_engine_by_type
 
 
-class DatalakeServicesBase(IcebergRESTCatalogTest):
-    """All inclusive base class for implementing datalake tests. Includes the
-    boiler plate to enable datalake and bring up related services.
-    """
+class DatalakeServices():
+    """Utility class for implementing datalake tests. Includes the
+    boiler plate to manage dependent services."""
     def __init__(self,
                  test_ctx,
+                 redpanda: RedpandaService,
                  filesystem_catalog_mode=True,
                  include_query_engines: list[QueryEngineType] = [
                      QueryEngineType.SPARK, QueryEngineType.TRINO
-                 ],
-                 *args,
-                 **kwargs):
-        super(DatalakeServicesBase,
-              self).__init__(test_ctx,
-                             extra_rp_conf={
-                                 "iceberg_enabled": "true",
-                                 "iceberg_catalog_commit_interval_ms": 5000
-                             },
-                             *args,
-                             **kwargs)
+                 ]):
         self.test_ctx = test_ctx
-        self.catalog_service.set_filesystem_wrapper_mode(
-            filesystem_catalog_mode)
+        self.redpanda = redpanda
+        si_settings = self.redpanda.si_settings
+        assert si_settings
+        self.catalog_service = IcebergRESTCatalog(
+            test_ctx,
+            cloud_storage_bucket=si_settings.cloud_storage_bucket,
+            cloud_storage_access_key=str(si_settings.cloud_storage_access_key),
+            cloud_storage_secret_key=str(si_settings.cloud_storage_secret_key),
+            cloud_storage_region=si_settings.cloud_storage_region,
+            cloud_storage_api_endpoint=str(si_settings.endpoint_url),
+            filesystem_wrapper_mode=filesystem_catalog_mode)
         self.included_query_engines = include_query_engines
         # To be populated later once we have the URI of the catalog
         # available
         self.query_engines = []
 
     def setUp(self):
-        super().setUp()
+        self.catalog_service.start()
         for engine in self.included_query_engines:
             svc_cls = get_query_engine_by_type(engine)
             svc = svc_cls(self.test_ctx, str(self.catalog_service.catalog_url),
@@ -56,7 +56,7 @@ class DatalakeServicesBase(IcebergRESTCatalogTest):
     def tearDown(self):
         for engine in self.query_engines:
             engine.stop()
-        return super().tearDown()
+        self.catalog_service.stop()
 
     def __enter__(self):
         self.setUp()
@@ -85,7 +85,7 @@ class DatalakeServicesBase(IcebergRESTCatalogTest):
 
         def table_created():
             namespaces = client.list_namespaces()
-            self.logger.debug(f"namespaces: {namespaces}")
+            self.redpanda.logger.debug(f"namespaces: {namespaces}")
             return (namespace, ) in namespaces and (
                 namespace, table) in client.list_tables(namespace)
 

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from enum import Enum
+
+
+class QueryEngineType(str, Enum):
+    SPARK = 'spark'
+    TRINO = 'trino'
+
+
+class QueryEngineBase(ABC):
+    """Captures all the common operations across registered query engines"""
+    @staticmethod
+    @abstractmethod
+    def engine_name() -> QueryEngineType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def make_client(self):
+        raise NotImplementedError
+
+    @contextmanager
+    def run_query(self, query):
+        client = self.make_client()
+        assert client
+        try:
+            try:
+                cursor = client.cursor()
+                cursor.execute(query)
+                yield cursor
+            finally:
+                cursor.close()
+        finally:
+            client.close()
+
+    def run_query_fetch_all(self, query):
+        with self.run_query(query) as cursor:
+            cursor.fetchall()
+
+    def count_table(self, table) -> int:
+        query = f"select count(*) from {table}"
+        with self.run_query(query) as cursor:
+            return int(cursor.fetchone()[0])

--- a/tests/rptest/tests/datalake/query_engine_factory.py
+++ b/tests/rptest/tests/datalake/query_engine_factory.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.spark_service import SparkService
+from rptest.services.trino_service import TrinoService
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+
+SUPPORTED_QUERY_ENGINES = [SparkService, TrinoService]
+
+
+def get_query_engine_by_type(type: QueryEngineType):
+    for svc in SUPPORTED_QUERY_ENGINES:
+        if svc.engine_name() == type:
+            return svc
+    raise NotImplementedError(f"No query engine of type {type}")

--- a/tests/rptest/tests/datalake/spark_sql_server_smoke_test.py
+++ b/tests/rptest/tests/datalake/spark_sql_server_smoke_test.py
@@ -26,13 +26,8 @@ class SparkSmokeTest(IcebergRESTCatalogTest):
     def setUp(self):
         super().setUp()
         si = self.redpanda.si_settings
-        self.spark = SparkService(
-            self.test_ctx,
-            iceberg_catalog_rest_uri=str(self.catalog_service.catalog_url),
-            cloud_storage_access_key=str(si.cloud_storage_access_key),
-            cloud_storage_secret_key=str(si.cloud_storage_secret_key),
-            cloud_storage_region=si.cloud_storage_region,
-            cloud_storage_api_endpoint=str(si.endpoint_url))
+        self.spark = SparkService(self.test_ctx,
+                                  self.catalog_service.catalog_url, si)
         self.spark.start()
 
     def tearDown(self):

--- a/tests/rptest/tests/datalake/trino_smoke_test.py
+++ b/tests/rptest/tests/datalake/trino_smoke_test.py
@@ -26,13 +26,8 @@ class TrinoSmokeTest(IcebergRESTCatalogTest):
     def setUp(self):
         super().setUp()
         si = self.redpanda.si_settings
-        self.trino = TrinoService(
-            self.test_ctx,
-            iceberg_catalog_rest_uri=str(self.catalog_service.catalog_url),
-            cloud_storage_access_key=str(si.cloud_storage_access_key),
-            cloud_storage_secret_key=str(si.cloud_storage_secret_key),
-            cloud_storage_region=si.cloud_storage_region,
-            cloud_storage_api_endpoint=str(si.endpoint_url))
+        self.trino = TrinoService(self.test_ctx,
+                                  self.catalog_service.catalog_url, si)
         self.trino.start()
 
     def tearDown(self):


### PR DESCRIPTION
Refactors the interfaces to abstract out query engine specifics into a base class and enables plugging in required SQL engines at test time. Refactored existing end-to-end with parameterization as an example.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
