### PR TITLE
config: bazelize unit tests

### DIFF
--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -77,6 +77,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "tls_config_convert_test",
+    timeout = "short",
+    srcs = [
+        "tls_config_convert_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:to_string",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -142,6 +142,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "cloud_credentials_source_test",
+    timeout = "short",
+    srcs = [
+        "cloud_credentials_source_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -45,6 +45,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "config_store_test",
+    timeout = "short",
+    srcs = [
+        "config_store_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/json",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -30,6 +30,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "retention_property_test",
+    timeout = "short",
+    srcs = [
+        "retention_property_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -111,6 +111,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "advertised_kafka_api_test",
+    timeout = "short",
+    srcs = [
+        "advertised_kafka_api_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -61,6 +61,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "socket_address_convert_test",
+    timeout = "short",
+    srcs = [
+        "socket_address_convert_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -126,6 +126,22 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "seed_server_property_test",
+    timeout = "short",
+    srcs = [
+        "seed_server_property_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:unresolved_address",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -158,6 +158,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "validator_test",
+    timeout = "short",
+    srcs = [
+        "validator_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -1,4 +1,19 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
+
+redpanda_cc_btest(
+    name = "bounded_property_test",
+    timeout = "short",
+    srcs = [
+        "bounded_property_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "enterprise_property_test",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -15,6 +15,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "enum_property_test",
+    timeout = "short",
+    srcs = [
+        "enum_property_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -173,6 +173,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "throughput_control_group_test",
+    timeout = "short",
+    srcs = [
+        "throughput_control_group_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -94,6 +94,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "scoped_config_test",
+    timeout = "short",
+    srcs = [
+        "scoped_config_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -190,6 +190,24 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "node_override_test",
+    timeout = "short",
+    srcs = [
+        "node_override_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:uuid",
+        "@seastar",
+        "@seastar//:testing",
+        "@yaml-cpp",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -1,0 +1,15 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "enterprise_property_test",
+    timeout = "short",
+    srcs = [
+        "enterprise_property_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/config/tests/BUILD
+++ b/src/v/config/tests/BUILD
@@ -208,6 +208,21 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "leaders_preference_test",
+    timeout = "short",
+    srcs = [
+        "leaders_preference_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "enterprise_property_test",
     timeout = "short",

--- a/src/v/config/tests/enterprise_property_test.cc
+++ b/src/v/config/tests/enterprise_property_test.cc
@@ -14,10 +14,6 @@
 
 #include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>
-#include <yaml-cpp/yaml.h>
-
-#include <concepts>
-#include <iostream>
 
 namespace config {
 namespace {

--- a/src/v/config/tests/throughput_control_group_test.cc
+++ b/src/v/config/tests/throughput_control_group_test.cc
@@ -21,10 +21,7 @@
 #include <yaml-cpp/emitterstyle.h>
 #include <yaml-cpp/exceptions.h>
 
-#include <algorithm>
-#include <exception>
 #include <iterator>
-#include <locale>
 #include <vector>
 
 using namespace std::string_literals;


### PR DESCRIPTION
Implements:
[CORE-7464](https://redpandadata.atlassian.net/browse/CORE-7464): `advertised_kafka_api_test.cc`
[CORE-7465](https://redpandadata.atlassian.net/browse/CORE-7465): `bounded_property_test.cc`
[CORE-7466](https://redpandadata.atlassian.net/browse/CORE-7466): `cloud_credentials_source_test.cc`
[CORE-7467](https://redpandadata.atlassian.net/browse/CORE-7467): `config_store_test.cc`
[CORE-7468](https://redpandadata.atlassian.net/browse/CORE-7468): `enum_property_test.cc`
[CORE-7469](https://redpandadata.atlassian.net/browse/CORE-7469): `retention_property_test.cc`
[CORE-7470](https://redpandadata.atlassian.net/browse/CORE-7470): `scoped_config_test.cc`
[CORE-7471](https://redpandadata.atlassian.net/browse/CORE-7471): `seed_server_property_test.cc`
[CORE-7472](https://redpandadata.atlassian.net/browse/CORE-7472): `socket_address_convert_test.cc`
[CORE-7473](https://redpandadata.atlassian.net/browse/CORE-7473): `throughput_control_group_test.cc`
[CORE-7474](https://redpandadata.atlassian.net/browse/CORE-7474): `tls_config_convert_test.cc`
[CORE-7475](https://redpandadata.atlassian.net/browse/CORE-7475): `validator_tests.cc`
`leaders_preference_test.cc`
`node_override_test.cc`
`enterprise_property_test.cc`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7464]: https://redpandadata.atlassian.net/browse/CORE-7464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7465]: https://redpandadata.atlassian.net/browse/CORE-7465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7466]: https://redpandadata.atlassian.net/browse/CORE-7466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7467]: https://redpandadata.atlassian.net/browse/CORE-7467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7468]: https://redpandadata.atlassian.net/browse/CORE-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7469]: https://redpandadata.atlassian.net/browse/CORE-7469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7470]: https://redpandadata.atlassian.net/browse/CORE-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7471]: https://redpandadata.atlassian.net/browse/CORE-7471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7472]: https://redpandadata.atlassian.net/browse/CORE-7472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7473]: https://redpandadata.atlassian.net/browse/CORE-7473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7474]: https://redpandadata.atlassian.net/browse/CORE-7474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7475]: https://redpandadata.atlassian.net/browse/CORE-7475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ