### PR TITLE
[CORE-8000] tiered storage sanctioning for alter topics

### DIFF
--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -644,6 +644,12 @@ public:
           _partitions_to_force_reconfigure.end());
     }
 
+    /**
+     * Return the result of applying the update to the topic properties.
+     */
+    static topic_properties update_topic_properties(
+      topic_properties updated_properties, update_topic_properties_cmd cmd);
+
 private:
     friend topic_table_probe;
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -85,10 +85,13 @@ std::vector<std::string_view> get_enterprise_features(
 std::vector<std::string_view> get_enterprise_features(
   const cluster::metadata_cache& metadata,
   const cluster::topic_properties_update& update) {
-    const auto& properties = metadata.get_topic_metadata_ref(update.tp_ns)
-                               ->get()
-                               .get_configuration()
-                               .properties;
+    auto tp_metadata = metadata.get_topic_metadata_ref(update.tp_ns);
+    if (!tp_metadata.has_value()) {
+        // Topic does not exist, nothing to validate
+        return {};
+    }
+
+    const auto& properties = tp_metadata->get().get_configuration().properties;
     auto updated_properties = cluster::topic_table::update_topic_properties(
       properties, {update.tp_ns, update.properties});
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -47,6 +47,7 @@
 #include "rpc/types.h"
 #include "ssx/future-util.h"
 #include "topic_configuration.h"
+#include "topic_properties.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -78,6 +79,28 @@ std::vector<std::string_view> get_enterprise_features(
     if (cfg.is_read_replica()) {
         features.emplace_back("remote read replicas");
     }
+    return features;
+}
+
+std::vector<std::string_view> get_enterprise_features(
+  const cluster::metadata_cache& metadata,
+  const cluster::topic_properties_update& update) {
+    const auto& properties = metadata.get_topic_metadata_ref(update.tp_ns)
+                               ->get()
+                               .get_configuration()
+                               .properties;
+    auto updated_properties = cluster::topic_table::update_topic_properties(
+      properties, {update.tp_ns, update.properties});
+
+    std::vector<std::string_view> features;
+    const auto si_disabled = model::shadow_indexing_mode::disabled;
+    if (
+      (properties.shadow_indexing.value_or(si_disabled)
+       < updated_properties.shadow_indexing.value_or(si_disabled))
+      || (properties.remote_delete < updated_properties.remote_delete)) {
+        features.emplace_back("tiered storage");
+    }
+
     return features;
 }
 
@@ -270,6 +293,19 @@ ss::future<std::vector<topic_result>> topics_frontend::update_topic_properties(
 
         auto results = co_await ssx::parallel_transform(
           std::move(updates), [this, timeout](topic_properties_update update) {
+              if (
+                _features.local().should_sanction()
+                && is_user_topic(update.tp_ns)) {
+                  if (auto f = get_enterprise_features(_metadata_cache, update);
+                      !f.empty()) {
+                      vlog(
+                        clusterlog.warn,
+                        "An enterprise license is required to enable {}.",
+                        f);
+                      return ss::make_ready_future<topic_result>(
+                        topic_result(update.tp_ns, errc::topic_invalid_config));
+                  }
+              }
               return do_update_topic_properties(std::move(update), timeout);
           });
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1325,6 +1325,15 @@ FIXTURE_TEST(test_unlicensed_alter_configs, alter_config_test_fixture) {
           props_t{with(p, true), non_enterprise_prop},
           alter_props_t{{remove(non_enterprise_prop.first)}},
           success);
+
+        // Skip creating topic. Expect no sanctions.
+        // Alter operations should fail downstream.
+        test_cases.emplace_back(
+          ssx::sformat("skip_create_{}", p),
+          props_t{},
+          alter_props_t{{set(p, true)}},
+          kafka::error_code::unknown_topic_or_partition,
+          skip_create::yes);
     }
 
     // Specific tests for tiered storage

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1246,3 +1246,152 @@ FIXTURE_TEST(
     assert_property_value(
       test_tp, "redpanda.remote.read", "true", describe_resp);
 }
+
+FIXTURE_TEST(test_unlicensed_alter_configs, alter_config_test_fixture) {
+    using props_t = absl::flat_hash_map<ss::sstring, ss::sstring>;
+    using alter_props_t = absl::flat_hash_map<
+      ss::sstring,
+      std::pair<std::optional<ss::sstring>, kafka::config_resource_operation>>;
+    std::vector<
+      std::tuple<ss::sstring, props_t, alter_props_t, kafka::error_code>>
+      test_cases;
+
+    constexpr auto success = kafka::error_code::none;
+    constexpr auto failure = kafka::error_code::invalid_config;
+
+    constexpr auto with =
+      [](std::string_view prop, auto val) -> props_t::value_type {
+        return {ss::sstring{prop}, ssx::sformat("{}", val)};
+    };
+
+    constexpr auto set =
+      [](std::string_view prop, auto val) -> alter_props_t::value_type {
+        return {
+          ss::sstring{prop},
+          {ssx::sformat("{}", val), kafka::config_resource_operation::set}};
+    };
+
+    constexpr auto remove =
+      [](std::string_view prop) -> alter_props_t::value_type {
+        return {
+          ss::sstring{prop},
+          {std::nullopt, kafka::config_resource_operation::remove}};
+    };
+
+    const auto enterprise_props = {
+      kafka::topic_property_remote_read,
+      kafka::topic_property_remote_write,
+    };
+
+    const auto non_enterprise_prop = props_t::value_type{
+      kafka::topic_property_max_message_bytes, "4096"};
+
+    for (const auto& p : enterprise_props) {
+        // A topic without an enterprise property set, and then enable it
+        test_cases.emplace_back(
+          ssx::sformat("enable_{}", p),
+          props_t{},
+          alter_props_t{{set(p, true)}},
+          failure);
+        // A topic with an enterprise property set, and then set it to false
+        test_cases.emplace_back(
+          ssx::sformat("set_false_{}", p),
+          props_t{with(p, true)},
+          alter_props_t{{set(p, false)}},
+          success);
+        // A topic with an enterprise property set, and then remove it
+        test_cases.emplace_back(
+          ssx::sformat("remove_{}", p),
+          props_t{with(p, true)},
+          alter_props_t{{remove(p)}},
+          success);
+        // A topic with an enterprise property set, and then change
+        // non-enterprise property
+        test_cases.emplace_back(
+          ssx::sformat("set_other_{}", p),
+          props_t{with(p, true)},
+          alter_props_t{{std::apply(set, non_enterprise_prop)}},
+          success);
+        // A topic with an enterprise property set, and then remove
+        // non-enterprise property
+        test_cases.emplace_back(
+          ssx::sformat("remove_other_{}", p),
+          props_t{with(p, true), non_enterprise_prop},
+          alter_props_t{{remove(non_enterprise_prop.first)}},
+          success);
+    }
+
+    // Specific tests for tiered storage
+    {
+        const auto full_si = props_t{
+          with(kafka::topic_property_remote_read, true),
+          with(kafka::topic_property_remote_write, true),
+          with(kafka::topic_property_remote_delete, true)};
+        test_cases.emplace_back(
+          "remove_remote.read_from_full",
+          full_si,
+          alter_props_t{{remove(kafka::topic_property_remote_read)}},
+          success);
+        test_cases.emplace_back(
+          "remove_remote.write_from_full",
+          full_si,
+          alter_props_t{{remove(kafka::topic_property_remote_write)}},
+          success);
+        test_cases.emplace_back(
+          "remove_remote.delete_from_full",
+          full_si,
+          alter_props_t{{remove(kafka::topic_property_remote_delete)}},
+          success);
+        test_cases.emplace_back(
+          "enable_remote.delete",
+          props_t{with(kafka::topic_property_remote_delete, false)},
+          alter_props_t{{set(kafka::topic_property_remote_delete, true)}},
+          failure);
+    }
+
+    // Create the topics for the tests
+    constexpr auto inc_alter_topic = [](std::string_view tp_raw) {
+        return model::topic{ssx::sformat("incremental_alter_{}", tp_raw)};
+    };
+    constexpr auto alter_topic = [](std::string_view tp_raw) {
+        return model::topic{ssx::sformat("alter_{}", tp_raw)};
+    };
+    for (const auto& t : test_cases) {
+        create_topic(inc_alter_topic(std::get<0>(t)), std::get<1>(t), 3);
+        create_topic(alter_topic(std::get<0>(t)), std::get<1>(t), 3);
+    }
+
+    revoke_license();
+
+    for (const auto& [tp_raw, props, alteration, expected] : test_cases) {
+        // Test incremental alter config
+        auto tp = inc_alter_topic(tp_raw);
+        BOOST_TEST_CONTEXT(tp) {
+            auto resp = incremental_alter_configs(
+              make_incremental_alter_topic_config_resource_cv(tp, alteration));
+            BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+            BOOST_CHECK_EQUAL(resp.data.responses[0].error_code, expected);
+        }
+
+        // Test alter config
+        tp = alter_topic(tp_raw);
+        BOOST_TEST_CONTEXT(tp) {
+            auto properties = props;
+            for (const auto& a : alteration) {
+                if (
+                  a.second.second == kafka::config_resource_operation::remove) {
+                    properties.erase(a.first);
+                } else if (
+                  a.second.second == kafka::config_resource_operation::set) {
+                    properties.insert_or_assign(
+                      a.first, a.second.first.value());
+                };
+            }
+
+            auto resp = alter_configs(
+              make_alter_topic_config_resource_cv(tp, properties));
+            BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+            BOOST_CHECK_EQUAL(resp.data.responses[0].error_code, expected);
+        }
+    }
+}

--- a/src/v/kafka/server/tests/topic_properties_helpers.h
+++ b/src/v/kafka/server/tests/topic_properties_helpers.h
@@ -20,6 +20,14 @@ public:
           .get();
     }
 
+    void reinstall_license() {
+        app.controller->get_feature_table()
+          .invoke_on_all([](auto& ft) {
+              return ft.set_builtin_trial_license(model::timestamp::now());
+          })
+          .get();
+    }
+
     void update_cluster_config(std::string_view k, std::string_view v) {
         app.controller->get_config_frontend()
           .local()


### PR DESCRIPTION
Implement sanctioning for altering tiered storage topic configs.

Notes to reviewer:
* Is it ok that this misses the `validate_only` flag?
* Is it required to check the diff after the `linearizable_barrier`?
* Is it ok that this can now fail? For example `topic_recovery_service::reset_topic_configurations`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
