### PR TITLE
iceberg: fix decimal type json writer

### DIFF
--- a/src/v/iceberg/datatypes_json.cc
+++ b/src/v/iceberg/datatypes_json.cc
@@ -142,7 +142,7 @@ public:
     void operator()(const iceberg::float_type&) { w.String("float"); }
     void operator()(const iceberg::double_type&) { w.String("double"); }
     void operator()(const iceberg::decimal_type& t) {
-        w.String("decimal({}, {})", t.precision, t.scale);
+        w.String(fmt::format("decimal({}, {})", t.precision, t.scale));
     }
     void operator()(const iceberg::date_type&) { w.String("date"); }
     void operator()(const iceberg::time_type&) { w.String("time"); }


### PR DESCRIPTION
Missing fmt::format call resulting in ill-formed serialization of decimal iceberg field type.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug where serializing manifests for Iceberg topics with decimal fields could cause Redpanda to crash or upload invalid manifests

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.



### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
