### PR TITLE
datalake: fix potential skipped leadership notification

### DIFF
--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -126,9 +126,7 @@ ss::future<> datalake_manager::start() {
       = _partition_mgr->local().register_unmanage_notification(
         model::kafka_namespace, [this](model::topic_partition_view tp) {
             model::ntp ntp{model::kafka_namespace, tp.topic, tp.partition};
-            ssx::spawn_with_gate(_gate, [this, ntp = std::move(ntp)] {
-                return stop_translator(ntp);
-            });
+            stop_translator(ntp);
         });
     // Handle leadership changes
     auto leadership_registration
@@ -217,9 +215,7 @@ void datalake_manager::on_group_notification(const model::ntp& ntp) {
                             == model::iceberg_mode::disabled;
     if (!partition->is_leader() || iceberg_disabled) {
         if (it != _translators.end()) {
-            ssx::spawn_with_gate(_gate, [this, partition] {
-                return stop_translator(partition->ntp());
-            });
+            stop_translator(partition->ntp());
         }
         return;
     }
@@ -260,14 +256,19 @@ void datalake_manager::start_translator(
     _translators.emplace(partition->ntp(), std::move(translator));
 }
 
-ss::future<> datalake_manager::stop_translator(const model::ntp& ntp) {
+void datalake_manager::stop_translator(const model::ntp& ntp) {
     auto it = _translators.find(ntp);
     if (it == _translators.end()) {
-        co_return;
+        return;
     }
-    auto translator = std::move(it->second);
+    auto t = std::move(it->second);
     _translators.erase(it);
-    co_await translator->stop();
+    ssx::spawn_with_gate(_gate, [t = std::move(t)]() mutable {
+        // Keep 't' alive by capturing it into the finally below. Use the raw
+        // pointer here to avoid a user-after-move.
+        auto* t_ptr = t.get();
+        return t_ptr->stop().finally([_ = std::move(t)] {});
+    });
 }
 
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -257,6 +257,10 @@ void datalake_manager::start_translator(
 }
 
 void datalake_manager::stop_translator(const model::ntp& ntp) {
+    if (_gate.is_closed()) {
+        // Cleanup should be deferred to stop().
+        return;
+    }
     auto it = _translators.find(ntp);
     if (it == _translators.end()) {
         return;

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -75,7 +75,7 @@ private:
     void on_group_notification(const model::ntp&);
     void start_translator(
       ss::lw_shared_ptr<cluster::partition>, model::iceberg_mode);
-    ss::future<> stop_translator(const model::ntp&);
+    void stop_translator(const model::ntp&);
 
     model::node_id _self;
     ss::sharded<raft::group_manager>* _group_mgr;


### PR DESCRIPTION
Previously the following sequence seemed possible:
- a replica has partition translator of term 9
- leadership is lost for term 9
- stop_translator() is called and a task is scheduled to remove the translator from the map and stop it, but doesn't run right away
- the replica becomes leader for term 10
- the leadership notification runs for term 10 and does a lookup of the translators, but one is still there from term 9, so the notification is a no-op
- stop_translator() task completes, removing the translator from term 9
- term 10 has no translator and never gets another notification to start a new one

This commit tweaks the code to make the notifications synchronously add and remove translators from the map, rather than deferring that to background work. The actual stopping of the translators is still backgrounded, but that shouldn't be problematic.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a race that could prevent Iceberg translation from happening following a leadership change.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
