### PR TITLE
c/tests: avoid ubsan signed integer overflow

### DIFF
--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -15,6 +15,8 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <chrono>
+
 static ss::logger logger{"rm_stm-test"};
 static prefix_logger ctx_logger{logger, ""};
 
@@ -24,7 +26,9 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         producer_state_manager
           .start(
             config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            config::mock_binding(std::chrono::milliseconds::max()),
+            config::mock_binding(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::microseconds::max())),
             config::mock_binding(std::numeric_limits<uint64_t>::max()))
           .get();
         producer_state_manager


### PR DESCRIPTION
Before the change ubsan would assert on a signed integer overflow
```
/vectorized/llvm/bin/../include/c++/v1/__chrono/duration.h:92:79: runtime error: signed integer overflow: 9223372036854775807 * 1000 cannot be represented in type '_Ct' (aka 'long long')
cluster::tx::producer_state_manager::evict_excess_producers() at /vectorized/llvm/bin/../include/c++/v1/__chrono/duration.h:92
```

The problem lies in that we try to subtract duration from a time_point with microsecond granularity. When doing that, duration is converted to a common type, microsecond representation and the millisecond::max() being already maximum value that can be represented in a long long can't be converted to micros (multiplied by 1000).

Not sure if this is the perfect fix but avoid the problem by initializing the duration with a value that can be later represented as micros.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
