### PR TITLE
kafka/client: replace std::vector with chunked vector

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -237,7 +237,7 @@ ss::future<produce_response::partition> client::produce_record_batch(
 }
 
 ss::future<produce_response> client::produce_records(
-  model::topic topic, std::vector<record_essence> records) {
+  model::topic topic, chunked_vector<record_essence> records) {
     absl::node_hash_map<model::partition_id, storage::record_batch_builder>
       partition_builders;
 

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -117,7 +117,7 @@ public:
       model::topic_partition tp, model::record_batch&& batch);
 
     ss::future<produce_response>
-    produce_records(model::topic topic, std::vector<record_essence> batch);
+    produce_records(model::topic topic, chunked_vector<record_essence> batch);
 
     ss::future<list_offsets_response> list_offsets(model::topic_partition tp);
 

--- a/src/v/pandaproxy/json/requests/produce.h
+++ b/src/v/pandaproxy/json/requests/produce.h
@@ -75,7 +75,7 @@ private:
 
 public:
     using Ch = typename Encoding::Ch;
-    using rjson_parse_result = std::vector<kafka::client::record_essence>;
+    using rjson_parse_result = chunked_vector<kafka::client::record_essence>;
     rjson_parse_result result;
 
     explicit produce_request_handler(serialization_format fmt)


### PR DESCRIPTION
Replaced `std::vector` with `chunked_vector` in kafka client.

In case of a very big produce request, this vector caused an allocation warning.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none
