### PR TITLE
archival: consistent log size probes across replicas (pull)

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -337,7 +337,8 @@ ss::future<> ntp_archiver::upload_until_abort(bool legacy_mode) {
         co_return;
     }
     if (!_probe) {
-        _probe.emplace(_conf->ntp_metrics_disabled, _ntp);
+        _probe.emplace(
+          _conf->ntp_metrics_disabled, _ntp, _parent.archival_meta_stm());
     }
 
     while (!_as.abort_requested()) {
@@ -459,7 +460,8 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
         co_return;
     }
     if (!_probe) {
-        _probe.emplace(_conf->ntp_metrics_disabled, _ntp);
+        _probe.emplace(
+          _conf->ntp_metrics_disabled, _ntp, _parent.archival_meta_stm());
     }
 
     while (!_as.abort_requested()) {
@@ -797,8 +799,6 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
             co_await maybe_flush_manifest_clean_offset();
         }
 
-        update_probe();
-
         // Drop _uploads_active lock: we are not considered active while
         // sleeping for backoff at the end of the loop.
         units.return_all();
@@ -1062,8 +1062,6 @@ ss::future<> ntp_archiver::upload_until_term_change() {
             // flush it for them.
             co_await maybe_flush_manifest_clean_offset();
         }
-
-        update_probe();
     }
 }
 
@@ -1161,22 +1159,6 @@ ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
 
     _last_sync_time = ss::lowres_clock::now();
     co_return cloud_storage::download_result::success;
-}
-
-void ntp_archiver::update_probe() {
-    const auto& man = manifest();
-
-    _probe->segments_in_manifest(man.size());
-
-    const auto first_addressable = man.first_addressable_segment();
-    const auto truncated_seg_count = first_addressable == man.end()
-                                       ? 0
-                                       : first_addressable.index();
-
-    _probe->segments_to_delete(
-      truncated_seg_count + man.replaced_segments_count());
-
-    _probe->cloud_log_size(man.cloud_log_size());
 }
 
 bool ntp_archiver::can_update_archival_metadata() const {

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -633,8 +633,6 @@ private:
     // the state of manifest uploads.
     bool uploaded_data_past_flush_offset() const;
 
-    void update_probe();
-
     /// Return true if archival metadata can be replicated.
     /// This means that the replica is a leader, the term did not
     /// change and the archiver is not stopping.

--- a/src/v/cluster/archival/probe.h
+++ b/src/v/cluster/archival/probe.h
@@ -19,6 +19,10 @@
 
 #include <cstdint>
 
+namespace cluster {
+class archival_metadata_stm;
+}
+
 namespace archival {
 
 /// \brief Per-ntp archval service probe
@@ -30,7 +34,10 @@ namespace archival {
 /// The unit of measure is offset delta.
 class ntp_level_probe {
 public:
-    ntp_level_probe(per_ntp_metrics_disabled disabled, const model::ntp& ntp);
+    ntp_level_probe(
+      per_ntp_metrics_disabled disabled,
+      const model::ntp& ntp,
+      ss::shared_ptr<const cluster::archival_metadata_stm> stm);
     ntp_level_probe(const ntp_level_probe&) = delete;
     ntp_level_probe& operator=(const ntp_level_probe&) = delete;
     ntp_level_probe(ntp_level_probe&&) = delete;
@@ -56,12 +63,6 @@ public:
         _segments_deleted += deleted_count;
     };
 
-    void segments_in_manifest(int64_t count) { _segments_in_manifest = count; };
-
-    void segments_to_delete(int64_t count) { _segments_to_delete = count; };
-
-    void cloud_log_size(uint64_t size) { _cloud_log_size = size; }
-
     void compacted_replaced_bytes(size_t bytes) {
         _compacted_replaced_bytes = bytes;
     }
@@ -77,17 +78,13 @@ private:
     int64_t _pending = 0;
     /// Number of segments deleted by garbage collection
     int64_t _segments_deleted = 0;
-    /// Number of accounted segments in the cloud
-    int64_t _segments_in_manifest = 0;
-    /// Number of segments awaiting deletion
-    int64_t _segments_to_delete = 0;
-    /// size in bytes of the user-visible log
-    uint64_t _cloud_log_size = 0;
     /// cloud bytes "removed" due to compaction operation
     size_t _compacted_replaced_bytes = 0;
 
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
+
+    ss::shared_ptr<const cluster::archival_metadata_stm> _stm;
 };
 
 /// Metrics probe for upload housekeeping service


### PR DESCRIPTION
We called update probe only from leaders and after exiting the upload loop which led to inconsistent and stale metrics.

Fix this by introducing a subscription mechanism to the STM which is the source of truth for the manifest state and must be consistent across all replicas.

The first attempt was in
https://github.com/redpanda-data/redpanda/pull/24257 but the feedback suggested that the approach in this commit is better.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Ensure `redpanda_cloud_storage_cloud_log_size` metric consistent across all replicas. We used to update it seldomly from the leader replica only which lead to inconsistent/stale values.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
