### PR TITLE
tests/connect: added timeout when checking if connect is started

### DIFF
--- a/tests/rptest/services/redpanda_connect.py
+++ b/tests/rptest/services/redpanda_connect.py
@@ -92,7 +92,8 @@ logger:
         self.url = f"http://{node.account.hostname}:4195"
 
         def _ready():
-            r = requests.get(f"http://{node.account.hostname}:4195/ready")
+            r = requests.get(f"http://{node.account.hostname}:4195/ready",
+                             timeout=5)
             return r.status_code == 200
 
         wait_until(_ready,


### PR DESCRIPTION
In CDT environment it is common for some requests to stale the connection. In this case a client should retry. Adding a timeout force the request to fail so the retry is possible.
Fixes: CORE-8382
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 