### PR TITLE
[v24.3.x] datalake/tests: deflake max_translated_offset utility

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -160,8 +160,10 @@ class DatalakeServices():
                     self.query_engines))
             self.redpanda.logger.debug(
                 f"Current translated offsets: {offsets}")
-            return all(
-                [offset <= max_offset for _, max_offset in offsets.items()])
+            return all([
+                offset and offset <= max_offset
+                for _, max_offset in offsets.items()
+            ])
 
         wait_until(
             translation_done,

--- a/tests/rptest/tests/datalake/query_engine_base.py
+++ b/tests/rptest/tests/datalake/query_engine_base.py
@@ -49,9 +49,9 @@ class QueryEngineBase(ABC):
     def count_table(self, table) -> int:
         query = f"select count(*) from {table}"
         with self.run_query(query) as cursor:
-            return int(cursor.fetchone()[0])
+            return cursor.fetchone()[0]
 
     def max_translated_offset(self, table, partition) -> int:
         query = f"select max(redpanda.offset) from {table} where redpanda.partition={partition}"
         with self.run_query(query) as cursor:
-            return int(cursor.fetchone()[0])
+            return cursor.fetchone()[0]


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24402
