### PR TITLE
rpc: bazelize some tests

### DIFF
--- a/src/v/rpc/test/BUILD
+++ b/src/v/rpc/test/BUILD
@@ -81,6 +81,26 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "connection_cache_test",
+    timeout = "short",
+    srcs = [
+        "connection_cache_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/rpc",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_bench(
     name = "rpc_bench",
     timeout = "short",

--- a/src/v/rpc/test/BUILD
+++ b/src/v/rpc/test/BUILD
@@ -65,6 +65,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "exponential_backoff",
+    timeout = "short",
+    srcs = [
+        "exponential_backoff.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/rpc",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_rpc_library(
     name = "cycling_rpc",
     src = "cycling_service.json",

--- a/src/v/rpc/test/BUILD
+++ b/src/v/rpc/test/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest")
 load("//src/v/rpc:compiler.bzl", "redpanda_cc_rpc_library")
 
 redpanda_cc_btest(
@@ -78,6 +78,19 @@ redpanda_cc_btest(
         "@boost//:test",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "rpc_bench",
+    timeout = "short",
+    srcs = [
+        "rpc_bench.cc",
+    ],
+    deps = [
+        "//src/v/reflection:adl",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )
 


### PR DESCRIPTION
Implements:
[CORE-7591](https://redpandadata.atlassian.net/browse/CORE-7591) : `connection_cache_test.cc`
[CORE-7592](https://redpandadata.atlassian.net/browse/CORE-7592) : `exponential_backoff.cc`
[CORE-7593](https://redpandadata.atlassian.net/browse/CORE-7593) : `rpc_bench.cc`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7591]: https://redpandadata.atlassian.net/browse/CORE-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7592]: https://redpandadata.atlassian.net/browse/CORE-7592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7593]: https://redpandadata.atlassian.net/browse/CORE-7593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ