### PR TITLE
[v24.2.x] tests/docker: increase cargo retry and verbosity

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/docker/library/ubuntu:jammy-20230816 AS base
+FROM public.ecr.aws/docker/library/ubuntu:jammy-20240911.1 AS base
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -7,7 +7,7 @@ git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
 git reset --hard 7ba96b8a78717c03392a3959a31e3c5a36cda472
-cargo build --config 'term.verbose=true' --release
+cargo build --config 'term.verbose=true' --config 'net.retry=6' --release
 cp target/release/client-swarm /usr/local/bin
 popd
 

--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -7,7 +7,7 @@ git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
 git reset --hard 7ba96b8a78717c03392a3959a31e3c5a36cda472
-cargo build --release
+cargo build --config 'term.verbose=true' --release
 cp target/release/client-swarm /usr/local/bin
 popd
 

--- a/tests/docker/ducktape-deps/rp-storage-tool
+++ b/tests/docker/ducktape-deps/rp-storage-tool
@@ -3,6 +3,6 @@ set -e
 set -x
 
 cd /rp_storage_tool
-cargo build --config 'term.verbose=true' --release
+cargo build --config 'term.verbose=true' --config 'net.retry=6' --release
 cp target/release/rp-storage-tool /usr/local/bin
 cd /

--- a/tests/docker/ducktape-deps/rp-storage-tool
+++ b/tests/docker/ducktape-deps/rp-storage-tool
@@ -3,6 +3,6 @@ set -e
 set -x
 
 cd /rp_storage_tool
-cargo build --release
+cargo build --config 'term.verbose=true' --release
 cp target/release/rp-storage-tool /usr/local/bin
 cd /


### PR DESCRIPTION
fixes: #24347
jira: [DEVPROD-2419]

manual backport of PR #24334

skipped cherry-pick 8fd3f60dbbae3c011a52722d647611dfe0da1c75 because changes don't exist on this branch. rest of cherry-pick clean, no conflicts.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

[DEVPROD-2419]: https://redpandadata.atlassian.net/browse/DEVPROD-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ