### PR TITLE
gha: add permissions for jira_issue_manage to write issue

### DIFF
--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
this PR addresses [error](https://github.com/redpanda-data/redpanda/actions/runs/12252479425/job/34179192198#step:8:104):
```
failed to update https://github.com/redpanda-data/redpanda/issues/24505: GraphQL: Resource not accessible by integration (updateIssue)
```

ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
