### PR TITLE
parquet: add zstd compression

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -119,6 +119,7 @@ redpanda_cc_library(
         ":schema",
         ":value",
         "//src/v/base",
+        "//src/v/compression",
         "//src/v/hashing:crc32",
         "@seastar",
     ],

--- a/src/v/serde/parquet/CMakeLists.txt
+++ b/src/v/serde/parquet/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     Seastar::seastar
     v::bytes
     v::container
+    v::compression
     v::utils
     v::serde_thrift
   )

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -33,7 +33,13 @@ class column_writer {
 public:
     class impl;
 
-    explicit column_writer(const schema_element&);
+    // Options for changing how a column writer behaves.
+    struct options {
+        // If true, use zstd compression for the column data.
+        bool compress = false;
+    };
+
+    explicit column_writer(const schema_element&, options);
     column_writer(const column_writer&) = delete;
     column_writer& operator=(const column_writer&) = delete;
     column_writer(column_writer&&) noexcept;
@@ -53,7 +59,7 @@ public:
     // Flush the currently buffered values to a page.
     //
     // This also resets the writer to be able to start writing a new page.
-    data_page flush_page();
+    ss::future<data_page> flush_page();
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -340,6 +340,7 @@ ss::future<iobuf> serialize_testcase(size_t test_case) {
       {
         .schema = all_types_schema(),
         .metadata = {{"foo", "bar"}},
+        .compress = test_case % 2 == 0,
       },
       make_iobuf_ref_output_stream(file));
     co_await w.init();

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -31,7 +31,9 @@ public:
         // Information used when filling out the `created_by` metadata.
         ss::sstring version = "latest";
         ss::sstring build = "dev";
-        // TODO(parquet): add settings around buffer settings, compression, etc.
+        // If true, compress the parquet column chunks using zstd compression
+        bool compress = false;
+        // TODO(parquet): add settings around buffer settings, etc.
     };
 
     // Create a new parquet file writer using the given options that


### PR DESCRIPTION
Add the ability to compress parquet column chunks using zstd.

We currently only support zstd because that is the defacto compression
format that seems to be used these days and it's the only compression codec
that we have futurized as to not cause stalls.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.2.x
- [ ] v24.1.x
- [ ] v23.3.x

## Release Notes

* none
