### PR TITLE
c/rm_stm: correct error codes

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -592,7 +592,7 @@ ss::future<tx::errc> rm_stm::abort_tx(
     auto synced_term = _insync_term;
     auto [producer, _] = maybe_create_producer(pid);
     if (pid != producer->id()) {
-        co_return cluster::errc::invalid_producer_epoch;
+        co_return tx::errc::invalid_producer_epoch;
     }
     co_return co_await producer->run_with_lock(
       [this, synced_term, tx_seq, timeout, producer](
@@ -1540,7 +1540,7 @@ void rm_stm::maybe_rearm_autoabort_timer(time_point_type deadline) {
 
 ss::future<tx::errc> rm_stm::abort_all_txes() {
     if (!co_await sync(_sync_timeout())) {
-        co_return cluster::errc::not_leader;
+        co_return tx::errc::stale;
     }
 
     tx::errc last_err = tx::errc::none;


### PR DESCRIPTION
Currently returned error codes are wrong because they get silently cast from `cluster::errc` to `tx::errc` via int.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
