### PR TITLE
[v24.1.x] ducktape: fix download of redpanda-data/ocsf-schema

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-OCSF_SCHEMA_VERSION=1.0.0
+OCSF_SCHEMA_VERSION=9608805fe0b61035cb821bb9068096fe47fed12d  # tip of v1.0.0 branch
 OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 
-wget "https://github.com/redpanda-data/ocsf-schema/archive/refs/tags/v${OCSF_SCHEMA_VERSION}.tar.gz"
+wget "https://github.com/redpanda-data/ocsf-schema/archive/${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
 tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24297
