### PR TITLE
fix "Unexpected EOF" log errors

### DIFF
--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -56,7 +56,7 @@ parse_v1_header(ss::input_stream<char>& src) {
 
     if (unlikely(client_id_size < 0)) {
         // header parsing error, force connection shutdown
-        throw std::runtime_error(
+        throw malformed_header_exception(
           fmt::format("Invalid client_id size {}", client_id_size));
     }
 

--- a/src/v/kafka/server/protocol_utils.h
+++ b/src/v/kafka/server/protocol_utils.h
@@ -13,6 +13,7 @@
 
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "net/types.h"
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/scattered_message.hh>
@@ -25,5 +26,11 @@ namespace kafka {
 ss::future<std::optional<request_header>> parse_header(ss::input_stream<char>&);
 
 ss::scattered_message<char> response_as_scattered(response_ptr response);
+
+class malformed_header_exception : public net::parsing_exception {
+public:
+    explicit malformed_header_exception(const std::string& m)
+      : net::parsing_exception(m) {}
+};
 
 } // namespace kafka

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -90,10 +90,11 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         // Happens on unclean client disconnect, when io_iterator_consumer
         // gets fewer bytes than it wanted
         return "short read";
-    } catch (const net::parsing_exception&) {
+    } catch (const net::parsing_exception& e) {
         // Happens on unclean client disconnect, typically wrapping
-        // an out_of_range
-        return "parse error";
+        // an out_of_range.
+        // Also raised from the kafka protocol layer on bad header
+        return ssx::sformat("parse error: {}", e.what());
     } catch (const invalid_request_error& e) {
         if (std::strlen(e.what())) {
             return fmt::format("invalid request: {}", e.what());

--- a/src/v/net/types.h
+++ b/src/v/net/types.h
@@ -32,6 +32,14 @@ protected:
       : std::runtime_error(m) {}
 };
 
-class parsing_exception : public std::exception {};
+class parsing_exception : public std::runtime_error {
+public:
+    parsing_exception()
+      : std::runtime_error("") {}
+
+protected:
+    explicit parsing_exception(const std::string& m)
+      : std::runtime_error(m) {}
+};
 
 } // namespace net


### PR DESCRIPTION
This PR updates `kafka::server` with a new exception type `malformed_header_exception`, which extends `net::parsing_exception`, and modifies `kafka::parse_v1_header` to raise one of those rather than a `std::runtime_error` when we receive a junk header from a client, which happens occasionally and previously would fail log ERROR checks in ducktape.

These will be identified by `net::is_disconnect_exception` and logged at INFO level, along with other "boring" client errors.

PR also modifies `net::parsing_error` slightly to extend `std::runtime_error` rather than `std::exception` so derived exception types can provide a message.

In principle, fixes:

CORE-8134
CORE-8059
CORE-7883
CORE-7324
CORE-6895

TODO:
- [x] Needs a CDT run - most of the logged failures were under CDT, specifically azure. Not sure why; perhaps just more likely to occur w/ actual cloud networking in the loop.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
