### PR TITLE
`config`: disable bounded property checks with environment variable

### DIFF
--- a/src/v/config/bounded_property.h
+++ b/src/v/config/bounded_property.h
@@ -12,6 +12,7 @@
 #include "config/base_property.h"
 #include "config/property.h"
 
+#include <cstdlib>
 #include <optional>
 
 namespace config {
@@ -83,6 +84,10 @@ concept bounds = requires(T bounds, const typename T::underlying_t& value) {
     { bounds.validate(value) } -> std::same_as<std::optional<ss::sstring>>;
     { bounds.clamp(value) } -> std::same_as<typename T::underlying_t>;
 };
+
+inline bool bounds_checking_disabled() {
+    return std::getenv("__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS");
+}
 
 } // namespace detail
 
@@ -197,6 +202,9 @@ public:
           meta,
           def,
           [this](T new_value) -> std::optional<ss::sstring> {
+              if (detail::bounds_checking_disabled()) {
+                  return std::nullopt;
+              }
               // Extract inner value if we are an optional<>,
               // and pass through into numeric_bounds::validate
               using outer_type = std::decay_t<T>;
@@ -235,6 +243,13 @@ public:
     }
 
 private:
+    I clamp_with_bounds(I val) {
+        if (detail::bounds_checking_disabled()) {
+            return val;
+        }
+        return _bounds.clamp(val);
+    }
+
     bool clamp_and_update(T val) {
         using outer_type = std::decay_t<T>;
 
@@ -248,13 +263,13 @@ private:
         if constexpr (reflection::is_std_optional<outer_type>) {
             if (val.has_value()) {
                 return property<T>::update_value(
-                  std::move(_bounds.clamp(val.value())));
+                  std::move(clamp_with_bounds(val.value())));
             } else {
                 // nullopt is always valid, never clamped.  Pass it through.
                 return property<T>::update_value(std::move(val));
             }
         } else {
-            return property<T>::update_value(std::move(_bounds.clamp(val)));
+            return property<T>::update_value(std::move(clamp_with_bounds(val)));
         }
     }
 


### PR DESCRIPTION
For the purpose of testing certain configurations outside the bounds imposed by `bounded_property`.

A new function `bounds_checking_disabled()` is added to `config/bounded_property.h`, which checks for the presence of the environment variable `__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS`.

Another function, `bounded_property::clamp_with_bounds()` is added to de-duplicate checks of this value before applying `_bounds.clamp()`.

If this env variable is set, `bounded_property` will neither validate nor clamp any values per the bounds set for it.

This is intended for test use only and should not be used or set in a production environment.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
