### PR TITLE
Re-add partition manifest logging

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2714,7 +2714,9 @@ void partition_manifest::process_anomalies(
 }
 
 std::ostream& operator<<(std::ostream& o, const partition_manifest& pm) {
+    o << "{manifest: ";
     pm.serialize_json(o, false);
+    o << "; last segment: " << pm.last_segment() << "}";
     return o;
 }
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2033,15 +2033,18 @@ ss::future<iobuf> partition_manifest::serialize_buf() const {
     return ss::make_ready_future<iobuf>(to_iobuf());
 }
 
-void partition_manifest::serialize_json(std::ostream& out) const {
+void partition_manifest::serialize_json(
+  std::ostream& out, bool include_segments) const {
     serialization_cursor_ptr c = make_cursor(out);
     serialize_begin(c);
-    while (!c->segments_done) {
-        serialize_segments(c);
-    }
-    serialize_replaced(c);
-    while (!c->spillover_done) {
-        serialize_spillover(c);
+    if (include_segments) {
+        while (!c->segments_done) {
+            serialize_segments(c);
+        }
+        serialize_replaced(c);
+        while (!c->spillover_done) {
+            serialize_spillover(c);
+        }
     }
     serialize_end(c);
 }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2713,4 +2713,9 @@ void partition_manifest::process_anomalies(
       _last_scrubbed_offset);
 }
 
+std::ostream& operator<<(std::ostream& o, const partition_manifest& pm) {
+    pm.serialize_json(o, false);
+    return o;
+}
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -700,4 +700,6 @@ private:
     model::offset _applied_offset;
 };
 
+std::ostream& operator<<(std::ostream& o, const partition_manifest& f);
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -448,7 +448,7 @@ public:
     /// Serialize manifest object
     ///
     /// \param out output stream that should be used to output the json
-    void serialize_json(std::ostream& out) const;
+    void serialize_json(std::ostream& out, bool include_segments = true) const;
 
     // Serialize the manifest to an ss::output_stream in JSON format
     /// \param out output stream to serialize into; must be kept alive

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -316,6 +316,10 @@ ss::future<log_recovery_result> partition_downloader::download_log() {
       _ntpc.get_revision(),
       retention);
     auto mat = co_await find_recovery_material();
+    vlog(
+      _ctxlog.debug,
+      "Partition manifest used for recovery: {}",
+      mat.partition_manifest);
     if (mat.partition_manifest.size() == 0) {
         // If the downloaded manifest doesn't have any segments
         log_recovery_result result{


### PR DESCRIPTION
Partition manifest logging was removed in https://github.com/redpanda-data/redpanda/pull/24476 to avoid oversized allocations and very long log lines. This is to re-add it, but without segments data.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
