### PR TITLE
CORE-8221 features: do not show built in trial after expiry

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -737,7 +737,16 @@ void feature_table::revoke_license() {
 }
 
 const std::optional<security::license>& feature_table::get_license() const {
-    return _license ? _license : _builtin_trial_license;
+    static const std::optional<security::license> no_license = std::nullopt;
+    if (_license) {
+        return _license;
+    } else if (
+      _builtin_trial_license && !_builtin_trial_license->is_expired()) {
+        // Don't not show the evaluation period license after it expired
+        return _builtin_trial_license;
+    } else {
+        return no_license;
+    }
 }
 
 const std::optional<security::license>&


### PR DESCRIPTION
Do not show the built-in trial license in metrics and in the response to `rpk cluster license info` after it has expired. This ensures that existing clusters that are >45 days old that upgrade to v24.3 won't observe the expired trial license.

Fixes https://redpandadata.atlassian.net/browse/CORE-8221

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
