### PR TITLE
Preventing tests using s3_impostor from running in parallel 

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -152,7 +152,8 @@ def redpanda_cc_gtest(
         env = {},
         cpu = None,
         memory = None,
-        data = []):
+        data = [],
+        tags = []):
     _redpanda_cc_unit_test(
         dash_dash_protocol = False,
         name = name,
@@ -165,6 +166,7 @@ def redpanda_cc_gtest(
         env = env,
         data = data,
         local_defines = ["IS_GTEST"],
+        tags = tags,
     )
 
 def redpanda_cc_btest(
@@ -177,7 +179,8 @@ def redpanda_cc_btest(
         cpu = None,
         memory = None,
         target_compatible_with = [],
-        data = []):
+        data = [],
+        tags = []):
     _redpanda_cc_unit_test(
         dash_dash_protocol = True,
         name = name,
@@ -190,6 +193,7 @@ def redpanda_cc_btest(
         env = env,
         target_compatible_with = target_compatible_with,
         data = data,
+        tags = tags,
     )
 
 def redpanda_cc_bench(

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -51,6 +51,7 @@ redpanda_cc_gtest(
         "iceberg_file_committer_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":state_test_utils",
         "//src/v/cloud_io:remote",

--- a/src/v/datalake/coordinator/tests/CMakeLists.txt
+++ b/src/v/datalake/coordinator/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ rp_test(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   BINARY_NAME coordinator_iceberg
   SOURCES

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -194,6 +194,7 @@ redpanda_cc_gtest(
         "record_multiplexer_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":catalog_and_registry_fixture",
         ":record_generator",

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ v_cc_library(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   BINARY_NAME gtest_record_multiplexer
   SOURCES gtest_record_multiplexer_test.cc
@@ -51,7 +51,7 @@ rp_test(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   BINARY_NAME datalake
   SOURCES
@@ -70,7 +70,7 @@ rp_test(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   BINARY_NAME datalake_cloud
   SOURCES
@@ -88,7 +88,7 @@ rp_test(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   BINARY_NAME catalog_schema_manager
   SOURCES catalog_schema_manager_test.cc

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -82,6 +82,7 @@ redpanda_cc_gtest(
         "filesystem_catalog_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/base",
@@ -140,6 +141,7 @@ redpanda_cc_gtest(
         "manifest_io_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/bytes:iobuf",
@@ -196,6 +198,7 @@ redpanda_cc_gtest(
         "merge_append_action_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/cloud_io:remote",
@@ -367,6 +370,7 @@ redpanda_cc_gtest(
         "table_io_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_table_metadata",
         "//src/v/bytes:iobuf",
@@ -452,6 +456,7 @@ redpanda_cc_gtest(
         "update_schema_action_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/iceberg:transaction",
@@ -517,6 +522,7 @@ redpanda_cc_gtest(
         "metadata_query_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/cloud_io:remote",
@@ -565,6 +571,7 @@ redpanda_cc_gtest(
         "rest_catalog_test.cc",
     ],
     cpu = 1,
+    tags = ["exclusive"],
     deps = [
         ":test_schemas",
         "//src/v/bytes:iobuf_parser",

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ v_cc_library(
 )
 
 rp_test(
-  UNIT_TEST
+  FIXTURE_TEST
   GTEST
   USE_CWD
   BINARY_NAME iceberg


### PR DESCRIPTION
Preventing tests using `s3_impostor` from running in parallel with each other to prevent listen port conflict. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none