### PR TITLE
[v24.1.x] tests/setup: update ducktape to 0.12

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@7772220005a27957d3a796de0e19d3c51eb61f6a',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@f51d83f1c035cf77f9389139646f5abdaa6d3648',
         'prometheus-client==0.9.0', 'kafka-python==2.0.2', 'crc32c==2.2',
         'confluent-kafka==2.2.0', 'zstandard==0.15.2', 'xxhash==2.0.2',
         'protobuf==4.21.8', 'fastavro==1.4.9', 'psutil==5.9.0',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -19,7 +19,7 @@ setup(
         'protobuf==4.21.8', 'fastavro==1.4.9', 'psutil==5.9.0',
         'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',
-        'kafkatest@git+https://github.com/apache/kafka.git@e146c7c9164c4e8817fe891ac9d7d1661889b2b4#egg=kafkatest&subdirectory=tests',
+        'kafkatest@git+https://github.com/apache/kafka.git@b3939f7901470048a70ee7cbaaa587f32cfac50e#egg=kafkatest&subdirectory=tests',
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',
         'cachetools==5.3.1', 'google-api-core==2.11.1', 'google-auth==2.22.0',
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24474