### PR TITLE
[v24.2.x] tests: added missing timeout setting in partition reconfiguration test

### DIFF
--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -231,7 +231,8 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         # Leadership should be stabilized
         self.redpanda._admin.await_stable_leader(topic=self.topic,
                                                  replication=len(alive),
-                                                 hosts=self._alive_nodes())
+                                                 hosts=self._alive_nodes(),
+                                                 timeout_s=self.WAIT_TIMEOUT_S)
 
         self._start_consumer()
         if controller_snapshots:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24375
