### PR TITLE
CORE-8082 cloud_io: add missing error handling to `remote::download_object`

### DIFF
--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -53,6 +53,7 @@ redpanda_cc_library(
         "//src/v/utils:functional",
         "//src/v/utils:log_hist",
         "//src/v/utils:named_type",
+        "//src/v/utils:retry_chain_node",
         "//src/v/utils:stop_signal",
         "@boost//:beast",
         "@boost//:lexical_cast",

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "bytes/streambuf.h"
 #include "net/connection.h"
+#include "utils/retry_chain_node.h"
 
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -39,8 +40,9 @@ bool has_abort_or_gate_close_exception(const ss::nested_exception& ex) {
            || is_abort_or_gate_close_exception(ex.outer);
 }
 
+template<typename Logger>
 error_outcome handle_client_transport_error(
-  std::exception_ptr current_exception, ss::logger& logger) {
+  std::exception_ptr current_exception, Logger& logger) {
     auto outcome = error_outcome::retry;
 
     try {
@@ -112,6 +114,11 @@ error_outcome handle_client_transport_error(
 
     return outcome;
 }
+
+template error_outcome
+handle_client_transport_error<ss::logger>(std::exception_ptr, ss::logger&);
+template error_outcome handle_client_transport_error<retry_chain_logger>(
+  std::exception_ptr, retry_chain_logger&);
 
 ss::future<iobuf>
 drain_response_stream(http::client::response_stream_ref resp) {

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -24,8 +24,9 @@ namespace cloud_storage_clients::util {
 /// cloud provider (e.g. connection error).
 /// \param current_exception is the current exception thrown by the client
 /// \param logger is the logger to use
+template<typename Logger>
 error_outcome handle_client_transport_error(
-  std::exception_ptr current_exception, ss::logger& logger);
+  std::exception_ptr current_exception, Logger& logger);
 
 /// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
 /// iobuf


### PR DESCRIPTION
The call to `drain_response_stream` may throw various transport related errors (see one example below of a broken pipe error observed in CI). These errors should be handled inside the `remote::download_object` method because the caller's expectation is that download-related errors are communicated via the `download_result` return type rather than through an exception. Some of these errors (like the broken pipe error below) could also be retried, whereas with the previous implementation, they were not retried.

These exceptions are often ignored by the caller and may be printed as "Exceptional future ignored" log lines, which cause CI failures and are less useful for debugging.

The below is an example of one such ignored exceptional future in the remote partition finalizing background fibre:
```
INFO  2024-10-29 12:41:17,708 [shard 1:main] cloud_storage - [fiber474 kafka/fuzzy-operator-6356-dzxvff/4] - remote_partition.cc:1406 - Finalizing remote storage state...
DEBUG 2024-10-29 12:41:17,723 [shard 1:main] cloud_io - [fiber819~0|1|19984ms] - remote.cc:430 - Receive OK response from "37836c6f-30b0-482f-bb4e-0f3dffdb5cbe/meta/kafka/fuzzy-operator-6356-dzxvff/1_3447/manifest.bin"
WARN  2024-10-29 12:41:17,723 [shard 1:main] http - /37836c6f-30b0-482f-bb4e-0f3dffdb5cbe/meta/kafka/fuzzy-operator-6356-dzxvff/1_3447/manifest.bin - client.cc:414 - receive error std::__1::system_error (error generic:32, System error during SSL read: [error:FFFFFFFF80000020:system library::Broken pipe]: Broken pipe)
WARN  2024-10-29 12:41:17,723 [shard 1:main] seastar - Exceptional future ignored: std::__1::system_error (error generic:32, System error during SSL read: [error:FFFFFFFF80000020:system library::Broken pipe]: Broken pipe), backtrace: 0xa73be23 0xa392e05 0x360a6b8 0x9352157 0x360a71a 0xa48cc6f 0xa49045c 0xa4e77ca 0xa402f3f /opt/redpanda/lib/libc.so.6+0x961b6 /opt/redpanda/lib/libc.so.6+0x11839b
```

This issue was highlighted by failures of the `RandomNodeOperations` test with tiered storage enabled running in CDT, which are linked below.

Fixes https://redpandadata.atlassian.net/browse/CORE-8082
Fixes https://redpandadata.atlassian.net/browse/CORE-8052
Fixes https://redpandadata.atlassian.net/browse/CORE-8018
Fixes https://redpandadata.atlassian.net/browse/CORE-8009
Fixes https://redpandadata.atlassian.net/browse/CORE-7979
Fixes https://redpandadata.atlassian.net/browse/CORE-7834
Fixes https://redpandadata.atlassian.net/browse/CORE-7767
Fixes https://redpandadata.atlassian.net/browse/CORE-7675
Fixes https://redpandadata.atlassian.net/browse/CORE-7315

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
### Bug Fixes
* Fixes a rare bug during remote partition manifest downloads where broken pipe exceptions weren't retried in an edge case.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
