### PR TITLE
bazel: add crypto unit test key_tests

### DIFF
--- a/src/v/crypto/tests/BUILD
+++ b/src/v/crypto/tests/BUILD
@@ -70,3 +70,17 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "key_test",
+    timeout = "short",
+    srcs = [
+        "key_tests.cc",
+    ],
+    deps = [
+        ":crypto_test_utils",
+        "//src/v/crypto",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)


### PR DESCRIPTION
Implements : [CORE-7477](https://redpandadata.atlassian.net/browse/CORE-7477)

Add `crypto/tests/key_tests.cc` to bazel build
 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7477]: https://redpandadata.atlassian.net/browse/CORE-7477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ