### PR TITLE
archival: calculate time based retention from first addressable segment

### DIFF
--- a/src/v/cluster/archival/retention_calculator.cc
+++ b/src/v/cluster/archival/retention_calculator.cc
@@ -109,7 +109,8 @@ std::optional<retention_calculator> retention_calculator::factory(
 
         if (
           manifest.size() > 0
-          && manifest.begin()->max_timestamp < oldest_allowed_timestamp) {
+          && manifest.first_addressable_segment()->max_timestamp
+               < oldest_allowed_timestamp) {
             strats.push_back(
               std::make_unique<time_based_strategy>(oldest_allowed_timestamp));
         }


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-7687

apply_retention() and garbage_collect() are 2 distinct routines. The former computes the new start offset while the later removes the physical files and removes the segment entries from the manifest.

However, if we bail out of the second routine (e.g. timeout, leadership lost) we will call apply_retention() again. If we apply the retention rules starting with the first segment entry in the manifest it can happen that we reach the same result (i.e. same new start offset). When this happens, we replicate a new update_start_offset command to the archival stm which tries to advance_start_offset to the current start offset. Currently, we log an error in that case from `archival_metadata_stm::apply_update_start_offset`. Nothing is broken beside printing that error log line.

```
if (!_manifest->advance_start_offset(so.start_offset)) {
    vlog(
      _logger.error,
      "Can't truncate manifest up to offset {}, offset out of range",
      so.start_offset);
}
```

This commit avoids this annoyance and avoids unnecessary redundant work for retention computation and replicating commands by computing retention from the first addressable segment rather than from the first segment in the manifest.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
