### PR TITLE
[CORE-8081] rptest: fix config_profile_verify_test null handling

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -68,12 +68,15 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         assert clusterConfig['cluster_id'] in (self._clusterId,
                                                f'rp-{self._clusterId}')
 
-        for k, v in self._configProfile["cluster_config"].items():
+        for k, expected_v in self._configProfile["cluster_config"].items():
+            actual_v = clusterConfig[k]
             self.logger.debug(
                 "asserting cluster config key {} has expected value: {}  actual: {}"
-                .format(k, v, clusterConfig[k]))
-            if clusterConfig[k] != v and "{}".format(clusterConfig[k]) != v:
-                assert False
+                .format(k, expected_v, actual_v))
+            if expected_v == "null":
+                expected_v = None
+            if actual_v != expected_v and "{}".format(actual_v) != expected_v:
+                assert False, f"incorrect config value for key '{k}': {actual_v} != {expected_v}"
 
     def _check_aws_nodes(self):
         cmd = self.redpanda.kubectl._ssh_prefix() + [


### PR DESCRIPTION
We see the given error if a given profile's config contains a 'null' value.

```
[DEBUG - 2024-10-29 10:04:39,665 - config_profile_verify_test - _check_rp_config - lineno:72]: asserting cluster config key kafka_rpc_server_tcp_recv_buf has expected value: null  actual: None
...
[INFO  - 2024-10-29 10:04:39,667 - runner_client - log - lineno:294]: RunnerClient: rptest.redpanda_cloud_tests.config_profile_verify_test.ConfigProfileVerifyTest.test_config_profile_verify: FAIL: AssertionError()
Traceback (most recent call last):
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 186, in _do_run
    data = self.run_test()
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 246, in run_test
    return self.test_context.function(self.test)
  File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py", line 59, in test_config_profile_verify
    self._check_rp_config()
  File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py", line 76, in _check_rp_config
    assert False
AssertionError
```

This commit updates the check to expect None if the expected value is "null".

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
