### PR TITLE
iceberg: couple miscellaneous fixes found in prolonged testing

### DIFF
--- a/src/v/iceberg/metadata_io.h
+++ b/src/v/iceberg/metadata_io.h
@@ -53,8 +53,8 @@ protected:
         retry_chain_node retry(
           io_.as(),
           ss::lowres_clock::duration{30s},
-          {},
-          retry_strategy::disallow);
+          10ms,
+          retry_strategy::backoff);
         iobuf buf;
         auto res = co_await ss::coroutine::as_future(io_.download_object({
           .transfer_details = {
@@ -109,8 +109,8 @@ protected:
         retry_chain_node retry(
           io_.as(),
           ss::lowres_clock::duration{30s},
-          {},
-          retry_strategy::disallow);
+          10ms,
+          retry_strategy::backoff);
         auto res = co_await ss::coroutine::as_future(io_.upload_object({
           .transfer_details = {
             .bucket = bucket_,
@@ -149,8 +149,8 @@ protected:
         retry_chain_node retry(
           io_.as(),
           ss::lowres_clock::duration{30s},
-          {},
-          retry_strategy::disallow);
+          10ms,
+          retry_strategy::backoff);
         auto res = co_await ss::coroutine::as_future(io_.object_exists(
           bucket_,
           cloud_storage_clients::object_key{path},

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -113,7 +113,7 @@ redpanda_cc_library(
         ":oauth_token",
         ":retry_policy",
         "//src/v/bytes:iobuf",
-        "//src/v/bytes:iobuf_parser",
+        "//src/v/bytes:streambuf",
         "//src/v/http",
         "//src/v/http:request_builder",
         "//src/v/http:utils",


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Addresses a couple issues seen when running the Iceberg integration for a moderate length of time:
- oversized allocs from loading table metadata as a string
- frequent EOSs that wouldn't be retried, and so we'd get stuck when performing many downloads in a row as a part of a merge append

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
