### PR TITLE
Made reconfiguration cancel in Raft symmetric

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -98,6 +98,8 @@ std::string_view to_string_view(feature f) {
         return "shadow_indexing_split_topic_property_update";
     case feature::datalake_iceberg:
         return "datalake_iceberg";
+    case feature::raft_symmetric_reconfiguration_cancel:
+        return "raft_symmetric_reconfiguration_cancel";
 
     /*
      * testing features

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -62,8 +62,6 @@ std::string_view to_string_view(feature f) {
         return "broker_time_based_retention";
     case feature::wasm_transforms:
         return "wasm_transforms";
-    case feature::raft_config_serde:
-        return "raft_config_serde";
     case feature::fast_partition_reconfiguration:
         return "fast_partition_reconfiguration";
     case feature::disabling_partitions:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -51,7 +51,6 @@ enum class feature : std::uint64_t {
     enhanced_force_reconfiguration = 1ULL << 33U,
     broker_time_based_retention = 1ULL << 34U,
     wasm_transforms = 1ULL << 35U,
-    raft_config_serde = 1ULL << 36U,
     fast_partition_reconfiguration = 1ULL << 38U,
     disabling_partitions = 1ULL << 39U,
     cloud_metadata_cluster_recovery = 1ULL << 40U,
@@ -113,6 +112,7 @@ inline const std::unordered_set<std::string_view> retired_features = {
   "partition_move_revert_cancel",
   "rpc_transport_unknown_errc",
   "raft_append_entries_serde",
+  "raft_config_serde",
 };
 
 // The latest_version associated with past releases. Increment this
@@ -304,12 +304,6 @@ inline constexpr std::array feature_schema{
     release_version::v23_3_1,
     "wasm_transforms",
     feature::wasm_transforms,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    release_version::v23_3_1,
-    "raft_config_serde",
-    feature::raft_config_serde,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -69,7 +69,7 @@ enum class feature : std::uint64_t {
     partition_properties_stm = 1ULL << 52U,
     shadow_indexing_split_topic_property_update = 1ULL << 53U,
     datalake_iceberg = 1ULL << 54U,
-
+    raft_symmetric_reconfiguration_cancel = 1ULL << 55U,
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
     test_bravo = 1ULL << 62U,
@@ -412,6 +412,12 @@ inline constexpr std::array feature_schema{
     release_version::v24_3_1,
     "datalake_iceberg",
     feature::datalake_iceberg,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_1_1,
+    "raft_symmetric_reconfiguration_cancel",
+    feature::raft_symmetric_reconfiguration_cancel,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1106,7 +1106,7 @@ ss::future<std::error_code> consensus::change_configuration(Func&& f) {
               return ss::make_ready_future<std::error_code>(
                 errc::configuration_change_in_progress);
           }
-          maybe_upgrade_configuration_to_v4(latest_cfg);
+          try_updating_configuration_version(latest_cfg);
           result<group_configuration> res = f(std::move(latest_cfg));
           if (res) {
               if (res.value().revision_id() < config().revision_id()) {
@@ -1176,29 +1176,30 @@ ss::future<std::error_code> consensus::add_group_member(
   model::revision_id new_revision,
   std::optional<model::offset> learner_start_offset) {
     vlog(_ctxlog.trace, "Adding member: {}", node);
-    return change_configuration([node, new_revision, learner_start_offset](
-                                  group_configuration current) mutable {
-        using ret_t = result<group_configuration>;
-        if (current.contains(node)) {
-            return ret_t{errc::node_already_exists};
-        }
-        current.set_version(raft::group_configuration::v_5);
-        current.add(node, new_revision, learner_start_offset);
+    return change_configuration(
+      [this, node, new_revision, learner_start_offset](
+        group_configuration current) mutable {
+          using ret_t = result<group_configuration>;
+          if (current.contains(node)) {
+              return ret_t{errc::node_already_exists};
+          }
+          try_updating_configuration_version(current);
+          current.add(node, new_revision, learner_start_offset);
 
-        return ret_t{std::move(current)};
-    });
+          return ret_t{std::move(current)};
+      });
 }
 
 ss::future<std::error_code>
 consensus::remove_member(vnode node, model::revision_id new_revision) {
     vlog(_ctxlog.trace, "Removing member: {}", node);
     return change_configuration(
-      [node, new_revision](group_configuration current) {
+      [this, node, new_revision](group_configuration current) {
           using ret_t = result<group_configuration>;
           if (!current.contains(node)) {
               return ret_t{errc::node_does_not_exists};
           }
-          current.set_version(raft::group_configuration::v_5);
+          try_updating_configuration_version(current);
           current.remove(node, new_revision);
 
           if (current.current_config().voters.empty()) {
@@ -1216,7 +1217,7 @@ ss::future<std::error_code> consensus::replace_configuration(
       [this, nodes = std::move(nodes), new_revision, learner_start_offset](
         group_configuration current) mutable {
           auto old = current;
-          current.set_version(raft::group_configuration::v_5);
+          try_updating_configuration_version(current);
           current.replace(nodes, new_revision, learner_start_offset);
           vlog(
             _ctxlog.debug,
@@ -1365,6 +1366,29 @@ ss::future<std::error_code> consensus::force_replace_configuration_locally(
         co_return errc::shutting_down;
     }
     co_return errc::success;
+}
+
+void consensus::try_updating_configuration_version(group_configuration& cfg) {
+    maybe_upgrade_configuration_to_v4(cfg);
+
+    auto version = cfg.version();
+    if (
+      version >= group_configuration::v_4
+      && version < group_configuration::v_7) {
+        version = supports_symmetric_reconfiguration_cancel()
+                      && cfg.get_state() == configuration_state::simple
+                    ? group_configuration::v_7
+                    : group_configuration::v_6;
+        if (version == cfg.version()) {
+            return;
+        }
+        vlog(
+          _ctxlog.debug,
+          "Upgrading configuration {} version to {}",
+          cfg,
+          version);
+        cfg.set_version(version);
+    }
 }
 
 ss::future<> consensus::start(
@@ -2610,12 +2634,7 @@ ss::future<std::error_code> consensus::replicate_configuration(
     vlog(_ctxlog.debug, "Replicating group configuration {}", cfg);
     return ss::with_gate(
       _bg, [this, u = std::move(u), cfg = std::move(cfg)]() mutable {
-          maybe_upgrade_configuration_to_v4(cfg);
-          if (cfg.version() == group_configuration::v_5) {
-              vlog(
-                _ctxlog.debug, "Upgrading configuration {} version to 6", cfg);
-              cfg.set_version(group_configuration::v_6);
-          }
+          try_updating_configuration_version(cfg);
 
           auto batches = details::serialize_configuration_as_batches(
             std::move(cfg));

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -779,6 +779,12 @@ private:
     flush_delay_t compute_max_flush_delay() const;
     ss::future<> do_flush();
 
+    bool supports_symmetric_reconfiguration_cancel() const {
+        return _features.is_active(
+          features::feature::raft_symmetric_reconfiguration_cancel);
+    }
+
+    void try_updating_configuration_version(group_configuration& cfg);
     // args
     vnode _self;
     raft::group_id _group;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -776,10 +776,6 @@ private:
 
     std::optional<model::offset> get_learner_start_offset() const;
 
-    bool use_serde_configuration() const {
-        return _features.is_active(features::feature::raft_config_serde);
-    }
-
     flush_delay_t compute_max_flush_delay() const;
     ss::future<> do_flush();
 

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -311,17 +311,13 @@ group_configuration::group_configuration(
 
 group_configuration::group_configuration(
   std::vector<vnode> initial_nodes, model::revision_id rev)
-  : _version(v_5)
-  , _revision(rev) {
-    _current.voters = std::move(initial_nodes);
-}
+  : group_configuration(std::move(initial_nodes), {}, rev) {}
 
 group_configuration::group_configuration(
   std::vector<vnode> voters,
   std::vector<vnode> learners,
   model::revision_id rev)
-  : _version(v_5)
-  , _revision(rev) {
+  : _revision(rev) {
     _current.voters = std::move(voters);
     _current.learners = std::move(learners);
 }

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -149,6 +149,49 @@ public:
 private:
     void cancel_update_in_transitional_state();
     void cancel_update_in_joint_state();
+
+    group_configuration& _cfg;
+};
+
+class configuration_change_strategy_v6
+  : public group_configuration::configuration_change_strategy {
+public:
+    explicit configuration_change_strategy_v6(group_configuration& cfg)
+      : _cfg(cfg) {}
+
+    void add_broker(model::broker, model::revision_id) final {
+        vassert(
+          false,
+          "broker based api is not supported in configuration version 6");
+    }
+    void remove_broker(model::node_id) final {
+        vassert(
+          false,
+          "broker based api is not supported in configuration version 6");
+    }
+    void
+    replace_brokers(std::vector<broker_revision>, model::revision_id) final {
+        vassert(
+          false,
+          "broker based api is not supported in configuration version 6");
+    }
+
+    void add(vnode, model::revision_id, std::optional<model::offset>) final;
+    void replace(
+      std::vector<vnode>,
+      model::revision_id,
+      std::optional<model::offset>) final;
+    void remove(vnode, model::revision_id) final;
+
+    void discard_old_config() final;
+    void abort_configuration_change(model::revision_id) final;
+    void cancel_configuration_change(model::revision_id) final;
+    void finish_configuration_transition() final;
+    void fill_learners_with_nodes_to_add();
+
+private:
+    void cancel_update_in_transitional_state();
+    void cancel_update_in_joint_state();
     group_configuration& _cfg;
 };
 
@@ -310,7 +353,9 @@ group_configuration::group_configuration(
 
 std::unique_ptr<group_configuration::configuration_change_strategy>
 group_configuration::make_change_strategy() {
-    if (_version >= v_5) {
+    if (_version >= v_7) {
+        return std::make_unique<configuration_change_strategy_v6>(*this);
+    } else if (_version >= v_5) {
         return std::make_unique<configuration_change_strategy_v5>(*this);
     } else if (_version == v_4) {
         return std::make_unique<configuration_change_strategy_v4>(*this);
@@ -1187,6 +1232,192 @@ void configuration_change_strategy_v5::discard_old_config() {
     _cfg._configuration_update.reset();
 }
 
+/**
+ * configuration_change_strategy_v6 differs from the previous versions as it
+ * makes the reconfiguration cancellation process symmetric. With this strategy
+ * when configuration is representing reconfiguration from replicas set A to
+ * replica set B (A -> B) the cancellation process will make the reconfiguration
+ * to change direction (B -> A). Reconfiguration strategy v6 allows to toggle
+ * the direction again i.e. cancellation of reconfiguration from B to A will
+ * make the reconfiguration to go from A to B again.
+ *
+ * The difference between v6 and v5 is that v6 does not loose the information
+ * about the update even if it is not strictly required to finish
+ * reconfiguration. The information is kept in the `_configuration_update` field
+ * even when the configuration in in joint state.
+ */
+void configuration_change_strategy_v6::replace(
+  std::vector<vnode> replicas,
+  model::revision_id rev,
+  std::optional<model::offset> learner_start_offset) {
+    _cfg._revision = rev;
+
+    /**
+     * If configurations are identical do nothing. Configurations are considered
+     * equal if requested nodes are voters
+     */
+    bool are_equal = _cfg._current.voters.size() == replicas.size()
+                     && std::all_of(
+                       replicas.begin(),
+                       replicas.end(),
+                       [this](const vnode& vn) { return _cfg.contains(vn); });
+
+    // configurations are identical, do nothing
+    if (are_equal) {
+        return;
+    }
+    // calculate configuration update
+    _cfg._configuration_update = calculate_configuration_update(
+      _cfg._current.voters, replicas);
+    // set learner start offset
+    _cfg._configuration_update->learner_start_offset = learner_start_offset;
+
+    // add replicas to current configuration
+    for (auto& vn : replicas) {
+        if (_cfg._configuration_update->is_to_add(vn)) {
+            _cfg._current.learners.push_back(vn);
+        }
+    }
+
+    // optimization: when there are only nodes to be deleted we may go straight
+    // to the joint configuration
+    if (_cfg._configuration_update->replicas_to_add.empty()) {
+        finish_configuration_transition();
+    }
+}
+
+void configuration_change_strategy_v6::add(
+  vnode node,
+  model::revision_id rev,
+  std::optional<model::offset> learner_start_offset) {
+    if (_cfg._current.contains(node)) {
+        throw std::invalid_argument(fmt::format(
+          "replica {} already found in current configuration {}", node, _cfg));
+    }
+    auto new_replicas = _cfg.all_nodes();
+    new_replicas.push_back(node);
+    replace(new_replicas, rev, learner_start_offset);
+}
+
+void configuration_change_strategy_v6::remove(
+  vnode node, model::revision_id rev) {
+    if (!_cfg._current.contains(node)) {
+        throw std::invalid_argument(fmt::format(
+          "replica {} not found in current configuration {}", node, _cfg));
+    }
+    auto new_replicas = _cfg.all_nodes();
+    std::erase_if(new_replicas, [node](const vnode& v) { return v == node; });
+    replace(new_replicas, rev, std::nullopt);
+}
+
+void configuration_change_strategy_v6::discard_old_config() {
+    _cfg._old.reset();
+    _cfg._configuration_update.reset();
+}
+
+void configuration_change_strategy_v6::abort_configuration_change(
+  model::revision_id revision) {
+    // collect all node ids that the configuration either contains or the one
+    // that were removed
+    absl::flat_hash_set<vnode> all_node_ids;
+
+    _cfg.for_each_learner(
+      [&all_node_ids](const vnode& learner) { all_node_ids.insert(learner); });
+
+    _cfg.for_each_voter(
+      [&all_node_ids](const vnode& voter) { all_node_ids.insert(voter); });
+
+    for (auto& to_remove : _cfg._configuration_update->replicas_to_remove) {
+        all_node_ids.insert(to_remove);
+    }
+
+    // clear the configuration
+    _cfg._current.voters.clear();
+    _cfg._current.learners.clear();
+    _cfg._old.reset();
+
+    // rebuild configuration
+    for (auto& vn : all_node_ids) {
+        if (!_cfg._configuration_update->is_to_add(vn)) {
+            _cfg._current.voters.push_back(vn);
+        }
+    }
+
+    // finally reset configuration update and set the revision
+    _cfg._configuration_update.reset();
+    _cfg._revision = revision;
+}
+
+void configuration_change_strategy_v6::cancel_configuration_change(
+  model::revision_id revision) {
+    switch (_cfg.get_state()) {
+    case configuration_state::simple:
+        vassert(
+          false,
+          "can not cancel, configuration change is not in progress - {}",
+          _cfg);
+    case configuration_state::transitional:
+        cancel_update_in_transitional_state();
+        break;
+    case configuration_state::joint:
+        cancel_update_in_joint_state();
+        break;
+    }
+    _cfg._revision = revision;
+}
+
+void configuration_change_strategy_v6::cancel_update_in_transitional_state() {
+    std::swap(
+      _cfg._configuration_update->replicas_to_add,
+      _cfg._configuration_update->replicas_to_remove);
+
+    // remove all learners that were added
+    std::erase_if(_cfg._current.learners, [this](const vnode& learner) {
+        return _cfg._configuration_update->is_to_remove(learner);
+    });
+
+    fill_learners_with_nodes_to_add();
+    finish_configuration_transition();
+}
+void configuration_change_strategy_v6::fill_learners_with_nodes_to_add() {
+    for (auto& to_add : _cfg._configuration_update->replicas_to_add) {
+        if (!_cfg._current.contains(to_add)) {
+            _cfg._current.learners.push_back(to_add);
+        }
+    }
+}
+void configuration_change_strategy_v6::cancel_update_in_joint_state() {
+    std::swap(
+      _cfg._configuration_update->replicas_to_add,
+      _cfg._configuration_update->replicas_to_remove);
+    _cfg._current = *_cfg._old;
+    _cfg._old.reset();
+
+    fill_learners_with_nodes_to_add();
+}
+
+void configuration_change_strategy_v6::finish_configuration_transition() {
+    if (_cfg.get_state() != configuration_state::transitional) {
+        return;
+    }
+
+    auto has_replicas_to_remove = std::any_of(
+      _cfg._configuration_update->replicas_to_remove.begin(),
+      _cfg._configuration_update->replicas_to_remove.end(),
+      [this](const vnode& v) { return _cfg._current.contains(v); });
+
+    if (!has_replicas_to_remove) {
+        _cfg._configuration_update.reset();
+        return;
+    }
+
+    _cfg._old = _cfg._current;
+
+    std::erase_if(_cfg._current.voters, [this](const vnode& voter) {
+        return _cfg._configuration_update->is_to_remove(voter);
+    });
+}
+
 std::vector<vnode> with_revisions_assigned(
   const std::vector<vnode>& vnodes, model::revision_id new_revision) {
     std::vector<vnode> with_rev;
@@ -1286,14 +1517,67 @@ group_configuration group_configuration::serde_direct_read(
     auto old = serde::read_nested<std::optional<group_nodes>>(
       p, h._bytes_left_limit);
     auto rev = serde::read_nested<model::revision_id>(p, h._bytes_left_limit);
-    return {std::move(current), rev, std::move(update), std::move(old)};
+    group_configuration ret{
+      std::move(current), rev, std::move(update), std::move(old)};
+
+    // if no version is set we assume that configuration is in version 6 (first
+    // that was serde serialized)
+    ret._version = group_configuration::v_6;
+
+    if (h._version >= 7) {
+        auto version = serde::read_nested<version_t>(p, h._bytes_left_limit);
+        ret._version = version;
+    }
+
+    if (p.bytes_left() > h._bytes_left_limit) {
+        p.skip(p.bytes_left() - h._bytes_left_limit);
+    }
+
+    return ret;
 }
 void group_configuration::serde_write(iobuf& out) {
+    using serde::write;
+    serde_write_v6(out);
+    write(out, _version);
+}
+
+void group_configuration::serde_write_v6(iobuf& out) {
     using serde::write;
     write(out, _current);
     write(out, _configuration_update);
     write(out, _old);
     write(out, _revision);
+}
+
+/**
+ * We need custom serde implementation for group_configuration as we can not
+ * simply add a field to it because of the bug in deserialization logic (missing
+ * skip)
+ */
+void tag_invoke(
+  serde::tag_t<serde::write_tag>, iobuf& out, group_configuration cfg) {
+    using serde::write;
+    const bool newer_than_v6 = cfg.version() >= group_configuration::v_7;
+    std::uint8_t s_version
+      = newer_than_v6 ? raft::group_configuration::redpanda_serde_version : 6;
+    write(out, s_version);
+    write(out, group_configuration::redpanda_serde_compat_version);
+
+    auto size_placeholder = out.reserve(sizeof(serde::serde_size_t));
+    const auto size_before = out.size_bytes();
+
+    if (newer_than_v6) {
+        cfg.serde_write(out);
+    } else {
+        cfg.serde_write_v6(out);
+    }
+
+    const auto written_size = out.size_bytes() - size_before;
+
+    const auto size = ss::cpu_to_le(
+      static_cast<serde::serde_size_t>(written_size));
+    size_placeholder.write(
+      reinterpret_cast<const char*>(&size), sizeof(serde::serde_size_t));
 }
 } // namespace raft
 

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -240,7 +240,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "group_configuration_test",
     timeout = "short",
     srcs = [
@@ -256,11 +256,12 @@ redpanda_cc_btest(
         "//src/v/resource_mgmt:io_priority",
         "//src/v/storage",
         "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:unresolved_address",
-        "@boost//:test",
         "@fmt",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -8,17 +8,6 @@ rp_test(
     ARGS "-- -c 8"
 )
 
-rp_test(
-    UNIT_TEST
-    BINARY_NAME group_configuration_tests
-    SOURCES group_configuration_tests.cc
-    DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES Boost::unit_test_framework v::raft
-    LABELS raft
-    ARGS "-- -c 8"
-)
-
-
 set(srcs
     jitter_tests.cc
     bootstrap_configuration_test.cc
@@ -55,6 +44,7 @@ set(gsrcs
     replication_monitor_tests.cc
     mux_state_machine_test.cc
     snapshot_recovery_test.cc
+    group_configuration_tests.cc
 )
 
 rp_test(

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -92,7 +92,9 @@ raft::group_configuration random_configuration() {
 
 SEASTAR_THREAD_TEST_CASE(roundtrip_raft_configuration_entry) {
     for (auto v :
-         {raft::group_configuration::v_5, raft::group_configuration::v_6}) {
+         {raft::group_configuration::v_5,
+          raft::group_configuration::v_6,
+          raft::group_configuration::v_7}) {
         auto cfg = random_configuration();
         cfg.set_version(v);
 

--- a/src/v/raft/tests/group_configuration_tests.cc
+++ b/src/v/raft/tests/group_configuration_tests.cc
@@ -7,12 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "model/metadata.h"
+#include "gmock/gmock.h"
 #include "raft/group_configuration.h"
-#include "test_utils/test.h"
-#include "utils/unresolved_address.h"
+#include "test_utils/randoms.h"
 
 #include <fmt/ostream.h>
+
+#include <ranges>
 
 namespace {
 raft::vnode create_vnode(int32_t id) {
@@ -87,3 +88,511 @@ TEST(
     ASSERT_EQ(test_grp.current_config().voters.size(), 1);
     ASSERT_EQ(test_grp.current_config().learners.size(), 0);
 }
+namespace {
+std::vector<raft::vnode>
+diff(const std::vector<raft::vnode>& lhs, const std::vector<raft::vnode>& rhs) {
+    std::vector<raft::vnode> result;
+    for (auto& lhs_node : lhs) {
+        auto it = std::find(rhs.begin(), rhs.end(), lhs_node);
+        if (it == rhs.end()) {
+            result.push_back(lhs_node);
+        }
+    }
+    return result;
+}
+
+void transition_configuration_update(raft::group_configuration& cfg) {
+    while (cfg.get_state() != raft::configuration_state::simple) {
+        if (cfg.get_state() == raft::configuration_state::joint) {
+            cfg.maybe_demote_removed_voters();
+            cfg.discard_old_config();
+        }
+
+        if (cfg.get_state() == raft::configuration_state::transitional) {
+            if (!cfg.current_config().learners.empty()) {
+                auto learners = cfg.current_config().learners;
+                for (const auto& vnode : learners) {
+                    cfg.promote_to_voter(vnode);
+                }
+            }
+            cfg.finish_configuration_transition();
+        }
+    }
+}
+
+} // namespace
+using namespace ::testing;
+struct configuration_cancel_test_params {
+    configuration_cancel_test_params(
+      std::initializer_list<int> source, std::initializer_list<int> target) {
+        for (auto& s : source) {
+            initial_replica_set.push_back(create_vnode(s));
+        }
+        for (auto t : target) {
+            target_replica_set.push_back(create_vnode(t));
+        }
+    }
+    std::vector<raft::vnode> initial_replica_set;
+    std::vector<raft::vnode> target_replica_set;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const configuration_cancel_test_params&);
+};
+
+std::ostream&
+operator<<(std::ostream& o, const configuration_cancel_test_params& p) {
+    fmt::print(
+      o,
+      "[{}] -> [{}]",
+      fmt::join(
+        std::ranges::views::transform(
+          p.initial_replica_set, [](auto& v) { return v.id(); }),
+        ","),
+      fmt::join(
+        std::ranges::views::transform(
+          p.target_replica_set, [](auto& v) { return v.id(); }),
+        ","));
+    return o;
+}
+
+class ConfigurationCancellationTest
+  : public TestWithParam<configuration_cancel_test_params> {};
+
+/**
+ * This test verifies if cancelling the configuration change twice at any point
+ * will lead to the cancellation being reverted.
+ * example:
+ * replicas are updated from set A to set B
+ *  1. A->B
+ * then a reconfiguration is cancelled
+ *  2. B->A
+ * then the reconfiguration is cancelled again
+ *  3. A->B
+ * Finally the replica set must be equal to B
+ */
+TEST_P(ConfigurationCancellationTest, TestEvenNumberOfCancellations) {
+    const auto params = GetParam();
+
+    const std::vector<raft::vnode> original_replicas
+      = params.initial_replica_set;
+    const std::vector<raft::vnode> target_replicas = params.target_replica_set;
+    const auto to_add = diff(target_replicas, original_replicas);
+    const auto to_remove = diff(original_replicas, target_replicas);
+
+    raft::group_configuration test_cfg = raft::group_configuration(
+      original_replicas, model::revision_id(0));
+    test_cfg.set_version(raft::group_configuration::v_7);
+
+    // trigger reconfiguration
+    test_cfg.replace(target_replicas, model::revision_id{0}, std::nullopt);
+
+    ASSERT_THAT(
+      test_cfg.get_configuration_update()->replicas_to_add,
+      ElementsAreArray(to_add));
+    ASSERT_THAT(
+      test_cfg.get_configuration_update()->replicas_to_remove,
+      ElementsAreArray(to_remove));
+
+    // CASE 1. Cancel right after change was requested
+
+    // cancel configuration change, goes straight to simple state as learner can
+    // be removed immediately
+    auto cfg_1 = test_cfg;
+    cfg_1.cancel_configuration_change(model::revision_id{0});
+    // check if reconfiguration is finished by optimizations
+    if (cfg_1.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(cfg_1.current_config().voters, original_replicas);
+        ASSERT_TRUE(cfg_1.current_config().learners.empty());
+    } else {
+        cfg_1.cancel_configuration_change(model::revision_id{0});
+        transition_configuration_update(cfg_1);
+        ASSERT_EQ(cfg_1.current_config().voters, target_replicas);
+        ASSERT_EQ(cfg_1.get_state(), raft::configuration_state::simple);
+        ASSERT_TRUE(cfg_1.current_config().learners.empty());
+    }
+    // CASE 2. Cancel after learners promotion
+    for (size_t cancel_after = 1; cancel_after <= to_add.size();
+         ++cancel_after) {
+        // create a copy of the configuration for each round
+        auto cfg = test_cfg;
+        for (size_t i = 0; i < cancel_after; ++i) {
+            cfg.promote_to_voter(to_add[i]);
+        }
+        // update the original configuration for the next step
+        if (cancel_after == to_add.size()) {
+            test_cfg = cfg;
+        }
+        cfg.cancel_configuration_change(model::revision_id{0});
+        cfg.cancel_configuration_change(model::revision_id{0});
+
+        transition_configuration_update(cfg);
+
+        ASSERT_EQ(cfg.current_config().voters, target_replicas);
+        ASSERT_EQ(cfg.get_state(), raft::configuration_state::simple);
+        ASSERT_TRUE(cfg.current_config().learners.empty());
+    }
+
+    // now finish the configuration transition as all learners were promoted
+    test_cfg.finish_configuration_transition();
+
+    // CASE 3. Cancel after leaving transitional state
+
+    // check if reconfiguration is finished by optimizations
+    if (test_cfg.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(test_cfg.current_config().voters, target_replicas);
+        ASSERT_TRUE(cfg_1.current_config().learners.empty());
+        return;
+    }
+    // at every step create a copy of test_cfg and execute cancellations against
+    // the copy
+    auto cfg_2 = test_cfg;
+
+    cfg_2.cancel_configuration_change(model::revision_id{0});
+    if (cfg_2.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(cfg_2.current_config().voters, original_replicas);
+        ASSERT_TRUE(cfg_2.current_config().learners.empty());
+    } else {
+        cfg_2.cancel_configuration_change(model::revision_id{0});
+
+        transition_configuration_update(cfg_2);
+
+        ASSERT_EQ(cfg_2.get_state(), raft::configuration_state::simple);
+        ASSERT_EQ(cfg_2.current_config().voters, target_replicas);
+        ASSERT_TRUE(cfg_2.current_config().learners.empty());
+    }
+
+    test_cfg.maybe_demote_removed_voters();
+
+    ASSERT_EQ(test_cfg.get_state(), raft::configuration_state::joint);
+
+    // CASE 4. Cancel after demoting removed voters
+
+    test_cfg.cancel_configuration_change(model::revision_id{0});
+    // check if reconfiguration is finished by optimizations
+    if (test_cfg.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(test_cfg.current_config().voters, original_replicas);
+        ASSERT_TRUE(test_cfg.current_config().learners.empty());
+    } else {
+        test_cfg.cancel_configuration_change(model::revision_id{0});
+        transition_configuration_update(test_cfg);
+        ASSERT_EQ(test_cfg.get_state(), raft::configuration_state::simple);
+        ASSERT_EQ(test_cfg.current_config().voters, target_replicas);
+        ASSERT_TRUE(test_cfg.current_config().learners.empty());
+    }
+}
+
+/**
+ * This test verifies if cancelling the configuration change twice at any point
+ * will lead to the cancellation being reverted.
+ * example:
+ * replicas are updated from set A to set B
+ *  1. A->B
+ * then a reconfiguration is cancelled
+ *  2. B->A
+ * then the reconfiguration is cancelled again
+ *  3. A->B
+ *  finally after last cancellation
+ *  4. B->A
+ *
+ */
+TEST_P(ConfigurationCancellationTest, TestOddNumberOfCancellations) {
+    const auto params = GetParam();
+
+    const std::vector<raft::vnode> original_replicas
+      = params.initial_replica_set;
+    const std::vector<raft::vnode> target_replicas = params.target_replica_set;
+
+    const auto to_add = diff(target_replicas, original_replicas);
+    const auto to_remove = diff(original_replicas, target_replicas);
+
+    raft::group_configuration test_cfg = raft::group_configuration(
+      original_replicas, model::revision_id(0));
+    test_cfg.set_version(raft::group_configuration::v_7);
+
+    // trigger reconfiguration
+    test_cfg.replace(target_replicas, model::revision_id{0}, std::nullopt);
+
+    ASSERT_THAT(
+      test_cfg.get_configuration_update()->replicas_to_add,
+      ElementsAreArray(to_add));
+    ASSERT_THAT(
+      test_cfg.get_configuration_update()->replicas_to_remove,
+      ElementsAreArray(to_remove));
+
+    // CASE 1. Cancel right after change was requested
+
+    // cancel configuration change, goes straight to simple state as learner can
+    // be removed immediately
+    auto cfg_1 = test_cfg;
+    cfg_1.cancel_configuration_change(model::revision_id{0});
+    // check if reconfiguration is finished by optimizations
+    if (cfg_1.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(cfg_1.current_config().voters, original_replicas);
+    } else {
+        cfg_1.cancel_configuration_change(model::revision_id{0});
+        cfg_1.cancel_configuration_change(model::revision_id{0});
+
+        transition_configuration_update(cfg_1);
+        ASSERT_EQ(cfg_1.current_config().voters, original_replicas);
+        ASSERT_EQ(cfg_1.get_state(), raft::configuration_state::simple);
+        ASSERT_TRUE(cfg_1.current_config().learners.empty());
+    }
+    // CASE 2. Cancel after learners promotion
+    for (size_t cancel_after = 1; cancel_after <= to_add.size();
+         ++cancel_after) {
+        // create a copy of the configuration for each round
+        auto cfg = test_cfg;
+        for (size_t i = 0; i < cancel_after; ++i) {
+            cfg.promote_to_voter(to_add[i]);
+        }
+        // update the original configuration for the next step
+        if (cancel_after == to_add.size()) {
+            test_cfg = cfg;
+        }
+        cfg.cancel_configuration_change(model::revision_id{0});
+        cfg.cancel_configuration_change(model::revision_id{0});
+        cfg.cancel_configuration_change(model::revision_id{0});
+
+        transition_configuration_update(cfg);
+
+        ASSERT_EQ(cfg.current_config().voters, original_replicas);
+        ASSERT_EQ(cfg.get_state(), raft::configuration_state::simple);
+        ASSERT_TRUE(cfg.current_config().learners.empty());
+    }
+
+    // now finish the configuration transition as all learners were promoted
+    test_cfg.finish_configuration_transition();
+
+    // CASE 3. Cancel after leaving transitional state
+
+    // check if reconfiguration is finished by optimizations
+    if (test_cfg.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(test_cfg.current_config().voters, target_replicas);
+        return;
+    }
+    // at every step create a copy of test_cfg and execute cancellations against
+    // the copy
+    auto cfg_2 = test_cfg;
+
+    cfg_2.cancel_configuration_change(model::revision_id{0});
+    if (cfg_2.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(cfg_2.current_config().voters, original_replicas);
+        ASSERT_TRUE(cfg_2.current_config().learners.empty());
+    } else {
+        cfg_2.cancel_configuration_change(model::revision_id{0});
+        cfg_2.cancel_configuration_change(model::revision_id{0});
+
+        transition_configuration_update(cfg_2);
+
+        ASSERT_EQ(cfg_2.get_state(), raft::configuration_state::simple);
+        ASSERT_EQ(cfg_2.current_config().voters, original_replicas);
+        ASSERT_TRUE(cfg_2.current_config().learners.empty());
+    }
+
+    test_cfg.maybe_demote_removed_voters();
+
+    ASSERT_EQ(test_cfg.get_state(), raft::configuration_state::joint);
+
+    // CASE 4. Cancel after demoting removed voters
+
+    test_cfg.cancel_configuration_change(model::revision_id{0});
+    // check if reconfiguration is finished by optimizations
+    if (test_cfg.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(test_cfg.current_config().voters, original_replicas);
+        ASSERT_TRUE(test_cfg.current_config().learners.empty());
+        return;
+    }
+    test_cfg.cancel_configuration_change(model::revision_id{0});
+    if (test_cfg.get_state() == raft::configuration_state::simple) {
+        ASSERT_EQ(test_cfg.current_config().voters, target_replicas);
+        ASSERT_TRUE(test_cfg.current_config().learners.empty());
+        return;
+    }
+    test_cfg.cancel_configuration_change(model::revision_id{0});
+    transition_configuration_update(test_cfg);
+    ASSERT_EQ(test_cfg.get_state(), raft::configuration_state::simple);
+    ASSERT_EQ(test_cfg.current_config().voters, original_replicas);
+    ASSERT_TRUE(test_cfg.current_config().learners.empty());
+}
+
+// Simple helper class to handle raft group configuration advancement
+struct configuration_advancement_state_machine {
+    explicit configuration_advancement_state_machine(
+      raft::group_configuration& cfg)
+      : cfg(cfg) {
+        reconcile_state();
+    }
+
+    enum class state {
+        done,
+        learners_promotion,
+        exiting_transitional_state,
+        demoting_voters,
+        exiting_joint_state,
+    };
+
+    enum class direction {
+        original_to_target,
+        target_to_original,
+    };
+
+    friend std::ostream& operator<<(std::ostream& o, state s) {
+        switch (s) {
+        case state::done:
+            return o << "done";
+        case state::learners_promotion:
+            return o << "learners_promotion";
+        case state::demoting_voters:
+            return o << "demoting_voters";
+        case state::exiting_transitional_state:
+            return o << "exiting_transitional_state";
+        case state::exiting_joint_state:
+            return o << "exiting_joint_state";
+        }
+    }
+
+    void advance_state() {
+        switch (current_state) {
+        case state::done:
+            break;
+        case state::learners_promotion:
+            cfg.promote_to_voter(cfg.current_config().learners[0]);
+            reconcile_state();
+            break;
+        case state::exiting_transitional_state:
+            cfg.finish_configuration_transition();
+            reconcile_state();
+            break;
+        case state::demoting_voters:
+            cfg.maybe_demote_removed_voters();
+            reconcile_state();
+            break;
+        case state::exiting_joint_state:
+            cfg.discard_old_config();
+            reconcile_state();
+            break;
+        }
+    }
+
+    void cancel_reconfiguration() {
+        vlog(
+          logger.info,
+          "Cancelling reconfiguration in state: {}",
+          current_state);
+        cfg.cancel_configuration_change(model::revision_id{0});
+        if (dir == direction::original_to_target) {
+            dir = direction::target_to_original;
+        } else {
+            dir = direction::original_to_target;
+        }
+        reconcile_state();
+    }
+    void abort_reconfiguration() {
+        vlog(
+          logger.info, "Aborting reconfiguration in state: {}", current_state);
+        cfg.abort_configuration_change(model::revision_id{0});
+
+        if (dir == direction::original_to_target) {
+            dir = direction::target_to_original;
+        } else {
+            dir = direction::original_to_target;
+        }
+        reconcile_state();
+    }
+    void reconcile_state() {
+        vlog(logger.info, "C: {}", cfg);
+        if (cfg.get_state() == raft::configuration_state::simple) {
+            current_state = state::done;
+        } else if (cfg.get_state() == raft::configuration_state::transitional) {
+            if (!cfg.current_config().learners.empty()) {
+                current_state = state::learners_promotion;
+            } else {
+                current_state = state::exiting_transitional_state;
+            }
+        } else if (cfg.get_state() == raft::configuration_state::joint) {
+            if (cfg.old_config()->learners.empty()) {
+                current_state = state::demoting_voters;
+            } else {
+                current_state = state::exiting_joint_state;
+            }
+        }
+    }
+    ss::logger logger = ss::logger("test-config-stm");
+    direction dir = direction::original_to_target;
+    state current_state = state::done;
+    raft::group_configuration& cfg;
+};
+
+TEST_P(ConfigurationCancellationTest, TestCancellationAfterAdvancement) {
+    const auto params = GetParam();
+
+    const std::vector<raft::vnode> original_replicas
+      = params.initial_replica_set;
+    const std::vector<raft::vnode> target_replicas = params.target_replica_set;
+
+    const auto to_add = diff(target_replicas, original_replicas);
+    const auto to_remove = diff(original_replicas, target_replicas);
+    // execute the test multiple times
+    for (int i = 0; i < 5000; ++i) {
+        raft::group_configuration test_cfg = raft::group_configuration(
+          original_replicas, model::revision_id(0));
+        test_cfg.set_version(raft::group_configuration::v_7);
+
+        // trigger reconfiguration
+        test_cfg.replace(target_replicas, model::revision_id{0}, std::nullopt);
+
+        configuration_advancement_state_machine stm(test_cfg);
+        /**
+         * Try advancing state until the reconfiguration is done, cancel in
+         * random points
+         */
+        while (stm.current_state
+               != configuration_advancement_state_machine::state::done) {
+            if (tests::random_bool()) {
+                if (tests::random_bool()) {
+                    stm.cancel_reconfiguration();
+                } else {
+                    stm.abort_reconfiguration();
+                }
+            }
+            stm.advance_state();
+        }
+        // at some point the configuration will end up in simple state, the
+        // direction defines if the expected replica set is the original or the
+        // target
+        if (
+          stm.dir
+          == configuration_advancement_state_machine::direction::
+            original_to_target) {
+            ASSERT_THAT(
+              test_cfg.current_config().voters,
+              UnorderedElementsAreArray(target_replicas));
+        } else {
+            ASSERT_THAT(
+              test_cfg.current_config().voters,
+              UnorderedElementsAreArray(original_replicas));
+        }
+        ASSERT_TRUE(test_cfg.current_config().learners.empty());
+    }
+}
+
+auto params = Values(
+  configuration_cancel_test_params({0}, {1}),
+  configuration_cancel_test_params({0, 1, 2}, {0, 1, 3}),
+  configuration_cancel_test_params({0, 1, 2}, {10, 11, 12}),
+  configuration_cancel_test_params({0, 1, 2}, {0}),
+  configuration_cancel_test_params({0}, {0, 1, 3}),
+  configuration_cancel_test_params({10}, {0, 1, 3}),
+  configuration_cancel_test_params({0, 1, 2}, {10}),
+  configuration_cancel_test_params({0, 1, 2, 3, 4}, {3, 10, 11}),
+  configuration_cancel_test_params({0, 1, 2}, {0, 1, 2, 3, 4}),
+  configuration_cancel_test_params({0, 1}, {10, 11}));
+
+INSTANTIATE_TEST_SUITE_P(
+  TestEvenNumberOfCancellations, ConfigurationCancellationTest, params);
+
+INSTANTIATE_TEST_SUITE_P(
+  TestOddNumberOfCancellations, ConfigurationCancellationTest, params);
+
+INSTANTIATE_TEST_SUITE_P(
+  TestCancellationAfterAdvancement, ConfigurationCancellationTest, params);

--- a/src/v/raft/tests/group_configuration_tests.cc
+++ b/src/v/raft/tests/group_configuration_tests.cc
@@ -9,112 +9,81 @@
 
 #include "model/metadata.h"
 #include "raft/group_configuration.h"
+#include "test_utils/test.h"
 #include "utils/unresolved_address.h"
 
-#include <boost/test/tools/old/interface.hpp>
 #include <fmt/ostream.h>
-#define BOOST_TEST_MODULE raft
-#include "raft/types.h"
 
-#include <boost/test/unit_test.hpp>
-
-model::broker create_broker(int32_t id) {
-    return model::broker(
-      model::node_id{id},
-      net::unresolved_address("127.0.0.1", 9002),
-      net::unresolved_address("127.0.0.1", 1234),
-      std::nullopt,
-      model::broker_properties{});
+namespace {
+raft::vnode create_vnode(int32_t id) {
+    return {model::node_id(id), model::revision_id(0)};
 }
 
-BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_learner) {
-    raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(1)}, model::revision_id(0));
-
-    auto contains = test_grp.contains_broker(model::node_id(1));
-    BOOST_REQUIRE_EQUAL(contains, true);
+raft::group_configuration create_configuration(std::vector<raft::vnode> nodes) {
+    return {std::move(nodes), model::revision_id(0)};
 }
 
-BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_voter) {
-    raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(1)}, model::revision_id(0));
+} // namespace
 
-    auto contains = test_grp.contains_broker(model::node_id(1));
-    BOOST_REQUIRE_EQUAL(contains, true);
-}
+TEST(test_raft_group_configuration, test_demoting_removed_voters) {
+    raft::group_configuration test_grp = create_configuration(
+      {create_vnode(3)});
 
-BOOST_AUTO_TEST_CASE(should_return_false_as_it_does_not_contain_machine) {
-    raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(3)}, model::revision_id(0));
-
-    auto contains = test_grp.contains_broker(model::node_id(1));
-    BOOST_REQUIRE_EQUAL(contains, false);
-}
-
-BOOST_AUTO_TEST_CASE(test_demoting_removed_voters) {
-    raft::group_configuration test_grp = raft::group_configuration(
-      std::vector<model::broker>{create_broker(3)}, model::revision_id(0));
-
-    // add brokers
-    test_grp.add_broker(create_broker(1), model::revision_id{0});
+    // add nodes
+    test_grp.add(create_vnode(1), model::revision_id{0}, std::nullopt);
     test_grp.promote_to_voter(
       raft::vnode(model::node_id{1}, model::revision_id(0)));
     test_grp.finish_configuration_transition();
 
-    test_grp.add_broker(create_broker(2), model::revision_id{0});
+    test_grp.add(create_vnode(2), model::revision_id{0}, std::nullopt);
     test_grp.promote_to_voter(
       raft::vnode(model::node_id{2}, model::revision_id(0)));
     test_grp.finish_configuration_transition();
 
     test_grp.finish_configuration_transition();
     // remove single broker
-    test_grp.remove_broker(model::node_id(1));
+    test_grp.remove(create_vnode(1), model::revision_id{0});
     // finish configuration transition
 
-    auto demoted = test_grp.maybe_demote_removed_voters();
-    BOOST_REQUIRE_EQUAL(demoted, true);
-    BOOST_REQUIRE_EQUAL(test_grp.old_config()->voters.size(), 2);
+    ASSERT_TRUE(test_grp.maybe_demote_removed_voters());
+    ASSERT_EQ(test_grp.old_config()->voters.size(), 2);
     // node 0 was demoted since it was removed from the cluster
-    BOOST_REQUIRE_EQUAL(
-      test_grp.old_config()->learners[0],
-      raft::vnode(model::node_id{1}, model::revision_id(0)));
+    ASSERT_EQ(test_grp.old_config()->learners[0], create_vnode(1));
     // assert that operation is idempotent
-    demoted = test_grp.maybe_demote_removed_voters();
-    BOOST_REQUIRE_EQUAL(demoted, false);
+    ASSERT_FALSE(test_grp.maybe_demote_removed_voters());
 }
 
-BOOST_AUTO_TEST_CASE(test_aborting_configuration_change) {
+TEST(test_raft_group_configuration, test_aborting_configuration_change) {
     raft::group_configuration test_grp = raft::group_configuration(
-      std::vector<model::broker>{create_broker(3)}, model::revision_id(0));
+      {create_vnode(3)}, model::revision_id(0));
 
-    auto original_brokers = test_grp.brokers();
     auto original_voters = test_grp.current_config().voters;
-
+    auto original_nodes = test_grp.all_nodes();
     // add brokers
-    test_grp.add_broker(create_broker(1), model::revision_id{0});
+    test_grp.add(create_vnode(1), model::revision_id{0}, std::nullopt);
 
     // abort change
     test_grp.abort_configuration_change(model::revision_id{1});
 
-    BOOST_REQUIRE_EQUAL(
-      test_grp.get_state(), raft::configuration_state::simple);
-    BOOST_REQUIRE_EQUAL(test_grp.brokers(), original_brokers);
-    BOOST_REQUIRE_EQUAL(test_grp.current_config().voters, original_voters);
+    ASSERT_EQ(test_grp.get_state(), raft::configuration_state::simple);
+    ASSERT_EQ(test_grp.current_config().voters, original_voters);
+    ASSERT_EQ(test_grp.all_nodes(), original_nodes);
 }
 
-BOOST_AUTO_TEST_CASE(test_reverting_configuration_change_when_adding) {
+TEST(
+  test_raft_group_configuration,
+  test_reverting_configuration_change_when_adding) {
     raft::group_configuration test_grp = raft::group_configuration(
-      std::vector<model::broker>{create_broker(3)}, model::revision_id(0));
+      {create_vnode(3)}, model::revision_id(0));
 
     // add brokers
-    test_grp.add_broker(create_broker(1), model::revision_id{0});
+    test_grp.add(create_vnode(1), model::revision_id{0}, std::nullopt);
 
     // abort change
     test_grp.cancel_configuration_change(model::revision_id{1});
 
-    BOOST_REQUIRE_EQUAL(
-      test_grp.get_state(), raft::configuration_state::simple);
-    BOOST_REQUIRE_EQUAL(test_grp.brokers().size(), 1);
-    BOOST_REQUIRE_EQUAL(test_grp.current_config().voters.size(), 1);
-    BOOST_REQUIRE_EQUAL(test_grp.current_config().learners.size(), 0);
+    ASSERT_EQ(test_grp.get_state(), raft::configuration_state::simple);
+    ASSERT_EQ(test_grp.all_nodes().size(), 1);
+    ASSERT_EQ(test_grp.current_config().voters.size(), 1);
+    ASSERT_EQ(test_grp.current_config().learners.size(), 0);
 }


### PR DESCRIPTION
In order to support cancellation of raft group reconfiguration
cancellation we must make the cancel operation symmetric. This means
that when reconfiguration is cancelled twice it must lead to the same
outcome as it would not be cancelled at all.

This commit introduces a new `raft::group_configuration` version
together with a new reconfiguration strategy. This is a first step
towards allowing cancelling cancellations in controller.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none