### PR TITLE
config: renamed iceberg rest catalog properties

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3785,17 +3785,17 @@ configuration::configuration()
         .visibility = visibility::user,
       },
       std::nullopt)
-  , iceberg_rest_catalog_user_id(
+  , iceberg_rest_catalog_client_id(
       *this,
-      "iceberg_rest_catalog_user_id",
+      "iceberg_rest_catalog_client_id",
       "Iceberg REST catalog user ID. This ID is used to query "
       "the catalog API for the OAuth token. Required if catalog type is set to "
       "`rest`",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt)
-  , iceberg_rest_catalog_secret(
+  , iceberg_rest_catalog_client_secret(
       *this,
-      "iceberg_rest_catalog_secret",
+      "iceberg_rest_catalog_client_secret",
       "Secret to authenticate against Iceberg REST catalog. Required if "
       "catalog type is set to `rest`",
       {.needs_restart = needs_restart::yes,
@@ -3807,7 +3807,7 @@ configuration::configuration()
       "iceberg_rest_catalog_token",
       "Token used to access the REST Iceberg catalog. If the token is present, "
       "Redpanda ignores credentials stored in the properties "
-      "iceberg_rest_catalog_user_id and iceberg_rest_catalog_secret",
+      "iceberg_rest_catalog_client_id and iceberg_rest_catalog_client_secret",
       {.needs_restart = needs_restart::yes,
        .visibility = visibility::user,
        .secret = is_secret::yes},

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3771,10 +3771,10 @@ configuration::configuration()
       *this,
       "iceberg_catalog_type",
       "Iceberg catalog type that Redpanda will use to commit table "
-      "metadata updates. Supported types: 'rest', 'filesystem'",
+      "metadata updates. Supported types: 'rest', 'object_storage'",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      datalake_catalog_type::filesystem,
-      {datalake_catalog_type::rest, datalake_catalog_type::filesystem})
+      datalake_catalog_type::object_storage,
+      {datalake_catalog_type::rest, datalake_catalog_type::object_storage})
   , iceberg_rest_catalog_endpoint(
       *this,
       "iceberg_rest_catalog_endpoint",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -708,8 +708,8 @@ struct configuration final : public config_store {
     // datalake catalog configuration
     enum_property<datalake_catalog_type> iceberg_catalog_type;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_endpoint;
-    property<std::optional<ss::sstring>> iceberg_rest_catalog_user_id;
-    property<std::optional<ss::sstring>> iceberg_rest_catalog_secret;
+    property<std::optional<ss::sstring>> iceberg_rest_catalog_client_id;
+    property<std::optional<ss::sstring>> iceberg_rest_catalog_client_secret;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_token;
     property<std::chrono::milliseconds> iceberg_rest_catalog_request_timeout_ms;
 

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -667,8 +667,8 @@ struct convert<config::datalake_catalog_type> {
                   to_string_view(config::datalake_catalog_type::rest),
                   config::datalake_catalog_type::rest)
                 .match(
-                  to_string_view(config::datalake_catalog_type::filesystem),
-                  config::datalake_catalog_type::filesystem);
+                  to_string_view(config::datalake_catalog_type::object_storage),
+                  config::datalake_catalog_type::object_storage);
 
         return true;
     }

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -118,12 +118,12 @@ inline std::ostream& operator<<(std::ostream& os, const tls_version& v) {
     return os << to_string_view(v);
 }
 
-enum class datalake_catalog_type { filesystem, rest };
+enum class datalake_catalog_type { object_storage, rest };
 
 constexpr std::string_view to_string_view(datalake_catalog_type ct) {
     switch (ct) {
-    case datalake_catalog_type::filesystem:
-        return "filesystem";
+    case datalake_catalog_type::object_storage:
+        return "object_storage";
     case datalake_catalog_type::rest:
         return "rest";
     }
@@ -131,7 +131,7 @@ constexpr std::string_view to_string_view(datalake_catalog_type ct) {
 static constexpr auto acceptable_datalake_catalog_types() {
     return std::to_array(
       {to_string_view(datalake_catalog_type::rest),
-       to_string_view(datalake_catalog_type::filesystem)});
+       to_string_view(datalake_catalog_type::object_storage)});
 }
 
 inline std::ostream& operator<<(std::ostream& o, datalake_catalog_type ct) {
@@ -146,8 +146,8 @@ inline std::istream& operator>>(std::istream& is, datalake_catalog_type& ct) {
              to_string_view(datalake_catalog_type::rest),
              datalake_catalog_type::rest)
            .match(
-             to_string_view(datalake_catalog_type::filesystem),
-             datalake_catalog_type::filesystem);
+             to_string_view(datalake_catalog_type::object_storage),
+             datalake_catalog_type::object_storage);
     return is;
 }
 

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -68,8 +68,8 @@ std::unique_ptr<iceberg::catalog> create_catalog(
     } else {
         // TODO: add config level validation
         throw_if_not_present(cfg.iceberg_rest_catalog_endpoint);
-        throw_if_not_present(cfg.iceberg_rest_catalog_secret);
-        throw_if_not_present(cfg.iceberg_rest_catalog_user_id);
+        throw_if_not_present(cfg.iceberg_rest_catalog_client_secret);
+        throw_if_not_present(cfg.iceberg_rest_catalog_client_id);
 
         vlog(
           datalake_log.info,
@@ -89,8 +89,8 @@ std::unique_ptr<iceberg::catalog> create_catalog(
           // TODO: make credentials optional, we should provide either
           // credentials or token
           iceberg::rest_client::credentials{
-            .client_id = cfg.iceberg_rest_catalog_user_id().value(),
-            .client_secret = cfg.iceberg_rest_catalog_secret().value()},
+            .client_id = cfg.iceberg_rest_catalog_client_id().value(),
+            .client_secret = cfg.iceberg_rest_catalog_client_secret().value()},
           std::nullopt, // base_path
           std::nullopt, // prefix
           std::nullopt, // api_version

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -57,7 +57,9 @@ std::unique_ptr<iceberg::catalog> create_catalog(
   cloud_io::remote& io,
   const cloud_storage_clients::bucket_name& bucket,
   config::configuration& cfg) {
-    if (cfg.iceberg_catalog_type == config::datalake_catalog_type::filesystem) {
+    if (
+      cfg.iceberg_catalog_type
+      == config::datalake_catalog_type::object_storage) {
         vlog(
           datalake_log.info,
           "Creating filesystem catalog with bucket: {} and location: {}",

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -42,7 +42,7 @@ BOOTSTRAP_CONFIG = {
 SECRET_CONFIG_NAMES = frozenset([
     "cloud_storage_secret_key",
     "cloud_storage_azure_shared_key",
-    "iceberg_rest_catalog_secret",
+    "iceberg_rest_catalog_client_secret",
     "iceberg_rest_catalog_token",
 ])
 

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -38,9 +38,9 @@ class RestCatalogConnectionTest(RedpandaTest):
             "rest",
             "iceberg_rest_catalog_endpoint":
             self.catalog_service.catalog_url,
-            "iceberg_rest_catalog_user_id":
+            "iceberg_rest_catalog_client_id":
             "panda-user",
-            "iceberg_rest_catalog_secret":
+            "iceberg_rest_catalog_client_secret":
             "panda-secret",
         })
         self.redpanda.start()


### PR DESCRIPTION
Renamed properties configuring cliend id and  secret for Iceberg REST catalog connection. Now the naming is aligned with what Iceberg spec and other catalog implementation uses.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none