### PR TITLE
[CORE-6933] `rptest`: deflake `si_utils` assertion functions

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -1731,10 +1731,8 @@ class BucketView:
         summaries = self.segment_summaries(ntp)
         if len(summaries) == 0:
             assert 'archive_start_offset' not in manifest
-            assert 'archive_start_offset' not in manifest
         else:
             next_base_offset = manifest.get('archive_start_offset')
-            stm_start_offset = manifest.get('start_offset')
             expected_last = manifest.get('last_offset')
 
             for summary in summaries:

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -1697,6 +1697,15 @@ class BucketView:
 
         return []
 
+    def are_all_segments_config_batches(self, summaries):
+        all_config_batches = all(
+            [summary.num_data_records == 0 for summary in summaries])
+        if all_config_batches:
+            self.logger.debug(
+                "Segments left in archive are composed of all non-data batches"
+            )
+        return all_config_batches
+
     def is_archive_cleanup_complete(self, ntp: NTP):
         self._ensure_listing()
         manifest = self.manifest_for_ntp(ntp.topic, ntp.partition)
@@ -1713,6 +1722,13 @@ class BucketView:
         if len(summaries) == 0:
             self.logger.debug(
                 f"archive is empty, start: {aso}, clean: {aco}, len: {num}")
+            return True
+
+        if self.are_all_segments_config_batches(summaries):
+            # quiesce_uploads() would not have waited for these segments
+            # to have been uploaded and the partition manifest
+            # to have been marked clean and reuploaded, since they
+            # didn't contribute to the HWM. Treat this race-y case as successful.
             return True
 
         first_segment = min(summaries, key=lambda seg: seg.base_offset)
@@ -1732,6 +1748,13 @@ class BucketView:
         if len(summaries) == 0:
             assert 'archive_start_offset' not in manifest
         else:
+            if self.are_all_segments_config_batches(summaries):
+                # quiesce_uploads() would not have waited for these segments
+                # to have been uploaded and the partition manifest
+                # to have been marked clean and reuploaded, since they
+                # didn't contribute to the HWM. Treat this race-y case as successful.
+                return
+
             next_base_offset = manifest.get('archive_start_offset')
             expected_last = manifest.get('last_offset')
 


### PR DESCRIPTION
These functions `is_archive_cleanup_complete()` and `check_archive_integrity()` are used in `archive_retention_test.py`.

For context, the function `quiesce_uploads()` is called before these assertion functions.

This function waits for segments to be uploaded to cloud storage until the remote high watermark is up to date with the local high watermark, and that the partition manifest also reflects this flushing operation.

Afterwards, we assert on some expected properties using the manifest offsets as well as the segments.

Because `quiesce_uploads()` doesn't take into account/forcefully flush segments composed of entirely non-data batches, these assertions can be quite race-y (and would be potentially race-y even if it did).

Add `are_all_segments_config_batches()` to `BucketView` and check the condition in `is_archive_cleanup_complete()` as well as `check_archive_integrity()` before performing any assertions that might flake depending on the sequence of previous events (was a non-data batch segment uploaded? Was the manifest marked clean and reuploaded? Etc).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
