### PR TITLE
iceberg: use c++23 static operator()

### DIFF
--- a/src/v/iceberg/datatypes.cc
+++ b/src/v/iceberg/datatypes.cc
@@ -16,17 +16,17 @@ namespace iceberg {
 
 struct primitive_type_comparison_visitor {
     template<typename T, typename U>
-    bool operator()(const T&, const U&) const {
+    static bool operator()(const T&, const U&) {
         return false;
     }
-    bool operator()(const decimal_type& lhs, const decimal_type& rhs) const {
+    static bool operator()(const decimal_type& lhs, const decimal_type& rhs) {
         return lhs.precision == rhs.precision && lhs.scale == rhs.scale;
     }
-    bool operator()(const fixed_type& lhs, const fixed_type& rhs) const {
+    static bool operator()(const fixed_type& lhs, const fixed_type& rhs) {
         return lhs.length == rhs.length;
     }
     template<typename T>
-    bool operator()(const T&, const T&) const {
+    static bool operator()(const T&, const T&) {
         return true;
     }
 };
@@ -37,20 +37,20 @@ bool operator==(const primitive_type& lhs, const primitive_type& rhs) {
 
 struct field_type_comparison_visitor {
     template<typename T, typename U>
-    bool operator()(const T&, const U&) const {
+    static bool operator()(const T&, const U&) {
         return false;
     }
-    bool
-    operator()(const primitive_type& lhs, const primitive_type& rhs) const {
+    static bool
+    operator()(const primitive_type& lhs, const primitive_type& rhs) {
         return lhs == rhs;
     }
-    bool operator()(const struct_type& lhs, const struct_type& rhs) const {
+    static bool operator()(const struct_type& lhs, const struct_type& rhs) {
         return lhs == rhs;
     }
-    bool operator()(const list_type& lhs, const list_type& rhs) const {
+    static bool operator()(const list_type& lhs, const list_type& rhs) {
         return lhs == rhs;
     }
-    bool operator()(const map_type& lhs, const map_type& rhs) const {
+    static bool operator()(const map_type& lhs, const map_type& rhs) {
         return lhs == rhs;
     }
 };
@@ -66,22 +66,24 @@ bool operator==(const nested_field& lhs, const nested_field& rhs) {
 namespace {
 
 struct type_copying_visitor {
-    field_type operator()(const primitive_type& t) { return make_copy(t); }
-    field_type operator()(const struct_type& t) {
+    static field_type operator()(const primitive_type& t) {
+        return make_copy(t);
+    }
+    static field_type operator()(const struct_type& t) {
         struct_type ret;
         for (const auto& field_ptr : t.fields) {
             ret.fields.emplace_back(field_ptr ? field_ptr->copy() : nullptr);
         }
         return ret;
     }
-    field_type operator()(const list_type& t) {
+    static field_type operator()(const list_type& t) {
         list_type ret;
         if (t.element_field) {
             ret.element_field = t.element_field->copy();
         }
         return ret;
     }
-    field_type operator()(const map_type& t) {
+    static field_type operator()(const map_type& t) {
         map_type ret;
         if (t.key_field) {
             ret.key_field = t.key_field->copy();


### PR DESCRIPTION
This is in principle a performance optimization because the compiler does not need to pass a pointer to `this` into the function.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
