### PR TITLE
omb: Limit cloud read throughput in TS read test

### DIFF
--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -23,6 +23,8 @@ class TSReadOpenmessagingTest(RedpandaTest):
             "retention_local_strict": True,
             "retention_local_target_bytes_default": 16 * 1_000_000,  # 16 MB
             "cloud_storage_spillover_manifest_size": None,
+            # approximate limit for m7gd.xlarge
+            "cloud_storage_max_throughput_per_shard": 25 * 1_000_000,
         }
         si_settings = SISettings(
             test_context=ctx,


### PR DESCRIPTION
With the switch to m7gd we are now maxing out disk throughput when
catching up from the backlog.

This makes produce latency go bad. To avoid this limit cloud
readthroughput (as we do in cloud).

We use the same formula as in the cloud: 150MB/s / 12 * 2 (throughput /
total_shard_count * 2).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
