### PR TITLE
[CORE-7058]: `storage`: fix race condition in `segment::release_appender_in_background()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1747,7 +1747,7 @@ void disk_log_impl::bg_checkpoint_offset_translator() {
 ss::future<> disk_log_impl::force_roll(ss::io_priority_class iopc) {
     auto roll_lock_holder = co_await _segments_rolling_lock.get_units();
     auto t = term();
-    auto next_offset = offsets().dirty_offset + model::offset(1);
+    auto next_offset = model::next_offset(offsets().dirty_offset);
     if (_segs.empty()) {
         co_return co_await new_segment(next_offset, t, iopc);
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -31,6 +31,7 @@
 
 #include <absl/container/flat_hash_map.h>
 
+struct storage_e2e_fixture;
 namespace storage {
 
 /// \brief offset boundary type
@@ -248,6 +249,7 @@ public:
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
+    friend ::storage_e2e_fixture;
     friend std::ostream& operator<<(std::ostream& o, const disk_log_impl& d);
 
     /// Compute file offset of the batch inside the segment

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -297,6 +297,8 @@ ss::future<> segment::release_appender(readers_cache* readers_cache) {
 }
 
 void segment::release_appender_in_background(readers_cache* readers_cache) {
+    _gate.check();
+
     auto a = std::exchange(_appender, nullptr);
     auto c = config::shard_local_cfg().release_cache_on_segment_roll()
                ? std::exchange(_cache, std::nullopt)

--- a/src/v/storage/tests/storage_e2e_fixture.h
+++ b/src/v/storage/tests/storage_e2e_fixture.h
@@ -1,0 +1,50 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "redpanda/tests/fixture.h"
+#include "storage/disk_log_impl.h"
+#include "storage/segment.h"
+#include "test_utils/scoped_config.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+
+struct storage_e2e_fixture : public redpanda_thread_fixture {
+    scoped_config test_local_cfg;
+
+    // Produces to the given fixture's partition for 10 seconds.
+    ss::future<> produce_to_fixture(model::topic topic_name, int* incomplete) {
+        tests::kafka_produce_transport producer(co_await make_kafka_client());
+        co_await producer.start();
+        const int cardinality = 10;
+        auto now = ss::lowres_clock::now();
+        while (ss::lowres_clock::now() < now + 5s) {
+            for (int i = 0; i < cardinality; i++) {
+                co_await producer.produce_to_partition(
+                  topic_name,
+                  model::partition_id(0),
+                  tests::kv_t::sequence(i, 1));
+            }
+        }
+        *incomplete -= 1;
+    }
+
+    ss::future<> remove_segment_permanently(
+      storage::disk_log_impl* log, ss::lw_shared_ptr<storage::segment> seg) {
+        return log->remove_segment_permanently(seg, "storage_e2e_fixture")
+          .then([&, log, seg]() {
+              auto& segs = log->segments();
+              auto it = std::find(segs.begin(), segs.end(), seg);
+              if (it == segs.end()) {
+                  return;
+              }
+              segs.erase(it, std::next(it));
+          });
+    }
+};

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -15,6 +15,7 @@
 #include "storage/tests/storage_e2e_fixture.h"
 #include "test_utils/fixture.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/lowres_clock.hh>
 
@@ -24,6 +25,16 @@
 #include <vector>
 
 using namespace std::chrono_literals;
+
+namespace {
+ss::future<> force_roll_log(storage::disk_log_impl* log) {
+    try {
+        co_await log->force_roll(ss::default_priority_class());
+    } catch (...) {
+    }
+}
+
+} // namespace
 
 FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
     test_local_cfg.get("log_segment_ms_min")
@@ -155,4 +166,32 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
     // log_eviction_stm may have removed the active segment after we finished
     // final round of eviction.
     BOOST_REQUIRE_LE(log->segment_count(), 1);
+}
+
+FIXTURE_TEST(test_concurrent_segment_roll_and_close, storage_e2e_fixture) {
+    const auto topic_name = model::topic("tapioca");
+    const auto ntp = model::ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto* log = dynamic_cast<storage::disk_log_impl*>(partition->log().get());
+    auto seg = log->segments().back();
+
+    // Hold a read lock, which will force release_appender() to go through
+    // release_appender_in_background()
+    auto read_lock_holder = seg->read_lock().get();
+
+    auto roll_fut = force_roll_log(log);
+    auto release_holder_fut = ss::sleep(100ms).then(
+      [read_locker_holder = std::move(read_lock_holder)] {});
+    auto remove_segment_fut = remove_segment_permanently(log, seg);
+
+    ss::when_all(
+      std::move(roll_fut),
+      std::move(remove_segment_fut),
+      std::move(release_holder_fut))
+      .get();
 }


### PR DESCRIPTION
This function presented a race between `segment::close()` and a segment roll.

Consider the following sequence of events:

1. `_gate.close()` called in `segment::close()`
2. `auto a = std::exchange(_appender, nullptr)` called in `segment::release_appender_in_background()`
3. `ssx::spawn_with_gate()` called in `segment::release_appender_in_background()`
4. `return ignore_shutdown_exceptions()` in `ssx::spawn_with_gate()`
5. rest of `release_appender_in_background()` is ignored
6. `a` goes out of scope in `release_appender_in_background()` without `close()`ing the `appender`
7. one sad panda:

> segment_appender.cc:78) '_bytes_flush_pending == 0 && _closed' Must flush & close before deleting {no_of_chunks:64, closed:0, fallocation_offset:33554432, stable_offset:5895, flushed_offset:5895, committed_offset:5895, inflight:0, dispatched:0, merged:0, bytes_flush_pending:0}"

Add an explicit check to `_gate.is_closed()` in `release_appender_in_background()` to defer the closing of the appender to `segment::close()` and avoid the potential race condition here.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a segment  being rolled and closed could race, leading to a triggered `vassert`.
