### PR TITLE
`storage`: add `tombstones_removed` metric to `probe`

### DIFF
--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -163,6 +163,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _compaction_removed_bytes; },
           sm::description("Number of bytes removed by a compaction operation"),
           labels),
+        sm::make_counter(
+          "tombstones_removed",
+          [this] { return _tombstones_removed; },
+          sm::description("Number of tombstone records removed by compaction "
+                          "due to the delete.retention.ms setting."),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -96,6 +96,8 @@ public:
         _cached_batches_read += batches;
     }
 
+    void add_removed_tombstone() { ++_tombstones_removed; }
+
     void batch_parse_error() { ++_batch_parse_errors; }
 
     void setup_metrics(const model::ntp&);
@@ -136,6 +138,7 @@ private:
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
     double _compaction_ratio = 1.0;
+    uint64_t _tombstones_removed = 0;
 
     ssize_t _compaction_removed_bytes = 0;
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -190,6 +190,7 @@ ss::future<index_state> deduplicate_segment(
     auto copy_reducer = internal::copy_data_segment_reducer(
       [&map,
        &may_have_tombstone_records,
+       &probe,
        segment_last_offset = seg->offsets().get_committed_offset(),
        past_tombstone_delete_horizon,
        compaction_placeholder_enabled](
@@ -213,6 +214,7 @@ ss::future<index_state> deduplicate_segment(
 
           // Deal with tombstone record removal
           if (r.is_tombstone() && past_tombstone_delete_horizon) {
+              probe.add_removed_tombstone();
               return ss::make_ready_future<bool>(false);
           }
 


### PR DESCRIPTION
This metric records the number of tombstones removed due to `delete.retention.ms` elapsing. It does not account for tombstone records removed by other forms of garbage collection.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
