### PR TITLE
util: Add bounds checking helper

### DIFF
--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -299,6 +299,16 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "bounds",
+    hdrs = [
+        "bounds.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+    ],
+)
+
+redpanda_cc_library(
     name = "stream_provider",
     hdrs = [
         "stream_provider.h",

--- a/src/v/utils/bounds.h
+++ b/src/v/utils/bounds.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <concepts>
+#include <limits>
+#include <type_traits>
+
+namespace bounds {
+template<std::signed_integral TargetIntegral, std::signed_integral SIntegral>
+bool within_limits(const SIntegral val) {
+    return val >= std::numeric_limits<TargetIntegral>::min()
+           && val <= std::numeric_limits<TargetIntegral>::max();
+}
+
+template<
+  std::unsigned_integral TargetIntegral,
+  std::unsigned_integral UIntegral>
+bool within_limits(const UIntegral val) {
+    return val <= std::numeric_limits<TargetIntegral>::max();
+}
+
+template<std::signed_integral TargetIntegral, std::unsigned_integral UIntegral>
+bool within_limits(const UIntegral val) {
+    using Unsigned = std::make_unsigned_t<TargetIntegral>;
+    return val
+           <= static_cast<Unsigned>(std::numeric_limits<TargetIntegral>::max());
+}
+
+template<std::unsigned_integral TargetIntegral, std::signed_integral SIntegral>
+bool within_limits(const SIntegral val) {
+    using Unsigned = std::make_unsigned_t<SIntegral>;
+    return val >= 0
+           && static_cast<Unsigned>(val)
+                <= std::numeric_limits<TargetIntegral>::max();
+}
+
+template<std::integral TargetIntegral, std::integral Integral>
+bool outside_limits(const Integral val) {
+    return !within_limits<TargetIntegral>(val);
+}
+
+} // namespace bounds

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -524,3 +524,16 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "bounds_test",
+    timeout = "short",
+    srcs = [
+        "bounds_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:bounds",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ rp_test(
   GTEST
   BINARY_NAME gtest_utils
   SOURCES
+    bounds_test.cc
     xid_test.cc
   LIBRARIES v::utils absl::flat_hash_map v::random v::gtest_main
   LABELS utils

--- a/src/v/utils/tests/bounds_test.cc
+++ b/src/v/utils/tests/bounds_test.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/bounds.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace {
+
+template<std::integral I>
+struct integral_range {
+    I min = std::numeric_limits<I>::min();
+    I max = std::numeric_limits<I>::max();
+};
+template<std::integral I>
+std::ostream& operator<<(std::ostream& os, const integral_range<I> ir) {
+    return os << "[" << ir.min << ", " << ir.max << "]";
+}
+
+template<std::integral To, std::integral From>
+testing::AssertionResult within_limits(From i) {
+    const integral_range<To> rng;
+    const auto b = bounds::within_limits<To>(i);
+    if (b) {
+        return testing::AssertionSuccess()
+               << "value " << i << " reported within range " << rng;
+    } else {
+        return testing::AssertionFailure()
+               << "value " << i << " reported out of range " << rng;
+    }
+}
+
+template<std::integral To, std::integral From>
+testing::AssertionResult outside_limits(From i) {
+    const integral_range<To> rng;
+    const auto b = bounds::outside_limits<To>(i);
+    if (b) {
+        return testing::AssertionSuccess()
+               << "value " << i << " reported out of range " << rng;
+    } else {
+        return testing::AssertionFailure()
+               << "value " << i << " reported within range " << rng;
+    }
+}
+using ushort = unsigned short;
+using uint = unsigned int;
+} // namespace
+
+TEST(bounds_check, signed_to_signed) {
+    const integral_range<short> shorts{};
+    const integral_range<int> ints{};
+    const std::vector<int> within_bounds{shorts.min, -1, 0, 1, shorts.max};
+    for (const int i : within_bounds) {
+        EXPECT_TRUE(::within_limits<short>(i));
+        EXPECT_FALSE(::outside_limits<short>(i));
+    }
+    const std::vector<int> out_of_bounds{
+      ints.min, shorts.min - 1, shorts.max + 1, ints.max};
+    for (const int i : out_of_bounds) {
+        EXPECT_FALSE(::within_limits<short>(i));
+        EXPECT_TRUE(::outside_limits<short>(i));
+    }
+}
+
+TEST(bounds_check, unsigned_to_unsigned) {
+    const integral_range<ushort> ushorts{};
+    const integral_range<uint> uints{};
+    const std::vector<uint> within_bounds{0, 1, ushorts.max};
+    for (const uint i : within_bounds) {
+        EXPECT_TRUE(::within_limits<ushort>(i));
+        EXPECT_FALSE(::outside_limits<ushort>(i));
+    }
+    const std::vector<uint> out_of_bounds{
+      static_cast<uint>(ushorts.max + 1), uints.max};
+    for (const uint i : out_of_bounds) {
+        EXPECT_FALSE(::within_limits<ushort>(i));
+        EXPECT_TRUE(::outside_limits<ushort>(i));
+    }
+}
+
+TEST(bounds_check, unsigned_to_signed) {
+    const integral_range<short> shorts{};
+    const integral_range<uint> uints{};
+    const std::vector<uint> within_bounds{0, 1, static_cast<uint>(shorts.max)};
+    for (const uint i : within_bounds) {
+        EXPECT_TRUE(::within_limits<short>(i));
+        EXPECT_FALSE(::outside_limits<short>(i));
+    }
+    const std::vector<uint> out_of_bounds{
+      static_cast<uint>(shorts.max + 1), uints.max};
+    for (const uint i : out_of_bounds) {
+        EXPECT_FALSE(::within_limits<short>(i));
+        EXPECT_TRUE(::outside_limits<short>(i));
+    }
+}
+
+TEST(bounds_check, signed_to_unsigned) {
+    const integral_range<ushort> ushorts{};
+    const integral_range<int> ints{};
+    const std::vector<int> within_bounds{0, 1, ushorts.max};
+    for (const int i : within_bounds) {
+        EXPECT_TRUE(::within_limits<ushort>(i));
+        EXPECT_FALSE(::outside_limits<ushort>(i));
+    }
+    const std::vector<int> out_of_bounds{
+      ints.min, -1, ushorts.max + 1, ints.max};
+    for (const int i : out_of_bounds) {
+        EXPECT_FALSE(::within_limits<ushort>(i));
+        EXPECT_TRUE(::outside_limits<ushort>(i));
+    }
+}


### PR DESCRIPTION
Add utility helpers to check if an integer value is within the limits of a different integer value.

TODO:
- Add documentation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
