### PR TITLE
[v24.3.x] CORE-8290 dt/redpanda: increase expect_fail timeout to 40s

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3171,10 +3171,10 @@ class RedpandaService(RedpandaServiceBase):
             if expect_fail:
                 wait_until(
                     lambda: self.redpanda_pid(node) == None,
-                    timeout_sec=10,
+                    timeout_sec=timeout,
                     backoff_sec=0.2,
                     err_msg=
-                    f"Redpanda processes did not terminate on {node.name} during startup as expected"
+                    f"Redpanda processes did not terminate on {node.name} during startup as expected in {timeout} sec"
                 )
             elif not skip_readiness_check:
                 wait_until(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24340
