### PR TITLE
`net`: use `vlog()` macro in `transport.cc` logging

### DIFF
--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -18,7 +18,7 @@ ss::future<ss::connected_socket> connect_with_timeout(
     auto f = socket->connect(address).finally([socket] {});
     return ss::with_timeout(timeout, std::move(f))
       .handle_exception([socket, address, log](const std::exception_ptr& e) {
-          log->trace("error connecting to {} - {}", address, e);
+          vlog(log->trace, "error connecting to {} - {}", address, e);
           socket->shutdown();
           return ss::make_exception_future<ss::connected_socket>(e);
       });
@@ -73,7 +73,7 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
         if (auto* p = _probe.value_or(nullptr); p != nullptr) {
             p->connection_error();
         }
-        _log->trace("Connection error: {}", e);
+        vlog(_log->trace, "Connection error: {}", e);
         std::rethrow_exception(e);
     }
 


### PR DESCRIPTION
There were two locations in which the `seastar::logger` was being used directly in `transport.cc` instead of the `vlog()` macro we default to using in `redpanda`.

Alter those two logging sites to use the `vlog()` macro.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
