### PR TITLE
storage: Reduce default read-ahead count

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -362,7 +362,7 @@ FIXTURE_TEST(
     try {
         auto headers_read
           = scan_remote_partition_incrementally_with_closest_lso(
-            *this, base, max, 5, 5);
+            *this, base, max, 5, 25);
         vlog(test_log.debug, "{} record batches consumed", headers_read.size());
         model::offset expected_offset{0};
         size_t ix_header = 0;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1340,7 +1340,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "1",
        .visibility = visibility::tunable},
-      10)
+      1)
   , segment_fallocation_step(
       *this,
       "segment_fallocation_step",


### PR DESCRIPTION
Lower `storage_read_readahead_count` from 10 to 1:

 - 1 read ahead at 128KiB readahead size (which is the default for
   storage_read_buffer_size) should be more than good enough to get good
   read throughput. Especially given this is per partition so in
   practice you'd have more than 1 in any case
 - On the non-TS path the memory used for read ahead is unaccounted for
   in the kafka/fetch semaphore. Hence this is a OOM risk. Obviously the
   real fix would be to account for it but the kafka/fetch semaphore
   accounting is already quite weird anyway so fixing that isn't
   immediately trivial
 - On the TS path we do account for the readahead in memory accounting.
   So that's good. At the same time I think we have lowered it in the
   past during some incidents to avoid overreading.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


