### PR TITLE
Using newer client versions in Ducktape tests

### DIFF
--- a/tests/docker/ducktape-deps/kafka-tools
+++ b/tests/docker/ducktape-deps/kafka-tools
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -e
-for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0"; do
+for ver in  "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
+
   mkdir -p "/opt/kafka-${ver}"
   chmod a+rw "/opt/kafka-${ver}"
   curl "$KAFKA_MIRROR/kafka_2.12-${ver}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${ver}"
 done
-ln -s /opt/kafka-3.0.0/ /opt/kafka-dev
+ln -s /opt/kafka-3.9.0/ /opt/kafka-dev
 
 set -e
 git -C /opt clone --depth 1 --branch 0.14.0-example-producer-args https://github.com/redpanda-data/strimzi-kafka-oauth.git

--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.2.0.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.6.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
 ./configure
 make -j$(nproc)

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -388,6 +388,8 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         assert split_str[-1] == ""
         partition_watermark_lines = split_str[2:-1]
         for partition_watermark_line in partition_watermark_lines:
+            if not partition_watermark_line.startswith("partition: "):
+                continue
             topic_partition_str, result_str = partition_watermark_line.strip(
             ).split('\t')
             topic_partition_str_split = topic_partition_str.split(

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -64,8 +64,9 @@ class KafkaCliTools:
     Wrapper around the Kafka admin command line tools.
     """
 
-    # See tests/docker/Dockerfile to add new versions
-    VERSIONS = ("3.0.0", "2.7.0", "2.5.0", "2.4.1", "2.3.1")
+    # See tests/docker/ducktape-deps/kafka-tools to add new versions
+    VERSIONS = ("3.9.0", "3.8.0", "3.7.0", "3.0.0", "2.7.0", "2.5.0", "2.4.1",
+                "2.3.1")
 
     def __init__(self,
                  redpanda: RedpandaServiceForClients,

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -330,7 +330,8 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
                 acks: int = -1,
                 throughput: int = -1,
                 batch_size: int = 81960,
-                linger_ms: int = 0):
+                linger_ms: int = 0,
+                enable_idempotence: bool = True):
         self._redpanda.logger.debug("Producing to topic: %s", topic)
         cmd = [self._script("kafka-producer-perf-test.sh")]
         cmd += ["--topic", topic]
@@ -345,6 +346,8 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
             "bootstrap.servers=%s" % self._redpanda.brokers(),
             "linger.ms=%d" % linger_ms,
         ]
+        if enable_idempotence is False:
+            cmd += ["enable.idempotence=false"]
         if self._command_config:
             cmd += ["--producer.config", self._command_config.name]
         return self._execute(cmd, "produce")

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -377,7 +377,7 @@ class ArchivalTest(RedpandaTest):
         self.redpanda.start_node(node)
         time.sleep(5)
         self.kafka_tools.produce(self.topic, 5000, 1024)
-        validate(self._cross_node_verify, self.logger, 90)
+        validate(self._cross_node_verify, self.logger, 120)
 
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type())
@@ -394,7 +394,7 @@ class ArchivalTest(RedpandaTest):
             self.redpanda.start_node(node)
         time.sleep(5)
         self.kafka_tools.produce(self.topic, 5000, 1024)
-        validate(self._cross_node_verify, self.logger, 90)
+        validate(self._cross_node_verify, self.logger, 120)
 
     @cluster(num_nodes=3)
     @matrix(acks=[-1, 0, 1], cloud_storage_type=get_cloud_storage_type())

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -45,6 +45,8 @@ MANIFEST_BIN_EXTENSION = ".bin"
 LOG_EXTENSION = ".log"
 
 CONTROLLER_LOG_PREFIX = os.path.join(RedpandaService.DATA_DIR, "redpanda")
+INTERNAL_TOPIC_PREFIX = os.path.join(RedpandaService.DATA_DIR,
+                                     "kafka_internal")
 
 # Log errors expected when connectivity between redpanda and the S3
 # backend is disrupted
@@ -803,8 +805,9 @@ class ArchivalTest(RedpandaTest):
 
         # Filter out all unwanted paths
         def included(path):
-            return not path.startswith(
-                CONTROLLER_LOG_PREFIX) and path.endswith(LOG_EXTENSION)
+            return not (path.startswith(CONTROLLER_LOG_PREFIX)
+                        or path.startswith(INTERNAL_TOPIC_PREFIX)
+                        ) and path.endswith(LOG_EXTENSION)
 
         # Remove data dir from path
         def normalize_path(path):

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -38,18 +38,11 @@ class FetchAfterDeleteTest(RedpandaTest):
         pass
 
     @cluster(num_nodes=3)
-    @parametrize(transactions_enabled=True)
-    @parametrize(transactions_enabled=False)
-    def test_fetch_after_committed_offset_was_removed(self,
-                                                      transactions_enabled):
+    def test_fetch_after_committed_offset_was_removed(self):
         """
         Test fetching when consumer offset was deleted by retention
         """
 
-        self.redpanda._extra_rp_conf[
-            "enable_transactions"] = transactions_enabled
-        self.redpanda._extra_rp_conf[
-            "enable_idempotence"] = transactions_enabled
         self.redpanda.start()
 
         topic = TopicSpec(partition_count=1,

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -378,7 +378,8 @@ class LocalDiskReportTimeTest(RedpandaTest):
                             1024,
                             throughput=500,
                             acks=-1,
-                            linger_ms=50)
+                            linger_ms=50,
+                            enable_idempotence=False)
 
         node = self.redpanda.nodes[0]
         reported = admin.get_local_storage_usage(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3953,6 +3953,8 @@ class SchemaRegistryConfluentClient(SchemaRegistryEndpoints):
         result = self.sr_client.get_versions(test_subject)
         assert result == [1], f"Result: {result}"
 
+        # reinitialize client to drop the cache
+        self.sr_client = SchemaRegistryClient({'url': self._base_uri()})
         with expect_exception(SchemaRegistryError, lambda e: True):
             self.sr_client.get_version(test_subject, 2)
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -86,7 +86,10 @@ def get_kvstore_topic_key_counts(redpanda):
                 if k['data'].get('ntp', {}).get('topic', None) == 'controller':
                     # Controller storage item
                     continue
-
+                if k['data'].get('ntp', {}).get('namespace',
+                                                None) == 'kafka_internal':
+                    # Internal topic storage item
+                    continue
                 excess_keys.append(k)
 
             redpanda.logger.info(

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1275,9 +1275,13 @@ class TopicRecoveryTest(RedpandaTest):
         def included(path):
             controller_log_prefix = os.path.join(RedpandaService.DATA_DIR,
                                                  "redpanda")
+            internal_log_prefix = os.path.join(RedpandaService.DATA_DIR,
+                                               "kafka_internal")
             log_segment_extension = ".log"
             return not path.startswith(
-                controller_log_prefix) and path.endswith(log_segment_extension)
+                controller_log_prefix) and path.endswith(
+                    log_segment_extension
+                ) and not path.startswith(internal_log_prefix)
 
         return self._get_log_segment_checksums(node, included)
 

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -205,7 +205,10 @@ class BaseCase:
             err_msg=
             f'failed to get high watermark before produce for {topic_spec}')
 
-        self._kafka_tools.produce(topic_spec.name, 10000, 1024)
+        self._kafka_tools.produce(topic_spec.name,
+                                  10000,
+                                  1024,
+                                  enable_idempotence=False)
 
         new_state = PartitionState(self._rpk, topic_spec.name)
         wait_until(

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,7 +17,7 @@ setup(
         'prometheus-client==0.9.0',
         'kafka-python==2.0.2',
         'crc32c==2.2',
-        'confluent-kafka==2.2.0',
+        'confluent-kafka==2.6.1',
         'zstandard==0.15.2',
         'xxhash==2.0.2',
         'protobuf==4.21.8',


### PR DESCRIPTION
Updated Kafka tools and librdkafka to the new versions in our test environments. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none