### PR TITLE
[v24.1.x] CORE-8082 cloud_io: add missing error handling to 

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -863,12 +863,18 @@ remote::download_object(cloud_storage::download_request download_request) {
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
-            auto buffer
-              = co_await cloud_storage_clients::util::drain_response_stream(
-                resp.value());
-            download_request.payload.append_fragments(std::move(buffer));
-            transfer_details.on_success(_probe);
-            co_return download_result::success;
+            try {
+                auto buffer
+                  = co_await cloud_storage_clients::util::drain_response_stream(
+                    resp.value());
+                download_request.payload.append_fragments(std::move(buffer));
+                transfer_details.on_success(_probe);
+                co_return download_result::success;
+            } catch (...) {
+                resp
+                  = cloud_storage_clients::util::handle_client_transport_error(
+                    std::current_exception(), ctxlog);
+            }
         }
 
         lease.client->shutdown();

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -24,8 +24,9 @@ namespace cloud_storage_clients::util {
 /// cloud provider (e.g. connection error).
 /// \param current_exception is the current exception thrown by the client
 /// \param logger is the logger to use
+template<typename Logger>
 error_outcome handle_client_transport_error(
-  std::exception_ptr current_exception, ss::logger& logger);
+  std::exception_ptr current_exception, Logger& logger);
 
 /// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
 /// iobuf


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24059 

Fixes https://github.com/redpanda-data/redpanda/issues/24077

Cherry pick conflicts:
 * BAZEL build not present earlier
 * `remote.cc` has moved to a different path