### PR TITLE
[CORE-8533] relax topic configs

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -1091,6 +1091,11 @@ public:
         return std::nullopt;
     }
 
+    /**
+     * @brief Checks current value of property to see if it is restricted
+     */
+    bool is_restricted() const { return do_check_restricted(this->value()); }
+
 private:
     bool do_check_restricted(const T& setting) const final {
         // depending on how the restriction was defined, construct an applicable

--- a/src/v/config/tests/enterprise_property_test.cc
+++ b/src/v/config/tests/enterprise_property_test.cc
@@ -109,4 +109,34 @@ TEST(EnterprisePropertyTest, TestTypeName) {
     EXPECT_EQ(cfg.enterprise_enum.type_name(), "string");
 }
 
+TEST(EnterprisePropertyTest, TestIsRestricted) {
+    test_config cfg;
+    cfg.enterprise_bool.set_value(false);
+    EXPECT_FALSE(cfg.enterprise_bool.is_restricted());
+    cfg.enterprise_bool.set_value(true);
+    EXPECT_TRUE(cfg.enterprise_bool.is_restricted());
+
+    cfg.enterprise_str_enum.set_value("foo");
+    EXPECT_FALSE(cfg.enterprise_str_enum.is_restricted());
+    cfg.enterprise_str_enum.set_value("bar");
+    EXPECT_TRUE(cfg.enterprise_str_enum.is_restricted());
+
+    cfg.enterprise_str_vec.set_value(
+      std::vector<ss::sstring>{"foo", "bar", "baz"});
+    EXPECT_FALSE(cfg.enterprise_str_vec.is_restricted());
+    cfg.enterprise_str_vec.set_value(
+      std::vector<ss::sstring>{"foo", "bar", "baz", "GSSAPI"});
+    EXPECT_TRUE(cfg.enterprise_str_vec.is_restricted());
+
+    cfg.enterprise_opt_int.set_value(10);
+    EXPECT_FALSE(cfg.enterprise_opt_int.is_restricted());
+    cfg.enterprise_opt_int.set_value(10000);
+    EXPECT_TRUE(cfg.enterprise_opt_int.is_restricted());
+
+    cfg.enterprise_enum.set_value(tls_version::v1_0);
+    EXPECT_FALSE(cfg.enterprise_enum.is_restricted());
+    cfg.enterprise_enum.set_value(tls_version::v1_3);
+    EXPECT_TRUE(cfg.enterprise_enum.is_restricted());
+}
+
 } // namespace config


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: #24543

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Redpanda will now permit topics to be created with `redpanda.remote.[read|write]` set to `true` when a license is expired or missing provided that the cluster config `cloud_storage_enabled` is set to `false`.
