### PR TITLE
Add `record_multiplexer` microbenchmarks

### DIFF
--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -101,7 +101,6 @@ redpanda_test_cc_library(
     implementation_deps = [
         "//src/v/container:chunked_hash_map",
         "//src/v/schema:registry",
-        "//src/v/serde/avro/tests:data_generator",
         "@avro",
     ],
     include_prefix = "datalake/tests",
@@ -112,6 +111,7 @@ redpanda_test_cc_library(
         "//src/v/container:fragmented_vector",
         "//src/v/model",
         "//src/v/pandaproxy",
+        "//src/v/serde/avro/tests:data_generator",
         "//src/v/storage:record_batch_builder",
         "//src/v/utils:named_type",
         "@seastar",

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -128,9 +128,11 @@ redpanda_test_cc_library(
     ],
     include_prefix = "datalake/tests",
     deps = [
+        "//src/v/datalake:serde_parquet_writer",
         "//src/v/datalake:writer",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:values",
+        "//src/v/utils:null_output_stream",
         "@seastar",
     ],
 )

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -101,7 +101,9 @@ redpanda_test_cc_library(
     implementation_deps = [
         "//src/v/container:chunked_hash_map",
         "//src/v/schema:registry",
+        "//src/v/utils:vint",
         "@avro",
+        "@protobuf",
     ],
     include_prefix = "datalake/tests",
     visibility = ["//visibility:public"],
@@ -112,6 +114,7 @@ redpanda_test_cc_library(
         "//src/v/model",
         "//src/v/pandaproxy",
         "//src/v/serde/avro/tests:data_generator",
+        "//src/v/serde/protobuf/tests:data_generator",
         "//src/v/storage:record_batch_builder",
         "//src/v/utils:named_type",
         "@seastar",

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -204,3 +204,20 @@ rp_test(
   LABELS datalake
   ARGS "-- -c 1"
 )
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME record_multiplexer
+  SOURCES record_multiplexer_bench.cc
+  LIBRARIES
+    Seastar::seastar_perf_testing
+    Boost::unit_test_framework
+    v::cloud_io_utils
+    v::application
+    v::datalake_test_utils
+    v::iceberg_test_utils
+    v::schema
+    v::s3_imposter
+  ARGS "-c 1 --duration=1 --runs=1 --memory=4G"
+  LABELS datalake
+)

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -10,7 +10,9 @@ v_cc_library(
   DEPS
     Avro::avro
     Seastar::seastar
+    protobuf::libprotobuf
     v::avro_test_utils
+    v::protobuf_test_utils
     v::schema
     v::schema_test_fixture
     v::storage

--- a/src/v/datalake/tests/datalake_avro_tests.cc
+++ b/src/v/datalake/tests/datalake_avro_tests.cc
@@ -509,8 +509,8 @@ prepare_avro_test(std::string_view schema) {
     // Convert to iceberg schema
     auto iceberg_struct_res = datalake::type_to_iceberg(valid_schema.root());
     // Generate random generic datum
-    generator_state state{0};
-    avro::GenericDatum datum = generate_datum(valid_schema.root(), state, 10);
+    avro_generator gen({});
+    avro::GenericDatum datum = gen.generate_datum(valid_schema.root());
 
     // Serialize using avro library
     auto buffer = serialize_with_avro(datum, valid_schema);

--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -9,15 +9,24 @@
  */
 #include "datalake/tests/record_generator.h"
 
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "schema/registry.h"
 #include "storage/record_batch_builder.h"
+#include "utils/vint.h"
 
+#include <seastar/core/temporary_buffer.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <avro/Encoder.hh>
 #include <avro/Generic.hh>
 #include <avro/Specific.hh>
 #include <avro/Stream.hh>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/text_format.h>
 
 namespace datalake::tests {
 
@@ -37,6 +46,105 @@ record_generator::register_avro_schema(
     if (!added) {
         co_return error{fmt::format("Failed to add schema {} to map", name)};
     }
+    co_return std::nullopt;
+}
+
+ss::future<checked<std::nullopt_t, record_generator::error>>
+record_generator::register_protobuf_schema(
+  std::string_view name, std::string_view schema) {
+    using namespace pandaproxy::schema_registry;
+    auto id = co_await ss::coroutine::as_future(
+      _sr->create_schema(unparsed_schema{
+        subject{"foo"},
+        unparsed_schema_definition{schema, schema_type::protobuf}}));
+    if (id.failed()) {
+        co_return error{fmt::format(
+          "Error creating schema {}: {}", name, id.get_exception())};
+    }
+    auto [_, added] = _id_by_name.emplace(name, id.get());
+    if (!added) {
+        co_return error{fmt::format("Failed to add schema {} to map", name)};
+    }
+    co_return std::nullopt;
+}
+
+iobuf encode_protobuf_message_index(const std::vector<int32_t>& message_index) {
+    iobuf ret;
+    if (message_index.size() == 1 && message_index[0] == 0) {
+        ret.append("\0", 1);
+        return ret;
+    }
+
+    std::array<uint8_t, vint::max_length> bytes{0};
+    size_t res_size = vint::serialize(message_index.size(), &bytes[0]);
+    ret.append(&bytes[0], res_size);
+
+    for (const auto& o : message_index) {
+        size_t res_size = vint::serialize(o, &bytes[0]);
+        ret.append(&bytes[0], res_size);
+    }
+
+    return ret;
+}
+
+ss::future<checked<std::nullopt_t, record_generator::error>>
+record_generator::add_random_protobuf_record(
+  storage::record_batch_builder& b,
+  std::string_view name,
+  const std::vector<int32_t>& message_index,
+  std::optional<iobuf> key,
+  testing::protobuf_generator_config config) {
+    using namespace pandaproxy::schema_registry;
+    auto it = _id_by_name.find(name);
+    if (it == _id_by_name.end()) {
+        co_return error{fmt::format("Schema {} is missing", name)};
+    }
+    auto schema_id = it->second;
+    auto schema_def = co_await _sr->get_valid_schema(schema_id);
+    if (!schema_def) {
+        co_return error{
+          fmt::format("Unable to find schema def for id: {}", schema_id)};
+    }
+    if (schema_def->type() != schema_type::protobuf) {
+        co_return error{fmt::format(
+          "Schema {} has wrong type: {}", name, schema_def->type())};
+    }
+
+    auto protobuf_def = schema_def
+                          ->visit(ss::make_visitor(
+                            [](const avro_schema_definition&)
+                              -> std::optional<protobuf_schema_definition> {
+                                return std::nullopt;
+                            },
+                            [](const protobuf_schema_definition& pb_def)
+                              -> std::optional<protobuf_schema_definition> {
+                                return {pb_def};
+                            },
+                            [](const json_schema_definition&)
+                              -> std::optional<protobuf_schema_definition> {
+                                return std::nullopt;
+                            }))
+                          .value();
+    auto md_res = pandaproxy::schema_registry::descriptor(
+      protobuf_def, message_index);
+    if (md_res.has_error()) {
+        co_return error{fmt::format(
+          "Wasn't able to get descriptor for protobuf def with id: {}",
+          schema_id)};
+    }
+
+    iobuf val;
+    val.append("\0", 1);
+    int32_t encoded_id = ss::cpu_to_be(schema_id());
+    val.append((const uint8_t*)(&encoded_id), 4);
+
+    testing::protobuf_generator pb_gen(config);
+    auto msg = pb_gen.generate_protobuf_message(&md_res.value().get());
+
+    val.append(encode_protobuf_message_index(message_index));
+    val.append(iobuf::from(msg->SerializeAsString()));
+
+    b.add_raw_kv(std::move(key), std::move(val));
     co_return std::nullopt;
 }
 

--- a/src/v/datalake/tests/record_generator.h
+++ b/src/v/datalake/tests/record_generator.h
@@ -12,10 +12,10 @@
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
-#include "model/record.h"
 #include "model/timestamp.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "serde/avro/tests/data_generator.h"
+#include "serde/protobuf/tests/data_generator.h"
 #include "storage/record_batch_builder.h"
 #include "utils/named_type.h"
 
@@ -37,12 +37,24 @@ public:
     ss::future<checked<std::nullopt_t, error>>
     register_avro_schema(std::string_view name, std::string_view schema);
 
+    // Registers the given schema with the given name.
+    ss::future<checked<std::nullopt_t, error>>
+    register_protobuf_schema(std::string_view name, std::string_view schema);
+
     // Adds a record of the given schema to the builder.
     ss::future<checked<std::nullopt_t, error>> add_random_avro_record(
       storage::record_batch_builder&,
       std::string_view schema_name,
       std::optional<iobuf> key,
       testing::avro_generator_config config = {});
+
+    // Adds a record of the given schema to the builder.
+    ss::future<checked<std::nullopt_t, error>> add_random_protobuf_record(
+      storage::record_batch_builder&,
+      std::string_view schema_name,
+      const std::vector<int32_t>& message_index,
+      std::optional<iobuf> key,
+      testing::protobuf_generator_config config = {});
 
 private:
     chunked_hash_map<std::string_view, pandaproxy::schema_registry::schema_id>

--- a/src/v/datalake/tests/record_generator.h
+++ b/src/v/datalake/tests/record_generator.h
@@ -15,6 +15,7 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "serde/avro/tests/data_generator.h"
 #include "storage/record_batch_builder.h"
 #include "utils/named_type.h"
 
@@ -40,7 +41,8 @@ public:
     ss::future<checked<std::nullopt_t, error>> add_random_avro_record(
       storage::record_batch_builder&,
       std::string_view schema_name,
-      std::optional<iobuf> key);
+      std::optional<iobuf> key,
+      testing::avro_generator_config config = {});
 
 private:
     chunked_hash_map<std::string_view, pandaproxy::schema_registry::schema_id>

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -1,0 +1,535 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "container/fragmented_vector.h"
+#include "datalake/catalog_schema_manager.h"
+#include "datalake/record_multiplexer.h"
+#include "datalake/record_schema_resolver.h"
+#include "datalake/record_translator.h"
+#include "datalake/table_creator.h"
+#include "datalake/tests/catalog_and_registry_fixture.h"
+#include "datalake/tests/record_generator.h"
+#include "datalake/tests/test_data_writer.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "serde/avro/tests/data_generator.h"
+#include "serde/protobuf/tests/data_generator.h"
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <optional>
+#include <string_view>
+
+namespace {
+std::string generate_nested_proto_internal(size_t total_depth) {
+    constexpr auto proto_template = R"(
+    message Foo{} {{
+        {} 
+        string a{} = {}; 
+        {}
+    }})";
+
+    if (total_depth == 0) {
+        return "";
+    }
+    std::string member = "";
+    if (total_depth > 1) {
+        member = std::format(
+          "Foo{} b{} = {}; ",
+          total_depth - 1,
+          total_depth,
+          2 * total_depth + 1);
+    }
+    return std::format(
+      proto_template,
+      total_depth,
+      generate_nested_proto_internal(total_depth - 1),
+      total_depth,
+      2 * total_depth,
+      member);
+}
+
+/**
+ * Generates a nested protobuf schema.
+ *
+ * I.e, if total_depth=3 then the following would be generated;
+ *
+ * syntax = "proto3";
+ * message Foo3 {
+ *      message Foo2 {
+ *          message Foo1 {
+ *              string a1 = 2;
+ *          }
+ *          string a2 = 4;
+ *          Foo1 b2 = 5;
+ *      }
+ *      string a3 = 6;
+ *      Foo2 b3 = 7;
+ * }
+ */
+std::string generate_nested_proto(size_t total_depth) {
+    return std::format(
+      "syntax = \"proto3\"; {}", generate_nested_proto_internal(total_depth));
+}
+
+/**
+ * Generates a linear protobuf schema.
+ *
+ * I.e, if total_fields=3 then the following would be generated;
+ *
+ * syntax = "proto3";
+ * message Linear {
+ *      string a1 = 1;
+ *      string a2 = 2;
+ *      string a3 = 3;
+ * }
+ */
+std::string generate_linear_proto(size_t total_fields) {
+    constexpr auto proto_template = R"(
+    syntax = "proto3";
+    message Linear {{
+        {}
+    }})";
+
+    std::string fields = "";
+    for (int i = 1; i <= total_fields; i++) {
+        fields += std::format("string a{} = {};\n", i, i);
+    }
+
+    return std::format(proto_template, fields);
+}
+
+std::string generate_nested_avro_internal(size_t total_depth) {
+    constexpr auto avro_template = R"(
+    {{
+        "name": "nestedval{}",
+        "type": {{
+            "type": "record",
+            "name": "nestedrecord{}",
+            "fields": [
+                {}
+                {}
+            ]
+        }}
+    }})";
+
+    if (total_depth == 0) {
+        return "";
+    }
+
+    std::string string_field = std::format(
+      R"({{ "name": "inval{}", "type": "string" }})", total_depth);
+    if (total_depth != 1) {
+        string_field += ",";
+    };
+
+    return std::format(
+      avro_template,
+      total_depth,
+      total_depth,
+      string_field,
+      generate_nested_avro_internal(total_depth - 1));
+}
+
+/**
+ * Generates a nested avro schema;
+ *
+ * I.e, if total_depth=2 then the following would be generated;
+ * {
+ *  "name": "base",
+ *  "type": "record",
+ *  "fields": [
+ *	{
+ *	  "name": "nestedval2",
+ *	  "type": {
+ *		"type": "record",
+ *		"name": "nestedrecord2",
+ *		"fields": [
+ *		  {
+ *			"name": "inval2",
+ *			"type": "string"
+ *		  },
+ *		  {
+ *			"name": "nestedval1",
+ *			"type": {
+ *			  "type": "record",
+ *			  "name": "nestedrecord1",
+ *			  "fields": [
+ *				{
+ *				  "name": "inval1",
+ *				  "type": "string"
+ *				}
+ *			  ]
+ *			}
+ *		  }
+ *		]
+ *	  }
+ *	}
+ *  ]
+ *}
+ *
+ */
+std::string generate_nested_avro(size_t total_depth) {
+    constexpr auto avro_template = R"({{
+    "name": "base",
+    "type": "record",
+    "fields": [
+        {}
+    ]}})";
+
+    return std::format(
+      avro_template, generate_nested_avro_internal(total_depth));
+}
+
+/**
+ * Generates a linear avro schema.
+ *
+ * I.e, if total_fields=3 then the following would be generated;
+ * {
+ *   "name": "base",
+ *   "type": "record",
+ *   "fields": [
+ *    {
+ *      "name": "field0",
+ *      "type": "string"
+ *    },
+ *    {
+ *      "name": "field1",
+ *      "type": "string"
+ *    },
+ *    {
+ *      "name": "field2",
+ *      "type": "string"
+ *    }
+ *  ]
+ * }
+ *
+ */
+std::string generate_linear_avro(size_t total_fields) {
+    constexpr auto avro_template = R"({{
+    "name": "base",
+    "type": "record",
+    "fields": [
+        {}
+    ]}})";
+    constexpr auto field_template
+      = R"({{ "name": "field{}", "type": "string" }})";
+    std::string ret = "";
+
+    for (size_t i = 0; i < total_fields; i++) {
+        ret += std::format(field_template, i);
+        if (i != total_fields - 1) {
+            ret += ",";
+        }
+    }
+
+    ret = std::format(avro_template, ret);
+    return ret;
+}
+
+chunked_vector<model::record_batch>
+share_batches(chunked_vector<model::record_batch>& batches) {
+    chunked_vector<model::record_batch> ret;
+    for (auto& batch : batches) {
+        ret.push_back(batch.share());
+    }
+    return ret;
+}
+
+struct counting_consumer {
+    size_t total_bytes = 0;
+    datalake::record_multiplexer mux;
+    ss::future<ss::stop_iteration> operator()(model::record_batch&& batch) {
+        total_bytes += batch.size_bytes();
+        return mux(std::move(batch));
+    }
+    ss::future<counting_consumer> end_of_stream() {
+        auto res = co_await mux.end_of_stream();
+        BOOST_REQUIRE(!res.has_error());
+        co_return std::move(*this);
+    }
+};
+
+} // namespace
+
+class record_multiplexer_bench_fixture
+  : public datalake::tests::catalog_and_registry_fixture {
+public:
+    record_multiplexer_bench_fixture()
+      : _schema_mgr(catalog)
+      , _type_resolver(registry)
+      , _record_gen(&registry)
+      , _table_creator(_type_resolver, _schema_mgr) {}
+
+    template<typename T>
+    requires std::same_as<T, ::testing::protobuf_generator_config>
+             || std::same_as<T, ::testing::avro_generator_config>
+    ss::future<> configure_bench(
+      T gen_config,
+      std::string schema,
+      size_t batches,
+      size_t records_per_batch) {
+        if constexpr (std::is_same_v<T, ::testing::protobuf_generator_config>) {
+            _batch_data = co_await generate_protobuf_batches(
+              records_per_batch,
+              batches,
+              "proto_schema",
+              schema,
+              {0},
+              gen_config);
+        } else {
+            _batch_data = co_await generate_avro_batches(
+              records_per_batch, batches, "avro_schema", schema, gen_config);
+        }
+    }
+
+    ss::future<size_t> run_bench() {
+        auto reader = model::make_fragmented_memory_record_batch_reader(
+          share_batches(_batch_data));
+        auto consumer = counting_consumer{.mux = create_mux()};
+
+        perf_tests::start_measuring_time();
+        auto res = co_await reader.consume(
+          std::move(consumer), model::no_timeout);
+        perf_tests::stop_measuring_time();
+
+        co_return res.total_bytes;
+    }
+
+private:
+    std::unordered_set<std::string> _added_names;
+    datalake::catalog_schema_manager _schema_mgr;
+    datalake::record_schema_resolver _type_resolver;
+    datalake::tests::record_generator _record_gen;
+    datalake::default_translator _translator;
+    datalake::direct_table_creator _table_creator;
+    chunked_vector<model::record_batch> _batch_data;
+
+    const model::ntp ntp{
+      model::ns{"rp"}, model::topic{"t"}, model::partition_id{0}};
+    const model::revision_id topic_rev{123};
+
+    datalake::record_multiplexer create_mux() {
+        return datalake::record_multiplexer(
+          ntp,
+          topic_rev,
+          std::make_unique<datalake::test_serde_parquet_writer_factory>(),
+          _schema_mgr,
+          _type_resolver,
+          _translator,
+          _table_creator);
+    }
+
+    ss::future<>
+    try_add_avro_schema(std::string_view name, std::string_view schema) {
+        auto [_, added] = _added_names.emplace(name);
+        if (!added) {
+            co_return;
+        }
+
+        auto reg_res = co_await _record_gen.register_avro_schema(name, schema);
+        BOOST_REQUIRE(reg_res.has_value());
+    }
+
+    ss::future<>
+    try_add_protobuf_schema(std::string_view name, std::string_view schema) {
+        auto [_, added] = _added_names.emplace(name);
+        if (!added) {
+            co_return;
+        }
+
+        auto reg_res = co_await _record_gen.register_protobuf_schema(
+          name, schema);
+        BOOST_REQUIRE(reg_res.has_value());
+    }
+
+    ss::future<chunked_vector<model::record_batch>> generate_batches(
+      size_t records_per_batch,
+      size_t batches,
+      std::function<ss::future<
+        checked<std::nullopt_t, datalake::tests::record_generator::error>>(
+        storage::record_batch_builder&)> add_batch) {
+        chunked_vector<model::record_batch> ret;
+        ret.reserve(batches);
+
+        model::offset o{0};
+        for (size_t i = 0; i < batches; ++i) {
+            storage::record_batch_builder batch_builder(
+              model::record_batch_type::raft_data, o);
+
+            // Add some records per batch.
+            for (size_t r = 0; r < records_per_batch; ++r) {
+                auto res = co_await add_batch(batch_builder);
+                ++o;
+
+                BOOST_REQUIRE(!res.has_error());
+            }
+            auto batch = std::move(batch_builder).build();
+            ret.emplace_back(std::move(batch));
+        }
+
+        co_return ret;
+    }
+
+    ss::future<chunked_vector<model::record_batch>> generate_protobuf_batches(
+      size_t records_per_batch,
+      size_t batches,
+      std::string schema_name,
+      std::string proto_schema,
+      std::vector<int32_t> msg_idx,
+      ::testing::protobuf_generator_config gen_config) {
+        co_await try_add_protobuf_schema(schema_name, proto_schema);
+        co_return co_await generate_batches(
+          records_per_batch, batches, [&](auto& bb) {
+              return _record_gen.add_random_protobuf_record(
+                bb, schema_name, msg_idx, std::nullopt, gen_config);
+          });
+    }
+
+    ss::future<chunked_vector<model::record_batch>> generate_avro_batches(
+      size_t records_per_batch,
+      size_t batches,
+      std::string schema_name,
+      std::string avro_schema,
+      ::testing::avro_generator_config gen_config) {
+        co_await try_add_avro_schema(schema_name, avro_schema);
+        co_return co_await generate_batches(
+          records_per_batch, batches, [&](auto& bb) {
+              return _record_gen.add_random_avro_record(
+                bb, schema_name, std::nullopt, gen_config);
+          });
+    }
+};
+
+namespace {
+
+// Specifies how many batches should be in the test dataset.
+static constexpr size_t batches = 1000;
+// Specifies how many records should be in each batch of the test dataset.
+static constexpr size_t records_per_batch = 10;
+
+} // namespace
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, protobuf_381_byte_message_linear_1_field) {
+    static ::testing::protobuf_generator_config gen_config = {
+      .string_length_range{302, 302}};
+    static std::string proto_schema = generate_linear_proto(1);
+
+    co_await configure_bench(
+      gen_config, proto_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_381_byte_message_linear_40_fields) {
+    static ::testing::protobuf_generator_config gen_config = {
+      .string_length_range{5, 5}};
+    static std::string proto_schema = generate_linear_proto(40);
+
+    co_await configure_bench(
+      gen_config, proto_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_381_byte_message_linear_80_fields) {
+    static ::testing::protobuf_generator_config gen_config = {
+      .string_length_range{1, 1}};
+    static std::string proto_schema = generate_linear_proto(80);
+
+    co_await configure_bench(
+      gen_config, proto_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_384_byte_message_nested_24_levels) {
+    static ::testing::protobuf_generator_config gen_config = {
+      .string_length_range{7, 7}, .max_nesting_level = 40};
+    static std::string proto_schema = generate_nested_proto(24);
+
+    co_await configure_bench(
+      gen_config, proto_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_386_byte_message_nested_31_levels) {
+    static ::testing::protobuf_generator_config gen_config = {
+      .string_length_range{4, 4}, .max_nesting_level = 40};
+    static std::string proto_schema = generate_nested_proto(31);
+
+    co_await configure_bench(
+      gen_config, proto_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_linear_1_field) {
+    static ::testing::avro_generator_config gen_config = {
+      .string_length_range{308, 308}};
+    static std::string avro_schema = generate_linear_avro(1);
+
+    co_await configure_bench(
+      gen_config, avro_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_linear_31_fields) {
+    static ::testing::avro_generator_config gen_config = {
+      .string_length_range{9, 9}};
+    static std::string avro_schema = generate_linear_avro(31);
+
+    co_await configure_bench(
+      gen_config, avro_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_linear_62_fields) {
+    static ::testing::avro_generator_config gen_config = {
+      .string_length_range{4, 4}};
+    static std::string avro_schema = generate_linear_avro(62);
+
+    co_await configure_bench(
+      gen_config, avro_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_nested_31_levels) {
+    static ::testing::avro_generator_config gen_config = {
+      .string_length_range{9, 9}, .max_nesting_level = 40};
+    static std::string avro_schema = generate_nested_avro(31);
+
+    co_await configure_bench(
+      gen_config, avro_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_nested_62_levels) {
+    static ::testing::avro_generator_config gen_config = {
+      .string_length_range{4, 4}, .max_nesting_level = 40};
+    static std::string avro_schema = generate_nested_avro(62);
+
+    co_await configure_bench(
+      gen_config, avro_schema, batches, records_per_batch);
+    co_return co_await run_bench();
+}

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "datalake/data_writer_interface.h"
+#include "datalake/serde_parquet_writer.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/values.h"
+#include "utils/null_output_stream.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -60,6 +62,46 @@ public:
 private:
     iceberg::struct_type _schema;
     bool _return_error;
+};
+
+class test_serde_parquet_data_writer : public parquet_file_writer {
+public:
+    explicit test_serde_parquet_data_writer(
+      std::unique_ptr<parquet_ostream> writer)
+      : _writer(std::move(writer))
+      , _result{} {}
+
+    ss::future<writer_error>
+    add_data_struct(iceberg::struct_value data, int64_t sz) override {
+        auto write_result = co_await _writer->add_data_struct(
+          std::move(data), sz);
+        _result.row_count++;
+        co_return write_result;
+    }
+
+    ss::future<result<local_file_metadata, writer_error>> finish() override {
+        return ss::make_ready_future<result<local_file_metadata, writer_error>>(
+          _result);
+    }
+
+private:
+    std::unique_ptr<parquet_ostream> _writer;
+    local_file_metadata _result;
+};
+
+class test_serde_parquet_writer_factory : public parquet_file_writer_factory {
+public:
+    ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
+    create_writer(const iceberg::struct_type& schema) override {
+        auto ostream_writer = co_await _serde_parquet_factory.create_writer(
+          schema, utils::make_null_output_stream());
+
+        co_return std::make_unique<test_serde_parquet_data_writer>(
+          std::move(ostream_writer));
+    }
+
+private:
+    serde_parquet_writer_factory _serde_parquet_factory;
 };
 
 } // namespace datalake

--- a/src/v/serde/avro/tests/data_generator.h
+++ b/src/v/serde/avro/tests/data_generator.h
@@ -19,13 +19,25 @@
 
 namespace testing {
 
-struct generator_state {
-    int level{0};
+struct avro_generator_config {
+    std::optional<size_t> elements_in_collection{};
+    std::pair<size_t, size_t> string_length_range{0, 32};
+    int max_nesting_level{10};
 };
-avro::GenericDatum generate_datum(
-  const avro::NodePtr& node,
-  generator_state& state,
-  int max_nesting_level,
-  std::optional<size_t> elements_in_collection = std::nullopt);
+
+class avro_generator {
+public:
+    explicit avro_generator(avro_generator_config c)
+      : _config(c) {}
+
+    avro::GenericDatum generate_datum(const avro::NodePtr& node) {
+        return generate_datum_impl(1, node);
+    }
+
+private:
+    avro::GenericDatum
+    generate_datum_impl(int level, const avro::NodePtr& node);
+    avro_generator_config _config;
+};
 
 } // namespace testing

--- a/src/v/serde/avro/tests/parser_test.cc
+++ b/src/v/serde/avro/tests/parser_test.cc
@@ -305,9 +305,9 @@ TEST_P(AvroParserTest, RoundtripTest) {
 
     for (int i = 0; i < 500; ++i) {
         // Generate random value
-        generator_state state;
-        ::avro::GenericDatum random_value = generate_datum(
-          valid_schema.root(), state, 10);
+        avro_generator gen({});
+        ::avro::GenericDatum random_value = gen.generate_datum(
+          valid_schema.root());
         // serialize data with AVRO library
         iobuf buffer = serialize_with_avro(random_value, valid_schema);
         // read using serde::avro
@@ -358,9 +358,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(AvroParserTest, TestTooManyBytes) {
     auto valid_schema = load_json_schema("record2");
-    generator_state state;
-    ::avro::GenericDatum random_value = generate_datum(
-      valid_schema.root(), state, 10);
+    avro_generator gen({});
+    ::avro::GenericDatum random_value = gen.generate_datum(valid_schema.root());
 
     iobuf buffer = serialize_with_avro(random_value, valid_schema);
     buffer.append(random_generators::make_iobuf(128));
@@ -415,9 +414,8 @@ bool try_deserialize_with_avro_lib(
 
 TEST_F(AvroParserTest, TestIncorrectSchema) {
     auto valid_schema = load_json_schema("record2");
-    generator_state state;
-    ::avro::GenericDatum random_value = generate_datum(
-      valid_schema.root(), state, 10);
+    avro_generator gen({});
+    ::avro::GenericDatum random_value = gen.generate_datum(valid_schema.root());
     iobuf buffer = serialize_with_avro(random_value, valid_schema);
     auto invalid_schema = load_json_schema("tree2");
     auto success = try_deserialize_with_avro_lib(invalid_schema, buffer);

--- a/src/v/serde/protobuf/CMakeLists.txt
+++ b/src/v/serde/protobuf/CMakeLists.txt
@@ -11,3 +11,5 @@ v_cc_library(
     v::utils
     protobuf::libprotobuf
   )
+
+add_subdirectory(tests)

--- a/src/v/serde/protobuf/tests/BUILD
+++ b/src/v/serde/protobuf/tests/BUILD
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 proto_library(
     name = "two_proto",
@@ -56,5 +56,23 @@ redpanda_cc_gtest(
         "@protobuf",
         "@protobuf//:differencer",
         "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "data_generator",
+    srcs = [
+        "data_generator.cc",
+    ],
+    hdrs = [
+        "data_generator.h",
+    ],
+    implementation_deps = [
+        "//src/v/random:generators",
+    ],
+    include_prefix = "serde/protobuf/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@protobuf",
     ],
 )

--- a/src/v/serde/protobuf/tests/CMakeLists.txt
+++ b/src/v/serde/protobuf/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+find_package(Protobuf REQUIRED)
+
+v_cc_library(
+  NAME protobuf_test_utils
+  HDRS
+    data_generator.h
+  SRCS
+    data_generator.cc
+  DEPS
+    protobuf::libprotobuf
+    v::random
+)

--- a/src/v/serde/protobuf/tests/data_generator.cc
+++ b/src/v/serde/protobuf/tests/data_generator.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/protobuf/tests/data_generator.h"
+
+#include "random/generators.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace testing {
+ss::sstring random_string(const protobuf_generator_config& config) {
+    auto [min, max] = config.string_length_range;
+    return random_generators::gen_alphanum_string(
+      random_generators::get_int(min, max));
+}
+
+std::unique_ptr<google::protobuf::Message>
+protobuf_generator::generate_protobuf_message_impl(
+  int level, const google::protobuf::Descriptor* d) {
+    auto& factory = _factory;
+    auto get_elements_count = [level, this]() -> size_t {
+        if (level >= _config.max_nesting_level) {
+            return 0;
+        }
+        return _config.elements_in_collection.value_or(
+          random_generators::get_int<size_t>(10));
+    };
+
+    auto message = std::unique_ptr<google::protobuf::Message>(
+      factory.GetPrototype(d)->New());
+    const google::protobuf::Reflection* r = message->GetReflection();
+    for (int i = 0; i < d->field_count(); i++) {
+        const auto* field_d = d->field(i);
+
+        // if its a union type select a random field in it, randomize its value,
+        // then jump to the end of all fields in the oneof.
+        if (auto oneof_d = field_d->real_containing_oneof()) {
+            auto num_fields = oneof_d->field_count();
+            field_d = d->field(
+              random_generators::get_int(i, i + (num_fields - 1)));
+            i += (num_fields - 1);
+
+            if (
+              _config.randomize_optional_fields && field_d->is_optional()
+              && random_generators::get_int(0, 1) == 1) {
+                continue;
+            }
+        }
+
+        using fdns = google::protobuf::FieldDescriptor;
+
+        if (field_d->is_repeated()) {
+            for (size_t i = 0; i < get_elements_count(); i++) {
+                switch (field_d->cpp_type()) {
+                case fdns::CPPTYPE_INT32: {
+                    auto v = random_generators::get_int<int32_t>();
+                    r->AddInt32(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_INT64: {
+                    auto v = random_generators::get_int<int64_t>();
+                    r->AddInt64(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_UINT32: {
+                    auto v = random_generators::get_int<uint32_t>();
+                    r->AddUInt32(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_UINT64: {
+                    auto v = random_generators::get_int<uint64_t>();
+                    r->AddUInt64(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_DOUBLE: {
+                    auto v = random_generators::get_real<double>();
+                    r->AddDouble(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_FLOAT: {
+                    auto v = random_generators::get_real<float>();
+                    r->AddFloat(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_BOOL: {
+                    auto v = random_generators::random_choice({true, false});
+                    r->AddBool(message.get(), field_d, v);
+                } break;
+                case fdns::CPPTYPE_ENUM: {
+                    const auto* enum_d = field_d->enum_type();
+                    auto ri = random_generators::get_int(
+                      0, enum_d->value_count() - 1);
+                    r->AddEnum(message.get(), field_d, enum_d->value(ri));
+                } break;
+                case fdns::CPPTYPE_STRING: {
+                    r->AddString(
+                      message.get(), field_d, random_string(_config));
+                } break;
+                case fdns::CPPTYPE_MESSAGE: {
+                    // TODO: does this work with maps?
+                    auto* sub_messsage = generate_protobuf_message_impl(
+                                           level + 1, field_d->message_type())
+                                           .release();
+                    r->AddAllocatedMessage(
+                      message.get(), field_d, sub_messsage);
+                } break;
+                }
+            }
+        } else {
+            if (
+              _config.randomize_optional_fields && field_d->is_optional()
+              && random_generators::get_int(0, 1) == 1) {
+                continue;
+            }
+
+            switch (field_d->cpp_type()) {
+            case fdns::CPPTYPE_INT32: {
+                auto v = random_generators::get_int<int32_t>();
+                r->SetInt32(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_INT64: {
+                auto v = random_generators::get_int<int64_t>();
+                r->SetInt64(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_UINT32: {
+                auto v = random_generators::get_int<uint32_t>();
+                r->SetUInt32(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_UINT64: {
+                auto v = random_generators::get_int<uint64_t>();
+                r->SetUInt64(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_DOUBLE: {
+                auto v = random_generators::get_real<double>();
+                r->SetDouble(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_FLOAT: {
+                auto v = random_generators::get_real<float>();
+                r->SetFloat(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_BOOL: {
+                auto v = random_generators::random_choice({true, false});
+                r->SetBool(message.get(), field_d, v);
+            } break;
+            case fdns::CPPTYPE_ENUM: {
+                const auto* enum_d = field_d->enum_type();
+                auto ri = random_generators::get_int(
+                  0, enum_d->value_count() - 1);
+                r->SetEnum(message.get(), field_d, enum_d->value(ri));
+            } break;
+            case fdns::CPPTYPE_STRING: {
+                r->SetString(message.get(), field_d, random_string(_config));
+            } break;
+            case fdns::CPPTYPE_MESSAGE: {
+                if (
+                  field_d->is_optional()
+                  && level >= _config.max_nesting_level) {
+                    break;
+                }
+                auto* sub_messsage = generate_protobuf_message_impl(
+                                       level + 1, field_d->message_type())
+                                       .release();
+                r->SetAllocatedMessage(message.get(), sub_messsage, field_d);
+            } break;
+            }
+        }
+    }
+
+    return message;
+}
+
+} // namespace testing

--- a/src/v/serde/protobuf/tests/data_generator.h
+++ b/src/v/serde/protobuf/tests/data_generator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/text_format.h>
+
+#include <memory>
+#include <optional>
+
+namespace testing {
+
+struct protobuf_generator_config {
+    std::optional<size_t> elements_in_collection{};
+    std::pair<size_t, size_t> string_length_range{0, 32};
+    int max_nesting_level{10};
+    // Enable randomly not setting values for optional fields in the message.
+    bool randomize_optional_fields{false};
+};
+
+class protobuf_generator {
+public:
+    explicit protobuf_generator(protobuf_generator_config c)
+      : _config(c) {}
+
+    std::unique_ptr<google::protobuf::Message>
+    generate_protobuf_message(const google::protobuf::Descriptor* d) {
+        return generate_protobuf_message_impl(1, d);
+    }
+
+private:
+    std::unique_ptr<google::protobuf::Message> generate_protobuf_message_impl(
+      int level, const google::protobuf::Descriptor* d);
+    protobuf_generator_config _config;
+    google::protobuf::DynamicMessageFactory _factory{};
+};
+} // namespace testing

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -420,6 +420,7 @@ redpanda_cc_library(
         "//src/v/utils:mutex",
         "//src/v/utils:named_type",
         "//src/v/utils:notification_list",
+        "//src/v/utils:null_output_stream",
         "//src/v/utils:prefix_logger",
         "//src/v/utils:stream_provider",
         "//src/v/utils:to_string",

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -677,3 +677,15 @@ redpanda_cc_library(
         "@boost//:intrusive",
     ],
 )
+
+redpanda_cc_library(
+    name = "null_output_stream",
+    hdrs = [
+        "null_output_stream.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/null_output_stream.h
+++ b/src/v/utils/null_output_stream.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "base/units.h"
+
+#include <seastar/core/iostream.hh>
+#include <seastar/util/later.hh>
+
+namespace utils {
+// Data sink for noop output_stream instance
+// needed to implement scanning
+struct null_data_sink final : ss::data_sink_impl {
+    ss::future<> put(ss::net::packet data) final { return put(data.release()); }
+    ss::future<> put(std::vector<ss::temporary_buffer<char>> all) final {
+        return ss::do_with(
+          std::move(all), [this](std::vector<ss::temporary_buffer<char>>& all) {
+              return ss::do_for_each(
+                all, [this](ss::temporary_buffer<char>& buf) {
+                    return put(std::move(buf));
+                });
+          });
+    }
+    ss::future<> put(ss::temporary_buffer<char>) final { return ss::now(); }
+    ss::future<> flush() final { return ss::now(); }
+    ss::future<> close() final { return ss::now(); }
+};
+
+ss::output_stream<char> make_null_output_stream() {
+    auto ds = ss::data_sink(std::make_unique<null_data_sink>());
+    ss::output_stream<char> ostr(std::move(ds), 4_KiB);
+    return ostr;
+}
+
+} // namespace utils


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds benchmarks for `record_multiplexer` along with the following that was needed to support that;
- A cmake-build-compatible random Protobuf message generator.
- Protobuf support for `record_generator`.
- A serde parquet writer that writes to a null ostream.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
