### PR TITLE
parquet: introduce column writer

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -92,8 +92,27 @@ redpanda_cc_library(
         ":schema",
         ":value",
         "//src/v/base",
-        "@boost//:range",
         "@abseil-cpp//absl/functional:function_ref",
+        "@boost//:range",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "column_writer",
+    srcs = [
+        "column_writer.cc",
+    ],
+    hdrs = [
+        "column_writer.h",
+    ],
+    include_prefix = "serde/parquet",
+    deps = [
+        ":encoding",
+        ":metadata",
+        ":value",
+        "//src/v/base",
+        "@abseil-cpp//absl/crc:crc32c",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -38,7 +38,7 @@ redpanda_cc_library(
         "//src/v/container:fragmented_vector",
         "//src/v/serde/thrift:compact",
         "//src/v/utils:vint",
-        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/crc:crc32c",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -18,7 +18,6 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/container:fragmented_vector",
-        "//src/v/utils:uuid",
         "@seastar",
     ],
 )
@@ -38,7 +37,6 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
         "//src/v/serde/thrift:compact",
-        "//src/v/utils:uuid",
         "//src/v/utils:vint",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@seastar",
@@ -58,9 +56,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
-        "//src/v/utils:base64",
-        "//src/v/utils:uuid",
-        "@abseil-cpp//absl/numeric:int128",
+        "@abseil-cpp//absl/strings",
         "@seastar",
     ],
 )
@@ -97,6 +93,7 @@ redpanda_cc_library(
         ":value",
         "//src/v/base",
         "@boost//:range",
+        "@abseil-cpp//absl/functional:function_ref",
         "@seastar",
     ],
 )

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -18,6 +18,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/container:fragmented_vector",
+        "//src/v/utils:named_type",
         "@seastar",
     ],
 )
@@ -71,6 +72,7 @@ redpanda_cc_library(
     ],
     include_prefix = "serde/parquet",
     deps = [
+        ":schema",
         ":value",
         "//src/v/base",
         "//src/v/bytes:iobuf",

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     value.cc
     schema.cc
     shredder.cc
+    column_writer.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/column_writer.h"
+
+#include "serde/parquet/encoding.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <absl/crc/crc32c.h>
+
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+namespace serde::parquet {
+
+class column_writer::impl {
+public:
+    impl() = default;
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+    impl(impl&&) = default;
+    impl& operator=(impl&&) = default;
+    virtual ~impl() = default;
+
+    virtual void add(value val, uint8_t rep_level, uint8_t def_level) = 0;
+    virtual data_page flush_page() = 0;
+};
+
+namespace {
+
+absl::crc32c_t extend_crc32(absl::crc32c_t crc, const iobuf& buf) {
+    for (const auto& frag : buf) {
+        crc = absl::ExtendCrc32c(crc, {frag.get(), frag.size()});
+    }
+    return crc;
+}
+
+template<typename... Args>
+absl::crc32c_t compute_crc32(Args&&... args) {
+    absl::crc32c_t crc{};
+    ((crc = extend_crc32(crc, std::forward<Args>(args))), ...);
+    return crc;
+}
+
+template<typename value_type>
+class buffered_column_writer final : public column_writer::impl {
+public:
+    buffered_column_writer(int16_t max_def_level, int16_t max_rep_level)
+      : _max_rep_level(max_rep_level)
+      , _max_def_level(max_def_level) {}
+
+    void add(value val, uint8_t rep_level, uint8_t def_level) override {
+        ++_num_values;
+        // A repetition level of zero means that it's the start of a new row and
+        // not a repeated value within the same row.
+        if (rep_level == 0) {
+            ++_num_rows;
+        }
+        ss::visit(
+          std::move(val),
+          [this](value_type& v) { _value_buffer.push_back(std::move(v)); },
+          [this](null_value&) {
+              // null values are valid, but are not encoded in the actual data,
+              // they are encoded in the defintion levels.
+              ++_num_nulls;
+          },
+          [](auto& v) {
+              throw std::runtime_error(fmt::format(
+                "invalid value for column: {:32}", value(std::move(v))));
+          });
+        _rep_levels.push_back(rep_level);
+        _def_levels.push_back(def_level);
+    }
+
+    data_page flush_page() override {
+        auto encoded_def_levels = encode_levels(_max_def_level, _def_levels);
+        _def_levels.clear();
+        auto encoded_rep_levels = encode_levels(_max_rep_level, _rep_levels);
+        _rep_levels.clear();
+        iobuf encoded_data;
+        if constexpr (std::is_trivially_copyable_v<value_type>) {
+            encoded_data = encode_plain(_value_buffer);
+            _value_buffer.clear();
+        } else {
+            encoded_data = encode_plain(std::exchange(_value_buffer, {}));
+        }
+        size_t page_size = encoded_def_levels.size_bytes()
+                           + encoded_rep_levels.size_bytes()
+                           + encoded_data.size_bytes();
+        if (page_size > std::numeric_limits<int32_t>::max()) {
+            throw std::runtime_error(
+              fmt::format("page size limit exceeded: {} bytes", page_size));
+        }
+        page_header header{
+          .uncompressed_page_size = static_cast<int32_t>(page_size),
+          .compressed_page_size = static_cast<int32_t>(page_size),
+          .crc = compute_crc32(encoded_rep_levels, encoded_def_levels, encoded_data),
+          .type = data_page_header{
+            .num_values = std::exchange(_num_values, 0),
+            .num_nulls = std::exchange(_num_nulls, 0),
+            .num_rows = std::exchange(_num_rows, 0),
+            .data_encoding = encoding::plain,
+            .definition_levels_byte_length = static_cast<int32_t>(encoded_def_levels.size_bytes()),
+            .repetition_levels_byte_length = static_cast<int32_t>(encoded_rep_levels.size_bytes()),
+            .is_compressed = false,
+          },
+        };
+        iobuf full_page_data = encode(header);
+        full_page_data.append(std::move(encoded_rep_levels));
+        full_page_data.append(std::move(encoded_def_levels));
+        full_page_data.append(std::move(encoded_data));
+        return {
+          .header = header,
+          .serialized = std::move(full_page_data),
+        };
+    }
+
+private:
+    // TODO: add compression and detailed stats
+    chunked_vector<value_type> _value_buffer;
+    chunked_vector<uint8_t> _def_levels;
+    chunked_vector<uint8_t> _rep_levels;
+    int32_t _num_rows = 0;
+    int32_t _num_nulls = 0;
+    int32_t _num_values = 0;
+    int16_t _max_rep_level;
+    int16_t _max_def_level;
+};
+
+template class buffered_column_writer<boolean_value>;
+template class buffered_column_writer<int32_value>;
+template class buffered_column_writer<int64_value>;
+template class buffered_column_writer<float32_value>;
+template class buffered_column_writer<float64_value>;
+template class buffered_column_writer<byte_array_value>;
+template class buffered_column_writer<fixed_byte_array_value>;
+
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element&, std::monostate) {
+    throw std::runtime_error("invariant error: cannot make a column writer "
+                             "from an intermediate value");
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, bool_type) {
+    return std::make_unique<buffered_column_writer<boolean_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, i32_type) {
+    return std::make_unique<buffered_column_writer<int32_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, i64_type) {
+    return std::make_unique<buffered_column_writer<int64_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, f32_type) {
+    return std::make_unique<buffered_column_writer<float32_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, f64_type) {
+    return std::make_unique<buffered_column_writer<float64_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+std::unique_ptr<column_writer::impl>
+make_impl(const schema_element& e, byte_array_type t) {
+    if (t.fixed_length.has_value()) {
+        return std::make_unique<buffered_column_writer<fixed_byte_array_value>>(
+          e.max_definition_level, e.max_repetition_level);
+    }
+    return std::make_unique<buffered_column_writer<byte_array_value>>(
+      e.max_definition_level, e.max_repetition_level);
+}
+
+} // namespace
+
+column_writer::column_writer(const schema_element& col)
+  : _impl(std::visit([&col](auto x) { return make_impl(col, x); }, col.type)) {}
+
+column_writer::~column_writer() = default;
+
+void column_writer::add(value val, uint8_t rep_level, uint8_t def_level) {
+    return _impl->add(std::move(val), rep_level, def_level);
+}
+
+data_page column_writer::flush_page() { return _impl->flush_page(); }
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -46,7 +46,7 @@ public:
     // nodes.
     //
     // Use `shred_record` to get the value and levels from an arbitrary value.
-    void add(value val, uint8_t rep_level, uint8_t def_level);
+    void add(value, rep_level, def_level);
 
     // Flush the currently buffered values to a page.
     //

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/metadata.h"
+#include "serde/parquet/value.h"
+
+namespace serde::parquet {
+
+// A serialized page for a column along with the page header metadata
+// as that is used when creating the metadata for the entire column.
+struct data_page {
+    // The unencoded header for this page.
+    page_header header;
+    // This serialized data already includes the header encoded in
+    // Apache Thrift format.
+    iobuf serialized;
+};
+
+// A writer for a single column of parquet data.
+class column_writer {
+public:
+    class impl;
+
+    explicit column_writer(const schema_element&);
+    column_writer(const column_writer&) = delete;
+    column_writer& operator=(const column_writer&) = delete;
+    column_writer(column_writer&&) = default;
+    column_writer& operator=(column_writer&&) = default;
+    ~column_writer();
+
+    // Add a value to this column along with it's repetition level and
+    // definition level.
+    //
+    // `value` here is only allowed to be the same value as `value_type`
+    // or `null` if there are non-required nodes in the schema ancestor
+    // nodes.
+    //
+    // Use `shred_record` to get the value and levels from an arbitrary value.
+    void add(value val, uint8_t rep_level, uint8_t def_level);
+
+    // Flush the currently buffered values to a page.
+    //
+    // This also resets the writer to be able to start writing a new page.
+    data_page flush_page();
+
+private:
+    std::unique_ptr<impl> _impl;
+};
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/encoding.h
+++ b/src/v/serde/parquet/encoding.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
 
 namespace serde::parquet {
@@ -44,6 +45,9 @@ iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals);
 // https://parquet.apache.org/docs/file-format/data-pages/encodings/#run-length-encoding--bit-packing-hybrid-rle--3
 //
 // If `levels` is empty `max_value` should be `0`.
-iobuf encode_levels(uint8_t max_value, const chunked_vector<uint8_t>& levels);
+iobuf encode_levels(
+  rep_level max_value, const chunked_vector<rep_level>& levels);
+iobuf encode_levels(
+  def_level max_value, const chunked_vector<def_level>& levels);
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/encoding.h
+++ b/src/v/serde/parquet/encoding.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "serde/parquet/value.h"
-#include "src/v/serde/parquet/value.h"
 
 namespace serde::parquet {
 

--- a/src/v/serde/parquet/metadata.cc
+++ b/src/v/serde/parquet/metadata.cc
@@ -825,7 +825,10 @@ iobuf encode(const page_header& header) {
       thrift::field_type::i32,
       vint::to_bytes(header.compressed_page_size));
     encoder.write_field(
-      crc_field_id, thrift::field_type::i32, vint::to_bytes(header.crc));
+      crc_field_id,
+      thrift::field_type::i32,
+      // sign extend the crc so that it's zig-zag encoded correctly.
+      vint::to_bytes(static_cast<int32_t>(static_cast<uint32_t>(header.crc))));
     ss::visit(
       header.type,
       [&](const index_page_header&) {

--- a/src/v/serde/parquet/metadata.h
+++ b/src/v/serde/parquet/metadata.h
@@ -33,7 +33,7 @@
 
 #include <seastar/core/sstring.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/crc/crc32c.h>
 
 #include <cmath>
 #include <cstdint>
@@ -224,7 +224,7 @@ struct page_header {
      * If enabled, this allows for disabling checksumming in HDFS if only a few
      * pages need to be read.
      */
-    int32_t crc;
+    absl::crc32c_t crc;
 
     // Headers for page specific data.  One only will be set.
     std::variant<index_page_header, dictionary_page_header, data_page_header>

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -25,12 +25,16 @@ bool schema_element::is_leaf() const {
 void index_schema(schema_element& root) {
     int32_t position = 0;
     struct entry {
-        int16_t rep_level;
-        int16_t def_level;
+        rep_level rep_level;
+        def_level def_level;
         schema_element* element;
     };
     chunked_vector<entry> to_visit;
-    to_visit.push_back({.rep_level = 0, .def_level = 0, .element = &root});
+    to_visit.push_back({
+      .rep_level = rep_level(0),
+      .def_level = def_level(0),
+      .element = &root,
+    });
     while (!to_visit.empty()) {
         auto [rep_level, def_level, element] = to_visit.back();
         to_visit.pop_back();
@@ -66,8 +70,8 @@ auto fmt::formatter<serde::parquet::schema_element>::format(
       e.position,
       e.type.index(),
       static_cast<uint8_t>(e.repetition_type),
-      e.max_definition_level,
-      e.max_repetition_level,
+      e.max_definition_level(),
+      e.max_repetition_level(),
       e.name,
       e.logical_type.index(),
       e.field_id.value_or(-1),

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -14,6 +14,8 @@
 #include <ranges>
 #include <variant>
 
+using std::ranges::reverse_view;
+
 namespace serde::parquet {
 
 bool schema_element::is_leaf() const {
@@ -22,14 +24,31 @@ bool schema_element::is_leaf() const {
 
 void index_schema(schema_element& root) {
     int32_t position = 0;
-    chunked_vector<schema_element*> to_visit;
-    to_visit.push_back(&root);
+    struct entry {
+        int16_t rep_level;
+        int16_t def_level;
+        schema_element* element;
+    };
+    chunked_vector<entry> to_visit;
+    to_visit.push_back({.rep_level = 0, .def_level = 0, .element = &root});
     while (!to_visit.empty()) {
-        schema_element* popped = to_visit.back();
+        auto [rep_level, def_level, element] = to_visit.back();
         to_visit.pop_back();
-        popped->position = position++;
-        for (auto& child : std::ranges::reverse_view(popped->children)) {
-            to_visit.push_back(&child);
+        element->position = position++;
+        if (element->repetition_type != field_repetition_type::required) {
+            ++def_level;
+        }
+        if (element->repetition_type == field_repetition_type::repeated) {
+            ++rep_level;
+        }
+        element->max_definition_level = def_level;
+        element->max_repetition_level = rep_level;
+        for (auto& child : reverse_view(element->children)) {
+            to_visit.push_back({
+              .rep_level = rep_level,
+              .def_level = def_level,
+              .element = &child,
+            });
         }
     }
 }
@@ -41,11 +60,14 @@ auto fmt::formatter<serde::parquet::schema_element>::format(
   fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{position: {}, type: {}, repetition_type: {}, name: {}, logical_type: "
+      "{{position: {}, type: {}, repetition_type: {}, max_def_level: {}, "
+      "max_rep_level: {}, name: {}, logical_type: "
       "{}, field_id: {}, children: [{}]}}",
       e.position,
       e.type.index(),
       static_cast<uint8_t>(e.repetition_type),
+      e.max_definition_level,
+      e.max_repetition_level,
       e.name,
       e.logical_type.index(),
       e.field_id.value_or(-1),

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -13,6 +13,7 @@
 
 #include "base/seastarx.h"
 #include "container/fragmented_vector.h"
+#include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -21,6 +22,9 @@
 #include <variant>
 
 namespace serde::parquet {
+
+using def_level = named_type<int16_t, struct def_level_tag>;
+using rep_level = named_type<int16_t, struct rep_level_tag>;
 
 struct bool_type {
     bool operator==(const bool_type&) const = default;
@@ -283,7 +287,7 @@ struct schema_element {
      * heirarchy of schema nodes. See shredder.h for more on definition level
      * and how it's computed.
      */
-    int16_t max_definition_level = -1;
+    def_level max_definition_level = def_level(-1);
 
     /**
      * The maximum repetition level for this node.
@@ -292,7 +296,7 @@ struct schema_element {
      * value heirarchy of (possibility repeated) schema nodes. See shredder.h
      * for more on repetition level and how it's computed.
      */
-    int16_t max_repetition_level = -1;
+    rep_level max_repetition_level = rep_level(-1);
 
     /**
      * A simple depth first traversal of the schema.

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -277,6 +277,24 @@ struct schema_element {
     logical_type logical_type;
 
     /**
+     * The maximum definition level for this node.
+     *
+     * The definition level is used to determine where the `null` value is in a
+     * heirarchy of schema nodes. See shredder.h for more on definition level
+     * and how it's computed.
+     */
+    int16_t max_definition_level = -1;
+
+    /**
+     * The maximum repetition level for this node.
+     *
+     * The repetition level is used to determine the list index in a repeated
+     * value heirarchy of (possibility repeated) schema nodes. See shredder.h
+     * for more on repetition level and how it's computed.
+     */
+    int16_t max_repetition_level = -1;
+
+    /**
      * A simple depth first traversal of the schema.
      *
      * This is the required order of the flattened schema in
@@ -301,7 +319,8 @@ struct schema_element {
 };
 
 /**
- * Index the schema such that the position is known for each element.
+ * Index the schema such that the position, and max level information is known
+ * for each element.
  */
 void index_schema(schema_element& root);
 

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -34,14 +34,6 @@ namespace {
 struct traversal_levels {
     rep_level repetition_level = rep_level(0);
     def_level definition_level = def_level(0);
-    // repetition_depth is the current number of ancestor schema nodes in the
-    // schema tree that are set to be repeated. We track this seperately because
-    // repeated is only set for the additional values in the repeated node, so
-    // the first time we repeat we need to use the current repetition_level so
-    // that assembly knows at which level the repetition is starting at, but
-    // additional repetitions need to use the current repetition_depth as the
-    // repetition_level.
-    rep_level repetition_depth = rep_level(0);
 };
 
 class record_shredder {
@@ -129,14 +121,12 @@ private:
             });
         }
         traversal_levels child_levels = levels;
-        // We are marking that there is a higher depth here we
-        // need to record, but the repetition_level is only set
-        // *when* we are repeating (so not for the first element).
-        ++child_levels.repetition_depth;
         auto it = list.begin();
         co_await process_leaf_value(
           element, child_levels, std::move(it->element));
-        child_levels.repetition_level = child_levels.repetition_depth;
+        // Repeated elements use this node's repetition level, as to signal
+        // at which level in the tree the repetition is happening at.
+        child_levels.repetition_level = element->max_repetition_level;
         for (++it; it != list.end(); ++it) {
             co_await process_leaf_value(
               element, child_levels, std::move(it->element));
@@ -242,15 +232,15 @@ private:
             co_return co_await process_optional_null_group(element, levels);
         }
         traversal_levels child_levels = levels;
-        // We are marking that there is a higher depth here we
-        // need to record, but the repetition_level is only set
-        // *when* we are repeating (so not for the first element).
-        ++child_levels.repetition_depth;
-        child_levels.repetition_level = child_levels.repetition_depth;
+        // Since these elements are repeated, we need to mark that they are
+        // repeated at this level within the tree.
+        child_levels.repetition_level = element->max_repetition_level;
         for (size_t i = list.size() - 1; i > 0; --i) {
             co_await process_optional_group_node(
               element, child_levels, std::move(list[i].element));
         }
+        // However the first node uses the parent repetition_level
+        // as to mark the start of a new list.
         child_levels.repetition_level = levels.repetition_level;
         co_await process_optional_group_node(
           element, child_levels, std::move(list.front().element));

--- a/src/v/serde/parquet/shredder.cc
+++ b/src/v/serde/parquet/shredder.cc
@@ -32,8 +32,8 @@ namespace {
 // A struct to track all the level related information we need during the tree
 // shredding traversal.
 struct traversal_levels {
-    uint8_t repetition_level = 0;
-    uint8_t definition_level = 0;
+    rep_level repetition_level = rep_level(0);
+    def_level definition_level = def_level(0);
     // repetition_depth is the current number of ancestor schema nodes in the
     // schema tree that are set to be repeated. We track this seperately because
     // repeated is only set for the additional values in the repeated node, so
@@ -41,7 +41,7 @@ struct traversal_levels {
     // that assembly knows at which level the repetition is starting at, but
     // additional repetitions need to use the current repetition_depth as the
     // repetition_level.
-    uint8_t repetition_depth = 0;
+    rep_level repetition_depth = rep_level(0);
 };
 
 class record_shredder {

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -25,8 +25,8 @@ namespace serde::parquet {
 struct shredded_value {
     int32_t schema_element_position;
     value val;
-    uint8_t rep_level;
-    uint8_t def_level;
+    rep_level rep_level;
+    def_level def_level;
 };
 
 // Preform the dremel record shredding algoritm on this struct,

--- a/src/v/serde/parquet/shredder.h
+++ b/src/v/serde/parquet/shredder.h
@@ -15,6 +15,8 @@
 
 #include <seastar/core/future.hh>
 
+#include <absl/functional/function_ref.h>
+
 namespace serde::parquet {
 
 // A shredded value that has an assigned repetition level

--- a/src/v/serde/parquet/tests/encoding_test.cc
+++ b/src/v/serde/parquet/tests/encoding_test.cc
@@ -186,9 +186,11 @@ class LevelEncoding
 
 TEST_P(LevelEncoding, CanEncode) {
     auto testcase = GetParam();
-    chunked_vector<uint8_t> levels(
-      testcase.levels.begin(), testcase.levels.end());
-    uint8_t max_value = 0;
+    chunked_vector<rep_level> levels;
+    for (uint8_t l : testcase.levels) {
+        levels.emplace_back(static_cast<int16_t>(l));
+    }
+    rep_level max_value = rep_level(0);
     if (!levels.empty()) {
         max_value = *std::ranges::max_element(levels);
     }

--- a/src/v/serde/parquet/tests/generate_metadata.cc
+++ b/src/v/serde/parquet/tests/generate_metadata.cc
@@ -12,7 +12,6 @@
 #include "base/seastarx.h"
 #include "bytes/iostream.h"
 #include "serde/parquet/metadata.h"
-#include "src/v/serde/parquet/metadata.h"
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/coroutine.hh>
@@ -41,14 +40,14 @@ iobuf serialize_testcase(size_t test_case) {
         return encode(page_header{
           .uncompressed_page_size = 42,
           .compressed_page_size = 22,
-          .crc = 0xBEEF,
+          .crc = absl::crc32c_t(0xBEEF),
           .type = index_page_header{},
         });
     case 1:
         return encode(page_header{
           .uncompressed_page_size = 2,
           .compressed_page_size = 1,
-          .crc = 0xDEAD,
+          .crc = absl::crc32c_t(0xDEAD),
           .type = data_page_header{
             .num_values = 22,
             .num_nulls = 0,
@@ -63,7 +62,7 @@ iobuf serialize_testcase(size_t test_case) {
         return encode(page_header{
           .uncompressed_page_size = 99999,
           .compressed_page_size = 0,
-          .crc = 0xEEEE,
+          .crc = absl::crc32c_t(0xEEEE),
           .type = dictionary_page_header{
             .num_values = 44,
             .data_encoding = encoding::rle,

--- a/src/v/serde/parquet/tests/schema_test.cc
+++ b/src/v/serde/parquet/tests/schema_test.cc
@@ -62,8 +62,8 @@ schema_element indexed_group_node(
       .repetition_type = rep_type,
       .name = std::move(name),
       .children = std::move(children),
-      .max_definition_level = info.def_level,
-      .max_repetition_level = info.rep_level,
+      .max_definition_level = def_level(info.def_level),
+      .max_repetition_level = rep_level(info.rep_level),
     };
 }
 
@@ -79,8 +79,8 @@ schema_element indexed_leaf_node(
       .repetition_type = rep_type,
       .name = std::move(name),
       .logical_type = ltype,
-      .max_definition_level = info.def_level,
-      .max_repetition_level = info.rep_level,
+      .max_definition_level = def_level(info.def_level),
+      .max_repetition_level = rep_level(info.rep_level),
     };
 }
 } // namespace

--- a/src/v/serde/parquet/tests/schema_test.cc
+++ b/src/v/serde/parquet/tests/schema_test.cc
@@ -42,35 +42,45 @@ schema_element leaf_node(
     };
 }
 
+struct indexed_info {
+    int32_t index;
+    int16_t def_level;
+    int16_t rep_level;
+};
+
 template<typename... Args>
 schema_element indexed_group_node(
-  int32_t index,
+  indexed_info info,
   ss::sstring name,
   field_repetition_type rep_type,
   Args... args) {
     chunked_vector<schema_element> children;
     (children.push_back(std::move(args)), ...);
     return {
-      .position = index,
+      .position = info.index,
       .type = std::monostate{},
       .repetition_type = rep_type,
       .name = std::move(name),
       .children = std::move(children),
+      .max_definition_level = info.def_level,
+      .max_repetition_level = info.rep_level,
     };
 }
 
 schema_element indexed_leaf_node(
-  int32_t index,
+  indexed_info info,
   ss::sstring name,
   field_repetition_type rep_type,
   physical_type ptype,
   logical_type ltype = logical_type{}) {
     return {
-      .position = index,
+      .position = info.index,
       .type = ptype,
       .repetition_type = rep_type,
       .name = std::move(name),
       .logical_type = ltype,
+      .max_definition_level = info.def_level,
+      .max_repetition_level = info.rep_level,
     };
 }
 } // namespace
@@ -106,40 +116,64 @@ TEST(Schema, CanBeIndexed) {
               leaf_node("type", optional, byte_array_type(), enum_type()))))));
     index_schema(root);
     auto expected = indexed_group_node(
-      0,
+      {.index = 0, .def_level = 0, .rep_level = 0},
       "schema",
       required,
       indexed_group_node(
-        1,
+        {.index = 1, .def_level = 1, .rep_level = 0},
         "persons",
         optional,
         indexed_group_node(
-          2,
+          {.index = 2, .def_level = 2, .rep_level = 1},
           "persons_tuple",
           repeated,
           indexed_group_node(
-            3,
+            {.index = 3, .def_level = 2, .rep_level = 1},
             "name",
             required,
             indexed_leaf_node(
-              4, "first_name", optional, byte_array_type(), string_type()),
+              {.index = 4, .def_level = 3, .rep_level = 1},
+              "first_name",
+              optional,
+              byte_array_type(),
+              string_type()),
             indexed_leaf_node(
-              5, "last_name", required, byte_array_type(), string_type())),
-          indexed_leaf_node(6, "id", optional, i32_type()),
+              {.index = 5, .def_level = 2, .rep_level = 1},
+              "last_name",
+              required,
+              byte_array_type(),
+              string_type())),
           indexed_leaf_node(
-            7, "email", required, byte_array_type(), string_type()),
+            {.index = 6, .def_level = 3, .rep_level = 1},
+            "id",
+            optional,
+            i32_type()),
+          indexed_leaf_node(
+            {.index = 7, .def_level = 2, .rep_level = 1},
+            "email",
+            required,
+            byte_array_type(),
+            string_type()),
           indexed_group_node(
-            8,
+            {.index = 8, .def_level = 3, .rep_level = 2},
             "phones",
             repeated,
             indexed_group_node(
-              9,
+              {.index = 9, .def_level = 4, .rep_level = 3},
               "phones_tuple",
               repeated,
               indexed_leaf_node(
-                10, "number", optional, byte_array_type(), string_type()),
+                {.index = 10, .def_level = 5, .rep_level = 3},
+                "number",
+                optional,
+                byte_array_type(),
+                string_type()),
               indexed_leaf_node(
-                11, "type", optional, byte_array_type(), enum_type()))))));
+                {.index = 11, .def_level = 5, .rep_level = 3},
+                "type",
+                optional,
+                byte_array_type(),
+                enum_type()))))));
     EXPECT_EQ(root, expected)
       << fmt::format("root={}\nexpected={}", root, expected);
 }

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -436,4 +436,23 @@ TEST(RecordShredding, RequiredGroupWrappedInOptionalGroup) {
       ElementsAre(ElementsAre(IsVal("NULL", 0, 0), IsVal("42", 0, 1))));
 }
 
+TEST(RecordShredding, RequiredValuesNotNullValidation) {
+    schema_element schema = group_node(
+      "Root",
+      field_repetition_type::required,
+      group_node(
+        "optional",
+        field_repetition_type::optional,
+        group_node(
+          "required",
+          field_repetition_type::required,
+          leaf_node("leaf", field_repetition_type::required, i32_type()))));
+    group_value r1 = record(record(null_value()));
+    group_value r2 = record(record(record(null_value())));
+    index_schema(schema);
+    value_collector collector(schema);
+    EXPECT_ANY_THROW(shred_record(schema, std::move(r1), collector).get());
+    EXPECT_ANY_THROW(shred_record(schema, std::move(r2), collector).get());
+}
+
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -86,8 +86,8 @@ struct value_collector {
 };
 
 MATCHER_P3(IsVal, val, r, d, "") {
-    return fmt::format("{}", arg.val) == val && r == arg.rep_level
-           && d == arg.def_level;
+    return fmt::format("{}", arg.val) == val && r == arg.rep_level()
+           && d == arg.def_level();
 }
 
 } // namespace

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -161,27 +161,27 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
             /*Language*/
             record(
               /*Code*/
-              string_value(iobuf::from("en-us")),
+              byte_array_value(iobuf::from("en-us")),
               /*Country*/
-              string_value(iobuf::from("us"))),
+              byte_array_value(iobuf::from("us"))),
             /*Language*/
-            record(string_value(iobuf::from("en")), null_value())),
+            record(byte_array_value(iobuf::from("en")), null_value())),
           /*Url*/
-          string_value(iobuf::from("http://A"))),
+          byte_array_value(iobuf::from("http://A"))),
         /*Name*/
         record(
           list(),
           /*Url*/
-          string_value(iobuf::from("http://B"))),
+          byte_array_value(iobuf::from("http://B"))),
         /*Name*/
         record(
           list(
             /*Language*/
             record(
               /*Code*/
-              string_value(iobuf::from("en-gb")),
+              byte_array_value(iobuf::from("en-gb")),
               /*Country*/
-              string_value(iobuf::from("gb")))),
+              byte_array_value(iobuf::from("gb")))),
           /*Url*/
           null_value())));
     group_value r2 = record(
@@ -195,7 +195,7 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
         /*Language*/
         repeated_value(),
         /*Url*/
-        string_value(iobuf::from("http://C")))));
+        byte_array_value(iobuf::from("http://C")))));
     index_schema(document_schema);
     value_collector collector(document_schema);
     shred_record(document_schema, std::move(r1), collector).get();
@@ -241,9 +241,9 @@ TEST(RecordShredding, ListOfStrings) {
       field_repetition_type::required,
       leaf_node("list", field_repetition_type::repeated, byte_array_type{}));
     group_value r = record(list(
-      string_value(iobuf::from("a")),
-      string_value(iobuf::from("b")),
-      string_value(iobuf::from("c"))));
+      byte_array_value(iobuf::from("a")),
+      byte_array_value(iobuf::from("b")),
+      byte_array_value(iobuf::from("c"))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -265,9 +265,11 @@ TEST(RecordShredding, LogicalMap) {
           "value", field_repetition_type::optional, byte_array_type())));
     group_value r = record(list(
       record(
-        string_value(iobuf::from("AL")), string_value(iobuf::from("Alabama"))),
+        byte_array_value(iobuf::from("AL")),
+        byte_array_value(iobuf::from("Alabama"))),
       record(
-        string_value(iobuf::from("AK")), string_value(iobuf::from("Alaska")))));
+        byte_array_value(iobuf::from("AK")),
+        byte_array_value(iobuf::from("Alaska")))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -319,18 +321,19 @@ TEST(RecordShredding, RepetitionLevels) {
           "level2", field_repetition_type::repeated, byte_array_type())));
     group_value r1 = record(list(
       record(list(
-        string_value(iobuf::from("a")),
-        string_value(iobuf::from("b")),
-        string_value(iobuf::from("c")))),
+        byte_array_value(iobuf::from("a")),
+        byte_array_value(iobuf::from("b")),
+        byte_array_value(iobuf::from("c")))),
       record(list(
-        string_value(iobuf::from("d")),
-        string_value(iobuf::from("e")),
-        string_value(iobuf::from("f")),
-        string_value(iobuf::from("g"))))));
+        byte_array_value(iobuf::from("d")),
+        byte_array_value(iobuf::from("e")),
+        byte_array_value(iobuf::from("f")),
+        byte_array_value(iobuf::from("g"))))));
     group_value r2 = record(list(
-      record(list(string_value(iobuf::from("h")))),
-      record(
-        list(string_value(iobuf::from("i")), string_value(iobuf::from("j"))))));
+      record(list(byte_array_value(iobuf::from("h")))),
+      record(list(
+        byte_array_value(iobuf::from("i")),
+        byte_array_value(iobuf::from("j"))))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();
@@ -378,17 +381,17 @@ TEST(RecordShredding, AddressBookExample) {
           byte_array_type(),
           string_type())));
     group_value r1 = record(
-      string_value(iobuf::from("Julien Le Dem")),
+      byte_array_value(iobuf::from("Julien Le Dem")),
       list(
-        string_value(iobuf::from("555 123 4567")),
-        string_value(iobuf::from("555 666 1337"))),
+        byte_array_value(iobuf::from("555 123 4567")),
+        byte_array_value(iobuf::from("555 666 1337"))),
       list(
         record(
-          string_value(iobuf::from("Dmitriy Ryaboy")),
-          string_value(iobuf::from("555 987 6543"))),
-        record(string_value(iobuf::from("Chris Anizczyk")), null_value())));
+          byte_array_value(iobuf::from("Dmitriy Ryaboy")),
+          byte_array_value(iobuf::from("555 987 6543"))),
+        record(byte_array_value(iobuf::from("Chris Anizczyk")), null_value())));
     group_value r2 = record(
-      string_value(iobuf::from("A. Nonymous")), list(), list());
+      byte_array_value(iobuf::from("A. Nonymous")), list(), list());
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();


### PR DESCRIPTION
- **parquet: remove logical value types**
- **parquet: use strongly typed crc value from absl**
- **parquet: encode the max rep and def levels in schema nodes**
- **parquet: add validation that required nodes are not null**
- **parquet: add column writer**
- **parquet: use named types for rep and def levels**

Note that there are currently no tests for the column writer. This sucks but there is not an external go library
that directly exposes the ability to read/write pages so it'd be hard to test. There will be test coverage when
we write full parquet files - that's kind of the best I can do for now :shrug:

Thankfully, the code there is not too complex so I feel pretty good about only being able to test indirectly.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
