### PR TITLE
DNM: This looks like a pretty reliable repro locally in debug mode

### DIFF
--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -135,7 +135,10 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
             tp.partition,
             std::make_exception_ptr(ss::abort_requested_exception())));
     }
-    return get_context(std::move(tp))->produce(std::move(batch));
+    return ss::sleep(std::chrono::seconds(60))
+      .then([this, tp = std::move(tp), batch = std::move(batch)]() mutable {
+          return get_context(std::move(tp))->produce(std::move(batch));
+      });
 }
 
 ss::future<produce_response::partition>

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -34,6 +34,7 @@ from rptest.services.admin import Admin, RoleMember
 from rptest.services.cluster import cluster
 from rptest.services import redpanda
 from rptest.services.keycloak import DEFAULT_REALM, KeycloakService
+from rptest.services.kgo_repeater_service import KgoRepeaterService, repeater_traffic
 from rptest.services.ocsf_server import OcsfServer
 from rptest.services.redpanda import AUDIT_LOG_ALLOW_LIST, LoggingConfig, MetricSamples, MetricsEndpoint, PandaproxyConfig, RedpandaServiceBase, SchemaRegistryConfig, SecurityConfig, TLSProvider
 from rptest.services.rpk_consumer import RpkConsumer


### PR DESCRIPTION

[2024-11-14--16.results.tar.gz](https://github.com/user-attachments/files/17742846/2024-11-14--16.results.tar.gz)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

(Maybe) reproducer for audit producer nuttiness. Problem with this is that injecting a 1m sleep into the produce path might be sort of extreme and/or imprecise...on the other hand, a lot of our hand waving seems to revolve around the idea of a "stuck" produce request, so maybe this is the right type of knob to turn here - push into the client buffers a bunch of requests that we know will take a long time, eventually cycle audit logging off & back on, continue on.

Observations:
- as expected (?) the shutdown routine doesn't complete
   - as a result of this the big "acquire all the units" operation (which times out) maybe seems to acquire some units anyway? if so, it doesn't release them? 
- we are then able to turn audit logging back on but nothing happens. subsequent cycling does nothing.
- it's not immediately clear whether we construct a new client or what. the layers of indirection make this confusing; just needs a bit more head scratching

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
