### PR TITLE
tests/datalake: deflake partition_movement_test

### DIFF
--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -55,9 +55,9 @@ class DatalakeVerifier():
         # > max_consumed_offset + 1 if there are gaps from non consumable
         # batches like aborted data batches / control batches
         self._next_positions = defaultdict(lambda: -1)
-
-        self._query: QueryEngineBase = query_engine
         self._cg = f"verifier-group-{random.randint(0, 1000000)}"
+        self._consumer: Consumer = self.create_consumer()
+        self._query: QueryEngineBase = query_engine
         self._lock = threading.Lock()
         self._stop = threading.Event()
         # number of messages buffered in memory
@@ -81,41 +81,30 @@ class DatalakeVerifier():
 
         return c
 
+    def update_and_get_fetch_positions(self):
+        with self._lock:
+            partitions = [
+                TopicPartition(topic=self.topic, partition=p)
+                for p in self._consumed_messages.keys()
+            ]
+            positions = self._consumer.position(partitions)
+            for p in positions:
+                if p.error is not None:
+                    self.logger.warning(
+                        f"Erorr querying position for partition {p.partition}")
+                else:
+                    self.logger.debug(
+                        f"next position for {p.partition} is {p.offset}")
+                    self._next_positions[p.partition] = p.offset
+            return self._next_positions.copy()
+
     def _consumer_thread(self):
         self.logger.info("Starting consumer thread")
-        consumer = self.create_consumer()
-
-        last_position_update = time()
-
-        def maybe_update_positions():
-            nonlocal last_position_update
-            if time() < last_position_update + 3:
-                # periodically sweep through all partitions
-                # and update positions
-                return
-            with self._lock:
-                partitions = [
-                    TopicPartition(topic=self.topic, partition=p)
-                    for p in self._consumed_messages.keys()
-                ]
-                positions = consumer.position(partitions)
-                for p in positions:
-                    if p.error is not None:
-                        self.logger.warning(
-                            f"Erorr querying position for partition {p.partition}"
-                        )
-                    else:
-                        self.logger.debug(
-                            f"next position for {p.partition} is {p.offset}")
-                        self._next_positions[p.partition] = p.offset
-                last_position_update = time()
-
         while not self._stop.is_set():
             self._msg_semaphore.acquire()
             if self._stop.is_set():
                 break
-            msg = consumer.poll(1.0)
-            maybe_update_positions()
+            msg = self._consumer.poll(1.0)
             if msg is None:
                 continue
             if msg.error():
@@ -134,8 +123,6 @@ class DatalakeVerifier():
                     msg.offset())
                 if len(self._errors) > 0:
                     return
-
-        consumer.close()
 
     def _get_query(self, partition, last_queried_offset, max_consumed_offset):
         return f"\
@@ -179,15 +166,11 @@ class DatalakeVerifier():
         self._consumed_messages[partition].pop(0)
         self._msg_semaphore.release()
 
-    def _get_partition_offsets_list(self):
-        with self._lock:
-            return self._next_positions.copy()
-
     def _query_thread(self):
         self.logger.info("Starting query thread")
         while not self._stop.is_set():
             try:
-                partitions = self._get_partition_offsets_list()
+                partitions = self.update_and_get_fetch_positions()
 
                 for partition, next_consume_offset in partitions.items():
                     last_queried_offset = self._max_queried_offsets[
@@ -276,14 +259,18 @@ class DatalakeVerifier():
             self.stop()
 
     def stop(self):
-        self._stop.set()
-        self._msg_semaphore.release()
-        self._executor.shutdown(wait=False)
-        assert len(
-            self._errors
-        ) == 0, f"Topic {self.topic} validation errors: {self._errors}"
+        try:
+            self._stop.set()
+            self._msg_semaphore.release()
+            self._executor.shutdown(wait=False)
+            assert len(
+                self._errors
+            ) == 0, f"Topic {self.topic} validation errors: {self._errors}"
 
-        self.logger.debug(f"consumed offsets: {self._max_consumed_offsets}")
-        self.logger.debug(f"queried offsets: {self._max_queried_offsets}")
+            self.logger.debug(
+                f"consumed offsets: {self._max_consumed_offsets}")
+            self.logger.debug(f"queried offsets: {self._max_queried_offsets}")
 
-        assert self._max_queried_offsets == self._max_consumed_offsets, "Mismatch between maximum offsets in topic vs iceberg table"
+            assert self._max_queried_offsets == self._max_consumed_offsets, "Mismatch between maximum offsets in topic vs iceberg table"
+        finally:
+            self._consumer.close()


### PR DESCRIPTION
- Fixes a subtle deadlock where positions are not updated before the memory fills up and query thread cannot make progress without correct fetch positions, so nothing drains the memory semaphore.

- Optimizes verification process to batch enough messages and thus reducing # of queries and also lowering the frequency of updating fetch positions.

Fixes https://redpandadata.atlassian.net/browse/CORE-8581

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
