### PR TITLE
[v24.3.x] config: iceberg_enabled should not be enterprise

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3728,7 +3728,6 @@ configuration::configuration()
        tls_version::v1_3})
   , iceberg_enabled(
       *this,
-      true,
       "iceberg_enabled",
       "Enables the translation of topic data into Iceberg tables. Setting "
       "iceberg_enabled to true activates the feature at the cluster level, but "

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -698,7 +698,7 @@ struct configuration final : public config_store {
     enum_property<tls_version> tls_min_version;
 
     // datalake configurations
-    enterprise<property<bool>> iceberg_enabled;
+    property<bool> iceberg_enabled;
     bounded_property<std::chrono::milliseconds>
       iceberg_catalog_commit_interval_ms;
     property<ss::sstring> iceberg_catalog_base_location;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24421
