### PR TITLE
Fixed race condition between appends and prefix truncation

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1637,31 +1637,27 @@ ss::future<> disk_log_impl::new_segment(
             });
       });
 }
+namespace {
+model::offset get_next_append_offset(const offset_stats& offsets) {
+    /**
+     * When dirty_offset < start_offset, the log is empty. In this case we use
+     * the start offset as the next offset for appender
+     */
+    if (offsets.dirty_offset < offsets.start_offset) {
+        return offsets.start_offset;
+    }
+    // otherwise next batch will be appended at dirty_offset + 1
+    return model::next_offset(offsets.dirty_offset);
+}
+} // namespace
 
 // config timeout is for the one calling reader consumer
 log_appender disk_log_impl::make_appender(log_append_config cfg) {
     vassert(!_closed, "make_appender on closed log - {}", *this);
     auto now = log_clock::now();
     auto ofs = offsets();
-    auto next_offset = ofs.dirty_offset;
-    if (next_offset() >= 0) {
-        // when dirty offset >= 0 it is implicity encoding the state of a
-        // non-empty log (see offsets()). for a non-empty log, the offset of the
-        // next batch to be applied is one past the last batch (dirty + 1).
-        next_offset++;
+    model::offset next_offset = get_next_append_offset(ofs);
 
-    } else {
-        // otherwise, the log is empty. in this case the offset of the next
-        // batch to be appended is the starting offset of the log, which may be
-        // explicitly set via operations like prefix truncation.
-        next_offset = ofs.start_offset;
-
-        // but, in the case of a brand new log, no starting offset has been
-        // explicitly set, so it is defined implicitly to be 0.
-        if (next_offset() < 0) {
-            next_offset = model::offset(0);
-        }
-    }
     vlog(
       stlog.trace,
       "creating log appender for: {}, next offset: {}, log offsets: {}",
@@ -2565,6 +2561,15 @@ ss::future<> disk_log_impl::remove_full_segments(model::offset o) {
           return remove_segment_permanently(ptr, "remove_full_segments");
       });
 }
+namespace {
+bool keep_segment_after_prefix_truncate(
+  const ss::lw_shared_ptr<segment>& segment,
+  model::offset prefix_truncate_offset) {
+    auto& offsets = segment->offsets();
+    return offsets.get_base_offset() >= prefix_truncate_offset
+           || offsets.get_dirty_offset() >= prefix_truncate_offset;
+}
+} // namespace
 ss::future<>
 disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
     return ss::do_until(
@@ -2573,25 +2578,34 @@ disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
           // (where dirty = base - 1). We don't want to remove it because
           // batches may be concurrently appended to it and we should keep them.
           return _segs.empty()
-                 || _segs.front()->offsets().get_base_offset()
-                      >= cfg.start_offset
-                 || _segs.front()->offsets().get_dirty_offset()
-                      >= cfg.start_offset;
+                 || keep_segment_after_prefix_truncate(
+                   _segs.front(), cfg.start_offset);
       },
-      [this] {
+      [this, prefix_truncate_offset = cfg.start_offset] {
+          // it is safe to capture the front segment pointer here. This
+          // operation is executed under the segment_rewrite_lock, we are
+          // guaranteed that no other operation will remove the segment from the
+          // segment list head (front).
           auto ptr = _segs.front();
-          // evict readers before trying to grab a write lock to prevent
-          // contention
           return _readers_cache->evict_segment_readers(ptr).then(
-            [this, ptr](readers_cache::range_lock_holder cache_lock) {
-                /**
-                 * If segment has outstanding locks wait for it to be unlocked
-                 * before prefixing truncating it, this way the prefix
-                 * truncation will not overlap with appends.
-                 */
+            [this, ptr, prefix_truncate_offset](
+              readers_cache::range_lock_holder cache_lock) {
                 return ptr->write_lock().then(
-                  [this, ptr, cache_lock = std::move(cache_lock)](
+                  [this,
+                   ptr,
+                   prefix_truncate_offset,
+                   cache_lock = std::move(cache_lock)](
                     ss::rwlock::holder lock_holder) {
+                      // after the lock is acquired, check if the segment is
+                      // still eligible for deletion as there might have been
+                      // concurrent appends. If segments collection is empty we
+                      // can skip prefix truncation as the segments were removed
+                      if (
+                        keep_segment_after_prefix_truncate(
+                          ptr, prefix_truncate_offset)
+                        || _segs.empty()) {
+                          return ss::make_ready_future<>();
+                      }
                       _segs.pop_front();
                       _probe->add_bytes_prefix_truncated(ptr->file_size());
                       // first call the remove segments, then release the lock
@@ -2631,6 +2645,11 @@ ss::future<> disk_log_impl::truncate_prefix(truncate_prefix_config cfg) {
 }
 
 ss::future<> disk_log_impl::do_truncate_prefix(truncate_prefix_config cfg) {
+    vlog(
+      stlog.trace,
+      "prefix truncate {} at {}",
+      config().ntp(),
+      cfg.start_offset);
     /*
      * Persist the desired starting offset
      */

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2534,6 +2534,12 @@ ss::future<> disk_log_impl::remove_segment_permanently(
     _probe->delete_segment(*s);
     // background close
     s->tombstone();
+    if (s->has_outstanding_locks()) {
+        vlog(
+          stlog.info,
+          "Segment has outstanding locks. Might take a while to close:{}",
+          s->reader().filename());
+    }
 
     return _readers_cache->evict_segment_readers(s)
       .then([s](readers_cache::range_lock_holder cache_lock) {


### PR DESCRIPTION
The race condition between prefix truncation and appends was leading to
an issue in which the same offset might have been assigned twiice to
batches that were appended to log. This invalidates the invariant and
may lead to inconsistencies.

The fix has two parts. The first part fixes calculation of next offset
for the newly created log appender. Previously the check incorrectly
validated if the log is empty. The condition was simplified and it is
now based on an invariant that if the `start_offset > dirty_offset` the
log is empty (there is one exception to it when the log is empty and
first initialized, but then the next offset is derived as usual by
incrementing the dirty offset).

The second part of the fix is an addition of check if the segment is
still removable after the segment write lock was acquired for its
removal. It is perfectly viable scenario that when the prefix truncation
fiber is waiting for the lock the segment is written to. In this case
the segment should not be removed as it contains valid data.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none