### PR TITLE
[rptest] Fix "ContainerAlreadyExists" in test_recovery_mode

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3383,7 +3383,7 @@ class RedpandaService(RedpandaServiceBase):
             )
         else:
             raise RuntimeError(
-                f"Unsuported cloud_storage_type: {self.si_settings.cloud_storage_type}"
+                f"Unsupported cloud_storage_type: {self.si_settings.cloud_storage_type}"
             )
 
         if not self.si_settings.bypass_bucket_creation:

--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -159,7 +159,9 @@ class RecoveryModeTest(RedpandaTest):
 
         # check that a new node can join the cluster
 
-        self.redpanda.start(nodes=[joiner_node], auto_assign_node_id=True)
+        self.redpanda.start(nodes=[joiner_node],
+                            auto_assign_node_id=True,
+                            start_si=False)
         self.redpanda.wait_for_membership(first_start=True)
 
         # restart the cluster back in normal mode


### PR DESCRIPTION
Occasionally, `rptest/tests/recovery_mode_test.py::RecoveryModeTest.test_recovery_mode` fails with an Azure storage "container already exists" error.  ~~If we try to create a container but it already exists, we should just treat that as a victory and move on instead of failing the test.~~

Further digging revealed that `test_recovery_mode` is actually calling `RedpandaService.start()` _twice_ per test execution, and the second execution explains why the Azure storage bucket/container name "already existed" - it was created by the first call to `RedpandaService.start()`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none