### PR TITLE
Cache parsed schemas in datalake

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -376,6 +376,8 @@ redpanda_cc_library(
         ":schema_avro",
         ":schema_protobuf",
         ":schema_registry",
+        "//src/v/config",
+        "//src/v/metrics",
         "//src/v/pandaproxy",
         "//src/v/schema:registry",
         "@avro",
@@ -387,6 +389,7 @@ redpanda_cc_library(
         ":schema_identifier",
         "//src/v/base",
         "//src/v/iceberg:datatypes",
+        "//src/v/utils:chunked_kv_cache",
         "@seastar",
     ],
 )

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -29,8 +29,8 @@ namespace datalake {
 
 namespace {
 
-static std::unique_ptr<type_resolver>
-make_type_resolver(model::iceberg_mode mode, schema::registry& sr) {
+static std::unique_ptr<type_resolver> make_type_resolver(
+  model::iceberg_mode mode, schema::registry& sr, schema_cache& cache) {
     switch (mode) {
     case model::iceberg_mode::disabled:
         vassert(
@@ -39,7 +39,7 @@ make_type_resolver(model::iceberg_mode mode, schema::registry& sr) {
     case model::iceberg_mode::key_value:
         return std::make_unique<binary_type_resolver>();
     case model::iceberg_mode::value_schema_id_prefix:
-        return std::make_unique<record_schema_resolver>(sr);
+        return std::make_unique<record_schema_resolver>(sr, cache);
     }
 }
 
@@ -89,6 +89,11 @@ datalake_manager::datalake_manager(
   , _schema_registry(schema::registry::make_default(sr_api))
   , _catalog_factory(std::move(catalog_factory))
   , _type_resolver(std::make_unique<record_schema_resolver>(*_schema_registry))
+  // TODO: The cache size is currently arbitrary. Figure out a more reasoned
+  // size and allocate a share of the datalake memory semaphore to this cache.
+  , _schema_cache(std::make_unique<chunked_schema_cache>(
+      chunked_schema_cache::cache_t::config{
+        .cache_size = 50, .small_size = 10}))
   , _as(as)
   , _sg(sg)
   , _effective_max_translator_buffered_data(
@@ -178,6 +183,7 @@ ss::future<> datalake_manager::start() {
             }
         });
     });
+    _schema_cache->start();
 }
 
 ss::future<> datalake_manager::stop() {
@@ -188,6 +194,7 @@ ss::future<> datalake_manager::stop() {
           return entry.second->stop();
       });
     co_await std::move(f);
+    _schema_cache->stop();
 }
 
 std::chrono::milliseconds datalake_manager::translation_interval_ms() const {
@@ -247,7 +254,7 @@ void datalake_manager::start_translator(
       _features,
       &_cloud_data_io,
       _schema_mgr.get(),
-      make_type_resolver(mode, *_schema_registry),
+      make_type_resolver(mode, *_schema_registry, *_schema_cache),
       make_record_translator(mode),
       translation_interval_ms(),
       _sg,

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -16,6 +16,7 @@
 #include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "datalake/fwd.h"
+#include "datalake/record_schema_resolver.h"
 #include "datalake/translation/partition_translator.h"
 #include "features/fwd.h"
 #include "pandaproxy/schema_registry/fwd.h"
@@ -92,6 +93,7 @@ private:
     std::unique_ptr<iceberg::catalog> _catalog;
     std::unique_ptr<datalake::schema_manager> _schema_mgr;
     std::unique_ptr<datalake::type_resolver> _type_resolver;
+    std::unique_ptr<datalake::schema_cache> _schema_cache;
     ss::sharded<ss::abort_source>* _as;
     ss::scheduling_group _sg;
     ss::gate _gate;

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -12,7 +12,9 @@
 #include "base/seastarx.h"
 #include "datalake/schema_identifier.h"
 #include "iceberg/datatypes.h"
+#include "metrics/metrics.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "utils/chunked_kv_cache.h"
 
 #include <seastar/core/future.hh>
 
@@ -26,18 +28,66 @@ class Descriptor;
 
 namespace datalake {
 
-struct wrapped_protobuf_descriptor {
-    std::reference_wrapper<const google::protobuf::Descriptor> descriptor;
-    // `descriptor` references an object owned by `schema_def`.
-    pandaproxy::schema_registry::protobuf_schema_definition schema_def;
+class schema_cache {
+public:
+    using key_t = pandaproxy::schema_registry::schema_id;
+    using val_t = pandaproxy::schema_registry::valid_schema;
+
+    virtual ss::optimized_optional<ss::shared_ptr<val_t>>
+    get_value(const key_t&) = 0;
+
+    virtual bool try_insert(const key_t&, ss::shared_ptr<val_t>) = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+
+    virtual ~schema_cache() = default;
 };
+
+class chunked_schema_cache : public schema_cache {
+public:
+    using cache_t = utils::chunked_kv_cache<key_t, val_t>;
+
+    explicit chunked_schema_cache(cache_t::config config);
+    ~chunked_schema_cache() override = default;
+
+    ss::optimized_optional<ss::shared_ptr<val_t>>
+    get_value(const key_t&) override;
+    bool try_insert(const key_t&, ss::shared_ptr<val_t>) override;
+
+    void start() override;
+    void stop() override;
+
+private:
+    cache_t cache_;
+    metrics::internal_metric_groups metrics_;
+
+    void setup_metrics();
+};
+
+using shared_schema_t
+  = ss::shared_ptr<pandaproxy::schema_registry::valid_schema>;
 
 // Represents an object that can be converted into an Iceberg schema.
 // NOTE: these aren't exactly just the schemas from the registry: Protobuf
 // schemas are FileDescriptors in the registry rather than Descriptors, and
 // require additional information to get the Descriptors.
-using resolved_schema
-  = std::variant<wrapped_protobuf_descriptor, avro::ValidSchema>;
+class resolved_schema {
+public:
+    using resolved_schema_t = std::variant<
+      std::reference_wrapper<const google::protobuf::Descriptor>,
+      std::reference_wrapper<const avro::ValidSchema>>;
+
+    resolved_schema(resolved_schema_t schema, shared_schema_t shared_schema)
+      : schema_(schema)
+      , shared_schema_(std::move(shared_schema)) {}
+
+    resolved_schema_t get_schema_ref() const noexcept { return schema_; }
+
+private:
+    // Note that `schema_` is a reference to data owned by `shared_schema_`.
+    resolved_schema_t schema_;
+    shared_schema_t shared_schema_;
+};
 
 struct resolved_type {
     // The resolved schema that corresponds to the type.
@@ -92,8 +142,11 @@ public:
 
 class record_schema_resolver : public type_resolver {
 public:
-    explicit record_schema_resolver(schema::registry& sr)
-      : sr_(sr) {}
+    explicit record_schema_resolver(
+      schema::registry& sr,
+      std::optional<std::reference_wrapper<schema_cache>> sc = std::nullopt)
+      : sr_(sr)
+      , cache_(sc) {}
 
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
@@ -104,6 +157,10 @@ public:
 
 private:
     schema::registry& sr_;
+    std::optional<std::reference_wrapper<schema_cache>> cache_;
+
+    ss::future<checked<shared_schema_t, type_resolver::errc>>
+      get_schema(pandaproxy::schema_registry::schema_id) const;
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -34,8 +34,8 @@ struct value_translating_visitor {
     const iceberg::field_type& type;
 
     ss::future<optional_value_outcome>
-    operator()(const wrapped_protobuf_descriptor& d) {
-        return deserialize_protobuf(std::move(parsable_buf), d.descriptor);
+    operator()(const google::protobuf::Descriptor& d) {
+        return deserialize_protobuf(std::move(parsable_buf), d);
     }
     ss::future<optional_value_outcome> operator()(const avro::ValidSchema& s) {
         auto value = co_await deserialize_avro(std::move(parsable_buf), s);
@@ -239,7 +239,7 @@ structured_data_translator::translate_data(
 
     auto translated_val = co_await std::visit(
       value_translating_visitor{std::move(*parsable_val), val_type->type},
-      val_type->schema);
+      val_type->schema.get_schema_ref());
     if (translated_val.has_error()) {
         vlog(
           datalake_log.error,

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -266,8 +266,9 @@ class record_multiplexer_bench_fixture
   : public datalake::tests::catalog_and_registry_fixture {
 public:
     record_multiplexer_bench_fixture()
-      : _schema_mgr(catalog)
-      , _type_resolver(registry)
+      : _schema_cache({10, 5})
+      , _schema_mgr(catalog)
+      , _type_resolver(registry, _schema_cache)
       , _record_gen(&registry)
       , _table_creator(_type_resolver, _schema_mgr)
       , _as([] { return std::nullopt; }) {}
@@ -309,6 +310,7 @@ public:
 
 private:
     std::unordered_set<std::string> _added_names;
+    datalake::chunked_schema_cache _schema_cache;
     datalake::catalog_schema_manager _schema_mgr;
     datalake::record_schema_resolver _type_resolver;
     datalake::tests::record_generator _record_gen;

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -7,6 +7,7 @@
  *
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
+#include "base/vassert.h"
 #include "bytes/bytes.h"
 #include "datalake/logger.h"
 #include "datalake/record_schema_resolver.h"
@@ -18,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <exception>
+#include <unordered_map>
 #include <variant>
 
 using namespace pandaproxy::schema_registry;
@@ -260,4 +262,286 @@ TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
     ASSERT_TRUE(resolved_buf.type.has_value());
     EXPECT_EQ(1, resolved_buf.type->id.schema_id());
     EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+}
+
+namespace {
+struct counting_store : public pandaproxy::schema_registry::schema_getter {
+    counting_store(
+      schema::fake_registry& registry,
+      std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>&
+        counts)
+      : registry(registry)
+      , counts(counts) {}
+
+    ss::future<pandaproxy::schema_registry::subject_schema> get_subject_schema(
+      pandaproxy::schema_registry::subject sub,
+      std::optional<pandaproxy::schema_registry::schema_version> version,
+      pandaproxy::schema_registry::include_deleted inc_dec) final {
+        auto* getter = co_await registry.getter();
+        co_return co_await getter->get_subject_schema(sub, version, inc_dec);
+    }
+
+    ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    get_schema_definition(pandaproxy::schema_registry::schema_id id) final {
+        counts[id] += 1;
+        auto* getter = co_await registry.getter();
+        co_return co_await getter->get_schema_definition(id);
+    }
+
+    ss::future<
+      std::optional<pandaproxy::schema_registry::canonical_schema_definition>>
+    maybe_get_schema_definition(
+      pandaproxy::schema_registry::schema_id id) final {
+        counts[id] += 1;
+        auto* getter = co_await registry.getter();
+        co_return co_await getter->maybe_get_schema_definition(id);
+    }
+
+    schema::fake_registry& registry;
+    std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>& counts;
+};
+
+class counting_registry : public schema::registry {
+public:
+    bool is_enabled() const override { return true; };
+
+    ss::future<pandaproxy::schema_registry::schema_getter*>
+    getter() const override {
+        co_return &_store;
+    }
+    ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    get_schema_definition(
+      pandaproxy::schema_registry::schema_id id) const override {
+        return _store.get_schema_definition(id);
+    }
+
+    ss::future<pandaproxy::schema_registry::subject_schema> get_subject_schema(
+      pandaproxy::schema_registry::subject sub,
+      std::optional<pandaproxy::schema_registry::schema_version> version)
+      const override {
+        return _registry.get_subject_schema(sub, version);
+    }
+
+    ss::future<pandaproxy::schema_registry::schema_id> create_schema(
+      pandaproxy::schema_registry::unparsed_schema unparsed) override {
+        return _registry.create_schema(std::move(unparsed));
+    }
+
+    const std::vector<pandaproxy::schema_registry::subject_schema>& get_all() {
+        return _registry.get_all();
+    }
+
+    size_t get_count(pandaproxy::schema_registry::schema_id id) {
+        return _counts[id];
+    }
+
+    void reset_counts() { _counts.clear(); }
+
+private:
+    schema::fake_registry _registry{};
+    std::unordered_map<pandaproxy::schema_registry::schema_id, size_t>
+      _counts{};
+    mutable counting_store _store{_registry, _counts};
+};
+
+chunked_schema_cache make_schema_cache() {
+    return chunked_schema_cache{chunked_schema_cache::cache_t::config{2, 1}};
+}
+
+std::unique_ptr<counting_registry> make_counting_sr() {
+    auto sr = std::make_unique<counting_registry>();
+
+    auto avro_schema_id = sr
+                            ->create_schema(unparsed_schema{
+                              subject{"foo"},
+                              unparsed_schema_definition{
+                                avro_record_schema, schema_type::avro}})
+                            .get();
+    vassert(1 == avro_schema_id(), "failed to registry avro schema");
+    auto pb_schema_id = sr
+                          ->create_schema(unparsed_schema{
+                            subject{"foo"},
+                            unparsed_schema_definition{
+                              pb_record_schema, schema_type::protobuf}})
+                          .get();
+    vassert(2 == pb_schema_id(), "failed to register protobuf schema");
+
+    auto get_simple_schema = [](int i) {
+        constexpr std::string_view schema_temp = R"(
+        syntax = "proto2";
+        message empty_message_{} {{}}
+        )";
+
+        return fmt::format(schema_temp, i);
+    };
+    for (auto i = 3; i < 10; i++) {
+        auto pb_schema_id = sr
+                              ->create_schema(unparsed_schema{
+                                subject{"foo"},
+                                unparsed_schema_definition{
+                                  get_simple_schema(i), schema_type::protobuf}})
+                              .get();
+        vassert(i == pb_schema_id(), "failed to register protobuf schema");
+    }
+    return sr;
+}
+} // namespace
+
+TEST(CachedRecordSchemaResolverTest, TestProtobufSchemaCache) {
+    // Kakfa magic byte + schema ID + pb offsets.
+    std::vector<int32_t> pb_offsets{2, 0};
+    iobuf buf;
+    buf.append("\0\0\0\0\2", 5);
+    buf.append(encode_pb_offsets(pb_offsets));
+    buf.append(generate_dummy_body());
+
+    auto schema_cache = make_schema_cache();
+    auto sr = make_counting_sr();
+    auto resolver = record_schema_resolver(*sr, schema_cache);
+
+    auto resolve_buffer_fn = [&](bool expect_sr_access) {
+        sr->reset_counts();
+        size_t expected_sr_count = expect_sr_access ? 1 : 0;
+
+        auto res = resolver.resolve_buf_type(buf.copy()).get();
+        ASSERT_FALSE(res.has_error());
+        auto& resolved_buf = res.value();
+        ASSERT_TRUE(resolved_buf.type.has_value());
+        EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+        ASSERT_EQ(
+          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
+        EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
+        EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
+
+        const auto expected_type = field_type{[] {
+            auto expected_struct = struct_type{};
+            expected_struct.fields.emplace_back(nested_field::create(
+              1, "inner_label_1", field_required::no, string_type{}));
+            expected_struct.fields.emplace_back(nested_field::create(
+              2, "inner_number_1", field_required::no, int_type{}));
+            return expected_struct;
+        }()};
+        EXPECT_EQ(resolved_buf.type->type, expected_type);
+    };
+
+    // First access to a schema, should hit the schema registry.
+    resolve_buffer_fn(true);
+    // All accesses afterwards should be cache hits.
+    resolve_buffer_fn(false);
+}
+
+TEST(CachedRecordSchemaResolverTest, TestAvroSchemaCache) {
+    // Kakfa magic byte + schema ID.
+    iobuf buf;
+    buf.append("\0\0\0\0\1", 5);
+    buf.append(generate_dummy_body());
+
+    auto schema_cache = make_schema_cache();
+    auto sr = make_counting_sr();
+    auto resolver = record_schema_resolver(*sr, schema_cache);
+
+    auto resolve_buffer_fn = [&](bool expect_sr_access) {
+        sr->reset_counts();
+        size_t expected_sr_count = expect_sr_access ? 1 : 0;
+
+        auto res = resolver.resolve_buf_type(buf.copy()).get();
+        ASSERT_FALSE(res.has_error());
+        auto& resolved_buf = res.value();
+        ASSERT_TRUE(resolved_buf.type.has_value());
+        EXPECT_EQ(1, resolved_buf.type->id.schema_id());
+        ASSERT_EQ(
+          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
+        EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
+
+        const auto expected_type = field_type{[] {
+            auto expected_struct = struct_type{};
+            expected_struct.fields.emplace_back(nested_field::create(
+              0, "value", field_required::yes, long_type{}));
+            expected_struct.fields.emplace_back(
+              nested_field::create(0, "next", field_required::yes, int_type{}));
+            return expected_struct;
+        }()};
+        EXPECT_EQ(resolved_buf.type->type, expected_type);
+    };
+
+    // First access to a schema, should hit the schema registry.
+    resolve_buffer_fn(true);
+    // All accesses afterwards should be cache hits.
+    resolve_buffer_fn(false);
+}
+
+TEST(CachedRecordSchemaResolverTest, TestSchemaCacheEviction) {
+    auto schema_cache = make_schema_cache();
+    auto sr = make_counting_sr();
+    auto resolver = record_schema_resolver(*sr, schema_cache);
+
+    auto resolve_buffer_fn = [&](
+                               bool expect_sr_access,
+                               uint8_t schema_id,
+                               const std::vector<int32_t>& pb_offsets,
+                               const field_type& expected_type) {
+        // Kakfa magic byte + schema ID + pb offsets.
+        iobuf buf;
+        buf.append("\0\0\0\0", 4);
+        buf.append(&schema_id, 1);
+        buf.append(encode_pb_offsets(pb_offsets));
+        buf.append(generate_dummy_body());
+
+        sr->reset_counts();
+        size_t expected_sr_count = expect_sr_access ? 1 : 0;
+
+        auto res = resolver.resolve_buf_type(buf.copy()).get();
+        ASSERT_FALSE(res.has_error());
+        auto& resolved_buf = res.value();
+        ASSERT_TRUE(resolved_buf.type.has_value());
+        EXPECT_EQ(schema_id, resolved_buf.type->id.schema_id());
+        ASSERT_EQ(
+          sr->get_count(resolved_buf.type->id.schema_id), expected_sr_count);
+        EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
+        EXPECT_EQ(resolved_buf.type->id.protobuf_offsets.value(), pb_offsets);
+        EXPECT_EQ(resolved_buf.type->type, expected_type);
+    };
+
+    const auto schema_2_expected_type = field_type{[] {
+        auto expected_struct = struct_type{};
+        expected_struct.fields.emplace_back(nested_field::create(
+          1, "inner_label_1", field_required::no, string_type{}));
+        expected_struct.fields.emplace_back(nested_field::create(
+          2, "inner_number_1", field_required::no, int_type{}));
+        return expected_struct;
+    }()};
+
+    const auto schema_3_expected_type = field_type{struct_type{}};
+
+    // First access to schema 2 should hit the schema registry.
+    resolve_buffer_fn(true, 2, {2, 0}, schema_2_expected_type);
+    // All accesses afterwards should be cache hits.
+    resolve_buffer_fn(false, 2, {2, 0}, schema_2_expected_type);
+
+    // Try to get schema from cache.
+    auto cached_schema_opt = schema_cache.get_value(
+      pandaproxy::schema_registry::schema_id{2});
+    EXPECT_TRUE(cached_schema_opt);
+    auto schema_buf = cached_schema_opt->get()->raw()().copy();
+
+    // Fill the cache with other schemas. Note that each is accessed 3 times to
+    // ensure that the main cache is filled.
+    resolve_buffer_fn(true, 3, {0}, schema_3_expected_type);
+    resolve_buffer_fn(false, 3, {0}, schema_3_expected_type);
+    resolve_buffer_fn(false, 3, {0}, schema_3_expected_type);
+    resolve_buffer_fn(true, 4, {0}, schema_3_expected_type);
+    resolve_buffer_fn(false, 4, {0}, schema_3_expected_type);
+    resolve_buffer_fn(false, 4, {0}, schema_3_expected_type);
+    resolve_buffer_fn(true, 5, {0}, schema_3_expected_type);
+
+    // Ensure schema 2 was evicted.
+    EXPECT_FALSE(
+      schema_cache.get_value(pandaproxy::schema_registry::schema_id{2}));
+    // Ensure that the shared pointer to the evicted schema is still valid.
+    EXPECT_EQ(cached_schema_opt->get()->raw()(), schema_buf);
+
+    // Try to resolve a schema 2 formatted buffer again.
+    resolve_buffer_fn(true, 2, {2, 0}, schema_2_expected_type);
+    // Ensure that schema 2 is once again in the cache.
+    resolve_buffer_fn(false, 2, {2, 0}, schema_2_expected_type);
 }

--- a/src/v/utils/tests/chunked_kv_cache_test.cc
+++ b/src/v/utils/tests/chunked_kv_cache_test.cc
@@ -25,6 +25,29 @@ TEST(ChunkedKVTest, InsertGetTest) {
     EXPECT_EQ(**v, str);
 }
 
+TEST(ChunkedKVTest, StatTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 2, .small_size = 1});
+    auto str = "avaluestr";
+
+    EXPECT_EQ(cache.try_insert(1, ss::make_shared<std::string>(str)), true);
+
+    auto stats = cache.stat();
+    EXPECT_EQ(stats.access_count, 0);
+    EXPECT_EQ(stats.hit_count, 0);
+
+    cache.get_value(1);
+    stats = cache.stat();
+    EXPECT_EQ(stats.access_count, 1);
+    EXPECT_EQ(stats.hit_count, 1);
+
+    cache.get_value(2);
+    stats = cache.stat();
+    EXPECT_EQ(stats.access_count, 2);
+    EXPECT_EQ(stats.hit_count, 1);
+}
+
 TEST(ChunkedKVTest, InvalidGetTest) {
     using cache_type = utils::chunked_kv_cache<int, std::string>;
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Microbenchmark results without caching;
  | test                                                                        |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |                                             
  | -                                                                           |           - |           - |           - |           - |           - |           - |           - |           - |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_1_field   |    45654000 |    21.613ns |     0.000ns |    21.613ns |    21.613ns |       0.694 |       0.000 |       291.5 |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_40_fields |     3261000 |   191.138ns |     0.000ns |   191.138ns |   191.138ns |       5.302 |       0.003 |      2972.1 |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_80_fields |     3261000 |   360.062ns |     0.000ns |   360.062ns |   360.062ns |       9.881 |       0.005 |      5718.3 |                                             
  | record_multiplexer_bench_fixture.protobuf_384_byte_message_nested_24_levels |     3291000 |   280.036ns |     0.000ns |   280.036ns |   280.036ns |      10.477 |       0.005 |      4684.5 |                                             
  | record_multiplexer_bench_fixture.protobuf_386_byte_message_nested_31_levels |     3311000 |   365.044ns |     0.000ns |   365.044ns |   365.044ns |      13.431 |       0.007 |      6070.1 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_1_field       |    66020000 |    14.661ns |     0.000ns |    14.661ns |    14.661ns |       0.440 |       0.000 |       175.0 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_31_fields     |     9903000 |   104.918ns |     0.000ns |   104.918ns |   104.918ns |       2.210 |       0.001 |      1369.0 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_62_fields     |     6602000 |   202.774ns |     0.000ns |   202.774ns |   202.774ns |       3.932 |       0.003 |      2618.2 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_31_levels     |     3301000 |   262.044ns |     0.000ns |   262.044ns |   262.044ns |       8.367 |       0.006 |      3823.9 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_62_levels     |     3301000 |   532.290ns |     0.000ns |   532.290ns |   532.290ns |      16.354 |       0.015 |      7760.2 |                                             

And with caching;
  | test                                                                        |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |                                             
  | -                                                                           |           - |           - |           - |           - |           - |           - |           - |           - |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_1_field   |   101091000 |     9.549ns |     0.000ns |     9.549ns |     9.549ns |       0.274 |       0.000 |       111.5 |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_40_fields |     9783000 |    81.919ns |     0.000ns |    81.919ns |    81.919ns |       0.701 |       0.001 |       834.0 |                                             
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_80_fields |     3261000 |   176.424ns |     0.000ns |   176.424ns |   176.424ns |       1.085 |       0.002 |      1567.9 |                                             
  | record_multiplexer_bench_fixture.protobuf_384_byte_message_nested_24_levels |     6582000 |    77.550ns |     0.000ns |    77.550ns |    77.550ns |       2.035 |       0.002 |      1021.1 |                                             
  | record_multiplexer_bench_fixture.protobuf_386_byte_message_nested_31_levels |     3311000 |    98.757ns |     0.000ns |    98.757ns |    98.757ns |       2.551 |       0.004 |      1299.1 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_1_field       |   102331000 |     9.562ns |     0.000ns |     9.562ns |     9.562ns |       0.256 |       0.000 |       108.8 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_31_fields     |    13204000 |    66.485ns |     0.000ns |    66.485ns |    66.485ns |       0.841 |       0.001 |       729.9 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_62_fields     |     6602000 |   123.961ns |     0.000ns |   123.961ns |   123.961ns |       1.417 |       0.002 |      1368.3 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_31_levels     |     3301000 |    95.581ns |     0.000ns |    95.581ns |    95.581ns |       2.410 |       0.004 |      1215.1 |                                             
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_62_levels     |     3301000 |   187.473ns |     0.000ns |   187.473ns |   187.473ns |       4.574 |       0.013 |      2433.4 |                                             

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
