### PR TITLE
datalake/metrics: miscellaneous improvements to lag metrics

### DIFF
--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -109,6 +109,8 @@ public:
     void clear_metrics() final;
 
 private:
+    int64_t iceberg_translation_offset_lag() const;
+    int64_t iceberg_commit_offset_lag() const;
     void reconfigure_metrics();
     void setup_public_metrics(const model::ntp&);
     void setup_internal_metrics(const model::ntp&);

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -186,7 +186,9 @@ struct fetch_latest_translated_offset_reply
     friend std::ostream&
     operator<<(std::ostream&, const fetch_latest_translated_offset_reply&);
 
-    auto serde_fields() { return std::tie(last_added_offset, errc); }
+    auto serde_fields() {
+        return std::tie(last_added_offset, errc, last_iceberg_committed_offset);
+    }
 };
 
 // For a given topic/partition fetches the latest translated offset from


### PR DESCRIPTION
This is based on our experience debugging Brandon's perf setup.

- Changes the metric reporting to report lag only on leaders. This makes it easy to monitor the metric using an aggregate across all replicas without having to worry about the current leader.

- Fixed a bug where lag entry was not added to serde fields, adjusted the test coverage to catch this scenario, refactored the test slightly while I'm there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes

* Fixes accounting of iceberg commit lag metric that can remain erroneously high in some cases even though the translation if fully caught up. Additionally the change ensures that only partition leaders emit lag metrics while followers emit 0 lag.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
