### PR TITLE
cluster: report cluster as unhealthy if data disk is degraded

### DIFF
--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -288,6 +288,7 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_overview& ho) {
     fmt::print(
       o,
       "{{controller_id: {}, nodes: {}, unhealthy_reasons: {}, nodes_down: {}, "
+      "data_disk_degraded: {}, "
       "nodes_in_recovery_mode: {}, bytes_in_cloud_storage: {}, "
       "leaderless_count: {}, under_replicated_count: {}, "
       "leaderless_partitions: {}, under_replicated_partitions: {}}}",
@@ -295,6 +296,7 @@ std::ostream& operator<<(std::ostream& o, const cluster_health_overview& ho) {
       ho.all_nodes,
       ho.unhealthy_reasons,
       ho.nodes_down,
+      ho.data_disk_degraded,
       ho.nodes_in_recovery_mode,
       ho.bytes_in_cloud_storage,
       ho.leaderless_count,

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -363,6 +363,8 @@ struct cluster_health_overview {
     // A list of known nodes which are down from the point of view of the health
     // subsystem.
     std::vector<model::node_id> nodes_down;
+    // A list of nodes that have data disk degraded.
+    std::vector<model::node_id> data_disk_degraded;
     // A list of nodes that have been booted up in recovery mode.
     std::vector<model::node_id> nodes_in_recovery_mode;
     std::vector<model::ntp> leaderless_partitions;

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -227,6 +227,13 @@
                     },
                     "description": "ids of all nodes being recognized as down"
                 },
+                "data_disk_degraded": {
+                    "type": "array",
+                    "items": {
+                        "type": "int"
+                    },
+                    "description": "ids of all nodes with data disk degraded"
+                },
                 "nodes_in_recovery_mode": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3621,12 +3621,14 @@ void admin_server::register_cluster_routes() {
                 ret.unhealthy_reasons._set = true;
                 ret.all_nodes._set = true;
                 ret.nodes_down._set = true;
+                ret.data_disk_degraded._set = true;
                 ret.leaderless_partitions._set = true;
                 ret.under_replicated_partitions._set = true;
 
                 ret.unhealthy_reasons = health_overview.unhealthy_reasons;
                 ret.all_nodes = health_overview.all_nodes;
                 ret.nodes_down = health_overview.nodes_down;
+                ret.data_disk_degraded = health_overview.data_disk_degraded;
                 ret.nodes_in_recovery_mode
                   = health_overview.nodes_in_recovery_mode;
 


### PR DESCRIPTION
Also surface information about the nodes on which data disk is degraded.

This is an addition to #24436. Separate PR since there is no pressure to backport it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
