### PR TITLE
dt: increase redpanda start timeout to 40s

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1296,7 +1296,7 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
     TEMP_OSSL_CONFIG_FILE = "/etc/openssl.cnf"
-    DEFAULT_NODE_READY_TIMEOUT_SEC = 30
+    DEFAULT_NODE_READY_TIMEOUT_SEC = 40
     NODE_READY_TIMEOUT_MIN_SEC_KEY = "node_ready_timeout_min_sec"
     DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC = 60
     DEDICATED_NODE_KEY = "dedicated_nodes"


### PR DESCRIPTION
In Azure CDT tests we are seeing that starting redpanda occasionally takes longer than 30s. This seems to be because of disk access, in particular creating directories, being slow while redpanda is starting up.

We have increased the timeout from 20s to 30s in the past for this reason, but we are still seeing startup taking longer than 30s, so this increases the timeout further to 40s.

Fixes https://redpandadata.atlassian.net/browse/CORE-8184

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
