### PR TITLE
raft: Make load_snapshot exception safe

### DIFF
--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -21,6 +21,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
+#include <exception>
 #include <filesystem>
 namespace raft {
 namespace {
@@ -119,24 +120,40 @@ file_backed_stm_snapshot::load_snapshot() {
     }
 
     storage::snapshot_reader& reader = *maybe_reader;
-    iobuf meta_buf = co_await reader.read_metadata();
-    iobuf_parser meta_parser(std::move(meta_buf));
-    auto header = read_snapshot_header(meta_parser, _ntp, name());
-    if (!header) {
-        vlog(_log.warn, "Skipping snapshot {} due to old format", store_path());
-
-        // can't load old format of the snapshot, since snapshot is missing
-        // it will be reconstructed by replaying the log
-        co_await reader.close();
-        co_return std::nullopt;
-    }
     stm_snapshot snapshot;
-    snapshot.header = *header;
-    snapshot.data = co_await read_iobuf_exactly(
-      reader.input(), snapshot.header.snapshot_size);
+    std::exception_ptr ex{nullptr};
+    try {
+        iobuf meta_buf = co_await reader.read_metadata();
+        iobuf_parser meta_parser(std::move(meta_buf));
+        auto header = read_snapshot_header(meta_parser, _ntp, name());
+        if (!header) {
+            vlog(
+              _log.warn,
+              "Skipping snapshot {} due to old format",
+              store_path());
 
-    _snapshot_size = co_await reader.get_snapshot_size();
+            // can't load old format of the snapshot, since snapshot is missing
+            // it will be reconstructed by replaying the log
+            co_await reader.close();
+            co_return std::nullopt;
+        }
+        snapshot.header = *header;
+        snapshot.data = co_await read_iobuf_exactly(
+          reader.input(), snapshot.header.snapshot_size);
+
+        _snapshot_size = co_await reader.get_snapshot_size();
+    } catch (...) {
+        ex = std::current_exception();
+        vlog(
+          _log.warn,
+          "Exception thrown while reading local snapshot: {}, exception: {}",
+          store_path(),
+          ex);
+    }
     co_await reader.close();
+    if (ex != nullptr) {
+        std::rethrow_exception(ex);
+    }
     co_await _snapshot_mgr.remove_partial_snapshots();
 
     co_return snapshot;


### PR DESCRIPTION
The 'load_snapshot' method of the 'file_backed_stm_snapshot' class is not exception safe. If the metadata loading operation throws the reader is not closed properly which in turn triggers assertion.

This commit fixes this by handling exception and closing the reader explicitly. If the metadata can't be loaded (snapshot is truncated) the method returns nullopt which should trigger log replay.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none