### PR TITLE
[CORE-8160] `storage`: add chunked compaction routine

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -15,6 +15,8 @@
 #include "model/record_batch_types.h"
 #include "model/record_utils.h"
 #include "random/generators.h"
+#include "storage/compacted_index.h"
+#include "storage/compaction.h"
 #include "storage/index_state.h"
 #include "storage/logger.h"
 #include "storage/parser_utils.h"
@@ -22,6 +24,7 @@
 #include "storage/segment_utils.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 
 #include <absl/algorithm/container.h>
 #include <boost/range/irange.hpp>
@@ -431,6 +434,47 @@ ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
         }
     }
     co_return co_await _delegate(std::move(b));
+}
+
+ss::future<ss::stop_iteration>
+map_building_reducer::operator()(model::record_batch batch) {
+    bool fully_indexed_batch = true;
+    // There is no point to indexing records in uncompactible batches, since
+    // their inclusion in the segment post compaction is irrespective of the map
+    // state (see copy_data_segment_reducer::filter()).
+    if (!is_compactible(batch)) {
+        co_return ss::stop_iteration::no;
+    }
+    auto b = co_await decompress_batch(std::move(batch));
+    co_await b.for_each_record_async(
+      [this,
+       &fully_indexed_batch,
+       base_offset = b.base_offset(),
+       type = b.header().type,
+       is_control = b.header().attrs.is_control()](
+        model::record r) -> ss::future<ss::stop_iteration> {
+          auto offset = base_offset + model::offset_delta(r.offset_delta());
+          if (offset < _start_offset) {
+              return ss::make_ready_future<ss::stop_iteration>(
+                ss::stop_iteration::no);
+          }
+          auto key_view = iobuf_to_bytes(r.key());
+          auto key = enhance_key(type, is_control, key_view);
+          return _map->put(key, offset)
+            .then([&fully_indexed_batch](bool success) -> ss::stop_iteration {
+                if (success) {
+                    return ss::stop_iteration::no;
+                }
+                fully_indexed_batch = false;
+                return ss::stop_iteration::yes;
+            });
+      });
+
+    if (fully_indexed_batch) {
+        co_return ss::stop_iteration::no;
+    }
+    _fully_indexed_segment = false;
+    co_return ss::stop_iteration::yes;
 }
 
 } // namespace storage::internal

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -25,6 +25,7 @@
 #include "storage/logger.h"
 #include "utils/tracking_allocator.h"
 
+#include <seastar/core/loop.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <absl/container/btree_map.h>
@@ -295,6 +296,13 @@ public:
     bool end_of_stream() { return _fully_indexed_segment; }
 
 private:
+    ss::future<ss::stop_iteration> maybe_index_record_in_map(
+      const model::record& r,
+      model::offset base_offset,
+      model::record_batch_type type,
+      bool is_control,
+      bool& fully_indexed_batch);
+
     key_offset_map* _map;
     model::offset _start_offset;
     bool _fully_indexed_segment = true;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -25,6 +25,7 @@
 #include "storage/compacted_offset_list.h"
 #include "storage/compaction_reducers.h"
 #include "storage/disk_log_appender.h"
+#include "storage/exceptions.h"
 #include "storage/fwd.h"
 #include "storage/key_offset_map.h"
 #include "storage/kvstore.h"
@@ -646,9 +647,14 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
                             ? dynamic_cast<key_offset_map&>(*cfg.hash_key_map)
                             : dynamic_cast<key_offset_map&>(*simple_map);
     model::offset idx_start_offset;
+    bool needs_chunked_sliding_window_compact = false;
     try {
         idx_start_offset = co_await build_offset_map(
           cfg, segs, _stm_manager, _manager.resources(), *_probe, map);
+    } catch (const zero_segments_indexed_exception&) {
+        // We failed to index even one segment (the last entry of the segs set).
+        // Perform chunked compaction on it.
+        needs_chunked_sliding_window_compact = true;
     } catch (...) {
         auto eptr = std::current_exception();
         if (ssx::is_shutdown_exception(eptr)) {
@@ -666,6 +672,11 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         _last_compaction_window_start_offset.reset();
         co_return false;
     }
+
+    if (needs_chunked_sliding_window_compact) {
+        co_return co_await chunked_sliding_window_compact(cfg, segs, map);
+    }
+
     vlog(
       gclog.debug,
       "[{}] built offset map with {} keys (max allowed {}), min segment fully "
@@ -1189,6 +1200,90 @@ ss::future<> disk_log_impl::do_compact(
         // segment compaction.
         co_await compact_adjacent_segments(compact_cfg);
     }
+}
+
+ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
+  const compaction_config& compact_cfg,
+  const segment_set& segs,
+  key_offset_map& map) {
+    // The unindexed segment.
+    auto seg = segs.back();
+    vlog(
+      gclog.debug,
+      "Unable to fully index segment with max allowed keys {}. Performing "
+      "chunked sliding window compaction for segment {}",
+      map.capacity(),
+      seg);
+
+    auto last_indexed_offset = model::offset{};
+    bool segment_fully_indexed = false;
+
+    // Hold the segment rewrite lock for the entirety of the chunked compaction
+    // routine. index_chunk_of_segment_for_map() will repeatedly obtain and
+    // release a seg->read_lock(), and rewriting of each segment in the window
+    // happens multiple times in the below while() loop.
+    auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
+    while (!segment_fully_indexed) {
+        if (compact_cfg.asrc) {
+            compact_cfg.asrc->check();
+        }
+
+        segment_fully_indexed = co_await index_chunk_of_segment_for_map(
+          compact_cfg, seg, map, *_probe, std::ref(last_indexed_offset));
+
+        for (auto& s : segs) {
+            if (compact_cfg.asrc) {
+                compact_cfg.asrc->check();
+            }
+
+            // Neither of these flags are true until chunked compaction is
+            // complete
+            static const bool is_finished_window_compaction = false;
+            static const bool is_clean_compacted = false;
+            co_await rewrite_segment_with_offset_map(
+              compact_cfg,
+              s,
+              map,
+              is_finished_window_compaction,
+              is_clean_compacted);
+        }
+    }
+
+    // Segments can now be marked as finished window compaction
+    for (auto& s : segs) {
+        co_await internal::mark_segment_as_finished_window_compaction(
+          s, false, *_probe);
+    }
+
+    // We can also mark the last segment as cleanly compacted now
+    co_await internal::mark_segment_as_finished_window_compaction(
+      seg, true, *_probe);
+
+    _last_compaction_window_start_offset = seg->offsets().get_base_offset();
+
+    // It is possible that chunked compaction on the last segment in the set
+    // resulted in all of the segments with compactible records being cleanly
+    // compacted. In this case, we need to reset the
+    // _last_compaction_window_start_offset.
+    const bool sliding_window_round_complete = std::ranges::all_of(
+      segs, [](const auto& s) {
+          if (!s->may_have_compactible_records()) {
+              return true;
+          }
+          return s->index().has_clean_compact_timestamp();
+      });
+
+    if (sliding_window_round_complete) {
+        _probe->add_sliding_window_round_complete();
+        _last_compaction_window_start_offset.reset();
+    }
+
+    vlog(
+      gclog.trace,
+      "Finished chunked sliding window compaction for segment {}",
+      seg);
+
+    co_return true;
 }
 
 ss::future<> disk_log_impl::rewrite_segment_with_offset_map(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -698,147 +698,15 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         if (cfg.asrc) {
             cfg.asrc->check();
         }
+
         // A segment is considered "clean" if it has been fully indexed (all
         // keys are de-duplicated)
+        const bool is_finished_window_compaction = true;
         const bool is_clean_compacted = seg->offsets().get_base_offset()
                                         >= idx_start_offset;
-        if (seg->offsets().get_base_offset() > map.max_offset()) {
-            // The map was built from newest to oldest segments within this
-            // sliding range. If we see a new segment whose offsets are all
-            // higher than those indexed, it may be because the segment is
-            // entirely comprised of non-data batches. Mark it as compacted so
-            // we can progress through compactions.
-            co_await internal::mark_segment_as_finished_window_compaction(
-              seg, is_clean_compacted, *_probe);
 
-            vlog(
-              gclog.debug,
-              "[{}] treating segment as compacted, offsets fall above highest "
-              "indexed key {}, likely because they are non-data batches: {}",
-              config().ntp(),
-              map.max_offset(),
-              seg->filename());
-            continue;
-        }
-        if (!seg->may_have_compactible_records()) {
-            // All data records are already compacted away. Skip to avoid a
-            // needless rewrite.
-            co_await internal::mark_segment_as_finished_window_compaction(
-              seg, is_clean_compacted, *_probe);
-
-            vlog(
-              gclog.trace,
-              "[{}] treating segment as compacted, either all non-data "
-              "records or the only record is a data record: {}",
-              config().ntp(),
-              seg->filename());
-            continue;
-        }
-
-        // TODO: implement a segment replacement strategy such that each term
-        // tries to write only one segment (or more if the term had a large
-        // amount of data), rather than replacing N segments with N segments.
-        const auto tmpname = seg->reader().path().to_compaction_staging();
-        const auto cmp_idx_tmpname = tmpname.to_compacted_index();
-        auto staging_to_clean = scoped_file_tracker{
-          cfg.files_to_cleanup, {tmpname, cmp_idx_tmpname}};
-
-        auto appender = co_await internal::make_segment_appender(
-          tmpname,
-          segment_appender::write_behind_memory
-            / internal::chunks().chunk_size(),
-          std::nullopt,
-          cfg.iopc,
-          resources(),
-          cfg.sanitizer_config);
-
-        auto cmp_idx_name = seg->path().to_compacted_index();
-        auto compacted_idx_writer = make_file_backed_compacted_index(
-          cmp_idx_tmpname, cfg.iopc, true, resources(), cfg.sanitizer_config);
-
-        vlog(
-          gclog.debug,
-          "[{}] Deduplicating data from segment {} to {}: {}",
-          config().ntp(),
-          seg->path(),
-          tmpname,
-          seg);
-        auto initial_generation_id = seg->get_generation_id();
-        std::exception_ptr eptr;
-        index_state new_idx;
-        try {
-            new_idx = co_await deduplicate_segment(
-              cfg,
-              map,
-              seg,
-              *appender,
-              compacted_idx_writer,
-              *_probe,
-              storage::internal::should_apply_delta_time_offset(_feature_table),
-              _feature_table);
-
-        } catch (...) {
-            eptr = std::current_exception();
-        }
-        // We must close the segment apender
-        co_await compacted_idx_writer.close();
-        co_await appender->close();
-        if (eptr) {
-            std::rethrow_exception(eptr);
-        }
-
-        vlog(
-          gclog.debug,
-          "[{}] Replacing segment {} with {}",
-          config().ntp(),
-          seg->path(),
-          tmpname);
-
-        auto rdr_holder = co_await _readers_cache->evict_segment_readers(seg);
-        auto write_lock = co_await seg->write_lock();
-        if (initial_generation_id != seg->get_generation_id()) {
-            throw std::runtime_error(fmt::format(
-              "Aborting compaction of segment: {}, segment was mutated "
-              "while compacting",
-              seg->path()));
-        }
-        if (seg->is_closed()) {
-            throw segment_closed_exception();
-        }
-        const auto size_before = seg->size_bytes();
-        const auto size_after = appender->file_byte_offset();
-
-        // Clear our indexes before swapping the data files (note, the new
-        // compaction index was opened with the truncate option above).
-        co_await seg->index().drop_all_data();
-
-        // Rename the data file.
-        co_await internal::do_swap_data_file_handles(
-          tmpname, seg, cfg, *_probe);
-
-        // Persist the state of our indexes in their new names.
-        seg->index().swap_index_state(std::move(new_idx));
-        seg->force_set_commit_offset_from_index();
-        seg->release_batch_cache_index();
-
-        // Mark the segment as completed window compaction, and possibly set the
-        // clean_compact_timestamp in it's index.
-        co_await internal::mark_segment_as_finished_window_compaction(
-          seg, is_clean_compacted, *_probe);
-
-        co_await seg->index().flush();
-        co_await ss::rename_file(
-          cmp_idx_tmpname.string(), cmp_idx_name.string());
-        _probe->segment_compacted();
-        _probe->add_compaction_removed_bytes(
-          ssize_t(size_before) - ssize_t(size_after));
-
-        compaction_result res(size_before, size_after);
-        _compaction_ratio.update(res.compaction_ratio());
-        seg->advance_generation();
-        staging_to_clean.clear();
-        vlog(
-          gclog.debug, "[{}] Final compacted segment {}", config().ntp(), seg);
+        co_await rewrite_segment_with_offset_map(
+          cfg, seg, map, is_finished_window_compaction, is_clean_compacted);
     }
 
     _last_compaction_window_start_offset = next_window_start_offset;
@@ -1321,6 +1189,149 @@ ss::future<> disk_log_impl::do_compact(
         // segment compaction.
         co_await compact_adjacent_segments(compact_cfg);
     }
+}
+
+ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
+  const compaction_config& cfg,
+  ss::lw_shared_ptr<segment> seg,
+  key_offset_map& map,
+  bool is_finished_window_compaction,
+  bool is_clean_compacted) {
+    if (seg->offsets().get_base_offset() > map.max_offset()) {
+        // The map was built from newest to oldest segments within this
+        // sliding range. If we see a new segment whose offsets are all
+        // higher than those indexed, it may be because the segment is
+        // entirely comprised of non-data batches. Mark it as compacted so
+        // we can progress through compactions.
+        co_await internal::mark_segment_as_finished_window_compaction(
+          seg, is_clean_compacted, *_probe);
+
+        vlog(
+          gclog.debug,
+          "[{}] treating segment as compacted, offsets fall above highest "
+          "indexed key {}, likely because they are non-data batches: {}",
+          config().ntp(),
+          map.max_offset(),
+          seg->filename());
+        co_return;
+    }
+    if (!seg->may_have_compactible_records()) {
+        // All data records are already compacted away. Skip to avoid a
+        // needless rewrite.
+        co_await internal::mark_segment_as_finished_window_compaction(
+          seg, is_clean_compacted, *_probe);
+
+        vlog(
+          gclog.trace,
+          "[{}] treating segment as compacted, either all non-data "
+          "records or the only record is a data record: {}",
+          config().ntp(),
+          seg->filename());
+        co_return;
+    }
+
+    // TODO: implement a segment replacement strategy such that each term
+    // tries to write only one segment (or more if the term had a large
+    // amount of data), rather than replacing N segments with N segments.
+    const auto tmpname = seg->reader().path().to_compaction_staging();
+    const auto cmp_idx_tmpname = tmpname.to_compacted_index();
+    auto staging_to_clean = scoped_file_tracker{
+      cfg.files_to_cleanup, {tmpname, cmp_idx_tmpname}};
+
+    auto appender = co_await internal::make_segment_appender(
+      tmpname,
+      segment_appender::write_behind_memory / internal::chunks().chunk_size(),
+      std::nullopt,
+      cfg.iopc,
+      resources(),
+      cfg.sanitizer_config);
+
+    auto cmp_idx_name = seg->path().to_compacted_index();
+    auto compacted_idx_writer = make_file_backed_compacted_index(
+      cmp_idx_tmpname, cfg.iopc, true, resources(), cfg.sanitizer_config);
+
+    vlog(
+      gclog.debug,
+      "[{}] Deduplicating data from segment {} to {}: {}",
+      config().ntp(),
+      seg->path(),
+      tmpname,
+      seg);
+    auto initial_generation_id = seg->get_generation_id();
+    std::exception_ptr eptr;
+    index_state new_idx;
+    try {
+        new_idx = co_await deduplicate_segment(
+          cfg,
+          map,
+          seg,
+          *appender,
+          compacted_idx_writer,
+          *_probe,
+          storage::internal::should_apply_delta_time_offset(_feature_table),
+          _feature_table);
+
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+    // We must close the segment apender
+    co_await compacted_idx_writer.close();
+    co_await appender->close();
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
+
+    vlog(
+      gclog.debug,
+      "[{}] Replacing segment {} with {}",
+      config().ntp(),
+      seg->path(),
+      tmpname);
+
+    auto rdr_holder = co_await _readers_cache->evict_segment_readers(seg);
+    auto write_lock = co_await seg->write_lock();
+    if (initial_generation_id != seg->get_generation_id()) {
+        throw std::runtime_error(fmt::format(
+          "Aborting compaction of segment: {}, segment was mutated "
+          "while compacting",
+          seg->path()));
+    }
+    if (seg->is_closed()) {
+        throw segment_closed_exception();
+    }
+    const auto size_before = seg->size_bytes();
+    const auto size_after = appender->file_byte_offset();
+
+    // Clear our indexes before swapping the data files (note, the new
+    // compaction index was opened with the truncate option above).
+    co_await seg->index().drop_all_data();
+
+    // Rename the data file.
+    co_await internal::do_swap_data_file_handles(tmpname, seg, cfg, *_probe);
+
+    // Persist the state of our indexes in their new names.
+    seg->index().swap_index_state(std::move(new_idx));
+    seg->force_set_commit_offset_from_index();
+    seg->release_batch_cache_index();
+
+    if (is_finished_window_compaction) {
+        // Mark the segment as completed window compaction, and possibly set the
+        // clean_compact_timestamp in it's index.
+        co_await internal::mark_segment_as_finished_window_compaction(
+          seg, is_clean_compacted, *_probe);
+    }
+
+    co_await seg->index().flush();
+    co_await ss::rename_file(cmp_idx_tmpname.string(), cmp_idx_name.string());
+    _probe->segment_compacted();
+    _probe->add_compaction_removed_bytes(
+      ssize_t(size_before) - ssize_t(size_after));
+
+    compaction_result res(size_before, size_after);
+    _compaction_ratio.update(res.compaction_ratio());
+    seg->advance_generation();
+    staging_to_clean.clear();
+    vlog(gclog.debug, "[{}] Final compacted segment {}", config().ntp(), seg);
 }
 
 ss::future<> disk_log_impl::gc(gc_config cfg) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1260,6 +1260,7 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
       seg, true, *_probe);
 
     _last_compaction_window_start_offset = seg->offsets().get_base_offset();
+    _probe->add_chunked_compaction_run();
 
     // It is possible that chunked compaction on the last segment in the set
     // resulted in all of the segments with compactible records being cleanly

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -233,6 +233,13 @@ public:
       const compaction_config& cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
+    ss::future<> rewrite_segment_with_offset_map(
+      const compaction_config& cfg,
+      ss::lw_shared_ptr<segment> seg,
+      key_offset_map& map,
+      bool is_finished_window_compaction,
+      bool is_clean_compacted);
+
     const auto& compaction_ratio() const { return _compaction_ratio; }
 
     static ss::future<> copy_kvstore_state(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -240,6 +240,11 @@ public:
       bool is_finished_window_compaction,
       bool is_clean_compacted);
 
+    ss::future<bool> chunked_sliding_window_compact(
+      const compaction_config& cfg,
+      const segment_set& segs,
+      key_offset_map& map);
+
     const auto& compaction_ratio() const { return _compaction_ratio; }
 
     static ss::future<> copy_kvstore_state(

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -28,3 +28,14 @@ public:
 private:
     ss::sstring _msg;
 };
+
+class zero_segments_indexed_exception : public std::exception {
+public:
+    explicit zero_segments_indexed_exception(ss::sstring s)
+      : _msg(std::move(s)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -48,6 +48,11 @@ model::offset simple_key_offset_map::max_offset() const { return _max_offset; }
 
 size_t simple_key_offset_map::size() const { return _map.size(); }
 size_t simple_key_offset_map::capacity() const { return _max_keys; }
+ss::future<> simple_key_offset_map::reset() {
+    _map.clear();
+    _max_offset = model::offset{};
+    return ss::now();
+};
 
 seastar::future<std::optional<model::offset>>
 hash_key_offset_map::get(const compaction_key& key) const {

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -60,6 +60,13 @@ public:
      * Returns the number of entries the map has space allocated for.
      */
     virtual size_t capacity() const = 0;
+
+    /**
+     * Prepares the container for use in a new context by resetting
+     * every element to an initial state. This call does not change the size of
+     * the container.
+     */
+    virtual seastar::future<> reset() = 0;
 };
 
 /**
@@ -86,6 +93,8 @@ public:
 
     size_t size() const override;
     size_t capacity() const override;
+
+    seastar::future<> reset() override;
 
 private:
     ss::shared_ptr<util::mem_tracker> _memory_tracker;
@@ -136,7 +145,7 @@ public:
      * every element to an initial state. This call does not change the size of
      * the container.
      */
-    seastar::future<> reset();
+    seastar::future<> reset() override;
 
     /**
      * The ratio of hash table searches (e.g. one get or put) to the number of

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -190,7 +190,8 @@ private:
     hash_type::digest_type hash_key(const compaction_key&) const;
 
     mutable hash_type hasher_;
-    chunked_vector<entry> entries_;
+    using entries_t = chunked_vector<entry>;
+    entries_t entries_;
 
     size_t size_{0};
     model::offset max_offset_;

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -221,6 +221,14 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of rounds of sliding window compaction that "
                           "have been driven to completion."),
           labels),
+        sm::make_counter(
+          "chunked_compaction_runs",
+          [this] { return _num_chunked_compaction_runs; },
+          sm::description(
+            "Number of times chunked compaction was ran. This metric also "
+            "corresponds to the number of times the compaction key-offset map "
+            "was unable to be built for a single segment."),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -106,6 +106,8 @@ public:
         ++_num_rounds_window_compaction;
     }
 
+    void add_chunked_compaction_run() { ++_num_chunked_compaction_runs; }
+
     void batch_parse_error() { ++_batch_parse_errors; }
 
     void setup_metrics(const model::ntp&);
@@ -145,12 +147,13 @@ private:
     uint32_t _log_segments_active = 0;
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
+
     double _compaction_ratio = 1.0;
     uint64_t _tombstones_removed = 0;
     uint64_t _segment_cleanly_compacted = 0;
     uint64_t _segments_marked_tombstone_free = 0;
     uint64_t _num_rounds_window_compaction = 0;
-
+    uint64_t _num_chunked_compaction_runs = 0;
     ssize_t _compaction_removed_bytes = 0;
 
     metrics::internal_metric_groups _metrics;

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -107,6 +107,9 @@ public:
     }
 
     void add_chunked_compaction_run() { ++_num_chunked_compaction_runs; }
+    auto get_chunked_compaction_runs() const {
+        return _num_chunked_compaction_runs;
+    }
 
     void batch_parse_error() { ++_batch_parse_errors; }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -12,6 +12,7 @@
 #include "model/timestamp.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
+#include "storage/exceptions.h"
 #include "storage/index_state.h"
 #include "storage/key_offset_map.h"
 #include "storage/probe.h"
@@ -159,7 +160,7 @@ ss::future<model::offset> build_offset_map(
     if (!min_segment_fully_indexed.has_value()) {
         // If we broke out without setting an offset, we failed to index even a
         // single segment, likely because it had too many keys.
-        throw std::runtime_error(
+        throw zero_segments_indexed_exception(
           fmt::format("Couldn't index {}", iter->get()->path()));
     }
     co_return min_segment_fully_indexed.value();

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -22,6 +22,8 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 
+#include <seastar/core/shared_ptr.hh>
+
 #include <exception>
 
 namespace storage {
@@ -253,6 +255,40 @@ ss::future<index_state> deduplicate_segment(
     }
 
     co_return new_idx;
+}
+
+ss::future<bool> index_chunk_of_segment_for_map(
+  const compaction_config& compact_cfg,
+  ss::lw_shared_ptr<segment> seg,
+  key_offset_map& map,
+  probe& pb,
+  model::offset& last_indexed_offset) {
+    co_await map.reset();
+    auto read_holder = co_await seg->read_lock();
+    auto start_offset_inclusive = model::next_offset(last_indexed_offset);
+    auto rdr = internal::create_segment_full_reader(
+      seg, compact_cfg, pb, std::move(read_holder), start_offset_inclusive);
+    internal::map_building_reducer reducer(&map, start_offset_inclusive);
+
+    bool fully_indexed_segment = co_await std::move(rdr).consume(
+      reducer, model::no_timeout);
+
+    last_indexed_offset = map.max_offset();
+    if (fully_indexed_segment) {
+        vlog(
+          gclog.trace,
+          "Finished building offset map for segment {}",
+          seg->reader().filename());
+    } else {
+        vlog(
+          gclog.trace,
+          "Built offset map up to offset {}/{} for segment {}",
+          last_indexed_offset,
+          seg->offsets().get_dirty_offset(),
+          seg->reader().filename());
+    }
+
+    co_return fully_indexed_segment;
 }
 
 } // namespace storage

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -60,4 +60,16 @@ ss::future<index_state> deduplicate_segment(
   ss::sharded<features::feature_table>&,
   bool inject_reader_failure = false);
 
+// Creates a reader for the segment starting from the last_indexed_offset
+// (exclusive) in order to index the next "chunk" of the segment (using the
+// map_building_reducer) for use in deduplication during chunked compaction.
+//
+// Returns true if the segment has been fully indexed, false otherwise.
+ss::future<bool> index_chunk_of_segment_for_map(
+  const compaction_config& compact_cfg,
+  ss::lw_shared_ptr<segment> seg,
+  key_offset_map& map,
+  probe& pb,
+  model::offset& last_indexed_offset);
+
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -473,10 +473,13 @@ model::record_batch_reader create_segment_full_reader(
   ss::lw_shared_ptr<storage::segment> s,
   storage::compaction_config cfg,
   storage::probe& pb,
-  ss::rwlock::holder h) {
+  ss::rwlock::holder h,
+  std::optional<model::offset> start_offset) {
     auto o = s->offsets();
     auto reader_cfg = log_reader_config(
-      o.get_base_offset(), o.get_dirty_offset(), cfg.iopc);
+      start_offset.value_or(o.get_base_offset()),
+      o.get_dirty_offset(),
+      cfg.iopc);
     reader_cfg.skip_batch_cache = true;
     segment_set::underlying_t set;
     set.reserve(1);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -191,7 +191,8 @@ model::record_batch_reader create_segment_full_reader(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
   storage::probe&,
-  ss::rwlock::holder);
+  ss::rwlock::holder,
+  std::optional<model::offset> start_offset = std::nullopt);
 
 ss::future<storage::index_state> do_copy_segment_data(
   ss::lw_shared_ptr<storage::segment>,

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -167,6 +167,16 @@ rp_test(
   ARGS "-- -c 1"
 )
 
+rp_test(
+  FIXTURE_TEST
+  GTEST
+  BINARY_NAME gtest_compaction_reducer
+  SOURCES compaction_reducer_fixture_test.cc
+  LIBRARIES  v::application v::features v::gtest_main v::storage_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)
+
 
 rp_test(
   UNIT_TEST

--- a/src/v/storage/tests/compaction_reducer_fixture_test.cc
+++ b/src/v/storage/tests/compaction_reducer_fixture_test.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "gtest/gtest.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "storage/compaction_reducers.h"
+#include "storage/key_offset_map.h"
+#include "storage/lock_manager.h"
+#include "storage/log_reader.h"
+#include "storage/probe.h"
+#include "storage/segment_deduplication_utils.h"
+#include "storage/segment_set.h"
+#include "storage/segment_utils.h"
+#include "storage/tests/storage_test_fixture.h"
+#include "storage/types.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/defer.hh>
+
+class MapBuildingReducerFixtureTest
+  : public storage_test_fixture
+  , public seastar_test {};
+
+TEST_F(MapBuildingReducerFixtureTest, TestMapIndexing) {
+    auto cfg = default_log_config(test_dir);
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("default", "test", 0);
+    storage::ntp_config::default_overrides overrides;
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    storage::ntp_config ntp_cfg(
+      ntp,
+      mgr.config().base_dir,
+      std::make_unique<storage::ntp_config::default_overrides>(overrides));
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
+    auto disk_log = log;
+
+    // Append some linear kv ints
+    int num_appends = 5;
+    append_random_batches<linear_int_kv_batch_generator>(log, num_appends);
+    log->flush().get();
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
+
+    auto& segments = disk_log->segments();
+    auto& seg = segments.front();
+
+    static constexpr int64_t max_keys = 4;
+    storage::simple_key_offset_map map(max_keys);
+    storage::compaction_config compact_cfg(
+      model::offset::max(), std::nullopt, ss::default_priority_class(), as);
+    auto pb = storage::probe{};
+
+    auto last_indexed_offset = model::offset{-1};
+    auto max_offset = seg->offsets().get_dirty_offset();
+    for (int64_t i = 0; last_indexed_offset < max_offset; ++i) {
+        storage::index_chunk_of_segment_for_map(
+          compact_cfg, seg, map, pb, last_indexed_offset)
+          .get();
+
+        int64_t offset
+          = (i + 1)
+              * (max_keys * linear_int_kv_batch_generator::records_per_batch)
+            - 1;
+        int64_t expected_offset = std::min(offset, max_offset());
+        ASSERT_EQ(map.max_offset(), model::offset{expected_offset});
+        ASSERT_EQ(last_indexed_offset, model::offset{expected_offset});
+    }
+
+    ASSERT_EQ(map.max_offset(), max_offset);
+}

--- a/src/v/storage/tests/key_offset_map_test.cc
+++ b/src/v/storage/tests/key_offset_map_test.cc
@@ -261,3 +261,21 @@ TEST(HashKeyOffsetMapTest, Initialize) {
         ASSERT_EQ(val.value(), model::offset(99));
     }
 }
+
+TEST(HashKeyOffsetMapTest, Capacity) {
+    storage::hash_key_offset_map map_1b;
+    map_1b.initialize(1).get();
+
+    storage::hash_key_offset_map map_1kb;
+    map_1kb.initialize(1_KiB).get();
+
+    storage::hash_key_offset_map map_1mb;
+    map_1mb.initialize(1_MiB).get();
+
+    storage::hash_key_offset_map map_10mb;
+    map_10mb.initialize(10_MiB).get();
+
+    ASSERT_LT(map_1b.capacity(), map_1kb.capacity());
+    ASSERT_LT(map_1kb.capacity(), map_1mb.capacity());
+    ASSERT_LT(map_1mb.capacity(), map_10mb.capacity());
+}

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -382,23 +382,6 @@ TEST(BuildOffsetMap, TestBuildSimpleMap) {
           .get();
     }
 
-    // Build a map, configuring it to hold too little data for even a single
-    // segment.
-    simple_key_offset_map too_small_map(5);
-    ASSERT_THAT(
-      [&] {
-          build_offset_map(
-            cfg,
-            segs,
-            disk_log.stm_manager(),
-            disk_log.resources(),
-            disk_log.get_probe(),
-            too_small_map)
-            .get();
-      },
-      testing::ThrowsMessage<std::runtime_error>(
-        testing::HasSubstr("Couldn't index")));
-
     // Now configure a map to index some segments.
     simple_key_offset_map partial_map(15);
     auto partial_o = build_offset_map(

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -27,6 +27,7 @@
 #include "storage/log_manager.h"
 #include "storage/types.h"
 #include "test_utils/fixture.h"
+#include "test_utils/test_macros.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/reactor.hh>
@@ -179,9 +180,9 @@ struct linear_int_kv_batch_generator {
       ss::circular_buffer<model::record_batch>&& batches) {
         int idx = 0;
         for (const auto& batch : batches) {
-            BOOST_REQUIRE_EQUAL(batch.record_count(), 1);
+            RPTEST_EXPECT_EQ(batch.record_count(), 1);
             batch.for_each_record([&idx](model::record rec) {
-                BOOST_REQUIRE_EQUAL(
+                RPTEST_EXPECT_EQ(
                   reflection::from_iobuf<int>(rec.release_key()), idx++);
             });
         }
@@ -282,7 +283,7 @@ public:
 
     struct batch_validating_consumer {
         ss::future<ss::stop_iteration> operator()(model::record_batch b) {
-            BOOST_REQUIRE_EQUAL(b.header().crc, model::crc_record_batch(b));
+            RPTEST_EXPECT_EQ(b.header().crc, model::crc_record_batch(b));
             batches.push_back(std::move(b));
             return ss::make_ready_future<ss::stop_iteration>(
               ss::stop_iteration::no);
@@ -362,8 +363,8 @@ public:
             // Check if after append offset was updated correctly
             auto expected_offset = model::offset(total_records - 1)
                                    + base_offset;
-            BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, res.last_offset);
-            BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, expected_offset);
+            RPTEST_EXPECT_EQ(log->offsets().dirty_offset, res.last_offset);
+            RPTEST_EXPECT_EQ(log->offsets().dirty_offset, expected_offset);
         }
 
         return headers;
@@ -393,8 +394,8 @@ public:
 
         log->flush().get();
 
-        BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, res.last_offset);
-        BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, expected_offset);
+        RPTEST_EXPECT_EQ(log->offsets().dirty_offset, res.last_offset);
+        RPTEST_EXPECT_EQ(log->offsets().dirty_offset, expected_offset);
     }
 
     // model::offset start_offset;

--- a/src/v/test_utils/test_macros.h
+++ b/src/v/test_utils/test_macros.h
@@ -23,6 +23,7 @@
 #define RPTEST_REQUIRE_EQ_CORO(m, n) BOOST_REQUIRE_EQUAL(m, n)
 #define RPTEST_REQUIRE_NE(m, n) BOOST_REQUIRE_NE(m, n)
 #define RPTEST_REQUIRE_NE_CORO(m, n) BOOST_REQUIRE_NE(m, n)
+#define RPTEST_EXPECT_EQ(m, n) BOOST_REQUIRE_EQUAL(m, n)
 #else
 #include "test_utils/test.h"
 
@@ -35,4 +36,5 @@
 #define RPTEST_REQUIRE_EQ_CORO(m, n) ASSERT_EQ_CORO(m, n)
 #define RPTEST_REQUIRE_NE(m, n) ASSERT_NE(m, n)
 #define RPTEST_REQUIRE_NE_CORO(m, n) ASSERT_NE_CORO(m, n)
+#define RPTEST_EXPECT_EQ(m, n) EXPECT_EQ(m, n)
 #endif


### PR DESCRIPTION
This PR deals with the case in which zero segments were indexed for a round of sliding window compaction. This can happen for segments with a large number of unique keys, and per the memory constraints imposed on our key-offset hash map by `storage_compaction_key_map_memory` (128MiB by default).

This (historically) has not come about often, and may also be naturally alleviated by deduplicating or partially indexing the problem segment in question during future rounds of compaction (provided there is a steady ingress rate to the partition, and that keys in the problem segment are present in newer segments in the log), but added here is a routine that can handle this corner case when it arises.

Instead of throwing and logging an error when zero segments are indexed, we will now fall back to a "chunked" compaction routine.

This implementation uses some of the current abstractions from the compaction utilities to perform several rounds (chunks) of sliding window compaction with a partially indexed map created from the un-indexed segment by reading it in a linear fashion.

This implementation is sub-optimal for a number of reasons- primarily, segment indexes are read and rewritten each time a round of chunked compaction is performed. These intermediate states are then used for the next round of chunked compaction.

In the future, there may be a more optimal way to perform these steps using less IO by holding more information in memory before flushing the final results to disk, instead of flushing every intermediate stage. However, this case in which chunked compaction is required has seemed to be infrequent enough that merely having the implementation is valuable. 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Adds a chunked compaction routine to local storage, which is used as a fallback in the case that we fail to index a single segment during sliding window compaction. 
