### PR TITLE
test: redirect boost test output under bazel

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -249,7 +249,10 @@ def redpanda_cc_btest_no_seastar(
         srcs = srcs,
         defines = defines,
         copts = redpanda_copts(),
-        deps = ["@boost//:test.so"] + deps,
+        deps = [
+            "//src/v/test_utils:boost_result_redirect",
+            "@boost//:test.so",
+        ] + deps,
     )
 
 def redpanda_test_cc_library(

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -61,8 +61,23 @@ redpanda_test_cc_library(
     include_prefix = "test_utils",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/v/test_utils:fixture",
+        ":boost_result_redirect",
+        ":fixture",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "boost_result_redirect",
+    srcs = [
+        "boost_result_redirect.cc",
+    ],
+    include_prefix = "test_utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost//:config",
+        "@boost//:core",
+        "@boost//:test",
     ],
 )
 

--- a/src/v/test_utils/boost_result_redirect.cc
+++ b/src/v/test_utils/boost_result_redirect.cc
@@ -1,0 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include <boost/test/detail/global_typedef.hpp>
+#include <boost/test/unit_test_log.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+#include <fstream>
+#include <iomanip>
+
+/**
+ * This test configuration object is used to redirect the JUNIT result output
+ * (if enabled) to the location specified by the XML_OUTPUT_FILE environment
+ * variable. This variable is set by the bazel test runner so that the test
+ * writes the results in a local that bazel can subsequently consume.
+ * Ref: CORE-8013.
+ */
+struct bazel_result_handler_for_boost {
+    bazel_result_handler_for_boost() {
+        using namespace boost::unit_test;
+        if (auto xml_path = std::getenv("XML_OUTPUT_FILE")) {
+            _out = std::ofstream(xml_path);
+            // use fixed format to avoid scientific notation as a work-around
+            // to https://github.com/bazelbuild/bazel/issues/24605
+            _out << std::fixed << std::setprecision(6);
+            unit_test_log.add_format(OF_JUNIT);
+            unit_test_log.set_stream(OF_JUNIT, _out);
+        }
+    }
+    std::ofstream _out;
+};
+
+BOOST_TEST_GLOBAL_CONFIGURATION(bazel_result_handler_for_boost);


### PR DESCRIPTION
The bazel test runner sets an XML_OUTPUT_FILE environment variable so that the test writes the results in a local that bazel can subsequently consume. If the test does not write anything to that location bazel instead builds a "default" result file which treats the entire test run as a single test case, and uses the stdout of the test binary as the output of the test case. In addition to not exposing the test cases contained in the test correctly, this process is extremely slow when there is a lot of test output (as many redpanda fixture tests have) since the output is injected via shell variable interpolation which apparently doesn't scale up to variables several GB in size.

This change introduces a boost global test configuration object which looks for the XML_OUTPUT_FILE variable and if set enables JUNIT output redirected to the specified path.

Here is an example of the detailed output of all "utils" tests before this change:

```
$ bazel test --cache_test_results=no //src/v/utils/tests/... --test_summary=detailed --test_tag_filters=-bench
INFO: Invocation ID: 5e3dacef-c3e6-4d64-bae0-74ab6f6c019e
INFO: Analyzed 32 targets (2 packages loaded, 82 targets configured).
INFO: Found 5 targets and 27 test targets...
INFO: Elapsed time: 32.914s, Critical Path: 26.07s
INFO: 187 processes: 59 disk cache hit, 83 internal, 45 linux-sandbox.
INFO: Build completed successfully, 187 total actions
//src/v/utils/tests:auto_fmt_test                                        PASSED in 0.0s
    PASSED  .src/v/utils/tests/auto_fmt_test (0.0s)
//src/v/utils/tests:base64_test                                          PASSED in 0.2s
    PASSED  .src/v/utils/tests/base64_test (0.0s)
//src/v/utils/tests:delta_for_test                                       PASSED in 7.8s
    PASSED  .src/v/utils/tests/delta_for_test (0.0s)
//src/v/utils/tests:directory_walker_test                                PASSED in 0.5s
    PASSED  .src/v/utils/tests/directory_walker_test (0.0s)
//src/v/utils/tests:expiring_promise_test                                PASSED in 0.4s
    PASSED  .src/v/utils/tests/expiring_promise_test (0.0s)
//src/v/utils/tests:external_process_test                                PASSED in 17.5s
    PASSED  external_process.bin_true (0.0s)
    PASSED  external_process.bin_false (0.0s)
    PASSED  external_process.echo_hi (0.0s)
    PASSED  external_process.run_long_process (10.0s)
    PASSED  external_process.run_long_process_and_terminate (1.0s)
    PASSED  external_process.test_sigterm_ignored (6.1s)
    PASSED  external_process.no_such_bin (0.0s)
    PASSED  external_process.test_bad_args (0.0s)
//src/v/utils/tests:filtered_lower_bound_test                            PASSED in 9.8s
    PASSED  .src/v/utils/tests/filtered_lower_bound_test (0.0s)
//src/v/utils/tests:human_test                                           PASSED in 0.1s
    PASSED  .src/v/utils/tests/human_test (0.0s)
//src/v/utils/tests:input_stream_fanout_test                             PASSED in 15.5s
    PASSED  .src/v/utils/tests/input_stream_fanout_test (0.0s)
//src/v/utils/tests:move_canary_test                                     PASSED in 0.1s
    PASSED  .src/v/utils/tests/move_canary_test (0.0s)
//src/v/utils/tests:moving_average_test                                  PASSED in 0.2s
    PASSED  .src/v/utils/tests/moving_average_test (0.0s)
//src/v/utils/tests:named_type_test                                      PASSED in 0.1s
    PASSED  .src/v/utils/tests/named_type_test (0.0s)
//src/v/utils/tests:object_pool_test                                     PASSED in 1.0s
    PASSED  .src/v/utils/tests/object_pool_test (0.0s)
//src/v/utils/tests:remote_test                                          PASSED in 0.5s
    PASSED  .src/v/utils/tests/remote_test (0.0s)
//src/v/utils/tests:retry_chain_node_test                                PASSED in 1.0s
    PASSED  .src/v/utils/tests/retry_chain_node_test (0.0s)
//src/v/utils/tests:retry_test                                           PASSED in 0.5s
    PASSED  .src/v/utils/tests/retry_test (0.0s)
//src/v/utils/tests:rwlock_test                                          PASSED in 0.4s
    PASSED  .src/v/utils/tests/rwlock_test (0.0s)
//src/v/utils/tests:seastar_histogram_test                               PASSED in 0.8s
    PASSED  .src/v/utils/tests/seastar_histogram_test (0.0s)
//src/v/utils/tests:stable_iterator_test                                 PASSED in 0.3s
    PASSED  .src/v/utils/tests/stable_iterator_test (0.0s)
//src/v/utils/tests:timed_mutex_test                                     PASSED in 11.0s
    PASSED  .src/v/utils/tests/timed_mutex_test (0.0s)
//src/v/utils/tests:token_bucket_test                                    PASSED in 2.2s
    PASSED  .src/v/utils/tests/token_bucket_test (0.0s)
//src/v/utils/tests:tracking_allocator_test                              PASSED in 10.1s
    PASSED  .src/v/utils/tests/tracking_allocator_test (0.0s)
//src/v/utils/tests:tristate_test                                        PASSED in 0.2s
    PASSED  .src/v/utils/tests/tristate_test (0.0s)
//src/v/utils/tests:uuid_test                                            PASSED in 0.9s
    PASSED  .src/v/utils/tests/uuid_test (0.0s)
//src/v/utils/tests:vint_test                                            PASSED in 0.4s
    PASSED  .src/v/utils/tests/vint_test (0.0s)
//src/v/utils/tests:waiter_queue_test                                    PASSED in 1.1s
    PASSED  .src/v/utils/tests/waiter_queue_test (0.0s)
//src/v/utils/tests:xid_test                                             PASSED in 0.5s
    PASSED  xid.string_formatting_test (0.0s)
    PASSED  xid.hashing_test (0.0s)
    PASSED  xid.string_round_trip_test (0.0s)
    PASSED  xid.serde_round_trip_test (0.0s)
    PASSED  xid.test_xid_string_validation (0.0s)
Test cases: finished with 38 passing and 0 failing out of 38 test cases
```

Note that most tests (which are btests) have only a single `PASSED ...` line with the name of the test itself, this is the synthetic test case created by bazel. There are only 38 total test cases. A few tests like `xid_test` have detailed test case results: these are gtests.

Now after this change:

```
$ bazel test --cache_test_results=no //src/v/utils/tests/... --test_summary=detailed --test_tag_filters=-bench
INFO: Invocation ID: 0fe61711-fd94-47c2-9cbc-017820987262
INFO: Analyzed 32 targets (0 packages loaded, 35 targets configured).
INFO: Found 5 targets and 27 test targets...
INFO: Elapsed time: 34.891s, Critical Path: 29.34s
INFO: 28 processes: 1 internal, 27 linux-sandbox.
INFO: Build completed successfully, 28 total actions
//src/v/utils/tests:auto_fmt_test                                        PASSED in 0.2s
    PASSED  .auto_fmt_0 (0.0s)
    PASSED  .auto_fmt_1 (0.0s)
    PASSED  .auto_fmt_2 (0.0s)
    PASSED  .auto_fmt_3 (0.0s)
    PASSED  .auto_fmt_4 (0.0s)
    PASSED  .auto_fmt_5 (0.0s)
    PASSED  .auto_fmt_6 (0.0s)
    PASSED  .auto_fmt_7 (0.0s)
    PASSED  .auto_fmt_8 (0.0s)
    PASSED  .auto_fmt_9 (0.0s)
    PASSED  .auto_fmt_10 (0.0s)
    PASSED  .auto_fmt_11 (0.0s)
    PASSED  .auto_fmt_12 (0.0s)
    PASSED  .auto_fmt_13 (0.0s)
    PASSED  .auto_fmt_14 (0.0s)
    PASSED  .auto_fmt_15 (0.0s)
    PASSED  .auto_fmt_16 (0.0s)
//src/v/utils/tests:base64_test                                          PASSED in 0.3s
    PASSED  .bytes_type (0.0s)
    PASSED  .iobuf_type (0.0s)
    PASSED  .test_base64_to_iobuf (0.0s)
    PASSED  .base64_url_decode_test_basic (0.0s)
    PASSED  .base64_url_decode_invalid_character (0.0s)
//src/v/utils/tests:delta_for_test                                       PASSED in 7.8s
    PASSED  .roundtrip_test_1 (0.0s)
    PASSED  .roundtrip_test_2 (0.0s)
    PASSED  .roundtrip_test_3 (0.0s)
    PASSED  .roundtrip_test_4 (0.0s)
    PASSED  .random_walk_test_1 (0.8s)
    PASSED  .random_walk_test_2 (0.8s)
    PASSED  .random_walk_test_3 (0.8s)
    PASSED  .random_walk_test_4 (0.8s)
    PASSED  .random_walk_test_5 (0.8s)
    PASSED  .random_walk_test_6 (0.8s)
    PASSED  .random_walk_test_7 (0.8s)
    PASSED  .random_walk_test_8 (0.8s)
    PASSED  .test_compression_ratio (0.8s)
    PASSED  .skip_test_1 (0.0s)
    PASSED  .skip_test_2 (0.0s)
    PASSED  .skip_test_3 (0.0s)
    PASSED  .skip_test_4 (0.0s)
    PASSED  .test_deltafor_generate_characterization_data (0.0s)
    PASSED  .test_deltafor_characterization (0.0s)
    PASSED  .test_delta_for_cstore_frame_append_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_append_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_append_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_append_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_append_tx_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_append_tx_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_append_tx_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_append_tx_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_iter_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_iter_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_iter_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_iter_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_find_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_find_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_find_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_find_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_col_find_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_find_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_col_find_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_find_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_lower_bound_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_lower_bound_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_lower_bound_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_lower_bound_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_col_lower_bound_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_lower_bound_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_col_lower_bound_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_lower_bound_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_upper_bound_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_upper_bound_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_upper_bound_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_upper_bound_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_col_upper_bound_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_upper_bound_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_col_upper_bound_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_upper_bound_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_col_at_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_at_xor_small (0.0s)
    PASSED  .test_delta_for_cstore_col_at_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_at_delta_small (0.0s)
    PASSED  .test_delta_for_cstore_frame_prefix_truncate_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_prefix_truncate_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_prefix_truncate_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_prefix_truncate_delta (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_with_hint_xor (0.0s)
    PASSED  .test_delta_for_cstore_frame_at_with_hint_delta (0.0s)
    PASSED  .test_delta_for_cstore_col_at_with_hint_xor (0.0s)
    PASSED  .test_delta_for_cstore_col_at_with_hint_delta (0.0s)
//src/v/utils/tests:directory_walker_test                                PASSED in 0.4s
    PASSED  .empty_dir (0.1s)
    PASSED  .non_empty_dir (0.0s)
    PASSED  .exceptional_future (0.0s)
    PASSED  .test_empty_dir (0.0s)
//src/v/utils/tests:expiring_promise_test                                PASSED in 0.5s
    PASSED  .test_expiring_promise_availability (0.1s)
    PASSED  .test_expiring_promise_availability2 (0.0s)
    PASSED  .test_expiring_promise_availability3 (0.0s)
//src/v/utils/tests:external_process_test                                PASSED in 17.7s
    PASSED  external_process.bin_true (0.0s)
    PASSED  external_process.bin_false (0.0s)
    PASSED  external_process.echo_hi (0.0s)
    PASSED  external_process.run_long_process (10.0s)
    PASSED  external_process.run_long_process_and_terminate (1.0s)
    PASSED  external_process.test_sigterm_ignored (6.1s)
    PASSED  external_process.no_such_bin (0.0s)
    PASSED  external_process.test_bad_args (0.0s)
//src/v/utils/tests:filtered_lower_bound_test                            PASSED in 17.6s
    PASSED  .filtered_lower_bound_test (0.0s)
    PASSED  .fuzz_test (17.2s)
//src/v/utils/tests:human_test                                           PASSED in 0.3s
    PASSED  human_bytes_suite.human_bytes (0.0s)
//src/v/utils/tests:input_stream_fanout_test                             PASSED in 14.5s
    PASSED  .test_mid_read_detach (10.1s)
    PASSED  .input_stream_fanout_test_2 (0.0s)
    PASSED  .input_stream_fanout_test_3 (0.0s)
    PASSED  .input_stream_fanout_test_4 (0.0s)
    PASSED  .input_stream_fanout_test_5 (0.0s)
    PASSED  .input_stream_fanout_test_6 (0.0s)
    PASSED  .input_stream_fanout_test_7 (0.0s)
    PASSED  .input_stream_fanout_test_8 (0.0s)
    PASSED  .input_stream_fanout_test_9 (0.0s)
    PASSED  .input_stream_fanout_test_10 (0.0s)
    PASSED  .input_stream_fanout_test_2_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_3_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_4_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_5_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_6_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_7_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_8_size_limit (0.0s)
    PASSED  .input_stream_fanout_test_9_size_limit (0.1s)
    PASSED  .input_stream_fanout_test_10_size_limit (0.1s)
    PASSED  .input_stream_fanout_async_2_1 (0.0s)
    PASSED  .input_stream_fanout_async_3_1 (0.0s)
    PASSED  .input_stream_fanout_async_4_1 (0.0s)
    PASSED  .input_stream_fanout_async_5_1 (0.0s)
    PASSED  .input_stream_fanout_async_6_1 (0.0s)
    PASSED  .input_stream_fanout_async_7_1 (0.0s)
    PASSED  .input_stream_fanout_async_8_1 (0.0s)
    PASSED  .input_stream_fanout_async_9_1 (0.0s)
    PASSED  .input_stream_fanout_async_10_1 (0.0s)
    PASSED  .input_stream_fanout_async_2_4 (0.0s)
    PASSED  .input_stream_fanout_async_3_4 (0.0s)
    PASSED  .input_stream_fanout_async_4_4 (0.0s)
    PASSED  .input_stream_fanout_async_5_4 (0.0s)
    PASSED  .input_stream_fanout_async_6_4 (0.0s)
    PASSED  .input_stream_fanout_async_7_4 (0.0s)
    PASSED  .input_stream_fanout_async_8_4 (0.0s)
    PASSED  .input_stream_fanout_async_9_4 (0.0s)
    PASSED  .input_stream_fanout_async_10_4 (0.0s)
    PASSED  .input_stream_fanout_async_2_size_limit (0.1s)
    PASSED  .input_stream_fanout_async_3_size_limit (0.2s)
    PASSED  .input_stream_fanout_async_4_size_limit (0.2s)
    PASSED  .input_stream_fanout_async_5_size_limit (0.2s)
    PASSED  .input_stream_fanout_async_6_size_limit (0.3s)
    PASSED  .input_stream_fanout_async_7_size_limit (0.3s)
    PASSED  .input_stream_fanout_async_8_size_limit (0.4s)
    PASSED  .input_stream_fanout_async_9_size_limit (0.3s)
    PASSED  .input_stream_fanout_async_10_size_limit (0.3s)
    PASSED  .input_stream_fanout_detach_2 (0.0s)
    PASSED  .input_stream_fanout_detach_3 (0.0s)
    PASSED  .input_stream_fanout_detach_4 (0.0s)
    PASSED  .input_stream_fanout_detach_5 (0.0s)
    PASSED  .input_stream_fanout_detach_6 (0.0s)
    PASSED  .input_stream_fanout_detach_7 (0.0s)
    PASSED  .input_stream_fanout_detach_8 (0.0s)
    PASSED  .input_stream_fanout_detach_9 (0.0s)
    PASSED  .input_stream_fanout_detach_10 (0.0s)
    PASSED  .input_stream_fanout_detach_2_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_3_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_4_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_5_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_6_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_7_size_limit (0.1s)
    PASSED  .input_stream_fanout_detach_8_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_9_size_limit (0.0s)
    PASSED  .input_stream_fanout_detach_10_size_limit (0.1s)
    PASSED  .input_stream_fanout_producer_throw (0.0s)
    PASSED  .input_stream_fanout_close (0.0s)
//src/v/utils/tests:move_canary_test                                     PASSED in 0.0s
    PASSED  .move_canary_default_ctor<move_canary> (0.0s)
    PASSED  .move_canary_default_ctor<canary_as_member> (0.0s)
    PASSED  .move_canary_default_ctor<canary_as_base> (0.0s)
    PASSED  .move_canary_move_ctor<move_canary> (0.0s)
    PASSED  .move_canary_move_ctor<canary_as_member> (0.0s)
    PASSED  .move_canary_move_ctor<canary_as_base> (0.0s)
    PASSED  .move_canary_move_assignment<move_canary> (0.0s)
    PASSED  .move_canary_move_assignment<canary_as_member> (0.0s)
    PASSED  .move_canary_move_assignment<canary_as_base> (0.0s)
    PASSED  .move_canary_copy_assignment<move_canary> (0.0s)
    PASSED  .move_canary_copy_assignment<canary_as_member> (0.0s)
    PASSED  .move_canary_copy_assignment<canary_as_base> (0.0s)
    PASSED  .move_canary_assignment_is_transitive<move_canary> (0.0s)
    PASSED  .move_canary_assignment_is_transitive<canary_as_member> (0.0s)
    PASSED  .move_canary_assignment_is_transitive<canary_as_base> (0.0s)
    PASSED  .move_canary_moved_to_not_moved<move_canary> (0.0s)
    PASSED  .move_canary_moved_to_not_moved<canary_as_member> (0.0s)
    PASSED  .move_canary_moved_to_not_moved<canary_as_base> (0.0s)
    PASSED  .move_canary_copy_ctor<move_canary> (0.0s)
    PASSED  .move_canary_copy_ctor<canary_as_member> (0.0s)
    PASSED  .move_canary_copy_ctor<canary_as_base> (0.0s)
//src/v/utils/tests:moving_average_test                                  PASSED in 0.4s
    PASSED  .test_moving_average (0.0s)
    PASSED  .test_timed_moving_average (0.0s)
//src/v/utils/tests:named_type_test                                      PASSED in 0.6s
    PASSED  .named_type_basic (0.0s)
    PASSED  .named_type_set (0.0s)
    PASSED  .named_type_unordered_map (0.0s)
    PASSED  .string_named_type_basic (0.0s)
    PASSED  .named_type_string_set (0.0s)
    PASSED  .named_type_prefix_increment (0.0s)
    PASSED  .named_type_rvalue_overload (0.0s)
    PASSED  .named_type_stream_operators (0.0s)
//src/v/utils/tests:object_pool_test                                     PASSED in 0.4s
    PASSED  .test_waiting_on_object (0.1s)
    PASSED  .testing_ready_object (0.0s)
    PASSED  .testing_move_only_object (0.0s)
    PASSED  .test_abort_on_wait (0.0s)
    PASSED  .test_abort_after_wait (0.0s)
    PASSED  .test_ordering_waiters (0.0s)
//src/v/utils/tests:remote_test                                          PASSED in 1.0s
    PASSED  .test_free_on_right_cpu (0.1s)
    PASSED  .test_free_on_right_cpu_with_foreign_ptr (0.0s)
//src/v/utils/tests:retry_chain_node_test                                PASSED in 0.4s
    PASSED  .check_fmt (0.1s)
    PASSED  .check_retry1 (0.0s)
    PASSED  .check_retry2 (0.0s)
    PASSED  .check_child_retry_canceled (0.0s)
    PASSED  .check_root_retry_canceled (0.0s)
    PASSED  .check_abort_requested (0.0s)
    PASSED  .check_deadline_propogation_1 (0.0s)
    PASSED  .check_deadline_propogation_2 (0.0s)
    PASSED  .check_deadline_propogation_3 (0.0s)
    PASSED  .check_node_comparison (0.0s)
//src/v/utils/tests:retry_test                                           PASSED in 0.6s
    PASSED  .retry_then_succed (0.1s)
    PASSED  .retry_then_fail (0.0s)
    PASSED  .retry_then_fail_when_cancelled (0.1s)
//src/v/utils/tests:rwlock_test                                          PASSED in 0.5s
    PASSED  .test_rwlock_r_blocks_w (0.1s)
    PASSED  .test_rwlock_w_blocks_r (0.0s)
    PASSED  .test_rwlock_r_permits_r (0.0s)
    PASSED  .test_rwlock_w_blocks_w (0.0s)
    PASSED  .test_rwlock_unit_move (0.0s)
    PASSED  .test_rwlock_assign (0.0s)
//src/v/utils/tests:seastar_histogram_test                               PASSED in 0.7s
    PASSED  .test_seastar_histograms_match (0.1s)
    PASSED  .test_public_log_hist_and_hdr_hist_equal_bounds (0.0s)
    PASSED  .test_public_log_hist_and_hdr_hist_equal_rand (0.2s)
    PASSED  .test_internal_hist_to_public_hist_bounds (0.0s)
    PASSED  .test_public_hist_to_internal_hist (0.0s)
    PASSED  .test_log_hist_measure (0.0s)
    PASSED  .test_log_hist_measure_pause (0.0s)
//src/v/utils/tests:stable_iterator_test                                 PASSED in 0.6s
    PASSED  .test_stable_iterator_basic (0.0s)
//src/v/utils/tests:timed_mutex_test                                     PASSED in 10.5s
    PASSED  .test_timed_mutex_counts_locks (5.1s)
    PASSED  .test_timed_mutex_doesnt_count_locks (5.0s)
//src/v/utils/tests:token_bucket_test                                    PASSED in 2.2s
    PASSED  .test_simple_throttle (0.1s)
    PASSED  .test_throttle_wait (1.7s)
    PASSED  .test_throttle_shutdown (0.0s)
    PASSED  .test_throttle_abort (0.0s)
    PASSED  .test_try_throttle (0.0s)
    PASSED  .test_throttle_then_try (0.0s)
    PASSED  .test_wait_until_available (0.0s)
    PASSED  .test_burst (0.0s)
    PASSED  .test_update_rate (0.0s)
    PASSED  .test_update_rate_burst (0.0s)
    PASSED  .test_available_tokens (0.0s)
    PASSED  .test_available_tokens_capacity (0.0s)
    PASSED  .test_available_tokens_change_capacity (0.0s)
//src/v/utils/tests:tracking_allocator_test                              PASSED in 12.7s
    PASSED  .allocator_basic (0.0s)
    PASSED  .mem_tracker_pretty_printing (12.0s)
    PASSED  .allocator_list_vector (0.0s)
    PASSED  .allocator_stl (0.0s)
//src/v/utils/tests:tristate_test                                        PASSED in 0.6s
    PASSED  .tristate_having_value (0.0s)
    PASSED  .disabled_tristate (0.0s)
    PASSED  .tristate_with_empty_value (0.0s)
//src/v/utils/tests:uuid_test                                            PASSED in 0.6s
    PASSED  .test_uuid_create (0.1s)
    PASSED  .test_uuid_default_construct (0.0s)
    PASSED  .test_lt (0.0s)
    PASSED  .test_named_uuid_type (0.0s)
    PASSED  .test_to_from_vec (0.0s)
    PASSED  .uuid_test (0.0s)
    PASSED  .complex_uuid_types_test (0.0s)
//src/v/utils/tests:vint_test                                            PASSED in 0.5s
    PASSED  .sanity_signed_sweep_64 (0.1s)
    PASSED  .sanity_unsigned_sweep_32 (0.0s)
    PASSED  .test_unsigned_stream_deserializer (0.0s)
//src/v/utils/tests:waiter_queue_test                                    PASSED in 0.5s
    PASSED  .test_notifying_value (0.1s)
    PASSED  .test_abort_after_await (0.0s)
    PASSED  .test_abort_before_await (0.0s)
    PASSED  .test_abort_after_notify (0.0s)
//src/v/utils/tests:xid_test                                             PASSED in 0.5s
    PASSED  xid.string_formatting_test (0.0s)
    PASSED  xid.hashing_test (0.0s)
    PASSED  xid.string_round_trip_test (0.0s)
    PASSED  xid.serde_round_trip_test (0.0s)
    PASSED  xid.test_xid_string_validation (0.0s)
Test cases: finished with 284 passing and 0 failing out of 284 test cases

Executed 27 out of 27 tests: 27 tests pass.
```

Now there are 284 test cases and all tests have detailed results. Note that most of the boost test have names starting with `.` like `.test_to_from_vec`. This is because their "class name" is empty, since we don't but them inside any test suite. This can be done with BOOST_AUTO_TEST_SUITE if the class name is important for some reason.

Fixes CORE-8013.

## Backports Required

- [x] none - bazel not necessary in prior releases
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
