### PR TITLE
datalake/tests: deflake max_translated_offset utility

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -159,8 +159,10 @@ class DatalakeServices():
                     self.query_engines))
             self.redpanda.logger.debug(
                 f"Current translated offsets: {offsets}")
-            return all(
-                [offset <= max_offset for _, max_offset in offsets.items()])
+            return all([
+                offset and offset <= max_offset
+                for _, max_offset in offsets.items()
+            ])
 
         wait_until(
             translation_done,

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -53,9 +53,9 @@ class QueryEngineBase(ABC):
     def count_table(self, namespace, table) -> int:
         query = f"select count(*) from {namespace}.{self.escape_identifier(table)}"
         with self.run_query(query) as cursor:
-            return int(cursor.fetchone()[0])
+            return cursor.fetchone()[0]
 
     def max_translated_offset(self, namespace, table, partition) -> int:
         query = f"select max(redpanda.offset) from {namespace}.{self.escape_identifier(table)} where redpanda.partition={partition}"
         with self.run_query(query) as cursor:
-            return int(cursor.fetchone()[0])
+            return cursor.fetchone()[0]


### PR DESCRIPTION
It may return None if nothing from the requested partition was committed to iceberg. Removes unneeded int casts and handle None results from the driver.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
