### PR TITLE
[v24.3.x] datalake/translator: ensure cleanup of log reader in all cases

### DIFF
--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -235,13 +235,13 @@ ss::shared_ptr<parquet_ostream_factory> get_parquet_writer_factory() {
 ss::future<std::optional<coordinator::translated_offset_range>>
 partition_translator::do_translation_for_range(
   retry_chain_node& parent,
-  model::record_batch_reader rdr,
-  kafka::offset begin_offset) {
+  kafka::offset read_begin_offset,
+  kafka::offset read_end_offset) {
     // This configuration only writes a single row group per file but we limit
     // the bytes via the reader max_bytes.
     auto writer_factory = std::make_unique<local_parquet_file_writer_factory>(
-      local_path{_writer_scratch_space}, // storage temp files are written to
-      fmt::format("{}", begin_offset),   // file prefix
+      local_path{_writer_scratch_space},    // storage temp files are written to
+      fmt::format("{}", read_begin_offset), // file prefix
       get_parquet_writer_factory());
 
     auto task = translation_task{
@@ -257,11 +257,36 @@ partition_translator::do_translation_for_range(
         return can_continue() ? std::nullopt
                               : std::make_optional("translator stopping");
     }};
+
+    vlog(
+      _logger.debug,
+      "translating data in kafka range: [{}, {}]",
+      read_begin_offset,
+      read_end_offset);
+
+    auto log_reader = co_await _partition_proxy->make_reader(
+      {kafka::offset_cast(read_begin_offset),
+       kafka::offset_cast(read_end_offset),
+       0,
+       _max_bytes_per_reader,
+       datalake_priority(),
+       std::nullopt,
+       std::nullopt,
+       _as});
+    auto tracker = kafka::aborted_transaction_tracker::create_default(
+      _partition_proxy.get(), std::move(log_reader.ot_state));
+    auto kafka_reader
+      = model::make_record_batch_reader<kafka::read_committed_reader>(
+        std::move(tracker), std::move(log_reader.reader));
+    // Be wary of introducing abortable code here that can skip cleanup
+    // of kafka_reader. The reader is cleaned up along with consumption,
+    // so we need to ensure that the reader is dispatched to translation
+    // in all cases.
     auto result = co_await task.translate(
       ntp,
       _partition->get_topic_revision_id(),
       std::move(writer_factory),
-      std::move(rdr),
+      std::move(kafka_reader),
       remote_path_prefix,
       parent,
       las);
@@ -314,29 +339,12 @@ partition_translator::do_translate_once(retry_chain_node& parent_rcn) {
     // accumulate. The resulting parquet files are only performant
     // if there is a big chunk of data in them. Smaller parquet files
     // are an overhead for iceberg metadata.
-    auto log_reader = co_await _partition_proxy->make_reader(
-      {kafka::offset_cast(read_begin_offset),
-       kafka::offset_cast(read_end_offset),
-       0,
-       _max_bytes_per_reader,
-       datalake_priority(),
-       std::nullopt,
-       std::nullopt,
-       _as});
-
     auto units = co_await ss::get_units(**_parallel_translations, 1, _as);
-    vlog(
-      _logger.debug,
-      "translating data in kafka range: [{}, {}]",
-      read_begin_offset,
-      read_end_offset);
-    auto tracker = kafka::aborted_transaction_tracker::create_default(
-      _partition_proxy.get(), std::move(log_reader.ot_state));
-    auto kafka_reader
-      = model::make_record_batch_reader<kafka::read_committed_reader>(
-        std::move(tracker), std::move(log_reader.reader));
+
     auto translation_result = co_await do_translation_for_range(
-      parent_rcn, std::move(kafka_reader), read_begin_offset);
+      parent_rcn, read_begin_offset, read_end_offset);
+
+    // release units and checkpoint outside of the lock.
     units.return_all();
     vlog(_logger.debug, "translation result: {}", translation_result);
     auto result = translation_success::no;

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -105,8 +105,8 @@ private:
     ss::future<std::optional<coordinator::translated_offset_range>>
     do_translation_for_range(
       retry_chain_node& parent,
-      model::record_batch_reader,
-      kafka::offset begin_offset);
+      kafka::offset read_begin,
+      kafka::offset read_end);
 
     using checkpoint_result = ss::bool_class<struct checkpoint_result>;
     ss::future<checkpoint_result> checkpoint_translated_data(


### PR DESCRIPTION
The reader is cleaned up in consume(). Other exit points between reader creation and consumption can potentially trigger an assert. The change moves the reader creation as close to the translation as possible.

(cherry picked from commit 454ca47d9560e770c6ba3430487c49f05c3e6153)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Fixes a crash resulting from incorrect cleanup of log readers used for iceberg translation.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
