### PR TITLE
[v24.2.x] CORE-8082 cloud_io: add missing error handling to 

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -854,12 +854,18 @@ remote::download_object(cloud_storage::download_request download_request) {
 
         if (resp) {
             vlog(ctxlog.debug, "Receive OK response from {}", path);
-            auto buffer
-              = co_await cloud_storage_clients::util::drain_response_stream(
-                resp.value());
-            download_request.payload.append_fragments(std::move(buffer));
-            transfer_details.on_success(_probe);
-            co_return download_result::success;
+            try {
+                auto buffer
+                  = co_await cloud_storage_clients::util::drain_response_stream(
+                    resp.value());
+                download_request.payload.append_fragments(std::move(buffer));
+                transfer_details.on_success(_probe);
+                co_return download_result::success;
+            } catch (...) {
+                resp
+                  = cloud_storage_clients::util::handle_client_transport_error(
+                    std::current_exception(), ctxlog);
+            }
         }
 
         lease.client->shutdown();

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -53,6 +53,7 @@ redpanda_cc_library(
         "//src/v/utils:functional",
         "//src/v/utils:log_hist",
         "//src/v/utils:named_type",
+        "//src/v/utils:retry_chain_node",
         "//src/v/utils:stop_signal",
         "@boost//:beast",
         "@boost//:lexical_cast",

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "bytes/streambuf.h"
 #include "net/connection.h"
+#include "utils/retry_chain_node.h"
 
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -39,8 +40,9 @@ bool has_abort_or_gate_close_exception(const ss::nested_exception& ex) {
            || is_abort_or_gate_close_exception(ex.outer);
 }
 
+template<typename Logger>
 error_outcome handle_client_transport_error(
-  std::exception_ptr current_exception, ss::logger& logger) {
+  std::exception_ptr current_exception, Logger& logger) {
     auto outcome = error_outcome::retry;
 
     try {
@@ -112,6 +114,11 @@ error_outcome handle_client_transport_error(
 
     return outcome;
 }
+
+template error_outcome
+handle_client_transport_error<ss::logger>(std::exception_ptr, ss::logger&);
+template error_outcome handle_client_transport_error<retry_chain_logger>(
+  std::exception_ptr, retry_chain_logger&);
 
 ss::future<iobuf>
 drain_response_stream(http::client::response_stream_ref resp) {

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -24,8 +24,9 @@ namespace cloud_storage_clients::util {
 /// cloud provider (e.g. connection error).
 /// \param current_exception is the current exception thrown by the client
 /// \param logger is the logger to use
+template<typename Logger>
 error_outcome handle_client_transport_error(
-  std::exception_ptr current_exception, ss::logger& logger);
+  std::exception_ptr current_exception, Logger& logger);
 
 /// \brief: Drain the reponse stream pointed to by the 'resp' handle into an
 /// iobuf


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24059 

Fixes https://github.com/redpanda-data/redpanda/issues/24076

Cherry pick conflicts:
 * `remote.cc` has moved to a different path