### PR TITLE
CORE-8172 Changed force recovery logic to select whichever state is more up to date from local and cloud data

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -281,6 +281,16 @@ public:
     ss::future<std::error_code>
     force_abort_replica_set_update(model::revision_id rev);
 
+    /**
+     * Downloads partition manifest to query for latest offset available in
+     * object store.
+     *
+     * IMPORTANT: this may not be the last offset of last segment uploaded to
+     * the cloud as partition manifest is eventually consistent.
+     */
+    ss::future<result<model::offset>> fetch_latest_cloud_offset_from_manifest(
+      model::timeout_clock::time_point deadline);
+
     consensus_ptr raft() const;
 
     std::optional<std::reference_wrapper<archival::ntp_archiver>> archiver() {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -742,7 +742,7 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
 
     u.return_all();
 
-    // wait for responsens in background
+    // wait for responses in background
     ssx::spawn_with_gate(_bg, [futures = std::move(send_futures)]() mutable {
         return ss::when_all_succeed(futures.begin(), futures.end());
     });
@@ -1468,7 +1468,7 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
          */
         _flushed_offset = lstats.dirty_offset;
         /**
-         * The configuration manager state may be divereged from the log
+         * The configuration manager state may be diverged from the log
          * state, as log is flushed lazily, we have to make sure that
          * the log and configuration manager has exactly the same
          * offsets range
@@ -1774,7 +1774,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request r) {
     /// Stable leadership optimization
     ///
     /// When current node is a leader (we set _hbeat to max after
-    /// successfull election) or already processed request from active
+    /// successful election) or already processed request from active
     /// leader  do not grant a vote to follower. This will prevent restarted
     /// nodes to disturb all groups leadership
     // Check if we updated the heartbeat timepoint in the last election
@@ -2061,7 +2061,7 @@ consensus::do_append_entries(append_entries_request&& r) {
     // as timeouts are asynchronous to append calls and can have stall data
     if (r.batches().is_end_of_stream()) {
         if (adjusted_prev_log_index < last_log_offset) {
-            // do not tuncate on heartbeat just response with false
+            // do not truncate on heartbeat just response with false
             reply.result = reply_result::failure;
             co_return reply;
         }


### PR DESCRIPTION
When force recovering partition the controller backend logic decides
which partition replica should be a voter and by that which partition
replica can become a leader. The default policy in controller backend
added all survivor replicas to the voter set, this way promoting their
local state as the source of truth for the partition data.

In some rare scenarios it may be the case that he survivor local state
is 'behind' the state from the cloud. In this case controller backend
should recognize that is is more beneficial to use cloud data as a
source of truth.

This commit adds a controller backend logic that reconciles with the
cloud and selects whichever state is more up to date when executing
partition force reconfiguration. If cloud offset is greater than the
replica dirty offset, the replica local state is removed and cloud
recovery is executed, this way the more up to date state is recovered
and data loss after critical failure is minimized.

Fixes: CORE-8172
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Minimizes data loss in recovery scenarios