### PR TITLE
ducktape: follow-up fix download of redpanda-data/ocsf-schema

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -7,8 +7,8 @@ OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 wget "https://github.com/redpanda-data/ocsf-schema/archive/${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
-tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz
-rm v${OCSF_SCHEMA_VERSION}.tar.gz
+tar -xvzf ${OCSF_SCHEMA_VERSION}.tar.gz
+rm ${OCSF_SCHEMA_VERSION}.tar.gz
 mv ocsf-schema-${OCSF_SCHEMA_VERSION} /opt/ocsf-schema
 
 tar -xvzf ${OCSF_SERVER_VERSION}.tar.gz


### PR DESCRIPTION
jira: [DEVPROD-2443]

[DEVPROD-2443]: https://redpandadata.atlassian.net/browse/DEVPROD-2433

Fixes PR #24297 [error](https://buildkite.com/redpanda/redpanda/builds/58737#019365cd-a47c-4b63-a618-d6fa53a8fce0/650-869):
```
#15 1.187 tar (child): v9608805fe0b61035cb821bb9068096fe47fed12d.tar.gz: Cannot open: No such file or directory
```

Uses correct name for tar file.

Needs backport to the same branches as PR #24297

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none