### PR TITLE
Revert "datalake: use serde parquet writer as a default"

### DIFF
--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -12,6 +12,7 @@
 
 #include "cluster/archival/types.h"
 #include "cluster/partition.h"
+#include "datalake/batching_parquet_writer.h"
 #include "datalake/coordinator/frontend.h"
 #include "datalake/coordinator/translated_offset_range.h"
 #include "datalake/data_writer_interface.h"
@@ -80,6 +81,8 @@ ss::futurize_t<FuncRet> retry_with_backoff(
 
 static constexpr std::chrono::milliseconds translation_jitter{500};
 constexpr ::model::timeout_clock::duration wait_timeout = 5s;
+constexpr size_t max_rows_per_row_group = std::numeric_limits<size_t>::max();
+constexpr size_t max_bytes_per_row_group = std::numeric_limits<size_t>::max();
 
 partition_translator::~partition_translator() = default;
 partition_translator::partition_translator(
@@ -174,6 +177,28 @@ partition_translator::max_offset_for_translation() const {
     return kafka::prev_offset(model::offset_cast(lso.value()));
 }
 
+namespace {
+/**
+ * In order to make it easily configurable we add a
+ * '__REDPANDA_USE_SERDE_PARQUET_WRITER' environment variable, when set a serde
+ * parquet writer will be used.
+ * TODO: remove this once serde parquet writer is ready to be used as
+ * default
+ */
+ss::shared_ptr<parquet_ostream_factory> get_parquet_writer_factory() {
+    auto use_serde_parquet_writer = std::getenv(
+      "__REDPANDA_USE_SERDE_PARQUET_WRITER");
+
+    if (use_serde_parquet_writer != nullptr) {
+        vlog(datalake_log.info, "Using serde parquet writer");
+        return ss::make_shared<serde_parquet_writer_factory>();
+    }
+    return ss::make_shared<batching_parquet_writer_factory>(
+      max_rows_per_row_group,   // max entries per single parquet row group
+      max_bytes_per_row_group); // max bytes per single parquet row group
+}
+} // namespace
+
 ss::future<std::optional<coordinator::translated_offset_range>>
 partition_translator::do_translation_for_range(
   retry_chain_node& parent,
@@ -184,7 +209,7 @@ partition_translator::do_translation_for_range(
     auto writer_factory = std::make_unique<local_parquet_file_writer_factory>(
       local_path{_writer_scratch_space}, // storage temp files are written to
       fmt::format("{}", begin_offset),   // file prefix
-      ss::make_shared<serde_parquet_writer_factory>());
+      get_parquet_writer_factory());
 
     auto task = translation_task{
       **_cloud_io, *_schema_mgr, *_type_resolver, *_record_translator};


### PR DESCRIPTION
Snowflake requires column stats, which we don't yet have with serde::parquet.

This reverts commit e70ff2970e2d6218603e04afb66eb0301281b7a3.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
