### PR TITLE
[v24.3.x] rptest/s: continue waiting for manifest uploads after MaxRetryError

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -31,6 +31,7 @@ import pathlib
 import shlex
 from enum import Enum, IntEnum
 from typing import Callable, List, Generator, Literal, Mapping, Optional, Protocol, Set, Tuple, Any, Type, cast
+from urllib3.exceptions import MaxRetryError
 
 import yaml
 from ducktape.services.service import Service
@@ -5018,6 +5019,11 @@ class RedpandaService(RedpandaServiceBase):
                 try:
                     status = self._admin.get_partition_cloud_storage_status(
                         p.topic, p.index, node=p.leader)
+                except MaxRetryError as e:
+                    self.logger.info(
+                        f"Max retries exceeded while fetching cloud partition status: {e}"
+                    )
+                    return False
                 except HTTPError as he:
                     if he.response.status_code == 404:
                         # Old redpanda, doesn't have this endpoint.  We can't

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -530,9 +530,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                 err_msg="Error waiting for cluster to report consistent version"
             )
 
-        if with_tiered_storage:
-            self.redpanda.stop_and_scrub_object_storage()
-
         # Validate that the controller log written during the test is readable by offline log viewer
         log_viewer = OfflineLogViewer(self.redpanda)
         for node in self.redpanda.started_nodes():


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24393
