### PR TITLE
fmt: remove formatter workaround for old fmt

### DIFF
--- a/src/v/ssx/sformat.h
+++ b/src/v/ssx/sformat.h
@@ -17,42 +17,7 @@
 #include <fmt/ostream.h>
 
 #if FMT_VERSION < 90100
-template<>
-struct fmt::formatter<seastar::sstring> final : fmt::formatter<string_view> {
-    template<typename FormatContext>
-    auto format(const seastar::sstring& s, FormatContext& ctx) const {
-        return formatter<string_view>::format(
-          string_view(s.data(), s.size()), ctx);
-    }
-};
-
-namespace fmt::detail {
-
-// TODO(BenP): Remove this hack with next libfmt upgrade
-//
-// If a type that has both operator<< and formatter<>, the former is chosen,
-// which is not what is desired. This is a regression betwen 7.0.3 and 8.1.1
-//
-// This hack disables picking operator<<, enabling the above formatter.
-//
-// A future version of fmtlib will require explicit opt-in:
-// template<> struct formatter<test_string> : ostream_formatter {};
-//
-// Without this hack:
-// test               iterations      median         mad         min         max
-// std_std_fmt_1K.join     11739    75.312us     1.073us    74.156us    97.341us
-// ss_ss_fmt_1K.join        5855   155.362us   925.138ns   154.437us   160.463us
-// ss_ss_ssx_1K.join        6642   148.931us     1.317us   147.613us   155.382us
-//
-// With this hack:
-// test               iterations      median         mad         min         max
-// std_std_fmt_1K.join     11684    71.891us   218.588ns    71.652us    72.854us
-// ss_ss_fmt_1K.join       10300    86.037us   444.582ns    84.775us    88.985us
-// ss_ss_ssx_1K.join       12311    72.840us     2.224us    70.616us   101.076us
-template<>
-struct is_streamable<seastar::sstring, char> : std::false_type {};
-
-} // namespace fmt::detail
+#error fmt library version is too old, must be >= 90100
 #endif
 
 namespace ssx {


### PR DESCRIPTION
We had a workaround for fmt versions less than 9.0.1 to avoid sstring being formatted using operator<< and to use the formatter<> specialization instead, but this is not needed after version 9.0.1, and it so was protected by #if FMT_VERSION < 090100. We can just remove this case entirely on dev as we have upgraded format to 9.0.1 on both the bazel and cmake sides.

We leave in place only a check that the FMT version is high enough.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
