### PR TITLE
[CORE-8001] Implement sanctions for create partition

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -67,12 +67,11 @@
 
 namespace {
 
-std::vector<std::string_view> get_enterprise_features(
-  const cluster::custom_assignable_topic_configuration& cfg) {
+std::vector<std::string_view>
+get_enterprise_features(const cluster::topic_configuration& cfg) {
     std::vector<std::string_view> features;
     const auto si_disabled = model::shadow_indexing_mode::disabled;
-    if (
-      cfg.cfg.properties.shadow_indexing.value_or(si_disabled) != si_disabled) {
+    if (cfg.properties.shadow_indexing.value_or(si_disabled) != si_disabled) {
         features.emplace_back("tiered storage");
     }
     if (cfg.is_recovery_enabled()) {
@@ -84,7 +83,7 @@ std::vector<std::string_view> get_enterprise_features(
     if (cfg.is_schema_id_validation_enabled()) {
         features.emplace_back("schema ID validation");
     }
-    if (const auto& leaders_pref = cfg.cfg.properties.leaders_preference;
+    if (const auto& leaders_pref = cfg.properties.leaders_preference;
         leaders_pref.has_value()
         && config::shard_local_cfg()
              .default_leaders_preference.check_restricted(
@@ -563,7 +562,8 @@ errc topics_frontend::validate_topic_configuration(
     if (
       _features.local().should_sanction()
       && is_user_topic(assignable_config.cfg.tp_ns)) {
-        if (auto f = get_enterprise_features(assignable_config); !f.empty()) {
+        if (auto f = get_enterprise_features(assignable_config.cfg);
+            !f.empty()) {
             vlog(
               clusterlog.warn,
               "An enterprise license is required to enable {}.",

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(srcs
   topic_recreate_test.cc
   fetch_session_test.cc
   alter_config_test.cc
+  create_partition_test.cc
   produce_consume_test.cc
   group_metadata_serialization_test.cc
   partition_reassignments_test.cc

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -43,6 +43,7 @@ inline ss::logger test_log("test"); // NOLINT
 
 class alter_config_test_fixture : public topic_properties_test_fixture {
 public:
+    using topic_properties_test_fixture::create_topic;
     void create_topic(
       model::topic name,
       int partitions,
@@ -58,53 +59,6 @@ public:
                 model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(i)),
                 model::offset(0));
           })
-          .get();
-    }
-
-    template<typename Func>
-    auto do_with_client(Func&& f) {
-        return make_kafka_client().then(
-          [f = std::forward<Func>(f)](kafka::client::transport client) mutable {
-              return ss::do_with(
-                std::move(client),
-                [f = std::forward<Func>(f)](
-                  kafka::client::transport& client) mutable {
-                    return client.connect().then(
-                      [&client, f = std::forward<Func>(f)]() mutable {
-                          return f(client);
-                      });
-                });
-          });
-    }
-
-    kafka::create_topics_response create_topic(
-      const model::topic& tp,
-      const absl::flat_hash_map<ss::sstring, ss::sstring>& properties,
-      int num_partitions = 1,
-      int16_t replication_factor = 1) {
-        kafka::creatable_topic topic{
-          .name = model::topic(tp),
-          .num_partitions = num_partitions,
-          .replication_factor = replication_factor,
-        };
-        for (auto& [k, v] : properties) {
-            kafka::createable_topic_config config;
-            config.name = k;
-            config.value = v;
-            topic.configs.push_back(std::move(config));
-        }
-
-        auto req = kafka::create_topics_request{.data{
-          .topics = {topic},
-          .timeout_ms = 10s,
-          .validate_only = false,
-        }};
-
-        return do_with_client([req = std::move(req)](
-                                kafka::client::transport& client) mutable {
-                   return client.dispatch(
-                     std::move(req), kafka::api_version(0));
-               })
           .get();
     }
 

--- a/src/v/kafka/server/tests/create_partition_test.cc
+++ b/src/v/kafka/server/tests/create_partition_test.cc
@@ -1,0 +1,84 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/configuration.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/server/tests/topic_properties_helpers.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/defer.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <boost/test/tools/context.hpp>
+
+using namespace std::chrono_literals; // NOLINT
+
+inline ss::logger test_log("test"); // NOLINT
+
+FIXTURE_TEST(
+  test_unlicensed_topic_prop_create_partition, topic_properties_test_fixture) {
+    using props_t = absl::flat_hash_map<ss::sstring, ss::sstring>;
+    using test_t = std::pair<std::string_view, props_t>;
+    const auto with = [](const std::string_view prop, const auto value) {
+        return std::make_pair(
+          prop, props_t{{ss::sstring{prop}, ssx::sformat("{}", value)}});
+    };
+
+    update_cluster_config(lconf().enable_schema_id_validation.name(), "compat");
+
+    std::initializer_list<test_t> enterprise_props{
+      // si_props
+      // The following properties are not supported for Create Partition
+      //  * kafka::topic_property_recovery
+      //  * kafka::topic_property_read_replica
+      with(kafka::topic_property_remote_read, true),
+      with(kafka::topic_property_remote_write, true),
+      // schema id validation
+      with(kafka::topic_property_record_key_schema_id_validation, true),
+      with(kafka::topic_property_record_key_schema_id_validation_compat, true),
+      with(kafka::topic_property_record_value_schema_id_validation, true),
+      with(
+        kafka::topic_property_record_value_schema_id_validation_compat, true),
+      // pin_leadership_props
+      with(
+        kafka::topic_property_leaders_preference,
+        config::leaders_preference{
+          .type = config::leaders_preference::type_t::racks,
+          .racks = {model::rack_id{"A"}}})};
+
+    const int32_t partitions = 3;
+
+    for (const auto& [prop, props] : enterprise_props) {
+        BOOST_TEST_CONTEXT(fmt::format("property: {}", prop)) {
+            auto tp = model::topic{ssx::sformat("{}", prop)};
+
+            auto c_res = create_topic(tp, props, 3).data;
+            BOOST_REQUIRE_EQUAL(c_res.topics.size(), 1);
+            BOOST_REQUIRE_EQUAL(
+              c_res.topics[0].error_code, kafka::error_code::none);
+
+            revoke_license();
+
+            auto res = create_partitions(tp, partitions + 1).data;
+            BOOST_REQUIRE_EQUAL(res.results.size(), 1);
+            BOOST_CHECK_EQUAL(
+              res.results[0].error_code, kafka::error_code::invalid_config);
+
+            delete_topic(
+              model::topic_namespace{model::kafka_namespace, std::move(tp)})
+              .get();
+
+            reinstall_license();
+        }
+    }
+}


### PR DESCRIPTION
Implement sanctions for create partition

Notes to reviewer:
* Should we check the same set of sanctioned properties for create topic and create partition?


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
