### PR TITLE
datalake/coordinator/api: rename fetch_latest_data_file types

### DIFF
--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -50,19 +50,19 @@ ss::future<add_translated_data_files_reply> add_files(
     }
     co_return add_translated_data_files_reply{errc::ok};
 }
-ss::future<fetch_latest_data_file_reply> fetch_latest_offset(
+ss::future<fetch_latest_translated_offset_reply> fetch_latest_offset(
   coordinator_manager& mgr,
   model::ntp coordinator_ntp,
-  fetch_latest_data_file_request req) {
+  fetch_latest_translated_offset_request req) {
     auto crd = mgr.get(coordinator_ntp);
     if (!crd) {
-        co_return fetch_latest_data_file_reply{errc::not_leader};
+        co_return fetch_latest_translated_offset_reply{errc::not_leader};
     }
     auto ret = co_await crd->sync_get_last_added_offset(req.tp);
     if (ret.has_error()) {
         co_return to_rpc_errc(ret.error());
     }
-    co_return fetch_latest_data_file_reply{ret.value()};
+    co_return fetch_latest_translated_offset_reply{ret.value()};
 }
 } // namespace
 
@@ -140,13 +140,13 @@ template auto frontend::process<
   add_translated_data_files_request, bool);
 
 template auto
-  frontend::remote_dispatch<&frontend::client::fetch_latest_data_file>(
-    fetch_latest_data_file_request, model::node_id);
+  frontend::remote_dispatch<&frontend::client::fetch_latest_translated_offset>(
+    fetch_latest_translated_offset_request, model::node_id);
 
 template auto frontend::process<
-  &frontend::fetch_latest_data_file_locally,
-  &frontend::client::fetch_latest_data_file>(
-  fetch_latest_data_file_request, bool);
+  &frontend::fetch_latest_translated_offset_locally,
+  &frontend::client::fetch_latest_translated_offset>(
+  fetch_latest_translated_offset_request, bool);
 
 // -- explicit instantiations ---
 
@@ -270,9 +270,9 @@ ss::future<add_translated_data_files_reply> frontend::add_translated_data_files(
       std::move(request), bool(local_only_exec));
 }
 
-ss::future<fetch_latest_data_file_reply>
-frontend::fetch_latest_data_file_locally(
-  fetch_latest_data_file_request request,
+ss::future<fetch_latest_translated_offset_reply>
+frontend::fetch_latest_translated_offset_locally(
+  fetch_latest_translated_offset_request request,
   const model::ntp& coordinator_partition,
   ss::shard_id shard) {
     co_return co_await _coordinator_mgr->invoke_on(
@@ -281,19 +281,21 @@ frontend::fetch_latest_data_file_locally(
        req = std::move(request)](coordinator_manager& mgr) mutable {
           auto partition = mgr.get(coordinator_partition);
           if (!partition) {
-              return ssx::now(fetch_latest_data_file_reply{errc::not_leader});
+              return ssx::now(
+                fetch_latest_translated_offset_reply{errc::not_leader});
           }
           return fetch_latest_offset(
             mgr, coordinator_partition, std::move(req));
       });
 }
 
-ss::future<fetch_latest_data_file_reply> frontend::fetch_latest_data_file(
-  fetch_latest_data_file_request request, local_only local_only_exec) {
+ss::future<fetch_latest_translated_offset_reply>
+frontend::fetch_latest_translated_offset(
+  fetch_latest_translated_offset_request request, local_only local_only_exec) {
     auto holder = _gate.hold();
     co_return co_await process<
-      &frontend::fetch_latest_data_file_locally,
-      &client::fetch_latest_data_file>(
+      &frontend::fetch_latest_translated_offset_locally,
+      &client::fetch_latest_translated_offset>(
       std::move(request), bool(local_only_exec));
 }
 

--- a/src/v/datalake/coordinator/frontend.h
+++ b/src/v/datalake/coordinator/frontend.h
@@ -49,8 +49,9 @@ public:
     ss::future<add_translated_data_files_reply> add_translated_data_files(
       add_translated_data_files_request, local_only = local_only::no);
 
-    ss::future<fetch_latest_data_file_reply> fetch_latest_data_file(
-      fetch_latest_data_file_request, local_only = local_only::no);
+    ss::future<fetch_latest_translated_offset_reply>
+      fetch_latest_translated_offset(
+        fetch_latest_translated_offset_request, local_only = local_only::no);
 
 private:
     using proto_t = datalake::coordinator::rpc::impl::
@@ -86,8 +87,9 @@ private:
       const model::ntp& coordinator_partition,
       ss::shard_id);
 
-    ss::future<fetch_latest_data_file_reply> fetch_latest_data_file_locally(
-      fetch_latest_data_file_request,
+    ss::future<fetch_latest_translated_offset_reply>
+    fetch_latest_translated_offset_locally(
+      fetch_latest_translated_offset_request,
       const model::ntp& coordinator_partition,
       ss::shard_id);
 

--- a/src/v/datalake/coordinator/rpc.json
+++ b/src/v/datalake/coordinator/rpc.json
@@ -11,9 +11,9 @@
             "output_type": "add_translated_data_files_reply"
         },
         {
-            "name": "fetch_latest_data_file",
-            "input_type": "fetch_latest_data_file_request",
-            "output_type": "fetch_latest_data_file_reply"
+            "name": "fetch_latest_translated_offset",
+            "input_type": "fetch_latest_translated_offset_request",
+            "output_type": "fetch_latest_translated_offset_reply"
         }
     ]
 }

--- a/src/v/datalake/coordinator/service.cc
+++ b/src/v/datalake/coordinator/service.cc
@@ -27,9 +27,10 @@ ss::future<add_translated_data_files_reply> service::add_translated_data_files(
       std::move(request), frontend::local_only::yes);
 }
 
-ss::future<fetch_latest_data_file_reply> service::fetch_latest_data_file(
-  fetch_latest_data_file_request request, ::rpc::streaming_context&) {
-    return _frontend->local().fetch_latest_data_file(
+ss::future<fetch_latest_translated_offset_reply>
+service::fetch_latest_translated_offset(
+  fetch_latest_translated_offset_request request, ::rpc::streaming_context&) {
+    return _frontend->local().fetch_latest_translated_offset(
       std::move(request), frontend::local_only::yes);
 }
 

--- a/src/v/datalake/coordinator/service.h
+++ b/src/v/datalake/coordinator/service.h
@@ -19,8 +19,10 @@ public:
     ss::future<add_translated_data_files_reply> add_translated_data_files(
       add_translated_data_files_request, ::rpc::streaming_context&) override;
 
-    ss::future<fetch_latest_data_file_reply> fetch_latest_data_file(
-      fetch_latest_data_file_request, ::rpc::streaming_context&) override;
+    ss::future<fetch_latest_translated_offset_reply>
+    fetch_latest_translated_offset(
+      fetch_latest_translated_offset_request,
+      ::rpc::streaming_context&) override;
 
 private:
     ss::sharded<frontend>* _frontend;

--- a/src/v/datalake/coordinator/types.cc
+++ b/src/v/datalake/coordinator/types.cc
@@ -59,14 +59,14 @@ operator<<(std::ostream& o, const add_translated_data_files_request& request) {
 }
 
 std::ostream&
-operator<<(std::ostream& o, const fetch_latest_data_file_reply& reply) {
+operator<<(std::ostream& o, const fetch_latest_translated_offset_reply& reply) {
     fmt::print(
       o, "{{errc: {}, offset: {}}}", reply.errc, reply.last_added_offset);
     return o;
 }
 
-std::ostream&
-operator<<(std::ostream& o, const fetch_latest_data_file_request& request) {
+std::ostream& operator<<(
+  std::ostream& o, const fetch_latest_translated_offset_request& request) {
     fmt::print(o, "{{partition: {}}}", request.tp);
     return o;
 }

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -88,17 +88,18 @@ struct add_translated_data_files_request
     auto serde_fields() { return std::tie(tp, ranges, translator_term); }
 };
 
-struct fetch_latest_data_file_reply
+struct fetch_latest_translated_offset_reply
   : serde::envelope<
-      fetch_latest_data_file_reply,
+      fetch_latest_translated_offset_reply,
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
-    fetch_latest_data_file_reply() = default;
-    explicit fetch_latest_data_file_reply(errc err)
+    fetch_latest_translated_offset_reply() = default;
+    explicit fetch_latest_translated_offset_reply(errc err)
       : errc(err) {}
-    explicit fetch_latest_data_file_reply(std::optional<kafka::offset> o)
+    explicit fetch_latest_translated_offset_reply(
+      std::optional<kafka::offset> o)
       : last_added_offset(o)
       , errc(errc::ok) {}
 
@@ -109,27 +110,29 @@ struct fetch_latest_data_file_reply
     errc errc;
 
     friend std::ostream&
-    operator<<(std::ostream&, const fetch_latest_data_file_reply&);
+    operator<<(std::ostream&, const fetch_latest_translated_offset_reply&);
 
     auto serde_fields() { return std::tie(last_added_offset, errc); }
 };
 
-struct fetch_latest_data_file_request
+// For a given topic/partition fetches the latest translated offset from
+// the coordinator.
+struct fetch_latest_translated_offset_request
   : serde::envelope<
-      fetch_latest_data_file_request,
+      fetch_latest_translated_offset_request,
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
-    using resp_t = fetch_latest_data_file_reply;
+    using resp_t = fetch_latest_translated_offset_reply;
 
-    fetch_latest_data_file_request() = default;
+    fetch_latest_translated_offset_request() = default;
 
     model::topic_partition tp;
 
     const model::topic_partition& topic_partition() const { return tp; }
 
     friend std::ostream&
-    operator<<(std::ostream&, const fetch_latest_data_file_request&);
+    operator<<(std::ostream&, const fetch_latest_translated_offset_request&);
 
     auto serde_fields() { return std::tie(tp); }
 };

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -129,12 +129,13 @@ public:
         auto max_offset = kafka::prev_offset(model::offset_cast(
           ot->from_log_offset(partition->last_stable_offset())));
         auto& fe = coordinator_frontend(fixture->app.controller->self());
-        coordinator::fetch_latest_data_file_request request;
+        coordinator::fetch_latest_translated_offset_request request;
         request.tp = ntp.tp;
         vlog(logger.info, "Waiting for last added offet: {}", max_offset);
         co_await ::tests::cooperative_spin_wait_with_timeout(20s, [&] {
-            return fe.local().fetch_latest_data_file(request).then(
-              [max_offset](coordinator::fetch_latest_data_file_reply resp) {
+            return fe.local().fetch_latest_translated_offset(request).then(
+              [max_offset](
+                coordinator::fetch_latest_translated_offset_reply resp) {
                   vlog(
                     logger.trace,
                     "Waiting for last added offet: {}, current: {}",

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -311,11 +311,12 @@ partition_translator::checkpoint_translated_data(
 
 ss::future<std::optional<kafka::offset>>
 partition_translator::reconcile_with_coordinator() {
-    auto request = coordinator::fetch_latest_data_file_request{};
+    auto request = coordinator::fetch_latest_translated_offset_request{};
     request.tp = _partition->ntp().tp;
-    vlog(_logger.trace, "fetch_latest_data_file, request: {}", request);
-    auto resp = co_await _frontend->local().fetch_latest_data_file(request);
-    vlog(_logger.trace, "fetch_latest_data_file, response: {}", resp);
+    vlog(_logger.trace, "fetch_latest_translated_offset, request: {}", request);
+    auto resp = co_await _frontend->local().fetch_latest_translated_offset(
+      request);
+    vlog(_logger.trace, "fetch_latest_translated_offset, response: {}", resp);
     if (resp.errc != coordinator::errc::ok) {
         vlog(_logger.warn, "reconciliation failed, response: {}", resp);
         co_return std::nullopt;


### PR DESCRIPTION
This API evolved over time, originally meant to fetch the latest translated file metadata from the coordinator but later simplified to fetch only the translated offset. Rename the types accordingly, no logic changes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
