### PR TITLE
datalake/translation: fix data partition to coordinator mapping

### DIFF
--- a/src/v/datalake/coordinator/frontend.h
+++ b/src/v/datalake/coordinator/frontend.h
@@ -77,8 +77,12 @@ private:
 
     ss::future<bool> ensure_topic_exists();
 
+    /**
+     * Returns the partition of datalake coordinator topic that
+     * coordinates datalake tasks for this topic partitions.
+     */
     std::optional<model::partition_id>
-    coordinator_partition(const model::topic_partition&) const;
+    coordinator_partition(const model::topic&) const;
 
     ss::future<add_translated_data_files_reply>
     add_translated_data_files_locally(

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -87,9 +87,10 @@ public:
     translated_files_for_partition(const model::ntp& ntp) {
         chunked_vector<datalake::coordinator::translated_offset_range> result;
         auto& fe = coordinator_frontend(model::node_id{0});
-        auto coordinator_partition = fe.local().coordinator_partition(ntp.tp);
+        auto coordinator_partition = fe.local().coordinator_partition(
+          ntp.tp.topic);
         if (!coordinator_partition) {
-            co_return datalake::coordinator::errc::not_leader;
+            co_return datalake::coordinator::errc::coordinator_topic_not_exists;
         }
         auto c_ntp = model::ntp{
           model::datalake_coordinator_nt.ns,

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -41,6 +41,6 @@ class DatalakeE2ETests(RedpandaTest):
                               redpanda=self.redpanda,
                               filesystem_catalog_mode=filesystem_catalog_mode,
                               include_query_engines=[query_engine]) as dl:
-            dl.create_iceberg_enabled_topic(self.topic_name)
+            dl.create_iceberg_enabled_topic(self.topic_name, partitions=10)
             dl.produce_to_topic(self.topic_name, 1024, count)
             dl.wait_for_translation(self.topic_name, msg_count=count)


### PR DESCRIPTION
An inherent assumption in coordinator implementation is that all topic/table related operations are performed by the same coordinator for correctness (so we have one active writer per table active at most times). This is particularly relevant in filesystem catalog implementation as it relies on the filesystem for concurrency and multiple interleaved writers can leave it in a questionable state.

This expectation is violated in our coordinator hash function that factors in topic and partition as input to the hash function resulting in ntps from same topic hashing to different coordinator partitions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
