### PR TITLE
cluster: Sanction redpanda.leaders.preference on invalid license - create topic

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -31,6 +31,7 @@
 #include "cluster/topic_recovery_validator.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/leaders_preference.h"
 #include "data_migration_types.h"
 #include "features/feature_table.h"
 #include "fwd.h"
@@ -80,6 +81,13 @@ std::vector<std::string_view> get_enterprise_features(
     }
     if (cfg.is_schema_id_validation_enabled()) {
         features.emplace_back("schema ID validation");
+    }
+    if (const auto& leaders_pref = cfg.cfg.properties.leaders_preference;
+        leaders_pref.has_value()
+        && config::shard_local_cfg()
+             .default_leaders_preference.check_restricted(
+               leaders_pref.value())) {
+        features.emplace_back("leadership pinning");
     }
     return features;
 }

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -447,27 +447,30 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
       pandaproxy::schema_registry::schema_id_validation_mode::compat);
 
     revoke_license();
-    auto si_props = {
-      ss::sstring{kafka::topic_property_remote_read},
-      ss::sstring{kafka::topic_property_remote_write},
-      ss::sstring{kafka::topic_property_recovery},
-      ss::sstring{kafka::topic_property_read_replica},
-      ss::sstring{kafka::topic_property_record_key_schema_id_validation},
-      ss::sstring{kafka::topic_property_record_key_schema_id_validation_compat},
-      ss::sstring{kafka::topic_property_record_value_schema_id_validation},
-      ss::sstring{
-        kafka::topic_property_record_value_schema_id_validation_compat},
+    using prop_t = std::map<ss::sstring, ss::sstring>;
+    const auto with = [](const std::string_view prop, const auto value) {
+        return std::make_pair(
+          prop, prop_t{{ss::sstring{prop}, ssx::sformat("{}", value)}});
     };
+    std::vector<std::pair<std::string_view, prop_t>> enterprise_props{
+      // si_props
+      with(kafka::topic_property_remote_read, true),
+      with(kafka::topic_property_remote_write, true),
+      with(kafka::topic_property_recovery, true),
+      with(kafka::topic_property_read_replica, true),
+      // schema id validation
+      with(kafka::topic_property_record_key_schema_id_validation, true),
+      with(kafka::topic_property_record_key_schema_id_validation_compat, true),
+      with(kafka::topic_property_record_value_schema_id_validation, true),
+      with(
+        kafka::topic_property_record_value_schema_id_validation_compat, true)};
 
     auto client = make_kafka_client().get();
     client.connect().get();
 
-    for (const auto& prop : si_props) {
+    for (const auto& [name, props] : enterprise_props) {
         auto topic = make_topic(
-          ssx::sformat("topic_{}", prop),
-          std::nullopt,
-          std::nullopt,
-          std::map<ss::sstring, ss::sstring>{{prop, "true"}});
+          ssx::sformat("topic_{}", name), std::nullopt, std::nullopt, props);
 
         auto resp
           = client.dispatch(make_req({topic}), kafka::api_version(5)).get();

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "config/leaders_preference.h"
 #include "container/fragmented_vector.h"
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/metadata.h"
@@ -463,7 +464,13 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
       with(kafka::topic_property_record_key_schema_id_validation_compat, true),
       with(kafka::topic_property_record_value_schema_id_validation, true),
       with(
-        kafka::topic_property_record_value_schema_id_validation_compat, true)};
+        kafka::topic_property_record_value_schema_id_validation_compat, true),
+      // pin_leadership_props
+      with(
+        kafka::topic_property_leaders_preference,
+        config::leaders_preference{
+          .type = config::leaders_preference::type_t::racks,
+          .racks = {model::rack_id{"A"}}})};
 
     auto client = make_kafka_client().get();
     client.connect().get();


### PR DESCRIPTION
Implements: [CORE-8042](https://redpandadata.atlassian.net/browse/CORE-8042) - Sanction 22

Implement sanction(s) on leadership pinning properties when there is no valid license:
- Requests to create a topic with a restricted `redpanda.leaders.preference` value will be denied.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

[CORE-8042]: https://redpandadata.atlassian.net/browse/CORE-8042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ