### PR TITLE
Added datalake verifier to RandomNodeOperationsTest

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -61,6 +61,15 @@ def random_string(length):
     )  # Using only lower case to avoid getting "ERROR" or other string that would be perceived as an error in the log
 
 
+def validate_topic_property(current_value: str, expected_value: str,
+                            property_name: str):
+    if (property_name.endswith(".ms")):
+        # RPK may add "ms" suffix to the value
+        current_value = current_value.replace("ms", "")
+
+    return current_value == expected_value
+
+
 @unique
 class RedpandaAdminOperation(Enum):
     CREATE_TOPIC = auto()
@@ -121,7 +130,7 @@ class CreateTopicOperation(Operation):
 
     def execute(self, ctx):
         ctx.redpanda.logger.info(
-            f"Creating topic with name {self.topic}, replication: {self.rf} partitions: {self.partitions}"
+            f"Creating topic with name {self.topic}, replication: {self.rf} partitions: {self.partitions}, configuration: {self.config}"
         )
         ctx.rpk().create_topic(self.topic, self.partitions, self.rf,
                                self.config)
@@ -136,7 +145,10 @@ class CreateTopicOperation(Operation):
             return False
         else:
             desc = ctx.rpk().describe_topic_configs(self.topic)
-            return all([desc[k][0] == str(v) for k, v in self.config.items()])
+            return all([
+                validate_topic_property(desc[k][0], str(v), k)
+                for k, v in self.config.items()
+            ])
 
     def describe(self):
         return {
@@ -237,7 +249,8 @@ class UpdateTopicOperation(Operation):
         )
 
         desc = ctx.rpk().describe_topic_configs(self.topic)
-        return desc[self.property][0] == str(self.value)
+        return validate_topic_property(desc[self.property][0], str(self.value),
+                                       self.property)
 
     def describe(self):
         return {

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -143,7 +143,7 @@ class CreateTopicOperation(Operation):
             "type": "create_topic",
             "properties": {
                 "name": self.topic,
-                "replication_factor": self.topic,
+                "replication_factor": self.rf,
                 "partitions": self.topic,
                 "config": self.config,
             }

--- a/tests/rptest/services/apache_iceberg_catalog.py
+++ b/tests/rptest/services/apache_iceberg_catalog.py
@@ -31,6 +31,15 @@ class IcebergRESTCatalog(CatalogService):
     LOG_FILE = os.path.join(PERSISTENT_ROOT, "iceberg_rest_server.log")
     JAR = "iceberg-rest-catalog-all.jar"
     JAR_PATH = f"/opt/iceberg-rest-catalog/build/libs/{JAR}"
+    LOG4J_CONFIG_PATH = os.path.join(PERSISTENT_ROOT, "log4j.properties")
+
+    LOG4J_CONFIG_TPL = jinja2.Template("""
+log4j.rootLogger={{log_level}}, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5p [%c] - %m%n
+""")
     logs = {"iceberg_rest_logs": {"path": LOG_FILE, "collect_default": True}}
 
     DB_CATALOG_IMPL = "org.apache.iceberg.jdbc.JdbcCatalog"
@@ -71,7 +80,8 @@ class IcebergRESTCatalog(CatalogService):
                  ctx,
                  cloud_storage_bucket: str,
                  warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME,
-                 filesystem_wrapper_mode: bool = False):
+                 filesystem_wrapper_mode: bool = False,
+                 log_level: str = "TRACE"):
         super(IcebergRESTCatalog, self).__init__(ctx,
                                                  cloud_storage_bucket,
                                                  warehouse_name,
@@ -94,6 +104,7 @@ class IcebergRESTCatalog(CatalogService):
         # Trino <-> REST server (JDBC Catalog) <-> local sqllite DB.
         self.db_file = None
         self._catalog_url = None
+        self.log_level = log_level
 
     def catalog_type(self) -> CatalogType:
         if self.filesystem_wrapper_mode:
@@ -178,7 +189,7 @@ class IcebergRESTCatalog(CatalogService):
         java = "/opt/java/java-17"
         envs = self._make_env()
         env = " ".join(f"{k}={v}" for k, v in envs.items())
-        return f"{env} {java} -jar  {IcebergRESTCatalog.JAR_PATH} \
+        return f"{env} {java}  -Dlog4j.configuration=file:{IcebergRESTCatalog.LOG4J_CONFIG_PATH} -jar  {IcebergRESTCatalog.JAR_PATH} \
             1>> {IcebergRESTCatalog.LOG_FILE} 2>> {IcebergRESTCatalog.LOG_FILE} &"
 
     def start_node(self, node, timeout_sec=60, **kwargs):
@@ -225,6 +236,11 @@ class IcebergRESTCatalog(CatalogService):
         self.logger.debug(f"Using hadoop config: {config_tmpl}")
         node.account.create_file(IcebergRESTCatalog.FS_CATALOG_CONF_PATH,
                                  config_tmpl)
+
+        node.account.create_file(
+            IcebergRESTCatalog.LOG4J_CONFIG_PATH,
+            IcebergRESTCatalog.LOG4J_CONFIG_TPL.render(
+                log_level=self.log_level))
 
         cmd = self._cmd()
         self.logger.info(

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -48,6 +48,7 @@ class DatalakeVerifier():
                  query_engine: QueryEngineBase,
                  compacted: bool = False,
                  table_override: Optional[str] = None,
+                 tolerate_deleted_messages: bool = False,
                  max_buffered_msgs=5000):
         self.redpanda = redpanda
         self.topic = topic
@@ -106,6 +107,10 @@ class DatalakeVerifier():
         # consuming, we assert that the size of this set is zero (otherwise,
         # it would imply an anomaly between the Iceberg table and the log).
         self._expected_compacted_keys = set()
+
+        # if set the verifier will tolerate messages that are missing in the
+        # topic but are present in the iceberg table
+        self._tolerate_deleted_messages = tolerate_deleted_messages
 
     def create_consumer(self):
         c = Consumer({
@@ -264,9 +269,13 @@ class DatalakeVerifier():
                 self._expected_compacted_keys.add(iceberg_key)
                 return
             else:
+                if self._tolerate_deleted_messages:
+                    return
+
                 self._errors.append(
-                    f"Offset from iceberg table {iceberg_offset} for {partition} does not match the next consumed offset {consumer_offset}"
+                    f"Offset from iceberg table {iceberg_offset=} for {partition=} does not match the next consumed offset {consumer_offset}"
                 )
+                # the offset might have already been deleted from the topic but it is still present in Iceberg table as it should be
                 return
         else:
             if self._compacted:

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -195,8 +195,14 @@ class DatalakeVerifier():
                 if msg.error():
                     self.logger.error(f"Consumer error: {msg.error()}")
                     continue
-
+                if msg.offset() <= self._max_consumed_offsets.get(
+                        msg.partition(), -1):
+                    self.logger.info(
+                        f"[{self.topic}] Duplicated message consumed from partition={msg.partition()}, current consumed: {msg.offset()}"
+                    )
+                    continue
                 with self._lock:
+
                     self._num_msgs_pending_verification += 1
                     self._consumed_messages[msg.partition()].append(msg)
                     if self._num_msgs_pending_verification >= self._query_batch_size:

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -132,11 +132,12 @@ class DatalakeVerifier():
                 for p in positions:
                     if p.error is not None:
                         self.logger.warning(
-                            f"Error querying position for partition {p.partition}"
+                            f"[{self.topic}] Error querying position for partition {p.partition}"
                         )
                     else:
                         self.logger.debug(
-                            f"next position for {p.partition} is {p.offset}")
+                            f"[{self.topic}] next position for {p.partition} is {p.offset}"
+                        )
                         self._next_positions[p.partition] = p.offset
                 return self._next_positions.copy()
 
@@ -149,24 +150,26 @@ class DatalakeVerifier():
     # to be called no more than once
     def go_offline(self, timeout=60):
         assert not self._offline_mode_requested.is_set()
-        self.logger.debug(f"offline mode requested")
+        self.logger.debug(f"[{self.topic}] offline mode requested")
         self._offline_mode_requested.set()
         assert self._consumer_stopped.wait(timeout)
-        self.logger.debug(f"consistent state reached")
+        self.logger.debug(f"[{self.topic}] consistent state reached")
         self._consumer_positions = self.update_and_get_fetch_positions()
-        self.logger.debug(f"remembered {self._consumer_positions=}")
+        self.logger.debug(
+            f"[{self.topic}] remembered {self._consumer_positions=}")
         self._partition_hwms = self.partition_hwms()
         for p in self._partition_hwms:
             self.logger.debug(
-                f"remembered partition {p.id=} hwm={p.high_watermark}, ")
+                f"[{self.topic}] remembered partition {p.id=} hwm={p.high_watermark}, "
+            )
         with self._consumer_lock:
             self._consumer.close()
             self._consumer = None
-            self.logger.debug(f"offline mode established")
+            self.logger.debug(f"[{self.topic}] offline mode established")
             self._offline_mode_established = True
 
     def _consumed_till_hwm(self, update: bool):
-        self.logger.debug("checking _consumed_till_hwm")
+        self.logger.debug(f"[{self.topic}] checking _consumed_till_hwm")
         if update:
             # reduce _lock contention
             if not self._consumed_till_hwm(False):
@@ -175,14 +178,14 @@ class DatalakeVerifier():
         for p in self.partition_hwms():
             if self._next_positions[p.id] < p.high_watermark:
                 self.logger.debug(
-                    f"partition {p.id} high watermark: {p.high_watermark} max offset: {self._next_positions[p.id]} has not been consumed fully"
+                    f"[{self.topic}] partition {p.id} high watermark: {p.high_watermark} max offset: {self._next_positions[p.id]} has not been consumed fully"
                 )
                 return False
         return True
 
     def _consumer_thread(self):
         try:
-            self.logger.info("Starting consumer thread")
+            self.logger.info(f"[{self.topic}] Starting consumer thread")
             while not self._stop.is_set() and not (
                     self._offline_mode_requested.is_set()
                     and self._consumed_till_hwm(update=True)):
@@ -193,7 +196,8 @@ class DatalakeVerifier():
                 if msg is None:
                     continue
                 if msg.error():
-                    self.logger.error(f"Consumer error: {msg.error()}")
+                    self.logger.error(
+                        f"[{self.topic}] Consumer error: {msg.error()}")
                     continue
                 if msg.offset() <= self._max_consumed_offsets.get(
                         msg.partition(), -1):
@@ -211,8 +215,6 @@ class DatalakeVerifier():
                     self._max_consumed_offsets[msg.partition()] = max(
                         self._max_consumed_offsets.get(msg.partition(), -1),
                         msg.offset())
-                    self.logger.debug(
-                        f"Max consumed offsets: {self._max_consumed_offsets}")
                     if len(self._errors) > 0:
                         return
         finally:
@@ -229,7 +231,7 @@ class DatalakeVerifier():
     def _verify_next_message(self, partition, iceberg_offset, iceberg_key):
         if partition not in self._consumed_messages:
             self._errors.append(
-                f"Partition {partition} returned from Iceberg query not found in consumed messages"
+                f"[{self.topic}]Partition {partition} returned from Iceberg query not found in consumed messages"
             )
 
         p_messages = self._consumed_messages[partition]
@@ -239,15 +241,18 @@ class DatalakeVerifier():
 
         message = p_messages[0]
         consumer_offset = message.offset()
+        self.logger.debug(
+            f"[{self.topic}] verifying message on {partition=} consumed offset={consumer_offset} iceberg offset={iceberg_offset}"
+        )
         if iceberg_offset > consumer_offset:
             self._errors.append(
-                f"Offset from Iceberg table {iceberg_offset} is greater than next consumed offset {consumer_offset} for partition {partition}, most likely there is a gap in the table"
+                f"[{self.topic}] Offset from Iceberg table {iceberg_offset} is greater than next consumed offset {consumer_offset} for partition {partition}, most likely there is a gap in the table"
             )
             return
 
         if iceberg_offset <= self._max_queried_offsets.get(partition, -1):
             self._errors.append(
-                f"Duplicate entry detected at offset {iceberg_offset} for partition {partition} "
+                f"[{self.topic}] Duplicate entry detected at offset {iceberg_offset} for partition {partition}"
             )
             return
         if not self._max_queried_offsets:
@@ -273,7 +278,7 @@ class DatalakeVerifier():
         self._msg_semaphore.release()
 
     def _query_thread(self):
-        self.logger.info("Starting query thread")
+        self.logger.info(f"[{self.topic}] Starting query thread")
         while not self._stop.is_set():
             try:
                 with self._msgs_batched:
@@ -293,7 +298,8 @@ class DatalakeVerifier():
 
                     query = self._get_query(partition, last_queried_offset,
                                             max_consumed)
-                    self.logger.debug(f"Executing query: {query}")
+                    self.logger.debug(
+                        f"[{self.topic}] Executing query: {query}")
 
                     with self._query.run_query(query) as cursor:
                         with self._lock:
@@ -301,20 +307,18 @@ class DatalakeVerifier():
                                 self._verify_next_message(partition, *row)
                                 if len(self._errors) > 0:
                                     self.logger.error(
-                                        f"violations detected: {self._errors}, stopping verifier"
+                                        f"[{self.topic}] violations detected: {self._errors}, stopping verifier"
                                     )
                                     return
-                                self.logger.debug(
-                                    f"verified message on {partition=} offset={row[0]}"
-                                )
 
                     if len(self._max_queried_offsets) > 0:
                         self.logger.debug(
-                            f"Max queried offsets: {self._max_queried_offsets}"
+                            f"[[{self.topic}]] Max queried offsets: {self._max_queried_offsets}"
                         )
 
             except Exception as e:
-                self.logger.error(f"Error querying iceberg table: {e}")
+                self.logger.error(
+                    f"[{self.table}] Error querying iceberg table: {e}")
                 sleep(2)
 
     def start(self, wait_first_iceberg_msg=False):
@@ -331,7 +335,7 @@ class DatalakeVerifier():
             for p in partition_hwms:
                 if p.id not in self._max_queried_offsets:
                     self.logger.debug(
-                        f"partition {p.id} not found in max offsets: {self._max_queried_offsets}"
+                        f"[{self.topic}] partition {p.id} not found in max offsets: {self._max_queried_offsets}"
                     )
                     return False
                 # Ensure all the consumed messages are drained.
@@ -344,8 +348,10 @@ class DatalakeVerifier():
     def _made_progress(self):
         progress = False
         with self._lock:
-            self.logger.debug(f"{self._max_queried_offsets=}")
-            self.logger.debug(f"{self._last_checkpoint=}")
+            self.logger.debug(
+                f"[{self.topic}] {self._max_queried_offsets=} {self._max_consumed_offsets=}"
+            )
+            self.logger.debug(f"[{self.topic}] {self._last_checkpoint=}")
             for partition, offset in self._max_queried_offsets.items():
                 if offset > self._last_checkpoint.get(partition, -1):
                     progress = True
@@ -367,9 +373,9 @@ class DatalakeVerifier():
                 assert len(
                     self._errors
                 ) == 0, f"Topic {self.topic} validation errors: {self._errors}"
-            self.logger.debug(f"No errors around waiting")
+            self.logger.debug(f"[{self.topic}] No errors around waiting")
         except Exception as e:
-            self.logger.error(f"Error around waiting: {e}")
+            self.logger.error(f"[{self.topic}] Error around waiting: {e}")
             raise
         finally:
             self.stop()
@@ -386,7 +392,8 @@ class DatalakeVerifier():
 
             self.logger.debug(
                 f"consumed offsets: {self._max_consumed_offsets}")
-            self.logger.debug(f"queried offsets: {self._max_queried_offsets}")
+            self.logger.debug(
+                f"[{self.topic}] queried offsets: {self._max_queried_offsets}")
 
             assert self._max_queried_offsets == self._max_consumed_offsets, "Mismatch between maximum offsets in topic vs iceberg table"
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -543,12 +543,16 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         # - topic with fast partition movements enabled
         if with_iceberg:
             dl_verifiers.append(
-                DatalakeVerifier(self.redpanda, regular_topic.name,
-                                 self.spark))
+                DatalakeVerifier(self.redpanda,
+                                 regular_topic.name,
+                                 self.spark,
+                                 tolerate_deleted_messages=True))
             if enable_fast_partition_movement():
                 dl_verifiers.append(
-                    DatalakeVerifier(self.redpanda, fast_topic.name,
-                                     self.spark))
+                    DatalakeVerifier(self.redpanda,
+                                     fast_topic.name,
+                                     self.spark,
+                                     tolerate_deleted_messages=True))
             for verifier in dl_verifiers:
                 verifier.start()
 

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -82,8 +82,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             **kwargs)
         self.nodes_with_prev_version = []
         self.installer = self.redpanda._installer
-        self.previous_version = self.installer.highest_from_prior_feature_version(
-            RedpandaInstaller.HEAD)
         self._si_settings = SISettings(self.test_context,
                                        cloud_storage_enable_remote_read=True,
                                        cloud_storage_enable_remote_write=True,
@@ -198,6 +196,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
 
         self.redpanda.set_seed_servers(self.redpanda.nodes)
         if mixed_versions:
+            self.previous_version = self.installer.highest_from_prior_feature_version(
+                RedpandaInstaller.HEAD)
             node_count = len(self.redpanda.nodes)
             with_prev_version = math.ceil(node_count / 2.0)
             self.logger.info(

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -14,12 +14,15 @@ import threading
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
+from rptest.services.catalog_service import CatalogType
+from rptest.services.spark_service import SparkService
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 
 from ducktape.mark import matrix, ignore
 from ducktape.utils.util import wait_until
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.cluster import cluster
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
@@ -88,7 +91,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         self.catalog_service = IcebergRESTCatalog(
             test_context,
             cloud_storage_bucket=self._si_settings.cloud_storage_bucket,
-            filesystem_wrapper_mode=False)
+            filesystem_wrapper_mode=False,
+            log_level="INFO")
 
     def min_producer_records(self):
         return 20 * self.producer_throughput
@@ -120,6 +124,12 @@ class RandomNodeOperationsTest(PreallocNodesTest):
 
     def setUp(self):
         self.catalog_service.start()
+        self.spark = SparkService(
+            ctx=self.test_context,
+            iceberg_catalog_uri=self.catalog_service.iceberg_rest_url,
+            default_warehouse_dir=self.catalog_service.DEFAULT_WAREHOUSE_NAME,
+            catalog_type=CatalogType.REST_JDBC)
+        self.spark.start()
 
     def _setup_test_scale(self):
         # test setup
@@ -332,13 +342,19 @@ class RandomNodeOperationsTest(PreallocNodesTest):
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
     @skip_fips_mode
     @skip_debug_mode
-    @cluster(num_nodes=9,
+    @cluster(num_nodes=10,
              log_allow_list=CHAOS_LOG_ALLOW_LIST +
              PREV_VERSION_LOG_ALLOW_LIST + TS_LOG_ALLOW_LIST)
     @matrix(enable_failures=[True, False],
             mixed_versions=[True, False],
             with_tiered_storage=[True, False],
-            with_iceberg=[True, False],
+            with_iceberg=[True],
+            with_chunked_compaction=[True, False],
+            cloud_storage_type=get_cloud_storage_type())
+    @cluster(num_nodes=8)
+    @matrix(enable_failures=[True, False],
+            mixed_versions=[True, False],
+            with_iceberg=[False],
             with_chunked_compaction=[True, False],
             cloud_storage_type=get_cloud_storage_type())
     def test_node_operations(self, enable_failures, mixed_versions,
@@ -526,6 +542,20 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                     is not TopicSpec.CLEANUP_DELETE),
                 tolerate_data_loss=True)
             write_caching_producer_consumer.start()
+        dl_verifiers = []
+        # when Iceberg is enabled, start a verifier for the two topics:
+        # - regular topic
+        # - topic with fast partition movements enabled
+        if with_iceberg:
+            dl_verifiers.append(
+                DatalakeVerifier(self.redpanda, regular_topic.name,
+                                 self.spark))
+            if enable_fast_partition_movement():
+                dl_verifiers.append(
+                    DatalakeVerifier(self.redpanda, fast_topic.name,
+                                     self.spark))
+            for verifier in dl_verifiers:
+                verifier.start()
 
         # start admin operations fuzzer, it will provide a stream of
         # admin day 2 operations executed during the test
@@ -611,6 +641,9 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             )
 
         verify_offset_translator_state_consistent(self.redpanda)
+        for verifier in dl_verifiers:
+            verifier.wait(progress_timeout_sec=60)
+
         # Validate that the controller log written during the test is readable by offline log viewer
         log_viewer = OfflineLogViewer(self.redpanda)
         for node in self.redpanda.started_nodes():

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -131,7 +131,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             catalog_type=CatalogType.REST_JDBC)
         self.spark.start()
 
-    def _setup_test_scale(self):
+    def _setup_test_scale(self, with_iceberg):
         # test setup
         self.producer_timeout = 180
         self.consumer_timeout = 180
@@ -140,14 +140,14 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             # scale test setup
             self.max_partitions = 32
             self.producer_throughput = 20000
-            self.node_operations = 30
+            self.node_operations = 15 if with_iceberg else 30
             self.msg_size = 1024  # 1KiB
             self.rate_limit = 100 * 1024 * 1024  # 100 MBps
             self.total_data = 5 * 1024 * 1024 * 1024
         else:
             self.max_partitions = 32
             self.producer_throughput = 1000 if self.debug_mode else 10000
-            self.node_operations = 10
+            self.node_operations = 5 if with_iceberg else 10
             self.msg_size = 128
             self.rate_limit = 1024 * 1024
             self.total_data = 50 * 1024 * 1024
@@ -403,7 +403,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         default_segment_size = 1024 * 1024
 
         # setup test case scale parameters
-        self._setup_test_scale()
+        self._setup_test_scale(with_iceberg)
 
         if self.should_skip:
             cleanup_on_early_exit(self)

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -380,17 +380,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                     "Skipping test with iceberg and unsupported cloud storage type"
                 )
 
-        def enable_fast_partition_movement():
-
-            initial_version = self.redpanda._installer.highest_from_prior_feature_version(
-                RedpandaInstaller.HEAD)
-            supported_by_prev = (initial_version[0] > 23) or \
-                                     (initial_version[0] == 23
-                                           and initial_version[1] > 2)
-            # do not enable fast partition movement with
-            # upgrades as the feature is not enabled
-            return supported_by_prev
-
         def enable_write_caching_testing():
             if not mixed_versions:
                 return True
@@ -475,36 +464,35 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         regular_producer_consumer.start()
         compacted_producer_consumer.start()
 
-        if enable_fast_partition_movement():
-            # if running with tiered storage create a topic with fast partition
-            # moves enabled
-            fast_topic = TopicSpec(name='tp-workload-fast',
-                                   partition_count=self.max_partitions,
-                                   cleanup_policy=TopicSpec.CLEANUP_DELETE,
-                                   segment_bytes=default_segment_size,
-                                   redpanda_remote_read=True,
-                                   redpanda_remote_write=True)
+        # if running with tiered storage create a topic with fast partition
+        # moves enabled
+        fast_topic = TopicSpec(name='tp-workload-fast',
+                               partition_count=self.max_partitions,
+                               cleanup_policy=TopicSpec.CLEANUP_DELETE,
+                               segment_bytes=default_segment_size,
+                               redpanda_remote_read=True,
+                               redpanda_remote_write=True)
 
-            client.create_topic(fast_topic)
+        client.create_topic(fast_topic)
 
-            client.alter_topic_config(fast_topic.name,
-                                      'initial.retention.local.target.bytes',
-                                      default_segment_size)
-            self._alter_local_topic_retention_bytes(fast_topic.name,
-                                                    8 * default_segment_size)
-            self.maybe_enable_iceberg_for_topic(fast_topic, with_iceberg)
-            fast_producer_consumer = RandomNodeOperationsTest.producer_consumer(
-                test_context=self.test_context,
-                logger=self.logger,
-                topic_name=fast_topic.name,
-                redpanda=self.redpanda,
-                nodes=[self.preallocated_nodes[2]],
-                msg_size=self.msg_size,
-                rate_limit_bps=self.rate_limit,
-                msg_count=self.msg_count,
-                consumers_count=self.consumers_count,
-                compaction_enabled=False)
-            fast_producer_consumer.start()
+        client.alter_topic_config(fast_topic.name,
+                                  'initial.retention.local.target.bytes',
+                                  default_segment_size)
+        self._alter_local_topic_retention_bytes(fast_topic.name,
+                                                8 * default_segment_size)
+        self.maybe_enable_iceberg_for_topic(fast_topic, with_iceberg)
+        fast_producer_consumer = RandomNodeOperationsTest.producer_consumer(
+            test_context=self.test_context,
+            logger=self.logger,
+            topic_name=fast_topic.name,
+            redpanda=self.redpanda,
+            nodes=[self.preallocated_nodes[2]],
+            msg_size=self.msg_size,
+            rate_limit_bps=self.rate_limit,
+            msg_count=self.msg_count,
+            consumers_count=self.consumers_count,
+            compaction_enabled=False)
+        fast_producer_consumer.start()
 
         write_caching_enabled = enable_write_caching_testing()
         if write_caching_enabled:
@@ -547,12 +535,11 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                  regular_topic.name,
                                  self.spark,
                                  tolerate_deleted_messages=True))
-            if enable_fast_partition_movement():
-                dl_verifiers.append(
-                    DatalakeVerifier(self.redpanda,
-                                     fast_topic.name,
-                                     self.spark,
-                                     tolerate_deleted_messages=True))
+            dl_verifiers.append(
+                DatalakeVerifier(self.redpanda,
+                                 fast_topic.name,
+                                 self.spark,
+                                 tolerate_deleted_messages=True))
             for verifier in dl_verifiers:
                 verifier.start()
 
@@ -605,8 +592,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             assert write_caching_producer_consumer
             write_caching_producer_consumer.verify()
 
-        if enable_fast_partition_movement():
-            fast_producer_consumer.verify()
+        fast_producer_consumer.verify()
 
         if mixed_versions:
             self.logger.info("Upgrading cluster with current Redpanda version")

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -165,14 +165,12 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             f"running test with: [message_size {self.msg_size},  total_bytes: {self.total_data}, message_count: {self.msg_count}, rate_limit: {self.rate_limit}, cluster_operations: {self.node_operations}]"
         )
 
-    def _start_redpanda(self, mixed_versions, with_tiered_storage,
-                        with_iceberg, with_chunked_compaction):
+    def _start_redpanda(self, mixed_versions, with_iceberg,
+                        with_chunked_compaction):
 
-        if with_tiered_storage or with_iceberg:
-            # since this test is deleting topics we must tolerate missing manifests
-            self._si_settings.set_expected_damage(
-                {"ntr_no_topic_manifest", "ntpr_no_manifest"})
-            self.redpanda.set_si_settings(self._si_settings)
+        self._si_settings.set_expected_damage(
+            {"ntr_no_topic_manifest", "ntpr_no_manifest"})
+        self.redpanda.set_si_settings(self._si_settings)
 
         if with_iceberg:
             self.redpanda.add_extra_rp_conf({
@@ -338,6 +336,9 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             client.alter_topic_config(topic_spec.name,
                                       TopicSpec.PROPERTY_ICEBERG_MODE,
                                       "key_value")
+            client.alter_topic_config(topic_spec.name,
+                                      TopicSpec.PROPERTY_ICEBERG_TARGET_LAG_MS,
+                                      "10000")
 
     # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
     @skip_fips_mode
@@ -347,7 +348,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
              PREV_VERSION_LOG_ALLOW_LIST + TS_LOG_ALLOW_LIST)
     @matrix(enable_failures=[True, False],
             mixed_versions=[True, False],
-            with_tiered_storage=[True, False],
             with_iceberg=[True],
             with_chunked_compaction=[True, False],
             cloud_storage_type=get_cloud_storage_type())
@@ -358,8 +358,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             with_chunked_compaction=[True, False],
             cloud_storage_type=get_cloud_storage_type())
     def test_node_operations(self, enable_failures, mixed_versions,
-                             with_tiered_storage, with_iceberg,
-                             with_chunked_compaction, cloud_storage_type):
+                             with_iceberg, with_chunked_compaction,
+                             cloud_storage_type):
         # In order to reduce the number of parameters and at the same time cover
         # as many use cases as possible this test uses 3 topics which 3 separate
         # producer/consumer pairs:
@@ -381,8 +381,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                 )
 
         def enable_fast_partition_movement():
-            if not with_tiered_storage:
-                return False
 
             initial_version = self.redpanda._installer.highest_from_prior_feature_version(
                 RedpandaInstaller.HEAD)
@@ -413,7 +411,6 @@ class RandomNodeOperationsTest(PreallocNodesTest):
 
         # start redpanda process
         self._start_redpanda(mixed_versions,
-                             with_tiered_storage=with_tiered_storage,
                              with_iceberg=with_iceberg,
                              with_chunked_compaction=with_chunked_compaction)
 
@@ -433,15 +430,13 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                   replication_factor=3,
                                   cleanup_policy=TopicSpec.CLEANUP_DELETE,
                                   segment_bytes=default_segment_size,
-                                  redpanda_remote_read=with_tiered_storage,
-                                  redpanda_remote_write=with_tiered_storage)
+                                  redpanda_remote_read=True,
+                                  redpanda_remote_write=True)
         client.create_topic(regular_topic)
         self.maybe_enable_iceberg_for_topic(regular_topic, with_iceberg)
 
-        if with_tiered_storage:
-            # change local retention policy to make some local segments will be deleted during the test
-            self._alter_local_topic_retention_bytes(regular_topic.name,
-                                                    3 * default_segment_size)
+        self._alter_local_topic_retention_bytes(regular_topic.name,
+                                                3 * default_segment_size)
 
         regular_producer_consumer = RandomNodeOperationsTest.producer_consumer(
             test_context=self.test_context,
@@ -459,8 +454,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                     partition_count=self.max_partitions,
                                     cleanup_policy=TopicSpec.CLEANUP_COMPACT,
                                     segment_bytes=default_segment_size,
-                                    redpanda_remote_read=with_tiered_storage,
-                                    redpanda_remote_write=with_tiered_storage)
+                                    redpanda_remote_read=True,
+                                    redpanda_remote_write=True)
         client.create_topic(compacted_topic)
         self.maybe_enable_iceberg_for_topic(compacted_topic, with_iceberg)
 
@@ -487,8 +482,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                                    partition_count=self.max_partitions,
                                    cleanup_policy=TopicSpec.CLEANUP_DELETE,
                                    segment_bytes=default_segment_size,
-                                   redpanda_remote_read=with_tiered_storage,
-                                   redpanda_remote_write=with_tiered_storage)
+                                   redpanda_remote_read=True,
+                                   redpanda_remote_write=True)
 
             client.create_topic(fast_topic)
 
@@ -520,8 +515,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                 partition_count=self.max_partitions,
                 cleanup_policy=cleanup_policy,
                 segment_bytes=default_segment_size,
-                redpanda_remote_read=with_tiered_storage,
-                redpanda_remote_write=with_tiered_storage)
+                redpanda_remote_read=True,
+                redpanda_remote_write=True)
 
             client.create_topic(write_caching_topic)
             client.alter_topic_config(write_caching_topic.name,

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -108,7 +108,8 @@ def verify_offset_translator_state_consistent(redpanda: RedpandaService):
                 lambda: _state_consistent(namespace, topic, partition),
                 timeout_sec=180,
                 backoff_sec=1,
-                err_msg="Error waiting for offsets to be consistent")
+                err_msg=
+                f"Error waiting for {partition_name} offsets to be consistent")
 
             logger.debug(
                 f"debug state of {partition_name} replica on node {node_id}: {state}"


### PR DESCRIPTION
Adding verifiers will give us the coverage for the translation process correctness. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 