### PR TITLE
raft/tests: adjust memory requirements for raft reconfiguration test

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -597,10 +597,12 @@ redpanda_test_cc_library(
 
 redpanda_cc_gtest(
     name = "raft_reconfiguration_test",
-    timeout = "moderate",
+    timeout = "long",
     srcs = [
         "raft_reconfiguration_test.cc",
     ],
+    cpu = 4,
+    memory = "2GiB",
     tags = ["exclusive"],
     deps = [
         "//src/v/base",


### PR DESCRIPTION
Raft reconfiguration test requires more memory than the default configured for tests in Bazel.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
