### PR TITLE
datalake/avro: fixed encoding decimal values

### DIFF
--- a/src/v/iceberg/tests/values_avro_test.cc
+++ b/src/v/iceberg/tests/values_avro_test.cc
@@ -113,3 +113,35 @@ TEST(ValuesAvroTest, TestDecimalConversionsLimitedSize) {
     ASSERT_EQ(
       decimal, iobuf_to_avro_decimal(avro_decimal_to_iobuf(decimal, 8)));
 }
+
+TEST(ValuesAvroTest, TestDecimalConversionAgainstJavaBigInteger) {
+    // value of 65536
+    ASSERT_EQ(
+      encode_avro_decimal(absl::MakeInt128(0, 65536)),
+      bytes({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}));
+    // value of 35209893291843950283695459221
+    ASSERT_EQ(
+      encode_avro_decimal(absl::MakeInt128(1908732140, 89247320981)),
+      bytes({0, 0, 0, 0, 113, 196, 240, 236, 0, 0, 0, 20, 199, 142, 11, 149}));
+
+    // value of -18218949492341193300753118315
+    ASSERT_EQ(
+      encode_avro_decimal(absl::MakeInt128(-987651231, 89247320981)),
+      bytes(
+        {255,
+         255,
+         255,
+         255,
+         197,
+         33,
+         163,
+         97,
+         0,
+         0,
+         0,
+         20,
+         199,
+         142,
+         11,
+         149}));
+}


### PR DESCRIPTION
In Java `BigInteger.toByteArray()` method is used to encode Avro decimals the method returns an array where the first element is the most significant byte of the encoded decimal. This commit fixes Redpanda Avro Bigdecimal encoding.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none