### PR TITLE
bytes: bazelize iobuf_fuzz

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ common --extra_toolchains=@llvm_18_toolchain//:all
 common --@toolchains_llvm//toolchain/config:libunwind=False
 common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
+build --linkopt -stdlib=libc++
 
 common:clang-19 --extra_toolchains=@llvm_19_toolchain//:all
 
@@ -47,6 +48,7 @@ build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function
 build:sanitizer --linkopt --rtlib=compiler-rt
 build:sanitizer --linkopt -fsanitize-link-c++-runtime
 build:sanitizer --copt -O1
+build:sanitizer --//bazel:has_sanitizers=True
 # seastar has to be run with system allocator when using sanitizers
 build:sanitizer --@seastar//:system_allocator=True
 # krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,13 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "has_sanitizers",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "enable_fuzz_testing",
+    flag_values = {
+        ":has_sanitizers": "true",
+    },
+)

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_fuzz_test", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "iobuf_test",
@@ -74,5 +74,20 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_fuzz_test(
+    name = "iobuf_fuzz",
+    timeout = "short",
+    srcs = ["iobuf_fuzz.cc"],
+    args = [
+        "-max_total_time=30",
+        "-rss_limit_mb=8192",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:scattered_message",
     ],
 )

--- a/src/v/bytes/tests/iobuf_fuzz.cc
+++ b/src/v/bytes/tests/iobuf_fuzz.cc
@@ -17,10 +17,10 @@
  * -format=html ../src/v/bytes/iobuf.h ../src/v/bytes/iobuf.cc > cov.html
  */
 #include "base/vassert.h"
-#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "bytes/scattered_message.h"
 
+#include <exception>
 #include <numeric>
 
 /*
@@ -508,7 +508,7 @@ private:
 
     template<typename T>
     T read() {
-        if (std::distance(pc_, program_.cend()) < sizeof(T)) {
+        if (std::cmp_less(std::distance(pc_, program_.cend()), sizeof(T))) {
             throw end_of_program();
         }
         T ret;


### PR DESCRIPTION
Implements:
[CORE-7353](https://redpandadata.atlassian.net/browse/CORE-7353) : `iobuf_fuzz.cc`

Added extra global linking argument `-stdlib=libc++`:
without this, `libfuzzer.a`, which is included by adding `-fsanitizer=fuzzer`, introduces a dependency on `stdlibc++.so`. This ends up with both `libc++.a` and `stdlibc++.so` being linked.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7353]: https://redpandadata.atlassian.net/browse/CORE-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ