### PR TITLE
[CORE-8338] `rptest`: add `timeout` to `_polaris_ready()` check

### DIFF
--- a/tests/rptest/services/polaris_catalog.py
+++ b/tests/rptest/services/polaris_catalog.py
@@ -137,8 +137,14 @@ class PolarisCatalog(Service):
             self.logger.debug(
                 f"Querying polaris healthcheck on http://{node.account.hostname}:8182/healthcheck"
             )
-            r = requests.get(
-                f"http://{node.account.hostname}:8182/healthcheck")
+            try:
+                r = requests.get(
+                    f"http://{node.account.hostname}:8182/healthcheck")
+            except:
+                # If we attempted to make a healthcheck before the port
+                # was opened on the node, this will raise an exception.
+                # Pass through and allow wait_until() to retry.
+                pass
 
             self.logger.info(
                 f"health check result status code: {r.status_code}")


### PR DESCRIPTION
We were getting `TimeoutError: [Errno 110] Connection timed out` errors after a period of about 3 minutes after issuing a polaris health check query in some CDT runs. It may help to terminate and retry the connection by adding a `timeout` parameter.

In case of a timeout exception being raised, the `wait_until()` call will retry the request.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
