### PR TITLE
[v24.1.x] ducktape: follow-up fix download of redpanda-data/ocsf-schema

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -7,8 +7,8 @@ OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 wget "https://github.com/redpanda-data/ocsf-schema/archive/refs/tags/v${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
-tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz
-rm v${OCSF_SCHEMA_VERSION}.tar.gz
+tar -xvzf ${OCSF_SCHEMA_VERSION}.tar.gz
+rm ${OCSF_SCHEMA_VERSION}.tar.gz
 mv ocsf-schema-${OCSF_SCHEMA_VERSION} /opt/ocsf-schema
 
 tar -xvzf ${OCSF_SERVER_VERSION}.tar.gz


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24304
