### PR TITLE
rptest: do not compare disk_free_bytes with cache_disk_free bytes

### DIFF
--- a/tests/rptest/tests/node_metrics_test.py
+++ b/tests/rptest/tests/node_metrics_test.py
@@ -19,7 +19,7 @@ from rptest.utils.node_metrics import NodeMetrics
 
 
 def assert_lists_equal(l1: list[float], l2: list[float]):
-    assert l1 == l2
+    assert l1 == l2, f"Expected {l1} == {l2}"
 
 
 class NodeMetricsTest(RedpandaTest):
@@ -110,5 +110,3 @@ class NodeMetricsTest(RedpandaTest):
         # Assert cache disk metrics match data disk metrics since it is the same disk in this test setup.
         assert_lists_equal(self.node_metrics.disk_total_bytes(),
                            self.node_metrics.cache_disk_total_bytes())
-        assert_lists_equal(self.node_metrics.disk_free_bytes(),
-                           self.node_metrics.cache_disk_free_bytes())


### PR DESCRIPTION
They are collected asynchronously so it is ok for them to drift apart. The test is flaky.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
