### PR TITLE
[CORE-8338] `rptest`: add `timeout` to `_polaris_ready()` check

### DIFF
--- a/tests/rptest/services/polaris_catalog.py
+++ b/tests/rptest/services/polaris_catalog.py
@@ -138,7 +138,7 @@ class PolarisCatalog(Service):
                 f"Querying polaris healthcheck on http://{node.account.hostname}:8182/healthcheck"
             )
             r = requests.get(
-                f"http://{node.account.hostname}:8182/healthcheck")
+                f"http://{node.account.hostname}:8182/healthcheck", timeout=10)
 
             self.logger.info(
                 f"health check result status code: {r.status_code}")

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -68,7 +68,7 @@ class PolarisCatalogSmokeTest(RedpandaTest):
     def setUp(self):
         pass
 
-    def _start_redpanad(self, catalog_prefix, client_id, client_secret,
+    def _start_redpanda(self, catalog_prefix, client_id, client_secret,
                         with_tls):
         self.redpanda._extra_rp_conf.update({
             "iceberg_enabled":
@@ -204,7 +204,7 @@ class PolarisCatalogSmokeTest(RedpandaTest):
         principal_name = "test-user"
         credentials = self._initialize_catalog(catalog_name, principal_name)
 
-        self._start_redpanad(catalog_prefix=catalog_name,
+        self._start_redpanda(catalog_prefix=catalog_name,
                              client_id=credentials.client_id,
                              client_secret=credentials.client_secret,
                              with_tls=with_tls)


### PR DESCRIPTION
We were getting `TimeoutError: [Errno 110] Connection timed out` errors after a period of about 3 minutes after issuing a Polaris health check query in some CDT runs. It _may_ help to terminate and retry the connection by adding a `timeout` parameter.

In case of a timeout exception being raised, the `wait_until()` call will retry the request.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
