### PR TITLE
[CORE-7750] Creating topic with huge number of partitions leads to segfault

### DIFF
--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -244,4 +244,14 @@ std::ostream& operator<<(std::ostream& o, const allocation_request& req) {
     fmt::print(o, "{{partion_constraints: {}}}", req.partitions);
     return o;
 }
+std::ostream&
+operator<<(std::ostream& o, const simple_allocation_request& req) {
+    fmt::print(
+      o,
+      "{{topic: {}, additional_partitions: {}, replication_factor: {}}}",
+      req.tp_ns,
+      req.additional_partitions,
+      req.replication_factor);
+    return o;
+}
 } // namespace cluster

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -111,6 +111,11 @@ struct partition_allocator_fixture {
           });
     }
 
+    cluster::simple_allocation_request make_simple_allocation_request(
+      int32_t partitions, int16_t replication_factor) {
+        return {tn, partitions, replication_factor};
+    }
+
     cluster::allocation_request
     make_allocation_request(int partitions, uint16_t replication_factor) {
         return make_allocation_request(tn, partitions, replication_factor);


### PR DESCRIPTION
Fixes: [CORE-7750](https://redpandadata.atlassian.net/browse/CORE-7750)

The size of the `allocation_request` created as part of the partition allocation scales linearly with the number of partitions needed to be created. Currently, the check to see if the request can be accepted happens on the `allocation_request` object. When the number of requested partitions is too big, we run out of memory while creating this object.

The fix is to be lazy on the creation of the `allocation_request`, where possible, and do the first step of the validation before we create the full object.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixed an issue where creating a topic with a huge number of partitions could lead to a crash.


[CORE-7750]: https://redpandadata.atlassian.net/browse/CORE-7750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ