### PR TITLE
[CORE-8042] cluster: Sanction redpanda.leaders.preference on invalid license - alter config

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -158,6 +158,15 @@ std::vector<std::string_view> get_enterprise_features(
         features.emplace_back("schema id validation");
     }
 
+    if (const auto& updated_pref = updated_properties.leaders_preference;
+        updated_pref != properties.leaders_preference
+        && updated_pref.has_value()
+        && config::shard_local_cfg()
+             .default_leaders_preference.check_restricted(
+               updated_pref.value())) {
+        features.emplace_back("leadership pinning");
+    }
+
     return features;
 }
 


### PR DESCRIPTION
Implements: [CORE-8042](https://redpandadata.atlassian.net/browse/CORE-8042) - Sanctions 20 and 21

Implement sanction(s) on leadership pinning properties when there is no valid license:

 - If there is no valid license, request to change `redpanda.leaders.preference` will be accepted only if it is to a non-restricted value.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none


[CORE-8042]: https://redpandadata.atlassian.net/browse/CORE-8042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ