### PR TITLE
serde: bazelize serde/bench

### DIFF
--- a/src/v/serde/test/BUILD
+++ b/src/v/serde/test/BUILD
@@ -1,4 +1,21 @@
-load("//bazel:test.bzl", "redpanda_cc_btest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest")
+
+redpanda_cc_bench(
+    name = "serde_bench",
+    timeout = "short",
+    srcs = [
+        "bench.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/serde",
+        "@boost//:container_hash",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)
 
 redpanda_cc_btest(
     name = "serde_test",

--- a/src/v/serde/test/bench.cc
+++ b/src/v/serde/test/bench.cc
@@ -12,7 +12,7 @@
 #include "cluster/node/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
-#include "serde/serde.h"
+#include "serde/envelope.h"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>


### PR DESCRIPTION
Add bazel target for `serde/test/serde_bench.cc`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
