### PR TITLE
`rptest`: bump `kgo-verifier` version

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard bffac1f1358875ee6e91308229d908f40d5fe18e
+git reset --hard 3c87c1c53a150ead7b53e6179c2d6105f53bd1cf
 go mod tidy
 make


### PR DESCRIPTION
To revert regressions discussed in https://github.com/redpanda-data/kgo-verifier/pull/63.

> [Using the modified `ValueGenerator::Generate()` function for each record in the `producer_worker`](https://github.com/redpanda-data/kgo-verifier/pull/60#discussion_r1842693465) was a lot slower than just simply making an empty payload.
> 
> 
> The following benchmarks were generated:
> 
> ```
> Benchmark_random_payload10-32           	 2445903	        485.2 ns/op
> Benchmark_random_payload100-32           	  678870	         1773 ns/op
> Benchmark_random_payload1000-32           	  105667	        13700 ns/op
> Benchmark_random_payload1e4-32          	    9104	       126782 ns/op
> Benchmark_random_payload1e5-32          	    1135	      1151425 ns/op
> Benchmark_random_payload1e6-32          	     100	     13046547 ns/op
> ====================================================================================
> Benchmark_empty_payload10-32            	79950942	        20.54 ns/op
> Benchmark_empty_payload100-32            	24089101	        54.78 ns/op
> Benchmark_empty_payload1000-32            	 3789248	        366.1 ns/op
> Benchmark_empty_payload1e4-32           	  670096	         2059 ns/op
> Benchmark_empty_payload1e5-32           	   58912	        23021 ns/op
> Benchmark_empty_payload1e6-32           	    5600	       290045 ns/op
> ```
> 
> As can be seen, generating the random payload and ensuring it is UTF-8 valid is orders of magnitude slower than the empty payload.
> 
> Revert the use of `Generate()` here in place of the empty payload.
> 
> However, if the user has indicated they want to validate the latest key-value pair produced, generate a `(value-{%018d}, offset)` message in the record.
> 
> This does mean that message sizes that are less than 24 bytes are not honored if the `validate-latest-values` flag is passed.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
