### PR TITLE
audit: clamp audit client max parallelism

### DIFF
--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -522,8 +522,10 @@ ss::future<> audit_client::produce(
     // here should usually be 1-2, since the default per-shard queue limit
     // is 1MiB, which is also the default for kafka_batch_max_bytes.
     // TODO(oren): a configurabale ratio might be better
-    [[maybe_unused]] auto max_concurrency
-      = _max_buffer_size / config::shard_local_cfg().kafka_batch_max_bytes();
+    auto max_concurrency = std::clamp<size_t>(
+      _max_buffer_size / config::shard_local_cfg().kafka_batch_max_bytes(),
+      1,
+      records.size());
 
     try {
         ssx::spawn_with_gate(


### PR DESCRIPTION
This fixes a bug in the audit client where if the cluster config value `kafka_batch_max_bytes` is greater than `audit_client_max_buffer_size`, the audit client ends up not producing any messages and fills up the audit log buffers.

The problem is the division here could lead to `max_concurrency=0`. In debug mode this is caught by an assert inside
`ss::max_concurrent_for_each` but in release mode stdlibrary `assert`s are disabled and the behaviour ends up being that the background fibre just blocks waiting for a semaphore unit to be available, but it never will become available because it was initialized to 0 and no tasks will ever release any units to it.

Fixes: CORE-8222

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.2.x
- [x] v24.1.x
- [ ] v23.3.x

## Release Notes
### Bug Fixes
* This fixes a bug in the audit client where if the cluster config value `kafka_batch_max_bytes` was greater than `audit_client_max_buffer_size`, the audit client ends up not producing any messages and becomes stuck filling up the audit log buffers.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
