### PR TITLE
`rptest`: deflake `max_translated_offset()`

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -160,7 +160,7 @@ class DatalakeServices():
             self.redpanda.logger.debug(
                 f"Current translated offsets: {offsets}")
             return all([
-                offset and offset <= max_offset
+                max_offset and offset <= max_offset
                 for _, max_offset in offsets.items()
             ])
 


### PR DESCRIPTION
The wrong variable was being checked for `None` here.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
