### PR TITLE
Fix race between bootstrap and shutdown

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -828,6 +828,13 @@ ss::future<> controller::shutdown_input() {
     if (_metadata_uploader) {
         _metadata_uploader->stop();
     }
+
+    co_await ss::smp::submit_to(controller_stm_shard, [&stm = _stm] {
+        if (stm.local_is_initialized()) {
+            stm.local().shutdown_apply_loop();
+        }
+    });
+
     co_await _as.invoke_on_all(&ss::abort_source::request_abort);
     vlog(clusterlog.debug, "Shut down controller inputs");
 }
@@ -839,16 +846,13 @@ ss::future<> controller::stop() {
         co_await shutdown_input();
     }
 
+    co_await ss::smp::submit_to(controller_stm_shard, [&stm = _stm] {
+        return stm.local_is_initialized() ? stm.local().shutdown() : ss::now();
+    });
+
     if (_leader_balancer) {
         co_await _leader_balancer->stop();
     }
-
-    co_await ss::smp::submit_to(controller_stm_shard, [&stm = _stm] {
-        if (stm.local_is_initialized()) {
-            return stm.local().shutdown();
-        }
-        return ss::now();
-    });
 
     if (_metadata_uploader) {
         co_await _metadata_uploader->stop_and_wait();

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -38,6 +38,7 @@ ss::future<> controller_stm::on_batch_applied() {
         _snapshot_debounce_timer.arm(_snapshot_max_age());
     };
 }
+void controller_stm::shutdown_apply_loop() { _as.request_abort(); }
 
 ss::future<> controller_stm::shutdown() {
     _snapshot_debounce_timer.cancel();

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -71,6 +71,7 @@ public:
         return _limiter.throttle<Cmd>();
     }
 
+    void shutdown_apply_loop();
     ss::future<> shutdown();
 
     virtual ss::future<> stop() final;

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -33,7 +33,8 @@ ss::future<> state_machine::start() {
     vlog(_log.debug, "Starting state machine for ntp={}", _raft->ntp());
     ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
-          [this] { return _gate.is_closed(); }, [this] { return apply(); });
+          [this] { return _as.abort_requested() || _gate.is_closed(); },
+          [this] { return apply(); });
     });
     return ss::now();
 }

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -179,14 +179,10 @@ ss::future<> state_machine::apply() {
             _raft->ntp());
       })
       .handle_exception([this](const std::exception_ptr& e) {
-          // do not log shutdown exceptions not to pollute logs with irrelevant
-          // errors
-          if (ssx::is_shutdown_exception(e)) {
-              return;
-          }
-
-          vlog(
-            _log.error,
+          vlogl(
+            _log,
+            ssx::is_shutdown_exception(e) ? ss::log_level::trace
+                                          : ss::log_level::error,
             "State machine for ntp={} caught exception {}",
             _raft->ntp(),
             e);

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -55,7 +55,9 @@ ss::future<> state_machine::handle_raft_snapshot() {
 ss::future<> state_machine::stop() {
     vlog(_log.debug, "Asked to stop state_machine {}", _raft->ntp());
     _waiters.stop();
-    _as.request_abort();
+    if (!_as.abort_requested()) {
+        _as.request_abort();
+    }
     return _gate.close().then([this] {
         vlog(_log.debug, "state_machine is stopped {}", _raft->ntp());
     });

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -119,6 +119,7 @@ protected:
 
     consensus* _raft;
     ss::gate _gate;
+    ss::abort_source _as;
 
 private:
     class batch_applicator {
@@ -141,7 +142,6 @@ private:
     ss::logger& _log;
     offset_monitor _waiters;
     model::offset _next;
-    ss::abort_source _as;
     model::offset _bootstrap_last_applied;
 };
 

--- a/tests/rptest/tests/quick_terminate_test.py
+++ b/tests/rptest/tests/quick_terminate_test.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+from rptest.services.cluster import cluster
+
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.tests.e2e_finjector import Finjector
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+
+
+class QuickTerminateTest(PreallocNodesTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super().__init__(test_ctx,
+                         num_brokers=3,
+                         *args,
+                         node_prealloc_count=1,
+                         **kwargs)
+
+    @cluster(num_nodes=3, log_allow_list=Finjector.LOG_ALLOW_LIST)
+    def test_terminate(self):
+        for _ in range(10):
+            node = random.choice(self.redpanda.started_nodes())
+            self.redpanda.stop_node(node)
+            time.sleep(random.uniform(0, 1))
+            self.redpanda.start_node(node, skip_readiness_check=True)
+            time.sleep(random.uniform(0, 1))


### PR DESCRIPTION
This is to fix `'_id_by_uuid.empty()' will not overwrite existing data` assert that happens if we shut down shortly after startup, which is not uncommon when testing with failure injector.
https://redpandadata.atlassian.net/browse/CORE-7799
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
