### PR TITLE
ducktape: Respect rpk timeout in rpk

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1149,6 +1149,7 @@ class RpkTool:
         if timeout is None:
             timeout = DEFAULT_TIMEOUT
 
+        cmd += ['-X', f'globals.request_timeout_overhead={timeout}s']
         # Unconditionally enable verbose logging
         cmd += ['-v']
 
@@ -1301,7 +1302,7 @@ class RpkTool:
         flags += self._tls_settings()
         return flags
 
-    def acl_list(self, flags: list[str] = [], request_timeout_overhead=None):
+    def acl_list(self, flags: list[str] = []):
         """
         Run `rpk acl list` and return the results.
 
@@ -1317,13 +1318,6 @@ class RpkTool:
             "acl",
             "list",
         ] + flags + self._kafka_conn_settings()
-
-        # How long rpk will wait for a response from the broker, default is 5s
-        if request_timeout_overhead is not None:
-            cmd += [
-                "-X", "globals.request_timeout_overhead=" +
-                f'{str(request_timeout_overhead)}s'
-            ]
 
         output = self._execute(cmd)
 

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -71,8 +71,7 @@ class RpkACLTest(RedpandaTest):
                 FailureSpec(FailureSpec.FAILURE_ISOLATE,
                             self.redpanda.controller()))
 
-            # Timeout must be larger then hardcoded timeout of 5s within redpanda
-            _ = superclient.acl_list(request_timeout_overhead=30)
+            _ = superclient.acl_list()
 
             # Of the other remaining nodes, none can be declared a leader before
             # the election timeout occurs; also the "current" leader is technically


### PR DESCRIPTION
Pass the timeout value for rpk that is passed to subprocess also to rpk
itself via `request_timeout_overhead`.

Otherwise the specified timeout will not really be respected if the
default timeout in rpk for a certain command is shorter.

Because `request_timeout_overhead` is on top of other possible timeouts
the total timeout might be larger than the subprocess one but that
should be fine.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
