### PR TITLE
datalake/metrics: lag metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -181,6 +181,16 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
               sm::description("Total number of offsets that are pending "
                               "translation to iceberg."),
               labels),
+            sm::make_gauge(
+              "iceberg_offsets_pending_commit",
+              [this] {
+                  return _partition.log()->config().iceberg_enabled()
+                           ? _iceberg_commit_offset_lag
+                           : metric_feature_disabled_state;
+              },
+              sm::description("Total number of offsets that are pending "
+                              "commit to iceberg catalog."),
+              labels),
           },
           {},
           {sm::shard_label, partition_label});

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -167,6 +167,25 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
       {},
       {sm::shard_label, partition_label});
 
+    if (model::is_user_topic(_partition.ntp())) {
+        _metrics.add_group(
+          cluster_metrics_name,
+          {
+            sm::make_gauge(
+              "iceberg_offsets_pending_translation",
+              [this] {
+                  return _partition.log()->config().iceberg_enabled()
+                           ? _iceberg_translation_offset_lag
+                           : metric_feature_disabled_state;
+              },
+              sm::description("Total number of offsets that are pending "
+                              "translation to iceberg."),
+              labels),
+          },
+          {},
+          {sm::shard_label, partition_label});
+    }
+
     if (
       config::shard_local_cfg().enable_schema_id_validation()
       != pandaproxy::schema_registry::schema_id_validation_mode::none) {

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -31,6 +31,7 @@ public:
         virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void add_bytes_fetched_from_follower(uint64_t) = 0;
         virtual void add_schema_id_validation_failed() = 0;
+        virtual void update_iceberg_translation_offset_lag(int64_t) = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual void clear_metrics() = 0;
         virtual ~impl() noexcept = default;
@@ -66,6 +67,10 @@ public:
         _impl->add_schema_id_validation_failed();
     }
 
+    void update_iceberg_translation_offset_lag(int64_t new_lag) {
+        _impl->update_iceberg_translation_offset_lag(new_lag);
+    }
+
     void clear_metrics() { _impl->clear_metrics(); }
 
 private:
@@ -88,6 +93,10 @@ public:
         ++_schema_id_validation_records_failed;
     };
 
+    void update_iceberg_translation_offset_lag(int64_t new_lag) final {
+        _iceberg_translation_offset_lag = new_lag;
+    }
+
     void clear_metrics() final;
 
 private:
@@ -98,6 +107,8 @@ private:
     void setup_public_scrubber_metric(const model::ntp&);
 
 private:
+    static constexpr int64_t metric_default_initialized_state{-2};
+    static constexpr int64_t metric_feature_disabled_state{-1};
     const partition& _partition;
     uint64_t _records_produced{0};
     uint64_t _records_fetched{0};
@@ -105,6 +116,7 @@ private:
     uint64_t _bytes_fetched{0};
     uint64_t _bytes_fetched_from_follower{0};
     uint64_t _schema_id_validation_records_failed{0};
+    int64_t _iceberg_translation_offset_lag{metric_default_initialized_state};
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -32,6 +32,7 @@ public:
         virtual void add_bytes_fetched_from_follower(uint64_t) = 0;
         virtual void add_schema_id_validation_failed() = 0;
         virtual void update_iceberg_translation_offset_lag(int64_t) = 0;
+        virtual void update_iceberg_commit_offset_lag(int64_t) = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual void clear_metrics() = 0;
         virtual ~impl() noexcept = default;
@@ -71,6 +72,10 @@ public:
         _impl->update_iceberg_translation_offset_lag(new_lag);
     }
 
+    void update_iceberg_commit_offset_lag(int64_t new_lag) {
+        _impl->update_iceberg_commit_offset_lag(new_lag);
+    }
+
     void clear_metrics() { _impl->clear_metrics(); }
 
 private:
@@ -97,6 +102,10 @@ public:
         _iceberg_translation_offset_lag = new_lag;
     }
 
+    void update_iceberg_commit_offset_lag(int64_t new_lag) final {
+        _iceberg_commit_offset_lag = new_lag;
+    }
+
     void clear_metrics() final;
 
 private:
@@ -117,6 +126,7 @@ private:
     uint64_t _bytes_fetched_from_follower{0};
     uint64_t _schema_id_validation_records_failed{0};
     int64_t _iceberg_translation_offset_lag{metric_default_initialized_state};
+    int64_t _iceberg_commit_offset_lag{metric_default_initialized_state};
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -65,8 +65,11 @@ public:
       model::revision_id topic_revision,
       chunked_vector<translated_offset_range>);
 
-    ss::future<checked<std::optional<kafka::offset>, errc>>
-    sync_get_last_added_offset(
+    struct last_offsets {
+        std::optional<kafka::offset> last_added_offset;
+        std::optional<kafka::offset> last_committed_offset;
+    };
+    ss::future<checked<last_offsets, errc>> sync_get_last_added_offsets(
       model::topic_partition tp, model::revision_id topic_rev);
 
     void notify_leadership(std::optional<model::node_id>);

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -80,12 +80,14 @@ ss::future<fetch_latest_translated_offset_reply> fetch_latest_offset(
     if (!crd) {
         co_return fetch_latest_translated_offset_reply{errc::not_leader};
     }
-    auto ret = co_await crd->sync_get_last_added_offset(
+    auto ret = co_await crd->sync_get_last_added_offsets(
       req.tp, req.topic_revision);
     if (ret.has_error()) {
         co_return to_rpc_errc(ret.error());
     }
-    co_return fetch_latest_translated_offset_reply{ret.value()};
+    auto& val = ret.value();
+    co_return fetch_latest_translated_offset_reply{
+      val.last_added_offset, val.last_committed_offset};
 }
 } // namespace
 

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -154,13 +154,14 @@ TEST_F_CORO(coordinator_stm_fixture, test_snapshots) {
         auto add_files_result = co_await retry_with_leader_coordinator(
           [&, this](coordinator& coordinator) mutable {
               auto tp = random_tp();
-              return coordinator->sync_get_last_added_offset(tp, rev).then(
+              return coordinator->sync_get_last_added_offsets(tp, rev).then(
                 [&, tp](auto result) {
                     if (!result) {
                         return ss::make_ready_future<bool>(false);
                     }
                     auto last_committed_offset = kafka::offset_cast(
-                      result.value().value_or(kafka::offset{-1}));
+                      result.value().last_added_offset.value_or(
+                        kafka::offset{-1}));
                     std::vector<std::pair<int64_t, int64_t>> offset_pairs;
                     offset_pairs.reserve(5);
                     auto next_offset = last_committed_offset() + 1;

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -169,12 +169,16 @@ struct fetch_latest_translated_offset_reply
     explicit fetch_latest_translated_offset_reply(errc err)
       : errc(err) {}
     explicit fetch_latest_translated_offset_reply(
-      std::optional<kafka::offset> o)
-      : last_added_offset(o)
+      std::optional<kafka::offset> last_added,
+      std::optional<kafka::offset> last_committed)
+      : last_added_offset(last_added)
+      , last_iceberg_committed_offset(last_committed)
       , errc(errc::ok) {}
 
     // The offset of the latest data file added to the coordinator.
     std::optional<kafka::offset> last_added_offset;
+
+    std::optional<kafka::offset> last_iceberg_committed_offset;
 
     // If not ok, the request processing has a problem.
     errc errc;

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -343,6 +343,19 @@ void partition_translator::update_translation_lag(
     _partition->probe().update_iceberg_translation_offset_lag(offset_lag);
 }
 
+void partition_translator::update_commit_lag(
+  std::optional<kafka::offset> max_committed_offset) const {
+    auto max_translatable_offset = max_offset_for_translation();
+    if (
+      !max_translatable_offset
+      || max_translatable_offset.value() < kafka::offset{0}) {
+        return;
+    }
+    auto offset_lag = max_translatable_offset.value()
+                      - max_committed_offset.value_or(kafka::offset{-1});
+    _partition->probe().update_iceberg_commit_offset_lag(offset_lag);
+}
+
 ss::future<partition_translator::checkpoint_result>
 partition_translator::checkpoint_translated_data(
   retry_chain_node& rcn,
@@ -404,6 +417,7 @@ partition_translator::reconcile_with_coordinator() {
         vlog(_logger.warn, "reconciliation failed, response: {}", resp);
         co_return std::nullopt;
     }
+    update_commit_lag(resp.last_iceberg_committed_offset);
     // No file entry signifies the translation was just enabled on the
     // topic. In such a case we start translation from the local start
     // of the log. The underlying assumption is that there is a reasonable

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -275,6 +275,7 @@ partition_translator::do_translate_once(retry_chain_node& parent_rcn) {
           read_begin_offset,
           read_end_offset,
           _partition->last_stable_offset());
+        _partition->probe().update_iceberg_translation_offset_lag(0);
         co_return translation_success::yes;
     }
     // We have some data to translate, make a reader
@@ -313,14 +314,33 @@ partition_translator::do_translate_once(retry_chain_node& parent_rcn) {
       parent_rcn, std::move(kafka_reader), read_begin_offset);
     units.return_all();
     vlog(_logger.debug, "translation result: {}", translation_result);
-    units.return_all();
-    if (
-      translation_result
-      && co_await checkpoint_translated_data(
-        parent_rcn, read_begin_offset, std::move(translation_result.value()))) {
-        co_return translation_success::yes;
+    auto result = translation_success::no;
+    auto max_translated_offset = kafka::prev_offset(read_begin_offset);
+    if (translation_result) {
+        auto last_translated_offset = translation_result->last_offset;
+        if (co_await checkpoint_translated_data(
+              parent_rcn,
+              read_begin_offset,
+              std::move(translation_result.value()))) {
+            max_translated_offset = last_translated_offset;
+            result = translation_success::yes;
+        }
     }
-    co_return translation_success::no;
+    update_translation_lag(max_translated_offset);
+    co_return result;
+}
+
+void partition_translator::update_translation_lag(
+  kafka::offset max_translated_offset) const {
+    auto max_translatable_offset = max_offset_for_translation();
+    if (
+      !max_translatable_offset
+      || max_translatable_offset.value() < kafka::offset{0}) {
+        return;
+    }
+    auto offset_lag = max_translatable_offset.value()
+                      - std::max(max_translated_offset, kafka::offset{-1});
+    _partition->probe().update_iceberg_translation_offset_lag(offset_lag);
 }
 
 ss::future<partition_translator::checkpoint_result>

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -94,6 +94,9 @@ private:
 
     ss::future<> do_translate();
 
+    void
+    update_translation_lag(kafka::offset max_translated_kafka_offset) const;
+
     using translation_success = ss::bool_class<struct translation_success>;
     ss::future<translation_success> do_translate_once(retry_chain_node& parent);
     ss::future<model::record_batch_reader> make_reader();

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -96,6 +96,8 @@ private:
 
     void
     update_translation_lag(kafka::offset max_translated_kafka_offset) const;
+    void update_commit_lag(
+      std::optional<kafka::offset> max_committed_kafka_offset) const;
 
     using translation_success = ss::bool_class<struct translation_success>;
     ss::future<translation_success> do_translate_once(retry_chain_node& parent);


### PR DESCRIPTION
Adds lag metrics that track translation and iceberg commit lag. Sample below.

```
vectorized_cluster_partition_iceberg_offsets_pending_commit{namespace="kafka",partition="1",shard="0",topic="foo"} 4.000000
vectorized_cluster_partition_iceberg_offsets_pending_translation{namespace="kafka",partition="1",shard="0",topic="foo"} 4.000000
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
