### PR TITLE
rpc: Change max internal rpc connection count limit

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -157,7 +157,7 @@ configuration::configuration()
       "The maximum number of connections a broker will open to each of its "
       "peers.",
       {.example = "8"},
-      32,
+      128,
       {.min = 8})
   , rpc_server_compress_replies(
       *this,


### PR DESCRIPTION
Previously we limited this to 32 for fear of connection explosion on
larger core machines but we haven't seen any issues so far and 64 core
machines (e.g.: AWS 16xlarge) are becoming more common so up the default
to account for this.

Having one per shard is important for even load distribution across
shards.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


