### PR TITLE
rpk: fix --help in `byoc` and `user update`

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
@@ -51,7 +51,10 @@ func init() {
 		cmd.Run = func(cmd *cobra.Command, args []string) {
 			cfg, redpandaID, pluginArgs, err := parseBYOCFlags(fs, p, cmd, args)
 			out.MaybeDieErr(err)
-
+			if cmd.Flags().Changed("help") {
+				cmd.Help()
+				return
+			}
 			// --redpanda-id is only required in apply or destroy commands.
 			// For validate commands we don't need the redpanda-id, instead,
 			// we download the latest version always.
@@ -168,7 +171,7 @@ and then come back to this command to complete the process.
 				}
 			}
 
-			if !isKnown || (redpandaID == "" && !isValidate) {
+			if !isKnown || (redpandaID == "" && !isValidate) || cmd.Flags().Changed("help") {
 				cmd.Help()
 				return
 			}

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -10,6 +10,7 @@
 package user
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
@@ -22,7 +23,7 @@ import (
 func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var newPass, mechanism string
 	cmd := &cobra.Command{
-		Use:   "update [USER] --new-password [PW]",
+		Use:   "update [USER] --new-password [PW] --mechanism [MECHANISM]",
 		Short: "Update SASL user credentials",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -46,9 +47,11 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&newPass, "new-password", "", "New user's password.")
-	cmd.Flags().StringVar(&mechanism, "mechanism", adminapi.ScramSha256, "SASL mechanism to use for the user you are updating (scram-sha-256, scram-sha-512, case insensitive)")
+	cmd.Flags().StringVar(&mechanism, "mechanism", "", fmt.Sprintf("SASL mechanism to use for the user you are updating (%v, %v, case insensitive)", adminapi.ScramSha256, adminapi.ScramSha512))
 	cmd.MarkFlagRequired("new-password")
 	cmd.MarkFlagRequired("mechanism")
-
+	cmd.RegisterFlagCompletionFunc("mechanism", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{adminapi.ScramSha256, adminapi.ScramSha512}, cobra.ShellCompDirectiveDefault
+	})
 	return cmd
 }


### PR DESCRIPTION
- cef1a3a2fc85bf37104571243e48d43612005f04 Fixes DEVEX-56, a bug that prevented rpk from parsing `--help` in `rpk cloud byoc <provider> apply when used along with `--redpanda-id` flag.
- 3746d3606af7a59bd87690b1f894109c2ac00768 clarifies the required flag `mechanism` in `rpk security user update`. And adds autocompletion to the flag. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug where `rpk` wasn't parsing `--help` when used alongside `--redpanda-id` in `rpk cloud <provider> byoc apply`
