### PR TITLE
CORE-8290 dt/redpanda: increase expect_fail timeout to 40s

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3240,10 +3240,10 @@ class RedpandaService(RedpandaServiceBase):
             if expect_fail:
                 wait_until(
                     lambda: self.redpanda_pid(node) == None,
-                    timeout_sec=10,
+                    timeout_sec=timeout,
                     backoff_sec=0.2,
                     err_msg=
-                    f"Redpanda processes did not terminate on {node.name} during startup as expected"
+                    f"Redpanda processes did not terminate on {node.name} during startup as expected in {timeout} sec"
                 )
             elif not skip_readiness_check:
                 wait_until(


### PR DESCRIPTION
This gives a starting redpanda node the same time to fail as we give it to successfully start up. It also allows reusing the timeout parameter to configure how much to wait for redpanda to fail on startup (which some call sites already attempt to do).

Reusing the startup timeout is a better guess than the current static 10s, because tests that expect a timeout typically expect it to happen during the same timeframe as what a normal startup would take.

This also means that the timeout is increased from the current 10s to 40s (`DEFAULT_NODE_READY_TIMEOUT_SEC`) by default. This solves some CI failures on Azure CDT where startup is occasionally slower.

Fixes https://redpandadata.atlassian.net/browse/CORE-8290

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
