### PR TITLE
Add a general key-value cache to utils

### DIFF
--- a/src/v/io/BUILD
+++ b/src/v/io/BUILD
@@ -15,7 +15,6 @@ redpanda_cc_library(
         "scheduler.cc",
     ],
     hdrs = [
-        "cache.h",
         "interval_map.h",
         "io_queue.h",
         "page.h",
@@ -33,6 +32,7 @@ redpanda_cc_library(
         "//src/v/container:intrusive",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
+        "//src/v/utils:s3_fifo",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@boost//:intrusive",

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -22,7 +22,7 @@ page::page(uint64_t offset, seastar::temporary_buffer<char> data)
 page::page(
   uint64_t offset,
   seastar::temporary_buffer<char> data,
-  const class cache_hook& hook)
+  const class utils::s3_fifo::cache_hook& hook)
   : cache_hook(hook)
   , offset_(offset)
   , size_(data.size())

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "container/intrusive_list_helpers.h"
-#include "io/cache.h"
+#include "utils/s3_fifo.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -40,7 +40,7 @@ public:
     page(
       uint64_t offset,
       seastar::temporary_buffer<char> data,
-      const cache_hook& hook);
+      const utils::s3_fifo::cache_hook& hook);
 
     page(const page&) = delete;
     page& operator=(const page&) = delete;
@@ -123,7 +123,7 @@ public:
      * Page cache entry intrusive list hook.
      */
     // NOLINTNEXTLINE(*-non-private-member-variables-in-classes)
-    cache_hook cache_hook;
+    utils::s3_fifo::cache_hook cache_hook;
 
     struct waiter {
         intrusive_list_hook waiter;

--- a/src/v/io/page_cache.h
+++ b/src/v/io/page_cache.h
@@ -9,8 +9,8 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
-#include "io/cache.h"
 #include "io/page.h"
+#include "utils/s3_fifo.h"
 
 namespace experimental::io {
 
@@ -26,7 +26,8 @@ class page_cache {
         size_t operator()(const page&) noexcept;
     };
 
-    using cache_type = cache<page, &page::cache_hook, evict, cost>;
+    using cache_type
+      = utils::s3_fifo::cache<page, &page::cache_hook, evict, cost>;
 
 public:
     using config = cache_type::config;

--- a/src/v/io/pager.cc
+++ b/src/v/io/pager.cc
@@ -45,8 +45,8 @@ seastar::future<> pager::close() noexcept {
     }
 }
 
-seastar::lw_shared_ptr<page>
-pager::alloc_page(uint64_t offset, std::optional<cache_hook> hook) noexcept {
+seastar::lw_shared_ptr<page> pager::alloc_page(
+  uint64_t offset, std::optional<utils::s3_fifo::cache_hook> hook) noexcept {
     auto buf = seastar::temporary_buffer<char>::aligned(page_size, page_size);
     if (hook.has_value()) {
         return seastar::make_lw_shared<page>(

--- a/src/v/io/pager.h
+++ b/src/v/io/pager.h
@@ -10,9 +10,9 @@
  */
 #pragma once
 
-#include "io/cache.h"
 #include "io/page_set.h"
 #include "io/scheduler.h"
+#include "utils/s3_fifo.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/temporary_buffer.hh>
@@ -92,7 +92,8 @@ public:
 
 private:
     static seastar::lw_shared_ptr<page> alloc_page(
-      uint64_t offset, std::optional<cache_hook> hook = std::nullopt) noexcept;
+      uint64_t offset,
+      std::optional<utils::s3_fifo::cache_hook> hook = std::nullopt) noexcept;
 
     /*
      * Read a page from the underlying file.

--- a/src/v/io/tests/BUILD
+++ b/src/v/io/tests/BUILD
@@ -30,16 +30,6 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "cache_test",
-    timeout = "short",
-    srcs = ["cache_test.cc"],
-    deps = [
-        "//src/v/io",
-        "//src/v/test_utils:gtest",
-    ],
-)
-
-redpanda_cc_gtest(
     name = "interval_map_test",
     timeout = "short",
     srcs = ["interval_map_test.cc"],

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -6,7 +6,6 @@ rp_test(
   SOURCES
     common.cc
     common_test.cc
-    cache_test.cc
     interval_map_test.cc
     persistence_test.cc
     page_test.cc

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -664,3 +664,16 @@ redpanda_cc_library(
         "@fmt",
     ],
 )
+
+redpanda_cc_library(
+    name = "chunked_kv_cache",
+    hdrs = [
+        "chunked_kv_cache.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "//src/v/container:chunked_hash_map",
+        "//src/v/utils:s3_fifo",
+        "@boost//:intrusive",
+    ],
+)

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -652,3 +652,15 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "s3_fifo",
+    hdrs = [
+        "s3_fifo.h",
+    ],
+    include_prefix = "utils",
+    deps = [
+        "@boost//:intrusive",
+        "@fmt",
+    ],
+)

--- a/src/v/utils/chunked_kv_cache.h
+++ b/src/v/utils/chunked_kv_cache.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_hash_map.h"
+#include "utils/s3_fifo.h"
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/optimized_optional.hh>
+
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/options.hpp>
+#include <boost/intrusive/parent_from_member.hpp>
+
+namespace utils {
+
+/**
+ * A basic key-value cache implementation built on top of the s3_fifo::cache.
+ */
+template<
+  typename Key,
+  typename Value,
+  typename Hash = std::conditional_t<
+    detail::has_absl_hash<Key>,
+    detail::avalanching_absl_hash<Key>,
+    ankerl::unordered_dense::hash<Key>>,
+  typename EqualTo = std::equal_to<Key>>
+class chunked_kv_cache {
+    struct cached_value;
+    struct evict;
+    using cache_t = s3_fifo::cache<
+      cached_value,
+      &cached_value::hook,
+      evict,
+      s3_fifo::default_cache_cost>;
+
+public:
+    using config = cache_t::config;
+
+    explicit chunked_kv_cache(config config)
+      : _cache{config, evict{*this}} {}
+
+    ~chunked_kv_cache() noexcept = default;
+
+    // These contructors need to be deleted to ensure a stable `this` pointer.
+    chunked_kv_cache(chunked_kv_cache&&) = delete;
+    chunked_kv_cache& operator=(chunked_kv_cache&&) noexcept = delete;
+    chunked_kv_cache(const chunked_kv_cache&) = delete;
+    chunked_kv_cache& operator=(const chunked_kv_cache&) noexcept = delete;
+
+    /**
+     * Inserts a value for a given key into the cache.
+     *
+     * Returns true if the value was inserted and false if there was already a
+     * value for the given key in the cache.
+     */
+    bool try_insert(const Key& key, ss::shared_ptr<Value> val);
+
+    /**
+     * Gets the key's corresponding value from the cache.
+     *
+     * Returns std::nullopt if the key doesn't have a value in the cache.
+     */
+    ss::optimized_optional<ss::shared_ptr<Value>> get_value(const Key& key);
+
+    using cache_stat = struct cache_t::stat;
+    /**
+     * Cache statistics.
+     */
+    struct stat : public cache_stat {
+        /// Current size of the cache index.
+        size_t index_size;
+    };
+
+    /**
+     * Returns the current cache statistics.
+     */
+    [[nodiscard]] stat stat() const noexcept;
+
+private:
+    using ghost_hook_t = boost::intrusive::list_member_hook<
+      boost::intrusive::link_mode<boost::intrusive::safe_link>>;
+
+    struct cached_value {
+        Key key;
+        ss::shared_ptr<Value> value;
+        s3_fifo::cache_hook hook;
+        ghost_hook_t ghost_hook;
+    };
+
+    using entry_t = std::unique_ptr<cached_value>;
+    using ghost_fifo_t = boost::intrusive::list<
+      cached_value,
+      boost::intrusive::
+        member_hook<cached_value, ghost_hook_t, &cached_value::ghost_hook>>;
+
+    chunked_hash_map<Key, entry_t, Hash, EqualTo> _map;
+    cache_t _cache;
+    ghost_fifo_t _ghost_fifo;
+
+    void gc_ghost_fifo();
+};
+
+template<typename Key, typename Value, typename Hash, typename EqualTo>
+struct chunked_kv_cache<Key, Value, Hash, EqualTo>::evict {
+    chunked_kv_cache& kv_c;
+
+    bool operator()(cached_value& e) noexcept {
+        e.value = nullptr;
+        kv_c._ghost_fifo.push_back(e);
+        return true;
+    }
+};
+
+template<typename Key, typename Value, typename Hash, typename EqualTo>
+bool chunked_kv_cache<Key, Value, Hash, EqualTo>::try_insert(
+  const Key& key, ss::shared_ptr<Value> val) {
+    gc_ghost_fifo();
+
+    auto e_it = _map.find(key);
+    if (e_it == _map.end()) {
+        auto [e_it, succ] = _map.try_emplace(
+          key, std::make_unique<cached_value>(key, std::move(val)));
+        if (!succ) {
+            return false;
+        }
+
+        _cache.insert(*e_it->second);
+        return true;
+    }
+
+    auto& entry = *e_it->second;
+    if (entry.hook.evicted()) {
+        entry.value = std::move(val);
+        _ghost_fifo.erase(_ghost_fifo.iterator_to(entry));
+        _cache.insert(entry);
+        return true;
+    }
+
+    return false;
+}
+
+template<typename Key, typename Value, typename Hash, typename EqualTo>
+ss::optimized_optional<ss::shared_ptr<Value>>
+chunked_kv_cache<Key, Value, Hash, EqualTo>::get_value(const Key& key) {
+    gc_ghost_fifo();
+
+    auto e_it = _map.find(key);
+    if (e_it == _map.end()) {
+        return std::nullopt;
+    }
+
+    auto& entry = *e_it->second;
+    if (entry.hook.evicted()) {
+        return std::nullopt;
+    }
+
+    entry.hook.touch();
+    return entry.value;
+}
+
+template<typename Key, typename Value, typename Hash, typename EqualTo>
+void chunked_kv_cache<Key, Value, Hash, EqualTo>::gc_ghost_fifo() {
+    for (auto it = _ghost_fifo.begin(); it != _ghost_fifo.end();) {
+        auto& entry = *it;
+        if (_cache.ghost_queue_contains(entry)) {
+            // The ghost queue is in fifo-order so any entry that comes after an
+            // entry that hasn't been evicted will also not be evicted.
+            return;
+        }
+
+        it = _ghost_fifo.erase(it);
+        _map.erase(entry.key);
+    }
+}
+template<typename Key, typename Value, typename Hash, typename EqualTo>
+struct chunked_kv_cache<Key, Value, Hash, EqualTo>::stat
+chunked_kv_cache<Key, Value, Hash, EqualTo>::stat() const noexcept {
+    struct stat s {
+        _cache.stat()
+    };
+    s.index_size = _map.size();
+    return s;
+}
+
+} // namespace utils

--- a/src/v/utils/s3_fifo.h
+++ b/src/v/utils/s3_fifo.h
@@ -175,7 +175,7 @@
  * @{
  */
 
-namespace experimental::io {
+namespace utils::s3_fifo {
 
 namespace testing_details {
 class cache_hook_accessor;
@@ -674,18 +674,18 @@ bool cache<T, Hook, Evictor, Cost>::evict_main() noexcept {
  * @}
  */
 
-} // namespace experimental::io
+} // namespace utils::s3_fifo
 
 template<
   typename T,
-  experimental::io::cache_hook T::*Hook,
-  experimental::io::cache_evictor<T> Evictor,
-  experimental::io::cache_cost<T> Cost>
-struct fmt::formatter<experimental::io::cache<T, Hook, Evictor, Cost>>
+  utils::s3_fifo::cache_hook T::*Hook,
+  utils::s3_fifo::cache_evictor<T> Evictor,
+  utils::s3_fifo::cache_cost<T> Cost>
+struct fmt::formatter<utils::s3_fifo::cache<T, Hook, Evictor, Cost>>
   : fmt::formatter<std::string_view> {
     template<typename FormatContext>
     auto format(
-      const experimental::io::cache<T, Hook, Evictor, Cost>& cache,
+      const utils::s3_fifo::cache<T, Hook, Evictor, Cost>& cache,
       FormatContext& ctx) const {
         const auto stat = cache.stat();
         return fmt::format_to(

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -513,3 +513,13 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "s3_fifo_test",
+    timeout = "short",
+    srcs = ["s3_fifo_test.cc"],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:s3_fifo",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -523,3 +523,14 @@ redpanda_cc_gtest(
         "//src/v/utils:s3_fifo",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "chunked_kv_cache_test",
+    timeout = "short",
+    srcs = ["chunked_kv_cache_test.cc"],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:chunked_kv_cache",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ rp_test(
   BINARY_NAME gtest_utils_single_thread
   SOURCES
     external_process_test.cc
+    s3_fifo_test.cc
   LIBRARIES
     v::utils
     v::gtest_main

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ rp_test(
   SOURCES
     external_process_test.cc
     s3_fifo_test.cc
+    chunked_kv_cache_test.cc
   LIBRARIES
     v::utils
     v::gtest_main

--- a/src/v/utils/tests/chunked_kv_cache_test.cc
+++ b/src/v/utils/tests/chunked_kv_cache_test.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "test_utils/test.h"
+#include "utils/chunked_kv_cache.h"
+
+#include <optional>
+
+TEST(ChunkedKVTest, InsertGetTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 2, .small_size = 1});
+    auto str = "avaluestr";
+
+    EXPECT_EQ(cache.try_insert(1, ss::make_shared<std::string>(str)), true);
+    auto v = cache.get_value(1);
+    EXPECT_TRUE(v);
+    EXPECT_EQ(**v, str);
+}
+
+TEST(ChunkedKVTest, InvalidGetTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 2, .small_size = 1});
+
+    EXPECT_EQ(cache.get_value(0), std::nullopt);
+}
+
+TEST(ChunkedKVTest, ReinsertionTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 2, .small_size = 1});
+    auto str = "avaluestr";
+
+    EXPECT_EQ(cache.try_insert(0, ss::make_shared<std::string>(str)), true);
+    auto stat = cache.stat();
+    EXPECT_EQ(stat.main_queue_size, 0);
+    EXPECT_EQ(stat.small_queue_size, 1);
+    EXPECT_EQ(stat.index_size, 1);
+
+    EXPECT_EQ(cache.try_insert(0, ss::make_shared<std::string>(str)), false);
+    stat = cache.stat();
+    EXPECT_EQ(stat.main_queue_size, 0);
+    EXPECT_EQ(stat.small_queue_size, 1);
+    EXPECT_EQ(stat.index_size, 1);
+}
+
+TEST(ChunkedKVTest, EvictionTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 2, .small_size = 1});
+    auto str = "avaluestr";
+
+    // Initial phase without any eviction. The `s3_fifo` cache allows for its
+    // max size to be exceeded by one.
+    for (int i = 0; i < 3; i++) {
+        EXPECT_EQ(cache.try_insert(i, ss::make_shared<std::string>(str)), true);
+        auto stat = cache.stat();
+        EXPECT_EQ(stat.main_queue_size, 0);
+        EXPECT_EQ(stat.small_queue_size, i + 1);
+        EXPECT_EQ(stat.index_size, i + 1);
+    }
+
+    // Next phase with evictions and one ghost queue entry. Ensures that entries
+    // that have been removed from the ghost queue are also removed from the
+    // index.
+    for (int i = 3; i < 10; i++) {
+        EXPECT_EQ(cache.try_insert(i, ss::make_shared<std::string>(str)), true);
+        auto stat = cache.stat();
+        EXPECT_EQ(stat.main_queue_size, 0);
+        EXPECT_EQ(stat.small_queue_size, 3);
+        EXPECT_EQ(stat.index_size, 4);
+    }
+}
+
+TEST(ChunkedKVTest, GhostToMainTest) {
+    using cache_type = utils::chunked_kv_cache<int, std::string>;
+
+    cache_type cache(cache_type::config{.cache_size = 4, .small_size = 1});
+    auto str = "avaluestr";
+
+    // Fill the cache
+    for (int i = 0; i < 5; i++) {
+        EXPECT_EQ(cache.try_insert(i, ss::make_shared<std::string>(str)), true);
+        auto stat = cache.stat();
+        EXPECT_EQ(stat.main_queue_size, 0);
+        EXPECT_EQ(stat.small_queue_size, i + 1);
+        EXPECT_EQ(stat.index_size, i + 1);
+    }
+
+    // Move one entry to the ghost queue
+    EXPECT_EQ(cache.try_insert(5, ss::make_shared<std::string>(str)), true);
+    auto stat = cache.stat();
+    EXPECT_EQ(stat.main_queue_size, 0);
+    EXPECT_EQ(stat.small_queue_size, 5);
+    EXPECT_EQ(stat.index_size, 6);
+
+    // Get the key for the entry in the ghost queue.
+    int key = -1;
+    for (int i = 0; i < 5; i++) {
+        if (!cache.get_value(i)) {
+            key = i;
+            break;
+        }
+    }
+
+    EXPECT_NE(key, -1);
+
+    // Move entry from ghost queue to main queue.
+    EXPECT_EQ(cache.try_insert(key, ss::make_shared<std::string>(str)), true);
+    stat = cache.stat();
+    EXPECT_EQ(stat.main_queue_size, 1);
+    EXPECT_EQ(stat.small_queue_size, 4);
+    EXPECT_EQ(stat.index_size, 6);
+}

--- a/src/v/utils/tests/s3_fifo_test.cc
+++ b/src/v/utils/tests/s3_fifo_test.cc
@@ -8,29 +8,29 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-#include "io/cache.h"
 #include "test_utils/test.h"
+#include "utils/s3_fifo.h"
 
 #include <map>
 
-namespace experimental::io::testing_details {
+namespace utils::s3_fifo::testing_details {
 class cache_hook_accessor {
 public:
     static std::optional<size_t>
-    get_hook_insertion_time(const io::cache_hook& hook) {
+    get_hook_insertion_time(const utils::s3_fifo::cache_hook& hook) {
         return hook.ghost_insertion_time_;
     }
 
-    static void
-    set_hook_insertion_time(io::cache_hook& hook, std::optional<size_t> time) {
+    static void set_hook_insertion_time(
+      utils::s3_fifo::cache_hook& hook, std::optional<size_t> time) {
         hook.ghost_insertion_time_ = time;
     }
 
-    static uint8_t get_hook_freq(io::cache_hook& hook) { return hook.freq_; }
+    static uint8_t get_hook_freq(utils::s3_fifo::cache_hook& hook) {
+        return hook.freq_;
+    }
 };
-} // namespace experimental::io::testing_details
-
-namespace io = experimental::io;
+} // namespace utils::s3_fifo::testing_details
 
 class CacheTest : public ::testing::Test {
 public:
@@ -39,7 +39,7 @@ public:
     static constexpr auto main_size = cache_size - small_size;
 
     struct entry {
-        io::cache_hook hook;
+        utils::s3_fifo::cache_hook hook;
         bool may_evict{true};
         bool evicted{false};
     };
@@ -58,7 +58,8 @@ public:
         size_t operator()(const entry& /*entry*/) noexcept { return 1; }
     };
 
-    using cache_type = io::cache<entry, &entry::hook, evict, entry_cost>;
+    using cache_type
+      = utils::s3_fifo::cache<entry, &entry::hook, evict, entry_cost>;
 
     void SetUp() override {
         cache = std::make_unique<cache_type>(cache_type::config{
@@ -78,19 +79,19 @@ public:
     }
 
     static std::optional<size_t> get_hook_insertion_time(const entry& entry) {
-        return io::testing_details::cache_hook_accessor::
+        return utils::s3_fifo::testing_details::cache_hook_accessor::
           get_hook_insertion_time(entry.hook);
     }
 
     static void
     set_hook_insertion_time(entry& entry, std::optional<size_t> time) {
-        io::testing_details::cache_hook_accessor::set_hook_insertion_time(
-          entry.hook, time);
+        utils::s3_fifo::testing_details::cache_hook_accessor::
+          set_hook_insertion_time(entry.hook, time);
     }
 
     static uint8_t get_hook_freq(entry& entry) {
-        return io::testing_details::cache_hook_accessor::get_hook_freq(
-          entry.hook);
+        return utils::s3_fifo::testing_details::cache_hook_accessor::
+          get_hook_freq(entry.hook);
     }
 
     template<typename... Entries>
@@ -700,7 +701,7 @@ TEST_F(CacheTest, Formattable) {
 
 TEST(CacheTestCustom, CustomCost) {
     struct entry {
-        io::cache_hook hook;
+        utils::s3_fifo::cache_hook hook;
         std::string data;
     };
 
@@ -713,8 +714,11 @@ TEST(CacheTestCustom, CustomCost) {
     constexpr auto cache_size = 100;
     constexpr auto small_size = 5;
 
-    using cache_type
-      = io::cache<entry, &entry::hook, io::default_cache_evictor, entry_cost>;
+    using cache_type = utils::s3_fifo::cache<
+      entry,
+      &entry::hook,
+      utils::s3_fifo::default_cache_evictor,
+      entry_cost>;
 
     cache_type cache(
       cache_type::config{.cache_size = cache_size, .small_size = small_size});


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Introduces a general key-value cache built on top of the `s3_fifo` cache.
 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
