### PR TITLE
[CORE-8010] cluster: Fix race condition in the `archival_metadata_stm`

### DIFF
--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -12,7 +12,6 @@
 #include "cloud_storage/types.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/errc.h"
-#include "features/feature_table.h"
 #include "http/tests/http_imposter.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -91,7 +90,6 @@ struct archival_metadata_stm_base_fixture
     archival_metadata_stm_base_fixture()
       : http_imposter_fixture(4446) {
         // Blank feature table to satisfy constructor interface
-        feature_table.start().get();
         // Cloud storage config
         cloud_cfg.start().get();
         cloud_cfg
@@ -134,10 +132,8 @@ struct archival_metadata_stm_base_fixture
         cloud_api.stop().get();
         cloud_conn_pool.stop().get();
         cloud_cfg.stop().get();
-        feature_table.stop().get();
     }
 
-    ss::sharded<features::feature_table> feature_table;
     ss::sharded<cloud_storage::configuration> cloud_cfg;
     ss::sharded<cloud_storage_clients::client_pool> cloud_conn_pool;
     ss::sharded<cloud_io::remote> cloud_io;
@@ -152,7 +148,7 @@ struct archival_metadata_stm_fixture : archival_metadata_stm_base_fixture {
         archival_stm = builder.create_stm<cluster::archival_metadata_stm>(
           _raft.get(),
           cloud_api.local(),
-          feature_table.local(),
+          _feature_table.local(),
           logger,
           std::nullopt,
           std::nullopt);
@@ -368,7 +364,7 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
     auto archival_stm = builder.create_stm<cluster::archival_metadata_stm>(
       _raft.get(),
       cloud_api.local(),
-      feature_table.local(),
+      _feature_table.local(),
       logger,
       std::nullopt,
       std::nullopt);
@@ -468,7 +464,7 @@ FIXTURE_TEST(test_sname_derivation, archival_metadata_stm_base_fixture) {
     auto archival_stm = builder.create_stm<cluster::archival_metadata_stm>(
       _raft.get(),
       cloud_api.local(),
-      feature_table.local(),
+      _feature_table.local(),
       logger,
       std::nullopt,
       std::nullopt);
@@ -688,7 +684,7 @@ FIXTURE_TEST(
     auto archival_stm = builder.create_stm<cluster::archival_metadata_stm>(
       _raft.get(),
       cloud_api.local(),
-      feature_table.local(),
+      _feature_table.local(),
       logger,
       std::nullopt,
       std::nullopt);


### PR DESCRIPTION
Several methods of the `archival_metadata_stm` are invoked by the `ntp_archiver` indirectly and require a lock to be held. The methods are `do_sync`, `do_replicate_commands`, and `do_add_segments`.

The methods are checking the invariant using this code:
```
    vassert(
      !_lock.try_get_units().has_value(),
      "Attempt to replicate STM command while not under lock");
```

So basically if the lock is not taken this assertion will be triggered. Another assertion that indicates that the method `do_sync` was called concurrently with `do_replicate_commands` was triggered. The problem was caused by the code in the `command_batch_builder`. The code was invoking the `do_replicate_commands` method this way:

```cpp
    auto units = co_await _stm.get()._lock.get_units(_as);

    ...!scheduling point!...

    auto batch = std::move(_builder).build();
    auto f = _stm.get()
               .do_replicate_commands(std::move(batch), _as)
               .finally([u = std::move(units), h = _stm.get()._gate.hold());

    co_return co_await ssx::with_timeout_abortable(
      std::move(f), model::no_timeout, _as);
```

Here the `do_replicate_commands` method is called first. It creates a future. Then we're calling `finally` method on this future and passing the continuation. This continuation is supposed to prolong the lifetime of the `units` to guarantee that the invariant is not broken. But if this method is invoked concurrently with `stop` method of the `archival_metadata_stm` it is possible that the units will be acquired successfully but `_gate.hold()` call will throw the exception. In this case the future will be running in the background and it will be possible to call `do_sync` or `do_replicate_commands` again and break the invariant.

The check inside the `do_replicate_commands` that calls `_lock.try_get_units()` to verify that the lock is held can still pass even if the semaphore was broken. The `try_get_units` method can't throw and when the race happens (when `_gate.hold` throws) can already pass.

In the failed test the assertion was triggered after the STM was stopped and I was able to reproduce the issue by inserting sleeps manually. I don't think that reliable reproducer in form of unit-test or ducktape test is possible here. The problem can only affect shutdown and is difficult to trigger.

The fix is twofold:
- change operation order in the `replicate` so we won't get a dangling future if `_gate.hold` throws
- hold gate in all three methods to prevent them to be called after `persisted_stm::stop`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none