### PR TITLE
base: Rename assert-unreachable logger to assert

### DIFF
--- a/src/v/base/unreachable.h
+++ b/src/v/base/unreachable.h
@@ -11,21 +11,17 @@
 
 #pragma once
 
-#include <seastar/util/backtrace.hh>
-#include <seastar/util/log.hh>
+#include "base/vassert.h"
 
-namespace details {
-// NOLINTNEXTLINE
-inline seastar::logger _g_unreachable_assert_logger("assert-unreachable");
-} // namespace details
+#include <seastar/util/backtrace.hh>
 
 // NOLINTNEXTLINE
 #define unreachable()                                                          \
     /* NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while) */                     \
     do {                                                                       \
-        ::details::_g_unreachable_assert_logger.error(                         \
+        ::detail::g_assert_log.l.error(                                        \
           "This code should not be reached ({}:{})", __FILE__, __LINE__);      \
-        ::details::_g_unreachable_assert_logger.error(                         \
+        ::detail::g_assert_log.l.error(                                        \
           "Backtrace below:\n{}", seastar::current_backtrace());               \
         __builtin_trap();                                                      \
     } while (0)


### PR DESCRIPTION
Subj.

The ducktape test infrastructure treats the name of this logger as an assert failure and reports false node crash. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none