### PR TITLE
[CORE-NNNN] archival: Use read-write fence in the ntp_archiver

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -249,7 +249,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
         ASSERT_TRUE(archiver.sync_for_tests().get());
         archiver
           .upload_next_candidates(
-            archival::archival_stm_fence{.unsafe_add = true})
+            archival::archival_stm_fence{.emit_rw_fence_cmd = false})
           .get();
     }
     ASSERT_EQ(
@@ -742,7 +742,7 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
         archiver.sync_for_tests().get();
         archiver
           .upload_next_candidates(
-            archival::archival_stm_fence{.unsafe_add = true})
+            archival::archival_stm_fence{.emit_rw_fence_cmd = false})
           .get();
 
         // not for synchronization... just to give the system time to propogate

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -247,7 +247,10 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
         log->force_roll(ss::default_priority_class()).get();
 
         ASSERT_TRUE(archiver.sync_for_tests().get());
-        archiver.upload_next_candidates().get();
+        archiver
+          .upload_next_candidates(
+            archival::archival_stm_fence{.unsafe_add = true})
+          .get();
     }
     ASSERT_EQ(
       cloud_storage::upload_result::success,
@@ -737,7 +740,10 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
         // drive the uploading
         auto& archiver = prt_l->archiver()->get();
         archiver.sync_for_tests().get();
-        archiver.upload_next_candidates().get();
+        archiver
+          .upload_next_candidates(
+            archival::archival_stm_fence{.unsafe_add = true})
+          .get();
 
         // not for synchronization... just to give the system time to propogate
         // all the state changes are are happening so that this overall loop

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -417,7 +417,9 @@ FIXTURE_TEST(
     while (produced_kafka_base_offset > stm_manifest.get_next_kafka_offset()) {
         BOOST_REQUIRE(archiver->sync_for_tests().get());
         BOOST_REQUIRE_EQUAL(
-          archiver->upload_next_candidates()
+          archiver
+            ->upload_next_candidates(
+              archival::archival_stm_fence{.unsafe_add = true})
             .get()
             .non_compacted_upload_result.num_failed,
           0);
@@ -497,7 +499,9 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
     // Upload more and truncate the manifest past the override.
     BOOST_REQUIRE(archiver->sync_for_tests().get());
     BOOST_REQUIRE_EQUAL(
-      archiver->upload_next_candidates()
+      archiver
+        ->upload_next_candidates(
+          archival::archival_stm_fence{.unsafe_add = true})
         .get()
         .non_compacted_upload_result.num_failed,
       0);

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -419,7 +419,7 @@ FIXTURE_TEST(
         BOOST_REQUIRE_EQUAL(
           archiver
             ->upload_next_candidates(
-              archival::archival_stm_fence{.unsafe_add = true})
+              archival::archival_stm_fence{.emit_rw_fence_cmd = false})
             .get()
             .non_compacted_upload_result.num_failed,
           0);
@@ -501,7 +501,7 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
     BOOST_REQUIRE_EQUAL(
       archiver
         ->upload_next_candidates(
-          archival::archival_stm_fence{.unsafe_add = true})
+          archival::archival_stm_fence{.emit_rw_fence_cmd = false})
         .get()
         .non_compacted_upload_result.num_failed,
       0);

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -90,7 +90,8 @@ public:
                 co_return -1;
             }
             if (
-              (co_await archiver.upload_next_candidates())
+              (co_await archiver.upload_next_candidates(
+                 archival::archival_stm_fence{.unsafe_add = true}))
                 .non_compacted_upload_result.num_failed
               > 0) {
                 co_return -1;

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -91,7 +91,7 @@ public:
             }
             if (
               (co_await archiver.upload_next_candidates(
-                 archival::archival_stm_fence{.unsafe_add = true}))
+                 archival::archival_stm_fence{.emit_rw_fence_cmd = false}))
                 .non_compacted_upload_result.num_failed
               > 0) {
                 co_return -1;

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -121,8 +121,8 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
         // Sync archiver, upload candidates (if needed) and upload manifest.
         archiver.sync_for_tests().get();
         std::ignore = archiver
-                        .upload_next_candidates(
-                          archival::archival_stm_fence{.unsafe_add = true})
+                        .upload_next_candidates(archival::archival_stm_fence{
+                          .emit_rw_fence_cmd = false})
                         .get();
         archiver.upload_topic_manifest().get();
     }
@@ -193,7 +193,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
     archiver.sync_for_tests().get();
     std::ignore = archiver
                     .upload_next_candidates(
-                      archival::archival_stm_fence{.unsafe_add = true})
+                      archival::archival_stm_fence{.emit_rw_fence_cmd = false})
                     .get();
 
     // Check requests with the same predicate at end of scope, just to be

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -120,7 +120,10 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
 
         // Sync archiver, upload candidates (if needed) and upload manifest.
         archiver.sync_for_tests().get();
-        std::ignore = archiver.upload_next_candidates().get();
+        std::ignore = archiver
+                        .upload_next_candidates(
+                          archival::archival_stm_fence{.unsafe_add = true})
+                        .get();
         archiver.upload_topic_manifest().get();
     }
 
@@ -188,7 +191,10 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
         .get());
 
     archiver.sync_for_tests().get();
-    std::ignore = archiver.upload_next_candidates().get();
+    std::ignore = archiver
+                    .upload_next_candidates(
+                      archival::archival_stm_fence{.unsafe_add = true})
+                    .get();
 
     // Check requests with the same predicate at end of scope, just to be
     // explicit about bad requests.

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1403,30 +1403,6 @@ void archival_metadata_stm::maybe_notify_waiter(std::exception_ptr e) noexcept {
 
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
-    bool disable_safe_add
-      = config::shard_local_cfg()
-          .cloud_storage_disable_metadata_consistency_checks.value();
-    if (
-      !disable_safe_add && segment.is_validated == segment_validated::yes
-      && !_manifest->safe_segment_meta_to_add(meta)) {
-        // We're only validating segment metadata records if they're validated.
-        // It goes like this
-        // - npt_archiver_service validates segment_meta instances before
-        //   replication
-        // - replicated add_segment commands have 'is_validated' field set to
-        //   'yes'
-        // - old records in the log have 'is_validated' field set to 'no'
-        // - the 'apply_add_segment' will only validate new commands and add old
-        //   ones unconditionally
-        auto last = _manifest->last_segment();
-        vlog(
-          _logger.error,
-          "Can't add segment: {}, previous segment: {}",
-          meta,
-          last);
-        maybe_notify_waiter(errc::inconsistent_stm_update);
-        return;
-    }
     if (meta.ntp_revision == model::initial_revision_id{}) {
         // metadata serialized by old versions of redpanda doesn't have the
         // ntp_revision field.

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1334,7 +1334,8 @@ archival_metadata_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
       .last_partition_scrub = _manifest->last_partition_scrub(),
       .last_scrubbed_offset = _manifest->last_scrubbed_offset(),
       .detected_anomalies = _manifest->detected_anomalies(),
-      .highest_producer_id = _manifest->highest_producer_id()});
+      .highest_producer_id = _manifest->highest_producer_id(),
+      .applied_offset = _manifest->get_applied_offset()});
     auto snapshot_offset = last_applied_offset();
     apply_units.return_all();
 

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -944,84 +944,42 @@ ss::future<std::error_code> archival_metadata_stm::add_segments(
   model::producer_id highest_pid,
   ss::lowres_clock::time_point deadline,
   ss::abort_source& as,
-  segment_validated is_validated) {
-    auto now = ss::lowres_clock::now();
-    auto timeout = now < deadline ? deadline - now : 0ms;
-    return _lock.with(
-      timeout,
-      [this,
-       s = std::move(segments),
-       clean_offset,
-       highest_pid,
-       deadline,
-       &as,
-       is_validated]() mutable {
-          return do_add_segments(
-            std::move(s),
-            clean_offset,
-            highest_pid,
-            deadline,
-            as,
-            is_validated);
-      });
-}
-
-ss::future<std::error_code> archival_metadata_stm::do_add_segments(
-  std::vector<cloud_storage::segment_meta> add_segments,
-  std::optional<model::offset> clean_offset,
-  model::producer_id highest_pid,
-  ss::lowres_clock::time_point deadline,
-  ss::abort_source& as,
-  segment_validated is_validated) {
+  segment_validated is_validated,
+  emit_read_write_fence rw_fence) {
     auto holder = _gate.hold();
-    {
-        auto now = ss::lowres_clock::now();
-        auto timeout = now < deadline ? deadline - now : 0ms;
-        if (!co_await do_sync(timeout, &as)) {
-            co_return errc::timeout;
-        }
-    }
-
-    as.check();
-
-    if (add_segments.empty()) {
+    if (segments.empty()) {
         co_return errc::success;
     }
 
-    storage::record_batch_builder b(
-      model::record_batch_type::archival_metadata, model::offset(0));
-    for (auto& meta : add_segments) {
-        iobuf key_buf = serde::to_iobuf(add_segment_cmd::key);
-        if (meta.ntp_revision == model::initial_revision_id{}) {
-            meta.ntp_revision = _manifest->get_revision_id();
-        }
-        auto record_val = add_segment_cmd::value{segment_from_meta(meta)};
-        record_val.is_validated = is_validated;
-        iobuf val_buf = serde::to_iobuf(std::move(record_val));
-        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    auto builder = batch_start(deadline, as);
+    if (rw_fence.has_value()) {
+        // The fence should be added first because it can only
+        // affect commands which are following it in the same record
+        // batch.
+        vlog(
+          _logger.debug,
+          "add_segments, read-write fence: {}",
+          rw_fence.value());
+        builder.read_write_fence(rw_fence.value());
     }
+    // Add actual segments
+    builder.add_segments(segments, is_validated);
 
+    // Update metadata
     if (clean_offset.has_value()) {
-        iobuf key_buf = serde::to_iobuf(
-          archival_metadata_stm::mark_clean_cmd::key);
-        iobuf val_buf = serde::to_iobuf(clean_offset.value());
-        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+        builder.mark_clean(clean_offset.value());
     }
-
     if (highest_pid != model::producer_id{}) {
-        iobuf key_buf = serde::to_iobuf(
-          archival_metadata_stm::update_highest_producer_id_cmd::key);
-        iobuf val_buf = serde::to_iobuf(highest_pid());
-        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+        builder.update_highest_producer_id(highest_pid);
     }
 
-    auto batch = std::move(b).build();
-    auto ec = co_await do_replicate_commands(std::move(batch), as);
+    // Replicate and log new metadata
+    auto ec = co_await builder.replicate();
     if (ec) {
         co_return ec;
     }
 
-    for (const auto& meta : add_segments) {
+    for (const auto& meta : segments) {
         auto name = cloud_storage::generate_local_segment_name(
           meta.base_offset, meta.segment_term);
         vlog(

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -50,6 +50,7 @@ class command_batch_builder_accessor;
 class archival_metadata_stm;
 
 using segment_validated = ss::bool_class<struct segment_validated_tag>;
+using emit_read_write_fence = std::optional<model::offset>;
 
 /// Batch builder allows to combine different archival_metadata_stm commands
 /// together in a single record batch
@@ -147,7 +148,8 @@ public:
       model::producer_id highest_pid,
       ss::lowres_clock::time_point deadline,
       ss::abort_source&,
-      segment_validated is_validated);
+      segment_validated is_validated,
+      emit_read_write_fence rw_fence = std::nullopt);
 
     /// Truncate local snapshot by moving start_offset forward
     ///
@@ -290,14 +292,6 @@ public:
 private:
     ss::future<bool>
     do_sync(model::timeout_clock::duration timeout, ss::abort_source* as);
-
-    ss::future<std::error_code> do_add_segments(
-      std::vector<cloud_storage::segment_meta>,
-      std::optional<model::offset> clean_offset,
-      model::producer_id highest_pid,
-      ss::lowres_clock::time_point deadline,
-      ss::abort_source&,
-      segment_validated is_validated);
 
     // Replicate commands in a batch and wait for their application.
     // Should be called under _lock to ensure linearisability

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2631,6 +2631,13 @@ ss::future<> ntp_archiver::apply_archive_retention() {
         vlog(_rtclog.trace, "NTP is not collectable");
         co_return;
     }
+
+    archival_stm_fence fence = {
+      .read_write_fence
+      = _parent.archival_meta_stm()->manifest().get_applied_offset(),
+      .unsafe_add = false,
+    };
+
     std::optional<size_t> retention_bytes = ntp_conf.retention_bytes();
     std::optional<std::chrono::milliseconds> retention_ms
       = ntp_conf.retention_duration();
@@ -2667,6 +2674,13 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     auto deadline = ss::lowres_clock::now() + sync_timeout;
 
     auto batch = _parent.archival_meta_stm()->batch_start(deadline, _as);
+    if (!fence.unsafe_add) {
+        vlog(
+          _rtclog.debug,
+          "truncate_archive_init, read-write fence: {}",
+          fence.read_write_fence);
+        batch.read_write_fence(fence.read_write_fence);
+    }
     batch.truncate_archive_init(res.value().offset, res.value().delta);
     auto error = co_await batch.replicate();
 
@@ -2688,6 +2702,11 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
     if (!may_begin_uploads()) {
         co_return;
     }
+    archival_stm_fence fence = {
+      .read_write_fence
+      = _parent.archival_meta_stm()->manifest().get_applied_offset(),
+      .unsafe_add = false,
+    };
     auto backlog = co_await _manifest_view->get_retention_backlog();
     if (backlog.has_failure()) {
         if (backlog.error() == cloud_storage::error_outcome::shutting_down) {
@@ -2870,8 +2889,16 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
         auto deadline = ss::lowres_clock::now() + sync_timeout;
-        auto error = co_await _parent.archival_meta_stm()->cleanup_archive(
-          new_clean_offset, bytes_to_remove, deadline, _as);
+        auto builder = _parent.archival_meta_stm()->batch_start(deadline, _as);
+        if (!fence.unsafe_add) {
+            vlog(
+              _rtclog.debug,
+              "cleanup_archive, read-write fence: {}",
+              fence.read_write_fence);
+            builder.read_write_fence(fence.read_write_fence);
+        }
+        builder.cleanup_archive(new_clean_offset, bytes_to_remove);
+        auto error = co_await builder.replicate();
 
         if (error != cluster::errc::success) {
             vlog(
@@ -3124,6 +3151,11 @@ ss::future<> ntp_archiver::apply_retention() {
     if (!may_begin_uploads()) {
         co_return;
     }
+    archival_stm_fence fence = {
+      .read_write_fence
+      = _parent.archival_meta_stm()->manifest().get_applied_offset(),
+      .unsafe_add = false,
+    };
     auto arch_so = manifest().get_archive_start_offset();
     auto stm_so = manifest().get_start_offset();
     if (arch_so != model::offset{} && arch_so != stm_so) {
@@ -3170,8 +3202,22 @@ ss::future<> ntp_archiver::apply_retention() {
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
         auto deadline = ss::lowres_clock::now() + sync_timeout;
-        auto error = co_await _parent.archival_meta_stm()->truncate(
-          *next_start_offset, deadline, _as);
+
+        auto builder = _parent.archival_meta_stm()->batch_start(deadline, _as);
+        if (!fence.unsafe_add) {
+            // Currently, the 'unsafe_add' is always set to 'false'
+            // because the fence is generated inside this method. It's still
+            // good to have this condition in case if this will be changed.
+            vlog(
+              _rtclog.debug,
+              "truncate, read-write fence: {}",
+              fence.read_write_fence);
+            builder.read_write_fence(fence.read_write_fence);
+        }
+        builder.truncate(*next_start_offset);
+
+        auto error = co_await builder.replicate();
+
         if (error != cluster::errc::success) {
             vlog(
               _rtclog.warn,
@@ -3199,6 +3245,12 @@ ss::future<> ntp_archiver::garbage_collect() {
     if (to_remove.size() == 0) {
         co_return;
     }
+
+    archival_stm_fence fence = {
+      .read_write_fence
+      = _parent.archival_meta_stm()->manifest().get_applied_offset(),
+      .unsafe_add = false,
+    };
 
     // If we are about to delete segments, we must ensure that the remote
     // manifest is fully up to date, so that it is definitely not referring
@@ -3260,8 +3312,17 @@ ss::future<> ntp_archiver::garbage_collect() {
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
         auto deadline = ss::lowres_clock::now() + sync_timeout;
-        auto error = co_await _parent.archival_meta_stm()->cleanup_metadata(
-          deadline, _as);
+
+        auto builder = _parent.archival_meta_stm()->batch_start(deadline, _as);
+        if (!fence.unsafe_add) {
+            vlog(
+              _rtclog.debug,
+              "cleanup_metadata, read-write fence: {}",
+              fence.read_write_fence);
+            builder.read_write_fence(fence.read_write_fence);
+        }
+        builder.cleanup_metadata();
+        auto error = co_await builder.replicate();
 
         if (error != cluster::errc::success) {
             vlog(

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3307,18 +3307,23 @@ ntp_archiver::get_housekeeping_jobs() {
     return res;
 }
 
-ss::future<std::pair<
-  std::optional<ssx::semaphore_units>,
-  std::optional<upload_candidate_with_locks>>>
+ss::future<ntp_archiver::find_reupload_candidate_result>
 ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     ss::gate::holder holder(_gate);
+    archival_stm_fence rw_fence{
+      .read_write_fence
+      = _parent.archival_meta_stm()->manifest().get_applied_offset(),
+      .unsafe_add = false,
+    };
     if (!may_begin_uploads()) {
-        co_return std::make_pair(std::nullopt, std::nullopt);
+        co_return find_reupload_candidate_result{
+          std::nullopt, std::nullopt, {}};
     }
     auto run = scanner(_parent.raft_start_offset(), manifest());
     if (!run.has_value()) {
         vlog(_rtclog.debug, "Scan didn't resulted in upload candidate");
-        co_return std::make_pair(std::nullopt, std::nullopt);
+        co_return find_reupload_candidate_result{
+          std::nullopt, std::nullopt, {}};
     } else {
         vlog(_rtclog.debug, "Scan result: {}", run);
     }
@@ -3337,18 +3342,16 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
         auto candidate = co_await collector.make_upload_candidate(
           _conf->upload_io_priority, _conf->segment_upload_timeout());
 
-        using ret_t = std::pair<
-          std::optional<ssx::semaphore_units>,
-          std::optional<upload_candidate_with_locks>>;
         co_return ss::visit(
           candidate,
-          [](std::monostate) -> ret_t {
+          [](std::monostate) -> find_reupload_candidate_result {
               vassert(
                 false,
                 "unexpected default re-upload candidate creation result");
           },
-          [this, &run, units = std::move(units)](
-            upload_candidate_with_locks& upload_candidate) mutable -> ret_t {
+          [this, &run, &rw_fence, units = std::move(units)](
+            upload_candidate_with_locks& upload_candidate) mutable
+          -> find_reupload_candidate_result {
               if (
                 upload_candidate.candidate.content_length
                   != run->meta.size_bytes
@@ -3363,27 +3366,28 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
                     "{}, run: {}",
                     upload_candidate.candidate,
                     run->meta);
-                  return std::make_pair(std::nullopt, std::nullopt);
+                  return {std::nullopt, std::nullopt, {}};
               }
 
-              return std::make_pair(
-                std::move(units), std::move(upload_candidate));
+              return {std::move(units), std::move(upload_candidate), rw_fence};
           },
-          [this](skip_offset_range& skip_offsets) -> ret_t {
+          [this](
+            skip_offset_range& skip_offsets) -> find_reupload_candidate_result {
               vlog(
                 _rtclog.warn,
                 "Failed to make reupload candidate: {}",
                 skip_offsets.reason);
-              return std::make_pair(std::nullopt, std::nullopt);
+              return {std::nullopt, std::nullopt, {}};
           },
-          [this](candidate_creation_error& error) -> ret_t {
+          [this](
+            candidate_creation_error& error) -> find_reupload_candidate_result {
               const auto log_level = log_level_for_error(error);
               vlogl(
                 _rtclog,
                 log_level,
                 "Failed to make reupload candidate: {}",
                 error);
-              return std::make_pair(std::nullopt, std::nullopt);
+              return {std::nullopt, std::nullopt, {}};
           });
     }
     // segment_name exposed_name;
@@ -3401,18 +3405,26 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
       = cloud_storage::partition_manifest::generate_remote_segment_name(
         run->meta);
     // Create a remote upload candidate
-    co_return std::make_pair(
-      std::move(units), upload_candidate_with_locks{std::move(candidate)});
+    co_return find_reupload_candidate_result{
+      std::move(units),
+      upload_candidate_with_locks{std::move(candidate)},
+      rw_fence};
 }
 
 ss::future<bool> ntp_archiver::upload(
-  ssx::semaphore_units archiver_units,
-  upload_candidate_with_locks upload_locks,
+  find_reupload_candidate_result find_res,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
     ss::gate::holder holder(_gate);
-    auto units = std::move(archiver_units);
-    if (upload_locks.candidate.sources.size() > 0) {
-        co_return co_await do_upload_local(std::move(upload_locks), source_rtc);
+    if (!find_res.locks.has_value() || !find_res.units.has_value()) {
+        // The method shouldn't be called if this is the case
+        co_return false;
+    }
+    auto units = std::move(find_res.units);
+    if (find_res.locks->candidate.sources.size() > 0) {
+        co_return co_await do_upload_local(
+          find_res.read_write_fence,
+          std::move(find_res.locks.value()),
+          source_rtc);
     }
     // Currently, the uploading of remote segments is disabled and
     // the only reason why the list of locks is empty is truncation.
@@ -3423,6 +3435,7 @@ ss::future<bool> ntp_archiver::upload(
 }
 
 ss::future<bool> ntp_archiver::do_upload_local(
+  archival_stm_fence fence,
   upload_candidate_with_locks upload_locks,
   std::optional<std::reference_wrapper<retry_chain_node>> source_rtc) {
     if (!may_begin_uploads()) {
@@ -3537,14 +3550,27 @@ ss::future<bool> ntp_archiver::do_upload_local(
           ? _parent.highest_producer_id()
           : model::producer_id{};
     auto deadline = ss::lowres_clock::now() + _conf->manifest_upload_timeout();
-    auto error = co_await _parent.archival_meta_stm()->add_segments(
+
+    auto builder = _parent.archival_meta_stm()->batch_start(deadline, _as);
+    if (!fence.unsafe_add) {
+        vlog(
+          archival_log.debug,
+          "(2) fence value is: {}, unsafe add: {}, manifest last applied "
+          "offset: {}, manifest in-sync offset: {}",
+          fence.read_write_fence,
+          fence.unsafe_add,
+          _parent.archival_meta_stm()->manifest().get_applied_offset(),
+          _parent.archival_meta_stm()->get_insync_offset());
+        builder.read_write_fence(fence.read_write_fence);
+    }
+    builder.add_segments(
       {meta},
-      std::nullopt,
-      highest_producer_id,
-      deadline,
-      _as,
       checks_disabled ? cluster::segment_validated::no
                       : cluster::segment_validated::yes);
+    builder.update_highest_producer_id(highest_producer_id);
+
+    auto error = co_await builder.replicate();
+
     if (error != cluster::errc::success && error != cluster::errc::not_leader) {
         vlog(
           _rtclog.warn,

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -760,8 +760,19 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
             continue;
         }
 
+        // This is the offset of the last applied command. It is used
+        // as a fence to implement optimistic concurrency control.
+        auto fence
+          = _parent.archival_meta_stm()->manifest().get_applied_offset();
+        vlog(
+          archival_log.debug,
+          "fence value is: {}, in-sync offset: {}",
+          fence,
+          _parent.archival_meta_stm()->get_insync_offset());
+
         auto [non_compacted_upload_result, compacted_upload_result]
-          = co_await upload_next_candidates();
+          = co_await upload_next_candidates(
+            archival_stm_fence{.read_write_fence = fence});
         if (non_compacted_upload_result.num_failed != 0) {
             // The logic in class `remote` already does retries: if we get here,
             // it means the upload failed after several retries, justifying
@@ -2087,6 +2098,7 @@ ntp_archiver::schedule_uploads(std::vector<upload_context> loop_contexts) {
 }
 
 ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
+  archival_stm_fence fence,
   std::vector<scheduled_upload> scheduled,
   segment_upload_kind segment_kind,
   bool inline_manifest) {
@@ -2165,6 +2177,21 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
       = config::shard_local_cfg()
           .cloud_storage_disable_upload_consistency_checks.value();
     if (!checks_disabled) {
+        // With read-write-fence it's guaranteed that the concurrent
+        // updates are not a problem. But we still need this check
+        // to prevent certain bugs from corrupting the cloud storage
+        // metadata.
+        // Overall, we're checking that the update makes sense here
+        // (that the new segment lines up with the previous one). Then
+        // we're checking that the segment actually matches its
+        // metadata. And then we're replicating the metadata with the
+        // fence that guarantees that no updates are made to the STM
+        // state interim.
+        // In other words, we're basing the decision to start an upload
+        // on the precondition. Then we're validating the actual uploads
+        // against this precondition and then we're discarding the
+        // changes to the STM state if the precondition is no longer
+        // valid.
         std::vector<cloud_storage::segment_meta> meta;
         for (size_t i = 0; i < segment_results.size(); i++) {
             meta.push_back(scheduled[ixupload[i]].meta.value());
@@ -2231,6 +2258,11 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
         mdiff.push_back(*upload.meta);
     }
 
+    if (mdiff.empty()) {
+        vlog(_rtclog.debug, "No upload metadata collected, returning early");
+        co_return total;
+    }
+
     if (total.num_succeeded != 0) {
         vassert(
           _parent.archival_meta_stm(),
@@ -2256,14 +2288,34 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
               ? _parent.highest_producer_id()
               : model::producer_id{};
 
-        auto error = co_await _parent.archival_meta_stm()->add_segments(
+        auto batch_builder = _parent.archival_meta_stm()->batch_start(
+          deadline, _as);
+        if (!fence.unsafe_add) {
+            // The fence should be added first because it can only
+            // affect commands which are following it in the same record
+            // batch.
+            vlog(
+              archival_log.debug,
+              "add_segments, read-write fence: {}, unsafe add: {}, manifest "
+              "last "
+              "applied offset: {}, manifest in-sync offset: {}",
+              fence.read_write_fence,
+              fence.unsafe_add,
+              _parent.archival_meta_stm()->manifest().get_applied_offset(),
+              _parent.archival_meta_stm()->get_insync_offset());
+            batch_builder.read_write_fence(fence.read_write_fence);
+        }
+        batch_builder.add_segments(
           mdiff,
-          manifest_clean_offset,
-          highest_producer_id,
-          deadline,
-          _as,
           checks_disabled ? cluster::segment_validated::no
                           : cluster::segment_validated::yes);
+        if (manifest_clean_offset.has_value()) {
+            batch_builder.mark_clean(manifest_clean_offset.value());
+        }
+        batch_builder.update_highest_producer_id(highest_producer_id);
+
+        auto error = co_await batch_builder.replicate();
+
         if (
           error != cluster::errc::success
           && error != cluster::errc::not_leader) {
@@ -2303,6 +2355,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
 }
 
 ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
+  archival_stm_fence fence,
   std::vector<ntp_archiver::scheduled_upload> scheduled) {
     // Split the set of scheduled uploads into compacted and non compacted
     // uploads, and then wait for them separately. They can also be waited on
@@ -2341,10 +2394,12 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
     auto [non_compacted_result, compacted_result]
       = co_await ss::when_all_succeed(
         wait_uploads(
+          fence,
           std::move(non_compacted_uploads),
           segment_upload_kind::non_compacted,
           inline_manifest_in_non_compacted_uploads),
         wait_uploads(
+          fence,
           std::move(compacted_uploads),
           segment_upload_kind::compacted,
           !inline_manifest_in_non_compacted_uploads));
@@ -2374,6 +2429,7 @@ model::offset ntp_archiver::max_uploadable_offset_exclusive() const {
 }
 
 ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
+  archival_stm_fence fence,
   std::optional<model::offset> unsafe_max_offset_override_exclusive) {
     auto max_offset_exclusive = unsafe_max_offset_override_exclusive
                                   ? *unsafe_max_offset_override_exclusive
@@ -2389,7 +2445,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
         auto scheduled_uploads = co_await schedule_uploads(
           max_offset_exclusive);
         co_return co_await wait_all_scheduled_uploads(
-          std::move(scheduled_uploads));
+          fence, std::move(scheduled_uploads));
     } catch (const ss::gate_closed_exception&) {
     } catch (const ss::abort_requested_exception&) {
     }

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -121,8 +121,8 @@ struct archival_stm_fence {
     // Offset of the last command added to the
     // archival STM
     model::offset read_write_fence;
-    // Disable fencing in tests
-    bool unsafe_add{false};
+    // Use read-write fence when replicating commands
+    bool emit_rw_fence_cmd{true};
 };
 
 /// This class performs per-ntp archival workload. Every ntp can be

--- a/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
@@ -550,10 +550,12 @@ TEST_F_CORO(
 
     repl_err = co_await get_leader_stm()
                  .batch_start(deadline, never_abort)
+                 // Invalid rw-fence to simulate concurent update
+                 .read_write_fence(model::offset(33))
                  .add_segments(
                    std::move(poisoned_segment), cluster::segment_validated::yes)
                  .replicate();
-    ASSERT_EQ_CORO(repl_err, cluster::errc::inconsistent_stm_update);
+    ASSERT_EQ_CORO(repl_err, cluster::errc::concurrent_modification_error);
 
     // Check that it still works with consistent updates
     good_segment.clear();

--- a/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
@@ -23,9 +23,14 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
+
+#include <gtest/gtest.h>
+
+#include <exception>
 
 using cloud_storage::segment_name;
 using segment_meta = cloud_storage::partition_manifest::segment_meta;
@@ -469,8 +474,11 @@ TEST_F_CORO(
 
     ASSERT_TRUE_CORO(synced);
 
-    auto slow_replication_res = co_await std::move(slow_replication_fut);
-    ASSERT_TRUE_CORO(!slow_replication_res);
+    auto slow_replication_res = co_await ss::coroutine::as_future(
+      std::move(slow_replication_fut));
+    ASSERT_TRUE_CORO(slow_replication_res.failed());
+    ASSERT_THROW_CORO(
+      slow_replication_res.get(), ss::abort_requested_exception);
 
     auto [committed_offset, term] = co_await with_leader(
       10s, [](raft::raft_node_instance& node) mutable {

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -404,7 +404,9 @@ FIXTURE_TEST(
     });
 
     retry_chain_node fib(never_abort);
-    auto res = archiver.upload_next_candidates().get();
+    auto res = archiver
+                 .upload_next_candidates(archival_stm_fence{.unsafe_add = true})
+                 .get();
 
     auto&& [non_compacted_result, compacted_result] = res;
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_succeeded, 0);

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -405,7 +405,8 @@ FIXTURE_TEST(
 
     retry_chain_node fib(never_abort);
     auto res = archiver
-                 .upload_next_candidates(archival_stm_fence{.unsafe_add = true})
+                 .upload_next_candidates(
+                   archival_stm_fence{.emit_rw_fence_cmd = false})
                  .get();
 
     auto&& [non_compacted_result, compacted_result] = res;

--- a/src/v/cluster/archival/tests/service_fixture.cc
+++ b/src/v/cluster/archival/tests/service_fixture.cc
@@ -559,7 +559,7 @@ archiver_fixture::do_upload_next(
         co_return archival::ntp_archiver::batch_result{};
     }
     auto result = co_await archiver.upload_next_candidates(
-      archival_stm_fence{.unsafe_add = true}, lso);
+      archival_stm_fence{.emit_rw_fence_cmd = false}, lso);
     auto num_success = result.compacted_upload_result.num_succeeded
                        + result.non_compacted_upload_result.num_succeeded;
     if (num_success > 0) {
@@ -584,7 +584,8 @@ void archiver_fixture::upload_and_verify(
       10s,
       [&archiver, expected, lso]() {
           return archiver
-            .upload_next_candidates(archival_stm_fence{.unsafe_add = true}, lso)
+            .upload_next_candidates(
+              archival_stm_fence{.emit_rw_fence_cmd = false}, lso)
             .then([expected](auto result) { return result == expected; });
       })
       .get();

--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -182,7 +182,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
         archiver.sync_for_tests().get();
         auto res = archiver
                      .upload_next_candidates(
-                       archival::archival_stm_fence{.unsafe_add = true})
+                       archival::archival_stm_fence{.emit_rw_fence_cmd = false})
                      .get();
         ASSERT_GT(res.non_compacted_upload_result.num_succeeded, 0);
         archiver.upload_topic_manifest().get();

--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -180,7 +180,10 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
         }
         auto& archiver = p->archiver().value().get();
         archiver.sync_for_tests().get();
-        auto res = archiver.upload_next_candidates().get();
+        auto res = archiver
+                     .upload_next_candidates(
+                       archival::archival_stm_fence{.unsafe_add = true})
+                     .get();
         ASSERT_GT(res.non_compacted_upload_result.num_succeeded, 0);
         archiver.upload_topic_manifest().get();
         archiver.upload_manifest("test").get();

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -81,7 +81,7 @@ enum class errc : int16_t {
     transform_count_limit_exceeded,
     role_exists,
     role_does_not_exist,
-    inconsistent_stm_update,
+    inconsistent_stm_update [[deprecated]],
     waiting_for_shard_placement_update,
     topic_invalid_partitions_core_limit,
     topic_invalid_partitions_memory_limit,
@@ -255,8 +255,6 @@ struct errc_category final : public std::error_category {
             return "Role already exists";
         case errc::role_does_not_exist:
             return "Role does not exist";
-        case errc::inconsistent_stm_update:
-            return "STM command can't be applied";
         case errc::waiting_for_shard_placement_update:
             return "Waiting for shard placement table update to finish";
         case errc::topic_invalid_partitions_core_limit:

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -150,8 +150,6 @@ std::ostream& operator<<(std::ostream& o, cluster::errc err) {
         return o << "cluster::errc::role_exists";
     case errc::role_does_not_exist:
         return o << "cluster::errc::role_does_not_exist";
-    case errc::inconsistent_stm_update:
-        return o << "cluster::errc::inconsistent_stm_update";
     case errc::waiting_for_shard_placement_update:
         return o << "cluster::errc::waiting_for_shard_placement_update";
     case errc::topic_invalid_partitions_core_limit:

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2372,13 +2372,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , cloud_storage_disable_metadata_consistency_checks(
-      *this,
-      "cloud_storage_disable_metadata_consistency_checks",
-      "Disable all metadata consistency checks. This will allow redpanda to "
-      "replay logs with inconsistent tiered-storage metadata. Normally, this "
-      "option should be disabled.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      *this, "cloud_storage_disable_metadata_consistency_checks")
   , cloud_storage_hydration_timeout_ms(
       *this,
       "cloud_storage_hydration_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2373,6 +2373,14 @@ configuration::configuration()
       false)
   , cloud_storage_disable_metadata_consistency_checks(
       *this, "cloud_storage_disable_metadata_consistency_checks")
+  , cloud_storage_disable_archival_stm_rw_fence(
+      *this,
+      "cloud_storage_disable_archival_stm_rw_fence",
+      "Disable concurrency control mechanism in the Tiered-Storage. This could "
+      "potentially break the metadata consistency and shouldn't be used in "
+      "production systems. It should only be used for testing.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , cloud_storage_hydration_timeout_ms(
       *this,
       "cloud_storage_hydration_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -464,7 +464,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
-    property<bool> cloud_storage_disable_metadata_consistency_checks;
+    deprecated_property cloud_storage_disable_metadata_consistency_checks;
     property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
     property<bool> cloud_storage_disable_remote_labels_for_tests;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -465,6 +465,7 @@ struct configuration final : public config_store {
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
     deprecated_property cloud_storage_disable_metadata_consistency_checks;
+    property<bool> cloud_storage_disable_archival_stm_rw_fence;
     property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
     property<bool> cloud_storage_disable_remote_labels_for_tests;
 

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -100,6 +100,8 @@ std::string_view to_string_view(feature f) {
         return "raft_symmetric_reconfiguration_cancel";
     case feature::datalake_iceberg_ga:
         return "datalake_iceberg_ga";
+    case feature::cloud_storage_metadata_rw_fence:
+        return "cloud_storage_metadata_rw_fence";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -70,7 +70,7 @@ enum class feature : std::uint64_t {
     datalake_iceberg = 1ULL << 54U,
     raft_symmetric_reconfiguration_cancel = 1ULL << 55U,
     datalake_iceberg_ga = 1ULL << 56U,
-
+    cloud_storage_metadata_rw_fence = 1ULL << 57U,
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
     test_bravo = 1ULL << 62U,

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -105,7 +105,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::transform_count_limit_exceeded:
     case cluster::errc::role_exists:
     case cluster::errc::role_does_not_exist:
-    case cluster::errc::inconsistent_stm_update:
     case cluster::errc::waiting_for_shard_placement_update:
     case cluster::errc::producer_ids_vcluster_limit_exceeded:
     case cluster::errc::validation_of_recovery_topic_failed:


### PR DESCRIPTION
The fence is a value which is produced by recording the current offset of the last applied archival STM command. The fence is added to the archival STM config batch. If no commands were applied to the STM the offset of the last applied command will be the same and the configuration batch will be applied. Otherwise, if some command was applied after the record batch was constructed the batch will not be applied.

This is essentially a concurrency control mechanism. The commands are already present in the STM but not used as for now. The existing metadata validation mechanism in the NTP archiver is still working but we no longer need to check the commands in the STM. If every archival STM command batch starts with the fence the batches become idempotent. This eliminates various scenarios in which Tiered-Storage metadata could be corrupted.

Some examples:
1. Some commands are replayed twice after bogus recovery. The archival STM is restored in one of the replicas and the insync offset is seeded to be equal to `last_uploaded_offset` and then the most recent part of the log is shipped from another replica. Then the STM replays commands starting from insync offset which means that it applies some commands twice. If all the commands contain `rw_fence` there will be no metadata corruption.
2. Concurrency violation after the cross-shard movement. The partition is moved to another shard without loosing leadership. The `ntp_archiver` stops on the old shard and then starts on the new shard. The problem is that on the new shard it starts in the middle of the term which means that the archival STM may apply commands asynchronously. If the segment upload is started concurrently with the application of commands we may upload segment which doesn't align well with the last segment.
3. Concurrency violation when the `ntp_archiver` is restarted mid-term. This is similar to x-shard movement case but the archiver is rested because we used an escape hatch to reset the manifest or because we enabled compaction for the topic.

All the problems mentioned above are fixed using other means. We should still use `rw_fence` mechanism to avoid similar problems in the future.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none