### PR TITLE
Handling missing features in snapshot

### DIFF
--- a/src/v/cluster/feature_backend.h
+++ b/src/v/cluster/feature_backend.h
@@ -41,7 +41,7 @@ public:
     ss::future<> fill_snapshot(controller_snapshot&) const;
     ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
 
-    /// this functions deal with the snapshot stored in local kvstore (in
+    /// these functions deal with the snapshot stored in local kvstore (in
     /// contrast to fill/apply_snapshot which deal with the feature table data
     /// in the replicated controller snapshot).
     bool has_local_snapshot();

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -197,7 +197,7 @@ bool is_major_version_upgrade(
 static std::array test_extra_schema{
   // For testing, a feature that does not auto-activate
   feature_spec{
-    cluster::cluster_version{2001},
+    TEST_VERSION,
     "__test_alpha",
     feature::test_alpha,
     feature_spec::available_policy::explicit_only,
@@ -205,7 +205,7 @@ static std::array test_extra_schema{
 
   // For testing, a feature that auto-activates
   feature_spec{
-    cluster::cluster_version{2001},
+    TEST_VERSION,
     "__test_bravo",
     feature::test_bravo,
     feature_spec::available_policy::always,
@@ -213,7 +213,7 @@ static std::array test_extra_schema{
 
   // For testing, a feature that auto-activates
   feature_spec{
-    cluster::cluster_version{2001},
+    TEST_VERSION,
     "__test_charlie",
     feature::test_charlie,
     feature_spec::available_policy::new_clusters_only,

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -163,6 +163,8 @@ constexpr cluster::cluster_version to_cluster_version(release_version rv) {
     vassert(false, "Invalid release_version");
 }
 
+constexpr cluster::cluster_version TEST_VERSION{2001};
+
 bool is_major_version_upgrade(
   cluster::cluster_version from, cluster::cluster_version to);
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -82,8 +82,13 @@ enum class feature : std::uint64_t {
 // controller messages for unknown features (unexpected), and controller
 // messages that refer to features that have been retired.
 //
-// retired does *not* mean the functionality is gone: it just means it
+// Retired does *not* mean the functionality is gone: it just means it
 // is no longer guarded by a feature flag.
+//
+// All feature checks need to be removed one version before the feature is
+// retired. That's because during upgrade, when a mixed version cluster is
+// running, the older version nodes may read a snaphot from the newer version
+// and get the feature automatically enabled.
 inline const std::unordered_set<std::string_view> retired_features = {
   "central_config",
   "consumer_offsets",

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -121,10 +121,10 @@ FIXTURE_TEST(feature_table_basic, feature_table_fixture) {
       ft.get_state(feature::test_alpha).get_state()
       == feature_state::state::unavailable);
 
-    // The dummy test features requires version 2001.  The feature
+    // The dummy test features requires version TEST_VERSION. The feature
     // should go available, but not any further: the feature table
     // relies on external stimulus to actually activate features.
-    set_active_version(cluster_version{2001});
+    set_active_version(TEST_VERSION);
 
     BOOST_REQUIRE(
       ft.get_state(feature::test_alpha).get_state()
@@ -274,7 +274,7 @@ FIXTURE_TEST(feature_uniqueness, feature_table_fixture) {
  * but also activates elegible features.
  */
 FIXTURE_TEST(feature_table_bootstrap, feature_table_fixture) {
-    bootstrap_active_version(cluster_version{2001});
+    bootstrap_active_version(TEST_VERSION);
 
     // A non-auto-activating feature should remain in available state:
     // explicit_only features always require explicit activation, even


### PR DESCRIPTION
This is mostly to admit that we cannot retire features in one go. But also to make snapshot application correct.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
