### PR TITLE
raft/c: fix an indefinite hang in transfer leadership

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -48,8 +48,9 @@ recovery_stm::recovery_stm(
   , _ctxlog(
       raftlog,
       ssx::sformat(
-        "[follower: {}] [group_id:{}, {}]",
+        "[follower: {}, term: {}] [group_id:{}, {}]",
         _node_id,
+        _term,
         _ptr->group(),
         _ptr->ntp()))
   , _memory_quota(quota) {}

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -142,6 +142,7 @@ void follower_index_metadata::reset() {
     last_successful_received_seq = follower_req_seq{0};
     inflight_append_request_count = 0;
     last_sent_protocol_meta.reset();
+    follower_state_change.broadcast();
 }
 
 std::ostream& operator<<(std::ostream& o, const vnode& id) {


### PR DESCRIPTION
This PR fixes a timeout in raft leadership transfer request. The timeout is caused by a race condition in raft that results in  a stuck recovery_stm, even after losing leadership. Exact sequence of events below:

- Request to transfer leadership in term - 10
- Starts a recovery_stm to catchup a follower  term - 10
- recovery_stm detects the follower has already been dispatched the latest log index, blocks on a CV until it hears back from the follower (indefinite wait)
- A racy step_down from a failed replicate request (stm initiated)
- A new leader takes over and local term incremented - term - 11
- recovery_stm  (in term 10) is stuck waiting for the CV is signaled (which happens if the node assumes leadership again in the future or at shutdown, an indefinite hang if it never assumes leadership)

This PR signals the CV upon step down to unblock the recovery_stm which then detects it is has to shutdown due to a step down (loss of leadership) and this automatically unblocks the transfer leadership request which was waiting for it.

An unrelated (but deeper) issue this PR avoids fixing is why the step down happens when a transfer is already in progress. In this case it was initiated by an STM invariant that requires a step down upon first failure (required for correctness). One can argue that it is not the right behavior to step down when a transfer is already in progress. The fix for it is likely invasive and has correctness implications at the state machine level (eg: idempotency), so avoiding for now.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
