### PR TITLE
Half chunk cache memory reservations

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2455,6 +2455,11 @@ void application::wire_up_bootstrap_services() {
     ss::smp::invoke_on_all([] {
         return storage::internal::chunks().start();
     }).get();
+    _deferred.emplace_back([] {
+        ss::smp::invoke_on_all([] {
+            return storage::internal::chunks().stop();
+        }).get();
+    });
     construct_service(stress_fiber_manager).get();
     syschecks::systemd_message("Constructing storage services").get();
     construct_single_service_sharded(

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -31,13 +31,13 @@ bool datalake_enabled() {
 }
 
 struct memory_shares {
-    constexpr static size_t chunk_cache = 3;
-    constexpr static size_t kafka = 3;
-    constexpr static size_t rpc = 2;
-    constexpr static size_t recovery = 1;
-    constexpr static size_t tiered_storage = 1;
-    constexpr static size_t data_transforms = 1;
-    constexpr static size_t datalake = 1;
+    constexpr static size_t chunk_cache = 30;
+    constexpr static size_t kafka = 30;
+    constexpr static size_t rpc = 20;
+    constexpr static size_t recovery = 10;
+    constexpr static size_t tiered_storage = 10;
+    constexpr static size_t data_transforms = 10;
+    constexpr static size_t datalake = 10;
 
     static size_t total_shares(bool with_wasm, bool with_datalake) {
         size_t total = chunk_cache + kafka + rpc + recovery + tiered_storage;

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -31,7 +31,7 @@ bool datalake_enabled() {
 }
 
 struct memory_shares {
-    constexpr static size_t chunk_cache = 30;
+    constexpr static size_t chunk_cache = 15;
     constexpr static size_t kafka = 30;
     constexpr static size_t rpc = 20;
     constexpr static size_t recovery = 10;

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-static constexpr size_t total_shares_without_optionals = 100;
+static constexpr size_t total_shares_without_optionals = 85;
 static constexpr size_t total_wasm_shares = 10;
 static constexpr size_t total_datalake_shares = 10;
 
@@ -68,10 +68,10 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     }
     EXPECT_THAT(
       groups.chunk_cache_min_memory(),
-      IsApprox(total_available_memory * 10.0 / total_shares));
+      IsApprox(total_available_memory * 5.0 / total_shares));
     EXPECT_THAT(
       groups.chunk_cache_max_memory(),
-      IsApprox(total_available_memory * 30.0 / total_shares));
+      IsApprox(total_available_memory * 15.0 / total_shares));
     EXPECT_THAT(
       groups.tiered_storage_max_memory(),
       IsApprox(total_available_memory * 10.0 / total_shares));

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -16,9 +16,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-static constexpr size_t total_shares_without_optionals = 10;
-static constexpr size_t total_wasm_shares = 1;
-static constexpr size_t total_datalake_shares = 1;
+static constexpr size_t total_shares_without_optionals = 100;
+static constexpr size_t total_wasm_shares = 10;
+static constexpr size_t total_datalake_shares = 10;
 
 // It's not really useful to know the exact byte values for each of these
 // numbers so we just make sure we're within a MB
@@ -68,33 +68,33 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     }
     EXPECT_THAT(
       groups.chunk_cache_min_memory(),
-      IsApprox(total_available_memory * 1.0 / total_shares));
+      IsApprox(total_available_memory * 10.0 / total_shares));
     EXPECT_THAT(
       groups.chunk_cache_max_memory(),
-      IsApprox(total_available_memory * 3.0 / total_shares));
+      IsApprox(total_available_memory * 30.0 / total_shares));
     EXPECT_THAT(
       groups.tiered_storage_max_memory(),
-      IsApprox(total_available_memory * 1.0 / total_shares));
+      IsApprox(total_available_memory * 10.0 / total_shares));
     EXPECT_THAT(
       groups.recovery_max_memory(),
-      IsApprox(total_available_memory * 1.0 / total_shares));
+      IsApprox(total_available_memory * 10.0 / total_shares));
     EXPECT_THAT(
       groups.kafka_total_memory(),
-      IsApprox(total_available_memory * 3.0 / total_shares));
+      IsApprox(total_available_memory * 30.0 / total_shares));
     EXPECT_THAT(
       groups.rpc_total_memory(),
-      IsApprox(total_available_memory * 2.0 / total_shares));
+      IsApprox(total_available_memory * 20.0 / total_shares));
     if (wasm_enabled()) {
         EXPECT_THAT(
           groups.data_transforms_max_memory(),
-          IsApprox(total_available_memory * 1.0 / total_shares));
+          IsApprox(total_available_memory * 10.0 / total_shares));
     } else {
         EXPECT_THAT(groups.data_transforms_max_memory(), 0);
     }
     if (datalake_enabled()) {
         EXPECT_THAT(
           groups.datalake_max_memory(),
-          IsApprox(total_available_memory * 1.0 / total_shares));
+          IsApprox(total_available_memory * 10.0 / total_shares));
     } else {
         EXPECT_THAT(groups.datalake_max_memory(), 0);
     }

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -187,6 +187,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/container:intrusive",
+        "//src/v/metrics",
         "//src/v/ssx:semaphore",
         "//src/v/utils:named_type",
         "@seastar",

--- a/src/v/storage/chunk_cache.cc
+++ b/src/v/storage/chunk_cache.cc
@@ -11,6 +11,7 @@
 #include "storage/chunk_cache.h"
 
 #include "config/configuration.h"
+#include "metrics/prometheus_sanitize.h"
 #include "resource_mgmt/memory_groups.h"
 
 #include <seastar/core/loop.hh>
@@ -25,6 +26,7 @@ chunk_cache::chunk_cache() noexcept
   , _chunk_size(config::shard_local_cfg().append_chunk_size()) {}
 
 ss::future<> chunk_cache::start() {
+    setup_metrics();
     const auto num_chunks = memory_groups().chunk_cache_min_memory()
                             / _chunk_size;
     return ss::do_for_each(
@@ -34,6 +36,38 @@ ss::future<> chunk_cache::start() {
           auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
           _size_total += _chunk_size;
           add(c);
+      });
+}
+
+ss::future<> chunk_cache::stop() {
+    _metrics.clear();
+    return ss::now();
+}
+
+void chunk_cache::setup_metrics() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("chunk_cache"),
+      {
+        sm::make_gauge(
+          "total_size_bytes",
+          [this] { return _size_total; },
+          sm::description("Total size of all segment appender chunks in any "
+                          "state, in bytes.")),
+        sm::make_gauge(
+          "available_size_bytes",
+          [this] { return _size_available; },
+          sm::description("Total size of all free segment appender chunks in "
+                          "the cache, in bytes.")),
+        sm::make_counter(
+          "wait_count",
+          [this] { return _wait_for_chunk_count; },
+          sm::description("Count of how many times we had to wait for a chunk "
+                          "to become available")),
       });
 }
 
@@ -54,16 +88,25 @@ ss::future<chunk_cache::chunk_ptr> chunk_cache::get() {
     if (!_sem.waiters()) {
         return do_get();
     }
-    return ss::get_units(_sem, 1).then(
-      [this](ssx::semaphore_units) { return do_get(); });
+
+    return wait_and_get();
 }
 
 ss::future<chunk_cache::chunk_ptr> chunk_cache::do_get() {
     if (auto c = pop_or_allocate(); c) {
         return ss::make_ready_future<chunk_ptr>(c);
     }
-    return ss::get_units(_sem, 1).then(
-      [this](ssx::semaphore_units) { return do_get(); });
+
+    return wait_and_get();
+}
+
+ss::future<chunk_cache::chunk_ptr> chunk_cache::wait_and_get() {
+    auto fut = ss::get_units(_sem, 1);
+    if (_sem.waiters()) {
+        _wait_for_chunk_count++;
+    }
+
+    return fut.then([this](ssx::semaphore_units) { return do_get(); });
 }
 
 chunk_cache::chunk_ptr chunk_cache::pop_or_allocate() {

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "metrics/metrics.h"
 #include "ssx/semaphore.h"
 #include "storage/segment_appender_chunk.h"
 
@@ -42,6 +43,7 @@ public:
     ~chunk_cache() noexcept = default;
 
     ss::future<> start();
+    ss::future<> stop();
 
     void add(const chunk_ptr& chunk);
 
@@ -51,6 +53,8 @@ public:
 
 private:
     ss::future<chunk_ptr> do_get();
+    void setup_metrics();
+    ss::future<chunk_cache::chunk_ptr> wait_and_get();
 
     chunk_ptr pop_or_allocate();
 
@@ -62,6 +66,9 @@ private:
     const size_t _size_limit;
 
     const size_t _chunk_size{0};
+
+    size_t _wait_for_chunk_count{0};
+    metrics::internal_metric_groups _metrics;
 };
 
 chunk_cache& chunks();

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -123,7 +123,7 @@ iobuf make_iobuf_with_char(size_t len, unsigned char c) {
     return ret;
 }
 
-size_t default_chunk_size() { return internal::chunks().chunk_size(); }
+size_t default_chunk_size() { return storage::internal::chunks().chunk_size(); }
 
 } // namespace
 


### PR DESCRIPTION
Assuming wasm and iceberg being disabled the chunkcache currently gets
assigned 30% of the total memory as per memory groups.

At rest it only preallocates a lower watermark of a third of its share
(aka. 10% of total memory) but the other two thirds are still reserved
away from other subsystems.

Even 10% of total memory is a massive overallocation for the chunk
cache.

Looking at some benchmarks the per shard usage is usually below 1MB. On
a 4GB per shard system the chunk cache preallocates 400MB of chunks with
allowance to go up to 1.2GB.

The worst case scenario is a high partition scenario. Even at rest each
partition seems to prereserve one chunk. Even in a super high partition
density scenario of lets say 10k partitions per core (this isn't really
realistic) this would only take 160MB of chunks and hence be still way
below the 400MB low water mark in this case.

Write caching can also increase the chunk cache usage but even in that
case we write chunks as soon as the chunk is full so chunk throughput is
high and we don't want to get too far behind in any case as that might
mean bursting above disk throughput.

Hence this patch halfs the current reserve amounts to free up some
space. As per the above numbers we could go even lower but we can gain
some further insight first with the metrics added in a previous patch
and we'd probably want to fix the case where partitions reserve a chunk
at idle.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
