### PR TITLE
gha: replace ubuntu-latest with ubuntu-22.04

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -25,7 +25,7 @@ jobs:
       commented_on: ${{ steps.get_backport_type.outputs.commented_on }}
       backport_branch: ${{ steps.get_backport_type.outputs.backport_branch }}
       target_milestone: ${{ steps.get_backport_type.outputs.target_milestone }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -64,7 +64,7 @@ jobs:
   # eg /backport v21.11.x
   type-branch:
     needs: backport-type
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BACKPORT_BRANCH: ${{ needs.backport-type.outputs.backport_branch }}
     steps:

--- a/.github/workflows/backport-on-merge.yml
+++ b/.github/workflows/backport-on-merge.yml
@@ -9,7 +9,7 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 jobs:
   backport-on-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -15,7 +15,7 @@ on:
       - test-release-pipeline-command
 jobs:
   run-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   trigger-bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   add_jira_comment:
     if: ${{ !github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -12,7 +12,7 @@ on:
       - unlabeled
 jobs:
   manage_jira_issue:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   cpp:
     name: Lint files with clang-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   go:
     name: Lint go files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   py:
     name: Lint python files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   sh:
     name: Lint shell scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
 jobs:
   yamllint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: yamllint -f github .yamllint .github/workflows/*.yml

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   cpp:
     name: Compile and check P models
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   trigger-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release-rp-storage-tool.yml
+++ b/.github/workflows/release-rp-storage-tool.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         platform:
           - release_for: linux-amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - release_for: linux-arm64
-            os: ubuntu-latest-2-arm64
+            os: ubuntu-22.04-2-arm64
     runs-on: ${{ matrix.platform.os }}
     permissions:
       id-token: write

--- a/.github/workflows/render-pr-body-release-notes.yml
+++ b/.github/workflows/render-pr-body-release-notes.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   render:
     if: ${{ ! ( github.event.pull_request.user.login == 'vbotbuildovich' && startsWith(github.event.pull_request.title, 'merge') ) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Curl rpchangelog
         run: |

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check:
     name: Compile check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
           args: --manifest-path tools/rp_storage_tool/Cargo.toml
   test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
     - cron: '32 6 * * 1-5'
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build-integration-tests:
     name: Build integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -46,7 +46,7 @@ jobs:
           retention-days: 1
   test-golang:
     name: Test Golang Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -64,7 +64,7 @@ jobs:
   integration-test-golang:
     name: Integration Test Golang Transform SDK
     needs: [test-golang, build-integration-tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -100,7 +100,7 @@ jobs:
           ./wasm-integration-test -test.v
   test-rust:
     name: Test Rust Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
@@ -120,7 +120,7 @@ jobs:
   integration-test-rust:
     name: Integration Test Rust Transform SDK
     needs: [test-rust, build-integration-tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
@@ -154,7 +154,7 @@ jobs:
           ./wasm-integration-test -test.v
   test-cpp:
     name: Test C++ Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: fedora:40
     steps:
@@ -176,7 +176,7 @@ jobs:
   integration-test-cpp:
     name: Integration Test C++ Transform SDK
     needs: [test-cpp, build-integration-tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:
@@ -201,7 +201,7 @@ jobs:
           ./wasm-integration-test -test.v
   test-js:
     name: Test JS Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: fedora:40
     steps:
@@ -223,7 +223,7 @@ jobs:
   integration-test-js:
     name: Integration Test JS Transform SDK
     needs: [test-js, build-integration-tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-24
     steps:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   list-golang:
     name: List Golang Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -44,7 +44,7 @@ jobs:
         run: go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{steps.gotag.outputs.result}}
   publish-rust:
     name: Publish Rust Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -72,7 +72,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
   publish-javascript:
     name: Publish JavaScript Transform SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
jira: [DEVPROD-2450]

Upcoming change: ubuntu-latest workflows will use ubuntu-24.04 image. There are breaking changes in ubuntu-24.04 so being conservative and replacing with ubuntu-22.04 since it is still supported for another 2 years. See https://github.com/actions/runner-images/issues/10636

```
find .github/workflows -type f -exec sed -i '' 's|ubuntu-latest|ubuntu-22.04|g' {} \;
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none

[DEVPROD-2450]: https://redpandadata.atlassian.net/browse/DEVPROD-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ