### PR TITLE
`rptest`: use proper `WriteCachingMode` string for parameterization

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -24,6 +24,7 @@ from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.machinetype import get_machine_info
 from rptest.utils.type_utils import rcast
+from rptest.tests.write_caching_test import WriteCachingMode
 
 # pyright: strict
 
@@ -231,7 +232,7 @@ class OMBValidationTest(RedpandaCloudTest):
         return math.floor(0.9537 * mb)
 
     @cluster(num_nodes=CLUSTER_NODES)
-    @matrix(write_caching=["on", "off"])
+    @matrix(write_caching=[WriteCachingMode.TRUE, WriteCachingMode.FALSE])
     def test_max_connections(self, write_caching: str):
         tier_limits = self.tier_limits
 
@@ -564,7 +565,7 @@ class OMBValidationTest(RedpandaCloudTest):
             self.logger.warn(str(results))
 
     @cluster(num_nodes=CLUSTER_NODES)
-    @matrix(write_caching=["on", "off"])
+    @matrix(write_caching=[WriteCachingMode.TRUE, WriteCachingMode.FALSE])
     def test_max_partitions(self, write_caching: str):
         tier_limits = self.tier_limits
 
@@ -670,7 +671,7 @@ class OMBValidationTest(RedpandaCloudTest):
         self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=CLUSTER_NODES)
-    @matrix(write_caching=["on", "off"])
+    @matrix(write_caching=[WriteCachingMode.TRUE, WriteCachingMode.FALSE])
     def test_common_workload(self, write_caching: str):
         tier_limits = self.tier_limits
 
@@ -728,7 +729,7 @@ class OMBValidationTest(RedpandaCloudTest):
         self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=CLUSTER_NODES)
-    @matrix(write_caching=["on", "off"])
+    @matrix(write_caching=[WriteCachingMode.TRUE, WriteCachingMode.FALSE])
     def test_retention(self, write_caching: str):
         tier_limits = self.tier_limits
 


### PR DESCRIPTION
`"on"` and `"off"` are not valid strings for write caching mode: https://github.com/redpanda-data/redpanda/blob/2a9f07c64a5599c83f3230f252915895f65a3d22/src/v/model/metadata.h#L558-L569

Replace the values used for write caching parameterization in `omb_validation_test.py` with the strings coded in the `WriteCachingMode` class.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
