### PR TITLE
High priority alerts detection

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/observe_test.py
+++ b/tests/rptest/redpanda_cloud_tests/observe_test.py
@@ -67,15 +67,16 @@ class HTObserveTest(RedpandaCloudTest):
 
         for alert in alerts:
             alert_message = f"alert firing for cluster: {alert.labels.grafana_folder} / {alert.labels.alertname}"
-            if "high priority" in alert_message.lower():
-                self.logger.error(f"High priority - {alert_message}")
-                high_priority_alerts.append(alert_message)
+            # Treat all alerts not explicitly marked as "low priority" as high priority
+            if "low priority" in alert_message.lower():
+                self.logger.warn(f"Low priority alert - {alert_message}")
             else:
-                self.logger.warning(f"Low priority - {alert_message}")
+                self.logger.error(f"High priority alert - {alert_message}")
+                high_priority_alerts.append(alert_message)
 
         # Fail the test if high-priority alerts are present
         assert not high_priority_alerts, (
-            f"Test failed due to high-priority alerts:\n{high_priority_alerts}"
+            f"Test failed due to potential high-priority alerts:\n{high_priority_alerts}"
         )
 
         self.logger.info("Cloud observe test completed successfully.")


### PR DESCRIPTION
Improves cloud observe test and fails if high priority alerts get detected. Also, makes them more visible by loggin as an error instead of warn, so it would be in the main log instead of debug.

We check cloud alerts and fail the test with any high priority alert from our grafana_url/alerting/list

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none