### PR TITLE
raft/tests/reconfiguration: allow more memory

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -610,7 +610,7 @@ redpanda_cc_gtest(
         "raft_reconfiguration_test.cc",
     ],
     cpu = 4,
-    memory = "2GiB",
+    memory = "4GiB",
     tags = ["exclusive"],
     deps = [
         "//src/v/base",

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -65,7 +65,7 @@ rp_test(
   SOURCES ${gsrcs}
   LIBRARIES  v::raft v::storage_test_utils v::model_test_utils v::features v::gtest_main
   LABELS raft
-  ARGS "-- -c 8 -m 2G"
+  ARGS "-- -c 8 -m 4G"
 )
 
 rp_test(


### PR DESCRIPTION
`raft_fixture.test_force_reconfiguration` often fails with failed allocations within 2-4 seconds from start
https://redpandadata.atlassian.net/browse/CORE-8086
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
