### PR TITLE
ducktape: fix download of redpanda-data/ocsf-schema

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-OCSF_SCHEMA_VERSION=1.0.0
+OCSF_SCHEMA_VERSION=9608805fe0b61035cb821bb9068096fe47fed12d  # tip of v1.0.0 branch
 OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 
-wget "https://github.com/redpanda-data/ocsf-schema/archive/refs/tags/v${OCSF_SCHEMA_VERSION}.tar.gz"
+wget "https://github.com/redpanda-data/ocsf-schema/archive/${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
 tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz


### PR DESCRIPTION
jira: [DEVPROD-2443]

[DEVPROD-2443]: https://redpandadata.atlassian.net/browse/DEVPROD-2433

Getting http 404 errors for downloading the v1.0.0 tar.gz asset:
```console 
bash$ curl -L -O -s -S --fail https://github.com/redpanda-data/ocsf-schema/archive/refs/tags/v1.0.0.tar.gz
curl: (56) The requested URL returned error: 404
```
Looks like the release for v1.0.0 does not have a tag but is just a release from the git commit from tip of v1.0.0 branch: https://github.com/redpanda-data/ocsf-schema/tree/refs/tags/v1.0.0

So, change download of asset to just the code at that git commit which is `9608805fe0b61035cb821bb9068096fe47fed12d`.

```console
bash$ curl -L -O -s -S --fail https://github.com/redpanda-data/ocsf-schema/archive/9608805fe0b61035cb821bb9068096fe47fed12d.tar.gz
```

Same as upstream release of v1.0.0: https://github.com/ocsf/ocsf-schema/releases/tag/v1.0.0

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none