### PR TITLE
dt/rbac_upgrade: pin upgraded version to 24.1

### DIFF
--- a/tests/rptest/tests/rbac_upgrade_test.py
+++ b/tests/rptest/tests/rbac_upgrade_test.py
@@ -49,8 +49,7 @@ class UpgradeMigrationCreatingDefaultRole(RedpandaTest):
         self.admin.create_user("bob")
 
         # Update all nodes to newest version
-        self.installer.install(self.redpanda.nodes,
-                               self.installer.head_version())
+        self.installer.install(self.redpanda.nodes, (24, 1))
         self.redpanda.restart_nodes(self.redpanda.nodes)
         _ = wait_for_num_versions(self.redpanda, 1)
 


### PR DESCRIPTION
Use 24.1 instead of the HEAD version for the `UpgradeMigrationCreatingDefaultRole` test, since the test is exercising the upgrade path from v23.3 -> v24.1, specifically. This is becoming important now that we are about to cut 25.1 and an upgrade from 23.3 to 25.1 (new head) won't be possible.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
