### PR TITLE
bazel: Update hwloc to 2.11.2

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -172,7 +172,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "OQVI3me8atNuaWqORrtVvvxL1zSzpYIVGCcmSSYW49s=",
+        "bzlTransitiveDigest": "faHV6ZVocQ3xY1djAhcDPYr1GFTHJ4vRwDNKcBMfGXw=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -239,9 +239,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:hwloc.BUILD",
-              "sha256": "1f6d0f3edddd0070717f9f17e3a090a26d203e026c192144aa5f587725cf11e3",
-              "strip_prefix": "hwloc-hwloc-2.9.3",
-              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/hwloc-2.9.3.tar.gz"
+              "sha256": "866ac8ef07b350a6a2ba0c6826c37d78e8994dcbcd443bdd2b436350de19d540",
+              "strip_prefix": "hwloc-2.11.2",
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/hwloc-2.11.2.tar.gz"
             }
           },
           "jsoncons": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -57,9 +57,9 @@ def data_dependency():
     http_archive(
         name = "hwloc",
         build_file = "//bazel/thirdparty:hwloc.BUILD",
-        sha256 = "1f6d0f3edddd0070717f9f17e3a090a26d203e026c192144aa5f587725cf11e3",
-        strip_prefix = "hwloc-hwloc-2.9.3",
-        url = "https://vectorized-public.s3.amazonaws.com/dependencies/hwloc-2.9.3.tar.gz",
+        sha256 = "866ac8ef07b350a6a2ba0c6826c37d78e8994dcbcd443bdd2b436350de19d540",
+        strip_prefix = "hwloc-2.11.2",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/hwloc-2.11.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Bring it inline with the vtools build


## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

