### PR TITLE
storage: track cache disk metrics separately

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3368,7 +3368,7 @@ disk_log_impl::disk_usage_target_time_retention(gc_config cfg) {
     if (segments.size() < 2) {
         vlog(
           stlog.trace,
-          "time-based-usage: skipping log without too few segments ({}) ntp {}",
+          "time-based-usage: skipping log with too few segments ({}) ntp {}",
           segments.size(),
           config().ntp());
         co_return std::nullopt;

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -37,12 +37,16 @@ ss::future<> node::start() {
 ss::future<> node::stop() { co_return; }
 
 void node::set_disk_metrics(disk_type t, disk_space_info info) {
-    if (t == disk_type::data) {
+    switch (t) {
+    case disk_type::data:
         _data_watchers.notify(info);
-    } else if (t == disk_type::cache) {
+        _probe.set_data_disk_metrics(info.total, info.free, info.alert);
+        break;
+    case disk_type::cache:
         _cache_watchers.notify(info);
+        _probe.set_cache_disk_metrics(info.total, info.free, info.alert);
+        break;
     }
-    _probe.set_data_disk_metrics(info.total, info.free, info.alert);
 }
 
 node::notification_id

--- a/src/v/storage/node.cc
+++ b/src/v/storage/node.cc
@@ -42,7 +42,7 @@ void node::set_disk_metrics(disk_type t, disk_space_info info) {
     } else if (t == disk_type::cache) {
         _cache_watchers.notify(info);
     }
-    _probe.set_disk_metrics(info.total, info.free, info.alert);
+    _probe.set_data_disk_metrics(info.total, info.free, info.alert);
 }
 
 node::notification_id

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -21,9 +21,9 @@
 
 namespace storage {
 
-void node_probe::set_disk_metrics(
+void node_probe::set_data_disk_metrics(
   uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert) {
-    _disk = {
+    _data_disk = {
       .total_bytes = total_bytes,
       .free_bytes = free_bytes,
       .space_alert = alert};
@@ -40,19 +40,19 @@ void node_probe::setup_node_metrics() {
       {
         sm::make_gauge(
           "total_bytes",
-          [this] { return _disk.total_bytes; },
+          [this] { return _data_disk.total_bytes; },
           sm::description("Total size of attached storage, in bytes."))
           .aggregate({sm::shard_label}),
         sm::make_gauge(
           "free_bytes",
-          [this] { return _disk.free_bytes; },
+          [this] { return _data_disk.free_bytes; },
           sm::description("Disk storage bytes free."))
           .aggregate({sm::shard_label}),
         sm::make_gauge(
           "free_space_alert",
           [this] {
               return static_cast<std::underlying_type_t<disk_space_alert>>(
-                _disk.space_alert);
+                _data_disk.space_alert);
           },
           sm::description(
             "Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded"))

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -31,7 +31,7 @@ struct disk_metrics {
 class node_probe {
 public:
     void setup_node_metrics();
-    void set_disk_metrics(
+    void set_data_disk_metrics(
       uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
 
     node_probe() = default;
@@ -42,7 +42,7 @@ public:
     ~node_probe() = default;
 
 private:
-    disk_metrics _disk;
+    disk_metrics _data_disk;
     metrics::public_metric_groups _public_metrics;
 };
 

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -33,6 +33,8 @@ public:
     void setup_node_metrics();
     void set_data_disk_metrics(
       uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
+    void set_cache_disk_metrics(
+      uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
 
     node_probe() = default;
     node_probe(const node_probe&) = delete;
@@ -43,6 +45,7 @@ public:
 
 private:
     disk_metrics _data_disk;
+    disk_metrics _cache_disk;
     metrics::public_metric_groups _public_metrics;
 };
 

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -34,8 +34,6 @@ public:
     void set_disk_metrics(
       uint64_t total_bytes, uint64_t free_bytes, disk_space_alert alert);
 
-    const disk_metrics& get_disk_metrics() const { return _disk; }
-
     node_probe() = default;
     node_probe(const node_probe&) = delete;
     node_probe& operator=(const node_probe&) = delete;

--- a/tests/rptest/tests/node_metrics_test.py
+++ b/tests/rptest/tests/node_metrics_test.py
@@ -107,3 +107,9 @@ class NodeMetricsTest(RedpandaTest):
         self.redpanda.logger.info(
             f"Elapsed: {t1-t0} sec to first metrics, {t2-t1} to consume space metric"
         )
+
+        # Assert cache disk metrics match data disk metrics since it is the same disk in this test setup.
+        assert_lists_equal(self.node_metrics.disk_total_bytes(),
+                           self.node_metrics.cache_disk_total_bytes())
+        assert_lists_equal(self.node_metrics.disk_free_bytes(),
+                           self.node_metrics.cache_disk_free_bytes())

--- a/tests/rptest/tests/node_metrics_test.py
+++ b/tests/rptest/tests/node_metrics_test.py
@@ -8,14 +8,13 @@
 # by the Apache License, Version 2.0
 
 from time import time
-from rptest.services.cluster import cluster
+
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.rpk import RpkTool
-from rptest.services.rpk_consumer import RpkConsumer
-from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.node_metrics import NodeMetrics
 
 

--- a/tests/rptest/utils/node_metrics.py
+++ b/tests/rptest/utils/node_metrics.py
@@ -41,6 +41,7 @@ class NodeMetrics:
     def wait_until_ready(self, timeout_sec=15):
         """ Wait until we have metrics for all nodes. """
         # disk metrics are updated via health monitor's periodic tick().
-        wait_until(lambda: all_greater_than_zero(self.disk_total_bytes()),
+        wait_until(lambda: all_greater_than_zero(self.disk_total_bytes()) and
+                   all_greater_than_zero(self.cache_disk_total_bytes()),
                    timeout_sec=15,
                    err_msg="Disk metrics not populated before timeout.")

--- a/tests/rptest/utils/node_metrics.py
+++ b/tests/rptest/utils/node_metrics.py
@@ -29,6 +29,15 @@ class NodeMetrics:
     def disk_space_alert(self) -> list[float]:
         return self._get_metrics_vals("storage_disk_free_space_alert")
 
+    def cache_disk_total_bytes(self) -> list[float]:
+        return self._get_metrics_vals("storage_cache_disk_total_bytes")
+
+    def cache_disk_free_bytes(self) -> list[float]:
+        return self._get_metrics_vals("storage_cache_disk_free_bytes")
+
+    def cache_disk_space_alert(self) -> list[float]:
+        return self._get_metrics_vals("storage_cache_disk_free_space_alert")
+
     def wait_until_ready(self, timeout_sec=15):
         """ Wait until we have metrics for all nodes. """
         # disk metrics are updated via health monitor's periodic tick().


### PR DESCRIPTION
Additional test in https://github.com/redpanda-data/redpanda/pull/24140

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

### Bug Fixes

* Previously if redpanda was configured with different mountpoints for data and cache directory we would report metrics only for the cache directory. Now, the original `storage_disk_{total,free}_bytes` metric will report metrics for the data directory mountpoint and a new `storage_cache_disk_{total,free}_bytes` metric will report metrics for the cache directory mountpoint. Metrics will be equivalent if both are on the same mountpoint.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
