### PR TITLE
[rptest] RedpandaInstaller async download rework

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -701,9 +701,16 @@ class RedpandaInstaller:
         """
         version_root = self.root_for_version(version)
 
+        results = []
         tgz = "redpanda.tar.gz"
-        cmd = f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz} && echo 'curl finished successfully' && gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root} && echo 'tarball extraction finished successfully' && rm {version_root}/{tgz} && echo 'tarball cleanup finished successfully'"
-        return node.account.ssh_capture(cmd)
+        cmds = [
+            f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz}",
+            f"gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root}",
+            f"rm {version_root}/{tgz}"
+        ]
+        for cmd in cmds:
+            results.extend(node.account.ssh_capture(cmd))
+        return results
 
     def reset_current_install(self, nodes):
         """


### PR DESCRIPTION
When the async download command fails, it's not clear which actual command on the remote host was the culprit. Splitting the commands up and running them separately should help us debug when something goes wrong.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
