### PR TITLE
`datalake`: relax `translation_stm::max_collectible_offset()` value (and add `compaction_test.py`)

### DIFF
--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -43,6 +43,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":model",
+        ":utils",
         "//src/v/cluster:state_machine_registry",
         "//src/v/datalake:logger",
         "//src/v/raft",

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -14,6 +14,24 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "utils",
+    srcs = [
+        "utils.cc",
+    ],
+    hdrs = [
+        "utils.h",
+    ],
+    include_prefix = "datalake/translation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/model",
+        "//src/v/serde",
+        "//src/v/storage",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "stm",
     srcs = [
         "state_machine.cc",
@@ -45,6 +63,7 @@ redpanda_cc_library(
     deps = [
         ":model",
         ":stm",
+        ":utils",
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/datalake:cloud_data_io",

--- a/src/v/datalake/translation/CMakeLists.txt
+++ b/src/v/datalake/translation/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
     SRCS
         partition_translator.cc
         state_machine.cc
+	utils.cc
     DEPS
         v::cluster
         v::datalake_writer

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -12,6 +12,7 @@
 
 #include "datalake/logger.h"
 #include "datalake/translation/types.h"
+#include "datalake/translation/utils.h"
 
 namespace {
 raft::replicate_options make_replicate_options() {
@@ -116,8 +117,9 @@ model::offset translation_stm::max_collectible_offset() {
     if (_highest_translated_offset == kafka::offset{}) {
         return model::offset{};
     }
-    return _raft->log()->to_log_offset(
-      kafka::offset_cast(_highest_translated_offset));
+
+    return highest_log_offset_below_next(
+      _raft->log(), _highest_translated_offset);
 }
 
 ss::future<raft::local_snapshot_applied> translation_stm::apply_local_snapshot(

--- a/src/v/datalake/translation/tests/BUILD
+++ b/src/v/datalake/translation/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     cpu = 1,
     deps = [
         "//src/v/datalake/translation:stm",
+        "//src/v/datalake/translation:utils",
         "//src/v/raft/tests:stm_test_fixture",
         "//src/v/random:generators",
         "//src/v/storage",

--- a/src/v/datalake/translation/tests/CMakeLists.txt
+++ b/src/v/datalake/translation/tests/CMakeLists.txt
@@ -12,3 +12,14 @@ rp_test(
   LABELS datalake
   ARGS "-- -c 1 -m 2G"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  TIMEOUT 2000
+  BINARY_NAME translated_log_offset_tests
+  SOURCES translated_log_offset_test.cc
+  LIBRARIES  v::datalake_translation v::features v::raft_fixture v::gtest_main v::storage v::storage_test_utils
+  LABELS datalake
+  ARGS "-- -c 1"
+)

--- a/src/v/datalake/translation/tests/state_machine_test.cc
+++ b/src/v/datalake/translation/tests/state_machine_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 #include "datalake/translation/state_machine.h"
+#include "datalake/translation/utils.h"
 #include "raft/tests/stm_test_fixture.h"
 #include "storage/disk_log_impl.h"
 #include "test_utils/scoped_config.h"
@@ -139,8 +140,9 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
     model::offset max_collectible_offset{};
     {
         auto log = std::get<0>(node_stms.begin()->second)->raft()->log();
-        max_collectible_offset = log->to_log_offset(
-          kafka::offset_cast(new_translated_offset));
+        max_collectible_offset
+          = datalake::translation::highest_log_offset_below_next(
+            log, new_translated_offset);
     }
     co_await check_max_collectible_offset(max_collectible_offset);
     co_await check_highest_translated_offset(new_translated_offset);

--- a/src/v/datalake/translation/tests/translated_log_offset_test.cc
+++ b/src/v/datalake/translation/tests/translated_log_offset_test.cc
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "consensus.h"
+#include "datalake/translation/types.h"
+#include "datalake/translation/utils.h"
+#include "fundamental.h"
+#include "gtest/gtest.h"
+#include "model/fundamental.h"
+#include "model/record_batch_types.h"
+#include "model/tests/random_batch.h"
+#include "storage/disk_log_impl.h"
+#include "storage/log.h"
+#include "storage/log_manager.h"
+#include "storage/ntp_config.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/tmp_dir.h"
+
+#include <seastar/util/defer.hh>
+
+// Checks that the highest translated log offset is equivalent to
+// an expected offset for a translated kafka offset.
+//
+// Returns true iff expected_offset == the highest translated log offset.
+bool check_translated_log_offset(
+  ss::shared_ptr<storage::log> log,
+  kafka::offset translated_offset,
+  model::offset expected_offset) {
+    auto translated_log_offset
+      = datalake::translation::highest_log_offset_below_next(
+        log, translated_offset);
+    return expected_offset == translated_log_offset;
+}
+
+TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLog) {
+    temporary_dir tmp_dir("translated_offset_test");
+    auto data_path = tmp_dir.get_path();
+
+    model::ntp test_ntp{"kafka", "tapioca", 0};
+    auto log_cfg = storage::log_config{
+      data_path.string(),
+      1024,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()};
+    auto translator_batch_types = raft::offset_translator_batch_types(test_ntp);
+    auto raft_group_id = raft::group_id{0};
+    storage::disk_log_builder b{
+      std::move(log_cfg), std::move(translator_batch_types), raft_group_id};
+
+    b.start(storage::ntp_config{test_ntp, {data_path}}).get();
+    auto defer = ss::defer([&b]() { b.stop().get(); });
+
+    auto log = b.get_log();
+
+    // Must initialize translator state.
+    log->start(std::nullopt).get();
+
+    // A good property to check.
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{}));
+
+    // Kaf offsets: []
+    // Log offsets: []
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{0}));
+
+    auto offset = 0;
+    auto make_and_add_record = [&offset, &b](model::record_batch_type bt) {
+        auto batch = model::test::make_random_batch(
+          model::offset{offset++}, 1, true, bt);
+        b.add_batch(std::move(batch)).get();
+    };
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets: [0]
+    // Log offsets: [0]
+    //               |
+    //               |-> TO/TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{0}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets: [0]
+    // Log offsets: [0]    [C]
+    //               |      |
+    //               |-> TO |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{1}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets: [0]
+    // Log offsets: [0] [C] [C]
+    //               |       |
+    //               |-> TO  |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{2}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets: [0]
+    // Log offsets: [0] [C] [C] [C]
+    //               |           |
+    //               |-> TO      |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{3}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets: [0]  .   .   .         [1]
+    // Log offsets: [0] [C] [C] [C]        [4]
+    //               |           |          |
+    //               |-> TO_0    |-> TLO_0  |
+    //                                      |-> TO_1/TLO_1
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{4}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets: [0]  .   .   .         [1] [2]
+    // Log offsets: [0] [C] [C] [C]        [4] [5]
+    //               |           |          |   |
+    //               |-> TO_0    |-> TLO_0  |   |
+    //                                      |-----> TO_1/TLO_1
+    //                                          |-> TO_2/TLO_2
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{4}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{2}, model::offset{5}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets: [0]  .   .   .         [1] [2]
+    // Log offsets: [0] [C] [C] [C]        [4] [5]             [C]
+    //               |           |          |   |               |
+    //               |-> TO_0    |-> TLO_0  |   |               |
+    //                                      |-----> TO_1/TLO_1  |
+    //                                          |-> TO_2        |-> TLO_2
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{4}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{2}, model::offset{6}));
+}
+
+TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLogConfigBatchStart) {
+    temporary_dir tmp_dir("translated_offset_test");
+    auto data_path = tmp_dir.get_path();
+
+    model::ntp test_ntp{"kafka", "tapioca", 0};
+    auto log_cfg = storage::log_config{
+      data_path.string(),
+      1024,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()};
+    auto translator_batch_types = raft::offset_translator_batch_types(test_ntp);
+    auto raft_group_id = raft::group_id{0};
+    storage::disk_log_builder b{
+      std::move(log_cfg), std::move(translator_batch_types), raft_group_id};
+
+    b.start(storage::ntp_config{test_ntp, {data_path}}).get();
+    auto defer = ss::defer([&b]() { b.stop().get(); });
+
+    auto log = b.get_log();
+
+    // Must initialize translator state.
+    log->start(std::nullopt).get();
+
+    // A good property to check.
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{}));
+
+    // Kaf offsets: []
+    // Log offsets: []
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{0}));
+
+    auto offset = 0;
+    auto make_and_add_record = [&offset, &b](model::record_batch_type bt) {
+        auto batch = model::test::make_random_batch(
+          model::offset{offset++}, 1, true, bt);
+        b.add_batch(std::move(batch)).get();
+    };
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Note: There is no Kafka batch produced yet, therefore TO ==
+    // kafka::offset{}.
+    //
+    // Kaf offsets:  .
+    // Log offsets: [C]
+    //               |
+    //               |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .   .
+    // Log offsets: [C] [C]
+    //                   |
+    //                   |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{1}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .   .   .
+    // Log offsets: [C] [C] [C]
+    //                       |
+    //                       |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{2}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .   .   .   .
+    // Log offsets: [C] [C] [C] [C]
+    //                           |
+    //                           |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{3}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets:  .   .   .   .         [0]
+    // Log offsets: [C] [C] [C] [C]        [4]
+    //                           |          |
+    //                           |-> TLO_{} |
+    //                                      |-> TO_0/TLO_0
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{4}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets:  .   .   .   .         [0] [1]
+    // Log offsets: [C] [C] [C] [C]        [4] [5]
+    //                           |          |   |
+    //                           |-> TLO_{} |   |
+    //                                      |-----> TO_0/TLO_0
+    //                                          |-> TO_1/TLO_1
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{4}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{5}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .   .   .   .         [0] [1]
+    // Log offsets: [C] [C] [C] [C]        [4] [5]             [C]
+    //                           |          |   |               |
+    //                           |-> TLO_{} |   |               |
+    //                                      |-----> TO_0/TLO_0  |
+    //                                          |-> TO_1        |-> TLO_1
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{3}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{4}));
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{6}));
+}
+
+TEST(
+  TranslatedLogOffsetTest,
+  TestTranslatedOffsetsGrowingLogConfigAlternatingBatches) {
+    temporary_dir tmp_dir("translated_offset_test");
+    auto data_path = tmp_dir.get_path();
+
+    model::ntp test_ntp{"kafka", "tapioca", 0};
+    auto log_cfg = storage::log_config{
+      data_path.string(),
+      1024,
+      ss::default_priority_class(),
+      storage::make_sanitized_file_config()};
+    auto translator_batch_types = raft::offset_translator_batch_types(test_ntp);
+    auto raft_group_id = raft::group_id{0};
+    storage::disk_log_builder b{
+      std::move(log_cfg), std::move(translator_batch_types), raft_group_id};
+
+    b.start(storage::ntp_config{test_ntp, {data_path}}).get();
+    auto defer = ss::defer([&b]() { b.stop().get(); });
+
+    auto log = b.get_log();
+
+    // Must initialize translator state.
+    log->start(std::nullopt).get();
+
+    // A good property to check.
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{}));
+
+    // Kaf offsets: []
+    // Log offsets: []
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{0}));
+
+    auto offset = 0;
+    auto make_and_add_record = [&offset, &b](model::record_batch_type bt) {
+        auto batch = model::test::make_random_batch(
+          model::offset{offset++}, 1, true, bt);
+        b.add_batch(std::move(batch)).get();
+    };
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Note: There is no Kafka batch produced yet, therefore TO ==
+    // kafka::offset{}.
+    //
+    // Kaf offsets:  .
+    // Log offsets: [C]
+    //               |
+    //               |-> TLO
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets:  .         [0]
+    // Log offsets: [C]        [1]
+    //               |          |
+    //               |->TLO_{}  |-> TO_0/TLO_0
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{1}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .         [0]        .
+    // Log offsets: [C]        [1]       [C]
+    //               |          |         |
+    //               |->TLO_{}  |-> TO_0  |-> TLO_0
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{2}));
+
+    make_and_add_record(model::record_batch_type::raft_data);
+    // Kaf offsets:  .         [0]        .          [1]
+    // Log offsets: [C]        [1]       [C]         [3]
+    //               |          |         |           |
+    //               |->TLO_{}  |-> TO_0  |-> TLO_0   |->TO_1/TLO_1
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{2}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{3}));
+
+    make_and_add_record(model::record_batch_type::raft_configuration);
+    // Kaf offsets:  .         [0]        .          [1]      .
+    // Log offsets: [C]        [1]       [C]         [3]     [C]
+    //               |          |         |           |       |
+    //               |->TLO_{}  |-> TO_0  |-> TLO_0   |->TO_1 |->TLO_1
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{}, model::offset{0}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{0}, model::offset{2}));
+
+    ASSERT_TRUE(
+      check_translated_log_offset(log, kafka::offset{1}, model::offset{4}));
+}

--- a/src/v/datalake/translation/utils.cc
+++ b/src/v/datalake/translation/utils.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/translation/utils.h"
+
+namespace datalake::translation {
+
+model::offset highest_log_offset_below_next(
+  ss::shared_ptr<storage::log> log, kafka::offset o) {
+    auto next_kafka_offset = kafka::next_offset(o);
+    auto log_offset_for_next_kafka_offset = log->to_log_offset(
+      kafka::offset_cast(next_kafka_offset));
+    auto translated_log_offset = model::prev_offset(
+      log_offset_for_next_kafka_offset);
+    return translated_log_offset;
+}
+
+} // namespace datalake::translation

--- a/src/v/datalake/translation/utils.h
+++ b/src/v/datalake/translation/utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "storage/log.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+namespace datalake::translation {
+
+// Returns the equivalent log offset which can be considered translated by the
+// datalake subsystem, while taking into account translator batch types, for a
+// given kafka offset.
+//
+// Note that the provided kafka::offset o MUST be a valid offset, i.e one that
+// has been produced to the log. This function will always return a value, and
+// its correctness depends on the validity of the input offset.
+//
+// For example, in the following situation:
+// Kaf offsets: [O]   .   .    .     [NKO]
+// Log offsets: [K]  [C] [C] [C/TLO] [NKO]
+// where O is the input offset, K is the last kafka record, C is a translator
+// (Config) batch, TLO is the translated log offset, and NKO is the next
+// expected kafka record. We should expect TLO to be equal to the offset of the
+// last configuration batch before the next kafka record.
+model::offset highest_log_offset_below_next(
+  ss::shared_ptr<storage::log> log, kafka::offset o);
+
+} // namespace datalake::translation

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -10,9 +10,10 @@
 from time import time
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.types import TopicSpec
-from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.services.redpanda import MetricsEndpoint
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import SISettings
 from rptest.tests.datalake.utils import supported_storage_types
@@ -20,6 +21,7 @@ from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
 from rptest.utils.mode_checks import skip_debug_mode
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 
 
 class CompactionGapsTest(RedpandaTest):
@@ -118,3 +120,126 @@ class CompactionGapsTest(RedpandaTest):
                               include_query_engines=[QueryEngineType.TRINO
                                                      ]) as dl:
             self.do_test_no_gaps(dl)
+
+
+class CompactionTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        self.extra_rp_conf = {
+            "iceberg_enabled": "true",
+            "iceberg_catalog_commit_interval_ms": 5000,
+            "datalake_coordinator_snapshot_max_delay_secs": 10,
+            "log_compaction_interval_ms": 2000,
+            "log_segment_size": 2 * 1024**2,  # 2 MiB
+            "compacted_log_segment_size": 1024**2  # 1 MiB
+        }
+
+        super(CompactionTest,
+              self).__init__(test_ctx,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context=test_ctx,
+                                                    fast_uploads=True),
+                             extra_rp_conf=self.extra_rp_conf,
+                             *args,
+                             **kwargs)
+        self.test_ctx = test_ctx
+        self.topic_name = "tapioca"
+        self.msg_size = 1024  # 1 KiB
+        self.total_data = 100 * 1024**2  # 100 MiB
+        self.msg_count = int(self.total_data / self.msg_size)
+        self.kafka_cat = KafkaCat(self.redpanda)
+
+    def setUp(self):
+        # redpanda will be started by DatalakeServices
+        pass
+
+    def produce(self):
+        producer = KgoVerifierProducer(self.test_ctx,
+                                       self.redpanda,
+                                       self.topic_name,
+                                       msg_size=self.msg_size,
+                                       msg_count=self.msg_count,
+                                       key_set_cardinality=100,
+                                       validate_latest_values=True)
+
+        producer.start(clean=True)
+        producer.wait()
+        producer.free()
+
+    def wait_for_compaction(self):
+        # Restart each redpanda broker to force roll segments
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        def get_complete_sliding_window_rounds():
+            return self.redpanda.metric_sum(
+                metric_name=
+                "vectorized_storage_log_complete_sliding_window_rounds_total",
+                metrics_endpoint=MetricsEndpoint.METRICS,
+                topic=self.topic_name)
+
+        # Sleep until the log has been fully compacted.
+        self.prev_sliding_window_rounds = -1
+
+        def compaction_has_completed():
+            new_sliding_window_rounds = get_complete_sliding_window_rounds()
+            res = new_sliding_window_rounds > 0 and self.prev_sliding_window_rounds == new_sliding_window_rounds
+            self.prev_sliding_window_rounds = new_sliding_window_rounds
+            return res
+
+        wait_until(
+            compaction_has_completed,
+            timeout_sec=120,
+            backoff_sec=self.extra_rp_conf['log_compaction_interval_ms'] /
+            1000 * 10,
+            err_msg="Compaction did not stabilize.")
+
+    def verify_log_and_table(self, dl: DatalakeServices):
+        # Verify a fully compacted log with a sequential consumer
+        consumer = KgoVerifierSeqConsumer(
+            self.test_ctx,
+            self.redpanda,
+            self.topic_name,
+            compacted=True,
+            validate_latest_values=True,
+        )
+
+        consumer.start(clean=False)
+        consumer.wait(timeout_sec=120)
+        consumer.free()
+
+        verifier = DatalakeVerifier(self.redpanda,
+                                    self.topic_name,
+                                    dl.trino(),
+                                    compacted=True)
+
+        verifier.start()
+        verifier.wait()
+
+        for partition, offset_consumed in verifier._max_consumed_offsets.items(
+        ):
+            assert consumer.consumer_status.validator.max_offsets_consumed[str(
+                partition)] == offset_consumed
+
+    def do_test_compaction(self, dl: DatalakeServices):
+        dl.create_iceberg_enabled_topic(
+            self.topic_name,
+            iceberg_mode="key_value",
+            config={"cleanup.policy": TopicSpec.CLEANUP_COMPACT})
+
+        for _ in range(5):
+            self.produce()
+            # Compact the data. Compaction settling indicates that
+            # everything will have been translated into the Iceberg table already.
+            self.wait_for_compaction()
+            # Assert on read log and on iceberg table.
+            self.verify_log_and_table(dl)
+
+    @cluster(num_nodes=4)
+    #@skip_debug_mode
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_compaction(self, cloud_storage_type):
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              filesystem_catalog_mode=False,
+                              include_query_engines=[QueryEngineType.TRINO
+                                                     ]) as dl:
+            self.do_test_compaction(dl)


### PR DESCRIPTION
Previously, the `datalake::translation::translation_stm` would return its max collectible as the following:

https://github.com/redpanda-data/redpanda/blob/925707c3fa2f899dede79954060c67227fcf65d4/src/v/datalake/translation/state_machine.cc#L112-L122

This offset translation leads to an overly restrictive condition for the max collectible offset, due to the fact that it is translation batch unaware.

Here, the utility function `highest_log_offset_below_next()` is added, which returns the "equivalent" translated log offset for a given kafka offset, taking into account translation batches (which don't need to be translated, and thus shouldn't restrict the max collectible offset).

`translation_stm::max_collectible_offset()` now uses this function to relax its returned offset.

Additionally, a new test for compaction with an Iceberg enabled topic is added to `datalake/compaction_test.py`, with some enhancements to the `datalake_verifier` service to make it compaction aware.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Fixes an overly restrictive condition for retention in Iceberg-enabled topics.
