### PR TITLE
dl/coordinator: add debug logging in coordinator

### DIFF
--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -110,8 +110,7 @@ ss::future<> coordinator_stm::do_apply(const model::record_batch& b) {
         // TODO: make updates a variant so we can share code more easily?
         case update_key::add_files: {
             auto update = co_await serde::read_async<add_files_update>(val_p);
-            vlog(
-              _log.debug, "Applying {} from offset {}: {}", key, o, update.tp);
+            vlog(_log.debug, "Applying {} from offset {}: {}", key, o, update);
             auto res = update.apply(state_, o);
             maybe_log_update_error(_log, key, o, res);
             continue;
@@ -119,8 +118,7 @@ ss::future<> coordinator_stm::do_apply(const model::record_batch& b) {
         case update_key::mark_files_committed: {
             auto update
               = co_await serde::read_async<mark_files_committed_update>(val_p);
-            vlog(
-              _log.debug, "Applying {} from offset {}: {}", key, o, update.tp);
+            vlog(_log.debug, "Applying {} from offset {}: {}", key, o, update);
             auto res = update.apply(state_);
             maybe_log_update_error(_log, key, o, res);
             continue;

--- a/src/v/datalake/coordinator/state_update.cc
+++ b/src/v/datalake/coordinator/state_update.cc
@@ -284,7 +284,34 @@ topic_lifecycle_update::apply(topics_state& state) {
     return true;
 }
 
-std::ostream& operator<<(std::ostream& o, topic_lifecycle_update u) {
+std::ostream& operator<<(std::ostream& o, const add_files_update& u) {
+    fmt::print(o, "{{tp: {}, revision: {}, entries: [", u.tp, u.topic_revision);
+    static constexpr size_t max_to_log = 6;
+    static constexpr size_t halved = max_to_log / 2;
+    const auto& e = u.entries;
+    if (e.size() <= max_to_log) {
+        fmt::print(o, "{}", fmt::join(e, ", "));
+    } else {
+        fmt::print(o, "{}", fmt::join(e.begin(), e.begin() + halved, ", "));
+        o << "...";
+        fmt::print(o, "{}", fmt::join(e.end() - halved, e.end(), ", "));
+    }
+    fmt::print(o, "] ({} entries)}}", e.size());
+    return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const mark_files_committed_update& u) {
+    fmt::print(
+      o,
+      "{{tp: {}, revision: {}, new_committed: {}}}",
+      u.tp,
+      u.topic_revision,
+      u.new_committed);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_lifecycle_update& u) {
     fmt::print(
       o,
       "{{topic: {}, revision: {}, new_state: {}}}",

--- a/src/v/datalake/coordinator/state_update.h
+++ b/src/v/datalake/coordinator/state_update.h
@@ -45,6 +45,7 @@ struct add_files_update
     checked<std::nullopt_t, stm_update_error> can_apply(const topics_state&);
     checked<std::nullopt_t, stm_update_error>
     apply(topics_state&, model::offset);
+    friend std::ostream& operator<<(std::ostream&, const add_files_update&);
 
     model::topic_partition tp;
     model::revision_id topic_revision;
@@ -68,6 +69,8 @@ struct mark_files_committed_update
 
     checked<std::nullopt_t, stm_update_error> can_apply(const topics_state&);
     checked<std::nullopt_t, stm_update_error> apply(topics_state&);
+    friend std::ostream&
+    operator<<(std::ostream&, const mark_files_committed_update&);
 
     model::topic_partition tp;
     model::revision_id topic_revision;
@@ -90,7 +93,8 @@ struct topic_lifecycle_update
     checked<bool, stm_update_error> can_apply(const topics_state&);
     checked<bool, stm_update_error> apply(topics_state&);
 
-    friend std::ostream& operator<<(std::ostream&, topic_lifecycle_update);
+    friend std::ostream&
+    operator<<(std::ostream&, const topic_lifecycle_update&);
 
     model::topic topic;
     model::revision_id revision;


### PR DESCRIPTION
Adds logging of the STM updates for the coordinator when applying. It's otherwise very difficult to infer what the current state tracked by the coordinator is.

Sample outputs for adding entries:

```
DEBUG 2024-12-12 20:36:50,031 [shard 0:main] datalake - [{kafka/node_1/0} (datalake_coordinator_stm.snapshot)] - state_machine.cc:113 - Applying update_key::add_files from offset 44: {tp: {test_topic_0/0}, revision: 1, entries: [{start_offset: 1270, last_offset: 1279, files: []}, {start_offset: 1280, last_offset: 1289, files: []}, {start_offset: 1290, last_offse t: 1299, files: []}, {start_offset: 1300, last_offset: 1309, files: []}, {start_offset: 1310, last_offset: 1319, files: []}, {start_offset: 1320, last_offset: 1329, files: []}] (6 entries)}
DEBUG 2024-12-12 20:36:50,171 [shard 0:main] datalake - [{kafka/node_2/0} (datalake_coordinator_stm.snapshot)] - state_machine.cc:113 - Applying update_key::add_files from offset 63: {tp: {test_topic_0/0}, revision: 1, entries: [{start_offset: 1820, last_offset: 1829, files: []}, {start_offset: 1830, last_offset: 1839, files: []}, {start_offset: 1840, last_offset: 1849, files: []}...{start_offset: 1880, last_offset: 1889, files: []}, {start_offset: 1890, last_offset: 1899, files: []}, {start_offset: 1900, last_offset: 1909, files: []}] (9 entries)}
```

NOTE: the above snippet is from a test that added empty files lists
NOTE: we log at most 6 entries to avoid oversized log messages

Sample outputs for committing offsets:

```
DEBUG 2024-12-12 20:36:50,314 [shard 0:main] datalake - [{kafka/node_0/0} (datalake_coordinator_stm.snapshot)] - state_machine.cc:121 - Applying update_key::mark_files_committed from offset 71: {tp: {test_topic_0/0}, revision: 1, new_committed: 1999}
```

Also adds some logging to the Iceberg file committer about decisions made when committing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Adds additional debug log messages in the datalake coordinator regarding files to be committed to Iceberg.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
