### PR TITLE
[v24.2.x] rptest: disable leader balancer in cache stress test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_cache_stress_test.py
@@ -65,6 +65,10 @@ class TieredStorageCacheStressTest(RedpandaTest):
             self.manifest_upload_interval,
             'disable_public_metrics': False,
             'cloud_storage_cache_check_interval': 500,
+            # We're consuming from leader node and expect specific changes in
+            # its local cache. Disable leader balancer so that our expectations
+            # are valid.
+            "enable_leader_balancer": False,
         }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24622
