### PR TITLE
rpk: add the output of 'uptime' to debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -276,6 +276,8 @@ BARE-METAL
  - dmidecode: The DMI table contents. Only included if this command is run
    as root.
 
+ - System load average: As reported by 'uptime'
+
 KUBERNETES
 
  - Kubernetes Resources: Kubernetes manifests for all resources in the given 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -158,6 +158,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveSyslog(ps),
 		saveTopOutput(ctx, ps),
 		saveUname(ctx, ps),
+		saveUptime(ctx, ps),
 		saveVmstat(ctx, ps),
 	}
 
@@ -829,6 +830,13 @@ func saveFree(ctx context.Context, ps *stepParams) step {
 			filepath.Join(linuxUtilsRoot, "free.txt"),
 			"free",
 		)
+	}
+}
+
+// Saves the output of `uptime`.
+func saveUptime(ctx context.Context, ps *stepParams) step {
+	return func() error {
+		return writeCommandOutputToZip(ctx, ps, filepath.Join(linuxUtilsRoot, "uptime.txt"), "uptime")
 	}
 }
 


### PR DESCRIPTION
This will be only available on bare-metal deployments, saved in /utils/uptime.txt

```
$ cat 127.0.0.1-1735943102-bundle/utils/uptime.txt 
 14:25:21 up 1 day,  6:12,  1 user,  load average: 0.76, 0.96, 1.38
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* rpk: save the output of `uptime` to bare-metal debug bundles created through rpk.
