### PR TITLE
[rptest] Use "redpanda" namespace for KubeNodeShell

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -450,7 +450,7 @@ class KubeNodeShell():
     def __init__(self,
                  kubectl: KubectlTool,
                  node_name: str,
-                 namespace: str = 'redpanda-node-setup',
+                 namespace: str = 'redpanda',
                  clean=False) -> None:
         self.kubectl = kubectl
         self.node_name = node_name

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -83,7 +83,7 @@ class CloudBroker():
         # Copy agent -> broker node
         remote_path = os.path.join("/tmp", script_name)
         _cp_cmd = self._kubeclient._ssh_prefix() + [
-            'kubectl', '-n', 'redpanda-node-setup', 'cp', script_name,
+            'kubectl', '-n', 'redpanda', 'cp', script_name,
             f"{self.nodeshell.pod_name}:{remote_path}"
         ]
         self.logger.debug(_cp_cmd)


### PR DESCRIPTION
Apparently the `redpanda-node-setup` namespace only exists in operator V2 clusters. But the `redpanda` namespace exists in both V1 and V2.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
