### PR TITLE
datalake/configs: rework iceberg enablement configs

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -479,7 +479,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      false,
+      model::iceberg_mode::disabled,
       std::nullopt,
       false,
       std::nullopt,

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -482,7 +482,6 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       model::iceberg_mode::disabled,
       std::nullopt,
       false,
-      std::nullopt,
       tristate<std::chrono::milliseconds>{},
       std::nullopt,
     };

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -484,6 +484,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       false,
       std::nullopt,
       tristate<std::chrono::milliseconds>{},
+      std::nullopt,
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -287,7 +287,8 @@ partition_state get_partition_state(ss::lw_shared_ptr<partition> partition) {
     } else {
         state.start_cloud_offset = state.next_cloud_offset = model::offset{-1};
     }
-    state.iceberg_enabled = partition->get_ntp_config().iceberg_enabled();
+    state.iceberg_mode = fmt::format(
+      "{}", partition->get_ntp_config().iceberg_mode());
     state.raft_state = get_partition_raft_state(partition->raft());
     return state;
 }

--- a/src/v/cluster/tests/topic_properties_generator.h
+++ b/src/v/cluster/tests/topic_properties_generator.h
@@ -73,7 +73,7 @@ inline cluster::topic_properties random_topic_properties() {
       [] { return tests::random_duration_ms(); });
     properties.flush_bytes = tests::random_optional(
       [] { return random_generators::get_int<size_t>(); });
-    properties.iceberg_enabled = false;
+    properties.iceberg_mode = model::iceberg_mode::disabled;
 
     return properties;
 }

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -55,7 +55,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .write_caching = properties.write_caching,
             .flush_ms = properties.flush_ms,
             .flush_bytes = properties.flush_bytes,
-            .iceberg_enabled = properties.iceberg_enabled,
+            .iceberg_mode = properties.iceberg_mode,
             .cloud_topic_enabled = properties.cloud_topic_enabled,
             .iceberg_translation_interval_ms
             = properties.iceberg_translation_interval_ms,

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -57,8 +57,6 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .flush_bytes = properties.flush_bytes,
             .iceberg_mode = properties.iceberg_mode,
             .cloud_topic_enabled = properties.cloud_topic_enabled,
-            .iceberg_translation_interval_ms
-            = properties.iceberg_translation_interval_ms,
             .tombstone_retention_ms = properties.delete_retention_ms,
           });
     }

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -41,7 +41,6 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "flush_bytes: {}, "
       "remote_label: {}, iceberg_mode: {}, "
       "leaders_preference: {}, "
-      "iceberg_translation_interval_ms: {}, "
       "delete_retention_ms: {}, "
       "iceberg_delete: {}",
       properties.compression,
@@ -79,7 +78,6 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.remote_label,
       properties.iceberg_mode,
       properties.leaders_preference,
-      properties.iceberg_translation_interval_ms,
       properties.delete_retention_ms,
       properties.iceberg_delete);
 
@@ -126,9 +124,8 @@ bool topic_properties::has_overrides() const {
         || write_caching.has_value() || flush_ms.has_value()
         || flush_bytes.has_value() || remote_label.has_value()
         || (iceberg_mode != storage::ntp_config::default_iceberg_mode)
-        || leaders_preference.has_value()
-        || iceberg_translation_interval_ms.has_value()
-        || delete_retention_ms.is_engaged() || iceberg_delete.has_value();
+        || leaders_preference.has_value() || delete_retention_ms.is_engaged()
+        || iceberg_delete.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -170,7 +167,6 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.flush_bytes = flush_bytes;
     ret.iceberg_mode = iceberg_mode;
     ret.cloud_topic_enabled = cloud_topic_enabled;
-    ret.iceberg_translation_interval_ms = iceberg_translation_interval_ms;
     ret.tombstone_retention_ms = delete_retention_ms;
     return ret;
 }
@@ -263,7 +259,6 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       model::iceberg_mode::disabled,
       std::nullopt,
       false,
-      std::nullopt,
       tristate<std::chrono::milliseconds>{disable_tristate},
       std::nullopt,
     };

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -42,7 +42,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "remote_label: {}, iceberg_enabled: {}, "
       "leaders_preference: {}, "
       "iceberg_translation_interval_ms: {}, "
-      "delete_retention_ms: {}",
+      "delete_retention_ms: {}, "
+      "iceberg_delete: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -79,7 +80,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.iceberg_enabled,
       properties.leaders_preference,
       properties.iceberg_translation_interval_ms,
-      properties.delete_retention_ms);
+      properties.delete_retention_ms,
+      properties.iceberg_delete);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(
@@ -126,7 +128,7 @@ bool topic_properties::has_overrides() const {
         || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
         || leaders_preference.has_value()
         || iceberg_translation_interval_ms.has_value()
-        || delete_retention_ms.is_engaged();
+        || delete_retention_ms.is_engaged() || iceberg_delete.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -263,6 +265,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       false,
       std::nullopt,
       tristate<std::chrono::milliseconds>{disable_tristate},
+      std::nullopt,
     };
 }
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "write_caching: {}, "
       "flush_ms: {}, "
       "flush_bytes: {}, "
-      "remote_label: {}, iceberg_enabled: {}, "
+      "remote_label: {}, iceberg_mode: {}, "
       "leaders_preference: {}, "
       "iceberg_translation_interval_ms: {}, "
       "delete_retention_ms: {}, "
@@ -77,7 +77,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.flush_ms,
       properties.flush_bytes,
       properties.remote_label,
-      properties.iceberg_enabled,
+      properties.iceberg_mode,
       properties.leaders_preference,
       properties.iceberg_translation_interval_ms,
       properties.delete_retention_ms,
@@ -125,7 +125,7 @@ bool topic_properties::has_overrides() const {
         || initial_retention_local_target_ms.is_engaged()
         || write_caching.has_value() || flush_ms.has_value()
         || flush_bytes.has_value() || remote_label.has_value()
-        || (iceberg_enabled != storage::ntp_config::default_iceberg_enabled)
+        || (iceberg_mode != storage::ntp_config::default_iceberg_mode)
         || leaders_preference.has_value()
         || iceberg_translation_interval_ms.has_value()
         || delete_retention_ms.is_engaged() || iceberg_delete.has_value();
@@ -168,7 +168,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.write_caching = write_caching;
     ret.flush_ms = flush_ms;
     ret.flush_bytes = flush_bytes;
-    ret.iceberg_enabled = iceberg_enabled;
+    ret.iceberg_mode = iceberg_mode;
     ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.iceberg_translation_interval_ms = iceberg_translation_interval_ms;
     ret.tombstone_retention_ms = delete_retention_ms;
@@ -260,7 +260,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      false,
+      model::iceberg_mode::disabled,
       std::nullopt,
       false,
       std::nullopt,

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -76,7 +76,8 @@ struct topic_properties
       std::optional<config::leaders_preference> leaders_preference,
       bool cloud_topic_enabled,
       std::optional<std::chrono::milliseconds> iceberg_translation_interval,
-      tristate<std::chrono::milliseconds> delete_retention_ms)
+      tristate<std::chrono::milliseconds> delete_retention_ms,
+      std::optional<bool> iceberg_delete)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -118,7 +119,8 @@ struct topic_properties
       , leaders_preference(std::move(leaders_preference))
       , cloud_topic_enabled(cloud_topic_enabled)
       , iceberg_translation_interval_ms(iceberg_translation_interval)
-      , delete_retention_ms(delete_retention_ms) {}
+      , delete_retention_ms(delete_retention_ms)
+      , iceberg_delete(iceberg_delete) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -194,6 +196,8 @@ struct topic_properties
     std::optional<std::chrono::milliseconds> iceberg_translation_interval_ms;
 
     tristate<std::chrono::milliseconds> delete_retention_ms{disable_tristate};
+    // Should we delete the corresponding iceberg table when deleting the topic.
+    std::optional<bool> iceberg_delete;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -241,7 +245,8 @@ struct topic_properties
           leaders_preference,
           cloud_topic_enabled,
           iceberg_translation_interval_ms,
-          delete_retention_ms);
+          delete_retention_ms,
+          iceberg_delete);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -72,7 +72,7 @@ struct topic_properties
       std::optional<model::write_caching_mode> write_caching,
       std::optional<std::chrono::milliseconds> flush_ms,
       std::optional<size_t> flush_bytes,
-      bool iceberg_enabled,
+      model::iceberg_mode iceberg_mode,
       std::optional<config::leaders_preference> leaders_preference,
       bool cloud_topic_enabled,
       std::optional<std::chrono::milliseconds> iceberg_translation_interval,
@@ -115,7 +115,7 @@ struct topic_properties
       , write_caching(write_caching)
       , flush_ms(flush_ms)
       , flush_bytes(flush_bytes)
-      , iceberg_enabled(iceberg_enabled)
+      , iceberg_mode(iceberg_mode)
       , leaders_preference(std::move(leaders_preference))
       , cloud_topic_enabled(cloud_topic_enabled)
       , iceberg_translation_interval_ms(iceberg_translation_interval)
@@ -174,7 +174,7 @@ struct topic_properties
     std::optional<model::write_caching_mode> write_caching;
     std::optional<std::chrono::milliseconds> flush_ms;
     std::optional<size_t> flush_bytes;
-    bool iceberg_enabled{storage::ntp_config::default_iceberg_enabled};
+    model::iceberg_mode iceberg_mode{storage::ntp_config::default_iceberg_mode};
 
     // Label to be used when generating paths of remote objects (manifests,
     // segments, etc) of this topic.
@@ -241,7 +241,7 @@ struct topic_properties
           flush_bytes,
           remote_label,
           remote_topic_namespace_override,
-          iceberg_enabled,
+          iceberg_mode,
           leaders_preference,
           cloud_topic_enabled,
           iceberg_translation_interval_ms,

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -75,7 +75,6 @@ struct topic_properties
       model::iceberg_mode iceberg_mode,
       std::optional<config::leaders_preference> leaders_preference,
       bool cloud_topic_enabled,
-      std::optional<std::chrono::milliseconds> iceberg_translation_interval,
       tristate<std::chrono::milliseconds> delete_retention_ms,
       std::optional<bool> iceberg_delete)
       : compression(compression)
@@ -118,7 +117,6 @@ struct topic_properties
       , iceberg_mode(iceberg_mode)
       , leaders_preference(std::move(leaders_preference))
       , cloud_topic_enabled(cloud_topic_enabled)
-      , iceberg_translation_interval_ms(iceberg_translation_interval)
       , delete_retention_ms(delete_retention_ms)
       , iceberg_delete(iceberg_delete) {}
 
@@ -193,8 +191,6 @@ struct topic_properties
 
     bool cloud_topic_enabled{storage::ntp_config::default_cloud_topic_enabled};
 
-    std::optional<std::chrono::milliseconds> iceberg_translation_interval_ms;
-
     tristate<std::chrono::milliseconds> delete_retention_ms{disable_tristate};
     // Should we delete the corresponding iceberg table when deleting the topic.
     std::optional<bool> iceberg_delete;
@@ -244,7 +240,6 @@ struct topic_properties
           iceberg_mode,
           leaders_preference,
           cloud_topic_enabled,
-          iceberg_translation_interval_ms,
           delete_retention_ms,
           iceberg_delete);
     }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1032,9 +1032,6 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(
       updated_properties.leaders_preference, overrides.leaders_preference);
     incremental_update(
-      updated_properties.iceberg_translation_interval_ms,
-      overrides.iceberg_translation_interval_ms);
-    incremental_update(
       updated_properties.delete_retention_ms, overrides.delete_retention_ms);
     incremental_update(
       updated_properties.iceberg_delete, overrides.iceberg_delete);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1026,9 +1026,9 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(updated_properties.flush_ms, overrides.flush_ms);
     incremental_update(updated_properties.flush_bytes, overrides.flush_bytes);
     incremental_update(
-      updated_properties.iceberg_enabled,
-      overrides.iceberg_enabled,
-      storage::ntp_config::default_iceberg_enabled);
+      updated_properties.iceberg_mode,
+      overrides.iceberg_mode,
+      storage::ntp_config::default_iceberg_mode);
     incremental_update(
       updated_properties.leaders_preference, overrides.leaders_preference);
     incremental_update(

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1036,6 +1036,8 @@ topic_properties topic_table::update_topic_properties(
       overrides.iceberg_translation_interval_ms);
     incremental_update(
       updated_properties.delete_retention_ms, overrides.delete_retention_ms);
+    incremental_update(
+      updated_properties.iceberg_delete, overrides.iceberg_delete);
     return updated_properties;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -402,7 +402,7 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.write_caching,
       i.flush_ms,
       i.flush_bytes,
-      i.iceberg_enabled,
+      i.iceberg_mode,
       i.leaders_preference,
       i.remote_read,
       i.remote_write,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -375,7 +375,7 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
       "flush_bytes: {}, iceberg_enabled: {}, leaders_preference: {}, "
       "remote_read: {}, remote_write: {}",
-      "iceberg_translation_interval_ms: {}",
+      "iceberg_translation_interval_ms: {}, iceberg_delete: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -406,7 +406,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.leaders_preference,
       i.remote_read,
       i.remote_write,
-      i.iceberg_translation_interval_ms);
+      i.iceberg_translation_interval_ms,
+      i.iceberg_delete);
     return o;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -374,8 +374,7 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
       "flush_bytes: {}, iceberg_enabled: {}, leaders_preference: {}, "
-      "remote_read: {}, remote_write: {}",
-      "iceberg_translation_interval_ms: {}, iceberg_delete: {}",
+      "remote_read: {}, remote_write: {}, iceberg_delete: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -406,7 +405,6 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.leaders_preference,
       i.remote_read,
       i.remote_write,
-      i.iceberg_translation_interval_ms,
       i.iceberg_delete);
     return o;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -629,8 +629,8 @@ struct incremental_topic_updates
     property_update<std::optional<model::write_caching_mode>> write_caching;
     property_update<std::optional<std::chrono::milliseconds>> flush_ms;
     property_update<std::optional<size_t>> flush_bytes;
-    property_update<bool> iceberg_enabled{
-      storage::ntp_config::default_iceberg_enabled,
+    property_update<model::iceberg_mode> iceberg_mode{
+      storage::ntp_config::default_iceberg_mode,
       incremental_update_operation::none};
     property_update<std::optional<config::leaders_preference>>
       leaders_preference;
@@ -672,7 +672,7 @@ struct incremental_topic_updates
           write_caching,
           flush_ms,
           flush_bytes,
-          iceberg_enabled,
+          iceberg_mode,
           leaders_preference,
           remote_read,
           remote_write,
@@ -2877,7 +2877,7 @@ struct partition_state
     bool is_remote_fetch_enabled;
     bool is_cloud_data_available;
     ss::sstring read_replica_bucket;
-    bool iceberg_enabled;
+    ss::sstring iceberg_mode;
     partition_raft_state raft_state;
 
     auto serde_fields() {
@@ -2898,7 +2898,7 @@ struct partition_state
           is_cloud_data_available,
           read_replica_bucket,
           raft_state,
-          iceberg_enabled);
+          iceberg_mode);
     }
 
     friend bool operator==(const partition_state&, const partition_state&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -634,8 +634,6 @@ struct incremental_topic_updates
       incremental_update_operation::none};
     property_update<std::optional<config::leaders_preference>>
       leaders_preference;
-    property_update<std::optional<std::chrono::milliseconds>>
-      iceberg_translation_interval_ms;
     property_update<tristate<std::chrono::milliseconds>> delete_retention_ms;
     property_update<std::optional<bool>> iceberg_delete;
 
@@ -676,7 +674,6 @@ struct incremental_topic_updates
           leaders_preference,
           remote_read,
           remote_write,
-          iceberg_translation_interval_ms,
           delete_retention_ms,
           iceberg_delete);
     }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -637,6 +637,7 @@ struct incremental_topic_updates
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_translation_interval_ms;
     property_update<tristate<std::chrono::milliseconds>> delete_retention_ms;
+    property_update<std::optional<bool>> iceberg_delete;
 
     // To allow us to better control use of the deprecated shadow_indexing
     // field, use getters and setters instead.
@@ -676,7 +677,8 @@ struct incremental_topic_updates
           remote_read,
           remote_write,
           iceberg_translation_interval_ms,
-          delete_retention_ms);
+          delete_retention_ms,
+          iceberg_delete);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -651,7 +651,7 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_optional([] { return tests::random_duration_ms(); }),
           tests::random_optional(
             [] { return random_generators::get_int<size_t>(); }),
-          false,
+          model::iceberg_mode::disabled,
           std::nullopt,
           false,
           std::nullopt,

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -655,7 +655,8 @@ struct instance_generator<cluster::topic_properties> {
           std::nullopt,
           false,
           std::nullopt,
-          tristate<std::chrono::milliseconds>{disable_tristate}};
+          tristate<std::chrono::milliseconds>{disable_tristate},
+          std::nullopt};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -654,7 +654,6 @@ struct instance_generator<cluster::topic_properties> {
           model::iceberg_mode::disabled,
           std::nullopt,
           false,
-          std::nullopt,
           tristate<std::chrono::milliseconds>{disable_tristate},
           std::nullopt};
     }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -625,7 +625,7 @@ inline void rjson_serialize(
     write_exceptional_member_type(w, "write_caching", tps.write_caching);
     write_member(w, "flush_bytes", tps.flush_bytes);
     write_member(w, "flush_ms", tps.flush_ms);
-    write_member(w, "iceberg_enabled", tps.iceberg_enabled);
+    write_member(w, "iceberg_mode", tps.iceberg_mode);
     write_member(
       w,
       "iceberg_translation_interval_ms",
@@ -701,7 +701,7 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
     read_member(rd, "write_caching", obj.write_caching);
     read_member(rd, "flush_bytes", obj.flush_bytes);
     read_member(rd, "flush_ms", obj.flush_ms);
-    read_member(rd, "iceberg_enabled", obj.iceberg_enabled);
+    read_member(rd, "iceberg_mode", obj.iceberg_mode);
     read_member(
       rd,
       "iceberg_translation_interval_ms",

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -626,10 +626,6 @@ inline void rjson_serialize(
     write_member(w, "flush_bytes", tps.flush_bytes);
     write_member(w, "flush_ms", tps.flush_ms);
     write_member(w, "iceberg_mode", tps.iceberg_mode);
-    write_member(
-      w,
-      "iceberg_translation_interval_ms",
-      tps.iceberg_translation_interval_ms);
     write_member(w, "delete_retention_ms", tps.delete_retention_ms);
     w.EndObject();
 }
@@ -702,10 +698,6 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
     read_member(rd, "flush_bytes", obj.flush_bytes);
     read_member(rd, "flush_ms", obj.flush_ms);
     read_member(rd, "iceberg_mode", obj.iceberg_mode);
-    read_member(
-      rd,
-      "iceberg_translation_interval_ms",
-      obj.iceberg_translation_interval_ms);
     read_member(rd, "delete_retention_ms", obj.delete_retention_ms);
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3680,15 +3680,6 @@ configuration::configuration()
         .visibility = visibility::user,
       },
       false)
-  , iceberg_translation_interval_ms_default(
-      *this,
-      "iceberg_translation_interval_ms_default",
-      "How often an Iceberg enabled topic is checked for new data to "
-      "translate. You can override this value at topic level using "
-      "redpanda.iceberg.translation.interval.ms.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      std::chrono::milliseconds(1min),
-      {.min = 10ms})
   , iceberg_catalog_commit_interval_ms(
       *this,
       "iceberg_catalog_commit_interval_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3790,6 +3790,17 @@ configuration::configuration()
       {.visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , iceberg_delete(
+      *this,
+      "iceberg_delete",
+      "Default value for the redpanda.iceberg.delete topic property that "
+      "determines if the corresponding Iceberg table is deleted upon deleting "
+      "the topic.",
+      meta{
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::user,
+      },
+      true)
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -717,6 +717,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl_file;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_prefix;
 
+    property<bool> iceberg_delete;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -699,8 +699,6 @@ struct configuration final : public config_store {
     // datalake configurations
     enterprise<property<bool>> iceberg_enabled;
     bounded_property<std::chrono::milliseconds>
-      iceberg_translation_interval_ms_default;
-    bounded_property<std::chrono::milliseconds>
       iceberg_catalog_commit_interval_ms;
     property<ss::sstring> iceberg_catalog_base_location;
     bounded_property<std::chrono::seconds>

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -177,6 +177,7 @@ redpanda_cc_library(
         ":catalog_schema_manager",
         ":cloud_data_io",
         ":logger",
+        ":record_translator",
         ":types",
         "//src/v/base",
         "//src/v/cluster",

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -71,6 +71,7 @@ private:
     using translator = std::unique_ptr<translation::partition_translator>;
     using translator_map = chunked_hash_map<model::ntp, translator>;
 
+    std::chrono::milliseconds translation_interval_ms() const;
     void on_group_notification(const model::ntp&);
     void start_translator(ss::lw_shared_ptr<cluster::partition>);
     ss::future<> stop_translator(const model::ntp&);
@@ -99,7 +100,7 @@ private:
     translator_map _translators;
     using deferred_action = ss::deferred_action<std::function<void()>>;
     std::vector<deferred_action> _deregistrations;
-    config::binding<std::chrono::milliseconds> _translation_ms_conf;
+    config::binding<std::chrono::milliseconds> _iceberg_commit_interval;
 
     // Translation requires buffering data batches in memory for efficient
     // output representation, this controls the maximum bytes buffered in memory

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -73,7 +73,8 @@ private:
 
     std::chrono::milliseconds translation_interval_ms() const;
     void on_group_notification(const model::ntp&);
-    void start_translator(ss::lw_shared_ptr<cluster::partition>);
+    void start_translator(
+      ss::lw_shared_ptr<cluster::partition>, model::iceberg_mode);
     ss::future<> stop_translator(const model::ntp&);
 
     model::node_id _self;

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -67,7 +67,7 @@ public:
     ss::future<> create_iceberg_topic(
       model::topic topic, int num_partitions = 1, int16_t num_replicas = 3) {
         cluster::topic_properties props;
-        props.iceberg_enabled = true;
+        props.iceberg_mode = model::iceberg_mode::value_schema_id_prefix;
         props.iceberg_translation_interval_ms = 50ms;
         return cluster_test_fixture::create_topic(
           {model::kafka_namespace, topic},

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -68,7 +68,6 @@ public:
       model::topic topic, int num_partitions = 1, int16_t num_replicas = 3) {
         cluster::topic_properties props;
         props.iceberg_mode = model::iceberg_mode::value_schema_id_prefix;
-        props.iceberg_translation_interval_ms = 50ms;
         return cluster_test_fixture::create_topic(
           {model::kafka_namespace, topic},
           num_partitions,

--- a/src/v/datalake/tests/fixture.h
+++ b/src/v/datalake/tests/fixture.h
@@ -67,7 +67,7 @@ public:
     ss::future<> create_iceberg_topic(
       model::topic topic, int num_partitions = 1, int16_t num_replicas = 3) {
         cluster::topic_properties props;
-        props.iceberg_mode = model::iceberg_mode::value_schema_id_prefix;
+        props.iceberg_mode = model::iceberg_mode::key_value;
         return cluster_test_fixture::create_topic(
           {model::kafka_namespace, topic},
           num_partitions,

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -88,7 +88,8 @@ partition_translator::partition_translator(
   ss::sharded<features::feature_table>* features,
   std::unique_ptr<cloud_data_io>* cloud_io,
   schema_manager* schema_mgr,
-  type_resolver* type_resolver,
+  std::unique_ptr<type_resolver> type_resolver,
+  std::unique_ptr<record_translator> record_translator,
   std::chrono::milliseconds translation_interval,
   ss::scheduling_group sg,
   size_t reader_max_bytes,
@@ -102,10 +103,8 @@ partition_translator::partition_translator(
   , _features(features)
   , _cloud_io(cloud_io)
   , _schema_mgr(schema_mgr)
-  // TODO: type resolver and record translator should be constructed based on
-  // topic configs.
-  , _type_resolver(type_resolver)
-  , _record_translator(std::make_unique<default_translator>())
+  , _type_resolver(std::move(type_resolver))
+  , _record_translator(std::move(record_translator))
   , _partition_proxy(std::make_unique<kafka::partition_proxy>(
       kafka::make_partition_proxy(_partition)))
   , _jitter{translation_interval, translation_jitter}

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -279,7 +279,7 @@ partition_translator::do_translate_once(retry_chain_node& parent_rcn) {
     if (
       translation_result
       && co_await checkpoint_translated_data(
-        parent_rcn, std::move(translation_result.value()))) {
+        parent_rcn, read_begin_offset, std::move(translation_result.value()))) {
         co_return translation_success::yes;
     }
     co_return translation_success::no;
@@ -288,9 +288,27 @@ partition_translator::do_translate_once(retry_chain_node& parent_rcn) {
 ss::future<partition_translator::checkpoint_result>
 partition_translator::checkpoint_translated_data(
   retry_chain_node& rcn,
+  kafka::offset reader_begin_offset,
   coordinator::translated_offset_range translated_range) {
     if (translated_range.files.empty()) {
         co_return checkpoint_result::yes;
+    }
+    if (reader_begin_offset != translated_range.start_offset) {
+        // This is possible if there is a gap in offsets range, eg from
+        // compaction. Normally that shouldn't be the case, as translation
+        // enforces max_collectible_offset which prevents compaction or other
+        // forms of retention from kicking in before translation actually
+        // happens. However there could be a sequence of enabling / disabling
+        // iceberg configuration on the topic that can temporarily unblock
+        // compaction thus creating gaps. Here we adjust the offset range to
+        // so the coordinator sees a contiguous offset range.
+        vlog(
+          _logger.info,
+          "detected an offset range gap in [{}, {}), adjusting the begin "
+          "offset to avoid gaps in coordinator tracked offsets.",
+          reader_begin_offset,
+          translated_range.start_offset);
+        translated_range.start_offset = reader_begin_offset;
     }
     auto last_offset = translated_range.last_offset;
     coordinator::add_translated_data_files_request request;

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -72,7 +72,8 @@ public:
       ss::sharded<features::feature_table>* features,
       std::unique_ptr<datalake::cloud_data_io>* cloud_io,
       schema_manager* schema_mgr,
-      type_resolver* type_resolver,
+      std::unique_ptr<type_resolver> type_resolver,
+      std::unique_ptr<record_translator> record_translator,
       std::chrono::milliseconds translation_interval,
       ss::scheduling_group sg,
       size_t reader_max_bytes,
@@ -117,7 +118,7 @@ private:
     ss::sharded<features::feature_table>* _features;
     std::unique_ptr<datalake::cloud_data_io>* _cloud_io;
     schema_manager* _schema_mgr;
-    type_resolver* _type_resolver;
+    std::unique_ptr<type_resolver> _type_resolver;
     std::unique_ptr<record_translator> _record_translator;
     std::unique_ptr<kafka::partition_proxy> _partition_proxy;
     using jitter_t

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -105,7 +105,9 @@ private:
 
     using checkpoint_result = ss::bool_class<struct checkpoint_result>;
     ss::future<checkpoint_result> checkpoint_translated_data(
-      retry_chain_node& parent, coordinator::translated_offset_range);
+      retry_chain_node& parent,
+      kafka::offset reader_begin_offset,
+      coordinator::translated_offset_range task_result);
 
     kafka::offset min_offset_for_translation() const;
     // Returns max consumable offset for translation.

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -83,7 +83,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 33,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 32,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -361,14 +361,6 @@ create_topic_properties_update(
                   cfg.value,
                   kafka::config_resource_operation::set,
                   delete_retention_ms_validator{});
-                continue;
-            }
-
-            if (cfg.name == topic_property_iceberg_translation_interval_ms) {
-                parse_and_set_optional_duration(
-                  update.properties.iceberg_translation_interval_ms,
-                  cfg.value,
-                  kafka::config_resource_operation::set);
                 continue;
             }
             if (cfg.name == topic_property_iceberg_delete) {

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -83,7 +83,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 32,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 33,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -368,6 +368,13 @@ create_topic_properties_update(
             if (cfg.name == topic_property_iceberg_translation_interval_ms) {
                 parse_and_set_optional_duration(
                   update.properties.iceberg_translation_interval_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
+            if (cfg.name == topic_property_iceberg_delete) {
+                parse_and_set_optional_bool_alpha(
+                  update.properties.iceberg_delete,
                   cfg.value,
                   kafka::config_resource_operation::set);
                 continue;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -329,13 +329,12 @@ create_topic_properties_update(
                   flush_bytes_validator{});
                 continue;
             }
-            if (cfg.name == topic_property_iceberg_enabled) {
-                parse_and_set_bool(
+            if (cfg.name == topic_property_iceberg_mode) {
+                parse_and_set_property(
                   tp_ns,
-                  update.properties.iceberg_enabled,
+                  update.properties.iceberg_mode,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  storage::ntp_config::default_iceberg_enabled,
                   iceberg_config_validator{});
                 continue;
             }

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -730,20 +730,6 @@ config_response_container_t make_topic_configs(
     add_topic_config_if_requested(
       config_keys,
       result,
-      topic_property_iceberg_translation_interval_ms,
-      config::shard_local_cfg().iceberg_translation_interval_ms_default(),
-      topic_property_iceberg_translation_interval_ms,
-      topic_properties.iceberg_translation_interval_ms,
-      include_synonyms,
-      maybe_make_documentation(
-        include_documentation,
-        "Controls how often iceberg translation is attempted on the topic "
-        "partitions."),
-      &describe_as_string<std::chrono::milliseconds>);
-
-    add_topic_config_if_requested(
-      config_keys,
-      result,
       topic_property_segment_ms,
       metadata_cache.get_default_segment_ms(),
       topic_property_segment_ms,

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -991,6 +991,20 @@ config_response_container_t make_topic_configs(
         "Preferred location (e.g. rack) for partition leaders of this topic."),
       &describe_as_string<config::leaders_preference>);
 
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      config::shard_local_cfg().iceberg_delete.name(),
+      config::shard_local_cfg().iceberg_delete(),
+      topic_property_iceberg_delete,
+      topic_properties.iceberg_delete,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        "If true, delete the corresponding Iceberg table when deleting the "
+        "topic."),
+      &describe_as_string<bool>);
+
     return result;
 }
 

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -73,7 +73,7 @@ bool is_supported(std::string_view name) {
        topic_property_write_caching,
        topic_property_flush_ms,
        topic_property_flush_bytes,
-       topic_property_iceberg_enabled,
+       topic_property_iceberg_mode,
        topic_property_leaders_preference,
        topic_property_iceberg_translation_interval_ms,
        topic_property_delete_retention_ms,

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -76,7 +76,8 @@ bool is_supported(std::string_view name) {
        topic_property_iceberg_enabled,
        topic_property_leaders_preference,
        topic_property_iceberg_translation_interval_ms,
-       topic_property_delete_retention_ms});
+       topic_property_delete_retention_ms,
+       topic_property_iceberg_delete});
 
     if (std::any_of(
           supported_configs.begin(),

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -75,7 +75,6 @@ bool is_supported(std::string_view name) {
        topic_property_flush_bytes,
        topic_property_iceberg_mode,
        topic_property_leaders_preference,
-       topic_property_iceberg_translation_interval_ms,
        topic_property_delete_retention_ms,
        topic_property_iceberg_delete});
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -335,13 +335,12 @@ create_topic_properties_update(
                   flush_bytes_validator{});
                 continue;
             }
-            if (cfg.name == topic_property_iceberg_enabled) {
-                parse_and_set_bool(
+            if (cfg.name == topic_property_iceberg_mode) {
+                parse_and_set_property(
                   tp_ns,
-                  update.properties.iceberg_enabled,
+                  update.properties.iceberg_mode,
                   cfg.value,
                   op,
-                  storage::ntp_config::default_iceberg_enabled,
                   iceberg_config_validator{});
                 continue;
             }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -377,6 +377,11 @@ create_topic_properties_update(
                   delete_retention_ms_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_iceberg_delete) {
+                parse_and_set_optional_bool_alpha(
+                  update.properties.iceberg_delete, cfg.value, op);
+                continue;
+            }
 
         } catch (const validation_error& e) {
             vlog(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -361,13 +361,6 @@ create_topic_properties_update(
                 }
                 throw validation_error("Cloud topics is not enabled");
             }
-            if (cfg.name == topic_property_iceberg_translation_interval_ms) {
-                parse_and_set_optional_duration(
-                  update.properties.iceberg_translation_interval_ms,
-                  cfg.value,
-                  op);
-                continue;
-            }
             if (cfg.name == topic_property_delete_retention_ms) {
                 parse_and_set_tristate(
                   update.properties.delete_retention_ms,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -272,6 +272,9 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.delete_retention_ms = get_delete_retention_ms(
       config_entries);
 
+    cfg.properties.iceberg_delete = get_bool_value(
+      config_entries, topic_property_iceberg_delete);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -266,10 +266,6 @@ to_cluster_type(const creatable_topic& t) {
 
     cfg.properties.leaders_preference = get_leaders_preference(config_entries);
 
-    cfg.properties.iceberg_translation_interval_ms
-      = get_duration_value<std::chrono::milliseconds>(
-        config_entries, topic_property_iceberg_translation_interval_ms, true);
-
     cfg.properties.delete_retention_ms = get_delete_retention_ms(
       config_entries);
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -259,9 +259,10 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.flush_bytes = get_config_value<size_t>(
       config_entries, topic_property_flush_bytes);
 
-    cfg.properties.iceberg_enabled
-      = get_bool_value(config_entries, topic_property_iceberg_enabled)
-          .value_or(storage::ntp_config::default_iceberg_enabled);
+    cfg.properties.iceberg_mode
+      = get_config_value<model::iceberg_mode>(
+          config_entries, topic_property_iceberg_mode)
+          .value_or(storage::ntp_config::default_iceberg_mode);
 
     cfg.properties.leaders_preference = get_leaders_preference(config_entries);
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -96,8 +96,8 @@ inline constexpr std::string_view
 inline constexpr std::string_view topic_property_mpx_virtual_cluster_id
   = "redpanda.virtual.cluster.id";
 
-inline constexpr std::string_view topic_property_iceberg_enabled
-  = "redpanda.iceberg.enabled";
+inline constexpr std::string_view topic_property_iceberg_mode
+  = "redpanda.iceberg.mode";
 
 inline constexpr std::string_view topic_property_leaders_preference
   = "redpanda.leaders.preference";

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -105,9 +105,6 @@ inline constexpr std::string_view topic_property_leaders_preference
 inline constexpr std::string_view topic_property_cloud_topic_enabled
   = "redpanda.cloud_topic.enabled";
 
-inline constexpr std::string_view topic_property_iceberg_translation_interval_ms
-  = "redpanda.iceberg.translation.interval.ms";
-
 inline constexpr std::string_view topic_property_iceberg_delete
   = "redpanda.iceberg.delete";
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -108,6 +108,9 @@ inline constexpr std::string_view topic_property_cloud_topic_enabled
 inline constexpr std::string_view topic_property_iceberg_translation_interval_ms
   = "redpanda.iceberg.translation.interval.ms";
 
+inline constexpr std::string_view topic_property_iceberg_delete
+  = "redpanda.iceberg.delete";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -280,16 +280,15 @@ struct iceberg_config_validator {
           c.configs.begin(),
           c.configs.end(),
           [](const createable_topic_config& cfg) {
-              return cfg.name == topic_property_iceberg_enabled;
+              return cfg.name == topic_property_iceberg_mode;
           });
         if (it == c.configs.end() || !it->value.has_value()) {
             return true;
         }
-        bool enabled_with_topic_override = false;
+        model::iceberg_mode parsed_mode;
         try {
-            enabled_with_topic_override = string_switch<bool>(it->value.value())
-                                            .match("true", true)
-                                            .match("false", false);
+            parsed_mode = boost::lexical_cast<model::iceberg_mode>(
+              it->value.value());
         } catch (...) {
             return false;
         }
@@ -298,7 +297,7 @@ struct iceberg_config_validator {
         // at the cluster level, it cannot be enabled with a topic
         // override.
         return config::shard_local_cfg().iceberg_enabled()
-               || !enabled_with_topic_override;
+               || parsed_mode == model::iceberg_mode::disabled;
     }
 };
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -379,6 +379,7 @@ FIXTURE_TEST(
       "redpanda.leaders.preference",
       "redpanda.iceberg.translation.interval.ms",
       "delete.retention.ms",
+      "redpanda.iceberg.delete",
     };
 
     // All properties_request

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -377,7 +377,6 @@ FIXTURE_TEST(
       "flush.bytes",
       "redpanda.iceberg.mode",
       "redpanda.leaders.preference",
-      "redpanda.iceberg.translation.interval.ms",
       "delete.retention.ms",
       "redpanda.iceberg.delete",
     };

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -588,6 +588,25 @@ enum class recovery_validation_mode : std::uint16_t {
 std::ostream& operator<<(std::ostream&, recovery_validation_mode);
 std::istream& operator>>(std::istream&, recovery_validation_mode&);
 
+// Iceberg enablement options for a topic
+enum class iceberg_mode : uint8_t {
+    // Iceberg is disabled
+    disabled = 0,
+    // Iceberg translation interprets record key and value as binary
+    // types and uses default Iceberg table schema.
+    key_value = 1,
+    // Iceberg translation interprets the record value using the schema
+    // id embedded in value. Kafka serializers embed a magic byte as the
+    // first byte of the value to indicate the presence of a schema id
+    // which is then resolved with the schema registry. The value bytes
+    // are then interepted using the schema and the resulting columns are
+    // mapped to appropriate iceberg types and corresponding table columns.
+    value_schema_id_prefix = 2
+};
+
+std::ostream& operator<<(std::ostream&, const iceberg_mode&);
+std::istream& operator>>(std::istream&, iceberg_mode&);
+
 } // namespace model
 
 template<>

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -582,6 +582,32 @@ std::istream& operator>>(std::istream& is, recovery_validation_mode& vm) {
     return is;
 }
 
+std::ostream& operator<<(std::ostream& os, const iceberg_mode& mode) {
+    switch (mode) {
+    case iceberg_mode::disabled:
+        return os << "disabled";
+    case iceberg_mode::key_value:
+        return os << "key_value";
+    case iceberg_mode::value_schema_id_prefix:
+        return os << "value_schema_id_prefix";
+    }
+}
+
+std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
+    using enum iceberg_mode;
+    ss::sstring s;
+    is >> s;
+    try {
+        mode = string_switch<iceberg_mode>(s)
+                 .match("disabled", disabled)
+                 .match("key_value", key_value)
+                 .match("value_schema_id_prefix", value_schema_id_prefix);
+    } catch (const std::runtime_error&) {
+        is.setstate(std::ios::failbit);
+    }
+    return is;
+}
+
 std::ostream& operator<<(std::ostream& os, const fips_mode_flag& f) {
     return os << to_string_view(f);
 }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1148,9 +1148,9 @@
                     "type": "long",
                     "description": "Next cloud offset"
                 },
-                "iceberg_enabled": {
-                    "type": "boolean",
-                    "description": "Whether iceberg translation is enabled on this replica."
+                "iceberg_mode": {
+                    "type": "string",
+                    "description": "Iceberg enablement mode for the topic"
                 },
                 "raft_state": {
                     "type": "raft_replica_state",

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -803,7 +803,7 @@ admin_server::get_partition_state_handler(
         replica.is_cloud_data_available = state.is_cloud_data_available;
         replica.start_cloud_offset = state.start_cloud_offset;
         replica.next_cloud_offset = state.next_cloud_offset;
-        replica.iceberg_enabled = state.iceberg_enabled;
+        replica.iceberg_mode = state.iceberg_mode;
         fill_raft_state(replica, std::move(state));
         response.replicas.push(std::move(replica));
     }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -33,7 +33,8 @@ public:
     // is handled during adl/serde decode).
     static constexpr bool default_remote_delete{true};
     static constexpr bool legacy_remote_delete{false};
-    static constexpr bool default_iceberg_enabled{false};
+    static constexpr model::iceberg_mode default_iceberg_mode
+      = model::iceberg_mode::disabled;
     static constexpr bool default_cloud_topic_enabled{false};
 
     static constexpr std::chrono::milliseconds read_replica_retention{3600000};
@@ -78,7 +79,7 @@ public:
 
         std::optional<std::chrono::milliseconds> flush_ms;
         std::optional<size_t> flush_bytes;
-        bool iceberg_enabled{default_iceberg_enabled};
+        model::iceberg_mode iceberg_mode{default_iceberg_mode};
         bool cloud_topic_enabled{default_cloud_topic_enabled};
         std::optional<std::chrono::milliseconds>
           iceberg_translation_interval_ms{std::nullopt};
@@ -343,12 +344,15 @@ public:
         return cleanup_policy_override().value_or(cluster_default);
     }
 
-    bool iceberg_enabled() const {
+    model::iceberg_mode iceberg_mode() const {
         if (!config::shard_local_cfg().iceberg_enabled) {
-            return false;
+            return model::iceberg_mode::disabled;
         }
-        return _overrides ? _overrides->iceberg_enabled
-                          : default_iceberg_enabled;
+        return _overrides ? _overrides->iceberg_mode : default_iceberg_mode;
+    }
+
+    bool iceberg_enabled() const {
+        return iceberg_mode() != model::iceberg_mode::disabled;
     }
 
     bool cloud_topic_enabled() const {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -81,8 +81,6 @@ public:
         std::optional<size_t> flush_bytes;
         model::iceberg_mode iceberg_mode{default_iceberg_mode};
         bool cloud_topic_enabled{default_cloud_topic_enabled};
-        std::optional<std::chrono::milliseconds>
-          iceberg_translation_interval_ms{std::nullopt};
 
         // Should not be enabled at the same time as any other tiered storage
         // properties.
@@ -361,14 +359,6 @@ public:
         }
         return _overrides ? _overrides->cloud_topic_enabled
                           : default_cloud_topic_enabled;
-    }
-    std::chrono::milliseconds iceberg_translation_interval_ms() const {
-        auto default_value
-          = config::shard_local_cfg().iceberg_translation_interval_ms_default();
-        return _overrides
-                 ? _overrides->iceberg_translation_interval_ms.value_or(
-                     default_value)
-                 : default_value;
     }
 
 private:

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -114,8 +114,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
-      "flush_bytes: {} iceberg_mode: {}, iceberg_translation_interval_ms: "
-      "{}}}",
+      "flush_bytes: {} iceberg_mode: {} }}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -131,8 +130,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.write_caching,
       v.flush_ms,
       v.flush_bytes,
-      v.iceberg_mode,
-      v.iceberg_translation_interval_ms);
+      v.iceberg_mode);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(o, ", cloud_topic_enabled: {}", v.cloud_topic_enabled);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -114,7 +114,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
-      "flush_bytes: {} iceberg_enabled: {}, iceberg_translation_interval_ms: "
+      "flush_bytes: {} iceberg_mode: {}, iceberg_translation_interval_ms: "
       "{}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
@@ -131,7 +131,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.write_caching,
       v.flush_ms,
       v.flush_bytes,
-      v.iceberg_enabled,
+      v.iceberg_mode,
       v.iceberg_translation_interval_ms);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -40,7 +40,6 @@ class TopicSpec:
     PROPERTY_FLUSH_MS = "flush.ms"
     PROPERTY_FLUSH_BYTES = "flush.bytes"
     PROPERTY_ICEBERG_MODE = "redpanda.iceberg.mode"
-    PROPERTY_ICEBERG_TRANSLATION_INTERVAL = "redpanda.iceberg.translation.interval.ms"
     PROPERTY_DELETE_RETENTION_MS = "delete.retention.ms"
 
     class CompressionTypes(str, Enum):

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -39,7 +39,7 @@ class TopicSpec:
     PROPERTY_WRITE_CACHING = "write.caching"
     PROPERTY_FLUSH_MS = "flush.ms"
     PROPERTY_FLUSH_BYTES = "flush.bytes"
-    PROPERTY_ICEBERG_ENABLED = "redpanda.iceberg.enabled"
+    PROPERTY_ICEBERG_MODE = "redpanda.iceberg.mode"
     PROPERTY_ICEBERG_TRANSLATION_INTERVAL = "redpanda.iceberg.translation.interval.ms"
     PROPERTY_DELETE_RETENTION_MS = "delete.retention.ms"
 

--- a/tests/rptest/tests/datalake/compaction_gaps_test.py
+++ b/tests/rptest/tests/datalake/compaction_gaps_test.py
@@ -1,0 +1,116 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from time import time
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.types import TopicSpec
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
+from rptest.tests.datalake.utils import supported_storage_types
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.services.cluster import cluster
+from rptest.utils.mode_checks import skip_debug_mode
+
+
+class CompactionGapsTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(CompactionGapsTest, self).__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx, fast_uploads=True),
+            extra_rp_conf={
+                "iceberg_enabled": "true",
+                "iceberg_catalog_commit_interval_ms": 5000,
+                "datalake_coordinator_snapshot_max_delay_secs": 10,
+                "log_compaction_interval_ms": 2000
+            },
+            *args,
+            **kwargs)
+        self.test_ctx = test_ctx
+        self.topic_name = "test"
+        self.segment_size = 5 * 1024 * 1024
+        self.kafka_cat = KafkaCat(self.redpanda)
+
+    def partition_segments(self) -> int:
+        assert len(self.redpanda.nodes) == 1, self.redpanda.nodes
+        node = self.redpanda.nodes[0]
+        storage = self.redpanda.node_storage(node)
+        topic_partitions = storage.partitions("kafka", self.topic_name)
+        assert len(topic_partitions) == 1, len(topic_partitions)
+        segment_count = len(topic_partitions[0].segments)
+        self.redpanda.logger.debug(f"Current segment count: {segment_count}")
+        return segment_count
+
+    def wait_until_segment_count(self, count):
+        wait_until(
+            lambda: self.partition_segments() == count,
+            timeout_sec=30,
+            backoff_sec=3,
+            err_msg=f"Timed out waiting for segment count to reach {count}")
+
+    def produce_until_segment_count(self, count):
+        timeout_sec = 30
+        deadline = time() + timeout_sec
+        while True:
+            current_segment_count = self.partition_segments()
+            if current_segment_count >= count:
+                return
+            if time() > deadline:
+                assert False, f"Unable to reach segment count {count} in {timeout_sec}s, current count {current_segment_count}"
+            KgoVerifierProducer.oneshot(self.test_ctx,
+                                        self.redpanda,
+                                        self.topic_name,
+                                        2024,
+                                        10000,
+                                        key_set_cardinality=2)
+
+    def ensure_translation(self, dl: DatalakeServices):
+        (_, max_offset) = self.kafka_cat.list_offsets(topic=self.topic_name,
+                                                      partition=0)
+        self.redpanda.logger.debug(
+            f"Ensuring translation until: {max_offset - 1}")
+        dl.wait_for_translation_until_offset(self.topic_name, max_offset - 1)
+
+    def do_test_no_gaps(self, dl: DatalakeServices):
+
+        dl.create_iceberg_enabled_topic(self.topic_name,
+                                        iceberg_mode="key_value",
+                                        config={
+                                            "cleanup.policy":
+                                            TopicSpec.CLEANUP_COMPACT,
+                                            "segment.bytes": self.segment_size
+                                        })
+
+        for _ in range(5):
+            self.produce_until_segment_count(5)
+            # # Ensure everything is translated
+            self.ensure_translation(dl)
+            # # Disable iceberg
+            dl.set_iceberg_mode_on_topic(self.topic_name, "disabled")
+            # Append more data
+            self.produce_until_segment_count(8)
+            # # Compact the data
+            # # One closed segment and one open (current) segment
+            self.wait_until_segment_count(2)
+            # # Enable iceberg again
+            dl.set_iceberg_mode_on_topic(self.topic_name, "key_value")
+
+    @cluster(num_nodes=4)
+    @skip_debug_mode
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_translation_no_gaps(self, cloud_storage_type):
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.TRINO
+                                                     ]) as dl:
+            self.do_test_no_gaps(dl)

--- a/tests/rptest/tests/datalake/coordinator_retention_test.py
+++ b/tests/rptest/tests/datalake/coordinator_retention_test.py
@@ -72,7 +72,7 @@ class CoordinatorRetentionTest(RedpandaTest):
         try:
             wait_until(
                 self.wait_until_coordinator_snapshots,
-                timeout_sec=20,
+                timeout_sec=30,
                 backoff_sec=3,
                 err_msg=
                 "Timed out waiting for coordinator partitions to snapshot.")

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -93,7 +93,8 @@ class DatalakeE2ETests(RedpandaTest):
                               redpanda=self.redpanda,
                               filesystem_catalog_mode=True,
                               include_query_engines=[query_engine]) as dl:
-            dl.create_iceberg_enabled_topic(self.topic_name)
+            dl.create_iceberg_enabled_topic(
+                self.topic_name, iceberg_mode="value_schema_id_prefix")
             avro_serde_client = self._get_serde_client(SchemaType.AVRO,
                                                        SerdeClientType.Golang,
                                                        self.topic_name, count)

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -83,9 +83,10 @@ class DatalakeServices():
                                      name,
                                      partitions=1,
                                      replicas=1,
+                                     iceberg_mode="key_value",
                                      translation_interval_ms=3000,
                                      config: dict[str, Any] = dict()):
-        config[TopicSpec.PROPERTY_ICEBERG_ENABLED] = "true"
+        config[TopicSpec.PROPERTY_ICEBERG_MODE] = iceberg_mode
         config[TopicSpec.
                PROPERTY_ICEBERG_TRANSLATION_INTERVAL] = translation_interval_ms
         rpk = RpkTool(self.redpanda)

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -84,11 +84,8 @@ class DatalakeServices():
                                      partitions=1,
                                      replicas=1,
                                      iceberg_mode="key_value",
-                                     translation_interval_ms=3000,
                                      config: dict[str, Any] = dict()):
         config[TopicSpec.PROPERTY_ICEBERG_MODE] = iceberg_mode
-        config[TopicSpec.
-               PROPERTY_ICEBERG_TRANSLATION_INTERVAL] = translation_interval_ms
         rpk = RpkTool(self.redpanda)
         rpk.create_topic(topic=name,
                          partitions=partitions,

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -92,6 +92,10 @@ class DatalakeServices():
                          replicas=replicas,
                          config=config)
 
+    def set_iceberg_mode_on_topic(self, topic: str, mode: str):
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(topic, "redpanda.iceberg.mode", mode)
+
     def wait_for_iceberg_table(self, namespace, table, timeout, backoff_sec):
         client = self.catalog_service.client("redpanda-iceberg-catalog")
 
@@ -107,6 +111,34 @@ class DatalakeServices():
             backoff_sec=backoff_sec,
             err_msg=
             f"Timed out waiting {namespace}.{table} to be created in the catalog"
+        )
+
+    def wait_for_translation_until_offset(self,
+                                          topic,
+                                          offset,
+                                          partition=0,
+                                          timeout=30,
+                                          backoff_sec=5):
+        self.wait_for_iceberg_table("redpanda", topic, timeout, backoff_sec)
+        table_name = f"redpanda.{topic}"
+
+        def translation_done():
+            offsets = dict(
+                map(
+                    lambda e: (e.engine_name(),
+                               e.max_translated_offset(table_name, partition)),
+                    self.query_engines))
+            self.redpanda.logger.debug(
+                f"Current translated offsets: {offsets}")
+            return all(
+                [offset <= max_offset for _, max_offset in offsets.items()])
+
+        wait_until(
+            translation_done,
+            timeout_sec=timeout,
+            backoff_sec=backoff_sec,
+            err_msg=
+            f"Timed out waiting for iceberg translation until offset: {offset}"
         )
 
     def wait_for_translation(self,

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -50,3 +50,8 @@ class QueryEngineBase(ABC):
         query = f"select count(*) from {table}"
         with self.run_query(query) as cursor:
             return int(cursor.fetchone()[0])
+
+    def max_translated_offset(self, table, partition) -> int:
+        query = f"select max(redpanda.offset) from {table} where redpanda.partition={partition}"
+        with self.run_query(query) as cursor:
+            return int(cursor.fetchone()[0])

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -92,8 +92,8 @@ class RestCatalogConnectionTest(RedpandaTest):
         topic = TopicSpec(name='datalake-test-topic', partition_count=3)
 
         self.client().create_topic(topic)
-        self.client().alter_topic_config(topic.name,
-                                         "redpanda.iceberg.enabled", "true")
+        self.client().alter_topic_config(topic.name, "redpanda.iceberg.mode",
+                                         "key_value")
 
         producer = self.start_producer(topic_name=topic.name)
         # wait for the producer to finish

--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -25,7 +25,6 @@ class RestCatalogConnectionTest(RedpandaTest):
                                    cloud_storage_enable_remote_write=False),
             extra_rp_conf={
                 "iceberg_enabled": True,
-                "iceberg_translation_interval_ms_default": 3000,
                 "iceberg_catalog_commit_interval_ms": 10000
             })
         self.catalog_service = IcebergRESTCatalog(

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -301,7 +301,14 @@ class DescribeTopicsTest(RedpandaTest):
                 value="-1",
                 doc_string=
                 "The retention time for tombstone records in a compacted topic. Cannot be enabled at the same time as any of `cloud_storage_enabled`, `cloud_storage_enable_remote_read`, or `cloud_storage_enable_remote_write`."
-            )
+            ),
+            "redpanda.iceberg.delete":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="true",
+                doc_string=
+                "If true, delete the corresponding Iceberg table when deleting the topic."
+            ),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -287,13 +287,6 @@ class DescribeTopicsTest(RedpandaTest):
                 doc_string=
                 "Preferred location (e.g. rack) for partition leaders of this topic."
             ),
-            "redpanda.iceberg.translation.interval.ms":
-            ConfigProperty(
-                config_type="LONG",
-                value="60000",
-                doc_string=
-                "Controls how often iceberg translation is attempted on the topic partitions."
-            ),
             "delete.retention.ms":
             ConfigProperty(
                 config_type="LONG",

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -275,12 +275,11 @@ class DescribeTopicsTest(RedpandaTest):
                 doc_string=
                 "Maximum number of bytes that are not flushed per partition. If the configured threshold is reached, the log is automatically flushed even if it has not been explicitly requested."
             ),
-            "redpanda.iceberg.enabled":
+            "redpanda.iceberg.mode":
             ConfigProperty(
-                config_type="BOOLEAN",
-                value="false",
-                doc_string=
-                "Iceberg format translation enabled on this topic if true."),
+                config_type="STRING",
+                value="disabled",
+                doc_string="Iceberg enablement mode for the topic."),
             "redpanda.leaders.preference":
             ConfigProperty(
                 config_type="STRING",

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -81,8 +81,6 @@ class PolarisCatalogSmokeTest(RedpandaTest):
             client_id,
             "iceberg_rest_catalog_client_secret":
             client_secret,
-            "iceberg_translation_interval_ms_default":
-            3000,
             "iceberg_catalog_commit_interval_ms":
             10000,
             "iceberg_rest_catalog_prefix":

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -235,8 +235,8 @@ class PolarisCatalogSmokeTest(RedpandaTest):
         topic = TopicSpec(partition_count=1, replication_factor=1)
         client = DefaultClient(self.redpanda)
         client.create_topic(topic)
-        client.alter_topic_config(topic.name,
-                                  TopicSpec.PROPERTY_ICEBERG_ENABLED, "true")
+        client.alter_topic_config(topic.name, TopicSpec.PROPERTY_ICEBERG_MODE,
+                                  "key_value")
         rpk = RpkTool(self.redpanda)
         for i in range(10):
             rpk.produce(topic.name, "key", f"value-{i}")

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -308,6 +308,7 @@ def read_incremental_topic_update_serde(rdr: Reader):
                 'iceberg_enabled': rdr.read_bool(),
                 'leaders_preference':
                 rdr.read_optional(read_leaders_preference),
+                'iceberg_delete': rdr.read_optional(Reader.read_bool),
             }
 
         return incr_obj

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -138,7 +138,7 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
     if version >= 10:
         topic_properties |= {
-            'iceberg_enabled': rdr.read_bool(),
+            'iceberg_mode': rdr.read_serde_enum(),
             'leaders_preference': rdr.read_optional(read_leaders_preference),
             'cloud_topic_enabled': rdr.read_bool(),
             'iceberg_translation_interval_ms':
@@ -305,7 +305,7 @@ def read_incremental_topic_update_serde(rdr: Reader):
             }
         if version >= 7:
             incr_obj |= {
-                'iceberg_enabled': rdr.read_bool(),
+                'iceberg_mode': rdr.read_serde_enum(),
                 'leaders_preference':
                 rdr.read_optional(read_leaders_preference),
                 'iceberg_delete': rdr.read_optional(Reader.read_bool),

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -141,8 +141,6 @@ def read_topic_properties_serde(rdr: Reader, version):
             'iceberg_mode': rdr.read_serde_enum(),
             'leaders_preference': rdr.read_optional(read_leaders_preference),
             'cloud_topic_enabled': rdr.read_bool(),
-            'iceberg_translation_interval_ms':
-            rdr.read_optional(Reader.read_int64),
             'delete_retention_ms': rdr.read_tristate(Reader.read_int64),
             'iceberg_delete': rdr.read_optional(Reader.read_bool),
         }

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -143,7 +143,8 @@ def read_topic_properties_serde(rdr: Reader, version):
             'cloud_topic_enabled': rdr.read_bool(),
             'iceberg_translation_interval_ms':
             rdr.read_optional(Reader.read_int64),
-            'delete_retention_ms': rdr.read_tristate(Reader.read_int64)
+            'delete_retention_ms': rdr.read_tristate(Reader.read_int64),
+            'iceberg_delete': rdr.read_optional(Reader.read_bool),
         }
 
     return topic_properties


### PR DESCRIPTION
* (new) `redpanda.iceberg.delete` = {true, false}, global configuration default `iceberg_delete` {true, false}
* (update) `redpanda.iceberg.mode`, accepted values={disabled, key_value, value_schema_id_prefix} replaces `redpanda.iceberg.enabled`={true/false}
* (delete) Removing `iceberg_translation_interval_ms_default` and `redpanda.iceberg.translation.interval.ms`


Additionally includes a fix for potentially translation gaps due to compaction.

Normally gaps shouldn't happen with translation due to the enforcement
of max_collectible_offset. However the following sequence of actions can
create a gap.

iceberg enabled
iceberg disabled
<-- compaction -->
iceberg enabled

This is an unfixable gap if compaction cleaned up an offset range
adjacent to last translated offset. The fix just plugs the gap by
adjusting the begin offset of the range that is to be committed with the
coordinator. This is a rare case but can result in a stuck translation
if it happens.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
