### PR TITLE
[CORE-8392] http: Shutdown connection if shutdown_now was called

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -194,7 +194,11 @@ ss::future<> client_pool::stop() {
 }
 
 void client_pool::shutdown_connections() {
-    vlog(pool_log.info, "Shutting down client pool: {}", _pool.size());
+    vlog(
+      pool_log.info,
+      "Shutting down client pool: {} ({} connections leased)",
+      _pool.size(),
+      _leased.size());
 
     _as.request_abort();
     _cvar.broken();

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -202,6 +202,11 @@ ss::future<reconnect_result_t> client::get_connected(
             vlog(
               ctxlog.debug,
               "Stopping connect attempts due to shutdown request");
+            if (is_valid()) {
+                // We might have established connection at this point
+                // which has to be closed.
+                shutdown();
+            }
             co_return reconnect_result_t::timed_out;
         }
         current = ss::lowres_clock::now();


### PR DESCRIPTION
If `shutdown_now` was called we may still establish the connection. In this case we're still returning the time_out error but the http connection remains in wrong state. To fix this this PR adds `shutdown` call if `shutdown_now` was called and we're attempting to exit the connection loop ASAP.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none