### PR TITLE
[CORE-8249] Allow more time for segment clean up

### DIFF
--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -631,8 +631,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             # Local storage deletion should proceed even if remote can't
             wait_until(
                 lambda: topic_storage_purged(self.redpanda, self.topic),
-                timeout_sec=30,
-                backoff_sec=1,
+                timeout_sec=90,
+                backoff_sec=10,
                 err_msg=
                 "Local storage purge did not complete while cloud storage was unavailable"
             )

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -628,9 +628,13 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             assert self.topic not in self.kafka_tools.list_topics()
 
             # Local storage deletion should proceed even if remote can't
-            wait_until(lambda: topic_storage_purged(self.redpanda, self.topic),
-                       timeout_sec=30,
-                       backoff_sec=1)
+            wait_until(
+                lambda: topic_storage_purged(self.redpanda, self.topic),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=
+                "Local storage purge did not complete while cloud storage was unavailable"
+            )
 
             # Erase timeout is hardcoded 60 seconds, wait long enough
             # for it to give up.

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -111,7 +111,8 @@ def topic_storage_purged(redpanda, topic_name):
             for topic_name, topic in ns.topics.items():
                 for p_id, p in topic.partitions.items():
                     for f in p.files:
-                        redpanda.logger.info(f"  {n.name}: {f}")
+                        redpanda.logger.info(
+                            f"  {n.name}: {topic_name}_{p_id}_{f}")
 
         return False
 


### PR DESCRIPTION
I see the last check in ducktape was here when ducktape was expecting this file to have been deleted on the broker:

```
  [INFO  - 2024-11-21 01:58:41,459 - topic_delete_test - topic_storage_purged - lineno:114]:   ip-172-31-45-99: 54-1-v1.log
```

Then a timeout occurs because the file isn't removed. But looking at the broker logs, the “removed:” line which happens right before ss::remove is called:

```
  DEBUG 2024-11-21 01:58:42,717 [shard 1:main] storage - segment.cc:171 - removed: "/var/lib/redpanda/data/kafka/topic-rmahmpbiye/2_29/54-1-v1.log" size 1048868
```

which was 1 second later. This appears to just be a race. Extend the time allowance before timeout.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

