### PR TITLE
[v24.3.x] `rptest`: deflake `max_translated_offset()`

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -161,7 +161,7 @@ class DatalakeServices():
             self.redpanda.logger.debug(
                 f"Current translated offsets: {offsets}")
             return all([
-                offset and offset <= max_offset
+                max_offset and offset <= max_offset
                 for _, max_offset in offsets.items()
             ])
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24420
