### PR TITLE
c/features: introduced a new release version

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -141,7 +141,7 @@ constexpr cluster_version latest_version = to_cluster_version(
 // a freshly initialized node will start at. All features up to this cluster
 // version will automatically be enabled when Redpanda starts.
 constexpr cluster_version earliest_version = to_cluster_version(
-  release_version::v23_3_1);
+  release_version::v24_1_1);
 
 static_assert(
   latest_version - earliest_version == 3L,
@@ -175,6 +175,7 @@ bool is_major_version_release(cluster::cluster_version version) {
     case release_version::v24_1_1:
     case release_version::v24_2_1:
     case release_version::v24_3_1:
+    case release_version::v25_1_1:
         return true;
     }
     __builtin_unreachable();

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -134,7 +134,8 @@ enum class release_version : int64_t {
     v24_1_1 = 12,
     v24_2_1 = 13,
     v24_3_1 = 14,
-    MAX = v24_3_1, // affects the latest_version
+    v25_1_1 = 15,
+    MAX = v25_1_1, // affects the latest_version
 };
 
 constexpr cluster::cluster_version to_cluster_version(release_version rv) {
@@ -151,6 +152,7 @@ constexpr cluster::cluster_version to_cluster_version(release_version rv) {
     case release_version::v24_1_1:
     case release_version::v24_2_1:
     case release_version::v24_3_1:
+    case release_version::v25_1_1:
         return cluster::cluster_version{static_cast<int64_t>(rv)};
     }
     vassert(false, "Invalid release_version");


### PR DESCRIPTION
Introduced `v25_1_1` together with the new cluster version for next release cycle.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none