### PR TITLE
bazel: patch protobuf warning

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,6 +42,15 @@ bazel_dep(name = "liburing", version = "2.5")
 bazel_dep(name = "lz4", version = "1.9.4")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.0")
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    # this patch is in upstream protobuf, so should be in an upcoming release.
+    patches = [
+        "//bazel/thirdparty:protobuf_capture_warning.patch",
+    ],
+)
+
 bazel_dep(name = "re2", version = "2024-07-02")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 bazel_dep(name = "rules_go", version = "0.50.1")

--- a/bazel/thirdparty/protobuf_capture_warning.patch
+++ b/bazel/thirdparty/protobuf_capture_warning.patch
@@ -1,0 +1,13 @@
+diff --git a/src/google/protobuf/map.cc b/src/google/protobuf/map.cc
+index 570b61bec86f..da6ceb99d993 100644
+--- a/src/google/protobuf/map.cc
++++ b/src/google/protobuf/map.cc
+@@ -116,7 +116,7 @@ void UntypedMapBase::ClearTable(const ClearInput input) {
+   ABSL_DCHECK_NE(num_buckets_, kGlobalEmptyTableSize);
+ 
+   if (alloc_.arena() == nullptr) {
+-    const auto loop = [=](auto destroy_node) {
++    const auto loop = [&, this](auto destroy_node) {
+       const TableEntryPtr* table = table_;
+       for (map_index_t b = index_of_first_non_null_, end = num_buckets_;
+            b < end; ++b) {


### PR DESCRIPTION
Patch to silence warning is in upstream protobuf. Should be shipping sometime in the future. But I don't really understand how the releases work. The patch has been there for at least a month, and 29.1 was released a couple days ago and doesn't have the patch. 🤷 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
