### PR TITLE
[UX-61] Support Public API in `rpk security user`

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/storage/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/storage/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//src/go/rpk/pkg/cli/cluster/storage/recovery",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
-        "//src/go/rpk/pkg/publicapi",
         "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1alpha2",
         "@com_connectrpc_connect//:connect",
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",

--- a/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
@@ -46,8 +46,8 @@ Cancel a mount/unmount operation
 			out.MaybeDie(err, "invalid migration ID: %v", err)
 
 			if p.FromCloud {
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				req := connect.NewRequest(
 					&dataplanev1alpha2.UpdateMountTaskRequest{

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
@@ -60,8 +60,8 @@ Use filter to list only migrations in a specific state
 
 			var migrations []rpadmin.MigrationState
 			if p.FromCloud {
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.ListMountTasks(cmd.Context(), connect.NewRequest(&dataplanev1alpha2.ListMountTasksRequest{}))
 				out.MaybeDie(err, "unable to list mount/unmount operations: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
@@ -41,8 +41,8 @@ List all mountable topics:
 
 			var mountableTopics []rpadmin.MountableTopic
 			if p.FromCloud {
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.ListMountableTopics(cmd.Context(), connect.NewRequest(&dataplanev1alpha2.ListMountableTopicsRequest{}))
 				out.MaybeDie(err, "unable to list mountable topics: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/storage/mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/mount.go
@@ -66,8 +66,8 @@ with my-new-topic as the new topic name
 				if an != "" && strings.ToLower(an) != "kafka" {
 					out.Die("Failed to parse '--to' flag: namespace %q not allowed. Only kafka topics can be mounted in Redpanda Cloud clusters", an)
 				}
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				topicMount := &dataplanev1alpha2.MountTopicsRequest_TopicMount{
 					SourceTopicReference: t,

--- a/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
@@ -51,8 +51,8 @@ Status for a mount/unmount operation
 
 			var mState rpadmin.MigrationState
 			if p.FromCloud {
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.GetMountTask(
 					cmd.Context(),

--- a/src/go/rpk/pkg/cli/cluster/storage/storage.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/storage.go
@@ -10,11 +10,8 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/storage/recovery"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -34,16 +31,4 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newListMountable(fs, p),
 	)
 	return cmd
-}
-
-func createDataplaneClient(p *config.RpkProfile) (*publicapi.DataPlaneClientSet, error) {
-	url, err := p.CloudCluster.CheckClusterURL()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster information from your profile: %v", err)
-	}
-	cl, err := publicapi.NewDataPlaneClientSet(url, p.CurrentAuth().AuthToken)
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize cloud client: %v", err)
-	}
-	return cl, nil
 }

--- a/src/go/rpk/pkg/cli/cluster/storage/unmount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/unmount.go
@@ -63,8 +63,8 @@ Unmount topic 'my-topic' from the cluster in the 'my-namespace'
 				if ns != "" && strings.ToLower(ns) != "kafka" {
 					out.Die("Namespace %q not allowed. Only kafka topics can be unmounted in Redpanda Cloud clusters", ns)
 				}
-				cl, err := createDataplaneClient(p)
-				out.MaybeDieErr(err)
+				cl, err := p.DataplaneClient()
+				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.UnmountTopics(
 					cmd.Context(),

--- a/src/go/rpk/pkg/cli/security/user/BUILD
+++ b/src/go/rpk/pkg/cli/security/user/BUILD
@@ -15,6 +15,8 @@ go_library(
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1alpha2",
+        "@com_connectrpc_connect//:connect",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/src/go/rpk/pkg/cli/security/user/user.go
+++ b/src/go/rpk/pkg/cli/security/user/user.go
@@ -10,6 +10,9 @@
 package user
 
 import (
+	"strings"
+
+	dataplanev1alpha2 "buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go/redpanda/api/dataplane/v1alpha2"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -38,4 +41,12 @@ true" in the redpanda section of your redpanda.yaml.
 		newUpdateCommand(fs, p),
 	)
 	return cmd
+}
+
+func stringToDataplaneMechanism(mechanism string) dataplanev1alpha2.SASLMechanism {
+	m := "SASL_MECHANISM_" + strings.ReplaceAll(strings.ToUpper(mechanism), "-", "_")
+	if sm, ok := dataplanev1alpha2.SASLMechanism_value[m]; ok {
+		return dataplanev1alpha2.SASLMechanism(sm)
+	}
+	return dataplanev1alpha2.SASLMechanism_SASL_MECHANISM_UNSPECIFIED
 }

--- a/src/go/rpk/pkg/config/BUILD
+++ b/src/go/rpk/pkg/config/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
         "//src/go/rpk/pkg/publicapi",
+        "@com_connectrpc_connect//:connect",
         "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -10,7 +10,6 @@
 package config
 
 import (
-	"connectrpc.com/connect"
 	"errors"
 	"fmt"
 	"os"
@@ -18,12 +17,12 @@ import (
 	"reflect"
 	"time"
 
+	"connectrpc.com/connect"
+	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-
-	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 )
 
 // DefaultRpkYamlPath returns the OS equivalent of ~/.config/rpk/rpk.yaml, if

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -10,6 +10,7 @@
 package config
 
 import (
+	"connectrpc.com/connect"
 	"errors"
 	"fmt"
 	"os"
@@ -359,6 +360,16 @@ func (p *RpkProfile) ActualConfig() (*RpkYaml, bool) {
 		return nil, false
 	}
 	return p.c.ActualRpkYaml()
+}
+
+// DataplaneClient creates a publicapi.DataPlaneClientSet with the information
+// loaded in the profile.
+func (p *RpkProfile) DataplaneClient(opts ...connect.ClientOption) (*publicapi.DataPlaneClientSet, error) {
+	url, err := p.CloudCluster.CheckClusterURL()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster information from your profile: %v", err)
+	}
+	return publicapi.NewDataPlaneClientSet(url, p.CurrentAuth().AuthToken, opts...)
 }
 
 // HasClientCredentials returns if both ClientID and ClientSecret are non-empty.

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -22,6 +22,7 @@ import (
 type DataPlaneClientSet struct {
 	Transform    transformServiceClient
 	CloudStorage dataplanev1alpha2connect.CloudStorageServiceClient
+	User         dataplanev1alpha2connect.UserServiceClient
 }
 
 // NewDataPlaneClientSet creates a Public API client set with the service
@@ -40,5 +41,6 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	return &DataPlaneClientSet{
 		Transform:    newTransformServiceClient(http.DefaultClient, host, authToken, opts...),
 		CloudStorage: dataplanev1alpha2connect.NewCloudStorageServiceClient(http.DefaultClient, host, opts...),
+		User:         dataplanev1alpha2connect.NewUserServiceClient(http.DefaultClient, host, opts...),
 	}, nil
 }


### PR DESCRIPTION
This change allows users with Cloud profiles to use 'rpk security user' commands, lifting the restriction on:

- create
- delete
- update
- list

Fixes UX-61

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* `rpk security user` is now available for users with Cloud profiles.