### PR TITLE
rpk connect: show rpk help text with --help/-h

### DIFF
--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -79,6 +79,10 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 					zap.L().Sugar().Warn("rpk is using a self-managed version of Redpanda Connect. If you want rpk to manage connect, use rpk connect uninstall && rpk connect install. To continue managing Connect manually, use our redpanda-connect package.")
 				}
 			}
+			if cmd.Flags().Changed("help") {
+				cmd.Help()
+				return
+			}
 			zap.L().Debug("executing connect plugin", zap.String("path", pluginPath), zap.Strings("args", pluginArgs))
 			err = execFn(pluginPath, pluginArgs)
 			out.MaybeDie(err, "unable to execute redpanda connect plugin: %v", err)


### PR DESCRIPTION
Previously we were displaying only the `connect`
plugin help text, and not the rpk one. We were
missing the lifecycle commands (install, uninstall, upgrade).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none