### PR TITLE
datalake: split record translator into distinct modes 

### DIFF
--- a/src/v/datalake/fwd.h
+++ b/src/v/datalake/fwd.h
@@ -12,6 +12,7 @@
 
 namespace datalake {
 struct data_writer_result;
+class record_translator;
 class schema_manager;
 class type_resolver;
 namespace coordinator {

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -91,6 +91,7 @@ record_multiplexer::operator()(model::record_batch batch) {
           header_kvs);
         if (record_data_res.has_error()) {
             switch (record_data_res.error()) {
+            case record_translator::errc::unexpected_schema:
             case record_translator::errc::translation_error:
                 vlog(
                   _log.debug,

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 namespace datalake {
+class record_translator;
 class schema_manager;
 class type_resolver;
 
@@ -42,7 +43,8 @@ public:
       const model::ntp& ntp,
       std::unique_ptr<parquet_file_writer_factory> writer,
       schema_manager& schema_mgr,
-      type_resolver& type_resolver);
+      type_resolver& type_resolver,
+      record_translator& record_translator);
 
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
     ss::future<result<write_result, writer_error>> end_of_stream();
@@ -64,6 +66,7 @@ private:
     std::unique_ptr<parquet_file_writer_factory> _writer_factory;
     schema_manager& _schema_mgr;
     type_resolver& _type_resolver;
+    record_translator& _record_translator;
     chunked_hash_map<
       record_schema_components,
       std::unique_ptr<partitioning_writer>>

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -55,57 +55,16 @@ std::optional<size_t> get_redpanda_idx(const iceberg::struct_type& val_type) {
     return std::nullopt;
 }
 
-} // namespace
-
-std::ostream& operator<<(std::ostream& o, const record_translator::errc& e) {
-    switch (e) {
-    case record_translator::errc::translation_error:
-        return o << "record_translator::errc::translation_error";
-    }
-}
-
-record_type
-record_translator::build_type(std::optional<resolved_type> val_type) {
-    auto ret_type = schemaless_struct_type();
-    std::optional<schema_identifier> val_id;
-    if (val_type.has_value()) {
-        val_id = std::move(val_type->id);
-        auto& struct_type = std::get<iceberg::struct_type>(val_type->type);
-        for (auto& field : struct_type.fields) {
-            if (field->name == rp_struct_name) {
-                // To avoid collisions, move user fields named "redpanda" into
-                // the nested "redpanda" system field.
-                auto& system_fields = std::get<iceberg::struct_type>(
-                  ret_type.fields[0]->type);
-                // Use the next id of the system defaults.
-                system_fields.fields.emplace_back(iceberg::nested_field::create(
-                  11, "data", field->required, std::move(field->type)));
-                continue;
-            }
-            // Add the extra user-defined fields.
-            ret_type.fields.emplace_back(std::move(field));
-        }
-    }
-    return record_type{
-      .comps = record_schema_components{
-          .key_identifier = std::nullopt,
-          .val_identifier = std::move(val_id),
-      },
-      .type = std::move(ret_type),
-    };
-}
-
-ss::future<checked<iceberg::struct_value, record_translator::errc>>
-record_translator::translate_data(
+// Builds a struct value meant to be used as the base of the "redpanda" struct.
+// Additional fields specific to the mode (e.g. "value" for key-value mode) may
+// be appended to the end.
+std::unique_ptr<iceberg::struct_value> build_rp_struct(
   model::partition_id pid,
   kafka::offset o,
   iobuf key,
-  const std::optional<resolved_type>& val_type,
-  iobuf parsable_val,
   model::timestamp ts,
   const chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>&
     headers) {
-    auto ret_data = iceberg::struct_value{};
     auto system_data = std::make_unique<iceberg::struct_value>();
     system_data->fields.emplace_back(iceberg::int_value(pid));
     system_data->fields.emplace_back(iceberg::long_value(o));
@@ -133,48 +92,175 @@ record_translator::translate_data(
     }
 
     system_data->fields.emplace_back(iceberg::binary_value{std::move(key)});
+    return system_data;
+}
+
+} // namespace
+
+std::ostream& operator<<(std::ostream& o, const record_translator::errc& e) {
+    switch (e) {
+    case record_translator::errc::translation_error:
+        return o << "record_translator::errc::translation_error";
+    case record_translator::errc::unexpected_schema:
+        return o << "record_translator::errc::unexpected_schema";
+    }
+}
+
+record_type
+default_translator::build_type(std::optional<resolved_type> val_type) {
     if (val_type.has_value()) {
-        // Fill in the internal value field.
-        system_data->fields.emplace_back(std::nullopt);
-        ret_data.fields.emplace_back(std::move(system_data));
+        return structured_translator.build_type(std::move(val_type));
+    }
+    return kv_translator.build_type(std::move(val_type));
+}
 
-        auto translated_val = co_await std::visit(
-          value_translating_visitor{std::move(parsable_val), val_type->type},
-          val_type->schema);
-        if (translated_val.has_error()) {
-            vlog(
-              datalake_log.error,
-              "Error converting buffer: {}",
-              translated_val.error());
-            // TODO: metric for data translation errors.
-            // Either needs to drop the data or send it to a dead-letter queue.
-            co_return errc::translation_error;
-        }
+ss::future<checked<iceberg::struct_value, record_translator::errc>>
+default_translator::translate_data(
+  model::partition_id pid,
+  kafka::offset o,
+  iobuf key,
+  const std::optional<resolved_type>& val_type,
+  iobuf parsable_val,
+  model::timestamp ts,
+  const chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>&
+    headers) {
+    if (val_type.has_value()) {
+        co_return co_await structured_translator.translate_data(
+          pid,
+          o,
+          std::move(key),
+          val_type,
+          std::move(parsable_val),
+          ts,
+          headers);
+    }
+    co_return co_await kv_translator.translate_data(
+      pid, o, std::move(key), val_type, std::move(parsable_val), ts, headers);
+}
 
-        auto redpanda_field_idx = get_redpanda_idx(
-          std::get<iceberg::struct_type>(val_type->type));
-        // Unwrap the struct fields.
-        auto& val_struct = std::get<std::unique_ptr<iceberg::struct_value>>(
-          translated_val.value().value());
-        for (size_t i = 0; i < val_struct->fields.size(); ++i) {
-            auto& field = val_struct->fields[i];
-            if (redpanda_field_idx == i) {
+record_type key_value_translator::build_type(std::optional<resolved_type>) {
+    auto ret_type = schemaless_struct_type();
+    std::optional<schema_identifier> val_id;
+    auto& system_fields = std::get<iceberg::struct_type>(
+      ret_type.fields[0]->type);
+    system_fields.fields.emplace_back(iceberg::nested_field::create(
+      10, "data", iceberg::field_required::no, iceberg::binary_type{}));
+    return record_type{
+      .comps = record_schema_components{
+          .key_identifier = std::nullopt,
+          .val_identifier = std::move(val_id),
+      },
+      .type = std::move(ret_type),
+    };
+}
+
+ss::future<checked<iceberg::struct_value, record_translator::errc>>
+key_value_translator::translate_data(
+  model::partition_id pid,
+  kafka::offset o,
+  iobuf key,
+  const std::optional<resolved_type>& val_type,
+  iobuf parsable_val,
+  model::timestamp ts,
+  const chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>&
+    headers) {
+    if (val_type.has_value()) {
+        vlog(
+          datalake_log.error,
+          "Must not have parsed schema when using key-value mode");
+        co_return record_translator::errc::unexpected_schema;
+    }
+    auto ret_data = iceberg::struct_value{};
+    auto system_data = build_rp_struct(pid, o, std::move(key), ts, headers);
+    system_data->fields.emplace_back(
+      iceberg::binary_value{std::move(parsable_val)});
+
+    ret_data.fields.emplace_back(std::move(system_data));
+    co_return ret_data;
+}
+
+record_type
+structured_data_translator::build_type(std::optional<resolved_type> val_type) {
+    auto ret_type = schemaless_struct_type();
+    std::optional<schema_identifier> val_id;
+    if (val_type.has_value()) {
+        val_id = std::move(val_type->id);
+        auto& struct_type = std::get<iceberg::struct_type>(val_type->type);
+        for (auto& field : struct_type.fields) {
+            if (field->name == rp_struct_name) {
                 // To avoid collisions, move user fields named "redpanda" into
                 // the nested "redpanda" system field.
-                auto& system_vals
-                  = std::get<std::unique_ptr<iceberg::struct_value>>(
-                    ret_data.fields[0].value());
-                system_vals->fields.emplace_back(std::move(field));
+                auto& system_fields = std::get<iceberg::struct_type>(
+                  ret_type.fields[0]->type);
+                // Use the next id of the system defaults.
+                system_fields.fields.emplace_back(iceberg::nested_field::create(
+                  10, "data", field->required, std::move(field->type)));
                 continue;
             }
-            ret_data.fields.emplace_back(std::move(field));
+            // Add the extra user-defined fields.
+            ret_type.fields.emplace_back(std::move(field));
         }
-    } else {
-        system_data->fields.emplace_back(
-          iceberg::binary_value{std::move(parsable_val)});
+    }
+    return record_type{
+      .comps = record_schema_components{
+          .key_identifier = std::nullopt,
+          .val_identifier = std::move(val_id),
+      },
+      .type = std::move(ret_type),
+    };
+}
 
-        // Just add the system fields.
-        ret_data.fields.emplace_back(std::move(system_data));
+ss::future<checked<iceberg::struct_value, record_translator::errc>>
+structured_data_translator::translate_data(
+  model::partition_id pid,
+  kafka::offset o,
+  iobuf key,
+  const std::optional<resolved_type>& val_type,
+  iobuf parsable_val,
+  model::timestamp ts,
+  const chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>&
+    headers) {
+    if (!val_type.has_value()) {
+        vlog(
+          datalake_log.error,
+          "Must have parsed schema when using structured data mode");
+        co_return record_translator::errc::unexpected_schema;
+    }
+    auto ret_data = iceberg::struct_value{};
+    auto system_data = build_rp_struct(pid, o, std::move(key), ts, headers);
+    // Fill in the internal value field.
+    ret_data.fields.emplace_back(std::move(system_data));
+
+    auto translated_val = co_await std::visit(
+      value_translating_visitor{std::move(parsable_val), val_type->type},
+      val_type->schema);
+    if (translated_val.has_error()) {
+        vlog(
+          datalake_log.error,
+          "Error converting buffer: {}",
+          translated_val.error());
+        // TODO: metric for data translation errors.
+        // Either needs to drop the data or send it to a dead-letter queue.
+        co_return errc::translation_error;
+    }
+
+    auto redpanda_field_idx = get_redpanda_idx(
+      std::get<iceberg::struct_type>(val_type->type));
+    // Unwrap the struct fields.
+    auto& val_struct = std::get<std::unique_ptr<iceberg::struct_value>>(
+      translated_val.value().value());
+    for (size_t i = 0; i < val_struct->fields.size(); ++i) {
+        auto& field = val_struct->fields[i];
+        if (redpanda_field_idx == i) {
+            // To avoid collisions, move user fields named "redpanda" into
+            // the nested "redpanda" system field.
+            auto& system_vals
+              = std::get<std::unique_ptr<iceberg::struct_value>>(
+                ret_data.fields[0].value());
+            system_vals->fields.emplace_back(std::move(field));
+            continue;
+        }
+        ret_data.fields.emplace_back(std::move(field));
     }
     co_return ret_data;
 }

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -29,10 +29,27 @@ class record_translator {
 public:
     enum class errc {
         translation_error,
+        unexpected_schema,
     };
     friend std::ostream& operator<<(std::ostream&, const errc&);
 
-    record_type build_type(std::optional<resolved_type> val_type);
+    virtual record_type build_type(std::optional<resolved_type> val_type) = 0;
+    virtual ss::future<checked<iceberg::struct_value, errc>> translate_data(
+      model::partition_id pid,
+      kafka::offset o,
+      iobuf key,
+      const std::optional<resolved_type>& val_type,
+      iobuf parsable_val,
+      model::timestamp ts,
+      const chunked_vector<
+        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers)
+      = 0;
+    virtual ~record_translator() = default;
+};
+
+class key_value_translator : public record_translator {
+public:
+    record_type build_type(std::optional<resolved_type> val_type) override;
     ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
@@ -41,7 +58,49 @@ public:
       iobuf parsable_val,
       model::timestamp ts,
       const chunked_vector<
-        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers);
+        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers)
+      override;
+    ~key_value_translator() override = default;
+};
+
+class structured_data_translator : public record_translator {
+public:
+    record_type build_type(std::optional<resolved_type> val_type) override;
+    ss::future<checked<iceberg::struct_value, errc>> translate_data(
+      model::partition_id pid,
+      kafka::offset o,
+      iobuf key,
+      const std::optional<resolved_type>& val_type,
+      iobuf parsable_val,
+      model::timestamp ts,
+      const chunked_vector<
+        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers)
+      override;
+    ~structured_data_translator() override = default;
+};
+
+// Switches between key-value and structured translator, depending on if there
+// is an input schema.
+// XXX: this is a temporary hack for tests to pass as we transition to toggling
+// mode with a topic config! Instead, callers should explicitly choose.
+class default_translator : public record_translator {
+public:
+    record_type build_type(std::optional<resolved_type> val_type) override;
+    ss::future<checked<iceberg::struct_value, errc>> translate_data(
+      model::partition_id pid,
+      kafka::offset o,
+      iobuf key,
+      const std::optional<resolved_type>& val_type,
+      iobuf parsable_val,
+      model::timestamp ts,
+      const chunked_vector<
+        std::pair<std::optional<iobuf>, std::optional<iobuf>>>& headers)
+      override;
+    ~default_translator() override = default;
+
+private:
+    key_value_translator kv_translator;
+    structured_data_translator structured_translator;
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_translator.h
+++ b/src/v/datalake/record_translator.h
@@ -31,8 +31,9 @@ public:
         translation_error,
     };
     friend std::ostream& operator<<(std::ostream&, const errc&);
-    static record_type build_type(std::optional<resolved_type> val_type);
-    static ss::future<checked<iceberg::struct_value, errc>> translate_data(
+
+    record_type build_type(std::optional<resolved_type> val_type);
+    ss::future<checked<iceberg::struct_value, errc>> translate_data(
       model::partition_id pid,
       kafka::offset o,
       iobuf key,

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -36,8 +36,6 @@ struct_type schemaless_struct_type() {
 
     system_fields.fields.emplace_back(
       nested_field::create(9, "key", field_required::no, binary_type{}));
-    system_fields.fields.emplace_back(
-      nested_field::create(10, "value", field_required::no, binary_type{}));
     struct_type res;
     res.fields.emplace_back(nested_field::create(
       1,

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -212,6 +212,7 @@ redpanda_cc_gtest(
         "//src/v/datalake:catalog_schema_manager",
         "//src/v/datalake:record_multiplexer",
         "//src/v/datalake:record_schema_resolver",
+        "//src/v/datalake:record_translator",
         "//src/v/datalake:table_definition",
         "//src/v/iceberg:filesystem_catalog",
         "//src/v/model",

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -37,7 +37,7 @@ simple_schema_manager simple_schema_mgr;
 binary_type_resolver bin_resolver;
 const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
-record_translator translator;
+default_translator translator;
 } // namespace
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
@@ -295,7 +295,7 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
         // Default columns + a nested struct.
         EXPECT_EQ(table->num_columns(), 8);
         auto expected_type
-          = R"(redpanda: struct<partition: int32 not null, offset: int64 not null, timestamp: timestamp[us] not null, headers: list<element: struct<key: binary, value: binary> not null>, key: binary, value: binary> not null
+          = R"(redpanda: struct<partition: int32 not null, offset: int64 not null, timestamp: timestamp[us] not null, headers: list<element: struct<key: binary, value: binary> not null>, key: binary> not null
 mylong: int64 not null
 nestedrecord: struct<inval1: double not null, inval2: string not null, inval3: int32 not null> not null
 myarray: list<element: double not null> not null

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -10,6 +10,7 @@
 #include "datalake/catalog_schema_manager.h"
 #include "datalake/record_multiplexer.h"
 #include "datalake/record_schema_resolver.h"
+#include "datalake/record_translator.h"
 #include "datalake/table_definition.h"
 #include "datalake/tests/catalog_and_registry_fixture.h"
 #include "datalake/tests/record_generator.h"
@@ -28,6 +29,7 @@
 using namespace datalake;
 
 namespace {
+record_translator translator;
 const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 // v1: struct field with one field.
@@ -129,7 +131,8 @@ public:
           ntp,
           std::make_unique<test_data_writer_factory>(false),
           schema_mgr,
-          type_resolver);
+          type_resolver,
+          translator);
         auto res = reader.consume(std::move(mux), model::no_timeout).get();
         EXPECT_FALSE(res.has_error()) << res.error();
         if (res.has_error()) {

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -29,7 +29,7 @@
 using namespace datalake;
 
 namespace {
-record_translator translator;
+structured_data_translator translator;
 const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 // v1: struct field with one field.
@@ -103,7 +103,8 @@ public:
     std::optional<record_multiplexer::write_result> mux(
       const records_param& param,
       model::offset o,
-      const std::function<void(storage::record_batch_builder&)>& cb) {
+      const std::function<void(storage::record_batch_builder&)>& cb,
+      bool expect_error = false) {
         auto start_offset = o;
         ss::circular_buffer<model::record_batch> batches;
         const auto start_ts = model::timestamp::now();
@@ -134,7 +135,11 @@ public:
           type_resolver,
           translator);
         auto res = reader.consume(std::move(mux), model::no_timeout).get();
-        EXPECT_FALSE(res.has_error()) << res.error();
+        if (expect_error) {
+            EXPECT_TRUE(res.has_error());
+        } else {
+            EXPECT_FALSE(res.has_error()) << res.error();
+        }
         if (res.has_error()) {
             return std::nullopt;
         }
@@ -179,29 +184,21 @@ class RecordMultiplexerParamTest
 public:
     std::optional<record_multiplexer::write_result> mux(
       model::offset o,
-      const std::function<void(storage::record_batch_builder&)>& cb) {
-        return RecordMultiplexerTestBase::mux(GetParam(), o, cb);
+      const std::function<void(storage::record_batch_builder&)>& cb,
+      bool expect_error = false) {
+        return RecordMultiplexerTestBase::mux(GetParam(), o, cb, expect_error);
     }
 };
 
 TEST_P(RecordMultiplexerParamTest, TestNoSchema) {
     auto start_offset = model::offset{0};
-    auto res = mux(start_offset, [](storage::record_batch_builder& b) {
-        b.add_raw_kv(std::nullopt, iobuf::from("foobar"));
-    });
-    ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), GetParam().hrs);
-
-    std::unordered_set<int> hrs;
-    for (auto& f : write_res.data_files) {
-        hrs.emplace(f.hour);
-        EXPECT_EQ(f.row_count, GetParam().records_per_hr());
-    }
-    EXPECT_EQ(hrs.size(), GetParam().hrs);
-    auto schema = get_current_schema();
-    ASSERT_TRUE(schema.has_value());
-    EXPECT_EQ(schema->schema_struct, schemaless_struct_type());
+    auto res = mux(
+      start_offset,
+      [](storage::record_batch_builder& b) {
+          b.add_raw_kv(std::nullopt, iobuf::from("foobar"));
+      },
+      true);
+    ASSERT_FALSE(res.has_value());
 }
 
 TEST_P(RecordMultiplexerParamTest, TestSimpleAvroRecords) {
@@ -229,7 +226,7 @@ TEST_P(RecordMultiplexerParamTest, TestSimpleAvroRecords) {
 
     // 4 default columns + RootRecord + mylong
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 11);
+    EXPECT_EQ(schema->highest_field_id(), 10);
 }
 
 TEST_P(RecordMultiplexerParamTest, TestAvroRecordsMultipleSchemas) {
@@ -265,7 +262,7 @@ TEST_P(RecordMultiplexerParamTest, TestAvroRecordsMultipleSchemas) {
     }
     EXPECT_EQ(hrs.size(), GetParam().hrs);
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 21);
+    EXPECT_EQ(schema->highest_field_id(), 20);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -320,31 +317,29 @@ TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
     // 1 nested redpanda column + 4 default columns + mylong + 1 user redpanda
     // column + 1 nested
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 13);
+    EXPECT_EQ(schema->highest_field_id(), 12);
 
     // The redpanda system fields should include the 'data' column.
     const auto& rp_struct = std::get<iceberg::struct_type>(
       schema->schema_struct.fields[0]->type);
-    EXPECT_EQ(7, rp_struct.fields.size());
+    EXPECT_EQ(6, rp_struct.fields.size());
     EXPECT_EQ("data", rp_struct.fields.back()->name);
 }
 
 TEST_F(RecordMultiplexerTest, TestMissingSchema) {
     auto start_offset = model::offset{0};
     auto res = mux(
-      default_param, start_offset, [](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [](storage::record_batch_builder& b) {
           iobuf buf;
           // Append data with a magic 0 byte that doesn't actually correspond to
           // anything.
           buf.append("\0\0\0\0\0\0\0", 7);
           b.add_raw_kv(std::nullopt, std::move(buf));
-      });
-    ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
-
-    auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 10);
+      },
+      true);
+    ASSERT_FALSE(res.has_value());
 }
 
 TEST_F(RecordMultiplexerTest, TestBadData) {
@@ -355,22 +350,17 @@ TEST_F(RecordMultiplexerTest, TestBadData) {
 
     auto start_offset = model::offset{0};
     auto res = mux(
-      default_param, start_offset, [](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [](storage::record_batch_builder& b) {
           iobuf buf;
           // Append data with a magic bytes that corresponds to the actual
           // schema.
           buf.append("\0\0\0\0\0\1\0", 7);
           b.add_raw_kv(std::nullopt, std::move(buf));
-      });
-    ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
-
-    // When we go to translate the data, the translation should fail and we
-    // shouldn't register the Avro schema -- instead we should see the default
-    // schema.
-    auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 10);
+      },
+      true);
+    ASSERT_FALSE(res.has_value());
 }
 
 TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
@@ -403,21 +393,22 @@ TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
 
     // This should have registered the valid schema.
     auto schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 11);
+    EXPECT_EQ(schema->highest_field_id(), 10);
 
     // Now try writing with an incompatible schema.
     res = mux(
-      default_param, start_offset, [&gen](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [&gen](storage::record_batch_builder& b) {
           auto res
             = gen.add_random_avro_record(b, "incompat", std::nullopt).get();
           ASSERT_FALSE(res.has_error());
-      });
+      },
+      true);
 
     // This should successfully write the binary records but not update the
     // schema.
-    ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
+    ASSERT_FALSE(res.has_value());
     schema = get_current_schema();
-    EXPECT_EQ(schema->highest_field_id(), 11);
+    EXPECT_EQ(schema->highest_field_id(), 10);
 }

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -15,6 +15,7 @@
 #include "datalake/cloud_data_io.h"
 #include "datalake/local_parquet_file_writer.h"
 #include "datalake/record_schema_resolver.h"
+#include "datalake/record_translator.h"
 #include "datalake/translation_task.h"
 #include "model/record_batch_reader.h"
 #include "storage/record_batch_builder.h"
@@ -31,6 +32,7 @@ using namespace datalake;
 namespace {
 auto schema_mgr = std::make_unique<simple_schema_manager>();
 auto schema_resolver = std::make_unique<binary_type_resolver>();
+auto translator = std::make_unique<record_translator>();
 const auto ntp = model::ntp{};
 } // namespace
 
@@ -157,7 +159,8 @@ private:
 };
 
 TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
-    datalake::translation_task task(cloud_io, *schema_mgr, *schema_resolver);
+    datalake::translation_task task(
+      cloud_io, *schema_mgr, *schema_resolver, *translator);
 
     auto result = task
                     .translate(
@@ -184,7 +187,8 @@ TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
 }
 
 TEST_F(TranslateTaskTest, TestDataFileMissing) {
-    datalake::translation_task task(cloud_io, *schema_mgr, *schema_resolver);
+    datalake::translation_task task(
+      cloud_io, *schema_mgr, *schema_resolver, *translator);
     // create deleting task to cause local io error
     deleter del(tmp_dir.get_path().string());
     del.start();
@@ -204,7 +208,8 @@ TEST_F(TranslateTaskTest, TestDataFileMissing) {
 }
 
 TEST_F(TranslateTaskTest, TestUploadError) {
-    datalake::translation_task task(cloud_io, *schema_mgr, *schema_resolver);
+    datalake::translation_task task(
+      cloud_io, *schema_mgr, *schema_resolver, *translator);
     // fail all PUT requests
     fail_request_if(
       [](const http_test_utils::request_info& req) -> bool {

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -32,7 +32,7 @@ using namespace datalake;
 namespace {
 auto schema_mgr = std::make_unique<simple_schema_manager>();
 auto schema_resolver = std::make_unique<binary_type_resolver>();
-auto translator = std::make_unique<record_translator>();
+auto translator = std::make_unique<default_translator>();
 const auto ntp = model::ntp{};
 } // namespace
 

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -84,6 +84,7 @@ constexpr ::model::timeout_clock::duration wait_timeout = 5s;
 constexpr size_t max_rows_per_row_group = std::numeric_limits<size_t>::max();
 constexpr size_t max_bytes_per_row_group = std::numeric_limits<size_t>::max();
 
+partition_translator::~partition_translator() = default;
 partition_translator::partition_translator(
   ss::lw_shared_ptr<cluster::partition> partition,
   ss::sharded<coordinator::frontend>* frontend,
@@ -107,7 +108,7 @@ partition_translator::partition_translator(
   // TODO: type resolver and record translator should be constructed based on
   // topic configs.
   , _type_resolver(type_resolver)
-  , _record_translator(std::make_unique<record_translator>())
+  , _record_translator(std::make_unique<default_translator>())
   , _partition_proxy(std::make_unique<kafka::partition_proxy>(
       kafka::make_partition_proxy(_partition)))
   , _jitter{translation_interval, translation_jitter}

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -19,6 +19,7 @@
 #include "datalake/local_parquet_file_writer.h"
 #include "datalake/logger.h"
 #include "datalake/record_multiplexer.h"
+#include "datalake/record_translator.h"
 #include "datalake/serde_parquet_writer.h"
 #include "datalake/translation/state_machine.h"
 #include "datalake/translation_task.h"
@@ -103,7 +104,10 @@ partition_translator::partition_translator(
   , _features(features)
   , _cloud_io(cloud_io)
   , _schema_mgr(schema_mgr)
+  // TODO: type resolver and record translator should be constructed based on
+  // topic configs.
   , _type_resolver(type_resolver)
+  , _record_translator(std::make_unique<record_translator>())
   , _partition_proxy(std::make_unique<kafka::partition_proxy>(
       kafka::make_partition_proxy(_partition)))
   , _jitter{translation_interval, translation_jitter}
@@ -207,7 +211,8 @@ partition_translator::do_translation_for_range(
       fmt::format("{}", begin_offset),   // file prefix
       get_parquet_writer_factory());
 
-    auto task = translation_task{**_cloud_io, *_schema_mgr, *_type_resolver};
+    auto task = translation_task{
+      **_cloud_io, *_schema_mgr, *_type_resolver, *_record_translator};
     const auto& ntp = _partition->ntp();
     auto remote_path_prefix = remote_path{
       fmt::format("{}/{}/{}", iceberg_file_path_prefix, ntp.path(), _term)};

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -30,8 +30,10 @@
 
 namespace kafka {
 class read_committed_reader;
-}
-
+} // namespace kafka
+namespace datalake {
+class record_translator;
+} // namespace datalake
 namespace datalake::translation {
 
 /**
@@ -115,6 +117,7 @@ private:
     std::unique_ptr<datalake::cloud_data_io>* _cloud_io;
     schema_manager* _schema_mgr;
     type_resolver* _type_resolver;
+    std::unique_ptr<record_translator> _record_translator;
     std::unique_ptr<kafka::partition_proxy> _partition_proxy;
     using jitter_t
       = simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>;

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -77,6 +77,7 @@ public:
       ss::scheduling_group sg,
       size_t reader_max_bytes,
       std::unique_ptr<ssx::semaphore>* parallel_translations);
+    ~partition_translator();
 
     void start_translation_in_background(ss::scheduling_group);
 

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -37,10 +37,12 @@ translation_task::errc map_error_code(cloud_data_io::errc errc) {
 translation_task::translation_task(
   cloud_data_io& cloud_io,
   schema_manager& schema_mgr,
-  type_resolver& type_resolver)
+  type_resolver& type_resolver,
+  record_translator& record_translator)
   : _cloud_io(&cloud_io)
   , _schema_mgr(&schema_mgr)
-  , _type_resolver(&type_resolver) {}
+  , _type_resolver(&type_resolver)
+  , _record_translator(&record_translator) {}
 
 ss::future<
   checked<coordinator::translated_offset_range, translation_task::errc>>
@@ -52,7 +54,11 @@ translation_task::translate(
   retry_chain_node& rcn,
   lazy_abort_source& lazy_as) {
     record_multiplexer mux(
-      ntp, std::move(writer_factory), *_schema_mgr, *_type_resolver);
+      ntp,
+      std::move(writer_factory),
+      *_schema_mgr,
+      *_type_resolver,
+      *_record_translator);
     // Write local files
     auto mux_result = co_await std::move(reader).consume(
       std::move(mux), _read_timeout + model::timeout_clock::now());

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -28,7 +28,8 @@ public:
     explicit translation_task(
       cloud_data_io& uploader,
       schema_manager& schema_mgr,
-      type_resolver& type_resolver);
+      type_resolver& type_resolver,
+      record_translator& record_translator);
     enum class errc {
         file_io_error,
         cloud_io_error,
@@ -65,5 +66,6 @@ private:
     cloud_data_io* _cloud_io;
     schema_manager* _schema_mgr;
     type_resolver* _type_resolver;
+    record_translator* _record_translator;
 };
 } // namespace datalake

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -107,7 +107,7 @@ class DatalakeE2ETests(RedpandaTest):
                 trino = dl.trino()
                 trino_expected_out = [(
                     'redpanda',
-                    'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary, value varbinary)',
+                    'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)',
                     '', ''), ('val', 'bigint', '', '')]
                 trino_describe_out = trino.run_query_fetch_all(
                     f"describe {table_name}")
@@ -117,7 +117,7 @@ class DatalakeE2ETests(RedpandaTest):
                 spark = dl.spark()
                 spark_expected_out = [(
                     'redpanda',
-                    'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary,value:binary>',
+                    'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>',
                     None), ('val', 'bigint', None), ('', '', ''),
                                       ('# Partitioning', '', ''),
                                       ('Part 0', 'hours(redpanda.timestamp)',


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Splits the record_translator into two implementations: one that
translates key-value records, and another that expects a schema. The
expectation is that users will explicitly choose which to use based on a
topic property.

With this change, key-value tables will have a redpanda.value column,
while structured tables will only have user-defined columns instead.

A "default translator" is left in with similar properties to the prior
record_translator, but this is just left in to smooth the transition
until we have a topic config.

NOTE: in this commit, we leave as is the invalid record handling, which
previously allowed going between key-value and structured data. Once we
have a more explicit toggle, this handling should replaced with a
dead-letter table or by dropping records on the floor.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
