### PR TITLE
model: bazelize some tests

### DIFF
--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -109,6 +109,22 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "record_batch_test",
+    timeout = "short",
+    srcs = [
+        "record_batch_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":random",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "record_batch_reader_test",
     timeout = "short",
     srcs = [

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -114,6 +114,7 @@ redpanda_cc_btest(
     srcs = [
         "record_batch_reader_test.cc",
     ],
+    cpu = 1,
     deps = [
         ":random",
         "//src/v/model",

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -125,6 +125,22 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "model_serialization_test",
+    timeout = "short",
+    srcs = [
+        "model_serialization_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/model",
+        "//src/v/test_utils:rpc",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "record_batch_reader_test",
     timeout = "short",
     srcs = [

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -75,6 +75,24 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "timeout_adl",
+    timeout = "short",
+    srcs = [
+        "timeout_adl.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/model",
+        "//src/v/reflection:adl",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:to_string",
+        "@boost//:test",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_btest(
     name = "topic_view_test",
     timeout = "short",
     srcs = [


### PR DESCRIPTION
Implements:
[CORE-7532](https://redpandadata.atlassian.net/browse/CORE-7532) : model_serialization_test.cc
[CORE-7533](https://redpandadata.atlassian.net/browse/CORE-7533) : record_batch_test.cc
[CORE-7534](https://redpandadata.atlassian.net/browse/CORE-7534) : timeout_adl.cc

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7532]: https://redpandadata.atlassian.net/browse/CORE-7532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7533]: https://redpandadata.atlassian.net/browse/CORE-7533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7534]: https://redpandadata.atlassian.net/browse/CORE-7534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ