### PR TITLE
config: Remove reference to `kafka_throughput_throttling_v2`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3388,8 +3388,7 @@ configuration::configuration()
       *this,
       "kafka_throughput_replenish_threshold",
       "Threshold for refilling the token bucket as part of enforcing "
-      "throughput limits. This only applies when "
-      "kafka_throughput_throttling_v2 is `true`. This threshold is evaluated "
+      "throughput limits. This threshold is evaluated "
       "with each request for data. When the number of tokens to replenish "
       "exceeds this threshold, then tokens are added to the token bucket. This "
       "ensures that the atomic is not being updated for the token count with "


### PR DESCRIPTION
See #16823

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
