### PR TITLE
Ik bazel tests serde

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -58,6 +58,7 @@ def _redpanda_cc_test(
         memory,
         cpu,
         srcs = [],
+        defines = [],
         deps = [],
         extra_args = [],
         custom_args = [],
@@ -74,6 +75,7 @@ def _redpanda_cc_test(
       timeout: same as native cc_test
       dash_dash_protocol: false for google test, true for boost test
       srcs: test source files
+      defines: definitions of object-like macros
       deps: test dependencies
       memory: seastar memory as a string ("1GB" or "512MiB" or "256M")
       cpu: seastar cores
@@ -114,6 +116,7 @@ def _redpanda_cc_test(
         name = name,
         timeout = timeout,
         srcs = srcs,
+        defines = defines,
         deps = deps,
         copts = redpanda_copts(),
         args = args,
@@ -147,6 +150,7 @@ def redpanda_cc_gtest(
         name,
         timeout,
         srcs = [],
+        defines = [],
         deps = [],
         args = [],
         env = {},
@@ -159,6 +163,7 @@ def redpanda_cc_gtest(
         name = name,
         timeout = timeout,
         srcs = srcs,
+        defines = defines,
         cpu = cpu,
         memory = memory,
         deps = deps,
@@ -173,6 +178,7 @@ def redpanda_cc_btest(
         name,
         timeout,
         srcs = [],
+        defines = [],
         deps = [],
         args = [],
         env = {},
@@ -186,6 +192,7 @@ def redpanda_cc_btest(
         name = name,
         timeout = timeout,
         srcs = srcs,
+        defines = defines,
         deps = deps,
         cpu = cpu,
         memory = memory,
@@ -200,6 +207,7 @@ def redpanda_cc_bench(
         name,
         timeout,
         srcs = [],
+        defines = [],
         deps = [],
         args = [],
         env = {},
@@ -215,6 +223,7 @@ def redpanda_cc_bench(
         name = name,
         timeout = timeout,
         srcs = srcs,
+        defines = defines,
         deps = deps,
         custom_args = args,
         tags = [

--- a/src/v/serde/test/BUILD
+++ b/src/v/serde/test/BUILD
@@ -1,0 +1,42 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "serde_test",
+    timeout = "short",
+    srcs = [
+        "serde_test.cc",
+    ],
+    defines = [
+        "SERDE_TEST",
+    ],
+    deps = [
+        "//src/v/bytes:random",
+        "//src/v/container:fragmented_vector",
+        "//src/v/hashing:crc32c",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/serde",
+        "//src/v/serde:array",
+        "//src/v/serde:bool_class",
+        "//src/v/serde:bytes",
+        "//src/v/serde:chrono",
+        "//src/v/serde:enum",
+        "//src/v/serde:inet_address",
+        "//src/v/serde:iobuf",
+        "//src/v/serde:map",
+        "//src/v/serde:set",
+        "//src/v/serde:sstring",
+        "//src/v/serde:variant",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:tristate",
+        "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:node_hash_map",
+        "@abseil-cpp//absl/container:node_hash_set",
+        "@boost//:container_hash",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -13,9 +13,21 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "random/generators.h"
+#include "serde/async.h"
+#include "serde/peek.h"
+#include "serde/rw/array.h"
+#include "serde/rw/bool_class.h"
+#include "serde/rw/bytes.h"
+#include "serde/rw/chrono.h"
+#include "serde/rw/enum.h"
+#include "serde/rw/envelope.h"
+#include "serde/rw/inet_address.h"
+#include "serde/rw/iobuf.h"
+#include "serde/rw/map.h"
 #include "serde/rw/rw.h"
+#include "serde/rw/set.h"
+#include "serde/rw/sstring.h"
 #include "serde/rw/variant.h"
-#include "serde/serde.h"
 #include "test_utils/randoms.h"
 #include "utils/tristate.h"
 
@@ -36,6 +48,7 @@
 #include <limits>
 #include <optional>
 #include <ratio>
+#include <utility>
 
 struct custom_read_write {
     friend inline void read_nested(
@@ -468,7 +481,7 @@ ss::future<> test_snapshot_header::serde_async_read(
     crc.extend(ss::cpu_to_le(version));
     crc.extend(ss::cpu_to_le(metadata_size));
 
-    if (header_crc != crc.value()) {
+    if (std::cmp_not_equal(header_crc, crc.value())) {
         throw std::runtime_error(fmt::format(
           "Corrupt snapshot. Failed to verify header crc: {} != "
           "{}: path?",


### PR DESCRIPTION
Implements: [CORE-7599](https://redpandadata.atlassian.net/browse/CORE-7599) `serde_test.cc`

In the bazel build we have the flags `-Werror,-Wsign-compare` enabled which requires a few comparisons to be changed to a signed-aware interface.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7599]: https://redpandadata.atlassian.net/browse/CORE-7599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ