### PR TITLE
ducktape: Fix TS reader stress test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
@@ -31,8 +31,7 @@ class TieredStorageReaderStressTest(RedpandaTest):
     cache_max_throughput = 10 * expect_throughput
     cache_size = SISettings.cache_size_for_throughput(cache_max_throughput)
 
-    # This is the same as the default at time of writing (v23.2)
-    readers_per_shard = 1000
+    readers_per_shard = 10000
 
     # To help reduce runtime by requiring less data to get a given segment count
     segment_size = 16 * 1024 * 1024


### PR DESCRIPTION
The test also explicitly sets
`cloud_storage_max_segment_readers_per_shard` so after https://github.com/redpanda-data/redpanda/commit/e4fc766bfa02e112f0195ffe221b63a0a8d3e1ab we
need bounce that value as that implicitly limits memory.

Fixes CORE-8630

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


