### PR TITLE
Abort translation using translation task abort source

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -346,6 +346,7 @@ redpanda_cc_library(
         ":table_creator",
         "//src/v/base",
         "//src/v/storage:parser_utils",
+        "//src/v/utils:lazy_abort_source",
         "//src/v/utils:prefix_logger",
     ],
     include_prefix = "datalake",

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -15,6 +15,7 @@
 #include "datalake/partitioning_writer.h"
 #include "datalake/schema_identifier.h"
 #include "model/record.h"
+#include "utils/lazy_abort_source.h"
 #include "utils/prefix_logger.h"
 
 #include <seastar/core/future.hh>
@@ -47,7 +48,8 @@ public:
       schema_manager& schema_mgr,
       type_resolver& type_resolver,
       record_translator& record_translator,
-      table_creator&);
+      table_creator&,
+      lazy_abort_source& as);
 
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
     ss::future<result<write_result, writer_error>> end_of_stream();
@@ -71,6 +73,7 @@ private:
     type_resolver& _type_resolver;
     record_translator& _record_translator;
     table_creator& _table_creator;
+    lazy_abort_source& _as;
     chunked_hash_map<
       record_schema_components,
       std::unique_ptr<partitioning_writer>>

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -38,6 +38,7 @@ const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 const model::revision_id rev{123};
 default_translator translator;
+lazy_abort_source as([] { return std::nullopt; });
 } // namespace
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
@@ -53,7 +54,8 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
       simple_schema_mgr,
       bin_resolver,
       translator,
-      t_creator);
+      t_creator,
+      as);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -93,7 +95,8 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
       simple_schema_mgr,
       bin_resolver,
       translator,
-      t_creator);
+      t_creator,
+      as);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -134,7 +137,8 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
       simple_schema_mgr,
       bin_resolver,
       translator,
-      t_creator);
+      t_creator,
+      as);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -251,7 +255,8 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
       schema_mgr,
       type_resolver,
       translator,
-      t_creator);
+      t_creator,
+      as);
     auto res = reader.consume(std::move(mux), model::no_timeout).get();
     ASSERT_FALSE(res.has_error()) << res.error();
     EXPECT_EQ(res.value().start_offset(), start_offset());

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -269,7 +269,8 @@ public:
       : _schema_mgr(catalog)
       , _type_resolver(registry)
       , _record_gen(&registry)
-      , _table_creator(_type_resolver, _schema_mgr) {}
+      , _table_creator(_type_resolver, _schema_mgr)
+      , _as([] { return std::nullopt; }) {}
 
     template<typename T>
     requires std::same_as<T, ::testing::protobuf_generator_config>
@@ -314,6 +315,7 @@ private:
     datalake::default_translator _translator;
     datalake::direct_table_creator _table_creator;
     chunked_vector<model::record_batch> _batch_data;
+    lazy_abort_source _as;
 
     const model::ntp ntp{
       model::ns{"rp"}, model::topic{"t"}, model::partition_id{0}};
@@ -327,7 +329,8 @@ private:
           _schema_mgr,
           _type_resolver,
           _translator,
-          _table_creator);
+          _table_creator,
+          _as);
     }
 
     ss::future<>

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -99,7 +99,8 @@ public:
     RecordMultiplexerTestBase()
       : schema_mgr(catalog)
       , type_resolver(registry)
-      , t_creator(type_resolver, schema_mgr) {}
+      , t_creator(type_resolver, schema_mgr)
+      , as([] { return std::nullopt; }) {}
 
     // Runs the multiplexer on records generated with cb() based on the test
     // parameters.
@@ -138,7 +139,8 @@ public:
           schema_mgr,
           type_resolver,
           translator,
-          t_creator);
+          t_creator,
+          as);
         auto res = reader.consume(std::move(mux), model::no_timeout).get();
         if (expect_error) {
             EXPECT_TRUE(res.has_error());
@@ -176,6 +178,7 @@ public:
     catalog_schema_manager schema_mgr;
     record_schema_resolver type_resolver;
     direct_table_creator t_creator;
+    lazy_abort_source as;
 
     static constexpr records_param default_param = {
       .records_per_batch = 1,

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -63,7 +63,8 @@ translation_task::translate(
       *_schema_mgr,
       *_type_resolver,
       *_record_translator,
-      *_table_creator);
+      *_table_creator,
+      lazy_as);
     // Write local files
     auto mux_result = co_await std::move(reader).consume(
       std::move(mux), _read_timeout + model::timeout_clock::now());


### PR DESCRIPTION
Partition data translation may take long time, passing in abort source to `datalake::record_multiplexer` will allow us to timely stop the translation when partition is stopping. The translation result would be discarded anyway as all cloud IO is already stopped.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none