### PR TITLE
rpk: improve error messages in security/acl

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -131,6 +131,22 @@ func NewHostClient(fs afero.Fs, p *config.RpkProfile, host string) (*rpadmin.Adm
 	return rpadmin.NewClient(addrs, tc, auth, p.FromCloud)
 }
 
+// TryDecodeMessageFromErr tries to decode the message if it's a
+// rpadmin.HTTPResponseError and logs the full error. Otherwise, it returns
+// the original error string.
+func TryDecodeMessageFromErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) {
+		zap.L().Sugar().Debugf("got admin API error: %v", strings.TrimSpace(err.Error()))
+		if body, err := he.DecodeGenericErrorBody(); err == nil {
+			return body.Message
+		}
+	}
+	return strings.TrimSpace(err.Error())
+}
+
 // licenseFeatureChecks checks if the user is talking to a cluster that has
 // enterprise features enabled without a license and returns a message with a
 // warning.

--- a/src/go/rpk/pkg/cli/security/acl/create.go
+++ b/src/go/rpk/pkg/cli/security/acl/create.go
@@ -69,6 +69,10 @@ Allow write permissions to user buzz to transactional ID "txn":
 			tw := out.NewTable(headersWithError...)
 			defer tw.Flush()
 			for _, c := range results {
+				errMsg := kafka.ErrMessage(c.Err)
+				if c.ErrMessage != "" {
+					errMsg = fmt.Sprintf("%v: %v", errMsg, c.ErrMessage)
+				}
 				tw.PrintStructFields(aclWithMessage{
 					c.Principal,
 					c.Host,
@@ -77,7 +81,7 @@ Allow write permissions to user buzz to transactional ID "txn":
 					c.Pattern,
 					c.Operation,
 					c.Permission,
-					kafka.ErrMessage(c.Err),
+					errMsg,
 				})
 			}
 		},

--- a/src/go/rpk/pkg/cli/security/role/create.go
+++ b/src/go/rpk/pkg/cli/security/role/create.go
@@ -46,7 +46,7 @@ flag in the 'rpk security acl create' command.`,
 
 			roleName := args[0]
 			_, err = cl.CreateRole(cmd.Context(), roleName)
-			out.MaybeDie(err, "unable to create role %q: %v", roleName, err)
+			out.MaybeDie(err, "unable to create role %q: %v", roleName, adminapi.TryDecodeMessageFromErr(err))
 
 			if isText, _, s, err := f.Format(createResponse{[]string{roleName}}); !isText {
 				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -307,7 +307,8 @@ class AccessControlListTest(AccessControlListTestBase):
 
         acl = [acl for acl in acls if acl.resource_name == resource]
         assert len(acl) == 1, f'Expected match for {resource} not found'
-        assert acl[0].error == 'INVALID_REQUEST'
+        assert 'INVALID_REQUEST' in acl[
+            0].error, f'expected INVALID_REQUEST to be in {acl[0].error}'
 
     '''
     The old config style has use_sasl at the top level, which enables


### PR DESCRIPTION
Fixes #24278 

- 3d21ec90b42c0132c82c93815179dca66d305b91 Adds the ErrMessage field that comes from the ACLCreate response to our Error:

```
$ rpk security acl create --allow-role "RedpandaRole:admin" --operation read --topic foo
PRINCIPAL           HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
RedpandaRole:admin  *     TOPIC          foo            LITERAL                READ       ALLOW       INVALID_CONFIG: A Redpanda Enterprise Edition license is required to create an ACL with a role binding. To request an Enterprise license, please visit https://redpanda.com/upgrade. To try Redpanda Enterprise for 30 days, visit https://redpanda.com/try-enterprise.
```

- 9625c2ffd6c6ec38dc7b70a8de6dc398cc0101d0 decode the Error Message from the admin API to avoid printing the full json (We log now the json response)

```
# Previously
$ rpk security role create admin
unable to create role "admin": request POST http://127.0.0.1:9644/v1/security/roles failed: Forbidden, body: "{\"message\": \"Enterprise License Required\", \"code\": 403}"

# Now
$ rpk security role create admin
unable to create role "admin": Enterprise License Required
```

The log will be:
```
12:42:40.026  DEBUG  got admin API error: request POST http://127.0.0.1:9644/v1/security/roles failed: Forbidden, body: "{\"message\": \"Enterprise License Required\", \"code\": 403}"
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
