### PR TITLE
Added conversion from `iceberg::value` to `serde::parquet::value`

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -439,3 +439,20 @@ redpanda_cc_library(
         "//src/v/serde/parquet:schema",
     ],
 )
+
+redpanda_cc_library(
+    name = "values_parquet",
+    srcs = [
+        "values_parquet.cc",
+    ],
+    hdrs = [
+        "values_parquet.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":conversion_outcome",
+        "//src/v/iceberg:values",
+        "//src/v/serde/parquet:value",
+    ],
+)

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -49,6 +49,7 @@ v_cc_library(
     cloud_data_io.cc
     translation_task.cc
     schema_parquet.cc
+    values_parquet.cc
   DEPS
     v::cloud_io
     v::datalake_common

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -282,7 +282,9 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/bytes:iobuf_parser",
         "//src/v/datalake:schema_parquet",
+        "//src/v/datalake:values_parquet",
         "//src/v/iceberg:datatypes",
+        "//src/v/iceberg/tests:value_generator",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random",
         "@fmt",

--- a/src/v/datalake/values_parquet.cc
+++ b/src/v/datalake/values_parquet.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/values_parquet.h"
+
+namespace datalake {
+namespace {
+struct primitive_value_converting_visitor {
+    parquet_conversion_outcome operator()(iceberg::boolean_value v) {
+        return serde::parquet::boolean_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::int_value v) {
+        return serde::parquet::int32_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::long_value v) {
+        return serde::parquet::int64_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::float_value v) {
+        return serde::parquet::float32_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::double_value v) {
+        return serde::parquet::float64_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::date_value v) {
+        return serde::parquet::int32_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::time_value v) {
+        return serde::parquet::int64_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::timestamp_value v) {
+        return serde::parquet::int64_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::timestamptz_value v) {
+        return serde::parquet::int64_value{.val = v.val};
+    }
+    parquet_conversion_outcome operator()(iceberg::string_value v) {
+        return serde::parquet::byte_array_value{.val = std::move(v.val)};
+    }
+    parquet_conversion_outcome operator()(iceberg::uuid_value v) {
+        iobuf buffer;
+        buffer.append(v.val.uuid().data, v.val.uuid().size());
+        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
+    }
+    parquet_conversion_outcome operator()(iceberg::fixed_value v) {
+        return serde::parquet::fixed_byte_array_value{.val = std::move(v.val)};
+    }
+    parquet_conversion_outcome operator()(iceberg::binary_value v) {
+        return serde::parquet::byte_array_value{.val = std::move(v.val)};
+    }
+    parquet_conversion_outcome operator()(iceberg::decimal_value v) {
+        iobuf buffer;
+        // big endian, starts from msb
+        auto low_part = ss::cpu_to_be(Int128Low64(v.val));
+        auto high_part = ss::cpu_to_be(Int128High64(v.val));
+        buffer.append(
+          reinterpret_cast<const char*>(&high_part), sizeof(int64_t));
+        buffer.append(
+          reinterpret_cast<const char*>(&low_part), sizeof(uint64_t));
+
+        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
+    }
+};
+struct value_converting_visitor {
+    ss::future<parquet_conversion_outcome>
+    operator()(iceberg::primitive_value value) {
+        co_return std::visit(
+          primitive_value_converting_visitor{}, std::move(value));
+    }
+    ss::future<parquet_conversion_outcome>
+    operator()(std::unique_ptr<iceberg::struct_value> value) {
+        serde::parquet::group_value group;
+        group.reserve(value->fields.size());
+        for (auto& field : value->fields) {
+            if (!field.has_value()) {
+                group.emplace_back(serde::parquet::null_value{});
+                continue;
+            }
+            auto result = co_await to_parquet_value(std::move(*field));
+            if (result.has_error()) {
+                co_return result.error();
+            }
+
+            group.emplace_back(std::move(result.value()));
+        }
+        co_return group;
+    }
+    ss::future<parquet_conversion_outcome>
+    operator()(std::unique_ptr<iceberg::list_value> list) {
+        serde::parquet::repeated_value repeated;
+        repeated.reserve(list->elements.size());
+        for (auto& element : list->elements) {
+            serde::parquet::group_value element_wrapper;
+            if (!element.has_value()) {
+                element_wrapper.emplace_back(serde::parquet::null_value{});
+            } else {
+                auto result = co_await to_parquet_value(std::move(*element));
+                if (result.has_error()) {
+                    co_return result.error();
+                }
+                element_wrapper.emplace_back(std::move(result.value()));
+            }
+            repeated.emplace_back(std::move(element_wrapper));
+        }
+
+        serde::parquet::group_value list_wrapper;
+        list_wrapper.emplace_back(std::move(repeated));
+        co_return list_wrapper;
+    }
+    ss::future<parquet_conversion_outcome>
+    operator()(std::unique_ptr<iceberg::map_value> map) {
+        serde::parquet::repeated_value repeated;
+        repeated.reserve(map->kvs.size());
+        for (auto& kv : map->kvs) {
+            serde::parquet::group_value group;
+            group.reserve(2);
+            auto key_result = co_await to_parquet_value(std::move(kv.key));
+            if (key_result.has_error()) {
+                co_return key_result.error();
+            }
+            group.emplace_back(std::move(key_result.value()));
+            if (kv.val.has_value()) {
+                auto val = co_await to_parquet_value(std::move(kv.val.value()));
+                if (val.has_error()) {
+                    co_return val.error();
+                }
+                group.emplace_back(std::move(val.value()));
+            } else {
+                group.emplace_back(serde::parquet::null_value{});
+            }
+            repeated.emplace_back(std::move(group));
+        }
+        serde::parquet::group_value map_wrapper;
+        map_wrapper.emplace_back(std::move(repeated));
+        co_return map_wrapper;
+    }
+};
+} // namespace
+
+ss::future<parquet_conversion_outcome> to_parquet_value(iceberg::value value) {
+    return std::visit(value_converting_visitor{}, std::move(value));
+}
+
+} // namespace datalake

--- a/src/v/datalake/values_parquet.h
+++ b/src/v/datalake/values_parquet.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/conversion_outcome.h"
+
+#include <serde/parquet/value.h>
+
+namespace datalake {
+using parquet_conversion_outcome
+  = checked<serde::parquet::value, value_conversion_exception>;
+
+/**
+ * Converts iceberg to parquet value, the value conversion only involves
+ * physical type, the logical type is not considered. The corresponding logical
+ * type can be determined from corresponding schema.
+ */
+ss::future<parquet_conversion_outcome> to_parquet_value(iceberg::value);
+
+} // namespace datalake

--- a/src/v/iceberg/values.h
+++ b/src/v/iceberg/values.h
@@ -140,6 +140,8 @@ bool operator==(
   const std::unique_ptr<map_value>&, const std::unique_ptr<map_value>&);
 bool operator==(const value&, const value&);
 
+value make_copy(const value&);
+
 std::ostream& operator<<(std::ostream&, const boolean_value&);
 std::ostream& operator<<(std::ostream&, const int_value&);
 std::ostream& operator<<(std::ostream&, const long_value&);


### PR DESCRIPTION
The value conversion is a necessary step before writing parquet format using `serde::parquet::writer`. Conversion translates the `iceberg::value` types into a corresponding `parquet::value`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none