### PR TITLE
tools/cmake_test: Fix _find_addr2line

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -152,7 +152,7 @@ class BacktraceCapture(threading.Thread):
             return ci_location
 
         # Workstation: find our build directory by searching back from binary
-        vbuild = find_vbuild_path_from_binary(self.binary, 3)
+        vbuild = find_vbuild_path_from_binary(self.binary, 5)
         if vbuild:
             location = os.path.join(
                 vbuild,


### PR DESCRIPTION
Since the new build directory layout, backtraces for failures locally have not been decoded as addr2line was not being found.

Fix that.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
