### PR TITLE
config: remove the meta tag for iceberg_delete

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3787,10 +3787,7 @@ configuration::configuration()
       "Default value for the redpanda.iceberg.delete topic property that "
       "determines if the corresponding Iceberg table is deleted upon deleting "
       "the topic.",
-      meta{
-        .needs_restart = needs_restart::no,
-        .visibility = visibility::user,
-      },
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
   , development_enable_cloud_topics(
       *this,


### PR DESCRIPTION
Changed the declaration to match other config properties. See https://redpandadata.slack.com/archives/C06NQP4LW2C/p1732637739710979 for context

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
