### PR TITLE
cluster: improve role-acl create sanction message

### DIFF
--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -234,7 +234,9 @@ ss::future<std::vector<errc>> security_frontend::do_create_acls(
     if (should_sanction) {
         err = errc::feature_disabled;
         vlog(
-          clusterlog.warn, "Found Role-ACL bindings in request, ignoring...");
+          clusterlog.warn,
+          "An enterprise license is required to create an ACL with a role "
+          "binding");
     } else {
         try {
             create_acls_cmd_data data;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1585,8 +1585,8 @@ ss::future<response_ptr> create_acls_handler::handle(
                 creatable_acl_result{.error_code = ec});
               if (results[i] == cluster::errc::feature_disabled) {
                   response.data.results.back().error_message.emplace(
-                    "An enterprise license is required to create "
-                    "Role-bound ACLs");
+                    "An enterprise license is required to create an ACL with a "
+                    "role binding");
               }
           },
           [&response](creatable_acl_result r) {


### PR DESCRIPTION
When a user tries to create a Role-bound ACL, we return an UNKNOWN_SERVER_ERROR to the Kafka API request and print this log message.

This log message should clarify that the reason for rejecting the ACL creation request was that the user was trying to create a Role-bound ACL without a valid enterprise license.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
