### PR TITLE
r/buffered_protocol: added a missing call to setup metrics

### DIFF
--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -253,6 +253,7 @@ append_entries_queue::append_entries_queue(
         }
         _current_max_inflight_requests = new_value;
     });
+    setup_internal_metrics();
     // start dispatch loop
     ssx::repeat_until_gate_closed(
       _gate,

--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -375,12 +375,7 @@ void append_entries_queue::setup_internal_metrics() {
          [this] { return _requests.size(); },
          sm::description(
            "Total number of append entries requests in the queue"),
-         {target_node_id_label}),
-       sm::make_histogram(
-         "append_entries_request_latency",
-         sm::description("Latency of append entries requests"),
-         {target_node_id_label},
-         [this] { return _hist.internal_histogram_logform(); })});
+         {target_node_id_label})});
 }
 
 void append_entries_queue::setup_public_metrics() {

--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -358,7 +358,7 @@ void append_entries_queue::setup_internal_metrics() {
     }
     sm::label_instance target_node_id_label("target_node_id", _target_node);
     _internal_metrics.add_group(
-      prometheus_sanitize::metrics_name("raft::buffered::protocol"),
+      prometheus_sanitize::metrics_name("raft:buffered:protocol"),
       {sm::make_gauge(
          "inflight_requests",
          [this] { return inflight_requests(); },


### PR DESCRIPTION
Added missing call to setup `raft::buffered_protocol` metrics.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none