### PR TITLE
bazel/version: remove version.cc as a runfile

### DIFF
--- a/src/v/version/expand_with_stamp_vars.bzl
+++ b/src/v/version/expand_with_stamp_vars.bzl
@@ -26,7 +26,6 @@ def _expand_with_stamp_vars(ctx):
     )
     return DefaultInfo(
         files = depset([ctx.outputs.out]),
-        runfiles = ctx.runfiles(files = [ctx.outputs.out]),
     )
 
 expand_with_stamp_vars = rule(


### PR DESCRIPTION
This prevents it from showing up in the packaged tarball for Bazel.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
