### PR TITLE
[rptest] More verbose _async_download_on_node_unlocked

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -691,7 +691,7 @@ class RedpandaInstaller:
         version_root = self.root_for_version(version)
 
         tgz = "redpanda.tar.gz"
-        cmd = f"curl -fsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz} && gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root} && rm {version_root}/{tgz}"
+        cmd = f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz} && echo 'curl finished successfully' && gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root} && echo 'tarball extraction finished successfully' && rm {version_root}/{tgz} && echo 'tarball cleanup finished successfully'"
         return node.account.ssh_capture(cmd)
 
     def reset_current_install(self, nodes):


### PR DESCRIPTION
Adds `-v` argument to curl and additional status messages to help debug intermittent RedpandaInstaller failures. See DEVPROD-2406.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none