### PR TITLE
d/coordinator: fixed possible iterator generation mismatch

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -356,12 +356,12 @@ coordinator::sync_add_files(
     if (repl_res.has_error()) {
         co_return convert_stm_errc(repl_res.error());
     }
-
+    // query the STM once again after the scheduling point
+    topic_it = stm_->state().topic_to_state.find(tp.topic);
     // Check that the resulting state matches that expected by the caller.
     // NOTE: a mismatch here just means there was a race to update the STM, and
     // this should be handled by callers.
     // TODO: would be nice to encapsulate this in some update validator.
-
     if (
       topic_it == stm_->state().topic_to_state.end()
       || topic_it->second.revision != topic_revision) {


### PR DESCRIPTION
Checking the `fragment_vector` iterator after the scheduling point may not be safe as the iterator may be modified.

Fixes assertion in datalake coordinator.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
