### PR TITLE
[CORE-7770]: `rptest`: use `wait_until_result` wrapper in `delete_records_test.py`

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -139,10 +139,19 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
             self.local_retention)
 
     def get_topic_info(self, topic_name):
-        topics_info = list(self.rpk.describe_topic(topic_name))
-        self.logger.info(topics_info)
-        assert len(topics_info) == 1
-        return topics_info[0]
+        def describe_topic():
+            topics_info = list(self.rpk.describe_topic(topic_name))
+            if len(topics_info) > 0:
+                self.logger.info(topics_info)
+                return True, topics_info[0]
+            else:
+                return False
+
+        topic_info = wait_until_result(describe_topic,
+                                       timeout_sec=15,
+                                       backoff_sec=1,
+                                       err_msg="Couldn't get topic info")
+        return topic_info
 
     def wait_until_records(self,
                            topic_name,


### PR DESCRIPTION
This test uses two threads to perform prefix truncations while moving partition leadership around. `rpk.describe_topic()` may return a `NOT_LEADER_FOR_PARTITION` result during this process, leading to a failed assert.

Wrap the command in a `wait_until_result()` call in order to avoid race-y failures.

JIRA Link: https://redpandadata.atlassian.net/browse/CORE-7770

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
