### PR TITLE
k/data: Add CMakeLists for record_batcher test

### DIFF
--- a/src/v/kafka/data/CMakeLists.txt
+++ b/src/v/kafka/data/CMakeLists.txt
@@ -33,3 +33,5 @@ v_cc_library(
     v::model
     v::storage
 )
+
+add_subdirectory(test)

--- a/src/v/kafka/data/test/CMakeLists.txt
+++ b/src/v/kafka/data/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+v_cc_library(
+  NAME kd_test_utils
+  HDRS
+    utils.h
+  SRCS
+    utils.cc
+  DEPS
+    v::utils
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_kd_record_batcher
+  SOURCES
+    record_batcher_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::kd_record_batcher
+    v::kd_test_utils
+  LABELS kafka
+)


### PR DESCRIPTION
This was left out of 3ddb1e38b7 by mistake. This code has been under test in the bazel build on dev, but it has _not_ been under test on v24.3.x since the branch cut, since the bazel build is not run there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
