### PR TITLE
tests/polaris: use curl to query polaris catalog health check

### DIFF
--- a/tests/rptest/services/polaris_catalog.py
+++ b/tests/rptest/services/polaris_catalog.py
@@ -137,12 +137,14 @@ class PolarisCatalog(Service):
             self.logger.debug(
                 f"Querying polaris healthcheck on http://{node.account.hostname}:8182/healthcheck"
             )
-            r = requests.get(
-                f"http://{node.account.hostname}:8182/healthcheck", timeout=10)
 
-            self.logger.info(
-                f"health check result status code: {r.status_code}")
-            return r.status_code == 200
+            out = node.account.ssh_output(
+                "curl -s -m 10 -o /dev/null -w '%{http_code}' http://localhost:8182/healthcheck"
+            )
+            status_code = int(out.decode('utf-8'))
+            self.logger.debug(
+                f"health check result status code: {status_code}")
+            return status_code == 200
 
         wait_until(_polaris_ready,
                    timeout_sec=timeout_sec,


### PR DESCRIPTION
Using `curl` which executes on the node where Polaris server runs so no additional ports have to be open.

Fixes: CORE-8338

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none