### PR TITLE
dt: Don't run pmap

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3243,8 +3243,7 @@ class RedpandaService(RedpandaServiceBase):
     def _log_node_process_state(self, node):
         """
         For debugging issues around starting and stopping processes: log
-        which processes are running and which ports are in use. Additionally,
-        capture detailed memory usage for the top 3 memory-consuming processes.
+        which processes are running and which ports are in use.
         """
 
         self.logger.debug(
@@ -3261,22 +3260,6 @@ class RedpandaService(RedpandaServiceBase):
         for line in node.account.ssh_capture("netstat -panelot",
                                              timeout_sec=30):
             self.logger.debug(line.strip())
-
-        # Analyze memory usage in detail for the top 3 processes
-        self.logger.debug(
-            "Gathering detailed memory usage for the top 3 memory-consuming processes..."
-        )
-        for process_line in process_lines[
-                1:4]:  # Skip header, get top 3 processes
-            fields = process_line.split()
-            pid = fields[1]
-            mem_usage = fields[3]
-            self.logger.debug(
-                f"Process PID: {pid}, Memory Usage: {mem_usage}%")
-            self.logger.debug(f"Memory map for PID {pid}:")
-            for pmap_line in node.account.ssh_capture(f"pmap {pid}",
-                                                      timeout_sec=30):
-                self.logger.debug(pmap_line.strip())
 
     def start_service(self, node, start):
         # Maybe the service collides with something that wasn't cleaned up


### PR DESCRIPTION
The pmap logic often seems to fail (I suspect a race condition between
getting the processe list and checking the processes) but it also seems
quite useless to me. The process memory mappings are only useful in some
niche debugging usecases. Hence remove.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


