### PR TITLE
iceberg: add simple drop_table support for filesystem_catalog

### DIFF
--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -59,4 +59,77 @@ table_io::version_hint_exists(const version_hint_path& path) {
     return object_exists(path, "iceberg::version_hint");
 }
 
+ss::future<checked<std::nullopt_t, metadata_io::errc>>
+table_io::delete_all_metadata(const metadata_location_path& path) {
+    retry_chain_node root_rcn(
+      io_.as(),
+      ss::lowres_clock::duration{30s},
+      100ms,
+      retry_strategy::polling);
+    retry_chain_logger ctxlog(log, root_rcn);
+
+    auto log_exception = [&](
+                           const std::exception_ptr& ex, std::string_view ctx) {
+        auto level = ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                                    : ss::log_level::warn;
+        vlogl(ctxlog, level, "exception while {} in {}: {}", ctx, path, ex);
+    };
+
+    // deleting may require several iterations if list_objects doesn't return
+    // everything at once.
+    while (true) {
+        retry_chain_node list_rcn(10ms, retry_strategy::backoff, &root_rcn);
+        auto list_fut = co_await ss::coroutine::as_future(io_.list_objects(
+          bucket_, list_rcn, cloud_storage_clients::object_key{path}));
+        if (list_fut.failed()) {
+            log_exception(list_fut.get_exception(), "listing objects");
+            co_return errc::failed;
+        }
+
+        auto list_res = std::move(list_fut.get());
+        if (list_res.has_error()) {
+            co_return errc::failed;
+        }
+
+        chunked_vector<cloud_storage_clients::object_key> to_delete;
+        to_delete.reserve(list_res.value().contents.size());
+        for (auto& obj : list_res.value().contents) {
+            vlog(ctxlog.debug, "deleting metadata object {}", obj.key);
+            to_delete.emplace_back(std::move(obj.key));
+        }
+
+        retry_chain_node delete_rcn(10ms, retry_strategy::backoff, &root_rcn);
+        auto delete_fut = co_await ss::coroutine::as_future(io_.delete_objects(
+          bucket_, std::move(to_delete), delete_rcn, [](size_t) {}));
+        if (delete_fut.failed()) {
+            log_exception(delete_fut.get_exception(), "deleting objects");
+            co_return errc::failed;
+        }
+
+        switch (delete_fut.get()) {
+        case cloud_io::upload_result::success:
+            break;
+        case cloud_io::upload_result::timedout:
+            co_return errc::timedout;
+        case cloud_io::upload_result::cancelled:
+            co_return errc::shutting_down;
+        case cloud_io::upload_result::failed:
+            co_return errc::failed;
+        }
+
+        if (!list_res.value().is_truncated) {
+            // deleted everything
+            break;
+        }
+
+        auto retry = root_rcn.retry();
+        if (!retry.is_allowed) {
+            co_return errc::timedout;
+        }
+        co_await ss::sleep_abortable(retry.delay, *retry.abort_source);
+    }
+
+    co_return std::nullopt;
+}
+
 } // namespace iceberg

--- a/src/v/iceberg/table_io.h
+++ b/src/v/iceberg/table_io.h
@@ -16,8 +16,13 @@
 
 namespace iceberg {
 
+// /<table-location>/metadata/
+using metadata_location_path
+  = named_type<std::filesystem::path, struct metadata_location_path_tag>;
+// /<table-location>/metadata/v0.metadata.json
 using table_metadata_path
   = named_type<std::filesystem::path, struct table_metadata_path_tag>;
+// /<table-location>/metadata/version-hint.text
 using version_hint_path
   = named_type<std::filesystem::path, struct table_metadata_path_tag>;
 
@@ -40,6 +45,9 @@ public:
 
     ss::future<checked<bool, metadata_io::errc>>
     version_hint_exists(const version_hint_path& path);
+
+    ss::future<checked<std::nullopt_t, metadata_io::errc>>
+    delete_all_metadata(const metadata_location_path& path);
 };
 
 } // namespace iceberg

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -134,7 +134,7 @@ class DatalakeE2ETests(RedpandaTest):
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[False])
+            filesystem_catalog_mode=[True, False])
     def test_topic_lifecycle(self, cloud_storage_type,
                              filesystem_catalog_mode):
         count = 100


### PR DESCRIPTION
This implementation leaves data files as orphans, but is enough for trying iceberg out.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
