### PR TITLE
[CORE-8532]Datalake/Iceberg: Add support for primitive type promotion

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_library(
         ":logger",
         ":table_definition",
         "//src/v/base",
+        "//src/v/iceberg:compatibility",
         "//src/v/iceberg:field_collecting_visitor",
         "//src/v/iceberg:schema",
         "//src/v/iceberg:transaction",

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -144,6 +144,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_io/tests:scoped_remote",
         "//src/v/cloud_storage/tests:s3_imposter_gtest",
         "//src/v/datalake:catalog_schema_manager",
+        "//src/v/iceberg:datatypes",
         "//src/v/iceberg:field_collecting_visitor",
         "//src/v/iceberg:filesystem_catalog",
         "//src/v/iceberg:table_identifier",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -121,6 +121,25 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "compatibility",
+    srcs = [
+        "compatibility.cc",
+    ],
+    hdrs = [
+        "compatibility.h",
+    ],
+    include_prefix = "iceberg",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":datatypes",
+        "//src/v/base",
+        "@abseil-cpp//absl/container:btree",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "datatypes_json",
     srcs = [
         "datatypes_json.cc",

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -30,6 +30,7 @@ v_cc_library(
     ${avro_hdrs}
     action.cc
     catalog.cc
+    compatibility.cc
     datatypes.cc
     datatypes_json.cc
     filesystem_catalog.cc

--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -1,0 +1,109 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/compatibility.h"
+
+#include "iceberg/datatypes.h"
+
+#include <absl/container/btree_map.h>
+#include <fmt/format.h>
+
+#include <variant>
+
+namespace iceberg {
+
+namespace {
+struct primitive_type_promotion_policy_visitor {
+    template<typename T, typename U>
+    requires(!std::is_same_v<T, U>)
+    type_check_result operator()(const T&, const U&) const {
+        return compat_errc::mismatch;
+    }
+
+    template<typename T>
+    type_check_result operator()(const T&, const T&) const {
+        return type_promoted::no;
+    }
+
+    type_check_result
+    operator()(const iceberg::int_type&, const iceberg::long_type&) const {
+        return type_promoted::yes;
+    }
+
+    type_check_result operator()(
+      const iceberg::date_type&, const iceberg::timestamp_type&) const {
+        return type_promoted::yes;
+    }
+
+    type_check_result
+    operator()(const iceberg::float_type&, const iceberg::double_type&) {
+        return type_promoted::yes;
+    }
+
+    type_check_result operator()(
+      const iceberg::decimal_type& src, const iceberg::decimal_type& dst) {
+        if (iceberg::primitive_type{src} == iceberg::primitive_type{dst}) {
+            return type_promoted::no;
+        }
+        if ((dst.scale == src.scale && dst.precision > src.precision)) {
+            return type_promoted::yes;
+        }
+        return compat_errc::mismatch;
+    }
+
+    type_check_result
+    operator()(const iceberg::fixed_type& src, const iceberg::fixed_type& dst) {
+        if (iceberg::primitive_type{src} == iceberg::primitive_type{dst}) {
+            return type_promoted::no;
+        }
+        return compat_errc::mismatch;
+    }
+};
+
+struct field_type_check_visitor {
+    explicit field_type_check_visitor(
+      primitive_type_promotion_policy_visitor policy)
+      : policy(policy) {}
+
+    template<typename T, typename U>
+    requires(!std::is_same_v<T, U>)
+    type_check_result operator()(const T&, const U&) const {
+        return compat_errc::mismatch;
+    }
+
+    // For non-primitives, type identity is sufficient to pass this check.
+    // e.g. any two struct types will pass w/o indicating type promotion,
+    // whereas a struct and, say, a list would produce a mismatch error code.
+    // The member fields of two such structs (or the element fields of two
+    // lists, k/v for a map, etc.) will be checked elsewhere.
+    template<typename T>
+    type_check_result operator()(const T&, const T&) const {
+        return type_promoted::no;
+    }
+
+    type_check_result
+    operator()(const primitive_type& src, const primitive_type& dest) {
+        return std::visit(policy, src, dest);
+    }
+
+private:
+    primitive_type_promotion_policy_visitor policy;
+};
+
+} // namespace
+
+type_check_result
+check_types(const iceberg::field_type& src, const iceberg::field_type& dest) {
+    return std::visit(
+      field_type_check_visitor{primitive_type_promotion_policy_visitor{}},
+      src,
+      dest);
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/compatibility.h
+++ b/src/v/iceberg/compatibility.h
@@ -1,0 +1,49 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "base/outcome.h"
+#include "iceberg/datatypes.h"
+
+#include <seastar/util/bool_class.hh>
+
+namespace iceberg {
+
+enum class compat_errc {
+    mismatch,
+};
+
+using type_promoted = ss::bool_class<struct type_promoted_tag>;
+using type_check_result = checked<type_promoted, compat_errc>;
+
+/**
+   check_types - Performs a basic type check between two Iceberg field types,
+   enforcing the Primitive Type Promotion policy laid out in
+   https://iceberg.apache.org/spec/#schema-evolution
+
+   - For non-primitive types, checks strict equality - i.e. struct == struct,
+     list != map
+   - Unwraps and compares input types, returns the result. Does not account for
+     nesting.
+
+   @param src  - The type of some field in an existing schema
+   @param dest - The type of some field in a new schema, possibly compatible
+                 with src.
+   @return The result of the type check:
+             - type_promoted::yes - if src -> dest is a valid type promotion
+               e.g. int -> long
+             - type_promoted::no  - if src == dest
+             - compat_errc::mismatch - if src != dest but src -> dest is not
+               permitted e.g. int -> string or struct -> list
+ */
+type_check_result
+check_types(const iceberg::field_type& src, const iceberg::field_type& dest);
+
+} // namespace iceberg

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -613,6 +613,24 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "compatibility_test",
+    timeout = "short",
+    srcs = [
+        "compatibility_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/iceberg:compatibility",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_bench(
     name = "uri_bench",
     timeout = "short",

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -15,6 +15,17 @@ v_cc_library(
 )
 
 rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME iceberg_compatibility
+  SOURCES
+    compatibility_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::iceberg_test_utils
+)
+
+rp_test(
   FIXTURE_TEST
   GTEST
   USE_CWD

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -1,0 +1,167 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "iceberg/compatibility.h"
+#include "iceberg/datatypes.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <vector>
+
+using namespace iceberg;
+
+namespace {
+
+using compat = ss::bool_class<struct compat_tag>;
+
+struct field_test_case {
+    field_test_case(
+      field_type source, field_type dest, type_check_result expected)
+      : source(std::move(source))
+      , dest(std::move(dest))
+      , expected(expected) {}
+
+    field_test_case(const field_test_case& other)
+      : source(make_copy(other.source))
+      , dest(make_copy(other.dest))
+      , expected(
+          other.expected.has_error()
+            ? type_check_result{other.expected.error()}
+            : type_check_result{other.expected.value()}) {}
+
+    field_test_case(field_test_case&&) = default;
+    field_test_case& operator=(const field_test_case& other) = delete;
+    field_test_case& operator=(field_test_case&&) = delete;
+    ~field_test_case() = default;
+
+    field_type source;
+    field_type dest;
+    type_check_result expected{compat_errc::mismatch};
+};
+
+std::ostream& operator<<(std::ostream& os, const field_test_case& ftc) {
+    fmt::print(
+      os,
+      "{}->{} [expected: {}]",
+      ftc.source,
+      ftc.dest,
+      ftc.expected.has_error()
+        ? std::string{"ERROR"}
+        : fmt::format("promoted={}", ftc.expected.value()));
+    return os;
+}
+} // namespace
+
+std::vector<field_test_case> generate_test_cases() {
+    std::vector<field_test_case> test_data{};
+
+    test_data.emplace_back(int_type{}, long_type{}, type_promoted::yes);
+    test_data.emplace_back(int_type{}, boolean_type{}, compat_errc::mismatch);
+
+    test_data.emplace_back(date_type{}, timestamp_type{}, type_promoted::yes);
+    test_data.emplace_back(date_type{}, long_type{}, compat_errc::mismatch);
+
+    test_data.emplace_back(float_type{}, double_type{}, type_promoted::yes);
+    test_data.emplace_back(
+      float_type{}, fixed_type{.length = 64}, compat_errc::mismatch);
+
+    test_data.emplace_back(
+      decimal_type{.precision = 10, .scale = 2},
+      decimal_type{.precision = 20, .scale = 2},
+      type_promoted::yes);
+    test_data.emplace_back(
+      decimal_type{.precision = 10, .scale = 2},
+      decimal_type{.precision = 10, .scale = 2},
+      type_promoted::no);
+    test_data.emplace_back(
+      decimal_type{.precision = 20, .scale = 2},
+      decimal_type{.precision = 10, .scale = 2},
+      compat_errc::mismatch);
+
+    test_data.emplace_back(
+      fixed_type{.length = 32}, fixed_type{.length = 32}, type_promoted::no);
+    test_data.emplace_back(
+      fixed_type{.length = 32},
+      fixed_type{.length = 64},
+      compat_errc::mismatch);
+    test_data.emplace_back(
+      fixed_type{.length = 64},
+      fixed_type{.length = 32},
+      compat_errc::mismatch);
+
+    struct_type s1{};
+    struct_type s2{};
+    s2.fields.emplace_back(
+      nested_field::create(0, "foo", field_required::yes, int_type{}));
+    field_type l1 = list_type::create(0, field_required::yes, int_type{});
+    field_type l2 = list_type::create(0, field_required::no, string_type{});
+    field_type m1 = map_type::create(
+      0, int_type{}, 0, field_required::yes, date_type{});
+    field_type m2 = map_type::create(
+      0, string_type{}, 0, field_required::no, timestamptz_type{});
+
+    // NOTE: basic type check doesn't descend into non-primitive types
+    // Checking stops at type ID - i.e. compat(struct, struct) == true,
+    // compat(struct, list) == false.
+    test_data.emplace_back(s1.copy(), s1.copy(), type_promoted::no);
+    test_data.emplace_back(s1.copy(), s2.copy(), type_promoted::no);
+    test_data.emplace_back(make_copy(l1), make_copy(l1), type_promoted::no);
+    test_data.emplace_back(make_copy(l1), make_copy(l2), type_promoted::no);
+    test_data.emplace_back(make_copy(m1), make_copy(m1), type_promoted::no);
+    test_data.emplace_back(make_copy(m1), make_copy(m2), type_promoted::no);
+
+    std::vector<field_type> non_promotable_types;
+    non_promotable_types.emplace_back(boolean_type{});
+    non_promotable_types.emplace_back(long_type{});
+    non_promotable_types.emplace_back(double_type{});
+    non_promotable_types.emplace_back(time_type{});
+    non_promotable_types.emplace_back(timestamp_type{});
+    non_promotable_types.emplace_back(timestamptz_type{});
+    non_promotable_types.emplace_back(string_type{});
+    non_promotable_types.emplace_back(uuid_type{});
+    non_promotable_types.emplace_back(binary_type{});
+    non_promotable_types.emplace_back(s1.copy());
+    non_promotable_types.emplace_back(make_copy(l1));
+    non_promotable_types.emplace_back(make_copy(m1));
+
+    for (const auto& fta : non_promotable_types) {
+        for (const auto& ftb : non_promotable_types) {
+            if (fta == ftb) {
+                continue;
+            }
+            test_data.emplace_back(
+              make_copy(fta), make_copy(ftb), compat_errc::mismatch);
+        }
+    }
+
+    return test_data;
+}
+
+struct CompatibilityTest
+  : ::testing::Test
+  , testing::WithParamInterface<field_test_case> {};
+
+INSTANTIATE_TEST_SUITE_P(
+  PrimitiveTypeCompatibilityTest,
+  CompatibilityTest,
+  ::testing::ValuesIn(generate_test_cases()));
+
+TEST_P(CompatibilityTest, CompatibleTypesAreCompatible) {
+    const auto& p = GetParam();
+
+    auto res = check_types(p.source, p.dest);
+    ASSERT_EQ(res.has_error(), p.expected.has_error());
+    if (res.has_error()) {
+        ASSERT_EQ(res.error(), p.expected.error());
+    } else {
+        ASSERT_EQ(res.value(), p.expected.value());
+    }
+}

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -1,0 +1,229 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import tempfile
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.services.redpanda_connect import RedpandaConnectService
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.util import expect_exception
+from ducktape.mark import matrix
+
+schema_avro = """
+{
+    "type": "record",
+    "name": "VerifierRecord",
+    "fields": [
+        {
+            "name": "verifier_string",
+            "type": "string"
+        },
+        {
+            "name": "ordinal",
+            "type": "int"
+        }
+    ]
+}
+"""
+
+legal_evo_schema_avro = """
+{
+    "type": "record",
+    "name": "VerifierRecord",
+    "fields": [
+        {
+            "name": "verifier_string",
+            "type": "string"
+        },
+        {
+            "name": "ordinal",
+            "type": "long"
+        },
+        {
+            "name": "another",
+            "type": "float"
+        }
+    ]
+}
+"""
+
+legal_evo_schema_avro_2 = """
+{
+    "type": "record",
+    "name": "VerifierRecord",
+    "fields": [
+        {
+            "name": "verifier_string",
+            "type": "string"
+        },
+        {
+            "name": "ordinal",
+            "type": "long"
+        }
+    ]
+}
+"""
+
+illegal_evo_schema_avro = """
+{
+    "type": "record",
+    "name": "VerifierRecord",
+    "fields": [
+        {
+            "name": "verifier_string",
+            "type": "double"
+        },
+        {
+            "name": "ordinal",
+            "type": "long"
+        }
+    ]
+}
+"""
+
+
+class SchemaEvolutionTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(SchemaEvolutionTest, self).__init__(
+            test_context=test_context,
+            num_brokers=1,
+            si_settings=SISettings(test_context,
+                                   cloud_storage_enable_remote_read=False,
+                                   cloud_storage_enable_remote_write=False),
+            extra_rp_conf={
+                "iceberg_enabled": True,
+                "iceberg_catalog_commit_interval_ms": 5000,
+            },
+            schema_registry_config=SchemaRegistryConfig())
+
+    def avro_stream_config(self, topic, subject, mapping: str):
+        return {
+            "input": {
+                "generate": {
+                    "mapping": mapping,
+                    "interval": "",
+                    "count": 1000,
+                    "batch_size": 1
+                }
+            },
+            "pipeline": {
+                "processors": [{
+                    "schema_registry_encode": {
+                        "url": self.redpanda.schema_reg().split(",")[0],
+                        "subject": subject,
+                        "refresh_period": "10s"
+                    }
+                }]
+            },
+            "output": {
+                "redpanda": {
+                    "seed_brokers": self.redpanda.brokers_list(),
+                    "topic": topic,
+                }
+            }
+        }
+
+    def setUp(self):
+        pass
+
+    def _create_schema(self, subject: str, schema: str, schema_type="avro"):
+        rpk = RpkTool(self.redpanda)
+        with tempfile.NamedTemporaryFile(suffix=f".{schema_type}") as tf:
+            tf.write(bytes(schema, 'UTF-8'))
+            tf.flush()
+            rpk.create_schema(subject, tf.name)
+
+    @cluster(num_nodes=4, log_allow_list=["Schema \d+ already exists"])
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        query_engine=[
+            QueryEngineType.SPARK,
+            QueryEngineType.TRINO,
+        ],
+    )
+    def test_evolving_avro_schemas(self, cloud_storage_type, query_engine):
+        topic_name = "ducky-topic"
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              filesystem_catalog_mode=True,
+                              include_query_engines=[
+                                  query_engine,
+                              ]) as dl:
+
+            dl.create_iceberg_enabled_topic(
+                topic_name,
+                partitions=5,
+                replicas=1,
+                iceberg_mode="value_schema_id_prefix")
+
+            def get_qe():
+                if query_engine == QueryEngineType.SPARK:
+                    return dl.spark()
+                else:
+                    return dl.trino()
+
+            self._create_schema("schema_avro", schema_avro)
+            self._create_schema("legal_evo_schema_avro", legal_evo_schema_avro)
+            self._create_schema("legal_evo_schema_avro_2",
+                                legal_evo_schema_avro_2)
+            self._create_schema("illegal_evo_schema_avro",
+                                illegal_evo_schema_avro)
+
+            connect = RedpandaConnectService(self.test_context, self.redpanda)
+            connect.start()
+
+            def run_verifier(schema: str, mapping: str):
+
+                # create verifier
+                verifier = DatalakeVerifier(self.redpanda, topic_name,
+                                            get_qe())
+                # create a stream
+                connect.start_stream(name="ducky_stream",
+                                     config=self.avro_stream_config(
+                                         topic_name, schema, mapping=mapping))
+
+                verifier.start()
+                connect.stop_stream("ducky_stream", wait_to_finish=True)
+                verifier.wait()
+
+            run_verifier("schema_avro",
+                         mapping=f"""
+                    root.verifier_string = uuid_v4()
+                    root.ordinal = counter()
+                    """)
+
+            # again w/ a new schema (extra field and promoted ordinal)
+            run_verifier("legal_evo_schema_avro",
+                         mapping=f"""
+                    root.verifier_string = uuid_v4()
+                    root.ordinal = counter()
+                    root.another = 12.0
+                    """)
+
+            # remove the extra field and do it one more time
+            run_verifier("legal_evo_schema_avro_2",
+                         mapping=f"""
+                    root.verifier_string = uuid_v4()
+                    root.ordinal = counter()
+                    """)
+
+            # finally once w/ a non-compatible schema, verifier should time out and fail its assertion
+            with expect_exception(
+                    AssertionError,
+                    lambda e: "Mismatch between maximum offsets" in str(e)):
+                run_verifier("illegal_evo_schema_avro",
+                             mapping=f"""
+                    root.verifier_string = 23.0
+                    root.ordinal = counter()
+                    """)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Expands support for schema evolution by introducing primitive type promotion.
Legal type promotions are as follows:

Primitive type | v1, v2 valid type promotions | v3+ valid type promotions | Requirements
-- | -- | -- | --
unknown |   | any type |  
int | long | long |  
date |   | timestamp, timestamp_ns | Promotion to timestamptz or timestamptz_ns is not allowed; values outside the promoted type's range must result in a runtime failure
float | double | double |  
decimal(P, S) | decimal(P', S) if P' > P | decimal(P', S) if P' > P | Widen precision only

Not addressed in this PR:
- Interactions with partition spec
- forward write compatibility 
   - producer updates are not synchronous w/ table metadata updates, so records published w/ a previous schema version will be dropped, though in many cases the write would be compatible with the new schema

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Iceberg/Datalake: Adds support for schema evolution by primitive type promotion

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
