### PR TITLE
[v24.3.x] [CORE-8361] rptest: Disable fips in one of the upgrade tests

### DIFF
--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -20,6 +20,7 @@ from rptest.services.cluster import cluster
 from ducktape.mark import parametrize, matrix
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
+from rptest.utils.mode_checks import skip_fips_mode
 
 from rptest.services.redpanda_installer import RedpandaVersionTriple
 from rptest.clients.types import TopicSpec
@@ -367,6 +368,8 @@ class AlterConfigMixedNodeTest(EndToEndTest):
     def __init__(self, ctx):
         super(AlterConfigMixedNodeTest, self).__init__(test_context=ctx)
 
+    # fips_mode requires the bucket to configured in virtual_host mode which is not available prior to v24.2
+    @skip_fips_mode
     @cluster(num_nodes=3)
     @matrix(incremental_update=[True, False])
     def test_alter_config_shadow_indexing_mixed_node(self, incremental_update):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24286
