### PR TITLE
storage: add log lines about removed data

### DIFF
--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -133,6 +133,11 @@ public:
         // of a compactible type.
         size_t non_compactible_batches{0};
 
+        // Returns whether any data was removed by this reducer.
+        bool has_removed_data() const {
+            return batches_discarded > 0 || records_discarded > 0;
+        }
+
         friend std::ostream& operator<<(std::ostream& os, const stats& s) {
             fmt::print(
               os,
@@ -144,6 +149,10 @@ public:
               s.non_compactible_batches);
             return os;
         }
+    };
+    struct idx_and_stats {
+        index_state new_idx;
+        stats reducer_stats;
     };
 
     copy_data_segment_reducer(
@@ -165,7 +174,7 @@ public:
       , _as(as) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
-    storage::index_state end_of_stream() { return std::move(_idx); }
+    idx_and_stats end_of_stream() { return {std::move(_idx), _stats}; }
 
 private:
     ss::future<ss::stop_iteration>

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -440,18 +440,33 @@ ss::future<storage::index_state> do_copy_segment_data(
       cfg.asrc);
 
     // create the segment, get the in-memory index for the new segment
-    auto new_index = co_await create_segment_full_reader(
-                       seg, cfg, pb, std::move(rw_lock_holder))
-                       .consume(std::move(copy_reducer), model::no_timeout)
-                       .finally([&] {
-                           return appender->close().handle_exception(
-                             [](std::exception_ptr e) {
-                                 vlog(
-                                   gclog.error,
-                                   "Error copying index to new segment:{}",
-                                   e);
-                             });
+    auto res = co_await create_segment_full_reader(
+                 seg, cfg, pb, std::move(rw_lock_holder))
+                 .consume(std::move(copy_reducer), model::no_timeout)
+                 .finally([&] {
+                     return appender->close().handle_exception(
+                       [](std::exception_ptr e) {
+                           vlog(
+                             gclog.error,
+                             "Error copying index to new segment:{}",
+                             e);
                        });
+                 });
+    const auto& stats = res.reducer_stats;
+    if (stats.has_removed_data()) {
+        vlog(
+          gclog.info,
+          "Self compaction filtering removing data from {}: {}",
+          seg->filename(),
+          stats);
+    } else {
+        vlog(
+          gclog.debug,
+          "Self compaction filtering not removing any records from {}: {}",
+          seg->filename(),
+          stats);
+    }
+    auto& new_index = res.new_idx;
 
     // restore broker timestamp and clean compact timestamp
     new_index.broker_timestamp = old_broker_timestamp;
@@ -466,7 +481,7 @@ ss::future<storage::index_state> do_copy_segment_data(
         pb.add_segment_marked_tombstone_free();
     }
 
-    co_return new_index;
+    co_return std::move(new_index);
 }
 
 model::record_batch_reader create_segment_full_reader(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
It's very difficult to retroactively debug why records are removed by compaction. This adds some logging about removed data.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Adds logging to mention data removed by compaction.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
