### PR TITLE
pandaproxy: bazelize tests

### DIFF
--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -24,6 +24,7 @@ redpanda_test_cc_library(
         "//src/v/random:generators",
     ],
     include_prefix = "kafka/client/test",
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/reflection:adl",
         "//src/v/storage:record_batch_builder",

--- a/src/v/pandaproxy/json/requests/test/BUILD
+++ b/src/v/pandaproxy/json/requests/test/BUILD
@@ -20,3 +20,22 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "produce",
+    timeout = "short",
+    srcs = [
+        "produce.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/kafka/protocol:produce",
+        "//src/v/kafka/protocol/schemata:produce_response",
+        "//src/v/model",
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:to_string",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/json/requests/test/BUILD
+++ b/src/v/pandaproxy/json/requests/test/BUILD
@@ -1,0 +1,22 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "fetch",
+    timeout = "short",
+    srcs = [
+        "fetch.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:fragmented_vector",
+        "//src/v/json",
+        "//src/v/kafka/client/test:utils",
+        "//src/v/kafka/protocol",
+        "//src/v/model",
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/json/test/BUILD
+++ b/src/v/pandaproxy/json/test/BUILD
@@ -1,0 +1,17 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "iobuf",
+    timeout = "short",
+    srcs = [
+        "iobuf.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/json",
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/parsing/test/BUILD
+++ b/src/v/pandaproxy/parsing/test/BUILD
@@ -16,3 +16,20 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "httpd",
+    timeout = "short",
+    srcs = [
+        "httpd.cc",
+    ],
+    deps = [
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@boost//:tuple",
+        "@boost//:utility",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/parsing/test/BUILD
+++ b/src/v/pandaproxy/parsing/test/BUILD
@@ -1,0 +1,18 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "from_chars",
+    timeout = "short",
+    srcs = [
+        "from_chars.cc",
+    ],
+    deps = [
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:named_type",
+        "@boost//:mpl",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/rest/test/BUILD
+++ b/src/v/pandaproxy/rest/test/BUILD
@@ -21,3 +21,23 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "fetch",
+    timeout = "short",
+    srcs = [
+        "fetch.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/http",
+        "//src/v/pandaproxy",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/rest/test/BUILD
+++ b/src/v/pandaproxy/rest/test/BUILD
@@ -41,3 +41,22 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "list_topics",
+    timeout = "short",
+    srcs = [
+        "list_topics.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/http",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/rest/test/BUILD
+++ b/src/v/pandaproxy/rest/test/BUILD
@@ -1,0 +1,23 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "consumer_group",
+    timeout = "short",
+    srcs = [
+        "consumer_group.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/http",
+        "//src/v/kafka/protocol:join_group",
+        "//src/v/pandaproxy",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:unresolved_address",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/rest/test/BUILD
+++ b/src/v/pandaproxy/rest/test/BUILD
@@ -60,3 +60,22 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "produce",
+    timeout = "short",
+    srcs = [
+        "produce.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/http",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/rest/test/produce.cc
+++ b/src/v/pandaproxy/rest/test/produce.cc
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0
 
 #include "http/client.h"
-#include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
 

--- a/src/v/pandaproxy/schema_registry/requests/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/requests/test/BUILD
@@ -14,3 +14,19 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "post_subject_versions",
+    timeout = "short",
+    srcs = [
+        "post_subject_versions.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/requests/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/requests/test/BUILD
@@ -1,0 +1,16 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "get_subject_versions_version",
+    timeout = "short",
+    srcs = [
+        "get_subject_versions_version.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/pandaproxy",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -227,3 +227,22 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "get_schema_types",
+    timeout = "short",
+    srcs = [
+        "get_schema_types.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/http",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -292,3 +292,24 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "delete_subject_endpoints",
+    timeout = "short",
+    srcs = [
+        "delete_subject_endpoints.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        ":avro_payloads",
+        ":client_utils",
+        "//src/v/pandaproxy",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:beast",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -159,6 +159,7 @@ redpanda_cc_btest(
     srcs = [
         "sharded_store.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/pandaproxy",
         "//src/v/pandaproxy/schema_registry/test:compatibility_protobuf",
@@ -175,6 +176,7 @@ redpanda_cc_btest(
     srcs = [
         "consume_to_store.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/model",
         "//src/v/pandaproxy",
@@ -191,6 +193,7 @@ redpanda_cc_btest(
     srcs = [
         "compatibility_store.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/pandaproxy",
         "//src/v/pandaproxy/schema_registry/test:compatibility_avro",
@@ -207,6 +210,7 @@ redpanda_cc_btest(
     srcs = [
         "compatibility_3rdparty.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/model",
         "//src/v/pandaproxy",
@@ -223,6 +227,7 @@ redpanda_cc_btest(
     srcs = [
         "compatibility_avro.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/pandaproxy",
         "//src/v/pandaproxy/schema_registry/test:compatibility_avro",
@@ -242,6 +247,7 @@ redpanda_cc_btest(
     srcs = [
         "test_json_schema.cc",
     ],
+    cpu = 1,
     deps = [
         "//src/v/pandaproxy",
         "//src/v/pandaproxy/schema_registry/test:compatibility_common",

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -1,6 +1,33 @@
 load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
+    name = "avro_payloads",
+    hdrs = [
+        "avro_payloads.h",
+    ],
+    include_prefix = "pandaproxy/schema_registry/test",
+    deps = [
+        "//src/v/pandaproxy",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "client_utils",
+    hdrs = [
+        "client_utils.h",
+    ],
+    include_prefix = "pandaproxy/schema_registry/test",
+    deps = [
+        "//src/v/http",
+        "//src/v/json",
+        "//src/v/pandaproxy",
+        "//src/v/pandaproxy/test:utils",
+        "@abseil-cpp//absl/algorithm:container",
+        "@boost//:beast",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "compatibility_avro",
     hdrs = [
         "compatibility_avro.h",
@@ -242,6 +269,25 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "@boost//:beast",
         "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "post_subjects_subject_version",
+    timeout = "short",
+    srcs = [
+        "post_subjects_subject_version.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        ":avro_payloads",
+        ":client_utils",
+        "//src/v/pandaproxy",
+        "//src/v/pandaproxy/test:fixture",
+        "//src/v/pandaproxy/test:utils",
+        "//src/v/test_utils:seastar_boost",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/pandaproxy/schema_registry/test/avro_payloads.h
+++ b/src/v/pandaproxy/schema_registry/test/avro_payloads.h
@@ -11,9 +11,6 @@
 
 #include "pandaproxy/schema_registry/avro.h"
 
-namespace pp = pandaproxy;
-namespace pps = pp::schema_registry;
-
 const ss::sstring avro_string_payload{
   R"(
 {

--- a/src/v/pandaproxy/test/BUILD
+++ b/src/v/pandaproxy/test/BUILD
@@ -14,6 +14,22 @@ redpanda_test_cc_library(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "fixture",
+    hdrs = [
+        "pandaproxy_fixture.h",
+    ],
+    implementation_deps = [
+    ],
+    include_prefix = "pandaproxy/test",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/http",
+        "//src/v/pandaproxy",
+        "//src/v/redpanda/tests:fixture_btest",
+    ],
+)
+
 redpanda_cc_btest(
     name = "errors_test",
     timeout = "short",

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -11,12 +11,7 @@
 
 #pragma once
 
-#include "config/configuration.h"
 #include "http/client.h"
-#include "kafka/client/client.h"
-#include "kafka/client/configuration.h"
-#include "kafka/protocol/metadata.h"
-#include "pandaproxy/rest/configuration.h"
 #include "redpanda/tests/fixture.h"
 
 class pandaproxy_test_fixture : public redpanda_thread_fixture {


### PR DESCRIPTION
Implements:
[https://redpandadata.atlassian.net/browse/CORE-7536](https://redpandadata.atlassian.net/browse/CORE-7536): json/requests/test/fetch.cc
[https://redpandadata.atlassian.net/browse/CORE-7537](https://redpandadata.atlassian.net/browse/CORE-7537): json/requests/test/produce.cc
[https://redpandadata.atlassian.net/browse/CORE-7538](https://redpandadata.atlassian.net/browse/CORE-7538): json/test/iobuf.cc
[https://redpandadata.atlassian.net/browse/CORE-7539](https://redpandadata.atlassian.net/browse/CORE-7539): parsing/test/from_chars.cc
[https://redpandadata.atlassian.net/browse/CORE-7540](https://redpandadata.atlassian.net/browse/CORE-7540): parsing/test/httpd.cc
[https://redpandadata.atlassian.net/browse/CORE-7541](https://redpandadata.atlassian.net/browse/CORE-7541): rest/test/consumer_group.cc
[https://redpandadata.atlassian.net/browse/CORE-7542](https://redpandadata.atlassian.net/browse/CORE-7542): rest/test/fetch.cc
[https://redpandadata.atlassian.net/browse/CORE-7543](https://redpandadata.atlassian.net/browse/CORE-7543): rest/test/list_topics.cc
[https://redpandadata.atlassian.net/browse/CORE-7544](https://redpandadata.atlassian.net/browse/CORE-7544): rest/test/produce.cc
[https://redpandadata.atlassian.net/browse/CORE-7545](https://redpandadata.atlassian.net/browse/CORE-7545): schema_registry/requests/test/get_subject_versions_version.cc
[https://redpandadata.atlassian.net/browse/CORE-7546](https://redpandadata.atlassian.net/browse/CORE-7546): schema_registry/requests/test/post_subject_versions.cc
[https://redpandadata.atlassian.net/browse/CORE-7552](https://redpandadata.atlassian.net/browse/CORE-7552): schema_registry/test/delete_subject_endpoints.cc
[https://redpandadata.atlassian.net/browse/CORE-7553](https://redpandadata.atlassian.net/browse/CORE-7553): schema_registry/test/get_schema_types.cc
[https://redpandadata.atlassian.net/browse/CORE-7555](https://redpandadata.atlassian.net/browse/CORE-7555): schema_registry/test/post_subjects_subject_version.cc


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
