### PR TITLE
[v24.2.x] c/controller_backend: allow `shutdown_partition` to fail on app shutdown

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1924,10 +1924,17 @@ controller_backend::shutdown_partition(ss::lw_shared_ptr<partition> partition) {
           ntp, gr, partition->get_log_revision_id());
         // shutdown partition
         co_return co_await _partition_manager.local().shutdown(ntp);
+    } catch (const seastar::gate_closed_exception&) {
+        // let it bubble up and break reconciliation loop
+        vlog(
+          clusterlog.debug,
+          "error shutting down {} partition, app shutting down",
+          ntp);
+        throw;
     } catch (...) {
         /**
-         * If partition shutdown failed we should crash, this error is
-         * unrecoverable
+         * If partition shutdown failed with any other exception we should
+         * crash, this error is unrecoverable
          */
         vassert(
           false,

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -302,6 +302,7 @@ private:
     ss::future<> remove_from_shard_table(
       model::ntp, raft::group_id, model::revision_id log_revision);
 
+    /* may fail only with ss::gate_closed_exception */
     ss::future<xshard_transfer_state>
       shutdown_partition(ss::lw_shared_ptr<partition>);
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24358
