### PR TITLE
[v24.3.x] cst/cache: fix use-after-move caused by calling get_exception twice

### DIFF
--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1309,6 +1309,11 @@ ss::future<> cache::put(
     // eager trim, and rethrow the exception.
     if (eptr) {
         if (!_gate.is_closed()) {
+            vlog(
+              cst_log.debug,
+              "Removing temporary file {}. Exception during copy: {}",
+              tmp_filepath.native(),
+              eptr);
             auto delete_tmp_fut = co_await ss::coroutine::as_future(
               delete_file_and_empty_parents(tmp_filepath.native()));
             if (delete_tmp_fut.failed()) {

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1311,14 +1311,15 @@ ss::future<> cache::put(
         if (!_gate.is_closed()) {
             auto delete_tmp_fut = co_await ss::coroutine::as_future(
               delete_file_and_empty_parents(tmp_filepath.native()));
-            if (
-              delete_tmp_fut.failed()
-              && !ssx::is_shutdown_exception(delete_tmp_fut.get_exception())) {
-                vlog(
-                  cst_log.error,
-                  "Failed to delete tmp file {}: {}",
-                  tmp_filepath.native(),
-                  delete_tmp_fut.get_exception());
+            if (delete_tmp_fut.failed()) {
+                auto e = delete_tmp_fut.get_exception();
+                if (!ssx::is_shutdown_exception(e)) {
+                    vlog(
+                      cst_log.error,
+                      "Failed to delete tmp file {}: {}",
+                      tmp_filepath.native(),
+                      e);
+                }
             }
         }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24189
