### PR TITLE
r/utils: fixed setting log start delta in snapshot

### DIFF
--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -377,7 +377,8 @@ ss::future<> create_raft_state_for_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<raft::vnode> initial_nodes) {
+  std::vector<raft::vnode> initial_nodes,
+  model::offset_delta log_start_delta) {
     // Prepare Raft state in kvstore
     vlog(
       raftlog.debug,
@@ -403,7 +404,7 @@ ss::future<> create_raft_state_for_pre_existing_partition(
       .version = raft::snapshot_metadata::current_version,
       .latest_configuration = std::move(group_config),
       .cluster_time = ss::lowres_clock::now(),
-      .log_start_delta = raft::offset_translator_delta{0},
+      .log_start_delta = offset_translator_delta{log_start_delta},
     };
 
     vlog(
@@ -458,7 +459,8 @@ ss::future<> bootstrap_pre_existing_partition(
       min_rp_offset,
       max_rp_offset,
       last_included_term,
-      initial_nodes);
+      initial_nodes,
+      model::offset_delta{ot_state->delta(min_rp_offset)});
 }
 
 } // namespace raft::details


### PR DESCRIPTION
When topic partition is recovered from cloud data Raft protocol is seeded with special snapshot created during recovery. The snapshot may then be used to seed out of date followers. The snapshot content must be valid in terms of offsets and offset translator deltas.

Previously the delta set in the snapshot created during recovery was set to 0. When this snapshot is delivered to the follower it will reset the follower offset translation state accordingly. This may lead to inconsistent deltas across replicas.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes rare bug leading to offset translation inconsistency in recovered topics