### PR TITLE
bazel: Enable SEASTAR_DEBUG_SHARED_PTR in debug

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -570,7 +570,10 @@ cc_library(
         ":use_logger_compile_time_fmt": ["SEASTAR_LOGGER_COMPILE_TIME_FMT"],
         "//conditions:default": [],
     }) + select({
-        ":with_debug": ["SEASTAR_DEBUG"],
+        ":with_debug": [
+            "SEASTAR_DEBUG",
+            "SEASTAR_DEBUG_SHARED_PTR",
+        ],
         "//conditions:default": [],
     }),
     includes = [


### PR DESCRIPTION
Adds seastar define to debug builds which enables `ss::(lw)_shared_ptr`
owner checks.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none


