### PR TITLE
[v24.3.x] [CORE-8338] `rptest`: add `timeout` to `_polaris_ready()` check

### DIFF
--- a/tests/rptest/services/polaris_catalog.py
+++ b/tests/rptest/services/polaris_catalog.py
@@ -138,7 +138,7 @@ class PolarisCatalog(Service):
                 f"Querying polaris healthcheck on http://{node.account.hostname}:8182/healthcheck"
             )
             r = requests.get(
-                f"http://{node.account.hostname}:8182/healthcheck")
+                f"http://{node.account.hostname}:8182/healthcheck", timeout=10)
 
             self.logger.info(
                 f"health check result status code: {r.status_code}")

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -68,7 +68,7 @@ class PolarisCatalogSmokeTest(RedpandaTest):
     def setUp(self):
         pass
 
-    def _start_redpanad(self, catalog_prefix, client_id, client_secret,
+    def _start_redpanda(self, catalog_prefix, client_id, client_secret,
                         with_tls):
         self.redpanda._extra_rp_conf.update({
             "iceberg_enabled":
@@ -204,7 +204,7 @@ class PolarisCatalogSmokeTest(RedpandaTest):
         principal_name = "test-user"
         credentials = self._initialize_catalog(catalog_name, principal_name)
 
-        self._start_redpanad(catalog_prefix=catalog_name,
+        self._start_redpanda(catalog_prefix=catalog_name,
                              client_id=credentials.client_id,
                              client_secret=credentials.client_secret,
                              with_tls=with_tls)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24386
