### PR TITLE
[v24.1.x] storage: remove assertion on `is_cloud_retention_active`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1284,8 +1284,13 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
         const auto offset = _cloud_gc_offset.value();
         _cloud_gc_offset.reset();
 
-        vassert(
-          is_cloud_retention_active(), "Expected remote retention active");
+        if (!is_cloud_retention_active()) {
+            vlog(
+              gclog.warn,
+              "[{}] expected remote retention to be active",
+              config().ntp());
+            co_return std::nullopt;
+        }
 
         vlog(
           gclog.info,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23936
