### PR TITLE
[CORE-8249] Shutdown http/client promptly on scrubber exit

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -486,7 +486,7 @@ ss::future<> abs_client::stop() {
     vlog(abs_log.debug, "Stopped ABS client");
 }
 
-void abs_client::shutdown() { _client.shutdown(); }
+void abs_client::shutdown() { _client.shutdown_now(); }
 
 template<typename T>
 ss::future<result<T, error_outcome>> abs_client::send_request(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -631,7 +631,7 @@ ss::future<bool> s3_client::self_configure_test(const bucket_name& bucket) {
 
 ss::future<> s3_client::stop() { return _client.stop(); }
 
-void s3_client::shutdown() { _client.shutdown(); }
+void s3_client::shutdown() { _client.shutdown_now(); }
 
 ss::future<result<http::client::response_stream_ref, error_outcome>>
 s3_client::get_object(

--- a/src/v/cluster/archival/adjacent_segment_merger.cc
+++ b/src/v/cluster/archival/adjacent_segment_merger.cc
@@ -53,7 +53,11 @@ adjacent_segment_merger::adjacent_segment_merger(
       _archiver.get_ntp());
 }
 
-ss::future<> adjacent_segment_merger::stop() { return _gate.close(); }
+ss::future<> adjacent_segment_merger::stop() {
+    vlog(_ctxlog.debug, "Stopping adjacent segment merger");
+    co_await _gate.close();
+    vlog(_ctxlog.debug, "Stopped adjacent segment merger");
+}
 
 void adjacent_segment_merger::set_enabled(bool enabled) {
     vlog(_ctxlog.trace, "Setting adjacent segment merger enabled: {}", enabled);

--- a/src/v/cluster/archival/scrubber.cc
+++ b/src/v/cluster/archival/scrubber.cc
@@ -175,7 +175,8 @@ void scrubber::release() {
 ss::future<> scrubber::stop() {
     vlog(_logger.info, "Stopping scrubber ({})...", _gate.get_count());
     _as.request_abort();
-    return _gate.close();
+    co_await _gate.close();
+    vlog(_logger.info, "Stopped scrubber");
 }
 
 retry_chain_node* scrubber::get_root_retry_chain_node() { return &_root_rtc; }

--- a/src/v/cluster/archival/scrubber.cc
+++ b/src/v/cluster/archival/scrubber.cc
@@ -123,6 +123,8 @@ ss::future<scrubber::run_result> scrubber::run(run_quota_t quota) {
     }
 
     if (_as.abort_requested()) {
+        vlog(
+          _logger.info, "Scrub abort after {} operations.", detect_result.ops);
         co_return run_result{
           .status = run_status::failed,
           .consumed = consumed,

--- a/src/v/cluster/archival/scrubber.cc
+++ b/src/v/cluster/archival/scrubber.cc
@@ -181,7 +181,9 @@ ss::future<> scrubber::stop() {
 
 retry_chain_node* scrubber::get_root_retry_chain_node() { return &_root_rtc; }
 
-ss::sstring scrubber::name() const { return "scrubber"; }
+ss::sstring scrubber::name() const {
+    return ssx::sformat("scrubber:{}", _archiver.get_ntp());
+}
 
 std::pair<bool, std::optional<ss::sstring>> scrubber::should_skip() const {
     if (!_feature_table.is_active(features::feature::cloud_storage_scrubbing)) {


### PR DESCRIPTION
The test cuts off network access to S3 and deletes a topic. It is expected that the topic on local storage is removed. It isn't always removed.

Part of removal of a partition (prior to physically removing segments) is to stop the partition. However, we can see here the long 2 minute delay, which corresponds to _archiver->stop() call.

```
DEBUG 2024-11-23 18:45:37,402 [shard 0:main] cluster - partition.cc:567 - Stopping archiver on partition: {kafka/topic-rhmomazlxk/2}
DEBUG 2024-11-23 18:47:13,085 [shard 0:main] cluster - partition.cc:576 - Stopping cloud_storage_partition on partition: {kafka/topic-rhmomazlxk/2}
```

If we dig in further we'll observe that while the scrubber is promptly stopped, there is an active scrubbing job that needs to finish before scrubber stop will fully close its gate.

```
DEBUG 2024-11-23 18:45:36,952 [shard 0:au  ] archival - upload_housekeeping_service.cc:395 - Running job scrubber with quota 5000
INFO  2024-11-23 18:45:36,952 [shard 0:au  ] archival - [fiber7 kafka/topic-rhmomazlxk/2] - scrubber.cc:88 - Starting scrub with 5000 quota from offset {nullopt}

DEBUG 2024-11-23 18:45:37,402 [shard 0:main] archival - upload_housekeeping_service.cc:230 - Deregistering job: scrubber
DEBUG 2024-11-23 18:45:37,402 [shard 0:main] archival - upload_housekeeping_service.cc:263 - interrupting the running job, it will beremoved upon exit
DEBUG 2024-11-23 18:45:37,402 [shard 0:main] archival - upload_housekeeping_service.cc:278 - deregistered job, current backlog 0, num completed jobs 1, num running jobs 1
INFO  2024-11-23 18:45:37,402 [shard 0:main] archival - [fiber7 kafka/topic-rhmomazlxk/2] - scrubber.cc:176 - Stopping scrubber (2)...

DEBUG 2024-11-23 18:47:13,085 [shard 0:au  ] archival - upload_housekeeping_service.cc:418 - upload housekeeping job scrubber ignoring shutdown error: seastar::abort_requested_exception (abort requested)
INFO  2024-11-23 18:47:13,085 [shard 0:au  ] archival - upload_housekeeping_service.cc:463 - housekeeping_workflow, transition to idle state from active, 2 jobs executed, 0 jobs failed. Housekeeping round lasted approx. 99 sec. Job execution time in the round: 96 sec
DEBUG 2024-11-23 18:47:13,085 [shard 0:au  ] archival - upload_housekeeping_service.cc:351 - housekeeping_workflow, BG job, state: idle, backlog: 1
```

The place where the job is stuck is in the anomolies detector, trying to download the manifest. We can see the repeated attempts to download the manifest here

```
TRACE 2024-11-23 18:45:58,079 [shard 0:au  ] http - transport.cc:21 - error connecting to 192.168.215.125:9000 - seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:45:58,079 [shard 0:au  ] http - transport.cc:76 - Connection error: seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:45:58,079 [shard 0:au  ] http - [/3e7bec98-e6b9-462d-ac8e-59a245c8bb25/meta/kafka/topic-rhmomazlxk/2_29/manifest.bin] - client.cc:192 - connection timeout
DEBUG 2024-11-23 18:45:58,110 [shard 0:main] storage-resources - storage_resources.cc:165 - calc_falloc_step: step 33554432 (max 33554432)
DEBUG 2024-11-23 18:45:58,312 [shard 0:main] archival - upload_housekeeping_service.cc:197 - Cloud storage is idle
TRACE 2024-11-23 18:45:58,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:218 - Coordination tick: unused bandwidth: 104857600, deficit bandwidth: 0
DEBUG 2024-11-23 18:45:58,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:54 - Throttler bucket capacity reset to: 52428800, waiting bytes: 0
TRACE 2024-11-23 18:45:59,079 [shard 0:au  ] http - transport.cc:21 - error connecting to 192.168.215.125:9000 - seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:45:59,079 [shard 0:au  ] http - transport.cc:76 - Connection error: seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:45:59,079 [shard 0:au  ] http - [/3e7bec98-e6b9-462d-ac8e-59a245c8bb25/meta/kafka/topic-rhmomazlxk/2_29/manifest.bin] - client.cc:192 - connection timeout
DEBUG 2024-11-23 18:45:59,110 [shard 0:main] storage-resources - storage_resources.cc:165 - calc_falloc_step: step 33554432 (max 33554432)
TRACE 2024-11-23 18:45:59,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:218 - Coordination tick: unused bandwidth: 104857600, deficit bandwidth: 0
DEBUG 2024-11-23 18:45:59,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:54 - Throttler bucket capacity reset to: 52428800, waiting bytes: 0
TRACE 2024-11-23 18:46:00,079 [shard 0:au  ] http - transport.cc:21 - error connecting to 192.168.215.125:9000 - seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:46:00,079 [shard 0:au  ] http - transport.cc:76 - Connection error: seastar::timed_out_error (timedout)
TRACE 2024-11-23 18:46:00,079 [shard 0:au  ] http - [/3e7bec98-e6b9-462d-ac8e-59a245c8bb25/meta/kafka/topic-rhmomazlxk/2_29/manifest.bin] - client.cc:192 - connection timeout
DEBUG 2024-11-23 18:46:00,111 [shard 0:main] storage-resources - storage_resources.cc:165 - calc_falloc_step: step 33554432 (max 33554432)
TRACE 2024-11-23 18:46:00,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:218 - Coordination tick: unused bandwidth: 104857600, deficit bandwidth: 0
DEBUG 2024-11-23 18:46:00,508 [shard 0:main] raft - coordinated_recovery_throttle.cc:54 - Throttler bucket capacity reset to: 52428800, waiting bytes: 0
```

In `remote::download_object` (used to download the manifest), while the http client pool lease subscribes to the root abort source, shutting down the connection (via the constructor on the client lease which invokes net::transport::shutdown) isn't a reliable way to stop the retry loop all the way down inside http::client::get_connected.

Even though the transport is shutdown once via the retry chain abort source registered with the client lease, this retry loop will attempt to reconnect when the connection timeout occurs.

The problem is that the shutdown signal is not reliably communicated from the transport to the higher level http client. There are a couple options

1. Plumb a retry chain node down or a separate abort source derived from the rtc to the http client so we can check its status
2. We can use a more robust shutdown signal, such as setting a flag on the the http client that will cause this loop to terminate.

While (1) is nice, it's also fairly invasive. The shutdown signal is already there, its just not very reliable. Since these connections are in a pool, they get reused. We coudl close the "_connect_gate", but it seems this is only done when the connection is removed from teh pool on shutdown. SO what we need is a flag that is checked in teh loop, but is reset the next time in so that the connection can be reused.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none
