### PR TITLE
datalake: cleanup schema registry error handling

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -286,6 +286,8 @@ redpanda_cc_library(
     srcs = ["schema_registry.cc"],
     hdrs = ["schema_registry.h"],
     implementation_deps = [
+        ":logger",
+        "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",
     ],

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -55,11 +55,11 @@ record_multiplexer::operator()(model::record_batch batch) {
           std::move(val));
         if (val_type_res.has_error()) {
             switch (val_type_res.error()) {
+            case type_resolver::errc::registry_error:
+                _error = writer_error::parquet_conversion_error;
+                co_return ss::stop_iteration::yes;
             case type_resolver::errc::bad_input:
             case type_resolver::errc::translation_error:
-                // XXX: need to differentiate missing schema ID from transient
-                // registry errors.
-            case type_resolver::errc::registry_error:
                 auto invalid_res = co_await handle_invalid_record(
                   offset, record.share_key(), record.share_value(), timestamp);
                 if (invalid_res.has_error()) {

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -71,27 +71,17 @@ struct schema_translating_visitor {
     }
     ss::future<checked<type_and_buf, type_resolver::errc>>
     operator()(ppsr::protobuf_schema_definition&& pb_def) {
-        const google::protobuf::Descriptor* d;
-        proto_offsets_message_data offsets;
-        try {
-            auto offsets_res = get_proto_offsets(buf_no_id);
-            if (offsets_res.has_error()) {
-                co_return type_resolver::errc::bad_input;
-            }
-            offsets = std::move(offsets_res.value());
-            // TODO: maybe there's another caching opportunity here.
-            auto d_res = descriptor(pb_def, offsets.protobuf_offsets);
-            if (d_res.has_error()) {
-                co_return type_resolver::errc::bad_input;
-            }
-            d = &d_res.value().get();
-        } catch (...) {
-            vlog(
-              datalake_log.error,
-              "Error getting protobuf offsets from buffer: {}",
-              std::current_exception());
+        auto offsets_res = get_proto_offsets(buf_no_id);
+        if (offsets_res.has_error()) {
             co_return type_resolver::errc::bad_input;
         }
+        auto offsets = std::move(offsets_res.value());
+        // TODO: maybe there's another caching opportunity here.
+        auto d_res = descriptor(pb_def, offsets.protobuf_offsets);
+        if (d_res.has_error()) {
+            co_return type_resolver::errc::bad_input;
+        }
+        const auto* d = &d_res.value().get();
         try {
             auto type = type_to_iceberg(*d).value();
             co_return type_and_buf{
@@ -144,28 +134,19 @@ binary_type_resolver::resolve_buf_type(iobuf b) const {
 
 ss::future<checked<type_and_buf, type_resolver::errc>>
 record_schema_resolver::resolve_buf_type(iobuf b) const {
-    schema_message_data schema_id_res;
-    try {
-        // NOTE: Kafka's serialization protocol relies on a magic byte to
-        // indicate if we have a schema. This has room for false positives, and
-        // we can't say for sure if an error is the result of the record not
-        // having a schema. Just translate to binary.
-        auto res = get_value_schema_id(b);
-        if (res.has_error()) {
-            vlog(
-              datalake_log.trace,
-              "Error parsing schema ID; using binary type: {}",
-              res.error());
-            co_return type_and_buf::make_raw_binary(std::move(b));
-        }
-        schema_id_res = std::move(res.value());
-    } catch (...) {
+    // NOTE: Kafka's serialization protocol relies on a magic byte to
+    // indicate if we have a schema. This has room for false positives, and
+    // we can't say for sure if an error is the result of the record not
+    // having a schema. Just translate to binary.
+    auto res = get_value_schema_id(b);
+    if (res.has_error()) {
         vlog(
           datalake_log.trace,
           "Error parsing schema ID; using binary type: {}",
-          std::current_exception());
+          res.error());
         co_return type_and_buf::make_raw_binary(std::move(b));
     }
+    auto schema_id_res = std::move(res.value());
     auto schema_id = schema_id_res.schema_id;
     auto buf_no_id = std::move(schema_id_res.shared_message_data);
 

--- a/src/v/datalake/schema_registry.cc
+++ b/src/v/datalake/schema_registry.cc
@@ -9,11 +9,15 @@
  */
 #include "datalake/schema_registry.h"
 
+#include "base/vlog.h"
 #include "bytes/iobuf_parser.h"
+#include "datalake/logger.h"
 #include "pandaproxy/schema_registry/types.h"
 
+#include <exception>
+
 namespace datalake {
-get_schema_id_result get_value_schema_id(iobuf& buf) {
+get_schema_id_result get_value_schema_id(iobuf& buf) noexcept {
     // Messages that use the schema registry have a 5-byte prefix:
     // offset 0: magic byte with value 0
     // offsets 1-4: schema ID as big-endian integer
@@ -22,23 +26,31 @@ get_schema_id_result get_value_schema_id(iobuf& buf) {
     if (buf.size_bytes() < sizeof(uint8_t) + sizeof(int32_t)) {
         return get_schema_error::not_enough_bytes;
     }
-    iobuf_const_parser parser(buf);
-    auto magic = parser.consume_type<uint8_t>();
-    if (magic != schema_registry_magic_byte) {
-        return get_schema_error::no_schema_id;
-    }
-    auto id = parser.consume_be_type<int32_t>();
-    schema_message_data res = {
-      .schema_id = pandaproxy::schema_registry::schema_id{id},
-      .shared_message_data = buf.share(
-        parser.bytes_consumed(), parser.bytes_left())};
+    try {
+        iobuf_const_parser parser(buf);
+        auto magic = parser.consume_type<uint8_t>();
+        if (magic != schema_registry_magic_byte) {
+            return get_schema_error::no_schema_id;
+        }
+        auto id = parser.consume_be_type<int32_t>();
+        schema_message_data res = {
+          .schema_id = pandaproxy::schema_registry::schema_id{id},
+          .shared_message_data = buf.share(
+            parser.bytes_consumed(), parser.bytes_left())};
 
-    return res;
+        return res;
+    } catch (...) {
+        vlog(
+          datalake_log.warn,
+          "Error parsing schema id: {}",
+          std::current_exception());
+        return get_schema_error::not_enough_bytes;
+    }
 }
 
 // TODO: this is mostly a copy-and-paste of get_proto_offsets from
 // pandaproxy::schema_registry with a slightly different interface. Unify these.
-get_proto_offsets_result get_schema_proto_offsets(iobuf& buf) {
+get_proto_offsets_result get_schema_proto_offsets(iobuf& buf) noexcept {
     auto header = get_value_schema_id(buf);
     if (!header.has_value()) {
         return header.error();
@@ -57,40 +69,48 @@ get_proto_offsets_result get_schema_proto_offsets(iobuf& buf) {
 }
 
 result<proto_offsets_message_data, get_schema_error>
-get_proto_offsets(iobuf& buf) {
+get_proto_offsets(iobuf& buf) noexcept {
     proto_offsets_message_data result;
     iobuf_const_parser parser(buf.share(0, buf.size_bytes()));
 
     // The encoding is a length, followed by indexes into the file or message.
     // Each number is a zigzag encoded integer.
-    auto [offset_count, bytes_read] = parser.read_varlong();
-    if (!bytes_read) {
-        return get_schema_error::bad_varint;
-    }
-    // Reject more offsets than bytes remaining; it's not possible
-    if (static_cast<size_t>(offset_count) > parser.bytes_left()) {
-        return get_schema_error::not_enough_bytes;
-    }
-    if (offset_count == 0) {
-        result.protobuf_offsets.push_back(0);
-        result.shared_message_data = buf.share(
-          parser.bytes_consumed(), parser.bytes_left());
-        return result;
-    }
-    result.protobuf_offsets.resize(offset_count);
-    for (auto& o : result.protobuf_offsets) {
-        if (parser.bytes_left() == 0) {
-            return get_schema_error::not_enough_bytes;
-        }
-        std::tie(o, bytes_read) = parser.read_varlong();
+    try {
+        auto [offset_count, bytes_read] = parser.read_varlong();
         if (!bytes_read) {
             return get_schema_error::bad_varint;
         }
-    }
+        // Reject more offsets than bytes remaining; it's not possible
+        if (static_cast<size_t>(offset_count) > parser.bytes_left()) {
+            return get_schema_error::not_enough_bytes;
+        }
+        if (offset_count == 0) {
+            result.protobuf_offsets.push_back(0);
+            result.shared_message_data = buf.share(
+              parser.bytes_consumed(), parser.bytes_left());
+            return result;
+        }
+        result.protobuf_offsets.resize(offset_count);
+        for (auto& o : result.protobuf_offsets) {
+            if (parser.bytes_left() == 0) {
+                return get_schema_error::not_enough_bytes;
+            }
+            std::tie(o, bytes_read) = parser.read_varlong();
+            if (!bytes_read) {
+                return get_schema_error::bad_varint;
+            }
+        }
 
-    result.shared_message_data = buf.share(
-      parser.bytes_consumed(), parser.bytes_left());
-    return result;
+        result.shared_message_data = buf.share(
+          parser.bytes_consumed(), parser.bytes_left());
+        return result;
+    } catch (...) {
+        vlog(
+          datalake_log.warn,
+          "Error parsing protobuf offsets: {}",
+          std::current_exception());
+        return get_schema_error::not_enough_bytes;
+    }
 }
 
 } // namespace datalake

--- a/src/v/datalake/schema_registry.h
+++ b/src/v/datalake/schema_registry.h
@@ -76,10 +76,10 @@ using get_proto_offsets_result
 
 // Extract the schema id from a record's value. This simply extracts the id. It
 // does not validate that the schema exists in the Schema Registry.
-get_schema_id_result get_value_schema_id(iobuf& record);
-get_proto_offsets_result get_schema_proto_offsets(iobuf& record);
+get_schema_id_result get_value_schema_id(iobuf& record) noexcept;
+get_proto_offsets_result get_schema_proto_offsets(iobuf& record) noexcept;
 result<proto_offsets_message_data, get_schema_error>
-get_proto_offsets(iobuf& record);
+get_proto_offsets(iobuf& record) noexcept;
 
 } // namespace datalake
 

--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -52,7 +52,11 @@ record_generator::add_random_avro_record(
         co_return error{fmt::format("Schema {} is missing", name)};
     }
     auto schema_id = it->second;
-    auto schema_def = co_await _sr->get_valid_schema(schema_id);
+    auto schema_def_res = co_await _sr->get_valid_schema(schema_id);
+    if (!schema_def_res.has_value()) {
+        co_return error{fmt::format("Schema {} not in store", schema_id)};
+    }
+    auto& schema_def = schema_def_res.value();
     if (schema_def.type() != schema_type::avro) {
         co_return error{
           fmt::format("Schema {} has wrong type: {}", name, schema_def.type())};

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -70,15 +70,6 @@ iobuf encode_pb_offsets(const std::vector<int32_t>& offsets) {
     }
     return buf;
 }
-
-// Checks that the given resolved buffer has no schema, and just returns a
-// single binary column that matches the input iobuf.
-void check_no_schema(const type_and_buf& resolved, const iobuf& expected) {
-    EXPECT_FALSE(resolved.type.has_value());
-
-    // The value should match the expected buf.
-    ASSERT_EQ(resolved.parsable_buf, expected);
-}
 } // namespace
 
 class RecordSchemaResolverTest : public ::testing::Test {
@@ -244,9 +235,8 @@ TEST_F(RecordSchemaResolverTest, TestMissingMagic) {
     buf.append(generate_dummy_body());
     auto resolver = record_schema_resolver(*sr);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
-    ASSERT_FALSE(res.has_error());
-    const auto& resolved_buf = res.value();
-    ASSERT_NO_FATAL_FAILURE(check_no_schema(resolved_buf, buf));
+    ASSERT_TRUE(res.has_error());
+    ASSERT_EQ(res.error(), type_resolver::errc::bad_input);
 }
 
 TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {

--- a/src/v/pandaproxy/schema_registry/schema_getter.h
+++ b/src/v/pandaproxy/schema_registry/schema_getter.h
@@ -27,6 +27,8 @@ public:
       = 0;
     virtual ss::future<canonical_schema_definition>
     get_schema_definition(schema_id id) = 0;
+    virtual ss::future<std::optional<canonical_schema_definition>>
+    maybe_get_schema_definition(schema_id id) = 0;
     virtual ~schema_getter() = default;
 };
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -74,6 +74,9 @@ public:
     ss::future<canonical_schema_definition>
     get_schema_definition(schema_id id) override;
 
+    ss::future<std::optional<canonical_schema_definition>>
+    maybe_get_schema_definition(schema_id id) override;
+
     ///\brief Return a list of subject-versions for the shema id.
     ss::future<chunked_vector<subject_version>>
     get_schema_subject_versions(schema_id id);

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -100,10 +100,15 @@ public:
 };
 } // namespace
 
-ss::future<ppsr::valid_schema>
+ss::future<std::optional<ppsr::valid_schema>>
 registry::get_valid_schema(ppsr::schema_id schema_id) const {
     auto reader = co_await getter();
-    auto schema_def = co_await reader->get_schema_definition(schema_id);
+    auto schema_def_opt = co_await reader->maybe_get_schema_definition(
+      schema_id);
+    if (!schema_def_opt.has_value()) {
+        co_return std::nullopt;
+    }
+    auto& schema_def = *schema_def_opt;
     auto schema_type = schema_def.type();
     switch (schema_type) {
     case ppsr::schema_type::json: {

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -43,7 +43,7 @@ public:
     virtual ss::future<pandaproxy::schema_registry::schema_getter*>
     getter() const = 0;
 
-    ss::future<pandaproxy::schema_registry::valid_schema>
+    ss::future<std::optional<pandaproxy::schema_registry::valid_schema>>
     get_valid_schema(pandaproxy::schema_registry::schema_id schema_id) const;
 
     virtual ss::future<pandaproxy::schema_registry::canonical_schema_definition>

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -52,6 +52,16 @@ schema::fake_store::get_schema_definition(ppsr::schema_id id) {
     throw std::runtime_error("unknown schema id");
 }
 
+ss::future<std::optional<ppsr::canonical_schema_definition>>
+schema::fake_store::maybe_get_schema_definition(ppsr::schema_id id) {
+    for (const auto& s : schemas) {
+        if (s.id == id) {
+            co_return s.schema.def().share();
+        }
+    }
+    co_return std::nullopt;
+}
+
 void schema::fake_registry::maybe_throw_injected_failure() const {
     if (_injected_failure) {
         std::rethrow_exception(_injected_failure);

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -25,6 +25,10 @@ public:
       pandaproxy::schema_registry::include_deleted inc_dec) final;
     ss::future<pandaproxy::schema_registry::canonical_schema_definition>
     get_schema_definition(pandaproxy::schema_registry::schema_id id) final;
+    ss::future<
+      std::optional<pandaproxy::schema_registry::canonical_schema_definition>>
+    maybe_get_schema_definition(
+      pandaproxy::schema_registry::schema_id id) final;
 
     std::vector<pandaproxy::schema_registry::subject_schema> schemas;
 };


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Cleans up some error handling related to schemas in datalake code, by making the schema registry return a specific (nullopt) result when when the schema is not found, rather than throwing.

Other schema registry errors are not considered transient and cause the record multiplexer to exit, expecting further retries.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
