### PR TITLE
Added ability to use datalake with `serde::parquet`

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -477,3 +477,26 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "serde_parquet_writer",
+    srcs = [
+        "serde_parquet_writer.cc",
+    ],
+    hdrs = [
+        "serde_parquet_writer.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":logger",
+        ":schema_parquet",
+        ":values_parquet",
+        ":writer",
+        "//src/v/base",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:values",
+        "//src/v/serde/parquet:writer",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -51,6 +51,7 @@ v_cc_library(
     schema_parquet.cc
     values_parquet.cc
     local_parquet_file_writer.cc
+    serde_parquet_writer.cc
   DEPS
     v::cloud_io
     v::datalake_common

--- a/src/v/datalake/schema_parquet.cc
+++ b/src/v/datalake/schema_parquet.cc
@@ -196,7 +196,6 @@ field_to_parquet(const iceberg::nested_field& field) {
     auto element = std::visit(
       type_converting_visitor{field.required}, field.type);
     element.field_id = field.id;
-    element.path.emplace_back(field.name);
 
     return element;
 }
@@ -207,7 +206,9 @@ struct_to_parquet(const iceberg::struct_type& schema) {
 
     res.children.reserve(schema.fields.size());
     for (const auto& f : schema.fields) {
-        res.children.push_back(field_to_parquet(*f));
+        auto field = field_to_parquet(*f);
+        field.path.emplace_back(f->name);
+        res.children.push_back(std::move(field));
     }
     return res;
 }

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -1,0 +1,46 @@
+#include "datalake/serde_parquet_writer.h"
+
+#include "base/vlog.h"
+#include "datalake/logger.h"
+#include "datalake/schema_parquet.h"
+#include "datalake/values_parquet.h"
+
+namespace datalake {
+
+ss::future<writer_error>
+serde_parquet_writer::add_data_struct(iceberg::struct_value value, size_t) {
+    auto conversion_result = co_await to_parquet_value(
+      std::make_unique<iceberg::struct_value>(std::move(value)));
+    if (conversion_result.has_error()) {
+        co_return writer_error::parquet_conversion_error;
+    }
+
+    auto group = std::get<serde::parquet::group_value>(
+      std::move(conversion_result.value()));
+    try {
+        co_await _writer.write_row(std::move(group));
+    } catch (...) {
+        vlog(
+          datalake_log.warn,
+          "Error writing parquet row - {}",
+          std::current_exception());
+        co_return writer_error::file_io_error;
+    }
+    co_return writer_error::ok;
+}
+
+ss::future<writer_error> serde_parquet_writer::finish() {
+    co_await _writer.close();
+    co_return writer_error::ok;
+}
+
+ss::future<std::unique_ptr<parquet_ostream>>
+serde_parquet_writer_factory::create_writer(
+  const iceberg::struct_type& schema, ss::output_stream<char> out) {
+    serde::parquet::writer::options opts{.schema = schema_to_parquet(schema)};
+    serde::parquet::writer writer(std::move(opts), std::move(out));
+    co_await writer.init();
+    co_return std::make_unique<serde_parquet_writer>(std::move(writer));
+}
+
+} // namespace datalake

--- a/src/v/datalake/serde_parquet_writer.h
+++ b/src/v/datalake/serde_parquet_writer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "datalake/data_writer_interface.h"
+#include "iceberg/datatypes.h"
+#include "serde/parquet/writer.h"
+
+namespace datalake {
+class serde_parquet_writer : public parquet_ostream {
+public:
+    explicit serde_parquet_writer(serde::parquet::writer writer)
+      : _writer(std::move(writer)) {}
+    ss::future<writer_error>
+      add_data_struct(iceberg::struct_value, size_t) final;
+
+    ss::future<writer_error> finish() final;
+
+private:
+    serde::parquet::writer _writer;
+};
+
+class serde_parquet_writer_factory : public parquet_ostream_factory {
+public:
+    ss::future<std::unique_ptr<parquet_ostream>>
+    create_writer(const iceberg::struct_type&, ss::output_stream<char>) final;
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -321,3 +321,23 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "serde_parquet_writer_test",
+    timeout = "short",
+    srcs = [
+        "serde_parquet_writer_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/datalake:serde_parquet_writer",
+        "//src/v/datalake/tests:test_data",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg/tests:value_generator",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:seastar_boost",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/tests/serde_parquet_writer_test.cc
+++ b/src/v/datalake/tests/serde_parquet_writer_test.cc
@@ -1,0 +1,30 @@
+#include "bytes/iostream.h"
+#include "datalake/serde_parquet_writer.h"
+#include "datalake/tests/test_data.h"
+#include "iceberg/tests/value_generator.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <gtest/gtest.h>
+
+TEST(SerdeParquetWriterTest, CheckIfTheWriterWritesData) {
+    auto schema = test_schema(iceberg::field_required::no);
+    iobuf target;
+
+    auto writer = datalake::serde_parquet_writer_factory{}
+                    .create_writer(schema, make_iobuf_ref_output_stream(target))
+                    .get();
+
+    auto v = iceberg::tests::make_value(
+      iceberg::tests::value_spec{.null_pct = 50},
+      iceberg::field_type{std::move(schema)});
+
+    auto s_v = std::get<std::unique_ptr<iceberg::struct_value>>(std::move(v));
+
+    auto result = writer->add_data_struct(std::move(*s_v), 0).get();
+    ASSERT_EQ(result, datalake::writer_error::ok);
+    auto finish_result = writer->finish().get();
+
+    ASSERT_EQ(finish_result, datalake::writer_error::ok);
+    ASSERT_GT(target.size_bytes(), 0);
+}

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     schema.cc
     shredder.cc
     column_writer.cc
+    writer.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2595,6 +2595,13 @@ class RedpandaService(RedpandaServiceBase):
         self._seed_servers = self.nodes
 
         self._expect_max_controller_records = 1000
+        #TODO: remove when sered parquet is enabled by default
+        if hasattr(self._context, 'injected_args') \
+            and self._context.injected_args is not None:
+            if 'use_serde_parquet' in  self._context.injected_args  \
+               and self._context.injected_args['use_serde_parquet']:
+                self._environment.update(
+                    {"__REDPANDA_USE_SERDE_PARQUET_WRITER": "1"})
 
     def redpanda_env_preamble(self):
         # Pass environment variables via FOO=BAR shell expressions

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -84,8 +84,9 @@ class DatalakeE2ETests(RedpandaTest):
 
     @cluster(num_nodes=4)
     @matrix(storage_type=supported_storage_types(),
-            query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO])
-    def test_avro_schema(self, storage_type, query_engine):
+            query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
+            use_serde_parquet=[False, True])
+    def test_avro_schema(self, storage_type, query_engine, use_serde_parquet):
         count = 100
         table_name = f"redpanda.{self.topic_name}"
 

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -88,8 +88,10 @@ class RestCatalogConnectionTest(RedpandaTest):
         return producer
 
     @cluster(num_nodes=5)
-    @matrix(storage_type=supported_storage_types())
-    def test_redpanda_connection_to_rest_catalog(self, storage_type):
+    @matrix(storage_type=supported_storage_types(),
+            use_serde_parquet=[False, True])
+    def test_redpanda_connection_to_rest_catalog(self, storage_type,
+                                                 use_serde_parquet):
 
         catalog = self.catalog_service.client()
         namespace = "redpanda"


### PR DESCRIPTION
Added an environment variable that will allow us to use serde parquet
writer in tests. The variable is going to be removed when we are going
to be ready to remove the dependency on the arrow library.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none