### PR TITLE
Remove need to copy `iobuf`s across shards

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -227,7 +227,6 @@ void details::io_fragment::trim_front(size_t pos) {
 }
 
 iobuf::placeholder iobuf::reserve(size_t sz) {
-    oncore_debug_verify(_verify_shard);
     vassert(sz, "zero length reservations are unsupported");
     reserve_memory(sz);
     _size += sz;

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "iobuf_test",
@@ -19,6 +19,25 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "@boost//:range",
         "@boost//:test",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "iobuf_mt_test",
+    timeout = "short",
+    srcs = [
+        "iobuf_tests_mt.cc",
+    ],
+    cpu = 8,
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/random:generators",
+        "//src/v/test_utils:gtest",
+        "@boost//:range",
         "@fmt",
         "@seastar",
         "@seastar//:testing",

--- a/src/v/bytes/tests/CMakeLists.txt
+++ b/src/v/bytes/tests/CMakeLists.txt
@@ -6,6 +6,16 @@ rp_test(
   LABELS bytes
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_bytes_multi_thread
+  SOURCES iobuf_tests_mt.cc
+  LIBRARIES v::random v::bytes v::gtest_main
+  ARGS "-- -c 8"
+  LABELS bytes
+)
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   add_executable(iobuf_fuzz_rpfixture iobuf_fuzz.cc)

--- a/src/v/bytes/tests/iobuf_tests_mt.cc
+++ b/src/v/bytes/tests/iobuf_tests_mt.cc
@@ -1,0 +1,41 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "random/generators.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/loop.hh>
+
+#include <boost/range/irange.hpp>
+
+TEST_CORO(iobuf_mt, test_cross_shard_shares) {
+    constexpr size_t parallel_shares = 10000;
+    constexpr size_t iterations = 100;
+    const auto a = random_generators::gen_alphanum_string(128);
+    const auto b = random_generators::gen_alphanum_string(128);
+    iobuf buf;
+    buf.append(a.data(), a.size());
+    buf.append(b.data(), b.size());
+
+    // If iobuf::share(..) isn't thread-safe then the code below is likely to
+    // generate a segfault.
+    for (size_t i = 0; i < iterations; i++) {
+        co_await ss::parallel_for_each(
+          boost::irange(0ul, parallel_shares),
+          [b = buf.share(0, buf.size_bytes())](auto s) mutable {
+              return ss::smp::submit_to(
+                s % ss::smp::count, [b = b.share(0, b.size_bytes())]() mutable {
+                    for (size_t i = 0; i < iterations; i++) {
+                        b.share(0, b.size_bytes());
+                    }
+                });
+          });
+    }
+}

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -312,11 +312,7 @@ struct read_result {
         return ss::visit(
           data,
           [](data_t& d) { return std::move(*d); },
-          [](foreign_data_t& d) {
-              auto ret = d->copy();
-              d.reset();
-              return ret;
-          });
+          [](foreign_data_t& d) { return std::move(*d); });
     }
 
     variant_t data;

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -61,16 +61,8 @@ record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
             }
             // TODO: this function should take an SMP group
             return ss::smp::submit_to(shard, [this, t] {
-                return _ptr->do_load_slice(t).then([](storage_t recs) {
-                    if (likely(std::holds_alternative<data_t>(recs))) {
-                        auto& d = std::get<data_t>(recs);
-                        auto p = std::make_unique<data_t>(std::move(d));
-                        return storage_t(foreign_data_t{
-                          .buffer = ss::make_foreign(std::move(p)),
-                          .index = 0});
-                    }
-                    return recs;
-                });
+                return _ptr->do_load_slice(t).then(
+                  [](storage_t recs) { return recs; });
             });
         }
 
@@ -120,12 +112,7 @@ record_batch_reader make_memory_record_batch_reader(storage_t batches) {
 
 record_batch_reader
 make_foreign_memory_record_batch_reader(record_batch_reader::data_t data) {
-    auto batches = std::make_unique<record_batch_reader::data_t>(
-      std::move(data));
-    return make_memory_record_batch_reader(record_batch_reader::foreign_data_t{
-      .buffer = ss::make_foreign(std::move(batches)),
-      .index = 0,
-    });
+    return make_memory_record_batch_reader(std::move(data));
 }
 
 record_batch_reader make_foreign_memory_record_batch_reader(record_batch b) {
@@ -219,7 +206,7 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
     return make_record_batch_reader<reader>(std::move(data));
 }
 
-template<bool is_foreign, typename Container>
+template<typename Container>
 std::vector<record_batch_reader::storage_t>
 make_fragmented_memory_storage_batches(Container batches) {
     std::vector<record_batch_reader::storage_t> data;
@@ -231,15 +218,7 @@ make_fragmented_memory_storage_batches(Container batches) {
     size_t i = 0;
     for (auto it = batches.begin(); it != batches.end(); ++i, ++it) {
         if (!data_chunk.empty() && i % elements_per_fragment == 0) {
-            if (is_foreign) {
-                data.emplace_back(record_batch_reader::foreign_data_t{
-                  .buffer = ss::make_foreign(
-                    std::make_unique<record_batch_reader::data_t>(
-                      std::exchange(data_chunk, {}))),
-                  .index = 0});
-            } else {
-                data.emplace_back(std::exchange(data_chunk, {}));
-            }
+            data.emplace_back(std::exchange(data_chunk, {}));
             data_chunk.reserve(
               std::min(elements_per_fragment, batches.size() - i));
         }
@@ -247,15 +226,7 @@ make_fragmented_memory_storage_batches(Container batches) {
         data_chunk.push_back(std::move(b));
     }
     if (!data_chunk.empty()) {
-        if (is_foreign) {
-            data.emplace_back(record_batch_reader::foreign_data_t{
-              .buffer = ss::make_foreign(
-                std::make_unique<record_batch_reader::data_t>(
-                  std::exchange(data_chunk, {}))),
-              .index = 0});
-        } else {
-            data.emplace_back(std::move(data_chunk));
-        }
+        data.emplace_back(std::move(data_chunk));
     }
     return data;
 }
@@ -284,7 +255,6 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        false,
         fragmented_vector<model::record_batch>>(std::move(batches)));
 }
 
@@ -292,7 +262,6 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
   chunked_vector<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        false,
         chunked_vector<model::record_batch>>(std::move(batches)));
 }
 
@@ -300,7 +269,6 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        true,
         fragmented_vector<model::record_batch>>(std::move(batches)));
 }
 
@@ -308,7 +276,6 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   chunked_vector<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        true,
         chunked_vector<model::record_batch>>(std::move(batches)));
 }
 
@@ -316,7 +283,6 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        true,
         ss::chunked_fifo<model::record_batch>>(std::move(batches)));
 }
 
@@ -324,7 +290,6 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch> batches) {
     return make_fragmented_memory_record_batch_reader(
       make_fragmented_memory_storage_batches<
-        false,
         ss::chunked_fifo<model::record_batch>>(std::move(batches)));
 }
 

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -23,6 +23,7 @@
 #include "utils/vint.h"
 
 #include <seastar/core/print.hh>
+#include <seastar/core/shard_id.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -344,6 +345,7 @@ model::record_batch transformed_data::make_batch(
 
     model::record_batch_header header;
     header.type = record_batch_type::raft_data;
+    header.ctx.owner_shard = ss::this_shard_id();
     // mark the batch as created with broker time
     header.attrs.set_timestamp_type(model::timestamp_type::append_time);
     header.first_timestamp = timestamp;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -89,7 +89,7 @@ public:
         if (it == _schemas.end()) {
             return not_found(id);
         }
-        return {it->second.definition.copy()};
+        return {it->second.definition.share()};
     }
 
     ///\brief Return the id of the schema, if it already exists.

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -161,11 +161,7 @@ replicate_batcher::do_cache_with_backpressure(
     data.reserve(batches.size());
     for (auto& b : batches) {
         record_count += b.record_count();
-        if (b.header().ctx.owner_shard == ss::this_shard_id()) {
-            data.push_back(std::move(b));
-        } else {
-            data.push_back(b.copy());
-        }
+        data.push_back(std::move(b));
     }
     auto i = ss::make_lw_shared<item>(
       record_count, std::move(data), std::move(u), expected_term, opts);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR removes most of the cases where we use `iobuf::copy` to safely share data across shards. It depends on https://github.com/redpanda-data/vtools/pull/3285 being merged first so that the CI run will use a seastar version with atomically reference counted.

A follow up to this PR should be removing the `record_batch_reader::foreign_data_t` variant from `record_batch_reader` as it no longer has any uses in RP outside of unit tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
