### PR TITLE
archival: Disable cross-term compaction

### DIFF
--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -10,6 +10,7 @@
 
 #include "segment_reupload.h"
 
+#include "base/vlog.h"
 #include "cloud_storage/partition_manifest.h"
 #include "config/configuration.h"
 #include "logger.h"
@@ -202,6 +203,8 @@ void segment_collector::do_collect(segment_collector_mode mode) {
 
     align_end_offset_to_manifest(
       _target_end_inclusive.value_or(current_segment_end));
+
+    maybe_clamp_end_to_term_boundary();
 }
 
 model::offset segment_collector::find_replacement_boundary() const {
@@ -271,6 +274,48 @@ void segment_collector::align_end_offset_to_manifest(
             _end_inclusive = it->base_offset - model::offset{1};
         }
     }
+}
+
+void segment_collector::maybe_clamp_end_to_term_boundary() {
+    auto opt_term = _log.get_term(_begin_inclusive);
+    if (!opt_term.has_value()) {
+        vlog(
+          archival_log.info,
+          "Can't find term for offset {}, the log could be truncated",
+          _begin_inclusive);
+        _can_replace_manifest_segment = false;
+        _begin_inclusive = {};
+        _end_inclusive = {};
+        return;
+    }
+    auto opt_max_offset = _log.get_term_last_offset(opt_term.value());
+    if (!opt_max_offset.has_value()) {
+        vlog(
+          archival_log.info,
+          "Can't find last offset for term {}",
+          opt_term.value());
+        _can_replace_manifest_segment = false;
+        _begin_inclusive = {};
+        _end_inclusive = {};
+        return;
+    }
+    vlog(
+      archival_log.debug,
+      "Aligned reupload with the term boundary, begin offset {}, end offset "
+      "{}, segment term {}, "
+      "last term offset {}",
+      _begin_inclusive,
+      _end_inclusive,
+      opt_term.value(),
+      opt_max_offset.value());
+    auto max_offset = opt_max_offset.value();
+    // Invariant: 'max_offset' can't be in the middle of the uploaded segment
+    // because we're rolling a segment when new term starts. The ntp_archiver
+    // never uploads segments across term boundaries.
+    // Because of that if the '_end_inclusive' crosses the term boundary we can
+    // safely return 'max_offset' because it's guaranteed to be aligned with
+    // the end of some segment in the manifest.
+    _end_inclusive = std::min(max_offset, _end_inclusive);
 }
 
 segment_collector::lookup_result segment_collector::find_next_segment(

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -191,6 +191,21 @@ void segment_collector::do_collect(segment_collector_mode mode) {
                result.segment->offsets().get_base_offset()});
             align_begin_offset_to_manifest();
         }
+
+        // Only segments from the same term can be concatenated together.
+        if (
+          !_segments.empty()
+          && _segments.back()->offsets().get_term()
+               != result.segment->offsets().get_term()) {
+            archival_log.debug(
+              "Segment collect for ntp {} stopping collection, last segment "
+              "term {} is different from current segment term: {}",
+              _manifest.get_ntp(),
+              _segments.back()->offsets().get_term(),
+              result.segment->offsets().get_term());
+            break;
+        }
+
         _segments.push_back(result.segment);
         current_segment_end = result.segment->offsets().get_committed_offset();
         start = current_segment_end + model::offset{1};
@@ -203,8 +218,6 @@ void segment_collector::do_collect(segment_collector_mode mode) {
 
     align_end_offset_to_manifest(
       _target_end_inclusive.value_or(current_segment_end));
-
-    maybe_clamp_end_to_term_boundary();
 }
 
 model::offset segment_collector::find_replacement_boundary() const {
@@ -274,48 +287,6 @@ void segment_collector::align_end_offset_to_manifest(
             _end_inclusive = it->base_offset - model::offset{1};
         }
     }
-}
-
-void segment_collector::maybe_clamp_end_to_term_boundary() {
-    auto opt_term = _log.get_term(_begin_inclusive);
-    if (!opt_term.has_value()) {
-        vlog(
-          archival_log.info,
-          "Can't find term for offset {}, the log could be truncated",
-          _begin_inclusive);
-        _can_replace_manifest_segment = false;
-        _begin_inclusive = {};
-        _end_inclusive = {};
-        return;
-    }
-    auto opt_max_offset = _log.get_term_last_offset(opt_term.value());
-    if (!opt_max_offset.has_value()) {
-        vlog(
-          archival_log.info,
-          "Can't find last offset for term {}",
-          opt_term.value());
-        _can_replace_manifest_segment = false;
-        _begin_inclusive = {};
-        _end_inclusive = {};
-        return;
-    }
-    vlog(
-      archival_log.debug,
-      "Aligned reupload with the term boundary, begin offset {}, end offset "
-      "{}, segment term {}, "
-      "last term offset {}",
-      _begin_inclusive,
-      _end_inclusive,
-      opt_term.value(),
-      opt_max_offset.value());
-    auto max_offset = opt_max_offset.value();
-    // Invariant: 'max_offset' can't be in the middle of the uploaded segment
-    // because we're rolling a segment when new term starts. The ntp_archiver
-    // never uploads segments across term boundaries.
-    // Because of that if the '_end_inclusive' crosses the term boundary we can
-    // safely return 'max_offset' because it's guaranteed to be aligned with
-    // the end of some segment in the manifest.
-    _end_inclusive = std::min(max_offset, _end_inclusive);
 }
 
 segment_collector::lookup_result segment_collector::find_next_segment(

--- a/src/v/cluster/archival/segment_reupload.h
+++ b/src/v/cluster/archival/segment_reupload.h
@@ -113,9 +113,6 @@ private:
     /// overlap.
     void align_end_offset_to_manifest(model::offset compacted_segment_end);
 
-    /// Make sure that reupload begins and ends in the same term.
-    void maybe_clamp_end_to_term_boundary();
-
     /// Finds the offset which the collection needs to progress upto in order to
     /// replace at least one manifest segment. The collection is valid if it
     /// reaches the replacement boundary.

--- a/src/v/cluster/archival/segment_reupload.h
+++ b/src/v/cluster/archival/segment_reupload.h
@@ -113,6 +113,9 @@ private:
     /// overlap.
     void align_end_offset_to_manifest(model::offset compacted_segment_end);
 
+    /// Make sure that reupload begins and ends in the same term.
+    void maybe_clamp_end_to_term_boundary();
+
     /// Finds the offset which the collection needs to progress upto in order to
     /// replace at least one manifest segment. The collection is valid if it
     /// reaches the replacement boundary.

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -18,6 +18,7 @@
 #include "storage/disk_log_impl.h"
 #include "storage/ntp_config.h"
 #include "test_utils/fixture.h"
+#include "test_utils/scoped_config.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -238,12 +239,15 @@ struct reupload_fixture : public archiver_fixture {
           manifest_view);
     }
 
-    // XXX: rename this! It doesn't just run self compaction -- it performs
-    // houskeeping which may also merge segments.
-    ss::lw_shared_ptr<storage::segment> self_compact_next_segment(
+    ss::lw_shared_ptr<storage::segment> run_disk_log_housekeeping(
       model::offset max_collectible = model::offset::max()) {
         auto& seg_set = disk_log_impl()->segments();
-
+        scoped_config cfg;
+        // Make sure that the compaction always runs
+        cfg.get("min_cleanable_dirty_ratio")
+          .set_value(std::make_optional(double(0)));
+        auto compacted_before
+          = disk_log_impl()->get_probe().get_segments_compacted();
         disk_log_impl()
           ->housekeeping(storage::housekeeping_config{
             model::timestamp::max(),
@@ -253,6 +257,11 @@ struct reupload_fixture : public archiver_fixture {
             ss::default_priority_class(),
             abort_source})
           .get();
+
+        // Check that the compaction actually compacts
+        auto compacted_after
+          = disk_log_impl()->get_probe().get_segments_compacted();
+        BOOST_REQUIRE(compacted_after > compacted_before);
 
         ss::lw_shared_ptr<storage::segment> last_compacted_segment;
         for (auto& i : seg_set) {
@@ -329,7 +338,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     // Mark first segment compacted, and re-upload, now only one segment is
     // uploaded.
     reset_http_call_state();
-    auto seg = self_compact_next_segment(
+    auto seg = run_disk_log_housekeeping(
       stm_manifest.first_addressable_segment()->committed_offset);
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
@@ -347,7 +356,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     BOOST_REQUIRE_EQUAL(replaced[0].base_offset, model::offset{0});
 
     // Mark second segment as compacted and re-upload.
-    seg = self_compact_next_segment(
+    seg = run_disk_log_housekeeping(
       std::next(stm_manifest.first_addressable_segment())->committed_offset);
 
     reset_http_call_state();
@@ -373,7 +382,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
 FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1), 1000, 2},
-      {manifest_ntp, model::offset(1000), model::term_id(4), 10, 2},
+      {manifest_ntp, model::offset(1000), model::term_id(1), 10, 2},
     };
 
     initialize(segments);
@@ -391,7 +400,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
-    verify_segment_request("1000-4-v1.log", manifest);
+    verify_segment_request("1000-1-v1.log", manifest);
 
     BOOST_REQUIRE(part->archival_meta_stm());
     const cloud_storage::partition_manifest& stm_manifest
@@ -404,7 +413,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     // Mark both segments compacted, and re-upload. One concatenated segment is
     // uploaded.
     reset_http_call_state();
-    auto seg = self_compact_next_segment();
+    auto seg = run_disk_log_housekeeping();
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
@@ -419,8 +428,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     BOOST_REQUIRE_EQUAL(replaced[0].base_offset, model::offset{0});
     BOOST_REQUIRE_EQUAL(replaced[1].base_offset, model::offset{1000});
 
-    verify_concat_segment_request(
-      {"0-1-v1.log", "1000-4-v1.log"}, part->archival_meta_stm()->manifest());
+    BOOST_REQUIRE_EQUAL(stm_manifest.size(), 1);
 }
 
 FIXTURE_TEST(
@@ -445,7 +453,7 @@ FIXTURE_TEST(
     listen();
 
     // Self-compact just the first couple segments.
-    self_compact_next_segment(model::offset{999});
+    run_disk_log_housekeeping(model::offset{999});
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
@@ -482,7 +490,7 @@ FIXTURE_TEST(test_upload_compacted_segments_fill_gap, reupload_fixture) {
 
     listen();
 
-    self_compact_next_segment();
+    run_disk_log_housekeeping();
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
@@ -549,7 +557,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     // NOTE: we can only compact up to what's been uploaded, since that
     // determines the max collectible offset.
     reset_http_call_state();
-    auto seg = self_compact_next_segment(
+    auto seg = run_disk_log_housekeeping(
       manifest.first_addressable_segment()->committed_offset);
 
     expected = archival::ntp_archiver::batch_result{{1, 0, 0}, {1, 0, 0}};
@@ -616,7 +624,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     // Self-compact the first segment and re-upload. One compacted
     // and one non-compacted segments are uploaded.
     reset_http_call_state();
-    auto seg = self_compact_next_segment(disk_log_impl()
+    auto seg = run_disk_log_housekeeping(disk_log_impl()
                                            ->segments()
                                            .begin()
                                            ->get()
@@ -680,11 +688,9 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(), model::offset{});
 
-    // Self-compact the first segment, since the topic has compaction
-    // disabled, and re-upload, nothing is uploaded.
+    // Since the topic has compaction is disabled nothing should
+    // be reuploaded
     reset_http_call_state();
-    auto seg = self_compact_next_segment();
-
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 0);
@@ -728,7 +734,7 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
     // Mark first segment compacted artificially, since the topic has compaction
     // disabled, and re-upload, nothing is uploaded.
     reset_http_call_state();
-    auto seg = self_compact_next_segment();
+    auto seg = run_disk_log_housekeeping();
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {0, 0, 0}};
 
@@ -754,10 +760,10 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     // NOTE: different terms so compaction leaves one segment each.
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(0), model::term_id(1), 10, 2},
-      {manifest_ntp, model::offset(10), model::term_id(2), 10, 2},
-      {manifest_ntp, model::offset(20), model::term_id(3), 10, 2},
-      {manifest_ntp, model::offset(30), model::term_id(4), 10, 2},
-      {manifest_ntp, model::offset(40), model::term_id(5), 10, 2},
+      {manifest_ntp, model::offset(10), model::term_id(1), 10, 2},
+      {manifest_ntp, model::offset(20), model::term_id(1), 10, 2},
+      {manifest_ntp, model::offset(30), model::term_id(1), 10, 2},
+      {manifest_ntp, model::offset(40), model::term_id(1), 10, 2},
     };
 
     initialize(segments);
@@ -776,9 +782,9 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
       get_targets().find(manifest_url)->second.content);
 
     verify_segment_request("0-1-v1.log", manifest);
-    verify_segment_request("10-2-v1.log", manifest);
-    verify_segment_request("20-3-v1.log", manifest);
-    verify_segment_request("30-4-v1.log", manifest);
+    verify_segment_request("10-1-v1.log", manifest);
+    verify_segment_request("20-1-v1.log", manifest);
+    verify_segment_request("30-1-v1.log", manifest);
 
     BOOST_REQUIRE(part->archival_meta_stm());
     const cloud_storage::partition_manifest& stm_manifest
@@ -799,7 +805,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
         create_segment(
           {manifest_ntp,
            last_segment->offsets().get_committed_offset() + model::offset{1},
-           model::term_id{6},
+           model::term_id{2},
            10});
     }
 
@@ -807,20 +813,20 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
 
     // Mark four segments as compacted, so they are valid for upload
     ss::lw_shared_ptr<storage::segment> seg;
-    seg = self_compact_next_segment(model::offset(39));
+    seg = run_disk_log_housekeeping(model::offset(39));
 
     expected = archival::ntp_archiver::batch_result{{4, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected, model::offset::max());
     BOOST_REQUIRE_EQUAL(get_requests().size(), 9);
 
     verify_segment_request(
-      "40-5-v1.log", part->archival_meta_stm()->manifest());
+      "40-1-v1.log", part->archival_meta_stm()->manifest());
     verify_segment_request(
-      "50-6-v1.log", part->archival_meta_stm()->manifest());
+      "50-2-v1.log", part->archival_meta_stm()->manifest());
     verify_segment_request(
-      "65-6-v1.log", part->archival_meta_stm()->manifest());
+      "65-2-v1.log", part->archival_meta_stm()->manifest());
     verify_segment_request(
-      "85-6-v1.log", part->archival_meta_stm()->manifest());
+      "85-2-v1.log", part->archival_meta_stm()->manifest());
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(), model::offset{});
@@ -834,19 +840,81 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     upload_and_verify(archiver.value(), expected);
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
-    verify_concat_segment_request(
-      {
-        "0-1-v1.log",
-        "10-2-v1.log",
-        "20-3-v1.log",
-        "30-4-v1.log",
-      },
-      part->archival_meta_stm()->manifest());
-
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
       seg->offsets().get_committed_offset());
 
     replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 4);
+    BOOST_REQUIRE_EQUAL(stm_manifest.size(), 5);
+}
+
+FIXTURE_TEST(test_upload_compacted_segments_cross_term, reupload_fixture) {
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset(0), model::term_id(1), 1000, 2},
+      {manifest_ntp, model::offset(1000), model::term_id(4), 10, 2},
+    };
+
+    initialize(segments);
+    auto action = ss::defer([this] { archiver->stop().get(); });
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    listen();
+
+    // Upload two non compacted segments, no segment is compacted yet.
+    archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
+    upload_and_verify(archiver.value(), expected);
+
+    // Two segments, two indices, one manifest
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
+
+    auto manifest = verify_manifest_request(*part);
+    verify_segment_request("0-1-v1.log", manifest);
+    verify_segment_request("1000-4-v1.log", manifest);
+
+    BOOST_REQUIRE(part->archival_meta_stm());
+    const cloud_storage::partition_manifest& stm_manifest
+      = part->archival_meta_stm()->manifest();
+    verify_stm_manifest(stm_manifest, segments);
+
+    BOOST_REQUIRE_EQUAL(
+      stm_manifest.get_last_uploaded_compacted_offset(), model::offset{});
+
+    // Mark both segments compacted, and re-upload. Both segments are
+    // re-uploaded.
+    reset_http_call_state();
+
+    vlog(test_log.info, "Waiting for segments to self-compact");
+    auto seg = run_disk_log_housekeeping();
+    vlog(test_log.info, "Self-compaction completed");
+
+    expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {2, 0, 0}};
+    upload_and_verify(archiver.value(), expected);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
+
+    BOOST_REQUIRE_EQUAL(
+      stm_manifest.get_last_uploaded_compacted_offset(),
+      seg->offsets().get_committed_offset());
+
+    auto replaced = stm_manifest.replaced_segments();
+    BOOST_REQUIRE_EQUAL(replaced.size(), 2);
+    BOOST_REQUIRE_EQUAL(replaced[0].base_offset, model::offset{0});
+    BOOST_REQUIRE_EQUAL(replaced[1].base_offset, model::offset{1000});
+
+    // We can't reupload x-term so we should end up with two
+    // compacted uploads.
+
+    {
+        auto it = stm_manifest.get(model::offset(0));
+        BOOST_REQUIRE_EQUAL(it->base_offset, model::offset(0));
+        BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset(999));
+        BOOST_REQUIRE_EQUAL(it->segment_term, model::term_id(1));
+    }
+
+    {
+        auto it = stm_manifest.get(model::offset(1000));
+        BOOST_REQUIRE_EQUAL(it->base_offset, model::offset(1000));
+        BOOST_REQUIRE_EQUAL(it->committed_offset, model::offset(1009));
+        BOOST_REQUIRE_EQUAL(it->segment_term, model::term_id(4));
+    }
 }


### PR DESCRIPTION
Currently, the segment_collector can collect data from segments generated in different terms. The component is used to generate compacted reuploads. This commit fixes this by disabling the cross term segment collection.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none