### PR TITLE
auditing: construct metrics probe during service construction

### DIFF
--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -283,7 +283,7 @@ private:
         return true;
     }
 
-    audit_probe& probe() { return *_probe; }
+    audit_probe& probe() { return _probe; }
 
     template<security::audit::returns_auditable_resource_vector Func>
     auto restrict_topics(Func&& func) const noexcept {
@@ -401,6 +401,10 @@ private:
     underlying_t _queue;
     ssx::semaphore _active_drain{1, "audit-drain"};
 
+    // Probe is mutable so it can be modified in const methods when they need to
+    // report auditing failures
+    mutable audit_probe _probe;
+
     /// Single instance contains a kafka::client::client instance.
     friend class audit_sink;
     std::unique_ptr<audit_sink> _sink;
@@ -409,7 +413,6 @@ private:
     model::node_id _self;
     cluster::controller* _controller;
     kafka::client::configuration& _config;
-    std::unique_ptr<audit_probe> _probe;
 
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
 };


### PR DESCRIPTION
Move the construction of the audit probe from service start to service construction. Previously, the audit probe was created as a unique pointer when the service was started and destroyed when the service stopped.

Since the audit service has the same lifespan as the application, creating the probe during service construction reduces the risk of dereferencing a null pointer if the probe is accessed before the service has started.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.2.x
- [X] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Construct audit metrics probe during service initialization to prevent null pointer access.
