### PR TITLE
[CORE-8187] Propagate an error message into `topic_result`

### DIFF
--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -273,8 +273,8 @@ private:
     ss::future<result<model::offset>>
       stm_linearizable_barrier(model::timeout_clock::time_point);
 
-    // returns true if the topic name is valid
-    static bool validate_topic_name(const model::topic_namespace&);
+    // returns whether the topic name is valid
+    static std::error_code validate_topic_name(const model::topic_namespace&);
 
     topic_result
     validate_topic_configuration(const custom_assignable_topic_configuration&);

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -276,7 +276,7 @@ private:
     // returns true if the topic name is valid
     static bool validate_topic_name(const model::topic_namespace&);
 
-    errc
+    topic_result
     validate_topic_configuration(const custom_assignable_topic_configuration&);
 
     ss::future<topic_result> do_create_partition(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -948,19 +948,25 @@ using topic_configuration_assignment
   = configuration_with_assignment<topic_configuration>;
 
 struct topic_result
-  : serde::envelope<topic_result, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<topic_result, serde::version<1>, serde::compat_version<0>> {
     topic_result() noexcept = default;
     explicit topic_result(model::topic_namespace t, errc ec = errc::success)
       : tp_ns(std::move(t))
       , ec(ec) {}
+    topic_result(model::topic_namespace t, errc ec, std::string_view msg)
+      : tp_ns(std::move(t))
+      , ec(ec)
+      , error_message{
+          ssx::sformat("{}: {}", make_error_code(ec).message(), msg)} {}
     model::topic_namespace tp_ns;
-    errc ec;
+    errc ec{errc::success};
+    std::optional<ss::sstring> error_message;
 
     friend bool operator==(const topic_result&, const topic_result&) = default;
 
     friend std::ostream& operator<<(std::ostream& o, const topic_result& r);
 
-    auto serde_fields() { return std::tie(tp_ns, ec); }
+    auto serde_fields() { return std::tie(tp_ns, ec, error_message); }
 };
 
 struct create_topics_request

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -253,6 +253,8 @@ ss::future<chunked_vector<R>> do_alter_topics_configuration(
     for (auto& res : update_results) {
         responses.push_back(R{
           .error_code = map_topic_error_code(res.ec),
+          .error_message = res.error_message.value_or(
+            make_error_code(res.ec).message()),
           .resource_type = static_cast<int8_t>(config_resource_type::topic),
           .resource_name = res.tp_ns.tp(),
         });

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -316,7 +316,8 @@ ss::future<response_ptr> create_partitions_handler::handle(
           return create_partitions_topic_result{
             .name = std::move(r.tp_ns.tp),
             .error_code = map_topic_error_code(r.ec),
-            .error_message = cluster::make_error_code(r.ec).message(),
+            .error_message = r.error_message.value_or(
+              make_error_code(r.ec).message()),
           };
       });
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -145,7 +145,8 @@ from_cluster_topic_result(const cluster::topic_result& err) {
     return {
       .name = err.tp_ns.tp,
       .error_code = map_topic_error_code(err.ec),
-      .error_message = cluster::make_error_code(err.ec).message()};
+      .error_message = err.error_message.value_or(
+        cluster::make_error_code(err.ec).message())};
 }
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1501,6 +1501,11 @@ FIXTURE_TEST(test_unlicensed_alter_configs, alter_config_test_fixture) {
               make_incremental_alter_topic_config_resource_cv(tp, alteration));
             BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
             BOOST_CHECK_EQUAL(resp.data.responses[0].error_code, expected);
+            if (expected == failure) {
+                BOOST_CHECK(
+                  resp.data.responses[0].error_message.value_or("").contains(
+                    "An enterprise license is required"));
+            }
         }
 
         delete_topic(

--- a/src/v/kafka/server/tests/create_partition_test.cc
+++ b/src/v/kafka/server/tests/create_partition_test.cc
@@ -73,6 +73,8 @@ FIXTURE_TEST(
             BOOST_REQUIRE_EQUAL(res.results.size(), 1);
             BOOST_CHECK_EQUAL(
               res.results[0].error_code, kafka::error_code::invalid_config);
+            BOOST_CHECK(res.results[0].error_message.value_or("").contains(
+              "An enterprise license is required"));
 
             delete_topic(
               model::topic_namespace{model::kafka_namespace, std::move(tp)})

--- a/src/v/kafka/server/tests/create_partition_test.cc
+++ b/src/v/kafka/server/tests/create_partition_test.cc
@@ -38,7 +38,7 @@ FIXTURE_TEST(
 
     std::initializer_list<test_t> enterprise_props{
       // si_props
-      // The following properties are not supported for Create Partition
+      // Exclude these; setting up s3_imposter is too complex for this test
       //  * kafka::topic_property_recovery
       //  * kafka::topic_property_read_replica
       with(kafka::topic_property_remote_read, true),

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -484,6 +484,12 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
 
         BOOST_CHECK_EQUAL(
           resp.data.topics[0].error_code, kafka::error_code::invalid_config);
+        auto expected_message = (name == kafka::topic_property_recovery
+                                 || name == kafka::topic_property_read_replica)
+                                  ? "Tiered storage is not enabled"
+                                  : "An enterprise license is required";
+        BOOST_CHECK(resp.data.topics[0].error_message.value_or("").contains(
+          expected_message));
     }
 }
 
@@ -506,6 +512,8 @@ FIXTURE_TEST(unlicensed_reject_defaults, create_topic_fixture) {
 
         BOOST_CHECK_EQUAL(
           resp.data.topics[0].error_code, kafka::error_code::invalid_config);
+        BOOST_CHECK(resp.data.topics[0].error_message.value_or("").contains(
+          "An enterprise license is required"));
         update_cluster_config(config, "false");
     }
 }


### PR DESCRIPTION
Prior to this commit:
```
rpk topic create foo9 -c redpanda.remote.read=true --profile=local
TOPIC  STATUS
foo9   INVALID_CONFIG: Configuration is invalid
```
After this commit:
```
rpk topic create foo9 -c redpanda.remote.read=true --profile=local
TOPIC  STATUS
foo9   INVALID_CONFIG: Configuration is invalid: An enterprise license is required to enable {tiered storage}.
```

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
