### PR TITLE
[v24.1.x] rptest: reduce cache eviction throttling for space leak test

### DIFF
--- a/tests/rptest/tests/test_si_cache_space_leak.py
+++ b/tests/rptest/tests/test_si_cache_space_leak.py
@@ -59,6 +59,7 @@ class ShadowIndexingCacheSpaceLeakTest(RedpandaTest):
             'segment_fallocation_step': 0x1000,
             'retention_local_target_bytes_default': self._segment_size,
             'retention_bytes': self._segment_size * 5,
+            'cloud_storage_cache_check_interval': 500,
         }
         super().__init__(test_context,
                          num_brokers=3,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/22796
Fixes: https://github.com/redpanda-data/redpanda/issues/24069,