### PR TITLE
[CORE-8278] `rptest`: adjust `num_segments_deleted()` condition

### DIFF
--- a/tests/rptest/tests/archive_retention_test.py
+++ b/tests/rptest/tests/archive_retention_test.py
@@ -162,11 +162,11 @@ class CloudArchiveRetentionTest(RedpandaTest):
             f"waiting until {segments_to_delete} segments will be removed")
         # Wait for the first truncation to the middle of the archive
         wait_until(
-            lambda: self.num_segments_deleted() == segments_to_delete,
+            lambda: self.num_segments_deleted() >= segments_to_delete,
             timeout_sec=100,
             backoff_sec=5,
             err_msg=
-            f"Segments were not removed from the cloud, expected {segments_to_delete} deletions"
+            f"Segments were not removed from the cloud, expected at least {segments_to_delete} deletions"
         )
 
         view.reset()
@@ -210,11 +210,11 @@ class CloudArchiveRetentionTest(RedpandaTest):
             f"waiting until {segments_to_delete} segments will be removed")
         # Wait for the second truncation of the entire archive
         wait_until(
-            lambda: self.num_segments_deleted() == segments_to_delete,
+            lambda: self.num_segments_deleted() >= segments_to_delete,
             timeout_sec=120,
             backoff_sec=5,
             err_msg=
-            f"Segments were not removed from the cloud, expected {segments_to_delete} "
+            f"Segments were not removed from the cloud, expected at least {segments_to_delete} "
             f"segments to be removed but only {self.num_segments_deleted()} was actually removed"
         )
 


### PR DESCRIPTION
This can race with a segment upload and end up deleting more segments than anticipated:

```
[DEBUG - 2024-12-05 19:07:50,121] waiting until 143 segments will be removed
[DEBUG - 2024-12-05 19:07:50,747] remote.cc:236 - Uploading segment to path ...
[INFO  - 2024-12-05 19:09:47,435] redpanda_cloud_storage_deleted_segments_total = 144
```

Adjust the value to account for `num_segments_deleted()` being >= than what is expected.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
