### PR TITLE
[v24.3.x] rm_stm/tests: add a stress test for concurrent eviction / replication / snapshots

### DIFF
--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -45,8 +45,10 @@ public:
      */
     void touch(producer_state&, std::optional<model::vcluster_id>);
 
+    void rearm_eviction_timer_for_testing(std::chrono::milliseconds);
+
 private:
-    static constexpr std::chrono::seconds period{5};
+    std::chrono::milliseconds _reaper_period{5000};
     /**
      *  Constant to be used when a partition has no vcluster_id assigned.
      */
@@ -83,7 +85,7 @@ private:
     config::binding<size_t> _virtual_cluster_min_producer_ids;
     // cache of all producers on this shard
     cache_t _cache;
-    ss::timer<ss::steady_clock_type> _reaper;
+    ss::timer<ss::lowres_clock> _reaper;
     ss::gate _gate;
     metrics::internal_metric_groups _metrics;
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -242,7 +242,8 @@ private:
       = ss::bool_class<struct new_producer_created_tag>;
     std::pair<tx::producer_ptr, producer_previously_known>
       maybe_create_producer(model::producer_identity);
-    void cleanup_producer_state(model::producer_identity);
+    void cleanup_producer_state(model::producer_identity) noexcept;
+    ss::future<> cleanup_evicted_producers();
     ss::future<> reset_producers();
     ss::future<checked<model::term_id, tx::errc>> do_begin_tx(
       model::term_id,
@@ -413,6 +414,8 @@ private:
     // a given producer_id remains active. This also works for idempotent
     // producers because epoch is unused.
     producers_t _producers;
+
+    ss::queue<model::producer_identity> _producers_pending_cleanup;
 
     // All the producers with open transactions in this partition.
     // The list is sorted by the open transaction begin offset, so

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -25,6 +25,8 @@ using cluster::tx_executor;
         _data_dir = "test_dir_" + random_generators::gen_alphanum_string(6);   \
         stop_all();                                                            \
         producer_state_manager.stop().get();                                   \
+        producer_expiration_ms.stop().get();                                   \
+        max_concurent_producers.stop().get();                                  \
         _stm = nullptr;                                                        \
     });                                                                        \
     wait_for_confirmed_leader();                                               \


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24490
