### PR TITLE
dt/license_enforcement: delay disabling trial license

### DIFF
--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -49,9 +49,6 @@ class LicenseEnforcementTest(RedpandaTest):
     )
     def test_license_enforcement(self, clean_node_before_recovery,
                                  clean_node_after_recovery):
-        self.redpanda.set_environment(
-            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
-
         installer = self.redpanda._installer
         prev_version = installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
@@ -72,6 +69,16 @@ class LicenseEnforcementTest(RedpandaTest):
         self.logger.info(f"Enabling an enterprise feature")
         self.redpanda.set_cluster_config(
             {"partition_autobalancing_mode": "continuous"})
+
+        self.logger.info(
+            "Disabling the trial license to simulate that the license expired")
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=60,
+                                 backoff_sec=1,
+                                 err_msg="The cluster hasn't stabilized")
 
         first_upgraded = self.redpanda.nodes[0]
         self.logger.info(
@@ -112,9 +119,6 @@ class LicenseEnforcementTest(RedpandaTest):
     @cluster(num_nodes=5, log_allow_list=LOG_ALLOW_LIST)
     @matrix(clean_node_before_upgrade=[False, True])
     def test_escape_hatch_license_variable(self, clean_node_before_upgrade):
-        self.redpanda.set_environment(
-            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
-
         installer = self.redpanda._installer
         prev_version = installer.highest_from_prior_feature_version(
             RedpandaInstaller.HEAD)
@@ -135,6 +139,16 @@ class LicenseEnforcementTest(RedpandaTest):
         self.logger.info(f"Enabling an enterprise feature")
         self.redpanda.set_cluster_config(
             {"partition_autobalancing_mode": "continuous"})
+
+        self.logger.info(
+            "Disabling the trial license to simulate that the license expired")
+        self.redpanda.set_environment(
+            {'__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE': True})
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_until(self.redpanda.healthy,
+                                 timeout_sec=60,
+                                 backoff_sec=1,
+                                 err_msg="The cluster hasn't stabilized")
 
         first_upgraded = self.redpanda.nodes[0]
         first_upgraded_id = self.redpanda.node_id(first_upgraded)


### PR DESCRIPTION
Previously the test relied on the fact that the previous major version (v24.2) did not do strict license enforcement.

We can no longer rely on that since the head version became v25.1 and the previous major version v24.3 which does do strict license enforcement.

This fixes the current CI failures on dev.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
