### PR TITLE
Prevent usage of debug bundle in developer_mmode

### DIFF
--- a/src/v/debug_bundle/debug_bundle_service.h
+++ b/src/v/debug_bundle/debug_bundle_service.h
@@ -228,5 +228,7 @@ private:
     /// Mutex to guard control over the rpk debug bundle process
     mutex _process_control_mutex;
     ss::gate _gate;
+    /// Flag that indicates if the node is in developer mode
+    bool _in_developer_mode;
 };
 } // namespace debug_bundle

--- a/src/v/debug_bundle/error.cc
+++ b/src/v/debug_bundle/error.cc
@@ -40,6 +40,8 @@ struct error_category final : std::error_category {
             return "rpk binary not present";
         case error_code::debug_bundle_expired:
             return "debug bundle expired and was removed";
+        case error_code::debug_bundle_service_unavailable_in_developer_mode:
+            return "debug_bundle_service_unavailable_in_developer_mode";
         }
 
         return "(unknown error code)";

--- a/src/v/debug_bundle/error.h
+++ b/src/v/debug_bundle/error.h
@@ -30,6 +30,7 @@ enum class error_code : int {
     debug_bundle_process_never_started,
     rpk_binary_not_present,
     debug_bundle_expired,
+    debug_bundle_service_unavailable_in_developer_mode,
 };
 
 std::error_code make_error_code(error_code e) noexcept;

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -98,6 +98,10 @@ std::unique_ptr<ss::http::reply> make_error_body(
     case debug_bundle::error_code::debug_bundle_expired:
         status = ss::http::reply::status_type::gone;
         break;
+    case debug_bundle::error_code::
+      debug_bundle_service_unavailable_in_developer_mode:
+        status = ss::http::reply::status_type::service_unavailable;
+        break;
     }
     return make_json_body(status, res, std::move(rep));
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

An issue with how Docker Desktop v4.34+ (particularly on macOS) handles  
`pidfd` functionality causes an assertion failure in Seastar’s `waitpid`  
method. Details can be found in [Seastar reactor.cc](https://github.com/redpanda-data/seastar/blob/f212c774ea3e58b91005926c6b99825fb04d2a64/src/core/reactor.cc#L2331-L2340).  

Summary of the issue:  
- Seastar creates a `pidfd` using `pidfd_open`.  
- It polls this file descriptor until it becomes readable.  
- When readable, the process should have completed.  
- However, `waitpid` unexpectedly returns `0`, leading to an assertion.  

This issue is observed when running Redpanda Docker containers on Docker  
Desktop v4.34+ (macOS).  

To prevent crashes when users generate debug bundles in this environment,  
the debug bundle service will be disabled when Redpanda is in  
`developer_mode`. Since `developer_mode` is enabled by default in the  
[quick-start documentation](https://docs.redpanda.com/current/get-started/quick-start/#deploy-redpanda), this change prevents prospective users of  
Redpanda from encountering the crash in a test environment.  

Ongoing investigations:  
- Examining what changed in Docker Desktop v4.34.  
- Collaborating with ScyllaDB to potentially adjust `waitpid` behavior in  
  Seastar.  

This change avoids crashes and ensures a better experience for new users  
evaluating Redpanda.  

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
