### PR TITLE
[CORE-6992, CORE-6760] cloud_storage_clients/abs_client: use item filter in list_objects

### DIFF
--- a/tests/rptest/tests/remote_label_test.py
+++ b/tests/rptest/tests/remote_label_test.py
@@ -11,11 +11,12 @@ from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda import RedpandaService, SISettings, make_redpanda_service
+from rptest.services.redpanda import RedpandaService, SISettings, get_cloud_storage_type, make_redpanda_service
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.read_replica_e2e_test import hwms_are_identical, create_read_replica_topic
 from rptest.util import wait_until
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from rptest.utils.si_utils import BucketView, NT, quiesce_uploads
 
@@ -90,7 +91,8 @@ class RemoteLabelsTest(RedpandaTest):
         producer.free()
 
     @cluster(num_nodes=3)
-    def test_clusters_share_bucket(self) -> None:
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_clusters_share_bucket(self, cloud_storage_type) -> None:
         """
         cluster 1 creates topic_a
         cluster 2 creates topic_a


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This seems like an oversight. Noticed in an ABS run of a test:

```
INFO  2024-11-12 02:16:37,966 [shard 1:main] cloud_storage - topic_manifest_downloader.cc:102 - Labeled topic manifest download resulted in 2 matching manifests with prefix '', printing first 2
INFO  2024-11-12 02:16:37,966 [shard 1:main] cloud_storage - topic_manifest_downloader.cc:112 - Match for hint '': meta/kafka/topic-a/83123841-40c1-47e4-92ed-5ac8d1f536c7/8/topic_manifest.bin
INFO  2024-11-12 02:16:37,966 [shard 1:main] cloud_storage - topic_manifest_downloader.cc:112 - Match for hint '': meta/kafka/topic-a/eb0359d1-a0fb-45aa-8995-d938a34caeef/8_lifecycle.bin
WARN  2024-11-12 02:16:37,966 [shard 1:main] kafka - create_topics.cc:185 - Failed to create topic(s) {{kafka/topic-a}} error_code observed: cluster::errc::topic_operation_error
```

In this snippet, the list results contain a lifecycle marker, despite
the filter passed in during manifest download being
ends_with("topic_manifest.bin").

Auditing the codebase a bit, there don't appear to be any other usages
of list_objects() with a filter.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug that could prevent topic recovery on ABS object storage when there are objects in a bucket from multiple clusters (e.g. following a whole cluster restore).
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
