### PR TITLE
iceberg: create namespace on demand

### DIFF
--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -99,6 +99,14 @@ public:
      */
 
     /**
+     * Create namespace API
+     *
+     * POST /v1/{prefix}/namespaces
+     */
+    ss::future<expected<create_namespace_response>>
+    create_namespace(create_namespace_request, retry_chain_node&);
+
+    /**
      * Load Table API
      *
      * GET /v1/{prefix}/namespaces/{namespace}/tables/{table}
@@ -126,7 +134,6 @@ public:
      * NOTE: using std::monostate instead of void, because
      * ss::future<expected<void>> is not no-throw move constructible
      */
-
     ss::future<expected<std::monostate>> drop_table(
       const chunked_vector<ss::sstring>& ns,
       const ss::sstring& table,

--- a/src/v/iceberg/rest_client/entities.cc
+++ b/src/v/iceberg/rest_client/entities.cc
@@ -23,4 +23,9 @@ ss::sstring table::resource_name() const {
     return fmt::format("namespaces/{}/tables", _namespace);
 }
 
+namespaces::namespaces(std::string_view root_url)
+  : rest_entity(root_url) {}
+
+ss::sstring namespaces::resource_name() const { return "namespaces"; }
+
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/entities.h
+++ b/src/v/iceberg/rest_client/entities.h
@@ -26,4 +26,10 @@ private:
     ss::sstring _namespace;
 };
 
+struct namespaces : public http::rest_client::rest_entity {
+    explicit namespaces(std::string_view root_url);
+
+    ss::sstring resource_name() const final;
+};
+
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/table_requests.h
+++ b/src/v/iceberg/table_requests.h
@@ -35,6 +35,16 @@ struct create_table_request {
     std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
 };
 
+struct create_namespace_request {
+    chunked_vector<ss::sstring> ns;
+    std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
+};
+
+struct create_namespace_response {
+    chunked_vector<ss::sstring> ns;
+    std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
+};
+
 struct load_table_result {
     table_metadata metadata;
     std::optional<ss::sstring> metadata_location;

--- a/src/v/iceberg/table_requests_json.h
+++ b/src/v/iceberg/table_requests_json.h
@@ -18,6 +18,7 @@ namespace iceberg {
 
 load_table_result parse_load_table_result(const json::Value&);
 commit_table_response parse_commit_table_response(const json::Value&);
+create_namespace_response parse_create_namespace_response(const json::Value&);
 
 } // namespace iceberg
 namespace json {
@@ -30,5 +31,8 @@ void rjson_serialize(
 
 void rjson_serialize(
   iceberg::json_writer& w, const iceberg::commit_table_request& r);
+
+void rjson_serialize(
+  iceberg::json_writer& w, const iceberg::create_namespace_request& r);
 
 } // namespace json

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -93,7 +93,6 @@ class RestCatalogConnectionTest(RedpandaTest):
 
         catalog = self.catalog_service.client()
         namespace = "redpanda"
-        catalog.create_namespace(namespace)
         topic = TopicSpec(name='datalake-test-topic', partition_count=3)
 
         self.client().create_topic(topic)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Today, we require an explicit call to create an endpoint before creating Iceberg tables. This isn't a great user experience, since it requires an Iceberg client to perform.

This PR adds the REST endpoint for creating namespace, and plugs it into the catalog impl.

Tested this manually against Open Catalog.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
