### PR TITLE
[CORE-8485] Reset translation state on snapshot

### DIFF
--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -138,7 +138,14 @@ translation_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     co_return raft::stm_snapshot::create(0, snapshot_offset, std::move(result));
 }
 
-ss::future<> translation_stm::apply_raft_snapshot(const iobuf&) { co_return; }
+ss::future<> translation_stm::apply_raft_snapshot(const iobuf&) {
+    // reset offset to not initalized when handling Raft snapshot, this way
+    // state machine will not hold any obsolete state that should be overriden
+    // with the snapshot.
+    vlog(_log.debug, "Applying raft snapshot, resetting state");
+    _highest_translated_offset = kafka::offset{};
+    co_return;
+}
 
 ss::future<iobuf> translation_stm::take_snapshot(model::offset) {
     co_return iobuf{};

--- a/src/v/datalake/translation/tests/state_machine_test.cc
+++ b/src/v/datalake/translation/tests/state_machine_test.cc
@@ -112,6 +112,7 @@ struct translator_stm_fixture : stm_raft_fixture<stm> {
 };
 
 TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
+    enable_offset_translation();
     co_await initialize_state_machines();
     co_await wait_for_leader(5s);
     scoped_config config;

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -158,7 +158,8 @@ public:
       leader_update_clb_t leader_update_clb,
       bool enable_longest_log_detection,
       config::binding<std::chrono::milliseconds> election_timeout,
-      config::binding<std::chrono::milliseconds> heartbeat_interval);
+      config::binding<std::chrono::milliseconds> heartbeat_interval,
+      bool with_offset_translation = false);
 
     raft_node_instance(
       model::node_id id,
@@ -168,7 +169,8 @@ public:
       leader_update_clb_t leader_update_clb,
       bool enable_longest_log_detection,
       config::binding<std::chrono::milliseconds> election_timeout,
-      config::binding<std::chrono::milliseconds> heartbeat_interval);
+      config::binding<std::chrono::milliseconds> heartbeat_interval,
+      bool with_offset_translation = false);
 
     raft_node_instance(const raft_node_instance&) = delete;
     raft_node_instance(raft_node_instance&&) noexcept = delete;
@@ -265,6 +267,7 @@ private:
     bool _enable_longest_log_detection;
     config::binding<std::chrono::milliseconds> _election_timeout;
     config::binding<std::chrono::milliseconds> _heartbeat_interval;
+    bool _with_offset_translation;
 };
 
 class raft_fixture
@@ -530,6 +533,8 @@ public:
         _heartbeat_interval.update(std::move(timeout));
     }
 
+    void enable_offset_translation() { _with_offset_translation = true; }
+
 protected:
     class raft_not_leader_exception : std::exception {};
 
@@ -561,6 +566,7 @@ private:
     std::optional<leader_update_clb_t> _leader_clb;
     config::mock_property<std::chrono::milliseconds> _election_timeout{500ms};
     config::mock_property<std::chrono::milliseconds> _heartbeat_interval{50ms};
+    bool _with_offset_translation = false;
 };
 
 template<class... STM>


### PR DESCRIPTION
When an stm receives Raft snapshot it indicates the whole in memory
state of that state machine should be replaced with the state from the
snapshot. The datalake translation state machine was incorrectly
handling raft snapshot which lead to its state being out of date after
the snapshot is applied. Raft snapshot for `translation_stm` is empty so
the correct action is to reset the state machine state and wait for the
update to be applied.

Fixes: CORE-8485

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none