### PR TITLE
serde/parquet: support creating multiple row groups

### DIFF
--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -28,6 +28,13 @@ struct data_page {
     iobuf serialized;
 };
 
+// The delta in stats when a value is written to a column.
+//
+// This is used to account memory usage at the row group level.
+struct incremental_column_stats {
+    uint64_t memory_usage;
+};
+
 // A writer for a single column of parquet data.
 class column_writer {
 public:
@@ -54,7 +61,7 @@ public:
     // nodes.
     //
     // Use `shred_record` to get the value and levels from an arbitrary value.
-    void add(value, rep_level, def_level);
+    incremental_column_stats add(value, rep_level, def_level);
 
     // Flush the currently buffered values to a page.
     //

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -350,6 +350,10 @@ ss::future<iobuf> serialize_testcase(size_t test_case) {
         auto v = generate_value(schema);
         rows.push_back(copy(v));
         co_await w.write_row(std::get<group_value>(std::move(v)));
+        // Create multiple row groups and make sure it works
+        if (i % 32 == 0) {
+            co_await w.flush_row_group();
+        }
     }
     co_await w.close();
     co_return json(testcase{

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -19,6 +19,14 @@
 
 namespace serde::parquet {
 
+// Statistics about the current row group.
+//
+// These are mainly provided to limit memory usage.
+struct row_group_stats {
+    uint64_t rows = 0;
+    uint64_t memory_usage = 0;
+};
+
 // A parquet file writer for seastar.
 class writer {
 public:
@@ -57,6 +65,12 @@ public:
     // This method may not be called concurrently with other methods on this
     // class.
     ss::future<> write_row(group_value);
+
+    // The current stats on the buffered row group.
+    //
+    // This can be used to account for memory usage and flush a row group
+    // when the memory usage is over some limit.
+    row_group_stats current_row_group_stats() const;
 
     // Flush the current row group to the output stream, creating a new row
     // group.

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -54,12 +54,27 @@ public:
     // Write the record as a row to the parquet file. This value must exactly
     // match the provided schema.
     //
-    // The returned future must be awaited *before* calling write_row again with
-    // another value.
+    // This method may not be called concurrently with other methods on this
+    // class.
     ss::future<> write_row(group_value);
+
+    // Flush the current row group to the output stream, creating a new row
+    // group.
+    //
+    // This may only be called if there is at least a single row in the group.
+    //
+    // This method may not be called concurrently with other methods on this
+    // class.
+    ss::future<> flush_row_group();
 
     // Close the writer by writing the parquet file footer. Then flush/close the
     // underlying stream that is being written too.
+    //
+    // This method will automatically flush the current row group if there are
+    // any rows buffered in it.
+    //
+    // This method may not be called concurrently with other methods on this
+    // class.
     //
     // The resulting future must be awaited before destroying this object.
     ss::future<> close();


### PR DESCRIPTION
- **serde/parquet: add method to flush row group**
- **serde/parquet: add stats for the current row group memory usage**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
