### PR TITLE
`storage`: reset compaction window start offset when offset map isn't built

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -659,6 +659,10 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           "[{}] failed to build offset map. Stopping compaction: {}",
           config().ntp(),
           std::current_exception());
+        // Reset the sliding window start offset so that compaction may still
+        // make progress in the future. Otherwise, we will fail to build the
+        // offset map for the same segment over and over.
+        _last_compaction_window_start_offset.reset();
         co_return false;
     }
     vlog(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -551,11 +551,8 @@ segment_set disk_log_impl::find_sliding_range(
 
         buf.emplace_back(seg);
     }
-    segment_set segs(std::move(buf));
-    if (segs.empty()) {
-        return segs;
-    }
 
+    segment_set segs(std::move(buf));
     return segs;
 }
 


### PR DESCRIPTION
The behavior of the sliding window considered for compaction was changed in this PR: https://github.com/redpanda-data/redpanda/pull/23380.

> Newly added/closed segments are ignored until the current "round" of sliding window compaction cleanly compacts all segments down to the start of the log. This allows for sliding window compaction to continually produce clean segments, and avoid a situation where clean segments are not being produced due to a high ingress rate or key cardinality (this situation would prevent timely tombstone removal). _last_compaction_window_offset must reach the base offset of the first segment in the log before new segments will be considered in the compaction window.

However, consider the following situation:

```
[0] [1] [2] [3] [4] [5]
            ^
            |----- _last_compaction_window_start_offset
```

In the event that segment [2] cannot have its keys completely added to the offset map due to memory constraints, if we do not reset the window start offset, compaction will become somewhat stuck as it repeatedly tries to index segment [2] in future compaction rounds.

By resetting the window's value in this situation, we can allow compaction to continue to make forward progression.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
