### PR TITLE
`storage`: book keep `dirty_ratio` in `disk_log_impl`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3974,4 +3974,32 @@ ss::future<> disk_log_impl::remove_kvstore_state(
       .discard_result();
 }
 
+double disk_log_impl::dirty_ratio() const {
+    // Avoid division by 0.
+    return (_closed_segment_bytes == 0)
+             ? 0.0
+             : static_cast<double>(_dirty_segment_bytes)
+                 / static_cast<double>(_closed_segment_bytes);
+}
+
+void disk_log_impl::add_dirty_segment_bytes(uint64_t bytes) {
+    _dirty_segment_bytes += bytes;
+    _probe->set_dirty_segment_bytes(_dirty_segment_bytes);
+}
+
+void disk_log_impl::add_closed_segment_bytes(uint64_t bytes) {
+    _closed_segment_bytes += bytes;
+    _probe->set_closed_segment_bytes(_closed_segment_bytes);
+}
+
+void disk_log_impl::subtract_dirty_segment_bytes(uint64_t bytes) {
+    _dirty_segment_bytes -= std::min(bytes, _dirty_segment_bytes);
+    _probe->set_dirty_segment_bytes(_dirty_segment_bytes);
+}
+
+void disk_log_impl::subtract_closed_segment_bytes(uint64_t bytes) {
+    _closed_segment_bytes -= std::min(bytes, _closed_segment_bytes);
+    _probe->set_closed_segment_bytes(_closed_segment_bytes);
+}
+
 } // namespace storage

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -148,6 +148,13 @@ disk_log_impl::disk_log_impl(
         if (_compaction_enabled) {
             s->mark_as_compacted_segment();
         }
+        if (s != _segs.back()) {
+            auto seg_size_bytes = s->size_bytes();
+            if (!s->index().has_clean_compact_timestamp()) {
+                add_dirty_segment_bytes(seg_size_bytes);
+            }
+            add_closed_segment_bytes(seg_size_bytes);
+        }
     }
     _probe->initial_segments_count(_segs.size());
     _probe->setup_metrics(this->config().ntp());
@@ -499,6 +506,10 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
         if (result.did_compact()) {
             segment->clear_cached_disk_usage();
             _compaction_ratio.update(result.compaction_ratio());
+            const auto removed_bytes = result.size_before - result.size_after;
+            subtract_dirty_segment_bytes(removed_bytes);
+            subtract_closed_segment_bytes(removed_bytes);
+
             co_return;
         }
     }
@@ -586,6 +597,11 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             continue;
         }
 
+        const auto removed_bytes = result.size_before - result.size_after;
+        if (!seg->index().has_clean_compact_timestamp()) {
+            subtract_dirty_segment_bytes(removed_bytes);
+        }
+        subtract_closed_segment_bytes(removed_bytes);
         vlog(
           gclog.debug,
           "[{}] segment {} self compaction result: {}",
@@ -614,8 +630,12 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         // For all intents and purposes, these segments are already cleanly
         // compacted.
         auto seg = segs.front();
-        co_await internal::mark_segment_as_finished_window_compaction(
-          seg, true, *_probe);
+        bool marked_as_cleanly_compacted
+          = co_await internal::mark_segment_as_finished_window_compaction(
+            seg, true, *_probe);
+        if (marked_as_cleanly_compacted) {
+            subtract_dirty_segment_bytes(seg->size_bytes());
+        }
         segs.pop_front();
     }
     if (segs.empty()) {
@@ -814,6 +834,9 @@ disk_log_impl::compact_adjacent_segments(storage::compaction_config cfg) {
           r);
         if (r->did_compact()) {
             _compaction_ratio.update(r->compaction_ratio());
+            const auto removed_bytes = r->size_before - r->size_after;
+            subtract_dirty_segment_bytes(removed_bytes);
+            subtract_closed_segment_bytes(removed_bytes);
         }
     } else {
         vlog(
@@ -1260,13 +1283,21 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
 
     // Segments can now be marked as finished window compaction
     for (auto& s : segs) {
-        co_await internal::mark_segment_as_finished_window_compaction(
-          s, false, *_probe);
+        std::ignore
+          = co_await internal::mark_segment_as_finished_window_compaction(
+            s, false, *_probe);
     }
 
-    // We can also mark the last segment as cleanly compacted now
-    co_await internal::mark_segment_as_finished_window_compaction(
-      seg, true, *_probe);
+    // We can also mark the last segment as cleanly compacted now.
+    bool marked_as_cleanly_compacted
+      = co_await internal::mark_segment_as_finished_window_compaction(
+        seg, true, *_probe);
+
+    // This should always be true - the unindexed segment would not have been
+    // cleanly compacted to begin with.
+    if (marked_as_cleanly_compacted) {
+        subtract_dirty_segment_bytes(seg->size_bytes());
+    }
 
     _last_compaction_window_start_offset = seg->offsets().get_base_offset();
     _probe->add_chunked_compaction_run();
@@ -1308,8 +1339,12 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
         // higher than those indexed, it may be because the segment is
         // entirely comprised of non-data batches. Mark it as compacted so
         // we can progress through compactions.
-        co_await internal::mark_segment_as_finished_window_compaction(
-          seg, is_clean_compacted, *_probe);
+        bool marked_as_cleanly_compacted
+          = co_await internal::mark_segment_as_finished_window_compaction(
+            seg, is_clean_compacted, *_probe);
+        if (marked_as_cleanly_compacted) {
+            subtract_dirty_segment_bytes(seg->size_bytes());
+        }
 
         vlog(
           gclog.debug,
@@ -1323,8 +1358,12 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     if (!seg->may_have_compactible_records()) {
         // All data records are already compacted away. Skip to avoid a
         // needless rewrite.
-        co_await internal::mark_segment_as_finished_window_compaction(
-          seg, is_clean_compacted, *_probe);
+        bool marked_as_cleanly_compacted
+          = co_await internal::mark_segment_as_finished_window_compaction(
+            seg, is_clean_compacted, *_probe);
+        if (marked_as_cleanly_compacted) {
+            subtract_dirty_segment_bytes(seg->size_bytes());
+        }
 
         vlog(
           gclog.trace,
@@ -1419,18 +1458,32 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     seg->force_set_commit_offset_from_index();
     seg->release_batch_cache_index();
 
+    const auto removed_bytes = ssize_t(size_before) - ssize_t(size_after);
+
+    // We must deduct the removed bytes from the dirty segment bytes.
+    // However, if the segment is marked as cleanly compacted below, the
+    // entire seg size (before compaction) will instead be removed from dirty
+    // segment bytes.
+    auto dirty_removed_bytes = removed_bytes;
+
     if (is_finished_window_compaction) {
         // Mark the segment as completed window compaction, and possibly set the
         // clean_compact_timestamp in it's index.
-        co_await internal::mark_segment_as_finished_window_compaction(
-          seg, is_clean_compacted, *_probe);
+        bool marked_as_cleanly_compacted
+          = co_await internal::mark_segment_as_finished_window_compaction(
+            seg, is_clean_compacted, *_probe);
+        if (marked_as_cleanly_compacted) {
+            dirty_removed_bytes = size_before;
+        }
     }
+
+    subtract_dirty_segment_bytes(dirty_removed_bytes);
+    subtract_closed_segment_bytes(removed_bytes);
 
     co_await seg->index().flush();
     co_await ss::rename_file(cmp_idx_tmpname.string(), cmp_idx_name.string());
     _probe->segment_compacted();
-    _probe->add_compaction_removed_bytes(
-      ssize_t(size_before) - ssize_t(size_after));
+    _probe->add_compaction_removed_bytes(removed_bytes);
 
     compaction_result res(size_before, size_after);
     _compaction_ratio.update(res.compaction_ratio());
@@ -1747,6 +1800,14 @@ ss::future<> disk_log_impl::new_segment(
                 vassert(!_closed, "cannot add log segment to closed log");
                 if (config().is_compacted()) {
                     h->mark_as_compacted_segment();
+                }
+                if (!_segs.empty()) {
+                    auto rolled_seg = _segs.back();
+                    const auto closed_segment_size = rolled_seg->size_bytes();
+                    if (!rolled_seg->index().has_clean_compact_timestamp()) {
+                        add_dirty_segment_bytes(closed_segment_size);
+                    }
+                    add_closed_segment_bytes(closed_segment_size);
                 }
                 _segs.add(std::move(h));
                 _probe->segment_created();
@@ -2686,6 +2747,11 @@ ss::future<> disk_log_impl::remove_segment_permanently(
     vlog(stlog.info, "Removing \"{}\" ({}, {})", s->filename(), ctx, s);
     // stats accounting must happen synchronously
     _probe->delete_segment(*s);
+    auto removed_segment_bytes = s->size_bytes();
+    if (!s->index().has_clean_compact_timestamp()) {
+        subtract_dirty_segment_bytes(removed_segment_bytes);
+    }
+    subtract_closed_segment_bytes(removed_segment_bytes);
     // background close
     s->tombstone();
     if (s->has_outstanding_locks()) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -258,6 +258,15 @@ public:
 
     size_t max_segment_size() const;
 
+    uint64_t dirty_segment_bytes() const { return _dirty_segment_bytes; }
+
+    uint64_t closed_segment_bytes() const { return _closed_segment_bytes; }
+
+    // Returns the dirty ratio of the log.
+    // The dirty ratio is the ratio of bytes in closed, dirty segments to the
+    // total number of bytes in all closed segments in the log.
+    double dirty_ratio() const;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -454,6 +463,33 @@ private:
     std::optional<model::offset> _last_compaction_window_start_offset;
 
     size_t _reclaimable_size_bytes{0};
+
+    uint64_t _dirty_segment_bytes{0};
+    uint64_t _closed_segment_bytes{0};
+
+    // Update the number of bytes in dirty segments.
+    //
+    // Dirty segments are closed segments which have not yet been cleanly
+    // compacted- i.e, duplicates for keys in this segment _could_ be found in
+    // the prefix of the log up to this segment.
+    //
+    // This value can increase AND decrease. It increases
+    // when a new segment is rolled, and decreases when the segment is marked as
+    // cleanly compacted, closed segments are evicted from the log, or when
+    // bytes are removed by compaction. For that reason, one of the tags add_tag
+    // or subtract_tag must be used.
+    void add_dirty_segment_bytes(uint64_t bytes);
+    void subtract_dirty_segment_bytes(uint64_t bytes);
+
+    // Update the number of bytes in closed segments.
+    //
+    // This value can increase AND decrease. It increases when a new
+    // segment is rolled, and decreases when closed segments are evicted from
+    // the log, or when bytes are removed by compaction. For that reason, one of
+    // the tags add_tag or subtract_tag must be used.
+    void add_closed_segment_bytes(uint64_t bytes);
+    void subtract_closed_segment_bytes(uint64_t bytes);
+
     bool _compaction_enabled;
 };
 

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -229,6 +229,16 @@ void probe::setup_metrics(const model::ntp& ntp) {
             "corresponds to the number of times the compaction key-offset map "
             "was unable to be built for a single segment."),
           labels),
+        sm::make_gauge(
+          "dirty_segment_bytes",
+          [this] { return _dirty_segment_bytes; },
+          sm::description("Number of bytes within dirty segments of the log"),
+          labels),
+        sm::make_gauge(
+          "closed_segment_bytes",
+          [this] { return _closed_segment_bytes; },
+          sm::description("Number of bytes within closed segments of the log"),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -132,6 +132,14 @@ public:
         _bytes_prefix_truncated += bytes;
     }
 
+    void set_dirty_segment_bytes(uint64_t bytes) {
+        _dirty_segment_bytes = bytes;
+    }
+
+    void set_closed_segment_bytes(uint64_t bytes) {
+        _closed_segment_bytes = bytes;
+    }
+
 private:
     uint64_t _partition_bytes = 0;
     uint64_t _bytes_written = 0;
@@ -157,6 +165,10 @@ private:
     uint64_t _segments_marked_tombstone_free = 0;
     uint64_t _num_rounds_window_compaction = 0;
     uint64_t _num_chunked_compaction_runs = 0;
+
+    uint64_t _dirty_segment_bytes = 0;
+    uint64_t _closed_segment_bytes = 0;
+
     ssize_t _compaction_removed_bytes = 0;
 
     metrics::internal_metric_groups _metrics;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1165,7 +1165,7 @@ offset_delta_time should_apply_delta_time_offset(
       && feature_table.local().is_active(features::feature::node_isolation)};
 }
 
-ss::future<> mark_segment_as_finished_window_compaction(
+ss::future<bool> mark_segment_as_finished_window_compaction(
   ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp, probe& pb) {
     seg->mark_as_finished_windowed_compaction();
     if (set_clean_compact_timestamp) {
@@ -1173,11 +1173,11 @@ ss::future<> mark_segment_as_finished_window_compaction(
           model::timestamp::now());
         if (did_set) {
             pb.add_cleanly_compacted_segment();
-            return seg->index().flush();
+            return seg->index().flush().then([] { return true; });
         }
     }
 
-    return ss::now();
+    return ss::make_ready_future<bool>(false);
 }
 
 bool is_past_tombstone_delete_horizon(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -284,7 +284,10 @@ bool may_have_removable_tombstones(
 // which case the `clean_compact_timestamp` is set in the segment's index).
 // Also potentially issues a call to seg->index()->flush(), if the
 // `clean_compact_timestamp` was set in the index.
-ss::future<> mark_segment_as_finished_window_compaction(
+//
+// Returns a boolean indicating if the segment was marked as cleanly compacted
+// for the first time and assigned a cleanly compacted timestamp.
+ss::future<bool> mark_segment_as_finished_window_compaction(
   ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp, probe& pb);
 
 template<typename Func>

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -24,6 +24,7 @@
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "storage/batch_cache.h"
+#include "storage/disk_log_impl.h"
 #include "storage/log_manager.h"
 #include "storage/log_reader.h"
 #include "storage/ntp_config.h"
@@ -5179,3 +5180,152 @@ FIXTURE_TEST(test_offset_range_size_incremental, storage_test_fixture) {
         }
     }
 };
+
+FIXTURE_TEST(dirty_ratio, storage_test_fixture) {
+    auto cfg = default_log_config(test_dir);
+    cfg.max_compacted_segment_size = config::mock_binding<size_t>(100_MiB);
+    cfg.cache = storage::with_cache::yes;
+    storage::ntp_config::default_overrides overrides;
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("default", "test", 0);
+    auto log = mgr
+                 .manage(storage::ntp_config(
+                   ntp,
+                   mgr.config().base_dir,
+                   std::make_unique<storage::ntp_config::default_overrides>(
+                     overrides)))
+                 .get();
+
+    auto* disk_log = static_cast<storage::disk_log_impl*>(log.get());
+
+    // add a segment with random keys until a certain size
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    static constexpr double tolerance = 1.0e-6;
+    uint64_t closed_segments_size_bytes = 0;
+    uint64_t dirty_segments_size_bytes = 0;
+    auto assert_on_new_segment = [&disk_log,
+                                  &closed_segments_size_bytes,
+                                  &dirty_segments_size_bytes](size_t index) {
+        auto new_segment_size_bytes = disk_log->segments()[index]->size_bytes();
+        closed_segments_size_bytes += new_segment_size_bytes;
+        dirty_segments_size_bytes += new_segment_size_bytes;
+        auto expected_dirty_ratio
+          = static_cast<double>(dirty_segments_size_bytes)
+            / static_cast<double>(closed_segments_size_bytes);
+        BOOST_REQUIRE_EQUAL(
+          disk_log->dirty_segment_bytes(), dirty_segments_size_bytes);
+        BOOST_REQUIRE_EQUAL(
+          disk_log->closed_segment_bytes(), closed_segments_size_bytes);
+        BOOST_REQUIRE_CLOSE(
+          disk_log->dirty_ratio(), expected_dirty_ratio, tolerance);
+    };
+
+    auto compact_and_assert = [&disk_log,
+                               &closed_segments_size_bytes,
+                               &dirty_segments_size_bytes,
+                               &as]() {
+        // Perform sliding window compaction, which will fully cleanly compact
+        // the log.
+        static const storage::compaction_config compact_cfg(
+          model::offset::max(), std::nullopt, ss::default_priority_class(), as);
+        disk_log->sliding_window_compact(compact_cfg).get();
+
+        dirty_segments_size_bytes = 0;
+
+        BOOST_REQUIRE_EQUAL(
+          disk_log->dirty_segment_bytes(), dirty_segments_size_bytes);
+        BOOST_REQUIRE_EQUAL(
+          disk_log->closed_segment_bytes(), closed_segments_size_bytes);
+        BOOST_REQUIRE_CLOSE(disk_log->dirty_ratio(), 0.0, tolerance);
+    };
+
+    add_segment(2_MiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 2);
+    assert_on_new_segment(0);
+    compact_and_assert();
+
+    add_segment(2_MiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
+    assert_on_new_segment(1);
+    compact_and_assert();
+
+    add_segment(5_MiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 4);
+    assert_on_new_segment(2);
+    compact_and_assert();
+
+    add_segment(16_KiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
+    assert_on_new_segment(3);
+    compact_and_assert();
+
+    add_segment(16_KiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 6);
+    assert_on_new_segment(4);
+    compact_and_assert();
+
+    // Add more segments, don't perform compaction to allow dirty_segment_bytes
+    // to remain non-zero.
+    add_segment(2_MiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    assert_on_new_segment(5);
+
+    add_segment(16_KiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    assert_on_new_segment(6);
+
+    add_segment(16_KiB, model::term_id(1));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    assert_on_new_segment(7);
+
+    std::vector<model::offset> base_offsets;
+    base_offsets.reserve(disk_log->segment_count());
+    for (const auto& s : disk_log->segments()) {
+        base_offsets.push_back(s->offsets().get_base_offset());
+    }
+    // Last base offset is not needed for truncation
+    base_offsets.pop_back();
+    std::reverse(base_offsets.begin(), base_offsets.end());
+
+    auto prev_dirty_segment_bytes = disk_log->dirty_segment_bytes();
+    auto prev_closed_segment_bytes = disk_log->dirty_segment_bytes();
+    auto prev_dirty_ratio = disk_log->dirty_ratio();
+
+    // Gradually truncate the log and see that dirty/closed segment bytes
+    // have decreased.
+    for (const auto& base_offset : base_offsets) {
+        disk_log
+          ->truncate(
+            storage::truncate_config(base_offset, ss::default_priority_class()))
+          .get();
+
+        auto new_dirty_segment_bytes = disk_log->dirty_segment_bytes();
+        auto new_closed_segment_bytes = disk_log->dirty_segment_bytes();
+        auto new_dirty_ratio = disk_log->dirty_ratio();
+        BOOST_REQUIRE_LE(new_dirty_segment_bytes, prev_dirty_segment_bytes);
+        BOOST_REQUIRE_LE(new_closed_segment_bytes, prev_closed_segment_bytes);
+        BOOST_REQUIRE_LE(new_dirty_ratio, prev_dirty_ratio);
+        prev_dirty_segment_bytes = new_dirty_segment_bytes;
+        prev_closed_segment_bytes = new_closed_segment_bytes;
+        prev_dirty_ratio = new_dirty_ratio;
+    }
+
+    BOOST_REQUIRE_EQUAL(disk_log->dirty_segment_bytes(), 0);
+    BOOST_REQUIRE_EQUAL(disk_log->closed_segment_bytes(), 0);
+    BOOST_REQUIRE_CLOSE(disk_log->dirty_ratio(), 0.0, tolerance);
+}

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -112,6 +112,24 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
             metrics_endpoint=MetricsEndpoint.METRICS,
             topic=self.topic_spec.name)
 
+    def get_dirty_segment_bytes(self):
+        return self.redpanda.metric_sum(
+            metric_name="vectorized_storage_log_dirty_segment_bytes",
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            topic=self.topic_spec.name)
+
+    def get_closed_segment_bytes(self):
+        return self.redpanda.metric_sum(
+            metric_name="vectorized_storage_log_closed_segment_bytes",
+            metrics_endpoint=MetricsEndpoint.METRICS,
+            topic=self.topic_spec.name)
+
+    def get_dirty_ratio(self):
+        dirty_segment_bytes = self.get_dirty_segment_bytes()
+        closed_segment_bytes = self.get_closed_segment_bytes()
+        return 0.0 if closed_segment_bytes == 0 else float(
+            dirty_segment_bytes) / float(closed_segment_bytes)
+
     def produce_and_consume(self):
         """
         Creates producer and consumer. Asserts that tombstones are seen
@@ -135,6 +153,18 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
 
         # Produce and wait
         producer.start()
+
+        def seen_dirty_ratio_above_zero():
+            dirty_bytes_nonzero = self.get_dirty_segment_bytes() > 0
+            closed_bytes_nonzero = self.get_closed_segment_bytes() > 0
+            dirty_ratio_nonzero = self.get_dirty_ratio() > 0.0
+            return dirty_bytes_nonzero and closed_bytes_nonzero and dirty_ratio_nonzero
+
+        wait_until(seen_dirty_ratio_above_zero,
+                   timeout_sec=10,
+                   backoff_sec=0.1,
+                   err_msg="Did not see a non-zero dirty ratio.")
+
         producer.wait_for_latest_value_map()
         producer.wait(timeout_sec=180)
 
@@ -209,6 +239,11 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
         else:
             assert self.get_chunked_compaction_runs() == 0
 
+        # There should be no dirty segments left
+        assert self.get_dirty_segment_bytes() == 0
+        assert self.get_closed_segment_bytes() > 0
+        assert self.get_dirty_ratio() < 1.0e-6
+
         consumer = KgoVerifierSeqConsumer(self.test_context,
                                           self.redpanda,
                                           self.topic_spec.name,
@@ -229,6 +264,38 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
         # Expect to see 0 tombstones consumed
         assert consumer.consumer_status.validator.tombstones_consumed == 0
         assert consumer.consumer_status.validator.invalid_reads == 0
+
+    def wait_for_log_truncation(self):
+        # Set log_retention_ms to an arbitrarily tiny value and wait for log truncation.
+        # This is done by watching the number of bytes in closed segments,
+        # which will decrease as segments are removed.
+        self.client().alter_topic_config(self.topic_spec.name,
+                                         TopicSpec.PROPERTY_RETENTION_TIME,
+                                         1000)
+
+        self.prev_closed_segment_bytes = self.get_closed_segment_bytes()
+        self.prev_dirty_segment_bytes = self.get_dirty_segment_bytes()
+        self.prev_dirty_ratio = self.get_dirty_ratio()
+
+        def all_segments_removed():
+            new_closed_segment_bytes = self.get_closed_segment_bytes()
+            new_dirty_segment_bytes = self.get_dirty_segment_bytes()
+            new_dirty_ratio = self.get_dirty_ratio()
+
+            assert new_closed_segment_bytes <= self.prev_closed_segment_bytes
+            assert new_dirty_segment_bytes <= self.prev_dirty_segment_bytes
+            assert new_dirty_ratio <= self.prev_dirty_ratio
+
+            self.prev_closed_segment_bytes = new_closed_segment_bytes
+            self.prev_dirty_segment_bytes = new_dirty_segment_bytes
+            self.prev_dirty_ratio = new_dirty_ratio
+
+            return new_dirty_segment_bytes == 0 and new_closed_segment_bytes == 0
+
+        wait_until(all_segments_removed,
+                   timeout_sec=120,
+                   backoff_sec=1,
+                   err_msg="Closed segment bytes did not reach zero.")
 
     @skip_debug_mode
     @cluster(num_nodes=4)
@@ -289,6 +356,9 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
         self.produce_and_consume()
 
         self.validate_log()
+
+        if cleanup_policy == TopicSpec.CLEANUP_COMPACT_DELETE:
+            self.wait_for_log_truncation()
 
         # Clean up partition movement thread
         partition_move_thread.join()


### PR DESCRIPTION
The dirty ratio of a log is defined as the ratio between the number of bytes in "dirty" segments and the total number of bytes in closed segments.

Dirty segments are closed segments which have not yet been cleanly compacted- i.e, duplicates for keys in this segment _could_ be found in the prefix of the log up to this segment.

Add book-keeping to `disk_log_impl` in order to cache both `_dirty_segment_bytes` as well as `_closed_segment_bytes`, which allows us to calculate the dirty ratio, and add observability for it in `storage::probe`.

In the future, this could be used in combination with a compaction configuration a la [min.cleanable.dirty.ratio](https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#min-cleanable-dirty-ratio) to schedule compaction.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Adds the observable metrics `dirty_segment_bytes` and `closed_segment_bytes` to the storage layer.
