### PR TITLE
`storage`: log on clamped `segment.ms` value

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -58,6 +58,7 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include <chrono>
 #include <exception>
 #include <iterator>
 #include <optional>
@@ -1819,13 +1820,36 @@ ss::future<> disk_log_impl::apply_segment_ms() {
     auto& local_config = config::shard_local_cfg();
     // clamp user provided value with (hopefully sane) server min and max
     // values, this should protect against overflow UB
-    if (
-      first_write_ts.value()
-        + std::clamp(
+    const auto clamped_seg_ms = std::clamp(
+      seg_ms.value(),
+      local_config.log_segment_ms_min(),
+      local_config.log_segment_ms_max());
+
+    static constexpr auto rate_limit = std::chrono::minutes(5);
+    thread_local static ss::logger::rate_limit rate(rate_limit);
+    if (seg_ms < clamped_seg_ms) {
+        stlog.log(
+          ss::log_level::warn,
+          rate,
+          "Configured segment.ms={} is lower than the configured cluster "
+          "bound {}={}",
           seg_ms.value(),
-          local_config.log_segment_ms_min(),
-          local_config.log_segment_ms_max())
-      > ss::lowres_clock::now()) {
+          local_config.log_segment_ms_min.name(),
+          local_config.log_segment_ms_min());
+    }
+
+    if (seg_ms > clamped_seg_ms) {
+        stlog.log(
+          ss::log_level::warn,
+          rate,
+          "Configured segment.ms={} is higher than the configured cluster "
+          "bound {}={}",
+          seg_ms.value(),
+          local_config.log_segment_ms_max.name(),
+          local_config.log_segment_ms_max());
+    }
+
+    if (first_write_ts.value() + clamped_seg_ms > ss::lowres_clock::now()) {
         // skip, time hasn't expired
         co_return;
     }


### PR DESCRIPTION
Users can configure `log_segment_ms` at the cluster level or `segment.ms` at the topic level. However, the cluster properties `log_segment_ms_min` and `log_segment_ms_max` will quietly clamp the value when trying to determine if a segment should be rolled or not.

Add warn level logging to `disk_log_impl::apply_segment_ms()` so that this clamping is no longer silent, and warns users that they may have a misconfiguration at some level between their topic and/or cluster level properties.

I.e,

```
segment.ms=5, log_segment_ms_min=10: 
    "Configured segment.ms=5 is lower than configured cluster bound log_segment_ms_min=10"

segment.ms=1500, log_segment_ms_max=1000:
    "Configured segment.ms=1500 is higher than configured cluster bound log_segment_ms_max=1000"
```


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
