### PR TITLE
[v24.3.x] c/controller_backend: allow `shutdown_partition` to fail on app shutdown

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -305,6 +305,7 @@ private:
     ss::future<> remove_from_shard_table(
       model::ntp, raft::group_id, model::revision_id log_revision);
 
+    /* may fail only with ss::gate_closed_exception */
     ss::future<xshard_transfer_state>
       shutdown_partition(ss::lw_shared_ptr<partition>);
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24358
