### PR TITLE
leader_balancer: implement and use even_node_load_constraint

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -253,4 +253,30 @@ double pinning_constraint::evaluate_internal(const reassignment& r) {
     return diff;
 }
 
+even_node_load_constraint::even_node_load_constraint(const shard_index& si) {
+    for (const auto& [bs, leaders] : si.shards()) {
+        auto& info = _node2info[bs.node_id];
+        info.shards += 1;
+        info.leaders += leaders.size();
+    }
+}
+
+void even_node_load_constraint::update_index(const reassignment& r) {
+    _node2info[r.from.node_id].leaders -= 1;
+    _node2info[r.to.node_id].leaders += 1;
+}
+
+double even_node_load_constraint::evaluate_internal(const reassignment& r) {
+    // Positive if the reassignment makes the weighted distribution more
+    // balanced. In particular, it is positive iff
+    // (from_info.leaders/from_info.shards - to_info.leaders/to_info.shards)^2
+    // decreases as a result of the reassignment (showing equivalence is
+    // straightforward with some algebraic transforms).
+    const auto& from_info = _node2info[r.from.node_id];
+    const auto& to_info = _node2info[r.to.node_id];
+    return 2 * (double(from_info.leaders) * to_info.shards
+           - double(to_info.leaders) * from_info.shards) - from_info.shards
+           - to_info.shards;
+}
+
 } // namespace cluster::leader_balancer_types

--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -218,6 +218,10 @@ std::vector<shard_load> even_shard_load_constraint::stats() const {
           // oddly, absl::btree::size returns a signed type
           return shard_load{e->first, static_cast<size_t>(e->second.size())};
       });
+    std::sort(
+      ret.begin(), ret.end(), [](const shard_load& l, const shard_load& r) {
+          return l.shard < r.shard;
+      });
     return ret;
 }
 

--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -288,4 +288,26 @@ private:
     preference_index _preference_idx;
 };
 
+// Constraint implementing node-wise balanced load objective (i.e. equal number
+// of leaders on each node as opposed to on each shard).
+class even_node_load_constraint final
+  : public soft_constraint
+  , public index {
+public:
+    explicit even_node_load_constraint(const shard_index& si);
+
+    void update_index(const reassignment& r) override;
+
+private:
+    double evaluate_internal(const reassignment& r) override;
+
+private:
+    struct node_info {
+        int32_t leaders = 0;
+        uint32_t shards = 0;
+    };
+
+    absl::flat_hash_map<model::node_id, node_info> _node2info;
+};
+
 } // namespace cluster::leader_balancer_types

--- a/src/v/cluster/tests/leader_balancer_test_utils.h
+++ b/src/v/cluster/tests/leader_balancer_test_utils.h
@@ -56,8 +56,9 @@ inline cluster::leader_balancer_strategy::index_type copy_cluster_index(
     cluster::leader_balancer_strategy::index_type index;
 
     for (const auto& [bs, leaders] : c_index) {
+        auto& gid2replicas = index[bs];
         for (const auto& [group_id, replicas] : leaders) {
-            index[bs][group_id] = replicas;
+            gid2replicas[group_id] = replicas;
         }
     }
 

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -474,7 +474,7 @@ class LeadershipPinningTest(RedpandaTest):
             "foo": {"A"},
             "bar": {"B", "C"}
         },
-                            timeout_sec=30)
+                            timeout_sec=60)
 
         # Decrease idle timeout to not wait too long after nodes are killed
         self.redpanda.set_cluster_config({"enable_leader_balancer": False})
@@ -504,7 +504,7 @@ class LeadershipPinningTest(RedpandaTest):
             "bar": {"C"}
         },
                             check_balance=False,
-                            timeout_sec=30)
+                            timeout_sec=60)
 
         self.logger.info("unset topic configs")
 
@@ -515,7 +515,7 @@ class LeadershipPinningTest(RedpandaTest):
             "foo": {"A"},
             "bar": {"A"}
         },
-                            timeout_sec=30)
+                            timeout_sec=60)
 
         self.logger.info("unset default preference")
 


### PR DESCRIPTION
Leader balancer treats all CPU cores available in the cluster as independent and tries to balance leadership among them and not among nodes (i.e. the objective is that each core has the same number of leaders, and not each node). This leads to unintuitive results, especially when the number of raft groups is comparable to the number of available shards.
    
Add a low-priority node balancing constraint to fix that.

Fixes https://redpandadata.atlassian.net/browse/CORE-8237

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
### Improvements
* Leader balancer: don't treat each core as independent and balance total number of leaders on each node as well.
