### PR TITLE
Iceberg to parquet schema conversion

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -423,3 +423,19 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "schema_parquet",
+    srcs = [
+        "schema_parquet.cc",
+    ],
+    hdrs = [
+        "schema_parquet.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/iceberg:datatypes",
+        "//src/v/serde/parquet:schema",
+    ],
+)

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     base_types.cc
     cloud_data_io.cc
     translation_task.cc
+    schema_parquet.cc
   DEPS
     v::cloud_io
     v::datalake_common
@@ -62,6 +63,7 @@ v_cc_library(
     v::iceberg
     v::serde_protobuf
     v::serde_avro
+    v::serde_parquet
 )
 
 add_subdirectory(tests)

--- a/src/v/datalake/schema_parquet.cc
+++ b/src/v/datalake/schema_parquet.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/datatypes.h"
+#include "serde/parquet/schema.h"
+
+namespace datalake {
+namespace {
+
+auto map_repetition_type(iceberg::field_required required) {
+    if (required) {
+        return serde::parquet::field_repetition_type::required;
+    }
+    return serde::parquet::field_repetition_type::optional;
+}
+
+struct primitive_type_converting_visitor {
+    serde::parquet::schema_element operator()(const iceberg::boolean_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::bool_type{},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::int_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i32_type{},
+          .logical_type
+          = serde::parquet::int_type{.bit_width = 32, .is_signed = true},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::long_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i64_type{},
+          .logical_type
+          = serde::parquet::int_type{.bit_width = 64, .is_signed = true},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::float_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::f32_type{},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::double_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::f64_type{},
+        };
+    }
+    serde::parquet::schema_element
+    operator()(const iceberg::decimal_type& type) {
+        return serde::parquet::schema_element{
+            // Redpanda uses int128 to represent decimal
+            .type = serde::parquet::byte_array_type{.fixed_length=16},
+            .logical_type = serde::parquet::decimal_type{
+                .scale = static_cast<int32_t>(type.scale),
+                .precision = static_cast<int32_t>(type.precision),
+            },
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::date_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i32_type{},
+          .logical_type = serde::parquet::date_type{},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::time_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i64_type{},
+          .logical_type = serde::parquet::
+            time_type{.is_adjusted_to_utc = false, .unit = serde::parquet::time_unit::micros},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::timestamp_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i64_type{},
+          .logical_type = serde::parquet::
+            timestamp_type{.is_adjusted_to_utc = false, .unit = serde::parquet::time_unit::micros},
+        };
+    }
+
+    serde::parquet::schema_element
+    operator()(const iceberg::timestamptz_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::i64_type{},
+          .logical_type = serde::parquet::
+            timestamp_type{.is_adjusted_to_utc = true, .unit = serde::parquet::time_unit::micros},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::string_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::byte_array_type{},
+          .logical_type = serde::parquet::string_type{},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::uuid_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::byte_array_type{.fixed_length = 16},
+          .logical_type = serde::parquet::uuid_type{},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::fixed_type& type) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::byte_array_type{.fixed_length = type.length},
+        };
+    }
+    serde::parquet::schema_element operator()(const iceberg::binary_type&) {
+        return serde::parquet::schema_element{
+          .type = serde::parquet::byte_array_type{},
+        };
+    }
+};
+
+serde::parquet::schema_element
+struct_to_parquet(const iceberg::struct_type& schema);
+serde::parquet::schema_element
+field_to_parquet(const iceberg::nested_field& field);
+
+struct type_converting_visitor {
+    serde::parquet::schema_element
+    operator()(const iceberg::primitive_type& type) {
+        auto res = std::visit(primitive_type_converting_visitor{}, type);
+        res.repetition_type = map_repetition_type(required);
+        return res;
+    }
+
+    serde::parquet::schema_element
+    operator()(const iceberg::struct_type& type) {
+        return struct_to_parquet(type);
+    }
+
+    serde::parquet::schema_element operator()(const iceberg::list_type& type) {
+        /**
+         * Lists in parquet are encoded as:
+         *
+         * <list-repetition> group <name> (LIST) {
+         *   repeated group list {
+         *     <element-repetition> <element-type> element;
+         *    }
+         * }
+         */
+        serde::parquet::schema_element res;
+        res.logical_type = serde::parquet::list_type{};
+        res.repetition_type = map_repetition_type(required);
+
+        serde::parquet::schema_element list_wrapper;
+        list_wrapper.repetition_type
+          = serde::parquet::field_repetition_type::repeated;
+        list_wrapper.path.emplace_back("list");
+        auto element = field_to_parquet(*type.element_field);
+        element.path.emplace_back("element");
+        list_wrapper.children.push_back(std::move(element));
+        res.children.push_back(std::move(list_wrapper));
+        return res;
+    }
+
+    serde::parquet::schema_element operator()(const iceberg::map_type& type) {
+        /*
+         * Maps in parquet are encoded as:
+         * <map - repetition> group<name>(MAP) {
+         *     repeated group key_value {
+         *         required<key - type> key;
+         *         <value - repetition><value - type> value;
+         *     }
+         * }
+         */
+        serde::parquet::schema_element res;
+        serde::parquet::schema_element map_wrapper;
+        map_wrapper.repetition_type
+          = serde::parquet::field_repetition_type::repeated;
+        map_wrapper.path.emplace_back("key_value");
+        map_wrapper.children.reserve(2);
+        auto key_element = field_to_parquet(*type.key_field);
+        key_element.repetition_type
+          = serde::parquet::field_repetition_type::required;
+        key_element.path.emplace_back("key");
+        map_wrapper.children.push_back(std::move(key_element));
+        auto value_element = field_to_parquet(*type.value_field);
+        value_element.path.emplace_back("value");
+        map_wrapper.children.push_back(std::move(value_element));
+        res.children.push_back(std::move(map_wrapper));
+        res.repetition_type = map_repetition_type(required);
+        return res;
+    }
+    iceberg::field_required required;
+};
+
+serde::parquet::schema_element
+field_to_parquet(const iceberg::nested_field& field) {
+    // type converting visitor takes care of setting the schema element
+    // repetition type
+    auto element = std::visit(
+      type_converting_visitor{field.required}, field.type);
+    element.field_id = field.id;
+    element.path.emplace_back(field.name);
+
+    return element;
+}
+
+serde::parquet::schema_element
+struct_to_parquet(const iceberg::struct_type& schema) {
+    serde::parquet::schema_element res;
+
+    res.children.reserve(schema.fields.size());
+    for (const auto& f : schema.fields) {
+        res.children.push_back(field_to_parquet(*f));
+    }
+    return res;
+}
+
+} // namespace
+
+serde::parquet::schema_element
+schema_to_parquet(const iceberg::struct_type& schema) {
+    auto root = struct_to_parquet(schema);
+    root.repetition_type = serde::parquet::field_repetition_type::required;
+    root.path.emplace_back("root");
+    return root;
+}
+} // namespace datalake

--- a/src/v/datalake/schema_parquet.h
+++ b/src/v/datalake/schema_parquet.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/datatypes.h"
+#include "serde/parquet/schema.h"
+
+namespace datalake {
+/**
+ * Translates an Iceberg schema to a parquet schema that is required to write
+ * parquet files. This function do not do any validation of the schema as it
+ * assumes that the schema was validated before.
+ */
+serde::parquet::schema_element schema_to_parquet(const iceberg::struct_type&);
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -272,3 +272,21 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "datalake_parquet_tests",
+    timeout = "short",
+    srcs = [
+        "datalake_parquet_tests.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/datalake:schema_parquet",
+        "//src/v/iceberg:datatypes",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -201,3 +201,19 @@ rp_test(
   LABELS datalake
   ARGS "-- -c 1"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  USE_CWD
+  BINARY_NAME datalake_parquet
+  SOURCES 
+    datalake_parquet_tests.cc
+  LIBRARIES
+    v::gtest_main
+    v::datalake_writer
+    v::iceberg_test_utils
+    v::avro_test_utils
+  LABELS datalake
+  ARGS "-- -c 1"
+)

--- a/src/v/datalake/tests/datalake_parquet_tests.cc
+++ b/src/v/datalake/tests/datalake_parquet_tests.cc
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/schema_parquet.h"
+#include "gtest/gtest.h"
+#include "test_utils/randoms.h"
+using namespace testing;
+namespace {
+iceberg::struct_type primitive_types() {
+    iceberg::struct_type primitives;
+    // all possible iceberg primitives
+
+    primitives.fields.push_back(iceberg::nested_field::create(
+      0,
+      "boolean_type_field_0",
+      iceberg::field_required::yes,
+      iceberg::boolean_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      1,
+      "int_type_field_1",
+      iceberg::field_required::yes,
+      iceberg::int_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      2,
+      "long_type_field_2",
+      iceberg::field_required::yes,
+      iceberg::long_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      3,
+      "float_type_field_3",
+      iceberg::field_required::yes,
+      iceberg::float_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      4,
+      "double_type_field_4",
+      iceberg::field_required::yes,
+      iceberg::double_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      5,
+      "decimal_type_field_5",
+      iceberg::field_required::yes,
+      iceberg::decimal_type{.precision = 10, .scale = 2}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      6,
+      "date_type_field_6",
+      iceberg::field_required::yes,
+      iceberg::date_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      7,
+      "time_type_field_7",
+      iceberg::field_required::yes,
+      iceberg::time_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      8,
+      "timestamp_type_field_8",
+      iceberg::field_required::yes,
+      iceberg::timestamp_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      9,
+      "timestamptz_type_field_9",
+      iceberg::field_required::yes,
+      iceberg::timestamptz_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      10,
+      "string_type_field_10",
+      iceberg::field_required::yes,
+      iceberg::string_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      11,
+      "uuid_type_field_11",
+      iceberg::field_required::yes,
+      iceberg::uuid_type{}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      12,
+      "fixed_type_field_12",
+      iceberg::field_required::yes,
+      iceberg::fixed_type{.length = 12}));
+    primitives.fields.push_back(iceberg::nested_field::create(
+      13,
+      "binary_type_field_13",
+      iceberg::field_required::yes,
+      iceberg::binary_type{}));
+
+    return primitives;
+}
+
+/**
+ * Map of type expectations for the primitive types from the schema above
+ */
+std::unordered_map<
+  int,
+  std::tuple<serde::parquet::physical_type, serde::parquet::logical_type>>
+  primitive_type_expectations = {
+    {0, {serde::parquet::bool_type{}, serde::parquet::logical_type{}}},
+    {1,
+     {serde::parquet::i32_type{},
+      serde::parquet::int_type{.bit_width = 32, .is_signed = true}}},
+    {2,
+     {serde::parquet::i64_type{},
+      serde::parquet::int_type{.bit_width = 64, .is_signed = true}}},
+    {3, {serde::parquet::f32_type{}, serde::parquet::logical_type{}}},
+    {4, {serde::parquet::f64_type{}, serde::parquet::logical_type{}}},
+    {5,
+     {serde::parquet::byte_array_type{.fixed_length = 16},
+      serde::parquet::decimal_type{.scale = 2, .precision = 10}}},
+    {6, {serde::parquet::i32_type{}, serde::parquet::date_type{}}},
+    {7,
+     {serde::parquet::i64_type{},
+      serde::parquet::time_type{
+        .is_adjusted_to_utc = false,
+        .unit = serde::parquet::time_unit::micros}}},
+    {8,
+     {serde::parquet::i64_type{},
+      serde::parquet::timestamp_type{
+        .is_adjusted_to_utc = false,
+        .unit = serde::parquet::time_unit::micros}}},
+    {9,
+     {serde::parquet::i64_type{},
+      serde::parquet::timestamp_type{
+        .is_adjusted_to_utc = true,
+        .unit = serde::parquet::time_unit::micros}}},
+    {10, {serde::parquet::byte_array_type{}, serde::parquet::string_type{}}},
+    {11,
+     {serde::parquet::byte_array_type{.fixed_length = 16},
+      serde::parquet::uuid_type{}}},
+    {12,
+     {serde::parquet::byte_array_type{.fixed_length = 12},
+      serde::parquet::logical_type{}}},
+    {13, {serde::parquet::byte_array_type{}, serde::parquet::logical_type{}}}
+
+};
+
+AssertionResult validate_basics(
+  const serde::parquet::schema_element& element,
+  std::string_view expected_name,
+  serde::parquet::field_repetition_type expected_repetition,
+  int expected_field_id) {
+    if (element.name() != expected_name) {
+        return AssertionFailure() << fmt::format(
+                 "Expected name {}, got {}", expected_name, element.name());
+    }
+    if (expected_repetition != element.repetition_type) {
+        return AssertionFailure() << fmt::format(
+                 "Expected repetition type {}, got {}, field name: {}",
+                 static_cast<int>(expected_repetition),
+                 static_cast<int>(element.repetition_type),
+                 element.name());
+    }
+    if (expected_field_id != element.field_id) {
+        return AssertionFailure() << fmt::format(
+                 "Expected field id {}, got {}, field name: {}",
+                 expected_field_id,
+                 element.field_id.value_or(-1),
+                 element.name());
+    }
+
+    return AssertionSuccess();
+}
+
+AssertionResult validate_primitive_element(
+  const serde::parquet::schema_element& element,
+  std::string_view expected_name,
+  serde::parquet::field_repetition_type expected_repetition,
+  int expected_field_id,
+  serde::parquet::physical_type expected_type,
+  serde::parquet::logical_type expected_logical) {
+    auto res = validate_basics(
+      element, expected_name, expected_repetition, expected_field_id);
+    if (!res) {
+        return res;
+    }
+
+    if (!element.children.empty()) {
+        return AssertionFailure() << "Expected leaf node, got group";
+    }
+    if (expected_type != element.type) {
+        return AssertionFailure() << fmt::format(
+                 "Expected physical type {}, got {}, field name: {}",
+                 expected_type.index(),
+                 element.type.index(),
+                 element.name());
+    }
+    if (expected_logical != element.logical_type) {
+        return AssertionFailure() << fmt::format(
+                 "Expected logical type {}, got {}, field name: {}",
+                 expected_logical.index(),
+                 element.logical_type.index(),
+                 element.name());
+    }
+
+    return AssertionSuccess();
+}
+
+AssertionResult primitive_schema_matches(
+  const serde::parquet::schema_element& element,
+  const iceberg::struct_type& primitive_schema) {
+    if (element.children.size() != 14) {
+        return AssertionFailure()
+               << "Expected 14 children, got " << element.children.size();
+    }
+    const auto match_primitive_field = [&](
+                                         int id,
+                                         serde::parquet::physical_type p_type,
+                                         serde::parquet::logical_type l_type) {
+        return validate_primitive_element(
+          element.children[id],
+          primitive_schema.fields[id]->name,
+          primitive_schema.fields[id]->required
+            ? serde::parquet::field_repetition_type::required
+            : serde::parquet::field_repetition_type::optional,
+          primitive_schema.fields[id]->id,
+          p_type,
+          l_type);
+    };
+    for (auto i = 0; i < 14; i++) {
+        auto& [p_type, l_type] = primitive_type_expectations[i];
+        auto res = match_primitive_field(i, p_type, l_type);
+        if (!res) {
+            return AssertionFailure() << res.failure_message();
+        }
+    }
+
+    return AssertionSuccess();
+}
+
+iceberg::struct_type list_types() {
+    iceberg::struct_type lists;
+
+    lists.fields.push_back(iceberg::nested_field::create(
+      0,
+      "required_booleans",
+      iceberg::field_required::yes,
+      iceberg::list_type{
+        .element_field = iceberg::nested_field::create(
+          1,
+          "element_field",
+          iceberg::field_required::yes,
+          iceberg::boolean_type{})}));
+    lists.fields.push_back(iceberg::nested_field::create(
+      1,
+      "optional_longs",
+      iceberg::field_required::yes,
+      iceberg::list_type{
+        .element_field = iceberg::nested_field::create(
+          1,
+          "element_field",
+          iceberg::field_required::no,
+          iceberg::long_type{})}));
+    lists.fields.push_back(iceberg::nested_field::create(
+      2,
+      "optional_top_level_decimals",
+      iceberg::field_required::no,
+      iceberg::list_type{
+        .element_field = iceberg::nested_field::create(
+          1,
+          "element_field",
+          iceberg::field_required::yes,
+          iceberg::decimal_type{.precision = 4, .scale = 12})}));
+
+    lists.fields.push_back(iceberg::nested_field::create(
+      3,
+      "structs",
+      iceberg::field_required::yes,
+      iceberg::list_type{
+        .element_field = iceberg::nested_field::create(
+          1,
+          "element_field",
+          iceberg::field_required::yes,
+          primitive_types())}));
+    return lists;
+}
+
+AssertionResult validate_list(
+  const serde::parquet::schema_element& element,
+  const iceberg::nested_field_ptr& list_schema,
+  serde::parquet::physical_type expected_type,
+  serde::parquet::logical_type expected_logical) {
+    if (element.children.size() != 1) {
+        return AssertionFailure() << "List is expected to have exactly 1 child "
+                                     "schema, current have: "
+                                  << element.children.size();
+    }
+    if (element.name() != list_schema->name) {
+        return AssertionFailure() << fmt::format(
+                 "Expected list name {}, got {}",
+                 list_schema->name,
+                 element.name());
+    }
+    if (element.field_id != list_schema->id) {
+        return AssertionFailure() << fmt::format(
+                 "Expected field id {}, got {}",
+                 list_schema->id,
+                 element.field_id.value_or(-1));
+    }
+    if (list_schema->required) {
+        if (
+          element.repetition_type
+          != serde::parquet::field_repetition_type::required) {
+            return AssertionFailure() << fmt::format(
+                     "Expected required repetition type, got {}",
+                     static_cast<int>(element.repetition_type));
+        }
+    }
+
+    if (!std::holds_alternative<serde::parquet::list_type>(
+          element.logical_type)) {
+        return AssertionFailure() << fmt::format(
+                 "Expected top level list element to have list type, got {}",
+                 element.logical_type.index());
+    }
+    auto& container = element.children[0];
+    if (container.name() != "list") {
+        return AssertionFailure() << fmt::format(
+                 "Expected list container name to be 'list', got '{}'",
+                 container.name());
+    }
+    if (
+      container.repetition_type
+      != serde::parquet::field_repetition_type::repeated) {
+        return AssertionFailure() << fmt::format(
+                 "Expected list container repetition type to be repeated, got "
+                 "'{}'",
+                 static_cast<int>(container.repetition_type));
+    }
+    if (!std::holds_alternative<std::monostate>(container.type)) {
+        return AssertionFailure() << fmt::format(
+                 "Expected list container type to be empty, got '{}'",
+                 container.type.index());
+    }
+    if (!std::holds_alternative<std::monostate>(container.logical_type)) {
+        return AssertionFailure() << fmt::format(
+                 "Expected list container logical_type to be empty, got '{}'",
+                 container.logical_type.index());
+    }
+    if (container.children.size() != 1) {
+        return AssertionFailure() << fmt::format(
+                 "Expected list container to have 1 child, got {}",
+                 container.children.size());
+    }
+    auto& list_element = container.children[0];
+
+    return validate_primitive_element(
+      list_element,
+      "element",
+      std::get<iceberg::list_type>(list_schema->type).element_field->required
+        ? serde::parquet::field_repetition_type::required
+        : serde::parquet::field_repetition_type::optional,
+      1,
+      expected_type,
+      expected_logical);
+}
+iceberg::struct_type map_types() {
+    iceberg::struct_type maps;
+    auto primitive = primitive_types();
+
+    for (auto& f : primitive.fields) {
+        auto value_type_idx = random_generators::get_int(
+          primitive.fields.size() - 1);
+
+        auto map = iceberg::map_type::create(
+          f->id,
+          iceberg::make_copy(f->type),
+          value_type_idx,
+          tests::random_bool() ? iceberg::field_required::yes
+                               : iceberg::field_required::no,
+          iceberg::make_copy(primitive.fields[value_type_idx]->type));
+        maps.fields.push_back(iceberg::nested_field::create(
+          f->id, f->name, f->required, std::move(map)));
+    }
+    auto key_type_idx = random_generators::get_int(primitive.fields.size() - 1);
+
+    auto map = iceberg::map_type::create(
+      key_type_idx,
+      iceberg::make_copy(primitive.fields[key_type_idx]->type),
+      0,
+      iceberg::field_required::yes,
+      primitive_types());
+
+    maps.fields.push_back(iceberg::nested_field::create(
+      15, "nested_struct_map", iceberg::field_required::yes, std::move(map)));
+
+    return maps;
+}
+} // namespace
+
+TEST(DatalakeParquetSchema, EmptySchemaConversionTest) {
+    iceberg::struct_type schema;
+    auto parquet_schema = datalake::schema_to_parquet(schema);
+    ASSERT_EQ(parquet_schema.name(), "root");
+    ASSERT_TRUE(parquet_schema.children.empty());
+    ASSERT_EQ(
+      parquet_schema.repetition_type,
+      serde::parquet::field_repetition_type::required);
+}
+
+TEST(DatalakeParquetSchema, PrimitiveTypes) {
+    auto schema = primitive_types();
+    // make random fields optional
+    for (auto& f : schema.fields) {
+        if (tests::random_bool()) {
+            f->required = iceberg::field_required::no;
+        }
+    }
+    auto parquet_schema = datalake::schema_to_parquet(schema);
+    ASSERT_EQ(parquet_schema.name(), "root");
+    ASSERT_EQ(parquet_schema.children.size(), 14);
+    ASSERT_TRUE(primitive_schema_matches(parquet_schema, schema));
+}
+
+TEST(DatalakeParquetSchema, Lists) {
+    auto schema = list_types();
+    auto parquet_schema = datalake::schema_to_parquet(schema);
+    ASSERT_EQ(parquet_schema.name(), "root");
+    ASSERT_EQ(parquet_schema.children.size(), 4);
+
+    ASSERT_TRUE(validate_list(
+      parquet_schema.children[0],
+      schema.fields[0],
+      serde::parquet::bool_type{},
+      serde::parquet::logical_type{}));
+
+    ASSERT_TRUE(validate_list(
+      parquet_schema.children[1],
+      schema.fields[1],
+      serde::parquet::i64_type{},
+      serde::parquet::int_type{.bit_width = 64, .is_signed = true}));
+
+    ASSERT_TRUE(validate_list(
+      parquet_schema.children[2],
+      schema.fields[2],
+      serde::parquet::byte_array_type{.fixed_length = 16},
+      serde::parquet::decimal_type{
+        .scale = 12,
+        .precision = 4,
+      }));
+
+    auto& nested_struct_list = parquet_schema.children[3];
+    ASSERT_TRUE(validate_basics(
+      nested_struct_list,
+      schema.fields[3]->name,
+      serde::parquet::field_repetition_type::required,
+      schema.fields[3]->id));
+    ASSERT_EQ(nested_struct_list.children.size(), 1);
+    ASSERT_EQ(nested_struct_list.children[0].name(), "list");
+    ASSERT_EQ(
+      nested_struct_list.children[0].repetition_type,
+      serde::parquet::field_repetition_type::repeated);
+    auto& element_schema = nested_struct_list.children[0].children[0];
+    ASSERT_TRUE(primitive_schema_matches(element_schema, primitive_types()));
+}
+
+TEST(DatalakeParquetSchema, Maps) {
+    for (int i = 0; i < 2000; ++i) {
+        auto schema = map_types();
+        auto parquet_schema = datalake::schema_to_parquet(schema);
+        ASSERT_EQ(parquet_schema.name(), "root");
+        ASSERT_EQ(parquet_schema.children.size(), 15);
+        for (int i = 0; i < 15; i++) {
+            auto& map = parquet_schema.children[i];
+            ASSERT_TRUE(validate_basics(
+              map,
+              schema.fields[i]->name,
+              schema.fields[i]->required
+                ? serde::parquet::field_repetition_type::required
+                : serde::parquet::field_repetition_type::optional,
+              schema.fields[i]->id));
+            // check map key_value wrapper
+            ASSERT_EQ(map.children.size(), 1);
+            ASSERT_EQ(map.children[0].name(), "key_value");
+            ASSERT_EQ(
+              map.children[0].repetition_type,
+              serde::parquet::field_repetition_type::repeated);
+            ASSERT_EQ(map.children[0].children.size(), 2);
+            // validation of nested struct map is handled separately
+            if (i >= 14) {
+                continue;
+            }
+            auto& key_element = map.children[0].children[0];
+            auto& value_element = map.children[0].children[1];
+            auto& [key_physical_type, key_logical_type]
+              = primitive_type_expectations[schema.fields[i]->id];
+            // when preparing test data we set a value field id to match the
+            // primitive type used as a value
+            auto value_idx = std::get<iceberg::map_type>(schema.fields[i]->type)
+                               .value_field->id;
+            auto value_required = std::get<iceberg::map_type>(
+                                    schema.fields[i]->type)
+                                    .value_field->required;
+            auto& [value_physical_type, value_logical_type]
+              = primitive_type_expectations[value_idx];
+
+            ASSERT_TRUE(validate_primitive_element(
+              key_element,
+              "key",
+              serde::parquet::field_repetition_type::required,
+              i,
+              key_physical_type,
+              key_logical_type));
+
+            ASSERT_TRUE(validate_primitive_element(
+              value_element,
+              "value",
+              value_required ? serde::parquet::field_repetition_type::required
+                             : serde::parquet::field_repetition_type::optional,
+              value_idx,
+              value_physical_type,
+              value_logical_type));
+        }
+    }
+}
+
+TEST(DatalakeParquetSchema, NestedStruct) {
+    iceberg::struct_type schema;
+    auto nested = primitive_types();
+    schema.fields.push_back(iceberg::nested_field::create(
+      0,
+      "nested_struct",
+      iceberg::field_required::yes,
+      iceberg::make_copy(primitive_types())));
+
+    auto parquet_schema = datalake::schema_to_parquet(schema);
+    ASSERT_EQ(parquet_schema.name(), "root");
+    ASSERT_EQ(parquet_schema.children.size(), 1);
+    ASSERT_EQ(parquet_schema.children[0].name(), "nested_struct");
+    ASSERT_TRUE(
+      primitive_schema_matches(parquet_schema.children[0], primitive_types()));
+}

--- a/src/v/serde/CMakeLists.txt
+++ b/src/v/serde/CMakeLists.txt
@@ -12,3 +12,5 @@ v_cc_library(
 add_subdirectory(protobuf)
 add_subdirectory(avro)
 add_subdirectory(test)
+add_subdirectory(parquet)
+add_subdirectory(thrift)

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -14,4 +14,5 @@ v_cc_library(
     v::bytes
     v::container
     v::utils
+    v::serde_thrift
   )


### PR DESCRIPTION
Added a function that translates the Iceberg schema to Parquet file schema that is necessary to write the Parquet files.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 