### PR TITLE
bazel: use a sysroot for compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,9 @@ common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
 build --linkopt -stdlib=libc++
 
+# By default build without CGO
+build --@rules_go//go/config:pure
+
 common:clang-19 --extra_toolchains=@llvm_19_toolchain//:all
 
 build:system-clang --extra_toolchains=@local_config_cc_toolchains//:all

--- a/BUILD
+++ b/BUILD
@@ -29,11 +29,13 @@ filegroup(
 alias(
     name = "redpanda",
     actual = "//src/v/redpanda:redpanda",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "rpk",
     actual = "//src/go/rpk/cmd/rpk:rpk",
+    visibility = ["//visibility:public"],
 )
 
 alias(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -271,6 +271,38 @@ crate.annotation(
 )
 
 # ====================================
+# OCI Base Images
+# ====================================
+bazel_dep(name = "rules_oci", version = "2.0.1", dev_dependency = True)
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+
+# Use a distroless docker image that only comes with the following:
+#
+# ca-certificates
+# /etc/passwd entry for a root user
+# /tmp directory
+# tzdata
+# glibc
+# libgcc1
+oci.pull(
+    name = "distroless_cc_debian12",
+    # This is the latest nonroot tag
+    digest = "sha256:594b5200fd1f06d17a877ebee16d4af84a9a7ab83c898632a2d5609c0593cbab",
+    image = "gcr.io/distroless/cc-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+use_repo(
+    oci,
+    "distroless_cc_debian12",
+    "distroless_cc_debian12_linux_amd64",
+    "distroless_cc_debian12_linux_arm64_v8",
+)
+
+# ====================================
 # clang-tidy
 # ====================================
 bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,6 +99,8 @@ use_repo(non_module_dependencies, "seastar")
 use_repo(non_module_dependencies, "unordered_dense")
 use_repo(non_module_dependencies, "wasmtime")
 use_repo(non_module_dependencies, "xxhash")
+use_repo(non_module_dependencies, "x86_64_sysroot")
+use_repo(non_module_dependencies, "aarch64_sysroot")
 
 bazel_dep(name = "toolchains_llvm", version = "1.1.2")
 single_version_override(
@@ -131,6 +133,16 @@ llvm.toolchain(
         "linux-x86_64": ["http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/llvm-19.1.1-ubuntu-22.04-x86_64.tar.gz"],
     },
 )
+llvm.sysroot(
+    name = "llvm_19_toolchain",
+    label = "@x86_64_sysroot//:sysroot",
+    targets = ["linux-x86_64"],
+)
+llvm.sysroot(
+    name = "llvm_19_toolchain",
+    label = "@aarch64_sysroot//:sysroot",
+    targets = ["linux-aarch64"],
+)
 use_repo(llvm, "llvm_19_toolchain", "llvm_19_toolchain_llvm")
 
 register_toolchains("@llvm_19_toolchain//:all")
@@ -147,6 +159,16 @@ llvm.toolchain(
         "linux-aarch64": ["http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/llvm-18.1.8-ubuntu-22.04-aarch64.tar.gz"],
         "linux-x86_64": ["http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/pgo/llvm-18.1.8-ubuntu-22.04-x86_64.tar.gz"],
     },
+)
+llvm.sysroot(
+    name = "llvm_18_toolchain",
+    label = "@x86_64_sysroot//:sysroot",
+    targets = ["linux-x86_64"],
+)
+llvm.sysroot(
+    name = "llvm_18_toolchain",
+    label = "@aarch64_sysroot//:sysroot",
+    targets = ["linux-aarch64"],
 )
 use_repo(llvm, "llvm_18_toolchain", "llvm_18_toolchain_llvm")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -269,6 +269,10 @@ use_repo(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
+    extra_target_triples = [
+        "aarch64-unknown-linux-gnu",
+        "x86_64-unknown-linux-gnu",
+    ],
     versions = ["1.80.0"],
 )
 use_repo(rust, "rust_toolchains")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -334,6 +334,6 @@ use_repo(
 bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
 git_override(
     module_name = "bazel_clang_tidy",
-    commit = "a95424548c494470258a23128f70244f7a79dac2",
+    commit = "db677011c7363509a288a9fb3bf0a50830bbf791",
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,7 +47,6 @@ single_version_override(
 bazel_dep(name = "re2", version = "2024-07-02")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 bazel_dep(name = "rules_go", version = "0.50.1")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_rust", version = "0.49.3")
 bazel_dep(name = "snappy", version = "1.2.1")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5574,7 +5574,7 @@
     "@@rules_rust~//rust:extensions.bzl%rust": {
       "general": {
         "bzlTransitiveDigest": "CILmbFT+SqDrQsN+vw/1IK15ku1PEmcYfkxJ53yyIvE=",
-        "usagesDigest": "kIFjD0j3UyHq8EH2APrpeiquQWPbz1TAnKvNNG68hSY=",
+        "usagesDigest": "N7it+zhc3dkqHc4KtgIXxFFRhT0KdBYoegcwutuRhl4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -5648,14 +5648,14 @@
               ]
             }
           },
-          "rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools": {
+          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -5673,11 +5673,11 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_aarch64__wasm32-unknown-unknown__stable": {
+          "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -5687,19 +5687,19 @@
                 "@platforms//os:osx"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
               ]
             }
           },
-          "rust_darwin_aarch64__wasm32-wasi__stable_tools": {
+          "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -5717,11 +5717,11 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_aarch64__wasm32-wasi__stable": {
+          "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -5731,8 +5731,8 @@
                 "@platforms//os:osx"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
               ]
             }
           },
@@ -5742,8 +5742,8 @@
             "attributes": {
               "toolchains": [
                 "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
-                "@rust_darwin_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_darwin_aarch64__wasm32-wasi__stable//:toolchain"
+                "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -5821,14 +5821,14 @@
               ]
             }
           },
-          "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
+          "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -5846,11 +5846,11 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
+          "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -5860,19 +5860,19 @@
                 "@platforms//os:windows"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
               ]
             }
           },
-          "rust_windows_aarch64__wasm32-wasi__stable_tools": {
+          "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -5890,11 +5890,11 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_aarch64__wasm32-wasi__stable": {
+          "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -5904,8 +5904,8 @@
                 "@platforms//os:windows"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
               ]
             }
           },
@@ -5915,8 +5915,8 @@
             "attributes": {
               "toolchains": [
                 "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
-                "@rust_windows_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_windows_aarch64__wasm32-wasi__stable//:toolchain"
+                "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_windows_aarch64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -5994,14 +5994,14 @@
               ]
             }
           },
-          "rust_linux_aarch64__wasm32-unknown-unknown__stable_tools": {
+          "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "aarch64-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6019,11 +6019,11 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_aarch64__wasm32-unknown-unknown__stable": {
+          "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6033,52 +6033,8 @@
                 "@platforms//os:linux"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_linux_aarch64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "aarch64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_aarch64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
+                "@platforms//cpu:x86_64",
                 "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
               ]
             }
           },
@@ -6088,8 +6044,7 @@
             "attributes": {
               "toolchains": [
                 "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
-                "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain"
+                "@rust_linux_aarch64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -6167,14 +6122,14 @@
               ]
             }
           },
-          "rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools": {
+          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6192,11 +6147,11 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
+          "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6206,19 +6161,19 @@
                 "@platforms//os:osx"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
               ]
             }
           },
-          "rust_darwin_x86_64__wasm32-wasi__stable_tools": {
+          "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-apple-darwin",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6236,11 +6191,11 @@
               "auth_patterns": []
             }
           },
-          "rust_darwin_x86_64__wasm32-wasi__stable": {
+          "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6250,8 +6205,8 @@
                 "@platforms//os:osx"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
               ]
             }
           },
@@ -6261,8 +6216,8 @@
             "attributes": {
               "toolchains": [
                 "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
-                "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain"
+                "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -6340,14 +6295,14 @@
               ]
             }
           },
-          "rust_windows_x86_64__wasm32-unknown-unknown__stable_tools": {
+          "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6365,11 +6320,11 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
+          "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6379,19 +6334,19 @@
                 "@platforms//os:windows"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
               ]
             }
           },
-          "rust_windows_x86_64__wasm32-wasi__stable_tools": {
+          "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-pc-windows-msvc",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6409,11 +6364,11 @@
               "auth_patterns": []
             }
           },
-          "rust_windows_x86_64__wasm32-wasi__stable": {
+          "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_windows_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6423,8 +6378,8 @@
                 "@platforms//os:windows"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
               ]
             }
           },
@@ -6434,8 +6389,8 @@
             "attributes": {
               "toolchains": [
                 "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
-                "@rust_windows_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_windows_x86_64__wasm32-wasi__stable//:toolchain"
+                "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_windows_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -6513,14 +6468,14 @@
               ]
             }
           },
-          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
+          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-freebsd",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6538,11 +6493,11 @@
               "auth_patterns": []
             }
           },
-          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
+          "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6552,19 +6507,19 @@
                 "@platforms//os:freebsd"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
               ]
             }
           },
-          "rust_freebsd_x86_64__wasm32-wasi__stable_tools": {
+          "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-freebsd",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
+              "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6582,11 +6537,11 @@
               "auth_patterns": []
             }
           },
-          "rust_freebsd_x86_64__wasm32-wasi__stable": {
+          "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6596,8 +6551,8 @@
                 "@platforms//os:freebsd"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
               ]
             }
           },
@@ -6607,8 +6562,8 @@
             "attributes": {
               "toolchains": [
                 "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
-                "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_freebsd_x86_64__wasm32-wasi__stable//:toolchain"
+                "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -6686,14 +6641,14 @@
               ]
             }
           },
-          "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
+          "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
             "attributes": {
               "exec_triple": "x86_64-unknown-linux-gnu",
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-unknown-unknown",
+              "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
               "version": "1.80.0",
               "rustfmt_version": "nightly/2024-07-25",
@@ -6711,11 +6666,11 @@
               "auth_patterns": []
             }
           },
-          "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
+          "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "toolchain": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
               "target_settings": [
                 "@rules_rust//rust/toolchain/channel:stable"
               ],
@@ -6725,52 +6680,8 @@
                 "@platforms//os:linux"
               ],
               "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:none"
-              ]
-            }
-          },
-          "rust_linux_x86_64__wasm32-wasi__stable_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_toolchain_tools_repository",
-            "attributes": {
-              "exec_triple": "x86_64-unknown-linux-gnu",
-              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
-              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
-              "target_triple": "wasm32-wasi",
-              "iso_date": "",
-              "version": "1.80.0",
-              "rustfmt_version": "nightly/2024-07-25",
-              "edition": "2021",
-              "dev_components": false,
-              "extra_rustc_flags": [],
-              "extra_exec_rustc_flags": [],
-              "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "netrc": "",
-              "auth_patterns": []
-            }
-          },
-          "rust_linux_x86_64__wasm32-wasi__stable": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
-              "target_settings": [
-                "@rules_rust//rust/toolchain/channel:stable"
-              ],
-              "toolchain_type": "@rules_rust//rust:toolchain",
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
+                "@platforms//cpu:aarch64",
                 "@platforms//os:linux"
-              ],
-              "target_compatible_with": [
-                "@platforms//cpu:wasm32",
-                "@platforms//os:wasi"
               ]
             }
           },
@@ -6780,8 +6691,7 @@
             "attributes": {
               "toolchains": [
                 "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
-                "@rust_linux_x86_64__wasm32-unknown-unknown__stable//:toolchain",
-                "@rust_linux_x86_64__wasm32-wasi__stable//:toolchain"
+                "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable//:toolchain"
               ]
             }
           },
@@ -6822,94 +6732,88 @@
               "toolchain_names": [
                 "rust_analyzer_1.80.0",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
-                "rust_darwin_aarch64__wasm32-wasi__stable",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable",
+                "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__aarch64-apple-darwin",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable",
-                "rust_windows_aarch64__wasm32-wasi__stable",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable",
+                "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable",
-                "rust_linux_aarch64__wasm32-wasi__stable",
+                "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
-                "rust_darwin_x86_64__wasm32-wasi__stable",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable",
+                "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__x86_64-apple-darwin",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable",
-                "rust_windows_x86_64__wasm32-wasi__stable",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable",
+                "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
-                "rust_freebsd_x86_64__wasm32-wasi__stable",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable",
+                "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable",
-                "rust_linux_x86_64__wasm32-wasi__stable",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu"
               ],
               "toolchain_labels": {
                 "rust_analyzer_1.80.0": "@rust_analyzer_1.80.0_tools//:rust_analyzer_toolchain",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable": "@rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rustfmt_nightly-2024-07-25__aarch64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_windows_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable": "@rust_windows_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable": "@rust_linux_aarch64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rustfmt_nightly-2024-07-25__x86_64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_windows_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_windows_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
-                "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": "@rust_linux_x86_64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
               },
               "toolchain_types": {
                 "rust_analyzer_1.80.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
-                "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
               },
               "exec_compatible_with": {
@@ -6918,11 +6822,11 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
@@ -6934,11 +6838,11 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_aarch64__wasm32-wasi__stable": [
+                "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
@@ -6950,11 +6854,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:aarch64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_aarch64__wasm32-wasi__stable": [
+                "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
@@ -6966,11 +6866,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
@@ -6982,11 +6882,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_x86_64__wasm32-wasi__stable": [
+                "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
@@ -6998,11 +6898,11 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
@@ -7014,11 +6914,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:x86_64",
-                  "@platforms//os:linux"
-                ],
-                "rust_linux_x86_64__wasm32-wasi__stable": [
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
@@ -7033,91 +6929,83 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
+                "rust_darwin_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
-                "rust_darwin_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_darwin_aarch64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__aarch64-apple-darwin": [],
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
+                "rust_windows_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
-                "rust_windows_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_windows_aarch64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__aarch64-pc-windows-msvc": [],
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_linux_aarch64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_linux_aarch64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__aarch64-unknown-linux-gnu": [],
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
+                "rust_darwin_x86_64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
-                "rust_darwin_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_darwin_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__x86_64-apple-darwin": [],
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
+                "rust_windows_x86_64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
-                "rust_windows_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_windows_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__x86_64-pc-windows-msvc": [],
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
+                "rust_freebsd_x86_64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
-                "rust_freebsd_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_freebsd_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-freebsd": [],
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:none"
-                ],
-                "rust_linux_x86_64__wasm32-wasi__stable": [
-                  "@platforms//cpu:wasm32",
-                  "@platforms//os:wasi"
+                "rust_linux_x86_64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
                 ],
                 "rustfmt_nightly-2024-07-25__x86_64-unknown-linux-gnu": []
               }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -216,7 +216,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "HVHZRxHddAfQ0vBrAdVSY8sKmokWh0Mo4YHA2eYHDR4=",
+        "bzlTransitiveDigest": "81IeyYMOu4p1oDSk/Tc4LcX0R41gfnPjfTP56+NuI14=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -442,6 +442,28 @@
               "sha256": "716fbe4fc85ecd36488afbbc635b59b5ab6aba5ed3b69d4a32a46eae5a453d38",
               "strip_prefix": "xxHash-bbb27a5efb85b92a0486cf361a8635715a53f6ba",
               "url": "https://github.com/Cyan4973/xxHash/archive/bbb27a5efb85b92a0486cf361a8635715a53f6ba.tar.gz"
+            }
+          },
+          "x86_64_sysroot": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "\nfilegroup(\n  name = \"sysroot\",\n  srcs = glob([\"*/**\"]),\n  visibility = [\"//visibility:public\"],\n)",
+              "sha256": "b7544f6931531eababde47d8723362bc9b3c9de8ef7d9a5d1d62d2e614904d5b",
+              "urls": [
+                "http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/sysroot-ubuntu-22.04-x86_64-2025-01-03.tar.gz"
+              ]
+            }
+          },
+          "aarch64_sysroot": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "\nfilegroup(\n  name = \"sysroot\",\n  srcs = glob([\"*/**\"]),\n  visibility = [\"//visibility:public\"],\n)",
+              "sha256": "a2d8c3ce82c70f884281db846e756f5877f2c77964cbfb1ba6b954e1f759e2ed",
+              "urls": [
+                "http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/sysroot-ubuntu-22.04-aarch64-2025-01-03.tar.gz"
+              ]
             }
           }
         },
@@ -17940,7 +17962,7 @@
     "@@toolchains_llvm~//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "y9h5L2NtWbogyWSOJgqnUaU50MTPWAW+waelXSirMVg=",
-        "usagesDigest": "vaOqtBKVYh0KUH0biytmgYkovSqWiLA9X1XBqLx7yw8=",
+        "usagesDigest": "zvCu5vCx2QCye7gaA3ii4ndd+o35O4MDmegRrMm3Ogg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -18001,7 +18023,10 @@
               "target_settings": {},
               "unfiltered_compile_flags": {},
               "toolchain_roots": {},
-              "sysroot": {}
+              "sysroot": {
+                "linux-x86_64": "'@@_main~non_module_dependencies~x86_64_sysroot//:sysroot'",
+                "linux-aarch64": "'@@_main~non_module_dependencies~aarch64_sysroot//:sysroot'"
+              }
             }
           },
           "llvm_18_toolchain_llvm": {
@@ -18060,7 +18085,10 @@
               "target_settings": {},
               "unfiltered_compile_flags": {},
               "toolchain_roots": {},
-              "sysroot": {}
+              "sysroot": {
+                "linux-x86_64": "'@@_main~non_module_dependencies~x86_64_sysroot//:sysroot'",
+                "linux-aarch64": "'@@_main~non_module_dependencies~aarch64_sysroot//:sysroot'"
+              }
             }
           }
         },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,7 +19,8 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/MODULE.bazel": "780d1a6522b28f5edb7ea09630748720721dfe27690d65a2d33aa7509de77e07",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/source.json": "a9ee2898e86eb8106e67b2adcd63de788cd922dd82f90f6775f13b0bf2248d75",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
@@ -28,6 +29,7 @@
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
@@ -159,6 +161,8 @@
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
+    "https://bcr.bazel.build/modules/rules_oci/2.0.1/MODULE.bazel": "b1984eceba83906786f99e7e8273754458e1c5f3d39e3b0b28f03d12be9d4099",
+    "https://bcr.bazel.build/modules/rules_oci/2.0.1/source.json": "70f86dc00a62cde2103e8c50b8fd1f120252f2cb735ecce8aba3842ff1b5875f",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -480,8 +484,8 @@
     },
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "wbW/fEUW6Ya4TMFK5PPIgAwWuJm4AQFeqnOO5DbiZjw=",
-        "usagesDigest": "2yV4A8xZ6FZbGGe74q8xCktC2QFZ9qOJZI8VbIbhxtE=",
+        "bzlTransitiveDigest": "qjpcu+jbmeT2L5+ioH/HKy64NswEV29s9cVZee/Nh3Y=",
+        "usagesDigest": "qhOn8OLBOBx2XwRV+kp+hSHWNb3MegweEDuWaTk1Gvk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -589,7 +593,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "darwin_amd64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq_darwin_arm64": {
@@ -597,7 +601,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "darwin_arm64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq_linux_amd64": {
@@ -605,7 +609,15 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "linux_amd64",
-              "version": "1.6"
+              "version": "1.7"
+            }
+          },
+          "jq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
             }
           },
           "jq_windows_amd64": {
@@ -613,7 +625,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "windows_amd64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq": {
@@ -701,7 +713,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "darwin_amd64",
-              "version": "0.0.16"
+              "version": "0.0.23"
             }
           },
           "coreutils_darwin_arm64": {
@@ -709,7 +721,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "darwin_arm64",
-              "version": "0.0.16"
+              "version": "0.0.23"
             }
           },
           "coreutils_linux_amd64": {
@@ -717,7 +729,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "linux_amd64",
-              "version": "0.0.16"
+              "version": "0.0.23"
             }
           },
           "coreutils_linux_arm64": {
@@ -725,7 +737,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "linux_arm64",
-              "version": "0.0.16"
+              "version": "0.0.23"
             }
           },
           "coreutils_windows_amd64": {
@@ -733,7 +745,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "windows_amd64",
-              "version": "0.0.16"
+              "version": "0.0.23"
             }
           },
           "coreutils_toolchains": {
@@ -741,6 +753,83 @@
             "ruleClassName": "coreutils_toolchains_repo",
             "attributes": {
               "user_repository_name": "coreutils"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "zstd_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "zstd_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "zstd_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
             }
           },
           "expand_template_darwin_amd64": {
@@ -791,6 +880,54 @@
             "attributes": {
               "user_repository_name": "expand_template"
             }
+          },
+          "bats_support": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
+              "urls": [
+                "https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz"
+              ],
+              "strip_prefix": "bats-support-0.3.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"support\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-support\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_assert": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd",
+              "urls": [
+                "https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz"
+              ],
+              "strip_prefix": "bats-assert-2.1.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"assert\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-assert\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_file": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b69043241f3af1c2d251f89b4fcafa5df3f05e97b89db18d7c9bdf5731bb27a",
+              "urls": [
+                "https://github.com/bats-core/bats-file/archive/v0.4.0.tar.gz"
+              ],
+              "strip_prefix": "bats-file-0.4.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"file\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-file\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_toolchains": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd",
+              "urls": [
+                "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
+              ],
+              "strip_prefix": "bats-core-1.10.0",
+              "build_file_content": "load(\"@local_config_platform//:constraints.bzl\", \"HOST_CONSTRAINTS\")\nload(\"@aspect_bazel_lib//lib/private:bats_toolchain.bzl\", \"bats_toolchain\")\nload(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"core\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"lib/**\",\n        \"libexec/**\"\n    ]) + [\"bin/bats\"],\n    out = \"bats-core\",\n)\n\nbats_toolchain(\n    name = \"toolchain\",\n    core = \":core\",\n    libraries = [\"@bats_support//:support\", \"@bats_assert//:assert\", \"@bats_file//:file\"]\n)\n\ntoolchain(\n    name = \"bats_toolchain\",\n    exec_compatible_with = HOST_CONSTRAINTS,\n    toolchain = \":toolchain\",\n    toolchain_type = \"@aspect_bazel_lib//lib:bats_toolchain_type\",\n)\n"
+            }
           }
         },
         "recordedRepoMappingEntries": [
@@ -814,7 +951,7 @@
     },
     "@@aspect_rules_js~//npm:extensions.bzl%pnpm": {
       "general": {
-        "bzlTransitiveDigest": "91jQ4cygqES+YTD1rq/AkD6GDg2XfwQUiCQEHxfwGXk=",
+        "bzlTransitiveDigest": "OLfAUMH0E9EQTAR7o6nH+CrPopEtjGmXkkiIyOaoFhg=",
         "usagesDigest": "1hU324o/rWis1wprOwPM+3YiIXklZvJ5jfmEbzKAClo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1853,6 +1990,490 @@
             "rules_nodejs~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_oci~//oci:extensions.bzl%oci": {
+      "general": {
+        "bzlTransitiveDigest": "612bAPF69Efx2if4/X+sVqL4u+ZvydZdBke/ubclGYw=",
+        "usagesDigest": "kzrX00V/p/4kqlabkS8l3pKFqv18ea8syZvAmvCfFh8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "distroless_cc_debian12_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/cc-debian12",
+              "identifier": "sha256:594b5200fd1f06d17a877ebee16d4af84a9a7ab83c898632a2d5609c0593cbab",
+              "platform": "linux/amd64",
+              "target_name": "distroless_cc_debian12_linux_amd64",
+              "bazel_tags": []
+            }
+          },
+          "distroless_cc_debian12_linux_arm64_v8": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/cc-debian12",
+              "identifier": "sha256:594b5200fd1f06d17a877ebee16d4af84a9a7ab83c898632a2d5609c0593cbab",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_cc_debian12_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
+          "distroless_cc_debian12": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_alias",
+            "attributes": {
+              "target_name": "distroless_cc_debian12",
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/cc-debian12",
+              "identifier": "sha256:594b5200fd1f06d17a877ebee16d4af84a9a7ab83c898632a2d5609c0593cbab",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@distroless_cc_debian12_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_cc_debian12_linux_arm64_v8"
+              },
+              "bzlmod_repository": "distroless_cc_debian12",
+              "reproducible": true
+            }
+          },
+          "bazel_features_version": {
+            "bzlFile": "@@bazel_features~//private:version_repo.bzl",
+            "ruleClassName": "version_repo",
+            "attributes": {}
+          },
+          "bazel_features_globals": {
+            "bzlFile": "@@bazel_features~//private:globals_repo.bzl",
+            "ruleClassName": "globals_repo",
+            "attributes": {
+              "globals": {
+                "CcSharedLibraryInfo": "6.0.0-pre.20220630.1",
+                "CcSharedLibraryHintInfo": "7.0.0-pre.20230316.2",
+                "PackageSpecificationInfo": "6.4.0",
+                "RunEnvironmentInfo": "5.3.0",
+                "DefaultInfo": "0.0.1",
+                "__TestingOnly_NeverAvailable": "1000000000.0.0"
+              },
+              "legacy_globals": {
+                "JavaInfo": "8.0.0",
+                "JavaPluginInfo": "8.0.0",
+                "ProtoInfo": "8.0.0",
+                "PyCcLinkParamsProvider": "8.0.0",
+                "PyInfo": "8.0.0",
+                "PyRuntimeInfo": "8.0.0"
+              }
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"
+              ]
+            }
+          },
+          "jq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.7"
+            }
+          },
+          "jq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
+            }
+          },
+          "jq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.23"
+            }
+          },
+          "coreutils_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "zstd_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "zstd_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "zstd_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
+            }
+          },
+          "oci_crane_darwin_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_darwin_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_linux_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_linux_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_armv6",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_linux_i386": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_i386",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_linux_s390x": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_windows_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "windows_armv6",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_windows_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_toolchains": {
+            "bzlFile": "@@rules_oci~//oci/private:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "toolchain_type": "@rules_oci//oci:crane_toolchain_type",
+              "toolchain": "@oci_crane_{platform}//:crane_toolchain"
+            }
+          },
+          "oci_regctl_darwin_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "oci_regctl_darwin_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "oci_regctl_linux_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "oci_regctl_linux_s390x": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_s390x"
+            }
+          },
+          "oci_regctl_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "oci_regctl_windows_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "oci_regctl_toolchains": {
+            "bzlFile": "@@rules_oci~//oci/private:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "toolchain_type": "@rules_oci//oci:regctl_toolchain_type",
+              "toolchain": "@oci_regctl_{platform}//:regctl_toolchain"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "distroless_cc_debian12",
+            "distroless_cc_debian12_linux_amd64",
+            "distroless_cc_debian12_linux_arm64_v8"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_oci~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "rules_oci~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_oci~",
+            "bazel_skylib",
+            "bazel_skylib~"
           ]
         ]
       }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5574,7 +5574,7 @@
     "@@rules_rust~//rust:extensions.bzl%rust": {
       "general": {
         "bzlTransitiveDigest": "CILmbFT+SqDrQsN+vw/1IK15ku1PEmcYfkxJ53yyIvE=",
-        "usagesDigest": "N7it+zhc3dkqHc4KtgIXxFFRhT0KdBYoegcwutuRhl4=",
+        "usagesDigest": "glh6v9y4udxz+afNeq1OFjowZm/6CEnkLoGTAqunkKA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bazel/install-deps.sh
+++ b/bazel/install-deps.sh
@@ -34,8 +34,6 @@ deb_deps=(
   make
   pkgconf
   ragel
-  valgrind
-  xfslibs-dev
   sudo
 )
 
@@ -48,8 +46,6 @@ fedora_deps=(
   libtool
   perl
   ragel
-  valgrind-devel
-  xfsprogs-devel
   xorg-x11-util-macros
   sudo
 )

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -1,111 +1,33 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load(":packaging.bzl", "redpanda_package")
 
-pkg_files(
-    name = "redpanda_binary_with_runfiles",
-    srcs = ["//src/v/redpanda"],
-    attributes = pkg_attributes(
-        mode = "0755",
-    ),
-    # Including runfiles has the effect of copying all of the shared libraries needed to run the binary.
-    # Although they always retain the directory structure that is found in bazel build output, meaning
-    # that `strip_prefix` has no effect on runfiles here (so we strip_prefix in the other targets).
-    include_runfiles = True,
-)
-
-pkg_files(
-    name = "redpanda_lib",
-    srcs = [":redpanda_binary_with_runfiles"],
-    # Exclude the redpanda binary, but this will still keep the runfiles, which for the redpanda
-    # binary is the shared libraries.
-    excludes = ["//src/v/redpanda"],
-    prefix = "lib",
-    # This flattens the files so that everything is directly in the `lib` folder.
-    strip_prefix = strip_prefix.files_only(),
-)
-
-pkg_files(
-    name = "redpanda_libexec",
-    srcs = [
-        "//src/go/rpk/cmd/rpk",
-        "//src/v/redpanda",
-    ],
-    attributes = pkg_attributes(
-        mode = "0755",
-    ),
-    prefix = "libexec",
-    # This flattens the files so that everything is directly in the `libexec` folder.
-    strip_prefix = strip_prefix.files_only(),
-)
-
-pkg_files(
-    name = "redpanda_conf",
-    srcs = ["//conf:redpanda.yaml"],
-    prefix = "etc/redpanda",
-    # This flattens the files so that everything is directly in the `etc/redpanda` folder.
-    strip_prefix = strip_prefix.files_only(),
-)
-
-pkg_files(
-    name = "redpanda_bin",
-    srcs = [
+redpanda_package(
+    name = "redpanda_tar",
+    out = "redpanda.tar.gz",
+    bin_wrappers = [
         "//bazel/packaging/bin_wrapper:redpanda",
         "//bazel/packaging/bin_wrapper:rpk",
     ],
-    attributes = pkg_attributes(
-        mode = "0755",
-    ),
-    prefix = "bin",
-    # This flattens the files so that everything is directly in the `bin` folder.
-    strip_prefix = strip_prefix.files_only(),
-)
-
-# TODO(bazel): Pull in all the system libraries that are still depended on and not packaged yet.
-# TODO(bazel): Add the other binaries we package (rp_util, hwloc, rpk, etc)
-pkg_tar(
-    name = "redpanda_tar",
-    srcs = [
-        ":redpanda_bin",
-        ":redpanda_lib",
-        ":redpanda_libexec",
-    ],
-    # This is also needed because it actually specifies compression.
-    extension = ".tar.gz",
-    package_file_name = "redpanda.tar.gz",
-)
-
-pkg_tar(
-    name = "redpanda_image_broker_files",
-    srcs = [
-        ":redpanda_bin",
-        ":redpanda_lib",
-        ":redpanda_libexec",
-    ],
-    package_dir = "/opt/redpanda",
+    default_yaml_config = "//conf:redpanda.yaml",
+    redpanda_binary = "//:redpanda",
+    rpk_binary = "//:rpk",
 )
 
 # This is the ID for the nonroot user in the distroless containers.
-NONROOT_USER = "65532"
+NONROOT_USER = 65532
 
-pkg_tar(
-    name = "redpanda_image_config_files",
-    srcs = [
-        ":redpanda_conf",
+redpanda_package(
+    name = "oci_image_contents",
+    out = "redpanda_nonroot.tar.gz",
+    bin_wrappers = [
+        "//bazel/packaging/bin_wrapper:redpanda",
+        "//bazel/packaging/bin_wrapper:rpk",
     ],
-    mode = "0o555",
-    owner = NONROOT_USER + "." + NONROOT_USER,
-    package_dir = "/etc/redpanda",
-)
-
-pkg_tar(
-    name = "redpanda_image_writable_dirs",
-    empty_dirs = [
-        "/etc/redpanda",
-        "/var/lib/redpanda/data",
-    ],
-    mode = "0o755",
-    owner = NONROOT_USER + "." + NONROOT_USER,
+    default_yaml_config = "//conf:redpanda.yaml",
+    owner = NONROOT_USER,
+    redpanda_binary = "//:redpanda",
+    rpk_binary = "//:rpk",
 )
 
 oci_image(
@@ -125,9 +47,7 @@ oci_image(
     ],
     labels = {"org.opencontainers.image.authors": "Redpanda Data <hi@redpanda.com>"},
     tars = [
-        ":redpanda_image_broker_files",
-        ":redpanda_image_config_files",
-        ":redpanda_image_writable_dirs",
+        ":oci_image_contents",
     ],
     user = "nonroot",
     volumes = ["/var/lib/redpanda/data"],
@@ -137,4 +57,17 @@ oci_load(
     name = "image_load",
     image = ":image",
     repo_tags = ["redpandadata/redpanda-dev:latest"],
+)
+
+go_binary(
+    name = "tool",
+    embed = [":packaging_lib"],
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "packaging_lib",
+    srcs = ["tool.go"],
+    importpath = "github.com/redpanda-data/redpanda/bazel/packaging",
+    visibility = ["//visibility:private"],
 )

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -1,10 +1,13 @@
-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 pkg_files(
     name = "redpanda_binary_with_runfiles",
     srcs = ["//src/v/redpanda"],
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
     # Including runfiles has the effect of copying all of the shared libraries needed to run the binary.
     # Although they always retain the directory structure that is found in bazel build output, meaning
     # that `strip_prefix` has no effect on runfiles here (so we strip_prefix in the other targets).
@@ -24,24 +27,32 @@ pkg_files(
 
 pkg_files(
     name = "redpanda_libexec",
-    srcs = ["//src/v/redpanda"],
+    srcs = [
+        "//src/go/rpk/cmd/rpk",
+        "//src/v/redpanda",
+    ],
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
     prefix = "libexec",
     # This flattens the files so that everything is directly in the `libexec` folder.
     strip_prefix = strip_prefix.files_only(),
 )
 
-expand_template(
-    name = "redpanda_binary_wrapper",
-    out = "redpanda",
-    substitutions = {
-        "%%BINARY%%": "redpanda",
-    },
-    template = "exec.tmpl.sh",
+pkg_files(
+    name = "redpanda_conf",
+    srcs = ["//conf:redpanda.yaml"],
+    prefix = "etc/redpanda",
+    # This flattens the files so that everything is directly in the `etc/redpanda` folder.
+    strip_prefix = strip_prefix.files_only(),
 )
 
 pkg_files(
     name = "redpanda_bin",
-    srcs = [":redpanda_binary_wrapper"],
+    srcs = [
+        "//bazel/packaging/bin_wrapper:redpanda",
+        "//bazel/packaging/bin_wrapper:rpk",
+    ],
     attributes = pkg_attributes(
         mode = "0755",
     ),
@@ -62,4 +73,68 @@ pkg_tar(
     # This is also needed because it actually specifies compression.
     extension = ".tar.gz",
     package_file_name = "redpanda.tar.gz",
+)
+
+pkg_tar(
+    name = "redpanda_image_broker_files",
+    srcs = [
+        ":redpanda_bin",
+        ":redpanda_lib",
+        ":redpanda_libexec",
+    ],
+    package_dir = "/opt/redpanda",
+)
+
+# This is the ID for the nonroot user in the distroless containers.
+NONROOT_USER = "65532"
+
+pkg_tar(
+    name = "redpanda_image_config_files",
+    srcs = [
+        ":redpanda_conf",
+    ],
+    mode = "0o555",
+    owner = NONROOT_USER + "." + NONROOT_USER,
+    package_dir = "/etc/redpanda",
+)
+
+pkg_tar(
+    name = "redpanda_image_writable_dirs",
+    empty_dirs = [
+        "/etc/redpanda",
+        "/var/lib/redpanda",
+    ],
+    mode = "0o755",
+    owner = NONROOT_USER + "." + NONROOT_USER,
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_cc_debian12",
+    cmd = [
+        "redpanda",
+        "start",
+        "--overprovisioned",
+    ],
+    entrypoint = ["/opt/redpanda/bin/rpk"],
+    exposed_ports = [
+        "8081",
+        "8082",
+        "9092",
+        "9644",
+    ],
+    labels = {"org.opencontainers.image.authors": "Redpanda Data <hi@redpanda.com>"},
+    tars = [
+        ":redpanda_image_broker_files",
+        ":redpanda_image_config_files",
+        ":redpanda_image_writable_dirs",
+    ],
+    user = "nonroot",
+    volumes = ["/var/lib/redpanda/data"],
+)
+
+oci_load(
+    name = "image_load",
+    image = ":image",
+    repo_tags = ["redpandadata/redpanda-dev:latest"],
 )

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -10,8 +10,16 @@ redpanda_package(
         "//bazel/packaging/bin_wrapper:rpk",
     ],
     default_yaml_config = "//conf:redpanda.yaml",
+    include_sysroot_libs = True,
     redpanda_binary = "//:redpanda",
     rpk_binary = "//:rpk",
+)
+
+redpanda_package(
+    name = "vtools_input",
+    out = "bazel_out.tar.gz",
+    include_sysroot_libs = True,
+    redpanda_binary = "//:redpanda",
 )
 
 # This is the ID for the nonroot user in the distroless containers.
@@ -30,6 +38,7 @@ redpanda_package(
     rpk_binary = "//:rpk",
 )
 
+# NOTE: this image is currently experimental, don't use this for production.
 oci_image(
     name = "image",
     base = "@distroless_cc_debian12",

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -102,7 +102,7 @@ pkg_tar(
     name = "redpanda_image_writable_dirs",
     empty_dirs = [
         "/etc/redpanda",
-        "/var/lib/redpanda",
+        "/var/lib/redpanda/data",
     ],
     mode = "0o755",
     owner = NONROOT_USER + "." + NONROOT_USER,

--- a/bazel/packaging/bin_wrapper/BUILD
+++ b/bazel/packaging/bin_wrapper/BUILD
@@ -5,7 +5,6 @@ load("@rules_go//go:def.bzl", "go_binary")
 go_binary(
     name = "rpk",
     srcs = ["main.go"],
-    pure = "on",
     visibility = ["//bazel/packaging:__pkg__"],
     x_defs = {
         "BinaryPath": "/opt/redpanda/libexec/rpk",
@@ -15,7 +14,6 @@ go_binary(
 go_binary(
     name = "redpanda",
     srcs = ["main.go"],
-    pure = "on",
     visibility = ["//bazel/packaging:__pkg__"],
     x_defs = {
         "BinaryPath": "/opt/redpanda/libexec/redpanda",

--- a/bazel/packaging/bin_wrapper/BUILD
+++ b/bazel/packaging/bin_wrapper/BUILD
@@ -7,7 +7,7 @@ go_binary(
     srcs = ["main.go"],
     visibility = ["//bazel/packaging:__pkg__"],
     x_defs = {
-        "BinaryPath": "/opt/redpanda/libexec/rpk",
+        "binaryPath": "/opt/redpanda/libexec/rpk",
     },
 )
 
@@ -16,7 +16,7 @@ go_binary(
     srcs = ["main.go"],
     visibility = ["//bazel/packaging:__pkg__"],
     x_defs = {
-        "BinaryPath": "/opt/redpanda/libexec/redpanda",
-        "LDLibraryPath": "/opt/redpanda/lib",
+        "binaryPath": "/opt/redpanda/libexec/redpanda",
+        "ldLibraryPath": "/opt/redpanda/lib",
     },
 )

--- a/bazel/packaging/bin_wrapper/BUILD
+++ b/bazel/packaging/bin_wrapper/BUILD
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_binary")
+
+# gazelle:ignore
+
+go_binary(
+    name = "rpk",
+    srcs = ["main.go"],
+    pure = "on",
+    visibility = ["//bazel/packaging:__pkg__"],
+    x_defs = {
+        "BinaryPath": "/opt/redpanda/libexec/rpk",
+    },
+)
+
+go_binary(
+    name = "redpanda",
+    srcs = ["main.go"],
+    pure = "on",
+    visibility = ["//bazel/packaging:__pkg__"],
+    x_defs = {
+        "BinaryPath": "/opt/redpanda/libexec/redpanda",
+        "LDLibraryPath": "/opt/redpanda/lib",
+    },
+)

--- a/bazel/packaging/bin_wrapper/main.go
+++ b/bazel/packaging/bin_wrapper/main.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	LDLibraryPath = ""
-	BinaryPath    = ""
+	ldLibraryPath = ""
+	binaryPath    = ""
 )
 
 func main() {
@@ -31,8 +31,8 @@ func main() {
 	}
 	env := slices.DeleteFunc(os.Environ(), func(envvar string) bool { return strings.HasPrefix(envvar, "PATH=") })
 	env = append(env, path)
-	if LDLibraryPath != "" {
-		env = append(env, "LD_LIBRARY_PATH="+LDLibraryPath)
+	if ldLibraryPath != "" {
+		env = append(env, "LD_LIBRARY_PATH="+ldLibraryPath)
 	}
-	syscall.Exec(BinaryPath, os.Args, env)
+	syscall.Exec(binaryPath, os.Args, env)
 }

--- a/bazel/packaging/bin_wrapper/main.go
+++ b/bazel/packaging/bin_wrapper/main.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package main
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"syscall"
+)
+
+var (
+	LDLibraryPath = ""
+	BinaryPath    = ""
+)
+
+func main() {
+	path := "PATH=/opt/redpanda/bin"
+	existingPath, ok := os.LookupEnv("PATH")
+	if ok {
+		path += string(os.PathListSeparator) + existingPath
+	}
+	env := slices.DeleteFunc(os.Environ(), func(envvar string) bool { return strings.HasPrefix(envvar, "PATH=") })
+	env = append(env, path)
+	if LDLibraryPath != "" {
+		env = append(env, "LD_LIBRARY_PATH="+LDLibraryPath)
+	}
+	syscall.Exec(BinaryPath, os.Args, env)
+}

--- a/bazel/packaging/exec.tmpl.sh
+++ b/bazel/packaging/exec.tmpl.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-export LD_LIBRARY_PATH="/opt/redpanda/lib"
-export PATH="/opt/redpanda/bin:${PATH}"
-exec -a "$0" "/opt/redpanda/libexec/%%BINARY%%" "$@"

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -1,0 +1,109 @@
+"""
+A rule to create a redpanda tarball given inputs from the build system.
+"""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _is_versioned_so(file):
+    """ Return true if this file has a name like libfoo.so.N """
+    parts = file.basename.rsplit(".", 3)
+    if len(parts) != 3:
+        return False
+    if not parts[0].startswith("lib"):
+        return False
+    if parts[1] != "so":
+        return False
+    for c in parts[2].elems():
+        if not c.isdigit():
+            return False
+    return True
+
+def _impl(ctx):
+    # Collect all shared libraries from the sysroot that we used.
+    shared_libraries = []
+    cc_toolchain = find_cpp_toolchain(ctx)
+    if cc_toolchain.sysroot != None:
+        for cc_file in cc_toolchain.all_files.to_list():
+            if cc_file.path.startswith(cc_toolchain.sysroot) and _is_versioned_so(cc_file):
+                # TODO(bazel): figure out how to make this work properly and slim down the
+                # base image even more.
+                # shared_libraries.append(cc_file)
+                pass
+
+    # Collect all the shared libraries that we built as part of Redpanda.
+    rp_runfiles = ctx.attr.redpanda_binary[DefaultInfo].default_runfiles.files.to_list()
+    for solib in rp_runfiles:
+        # Why the redpanda binary is marked as a runfile of itself? No idea...
+        if solib == ctx.file.redpanda_binary:
+            continue
+        shared_libraries.append(solib)
+
+    # Create the configuration file for the packaging tool
+    cfg_file = ctx.actions.declare_file("%s.config.json" % ctx.attr.name)
+    cfg = {
+        "redpanda_binary": ctx.file.redpanda_binary.path,
+        "rpk": ctx.file.rpk_binary.path,
+        "shared_libraries": [solib.path for solib in shared_libraries],
+        "default_yaml_config": ctx.file.default_yaml_config.path,
+        "bin_wrappers": [f.path for f in ctx.files.bin_wrappers],
+        "owner": ctx.attr.owner,
+    }
+    ctx.actions.write(cfg_file, content = json.encode_indent(cfg))
+
+    # run the packaging tool
+    ctx.actions.run(
+        outputs = [ctx.outputs.out],
+        inputs = [
+            cfg_file,
+            ctx.file.redpanda_binary,
+            ctx.file.rpk_binary,
+            ctx.file.default_yaml_config,
+        ] + ctx.files.bin_wrappers + shared_libraries,
+        tools = [ctx.executable._tool],
+        executable = ctx.executable._tool,
+        arguments = [
+            "-config",
+            cfg_file.path,
+            "-output",
+            ctx.outputs.out.path,
+        ],
+        mnemonic = "BuildingRedpandaPackage",
+        use_default_shell_env = False,
+    )
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+redpanda_package = rule(
+    implementation = _impl,
+    attrs = {
+        "redpanda_binary": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "default_yaml_config": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "bin_wrappers": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+        "rpk_binary": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "owner": attr.int(),
+        "out": attr.output(
+            mandatory = True,
+        ),
+        "_tool": attr.label(
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("//bazel/packaging:tool"),
+        ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type pkgConfig struct {
+	RedpandaBinary    string   `json:"redpanda_binary"`
+	RPKBinary         string   `json:"rpk"`
+	SharedLibraries   []string `json:"shared_libraries"`
+	DefaultYAMLConfig string   `json:"default_yaml_config"`
+	BinWrappers       []string `json:"bin_wrappers"`
+	Owner             int      `json:"owner"`
+}
+
+func createTarball(cfg pkgConfig, w io.Writer) error {
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+	writeFile := func(tarPath, fsPath string) error {
+		file, err := os.Open(fsPath)
+		if err != nil {
+			return err
+		}
+		info, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		err = tw.WriteHeader(&tar.Header{
+			Name:     tarPath,
+			Mode:     int64(info.Mode()),
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Unix(0, 0),
+			Uid:      cfg.Owner,
+			Gid:      cfg.Owner,
+			Size:     info.Size(),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, file)
+		return err
+	}
+	writeDir := func(path string) error {
+		return tw.WriteHeader(&tar.Header{
+			Name:     path,
+			Mode:     0755,
+			Typeflag: tar.TypeDir,
+			ModTime:  time.Unix(0, 0),
+			Uid:      cfg.Owner,
+			Gid:      cfg.Owner,
+		})
+	}
+	// Collect the layout of the tarball first, then execute creating the tarball,
+	// so that defining the structure is not muddied up with error handling.
+	var ops []func() error
+	file := func(tarPath, fsPath string) {
+		ops = append(ops, func() error { return writeFile(tarPath, fsPath) })
+	}
+	dir := func(path string) {
+		ops = append(ops, func() error { return writeDir(path) })
+	}
+
+	dir("etc/")
+	dir("etc/redpanda/")
+	file("etc/redpanda/redpanda.yaml", cfg.DefaultYAMLConfig)
+	dir("opt/")
+	dir("opt/redpanda/")
+	dir("opt/redpanda/bin/")
+	for _, bin := range cfg.BinWrappers {
+		file(filepath.Join("opt/redpanda/bin", filepath.Base(bin)), bin)
+	}
+	dir("opt/redpanda/lib/")
+	for _, so := range cfg.SharedLibraries {
+		file(filepath.Join("opt/redpanda/lib", filepath.Base(so)), so)
+	}
+	dir("opt/redpanda/libexec/")
+	file("opt/redpanda/libexec/redpanda", cfg.RedpandaBinary)
+	file("opt/redpanda/libexec/rpk", cfg.RPKBinary)
+	dir("var/")
+	dir("var/lib/")
+	dir("var/lib/redpanda/")
+	dir("var/lib/redpanda/data/")
+
+	// Now execute the above plan, handling errors.
+	for _, op := range ops {
+		if err := op(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runTool() error {
+	configPath := flag.String("config", "", "path to a configuration file to create the tarball")
+	output := flag.String("output", "redpanda.tar.gz", "the output .tar.gz location")
+	flag.Parse()
+	var cfg pkgConfig
+	if b, err := os.ReadFile(*configPath); err != nil {
+		return fmt.Errorf("unable to read file: %w", err)
+	} else if err := json.Unmarshal(b, &cfg); err != nil {
+		return fmt.Errorf("unable to parse config: %w", err)
+	}
+	file, err := os.OpenFile(*output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("unable to open output file: %w", err)
+	}
+	defer file.Close()
+	bw := bufio.NewWriter(file)
+	defer bw.Flush()
+	gw := gzip.NewWriter(bw)
+	defer gw.Close()
+	if err := createTarball(cfg, gw); err != nil {
+		return fmt.Errorf("unable to create tarball: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := runTool(); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to generate package: %s", err.Error())
+		os.Exit(1)
+	}
+}

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -29,9 +29,9 @@ import (
 
 type pkgConfig struct {
 	RedpandaBinary    string   `json:"redpanda_binary"`
-	RPKBinary         string   `json:"rpk"`
+	RPKBinary         *string  `json:"rpk"`
 	SharedLibraries   []string `json:"shared_libraries"`
-	DefaultYAMLConfig string   `json:"default_yaml_config"`
+	DefaultYAMLConfig *string  `json:"default_yaml_config"`
 	BinWrappers       []string `json:"bin_wrappers"`
 	Owner             int      `json:"owner"`
 }
@@ -83,9 +83,11 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 		ops = append(ops, func() error { return writeDir(path) })
 	}
 
-	dir("etc/")
-	dir("etc/redpanda/")
-	file("etc/redpanda/redpanda.yaml", cfg.DefaultYAMLConfig)
+	if cfg.DefaultYAMLConfig != nil {
+		dir("etc/")
+		dir("etc/redpanda/")
+		file("etc/redpanda/redpanda.yaml", *cfg.DefaultYAMLConfig)
+	}
 	dir("opt/")
 	dir("opt/redpanda/")
 	dir("opt/redpanda/bin/")
@@ -98,7 +100,9 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 	}
 	dir("opt/redpanda/libexec/")
 	file("opt/redpanda/libexec/redpanda", cfg.RedpandaBinary)
-	file("opt/redpanda/libexec/rpk", cfg.RPKBinary)
+	if cfg.RPKBinary != nil {
+		file("opt/redpanda/libexec/rpk", *cfg.RPKBinary)
+	}
 	dir("var/")
 	dir("var/lib/")
 	dir("var/lib/redpanda/")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -197,3 +197,23 @@ def data_dependency():
         strip_prefix = "xxHash-bbb27a5efb85b92a0486cf361a8635715a53f6ba",
         url = "https://github.com/Cyan4973/xxHash/archive/bbb27a5efb85b92a0486cf361a8635715a53f6ba.tar.gz",
     )
+
+    sysroot_build_file = """
+filegroup(
+  name = "sysroot",
+  srcs = glob(["*/**"]),
+  visibility = ["//visibility:public"],
+)"""
+    http_archive(
+        name = "x86_64_sysroot",
+        build_file_content = sysroot_build_file,
+        sha256 = "b7544f6931531eababde47d8723362bc9b3c9de8ef7d9a5d1d62d2e614904d5b",
+        urls = ["http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/sysroot-ubuntu-22.04-x86_64-2025-01-03.tar.gz"],
+    )
+
+    http_archive(
+        name = "aarch64_sysroot",
+        build_file_content = sysroot_build_file,
+        sha256 = "a2d8c3ce82c70f884281db846e756f5877f2c77964cbfb1ba6b954e1f759e2ed",
+        urls = ["http://redpanda-core-toolchain.s3-website-us-east-1.amazonaws.com/sysroot-ubuntu-22.04-aarch64-2025-01-03.tar.gz"],
+    )

--- a/bazel/thirdparty/seastar.bzl
+++ b/bazel/thirdparty/seastar.bzl
@@ -23,8 +23,9 @@ def seastar_cc_swagger_library(name, src, definitions = [], visibility = None):
         name = name + "_genrule",
         srcs = [src] + definitions,
         outs = [hh_out, cc_out],
-        cmd = "$(location @seastar//:seastar-json2code) --create-cc -f " + src_abs + " -o " + hh_out_abs,
+        cmd = "$(PYTHON3) $(location @seastar//:seastar-json2code) --create-cc -f " + src_abs + " -o " + hh_out_abs,
         tools = ["@seastar//:seastar-json2code"],
+        toolchains = ["@rules_python//python:current_py_toolchain"],
     )
 
     redpanda_cc_library(

--- a/bazel/toolchain/.gitignore
+++ b/bazel/toolchain/.gitignore
@@ -1,1 +1,1 @@
-llvm-*.tar.gz
+*.tar.gz

--- a/bazel/toolchain/Dockerfile.llvm
+++ b/bazel/toolchain/Dockerfile.llvm
@@ -14,7 +14,7 @@ ADD --chmod=755 https://github.com/kadwanev/retry/raw/20997c7712a4/retry /usr/bi
 
 WORKDIR /opt
 
-ARG LLVM_VERSION=17.0.6
+ARG LLVM_VERSION=19.1.6
 
 RUN git clone --branch llvmorg-${LLVM_VERSION} --single-branch https://github.com/llvm/llvm-project.git
 

--- a/bazel/toolchain/Dockerfile.sysroot
+++ b/bazel/toolchain/Dockerfile.sysroot
@@ -1,0 +1,37 @@
+FROM ubuntu:jammy AS pkgs
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y \
+    libc6 \
+    libc6-dev \
+    libc6-dbg \
+    libgcc-12-dev \
+    valgrind \
+    xfslibs-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy required glibc files
+RUN mkdir -p /output/pkgs/{usr/,}lib/$(uname -m)-linux-gnu /output/pkgs/usr/include /output/pkgs/lib64 \
+    && cp -r /usr/lib/*-linux-gnu/ld-linux-*.so* /output/pkgs/lib64/ \
+    && cp -r /usr/lib/*-linux-gnu/libc.{a,so}* /output/pkgs/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libc_nonshared.a* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libm.{a,so}* /output/pkgs/lib/$(uname -m)-linux-gnu/ \
+    && (if test $(uname -m) = "x86_64"; then cp -r /usr/lib/x86_64-linux-gnu/libmvec.{a,so}* /output/pkgs/lib/x86_64-linux-gnu/; fi) \
+    && cp -r /usr/lib/*-linux-gnu/libdl.{a,so}* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/librt.{a,so}* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libutil.{a,so}* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libpthread.{a,so}* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libgcc_s.so* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/*crt*.o /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/*-linux-gnu/libatomic.so* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/gcc/*-linux-gnu/12/*.o /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/lib/gcc/*-linux-gnu/12/libgcc*.{a,so}* /output/pkgs/usr/lib/$(uname -m)-linux-gnu/ \
+    && cp -r /usr/include/* /output/pkgs/usr/include/
+
+FROM scratch
+
+COPY --from=pkgs /output/pkgs /
+
+

--- a/bazel/toolchain/README.md
+++ b/bazel/toolchain/README.md
@@ -28,3 +28,23 @@ docker buildx build --platform=linux/arm64 --build-arg "LLVM_VERSION=17.0.6" --f
 
 By default we build with PGO+LTO, but if PGO is causing issues (like on AArch64), we can choose a different build (resulting
 in a slower compiler) by adding the flag `--target=lto`. The current default target is `--target=pgo`
+
+
+## Sysroot
+
+To make builds more hermetic we build with a sysroot from an older linux distro. These sysroots are crafted by creating a docker image with
+the correct packages in it, then extracting out the exact set of headers and shared libraries that are needed.
+
+To build an `x86_64` sysroot on an `x86_64` machine the following command can be used
+
+```
+OUTPUT_FILE="sysroot-ubuntu-22.04-x86_64-$(date --rfc-3339=date -u).tar.gz"
+docker build --file Dockerfile.sysroot --output type=tar,dest=- . | gzip > "$OUTPUT_FILE"
+```
+
+Building for `arm64` can be done from an `x86_64` host with the following command
+
+```
+OUTPUT_FILE="sysroot-ubuntu-22.04-aarch64-$(date --rfc-3339=date -u).tar.gz"
+docker buildx build --platform=linux/arm64 --file Dockerfile.sysroot --output type=tar,dest=- . | gzip > "$OUTPUT_FILE"
+```

--- a/src/go/rpk/cmd/rpk/BUILD
+++ b/src/go/rpk/cmd/rpk/BUILD
@@ -11,5 +11,6 @@ go_library(
 go_binary(
     name = "rpk",
     embed = [":rpk_lib"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/src/go/rpk/cmd/rpk/BUILD
+++ b/src/go/rpk/cmd/rpk/BUILD
@@ -11,6 +11,5 @@ go_library(
 go_binary(
     name = "rpk",
     embed = [":rpk_lib"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/src/v/kafka/protocol/schemata/generator.bzl
+++ b/src/v/kafka/protocol/schemata/generator.bzl
@@ -82,10 +82,11 @@ def generate_kafka_messages(name = "generate_kafka_messages"):
                     source,
                     header,
                 ],
-                cmd = "$(execpath //src/v/kafka/protocol/schemata:generator) $< $(OUTS)",
+                cmd = "$(PYTHON3) $(execpath //src/v/kafka/protocol/schemata:generator) $< $(OUTS)",
                 tools = [
                     "//src/v/kafka/protocol/schemata:generator",
                 ],
+                toolchains = ["@rules_python//python:current_py_toolchain"],
             )
 
             redpanda_cc_library(

--- a/src/v/rpc/compiler.bzl
+++ b/src/v/rpc/compiler.bzl
@@ -27,8 +27,9 @@ def redpanda_cc_rpc_library(name, src, out = None, deps = [], include_prefix = N
         name = name + "_genrule",
         srcs = [src],
         outs = [out],
-        cmd = "$(execpath //src/v/rpc:compiler) --service_file $< --output_file $@",
+        cmd = "$(PYTHON3) $(execpath //src/v/rpc:compiler) --service_file $< --output_file $@",
         tools = ["//src/v/rpc:compiler"],
+        toolchains = ["@rules_python//python:current_py_toolchain"],
     )
 
     rpc_template_deps = [

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright 2020 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License

--- a/src/v/version/expand_with_stamp_vars.bzl
+++ b/src/v/version/expand_with_stamp_vars.bzl
@@ -7,12 +7,14 @@ is not stamped (ie. dev builds).
 """
 
 def _expand_with_stamp_vars(ctx):
+    toolchain = ctx.toolchains[Label("@rules_python//python:toolchain_type")]
     ctx.actions.run(
         outputs = [ctx.outputs.out],
         inputs = [ctx.file.defaults_file, ctx.file.template, ctx.info_file],
-        tools = [ctx.executable._tool],
-        executable = ctx.executable._tool,
+        tools = [ctx.executable._tool, toolchain.py3_runtime.interpreter],
+        executable = toolchain.py3_runtime.interpreter,
         arguments = [
+            ctx.executable._tool.path,
             "--template",
             ctx.file.template.path,
             "--variables",
@@ -49,4 +51,7 @@ expand_with_stamp_vars = rule(
             mandatory = True,
         ),
     },
+    toolchains = [
+        "@rules_python//python:toolchain_type",
+    ],
 )

--- a/tests/docker/ducktape-deps/kafka-tools
+++ b/tests/docker/ducktape-deps/kafka-tools
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-for ver in  "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
+for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
 
   mkdir -p "/opt/kafka-${ver}"
   chmod a+rw "/opt/kafka-${ver}"


### PR DESCRIPTION
This patchset is two fold:

First and foremost we have a hermetic sysroot we compile against for all builds so now system dependencies should not leak into the build, and we can define them from a docker image. This means we can remove some dependencies from the `install-deps.sh` script.

Secondly, wire up a docker image that can run the broker using the [ultra slim distroless series of containers](https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#why-should-i-use-distroless-images). There is probably more we can do on the packaging front, but this is a good step. I moved the `LD_LIBRARY_PATH` script to a golang binary since bash is not installed on the distroless images. I'm also thinking that we could move completely to the base image that distroless provides (no shared libraries present), then copy in our shared libraries from our sysroot, but I'm punting on that for now.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
