### PR TITLE
c/leader_balancer: improve log message wording

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -732,7 +732,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     vlog(
       clusterlog.info,
       "balancer iteration finished: "
-      "total error: {:.4}, number of muted groups: {}, "
+      "objective: {:.4}, number of muted groups: {}, "
       "number in flight: {}, dispatched in this tick: {}",
       strategy->error(),
       _muted.size(),


### PR DESCRIPTION
Don't use the word "error" so as not to trigger humans and machines.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
