### PR TITLE
[v24.3.x] ducktape: fix download of redpanda-data/ocsf-schema

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -7,8 +7,8 @@ OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 wget "https://github.com/redpanda-data/ocsf-schema/archive/${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
-tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz
-rm v${OCSF_SCHEMA_VERSION}.tar.gz
+tar -xvzf ${OCSF_SCHEMA_VERSION}.tar.gz
+rm ${OCSF_SCHEMA_VERSION}.tar.gz
 mv ocsf-schema-${OCSF_SCHEMA_VERSION} /opt/ocsf-schema
 
 tar -xvzf ${OCSF_SERVER_VERSION}.tar.gz

--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-OCSF_SCHEMA_VERSION=1.0.0
+OCSF_SCHEMA_VERSION=9608805fe0b61035cb821bb9068096fe47fed12d  # tip of v1.0.0 branch
 OCSF_SERVER_VERSION=d3b26de39df9eb33c6d63e34a126c77c0811c7a0
 
-wget "https://github.com/redpanda-data/ocsf-schema/archive/refs/tags/v${OCSF_SCHEMA_VERSION}.tar.gz"
+wget "https://github.com/redpanda-data/ocsf-schema/archive/${OCSF_SCHEMA_VERSION}.tar.gz"
 wget "https://github.com/redpanda-data/ocsf-server/archive/${OCSF_SERVER_VERSION}.tar.gz"
 
 tar -xvzf v${OCSF_SCHEMA_VERSION}.tar.gz


### PR DESCRIPTION
Backport of #24297 and #24304
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none