### PR TITLE
cst/cache: fix use-after-move caused by calling get_exception twice

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1309,6 +1309,11 @@ ss::future<> cache::put(
     // eager trim, and rethrow the exception.
     if (eptr) {
         if (!_gate.is_closed()) {
+            vlog(
+              cst_log.debug,
+              "Removing temporary file {}. Exception during copy: {}",
+              tmp_filepath.native(),
+              eptr);
             auto delete_tmp_fut = co_await ss::coroutine::as_future(
               delete_file_and_empty_parents(tmp_filepath.native()));
             if (delete_tmp_fut.failed()) {

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1311,14 +1311,15 @@ ss::future<> cache::put(
         if (!_gate.is_closed()) {
             auto delete_tmp_fut = co_await ss::coroutine::as_future(
               delete_file_and_empty_parents(tmp_filepath.native()));
-            if (
-              delete_tmp_fut.failed()
-              && !ssx::is_shutdown_exception(delete_tmp_fut.get_exception())) {
-                vlog(
-                  cst_log.error,
-                  "Failed to delete tmp file {}: {}",
-                  tmp_filepath.native(),
-                  delete_tmp_fut.get_exception());
+            if (delete_tmp_fut.failed()) {
+                auto e = delete_tmp_fut.get_exception();
+                if (!ssx::is_shutdown_exception(e)) {
+                    vlog(
+                      cst_log.error,
+                      "Failed to delete tmp file {}: {}",
+                      tmp_filepath.native(),
+                      e);
+                }
             }
         }
 


### PR DESCRIPTION
cst/cache: fix use-after-move caused by calling get_exception twice

Found by @dotnwat https://github.com/redpanda-data/redpanda/pull/24000#discussion_r1849302646

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
