### PR TITLE
datalake: update system fields

### DIFF
--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -164,7 +164,7 @@ TEST_F(FileCommitterTest, TestLoadOrCreateTable) {
     // Simple check for the schema.
     const auto& table = load_res.value();
     ASSERT_EQ(1, table.schemas.size());
-    ASSERT_EQ(4, table.schemas[0].schema_struct.fields.size());
+    ASSERT_EQ(1, table.schemas[0].schema_struct.fields.size());
     ASSERT_EQ(1, table.partition_specs.size());
     ASSERT_EQ(1, table.partition_specs[0].fields.size());
 }

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -52,8 +52,12 @@ private:
     // target table.
     // TODO: this just writes to the existing table, populating internal
     // columns. Consider a separate table entirely.
-    ss::future<result<std::nullopt_t, writer_error>>
-      handle_invalid_record(kafka::offset, iobuf, iobuf, model::timestamp);
+    ss::future<result<std::nullopt_t, writer_error>> handle_invalid_record(
+      kafka::offset,
+      iobuf,
+      iobuf,
+      model::timestamp,
+      chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>);
 
     prefix_logger _log;
     const model::ntp& _ntp;

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -33,11 +33,14 @@ public:
     friend std::ostream& operator<<(std::ostream&, const errc&);
     static record_type build_type(std::optional<resolved_type> val_type);
     static ss::future<checked<iceberg::struct_value, errc>> translate_data(
+      model::partition_id pid,
       kafka::offset o,
       iobuf key,
       const std::optional<resolved_type>& val_type,
       iobuf parsable_val,
-      model::timestamp ts);
+      model::timestamp ts,
+      const chunked_vector<
+        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers);
 };
 
 } // namespace datalake

--- a/src/v/datalake/schema_parquet.cc
+++ b/src/v/datalake/schema_parquet.cc
@@ -130,7 +130,9 @@ struct type_converting_visitor {
 
     serde::parquet::schema_element
     operator()(const iceberg::struct_type& type) {
-        return struct_to_parquet(type);
+        auto res = struct_to_parquet(type);
+        res.repetition_type = map_repetition_type(required);
+        return res;
     }
 
     serde::parquet::schema_element operator()(const iceberg::list_type& type) {

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -26,7 +26,10 @@ struct_type schemaless_struct_type() {
       nested_field::create(5, "value", field_required::no, binary_type{}));
     struct_type res;
     res.fields.emplace_back(nested_field::create(
-      1, "redpanda", field_required::yes, std::move(system_fields)));
+      1,
+      ss::sstring{rp_struct_name},
+      field_required::yes,
+      std::move(system_fields)));
 
     return res;
 }

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -15,15 +15,18 @@ namespace datalake {
 using namespace iceberg;
 struct_type schemaless_struct_type() {
     using namespace iceberg;
+    struct_type system_fields;
+    system_fields.fields.emplace_back(
+      nested_field::create(2, "offset", field_required::yes, long_type{}));
+    system_fields.fields.emplace_back(nested_field::create(
+      3, "timestamp", field_required::yes, timestamp_type{}));
+    system_fields.fields.emplace_back(
+      nested_field::create(4, "key", field_required::no, binary_type{}));
+    system_fields.fields.emplace_back(
+      nested_field::create(5, "value", field_required::no, binary_type{}));
     struct_type res;
     res.fields.emplace_back(nested_field::create(
-      1, "redpanda_offset", field_required::yes, long_type{}));
-    res.fields.emplace_back(nested_field::create(
-      2, "redpanda_timestamp", field_required::yes, timestamp_type{}));
-    res.fields.emplace_back(nested_field::create(
-      3, "redpanda_key", field_required::no, binary_type{}));
-    res.fields.emplace_back(nested_field::create(
-      4, "redpanda_value", field_required::no, binary_type{}));
+      1, "redpanda", field_required::yes, std::move(system_fields)));
 
     return res;
 }
@@ -39,7 +42,7 @@ schema default_schema() {
 partition_spec hour_partition_spec() {
     chunked_vector<partition_field> fields;
     fields.emplace_back(partition_field{
-      .source_id = nested_field::id_t{2},
+      .source_id = nested_field::id_t{3},
       .field_id = partition_field::id_t{1000},
       .name = "redpanda_timestamp_hour",
       .transform = hour_transform{},

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -17,13 +17,27 @@ struct_type schemaless_struct_type() {
     using namespace iceberg;
     struct_type system_fields;
     system_fields.fields.emplace_back(
-      nested_field::create(2, "offset", field_required::yes, long_type{}));
+      nested_field::create(2, "partition", field_required::yes, int_type{}));
+    system_fields.fields.emplace_back(
+      nested_field::create(3, "offset", field_required::yes, long_type{}));
     system_fields.fields.emplace_back(nested_field::create(
-      3, "timestamp", field_required::yes, timestamp_type{}));
+      4, "timestamp", field_required::yes, timestamp_type{}));
+
+    struct_type headers_kv;
+    headers_kv.fields.emplace_back(
+      nested_field::create(7, "key", field_required::no, binary_type{}));
+    headers_kv.fields.emplace_back(
+      nested_field::create(8, "value", field_required::no, binary_type{}));
+    system_fields.fields.emplace_back(nested_field::create(
+      5,
+      "headers",
+      field_required::no,
+      list_type::create(6, field_required::yes, std::move(headers_kv))));
+
     system_fields.fields.emplace_back(
-      nested_field::create(4, "key", field_required::no, binary_type{}));
+      nested_field::create(9, "key", field_required::no, binary_type{}));
     system_fields.fields.emplace_back(
-      nested_field::create(5, "value", field_required::no, binary_type{}));
+      nested_field::create(10, "value", field_required::no, binary_type{}));
     struct_type res;
     res.fields.emplace_back(nested_field::create(
       1,
@@ -45,7 +59,7 @@ schema default_schema() {
 partition_spec hour_partition_spec() {
     chunked_vector<partition_field> fields;
     fields.emplace_back(partition_field{
-      .source_id = nested_field::id_t{3},
+      .source_id = nested_field::id_t{4},
       .field_id = partition_field::id_t{1000},
       .name = "redpanda_timestamp_hour",
       .transform = hour_transform{},

--- a/src/v/datalake/table_definition.h
+++ b/src/v/datalake/table_definition.h
@@ -20,6 +20,7 @@ namespace datalake {
 // TODO: rename to redpanda_fields_struct_type?
 iceberg::struct_type schemaless_struct_type();
 iceberg::schema default_schema();
+inline constexpr std::string_view rp_struct_name = "redpanda";
 
 // Hourly partitioning on the timestamp of a schema with the above fields.
 iceberg::partition_spec hour_partition_spec();

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -281,7 +281,7 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
         // Default columns + a nested struct.
         EXPECT_EQ(table->num_columns(), 8);
         auto expected_type
-          = R"(redpanda: struct<offset: int64 not null, timestamp: timestamp[us] not null, key: binary, value: binary> not null
+          = R"(redpanda: struct<partition: int32 not null, offset: int64 not null, timestamp: timestamp[us] not null, headers: list<element: struct<key: binary, value: binary> not null>, key: binary, value: binary> not null
 mylong: int64 not null
 nestedrecord: struct<inval1: double not null, inval2: string not null, inval3: int32 not null> not null
 myarray: list<element: double not null> not null

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -164,8 +164,8 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
         ASSERT_TRUE(r.ok());
 
         EXPECT_EQ(table->num_rows(), record_count * batch_count);
-        // Expect 4 columns for schemaless: offset, timestamp, key, value
-        EXPECT_EQ(table->num_columns(), 4);
+        // Expect one nested column.
+        EXPECT_EQ(table->num_columns(), 1);
     }
     // Expect this test to create exactly 1 file
     EXPECT_EQ(file_count, 1);
@@ -279,12 +279,16 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
         EXPECT_EQ(table->num_rows(), num_records / num_hrs);
 
         // Default columns + a nested struct.
-        EXPECT_EQ(table->num_columns(), 5);
-        auto expected_type = R"(redpanda_offset: int64 not null
-redpanda_timestamp: timestamp[us] not null
-redpanda_key: binary
-redpanda_value: binary
-RootRecord: struct<mylong: int64 not null, nestedrecord: struct<inval1: double not null, inval2: string not null, inval3: int32 not null> not null, myarray: list<element: double not null> not null, mybool: bool not null, myfixed: fixed_size_binary[16] not null, anotherint: int32 not null, bytes: binary not null>)";
+        EXPECT_EQ(table->num_columns(), 8);
+        auto expected_type
+          = R"(redpanda: struct<offset: int64 not null, timestamp: timestamp[us] not null, key: binary, value: binary> not null
+mylong: int64 not null
+nestedrecord: struct<inval1: double not null, inval2: string not null, inval3: int32 not null> not null
+myarray: list<element: double not null> not null
+mybool: bool not null
+myfixed: fixed_size_binary[16] not null
+anotherint: int32 not null
+bytes: binary not null)";
         EXPECT_EQ(expected_type, table->schema()->ToString());
     }
     // Expect this test to create exactly 1 file

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -287,7 +287,7 @@ TEST_F(RecordMultiplexerInvalidAppendTest, TestMissingSchema) {
     EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
 
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 4);
+    EXPECT_EQ(schema->highest_field_id(), 5);
 }
 
 TEST_F(RecordMultiplexerInvalidAppendTest, TestBadData) {
@@ -313,7 +313,7 @@ TEST_F(RecordMultiplexerInvalidAppendTest, TestBadData) {
     // shouldn't register the Avro schema -- instead we should see the default
     // schema.
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 4);
+    EXPECT_EQ(schema->highest_field_id(), 5);
 }
 
 TEST_F(RecordMultiplexerInvalidAppendTest, TestBadSchemaChange) {

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -226,7 +226,7 @@ TEST_P(RecordMultiplexerParamTest, TestSimpleAvroRecords) {
 
     // 4 default columns + RootRecord + mylong
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 6);
+    EXPECT_EQ(schema->highest_field_id(), 11);
 }
 
 TEST_P(RecordMultiplexerParamTest, TestAvroRecordsMultipleSchemas) {
@@ -262,7 +262,7 @@ TEST_P(RecordMultiplexerParamTest, TestAvroRecordsMultipleSchemas) {
     }
     EXPECT_EQ(hrs.size(), GetParam().hrs);
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 16);
+    EXPECT_EQ(schema->highest_field_id(), 21);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -297,10 +297,12 @@ TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
 
     // Add Avro records.
     auto start_offset = model::offset{0};
-    auto res = mux(default_param, start_offset, [&gen](storage::record_batch_builder& b) {
-        auto res = gen.add_random_avro_record(b, "avro_rp", std::nullopt).get();
-        ASSERT_FALSE(res.has_error());
-    });
+    auto res = mux(
+      default_param, start_offset, [&gen](storage::record_batch_builder& b) {
+          auto res
+            = gen.add_random_avro_record(b, "avro_rp", std::nullopt).get();
+          ASSERT_FALSE(res.has_error());
+      });
     ASSERT_TRUE(res.has_value());
     const auto& write_res = res.value();
     EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
@@ -315,11 +317,12 @@ TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
     // 1 nested redpanda column + 4 default columns + mylong + 1 user redpanda
     // column + 1 nested
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 8);
+    EXPECT_EQ(schema->highest_field_id(), 13);
 
     // The redpanda system fields should include the 'data' column.
-    const auto& rp_struct = std::get<iceberg::struct_type>(schema->schema_struct.fields[0]->type);
-    EXPECT_EQ(5, rp_struct.fields.size());
+    const auto& rp_struct = std::get<iceberg::struct_type>(
+      schema->schema_struct.fields[0]->type);
+    EXPECT_EQ(7, rp_struct.fields.size());
     EXPECT_EQ("data", rp_struct.fields.back()->name);
 }
 
@@ -338,7 +341,7 @@ TEST_F(RecordMultiplexerTest, TestMissingSchema) {
     EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
 
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 5);
+    EXPECT_EQ(schema->highest_field_id(), 10);
 }
 
 TEST_F(RecordMultiplexerTest, TestBadData) {
@@ -364,7 +367,7 @@ TEST_F(RecordMultiplexerTest, TestBadData) {
     // shouldn't register the Avro schema -- instead we should see the default
     // schema.
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 5);
+    EXPECT_EQ(schema->highest_field_id(), 10);
 }
 
 TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
@@ -397,7 +400,7 @@ TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
 
     // This should have registered the valid schema.
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 6);
+    EXPECT_EQ(schema->highest_field_id(), 11);
 
     // Now try writing with an incompatible schema.
     res = mux(
@@ -413,5 +416,5 @@ TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
     const auto& write_res = res.value();
     EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
     schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 6);
+    EXPECT_EQ(schema->highest_field_id(), 11);
 }

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -61,6 +61,23 @@ constexpr std::string_view avro_schema_v2_str = R"({
         { "name": "bytes", "type": "bytes" }
     ]
 })";
+constexpr std::string_view avro_schema_w_redpanda_str = R"({
+    "type": "record",
+    "name": "RootRecord",
+    "fields": [
+        { "name": "mylong", "doc": "mylong field doc.", "type": "long" },
+        {
+            "name": "redpanda",
+            "type": {
+                "type": "record",
+                "name": "Nested",
+                "fields": [
+                    { "name": "foo", "type": "double" }
+                ]
+            }
+        }
+    ]
+})";
 } // namespace
 
 struct records_param {
@@ -268,11 +285,45 @@ INSTANTIATE_TEST_SUITE_P(
         "rpb{}_bph{}_h{}", p.records_per_batch, p.batches_per_hr, p.hrs);
   });
 
-class RecordMultiplexerInvalidAppendTest
+class RecordMultiplexerTest
   : public RecordMultiplexerTestBase
   , public ::testing::Test {};
 
-TEST_F(RecordMultiplexerInvalidAppendTest, TestMissingSchema) {
+TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
+    tests::record_generator gen(&registry);
+    auto reg_res
+      = gen.register_avro_schema("avro_rp", avro_schema_w_redpanda_str).get();
+    EXPECT_FALSE(reg_res.has_error()) << reg_res.error();
+
+    // Add Avro records.
+    auto start_offset = model::offset{0};
+    auto res = mux(default_param, start_offset, [&gen](storage::record_batch_builder& b) {
+        auto res = gen.add_random_avro_record(b, "avro_rp", std::nullopt).get();
+        ASSERT_FALSE(res.has_error());
+    });
+    ASSERT_TRUE(res.has_value());
+    const auto& write_res = res.value();
+    EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
+
+    std::unordered_set<int> hrs;
+    for (auto& f : write_res.data_files) {
+        hrs.emplace(f.hour);
+        EXPECT_EQ(f.row_count, default_param.records_per_hr());
+    }
+    EXPECT_EQ(hrs.size(), default_param.hrs);
+
+    // 1 nested redpanda column + 4 default columns + mylong + 1 user redpanda
+    // column + 1 nested
+    auto schema = get_current_schema();
+    EXPECT_EQ(schema->highest_field_id(), 8);
+
+    // The redpanda system fields should include the 'data' column.
+    const auto& rp_struct = std::get<iceberg::struct_type>(schema->schema_struct.fields[0]->type);
+    EXPECT_EQ(5, rp_struct.fields.size());
+    EXPECT_EQ("data", rp_struct.fields.back()->name);
+}
+
+TEST_F(RecordMultiplexerTest, TestMissingSchema) {
     auto start_offset = model::offset{0};
     auto res = mux(
       default_param, start_offset, [](storage::record_batch_builder& b) {
@@ -290,7 +341,7 @@ TEST_F(RecordMultiplexerInvalidAppendTest, TestMissingSchema) {
     EXPECT_EQ(schema->highest_field_id(), 5);
 }
 
-TEST_F(RecordMultiplexerInvalidAppendTest, TestBadData) {
+TEST_F(RecordMultiplexerTest, TestBadData) {
     tests::record_generator gen(&registry);
     auto reg_res
       = gen.register_avro_schema("avro_v1", avro_schema_v1_str).get();
@@ -316,7 +367,7 @@ TEST_F(RecordMultiplexerInvalidAppendTest, TestBadData) {
     EXPECT_EQ(schema->highest_field_id(), 5);
 }
 
-TEST_F(RecordMultiplexerInvalidAppendTest, TestBadSchemaChange) {
+TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
     constexpr std::string_view avro_incompat_schema_str = R"({
         "type": "record",
         "name": "RootRecord",

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -105,6 +105,15 @@ public:
     iobuf release_value() { return std::exchange(_value, {}); }
     iobuf share_value() { return _value.share(0, _value.size_bytes()); }
 
+    std::optional<iobuf> share_key_opt() {
+        return key_size() < 0 ? std::nullopt
+                              : std::make_optional<iobuf>(share_key());
+    }
+    std::optional<iobuf> share_value_opt() {
+        return value_size() < 0 ? std::nullopt
+                                : std::make_optional<iobuf>(share_value());
+    }
+
     bool operator==(const record_header& rhs) const {
         return _key_size == rhs._key_size && _val_size == rhs._val_size
                && _key == rhs._key && _value == rhs._value;
@@ -113,8 +122,10 @@ public:
     friend std::ostream& operator<<(std::ostream&, const record_header&);
 
 private:
+    // If negative, the key is nil.
     int32_t _key_size{-1};
     iobuf _key;
+    // If negative, the value is nil.
     int32_t _val_size{-1};
     iobuf _value;
 };

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -261,7 +261,7 @@ struct schema_element {
      *
      * This must be set to required on the schema root
      */
-    field_repetition_type repetition_type;
+    field_repetition_type repetition_type{field_repetition_type::required};
 
     /**
      * The full path of the node within the schema.

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -106,7 +106,7 @@ class DatalakeE2ETests(RedpandaTest):
                 trino = dl.trino()
                 trino_expected_out = [(
                     'redpanda',
-                    'row(offset bigint, timestamp timestamp(6), key varbinary, value varbinary)',
+                    'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary, value varbinary)',
                     '', ''), ('val', 'bigint', '', '')]
                 trino_describe_out = trino.run_query_fetch_all(
                     f"describe {table_name}")
@@ -116,7 +116,7 @@ class DatalakeE2ETests(RedpandaTest):
                 spark = dl.spark()
                 spark_expected_out = [(
                     'redpanda',
-                    'struct<offset:bigint,timestamp:timestamp_ntz,key:binary,value:binary>',
+                    'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary,value:binary>',
                     None), ('val', 'bigint', None), ('', '', ''),
                                       ('# Partitioning', '', ''),
                                       ('Part 0', 'hours(redpanda.timestamp)',

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -104,27 +104,23 @@ class DatalakeE2ETests(RedpandaTest):
 
             if query_engine == QueryEngineType.TRINO:
                 trino = dl.trino()
-                trino_expected_out = [('redpanda_offset', 'bigint', '', ''),
-                                      ('redpanda_timestamp', 'timestamp(6)',
-                                       '', ''),
-                                      ('redpanda_key', 'varbinary', '', ''),
-                                      ('redpanda_value', 'varbinary', '', ''),
-                                      ('payload', 'row(val bigint)', '', '')]
+                trino_expected_out = [(
+                    'redpanda',
+                    'row(offset bigint, timestamp timestamp(6), key varbinary, value varbinary)',
+                    '', ''), ('val', 'bigint', '', '')]
                 trino_describe_out = trino.run_query_fetch_all(
                     f"describe {table_name}")
                 assert trino_describe_out == trino_expected_out, str(
                     trino_describe_out)
             else:
                 spark = dl.spark()
-                spark_expected_out = [
-                    ('redpanda_offset', 'bigint', None),
-                    ('redpanda_timestamp', 'timestamp_ntz', None),
-                    ('redpanda_key', 'binary', None),
-                    ('redpanda_value', 'binary', None),
-                    ('payload', 'struct<val:bigint>', None), ('', '', ''),
-                    ('# Partitioning', '', ''),
-                    ('Part 0', 'hours(redpanda_timestamp)', '')
-                ]
+                spark_expected_out = [(
+                    'redpanda',
+                    'struct<offset:bigint,timestamp:timestamp_ntz,key:binary,value:binary>',
+                    None), ('val', 'bigint', None), ('', '', ''),
+                                      ('# Partitioning', '', ''),
+                                      ('Part 0', 'hours(redpanda.timestamp)',
+                                       '')]
                 spark_describe_out = spark.run_query_fetch_all(
                     f"describe {table_name}")
                 assert spark_describe_out == spark_expected_out, str(

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -127,12 +127,9 @@ class RestCatalogConnectionTest(RedpandaTest):
         def all_data_translated():
             table = catalog.load_table(f"{namespace}.{topic.name}")
             df = table.scan().to_pandas()
-            self.logger.info(
-                f"offsets: {df['redpanda_offset'].head(5).to_list()}")
-            return all([
-                isinstance(o, int)
-                for o in df['redpanda_offset'].head(5).to_list()
-            ])
+            offsets_df = df['redpanda'].str.get('offset').head(5).to_list()
+            self.logger.info(f"offsets: {offsets_df}")
+            return all([isinstance(o, int) for o in offsets_df])
 
         wait_until(
             all_data_translated,


### PR DESCRIPTION
Updates the default table fields:
- wraps all system fields in a top level `redpanda` nested struct
- unwraps user fields instead of having them all be in a nested struct

This isn't the final form of default schemas, as we currently still allow going from "schemaless" to schema-ed, while the desired end state is to use topic configs to force users to choose. Until that is implemented, the `redpanda` struct still contains the `value` field to allow for going between the two modes.

Collisions with `redpanda` user fields are handled by moving the conflicting user fields into the `redpanda` struct as `redpanda.data`.

Also adds a Kafka partition field and headers field.

NOTE: the top level `value` field is still here. That will need to be moved when the enabling topic config learns how to switch between schema resolution modes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
