### PR TITLE
[rptest] Remove Azure-specific logic for critical topics

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -854,17 +854,12 @@ class CloudCluster():
         # Check topic count
         self._logger.info("Checking cluster topics")
         _topics = self._query_panda_proxy("/topics")
-        # For Azure, connect is in development
-        if self.config.provider == PROVIDER_AZURE:
-            _critical = ["_schemas", "_redpanda_e2e_probe"]
-            required_critical_topic_count = 2
-        else:
-            _critical = [
-                "_schemas", "__redpanda.connectors_logs",
-                "_internal_connectors_status", "_internal_connectors_configs",
-                "_redpanda_e2e_probe", "_internal_connectors_offsets"
-            ]
-            required_critical_topic_count = 6
+        _critical = [
+            "_schemas", "__redpanda.connectors_logs",
+            "_internal_connectors_status", "_internal_connectors_configs",
+            "_redpanda_e2e_probe", "_internal_connectors_offsets"
+        ]
+        required_critical_topic_count = 6
 
         _intersect = list(set(_topics) & set(_critical))
         if len(_intersect) < required_critical_topic_count:


### PR DESCRIPTION
Marat mentioned this last week; this particular Azure-specific code was always intended to be temporary, so let's see if it's still necessary or not, and if not, remove it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none