### PR TITLE
Fixes for migrations tests

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -767,7 +767,7 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
           });
     } catch (const ss::broken_condition_variable& e) {
         co_return ret_t(make_error_code(errc::shutting_down));
-    } catch (const ss::timed_out_error& e) {
+    } catch (const ss::condition_variable_timed_out& e) {
         co_return errc::timeout;
     }
     // grab an oplock to serialize state updates i.e. wait for all updates in


### PR DESCRIPTION
Tests/migrations: relax migrations tests: do not check for number of migrations when using high level API under failure injector.
Eventual consistency of migrations table may come late, and we'd rather not wait for it to test but move on with other actions to see how a disturbed cluster copes with active use.

Raft/consensus: catch `ss::condition_variable_timed_out` not `ss::timed_out_error` when waiting for a condvar with timeout. Otherwise it bubbles up unhandled appearing in logs and potentially breaking the logic too.

Tests/migrations: run mount/unmount commands without finjector. Otherwise we'd need to be prepared to a situation where we get no successful reply from admin API, but the migration is nevertheless created (node killed right before it has sent a reply). When testing low level API we handle this by checking the migration is present. But high-level mount/unmount commands auto-remove migration objects on completion. Telling apart an uncreated and a completed migration in the test logic would be somewhat tricky.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
