### PR TITLE
`storage`: add calls to `segment_index::flush()` in compaction

### DIFF
--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -199,11 +199,15 @@ public:
     }
 
     // Set the compacted timestamp, if it doesn't already have a value.
-    void maybe_set_clean_compact_timestamp(model::timestamp t) {
+    // Returns a boolean indicating whether the clean compact timestamp was set
+    // or not.
+    bool maybe_set_clean_compact_timestamp(model::timestamp t) {
         if (!_state.clean_compact_timestamp.has_value()) {
             _state.clean_compact_timestamp = t;
             _needs_persistence = true;
+            return true;
         }
+        return false;
     }
 
     // Get the compacted timestamp.

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -281,7 +281,9 @@ bool may_have_removable_tombstones(
 
 // Mark a segment as completed window compaction, and whether it is "clean" (in
 // which case the `clean_compact_timestamp` is set in the segment's index).
-void mark_segment_as_finished_window_compaction(
+// Also potentially issues a call to seg->index()->flush(), if the
+// `clean_compact_timestamp` was set in the index.
+ss::future<> mark_segment_as_finished_window_compaction(
   ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp);
 
 template<typename Func>


### PR DESCRIPTION
A call to `maybe_set_clean_compact_timestamp()` should be followed by a call to `flush()` in order to persist the clean compact timestamp to disk.

Without a call to `flush()`, a broker failure could potentially make compaction/tombstone removal less efficient than it could be (as the earliest clean compact timestamp could be lost).

Make `mark_segment_as_finished_window_compaction()` async and add a call to `flush()` in case it is required (`maybe_set_clean_compact_timestamp()` now returns a boolean indicating whether or not the timestamp was set).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
