### PR TITLE
Bazelize ssx tests

### DIFF
--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "future-util_test",
@@ -209,5 +209,19 @@ redpanda_cc_gtest(
         "//src/v/utils:move_canary",
         "@googletest//:gtest",
         "@seastar",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "thread_worker_bench",
+    timeout = "short",
+    srcs = [
+        "thread_worker_bench.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:thread_worker",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -78,6 +78,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "watchdog_test",
+    timeout = "short",
+    srcs = [
+        "watchdog_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:watchdog",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -225,3 +225,18 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_bench(
+    name = "sformat_bench",
+    timeout = "short",
+    srcs = [
+        "sformat_bench.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:sformat",
+        "@boost//:uuid",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -94,6 +94,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "task_local_ptr_test",
+    timeout = "short",
+    srcs = [
+        "task_local_ptr_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:task_local",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/algorithm:container",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -128,6 +128,24 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "single_sharded_test",
+    timeout = "short",
+    srcs = [
+        "single_sharded_test.cc",
+    ],
+    cpu = 2,
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:single_sharded",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -79,3 +79,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "work_queue_test",
+    timeout = "short",
+    srcs = [
+        "work_queue_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:work_queue",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -109,3 +109,21 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "async_algorithm_test",
+    timeout = "short",
+    srcs = [
+        "async_algorithm_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:async_clear",
+        "//src/v/ssx:future_util",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:move_canary",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -62,6 +62,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "sleep_abortable_test",
+    timeout = "short",
+    srcs = [
+        "sleep_abortable_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:sleep_abortable",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_btest(
     srcs = [
         "abort_source_test.cc",
     ],
+    cpu = 2,
     deps = [
         "//src/v/base",
         "//src/v/ssx:abort_source",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -111,6 +111,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "sharded_ptr_test",
+    timeout = "short",
+    srcs = [
+        "sharded_ptr_test.cc",
+    ],
+    cpu = 2,
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:sharded_ptr",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -94,3 +94,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "event_test",
+    timeout = "short",
+    srcs = [
+        "event_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:event",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/async_algorithm_test.cc
+++ b/src/v/ssx/tests/async_algorithm_test.cc
@@ -103,7 +103,7 @@ struct task_counter {
 
 } // namespace
 
-std::vector<int> make_container(size_t elems, std::vector<int>) {
+std::vector<int> make_container(int elems, std::vector<int>) {
     std::vector<int> ret;
     for (int i = 0; i < elems; i++) {
         ret.push_back(i);
@@ -112,7 +112,7 @@ std::vector<int> make_container(size_t elems, std::vector<int>) {
 }
 
 std::unordered_map<int, int>
-make_container(size_t elems, std::unordered_map<int, int>) {
+make_container(int elems, std::unordered_map<int, int>) {
     std::unordered_map<int, int> ret;
     for (int i = 0; i < elems; i++) {
         ret[i] = i;
@@ -124,7 +124,7 @@ template<typename T>
 struct AsyncAlgo : public testing::Test {
     using container = T;
 
-    static T make(size_t size) { return make_container(size, T{}); }
+    static T make(int size) { return make_container(size, T{}); }
 };
 
 // using container_types = ::testing::Types<std::vector<int>>;

--- a/src/v/ssx/tests/sformat_bench.cc
+++ b/src/v/ssx/tests/sformat_bench.cc
@@ -39,7 +39,7 @@ void run_test(Fun fun, size_t data_size) {
     std::vector<Val> vec;
     vec.reserve(data_size);
     perf_tests::start_measuring_time();
-    for (int i = 0; i < data_size; ++i) {
+    for (size_t i = 0; i < data_size; ++i) {
         vec.emplace_back(fun(fmt::runtime("{}"), identifier));
     }
     perf_tests::do_not_optimize(


### PR DESCRIPTION
Implements:
[CORE-7600](https://redpandadata.atlassian.net/browse/CORE-7600) : async_algorithm_test.cc
[CORE-7602](https://redpandadata.atlassian.net/browse/CORE-7602) : event_test.cc
[CORE-7603](https://redpandadata.atlassian.net/browse/CORE-7603) : sformat_bench.cc
[CORE-7604](https://redpandadata.atlassian.net/browse/CORE-7604) : sharded_ptr_test.cc
[CORE-7605](https://redpandadata.atlassian.net/browse/CORE-7605) : single_sharded_test.cc
[CORE-7606](https://redpandadata.atlassian.net/browse/CORE-7606) : sleep_abortable_test.cc
[CORE-7607](https://redpandadata.atlassian.net/browse/CORE-7607) : task_local_ptr_test.cc
[CORE-7608](https://redpandadata.atlassian.net/browse/CORE-7608) : thread_worker_bench.cc
[CORE-7609](https://redpandadata.atlassian.net/browse/CORE-7609) : watchdog_test.cc
[CORE-7610](https://redpandadata.atlassian.net/browse/CORE-7610) : work_queue_test.cc

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7610]: https://redpandadata.atlassian.net/browse/CORE-7610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7602]: https://redpandadata.atlassian.net/browse/CORE-7602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7600]: https://redpandadata.atlassian.net/browse/CORE-7600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7606]: https://redpandadata.atlassian.net/browse/CORE-7606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7609]: https://redpandadata.atlassian.net/browse/CORE-7609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7607]: https://redpandadata.atlassian.net/browse/CORE-7607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7604]: https://redpandadata.atlassian.net/browse/CORE-7604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7605]: https://redpandadata.atlassian.net/browse/CORE-7605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7608]: https://redpandadata.atlassian.net/browse/CORE-7608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-7603]: https://redpandadata.atlassian.net/browse/CORE-7603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ