### PR TITLE
iobuf: update the allocator schedule

### DIFF
--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -379,38 +379,36 @@ SEASTAR_THREAD_TEST_CASE(iobuf_as_ostream) {
 }
 
 SEASTAR_THREAD_TEST_CASE(alloctor_forward_progress) {
-    static constexpr std::array<uint32_t, 14> src = {{
+    static constexpr auto src = std::to_array<uint32_t>({
       512,
       768,
-      1152,
-      1728,
-      2592,
-      3888,
-      5832,
-      8748,
-      13122,
-      19683,
-      29525,
-      44288,
-      66432,
-      99648,
-    }};
-    static constexpr std::array<uint32_t, 14> expected = {{
-      768,
-      1152,
-      1728,
-      2592,
-      3888,
-      5832,
-      8748,
-      13122,
-      19683,
-      29525,
-      44288,
-      66432,
-      99648,
+      1280,
+      1792,
+      2560,
+      3584,
+      6144,
+      8192,
+      12288,
+      16384,
+      32768,
+      65536,
       131072,
-    }};
+    });
+    static constexpr auto expected = std::to_array<uint32_t>({
+      768,
+      1280,
+      1792,
+      2560,
+      3584,
+      6144,
+      8192,
+      12288,
+      16384,
+      32768,
+      65536,
+      131072,
+      131072,
+    });
     BOOST_REQUIRE_EQUAL(src.size(), expected.size());
     for (size_t i = 0; i < src.size(); ++i) {
         BOOST_REQUIRE_EQUAL(
@@ -429,7 +427,7 @@ SEASTAR_THREAD_TEST_CASE(test_next_chunk_allocation_append_temp_buf) {
     }
     // slow but tha'ts life.
     auto distance = std::distance(buf.begin(), buf.end());
-    BOOST_REQUIRE_EQUAL(distance, 324);
+    BOOST_REQUIRE_EQUAL(distance, 323);
     constexpr size_t sz = 40000 * 1024;
     auto msg = iobuf_as_scattered(std::move(buf));
     BOOST_REQUIRE_EQUAL(msg.size(), sz);
@@ -445,7 +443,7 @@ SEASTAR_THREAD_TEST_CASE(test_next_chunk_allocation_append_iobuf) {
     }
     // slow but tha'ts life.
     auto distance = std::distance(buf.begin(), buf.end());
-    BOOST_REQUIRE_EQUAL(distance, 324);
+    BOOST_REQUIRE_EQUAL(distance, 323);
     constexpr size_t sz = 40000 * 1024;
     auto msg = iobuf_as_scattered(std::move(buf));
     BOOST_REQUIRE_EQUAL(msg.size(), sz);


### PR DESCRIPTION
iobuf uses a growing schedule of allocations (growth factor 1.5) for each fragment. This schedule was not aware of the seastar allocation sizes, so it would request, for example 66K allocation, but seastar internally rounds that up to 128K, so for that allocation we waste ~50% of the memory which is invisible to iobuf.

In this change we update the schedule to be seastar allocator aware, i.e., using the same ~1.5x growth factor, but rounding up to the next seastar allocator boundary. At 16K or below, these boundaries are log-linear: every 2^n size, plus 3 evenly spread sizes in between each power of 2. Above 16K, sizes are 2^n.

This change slightly reduces the total number of steps until we get to the max size of 128K, as from 32K to 128K we use doubling steps instead of 1.5. For large iobufs this results in 1 fewer total which is why some tests which tested the exact number of fragments needed to be decreased by 1.

Fixes CORE-8478.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
