### PR TITLE
archival: Deduplicate archival STM commands

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1050,6 +1050,22 @@ ss::future<> archival_metadata_stm::do_apply(const model::record_batch& b) {
         _manifest->advance_insync_offset(b.last_offset());
         co_return;
     }
+    if (b.last_offset() < _manifest->get_insync_offset()) {
+        // Archival STM commands are not idempotent. Applying same command twice
+        // may cause a problem. This branch is used to deduplicate the commands.
+        // It's only applied to non-data batches that can affect the state of
+        // this STM.
+        // We're assuming that commands are applied in all or nothing
+        // fashion and there is no need to track in-sync offset within the
+        // record batch.
+        vlog(
+          _logger.warn,
+          "Command with offset {} (type: {}) is already applied to the "
+          "archival_metadata_stm",
+          b.base_offset(),
+          b.header().type);
+        co_return;
+    }
 
     if (b.header().type == model::record_batch_type::prefix_truncate) {
         // Special case handling for prefix_truncate batches: these


### PR DESCRIPTION
The archival STM commands are not idempotent. The STM implementation depends on the right order of the log replay. At the same time the STM maintains its own copy of the insync-offset. This value is stored in the manifest and in the local snapshot.

This commit adds simple mechanism that checks the offset of every new command before this command can be applied. If the offset is below the insync offset of the STM the command is not applied. The implementation assumes that archival STM batches are either applied or not. The batch can't be applied partially. This allows us to check only the last offset of the batch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none