### PR TITLE
`rptest`: make check for `None` explicit

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -191,7 +191,7 @@ class DatalakeServices():
             self.redpanda.logger.debug(
                 f"Current translated offsets: {offsets}")
             return all([
-                max_offset and offset <= max_offset
+                max_offset is not None and offset <= max_offset
                 for _, max_offset in offsets.items()
             ])
 


### PR DESCRIPTION
In the case that `offset == max_offset == 0`, checking the boolean `max_offset` will return `False`.

Since the intention here is just to check for `None`, make it explicit and avoid this mishandled corner case.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

