### PR TITLE
bazel: Enable LTO for redpanda

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,8 +89,9 @@ build:secure --config=relro
 build:release --compilation_mode opt
 build:release --config=secure
 build:release --copt -mllvm --copt -inline-threshold=2500
-build:release --linkopt=-flto
 build:release --@seastar//:stack_guards=False
+build:release --//src/v/redpanda:lto=True
+build:release --copt -flto=thin --copt -ffat-lto-objects
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh
 

--- a/bazel/build.bzl
+++ b/bazel/build.bzl
@@ -51,6 +51,7 @@ def redpanda_cc_binary(
         local_defines = [],
         visibility = None,
         copts = [],
+        linkopts = [],
         deps = []):
     """
     Define a Redpanda C++ binary.
@@ -64,6 +65,7 @@ def redpanda_cc_binary(
         visibility = visibility,
         deps = deps,
         copts = redpanda_copts() + copts,
+        linkopts = linkopts,
         features = [
             "layering_check",
         ],

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -48,6 +48,10 @@ configure_make(
         "--disable-static",
         "--enable-asan=$(SANITIZERS)",
     ],
+    # Need to pass this additionally here because of a bug in the kerberos build where it doesn't properly pass the linker flag down
+    copts = [
+        "-fuse-ld=lld",
+    ],
     env = {
         "KRB5_BUILD_JOBS": "$(BUILD_JOBS)",
     },

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//bazel:build.bzl", "redpanda_cc_binary", "redpanda_cc_library")
 
 redpanda_cc_library(
@@ -95,11 +96,34 @@ redpanda_cc_library(
     ],
 )
 
+# Enable or disable (thin) LTO for the redpanda binary (only)
+bool_flag(
+    name = "lto",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_lto",
+    flag_values = {
+        ":lto": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
 redpanda_cc_binary(
     name = "redpanda",
     srcs = [
         "main.cc",
     ],
+    linkopts =
+        select({
+            ":use_lto": [
+                "-flto=thin",
+                "-ffat-lto-objects",
+            ],
+            "//conditions:default": [
+            ],
+        }),
     visibility = ["//visibility:public"],
     deps = [
         ":application",


### PR DESCRIPTION
This patch enables LTO for redpanda by default (main binary only).

We add `-flto=thin` and `-ffat-lto-objects` to the compile flags. This
allows for the final link step to chose whether to use LTO or not (by
passing `flto` to the linker step).

Hence, we can selectively enable LTO only for the redpanda binary and
not for the test binaries. Note this isn't a massive advantage yet for
the bazel build because of the thing where it builds everything twice
anyway). It is however already useful for not using LTO for initial
local dev (lto=False) but then enabling it for an eventual microbench or
a package build.

We chose thin-lto over full lto as compile times are a lot slower with
that (~5x) and additional perf improvements are small. Also we can
always change later.

As is the final link step is about a minute. This will go up once we
enable debug info as that has quite the impact on compile and link
times.

Note we can't use the clang thin-lto cache option because it would
require a bunch of bazel work to use a cache dir.

In a librdkafka bench this change shows a 2-3% improvement. There is
some microbench results in CORE-327 but note that microbenches aren't
really that representative for LTO.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

