### PR TITLE
[v24.2.x] tx/group compaction fixes

### DIFF
--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -1219,7 +1219,8 @@ ss::future<> archival_metadata_stm::apply_raft_snapshot(const iobuf&) {
       get_last_offset());
 }
 
-ss::future<> archival_metadata_stm::apply_local_snapshot(
+ss::future<raft::local_snapshot_applied>
+archival_metadata_stm::apply_local_snapshot(
   raft::stm_snapshot_header header, iobuf&& data) {
     auto snap = serde::from_iobuf<snapshot>(std::move(data));
 
@@ -1287,7 +1288,7 @@ ss::future<> archival_metadata_stm::apply_local_snapshot(
     } else {
         _last_clean_at = header.offset;
     }
-    co_return;
+    co_return raft::local_snapshot_applied::yes;
 }
 
 ss::future<raft::stm_snapshot>

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -305,7 +305,7 @@ private:
     ss::future<> do_apply(const model::record_batch& batch) override;
     ss::future<> apply_raft_snapshot(const iobuf&) override;
 
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
     ss::future<raft::stm_snapshot>
     take_local_snapshot(ssx::semaphore_units apply_units) override;

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -130,7 +130,7 @@ public:
           });
     }
 
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override {
         auto holder = _gate.hold();
         iobuf_parser parser(std::move(bytes));
@@ -144,6 +144,7 @@ public:
             }
         }
         _kvs = std::move(snap.kv_data);
+        co_return raft::local_snapshot_applied::yes;
     }
 
     ss::future<raft::stm_snapshot>

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -223,9 +223,9 @@ ss::future<> id_allocator_stm::write_snapshot() {
       .finally([this] { _is_writing_snapshot = false; });
 }
 
-ss::future<>
+ss::future<raft::local_snapshot_applied>
 id_allocator_stm::apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) {
-    return ss::make_exception_future<>(
+    return ss::make_exception_future<raft::local_snapshot_applied>(
       std::logic_error("id_allocator_stm doesn't support snapshots"));
 }
 

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -106,7 +106,7 @@ private:
       advance_state(int64_t, model::timeout_clock::duration);
 
     ss::future<> write_snapshot();
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
     ss::future<raft::stm_snapshot>
     take_local_snapshot(ssx::semaphore_units apply_units) override;

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -440,14 +440,14 @@ ss::future<> log_eviction_stm::apply_raft_snapshot(const iobuf&) {
     co_return;
 }
 
-ss::future<> log_eviction_stm::apply_local_snapshot(
+ss::future<raft::local_snapshot_applied> log_eviction_stm::apply_local_snapshot(
   raft::stm_snapshot_header header, iobuf&& data) {
     auto snapshot = serde::from_iobuf<snapshot_data>(std::move(data));
     vlog(
       _log.info, "Applying snapshot {} at offset: {}", snapshot, header.offset);
 
     _delete_records_eviction_offset = snapshot.effective_start_offset;
-    return ss::now();
+    co_return raft::local_snapshot_applied::yes;
 }
 
 ss::future<raft::stm_snapshot>

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -109,7 +109,7 @@ public:
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 protected:
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
 
     ss::future<raft::stm_snapshot>

--- a/src/v/cluster/rm_group_proxy.h
+++ b/src/v/cluster/rm_group_proxy.h
@@ -55,5 +55,8 @@ public:
 
     virtual ss::future<abort_group_tx_reply>
       abort_group_tx_locally(abort_group_tx_request) = 0;
+
+    virtual ss::future<get_producers_reply>
+      get_group_producers_locally(get_producers_request) = 0;
 };
 } // namespace cluster

--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -49,6 +49,8 @@ public:
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
+    ss::future<get_producers_reply>
+      get_producers_locally(get_producers_request);
     ss::future<> stop() {
         _as.request_abort();
         return ss::make_ready_future<>();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -260,7 +260,7 @@ private:
       tx::producer_ptr,
       std::optional<model::tx_seq>,
       model::timeout_clock::duration);
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
     ss::future<raft::stm_snapshot>
     take_local_snapshot(ssx::semaphore_units apply_units) override;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -599,7 +599,7 @@ fragmented_vector<tx_metadata> tm_stm::get_transactions_list() const {
     return ret;
 }
 
-ss::future<>
+ss::future<raft::local_snapshot_applied>
 tm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tm_ss_buf) {
     vassert(
       hdr.version >= tm_snapshot_v0::version
@@ -624,7 +624,7 @@ tm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tm_ss_buf) {
         vlog(_ctx_log.trace, "Applied snapshot at offset: {}", hdr.offset);
     }
 
-    return ss::now();
+    co_return raft::local_snapshot_applied::yes;
 }
 
 ss::future<raft::stm_snapshot>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -359,7 +359,7 @@ protected:
 
 private:
     std::optional<tx_metadata> find_tx(const kafka::transactional_id&);
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;
     ss::future<raft::stm_snapshot>
     take_local_snapshot(ssx::semaphore_units apply_units) override;

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -119,4 +119,10 @@ ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
     co_return co_await _tx_gateway_frontend.local().find_coordinator(r.tid);
 }
 
+ss::future<get_producers_reply> tx_gateway::get_producers(
+  get_producers_request request, rpc::streaming_context&) {
+    co_return co_await _tx_gateway_frontend.local().get_producers(
+      std::move(request));
+}
+
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -71,6 +71,9 @@ public:
     ss::future<find_coordinator_reply> find_coordinator(
       find_coordinator_request, rpc::streaming_context&) override;
 
+    ss::future<get_producers_reply>
+    get_producers(get_producers_request, rpc::streaming_context&) override;
+
 private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     rm_group_proxy* _rm_group_proxy;

--- a/src/v/cluster/tx_gateway.json
+++ b/src/v/cluster/tx_gateway.json
@@ -64,6 +64,11 @@
             "name": "find_coordinator",
             "input_type": "find_coordinator_request",
             "output_type": "find_coordinator_reply"
+        },
+        {
+            "name": "get_producers",
+            "input_type": "get_producers_request",
+            "output_type": "get_producers_reply"
         }
     ]
 }

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2980,4 +2980,67 @@ ss::future<tx::errc> tx_gateway_frontend::unsafe_abort_group_transaction(
     co_return result.ec;
 }
 
+ss::future<get_producers_reply>
+tx_gateway_frontend::get_producers(get_producers_request request) {
+    auto holder = _gate.hold();
+    const auto& ntp = request.ntp;
+    if (!_metadata_cache.local().contains(ntp)) {
+        co_return get_producers_reply{
+          .error_code = tx::errc::partition_not_exists};
+    }
+
+    auto leader_opt = _leaders.local().get_leader(ntp);
+    if (!leader_opt) {
+        co_return get_producers_reply{.error_code = tx::errc::leader_not_found};
+    }
+    auto leader = leader_opt.value();
+    if (leader == _self) {
+        auto shard = _shard_table.local().shard_for(ntp);
+        if (!shard.has_value()) {
+            co_return get_producers_reply{
+              .error_code = tx::errc::shard_not_found};
+        }
+        co_return co_await container().invoke_on(
+          shard.value(),
+          _ssg,
+          [request = std::move(request)](tx_gateway_frontend& local) mutable {
+              return local.get_producers_locally(std::move(request));
+          });
+    }
+    auto timeout = request.timeout;
+    auto result = co_await _connection_cache.local()
+                    .with_node_client<tx_gateway_client_protocol>(
+                      _self,
+                      ss::this_shard_id(),
+                      leader,
+                      model::timeout_clock::now() + timeout,
+                      [request = std::move(request),
+                       timeout](tx_gateway_client_protocol cp) mutable {
+                          return cp.get_producers(
+                            std::move(request),
+                            rpc::client_opts(
+                              model::timeout_clock::now() + timeout));
+                      });
+    if (result.has_error()) {
+        co_return get_producers_reply{.error_code = tx::errc::not_coordinator};
+    }
+    co_return std::move(result.value().data);
+}
+
+ss::future<get_producers_reply>
+tx_gateway_frontend::get_producers_locally(get_producers_request request) {
+    auto& ntp = request.ntp;
+    bool is_consumer_offsets_ntp = ntp.ns()
+                                     == model::kafka_consumer_offsets_nt.ns()
+                                   && ntp.tp.topic
+                                        == model::kafka_consumer_offsets_nt.tp;
+
+    if (is_consumer_offsets_ntp) {
+        co_return co_await _rm_group_proxy->get_group_producers_locally(
+          std::move(request));
+    }
+    co_return co_await _rm_partition_frontend.local().get_producers_locally(
+      std::move(request));
+}
+
 } // namespace cluster

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -2961,4 +2961,23 @@ ss::future<tx::errc> tx_gateway_frontend::do_delete_partition_from_tx(
     co_return tx::errc::none;
 }
 
+ss::future<tx::errc> tx_gateway_frontend::unsafe_abort_group_transaction(
+  kafka::group_id group,
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  model::timeout_clock::duration timeout) {
+    auto holder = _gate.hold();
+    vlog(
+      txlog.warn,
+      "Issuing an unsafe abort of group transaction, group: {}, pid: {}, seq: "
+      "{}, timeout: {}",
+      group,
+      pid,
+      tx_seq,
+      timeout);
+    auto result = co_await _rm_group_proxy->abort_group_tx(
+      std::move(group), pid, tx_seq, timeout);
+    co_return result.ec;
+}
+
 } // namespace cluster

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -72,6 +72,20 @@ public:
     ss::future<find_coordinator_reply>
       find_coordinator(kafka::transactional_id);
 
+    // This is unsafe because it does not do any required checks to see
+    // if a particular transaction is in progress and is a candidate for abort.
+    // For example if a transaction is committed by the coordinator and pending
+    // commit on the group, using this escape hatch to abort the transaction
+    // can cause correctness issues. To be used with caution as an escape hatch
+    // for aborting transactions that the group has lost track of are ok to
+    // be aborted. This situation usually is indicative of a bug in the
+    // implementation.
+    ss::future<tx::errc> unsafe_abort_group_transaction(
+      kafka::group_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
+
     ss::future<> stop();
 
 private:

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -86,6 +86,8 @@ public:
       model::tx_seq,
       model::timeout_clock::duration);
 
+    ss::future<get_producers_reply> get_producers(get_producers_request);
+
     ss::future<> stop();
 
 private:
@@ -292,6 +294,9 @@ private:
       tx_metadata,
       model::timeout_clock::duration,
       bool ignore_update_ts);
+
+    ss::future<get_producers_reply>
+      get_producers_locally(get_producers_request);
 
     friend tx_gateway;
 };

--- a/src/v/cluster/tx_protocol_types.cc
+++ b/src/v/cluster/tx_protocol_types.cc
@@ -236,4 +236,54 @@ std::ostream& operator<<(std::ostream& o, const try_abort_reply& r) {
       r.ec);
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const idempotent_request_info& info) {
+    fmt::print(
+      o,
+      "{{ first: {}, last: {}, term: {} }}",
+      info.first_sequence,
+      info.last_sequence,
+      info.term);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const producer_state_info& info) {
+    fmt::print(
+      o,
+      "{{ pid: {}, inflight_requests: {}, finished: {}, begin offset: {}, end "
+      "offset: {}, sequence: {}, timeout: "
+      "{}, coordinator: {}, last_update: {}, group: {} }}",
+      info.pid,
+      info.inflight_requests,
+      info.finished_requests,
+      info.tx_begin_offset,
+      info.tx_end_offset,
+      info.tx_seq,
+      info.tx_timeout,
+      info.coordinator_partition,
+      info.last_update,
+      info.group_id);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const get_producers_reply& r) {
+    fmt::print(
+      o,
+      "{{ ec: {}, producers: {} , count: {} }}",
+      r.error_code,
+      r.producers,
+      r.producer_count);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const get_producers_request& r) {
+    fmt::print(
+      o,
+      "{{ ntp: {} timeout: {}, max_producers_to_include: {} }}",
+      r.ntp,
+      r.timeout,
+      r.max_producers_to_include);
+    return o;
+}
+
 } // namespace cluster

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2530,12 +2530,20 @@ ss::future<error_code> group::remove() {
         co_return error_code::group_id_not_found;
 
     case group_state::empty:
-        set_state(group_state::dead);
         break;
 
     default:
         co_return error_code::non_empty_group;
     }
+
+    // check if there are any transactions in progress
+    // tombstoning a group with open transactions will result
+    // in hanging transactions in the log.
+    if (has_transactions_in_progress()) {
+        co_return error_code::non_empty_group;
+    }
+
+    set_state(group_state::dead);
 
     // build offset tombstones
     storage::record_batch_builder builder(
@@ -3504,14 +3512,18 @@ group::get_expired_offsets(std::chrono::seconds retention_period) {
     }
 }
 
+bool group::has_transactions_in_progress() const {
+    return std::any_of(
+      _producers.begin(),
+      _producers.end(),
+      [](const producers_map::value_type& p) {
+          return p.second.transaction != nullptr;
+      });
+}
+
 bool group::has_offsets() const {
     return !_offsets.empty() || !_pending_offset_commits.empty()
-           || std::any_of(
-             _producers.begin(),
-             _producers.end(),
-             [](const producers_map::value_type& p) {
-                 return p.second.transaction != nullptr;
-             });
+           || has_transactions_in_progress();
 }
 
 std::vector<model::topic_partition>

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -175,11 +175,13 @@ bool group::valid_previous_state(group_state s) const {
 group::ongoing_transaction::ongoing_transaction(
   model::tx_seq tx_seq,
   model::partition_id coordinator_partition,
-  model::timeout_clock::duration tx_timeout)
+  model::timeout_clock::duration tx_timeout,
+  model::offset begin_offset)
   : tx_seq(tx_seq)
   , coordinator_partition(coordinator_partition)
   , timeout(tx_timeout)
-  , last_update(model::timeout_clock::now()) {}
+  , last_update(model::timeout_clock::now())
+  , begin_offset(begin_offset) {}
 
 group::tx_producer::tx_producer(model::producer_epoch epoch)
   : epoch(epoch) {}
@@ -1878,7 +1880,8 @@ group::begin_tx(cluster::begin_group_tx_request r) {
       r.pid.get_id(), r.pid.get_epoch());
     producer_it->second.epoch = r.pid.get_epoch();
     producer_it->second.transaction = std::make_unique<ongoing_transaction>(
-      ongoing_transaction(r.tx_seq, r.tm_partition, r.timeout));
+      ongoing_transaction(
+        r.tx_seq, r.tm_partition, r.timeout, result.value().last_offset));
 
     try_arm(producer_it->second.transaction->deadline());
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -202,6 +202,8 @@ public:
         std::unique_ptr<ongoing_transaction> transaction;
     };
 
+    using producers_map = chunked_hash_map<model::producer_id, tx_producer>;
+
     struct offset_metadata {
         model::offset log_offset;
         model::offset offset;
@@ -659,6 +661,8 @@ public:
         }
     }
 
+    const producers_map& producers() const { return _producers; }
+
     // helper for the kafka api: describe groups
     described_group describe() const;
 
@@ -715,7 +719,6 @@ public:
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;
-    using producers_map = chunked_hash_map<model::producer_id, tx_producer>;
 
     friend std::ostream& operator<<(std::ostream&, const group&);
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -843,6 +843,8 @@ private:
 
     bool has_offsets() const;
 
+    bool has_transactions_in_progress() const;
+
     bool has_pending_transaction(const model::topic_partition& tp) {
         if (std::any_of(
               _pending_offset_commits.begin(),

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -166,7 +166,10 @@ public:
      */
     struct ongoing_transaction {
         ongoing_transaction(
-          model::tx_seq, model::partition_id, model::timeout_clock::duration);
+          model::tx_seq,
+          model::partition_id,
+          model::timeout_clock::duration,
+          model::offset);
 
         model::tx_seq tx_seq;
         model::partition_id coordinator_partition;
@@ -175,6 +178,7 @@ public:
         model::timeout_clock::time_point last_update;
 
         bool is_expiration_requested{false};
+        model::offset begin_offset{-1};
 
         model::timeout_clock::time_point deadline() const {
             return last_update + timeout;

--- a/src/v/kafka/server/group_data_parser.h
+++ b/src/v/kafka/server/group_data_parser.h
@@ -111,7 +111,7 @@ protected:
               std::move(b));
             return handle_version_fence(fence);
         }
-        vlog(klog.warn, "ignoring batch with type: {}", b.header().type);
+        vlog(klog.debug, "ignoring batch with type: {}", b.header().type);
         return ss::make_ready_future<>();
     }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -978,7 +978,7 @@ ss::future<> group_manager::do_recover_group(
             if (session.tx) {
                 auto& tx = *session.tx;
                 group::ongoing_transaction group_tx(
-                  tx.tx_seq, tx.tm_partition, tx.timeout);
+                  tx.tx_seq, tx.tm_partition, tx.timeout, tx.begin_offset);
                 for (auto& [tp, o_md] : tx.offsets) {
                     group_tx.offsets[tp] = group::pending_tx_offset{
                   .offset_metadata = group_tx::partition_offset{

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -29,6 +29,7 @@
 #include "kafka/server/group.h"
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/group_recovery_consumer.h"
+#include "kafka/server/group_tx_tracker_stm.h"
 #include "kafka/server/logger.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
@@ -1618,6 +1619,64 @@ group_manager::describe_group(const model::ntp& ntp, const kafka::group_id& g) {
     }
 
     return group->describe();
+}
+
+group_manager::partition_producers
+group_manager::describe_partition_producers(const model::ntp& ntp) {
+    vlog(klog.debug, "describe producers: {}", ntp);
+    partition_producers response;
+    response.partition_index = ntp.tp.partition;
+    auto it = _partitions.find(ntp);
+    if (it == _partitions.end() || !it->second->partition->is_leader()) {
+        response.error_code = error_code::not_leader_for_partition;
+        return response;
+    }
+    response.error_code = kafka::error_code::none;
+    // snapshot the list of groups attached to this partition
+    chunked_vector<std::pair<group_id, group_ptr>> groups;
+    std::copy_if(
+      _groups.begin(),
+      _groups.end(),
+      std::back_inserter(groups),
+      [&ntp](const auto& g_pair) {
+          const auto& [group_id, group] = g_pair;
+          return group->partition()->ntp() == ntp;
+      });
+    for (auto& [gid, group] : groups) {
+        if (group->in_state(group_state::dead)) {
+            continue;
+        }
+        auto partition = group->partition();
+        if (!partition) {
+            // unlikely, conservative check
+            continue;
+        }
+        for (const auto& [id, state] : group->producers()) {
+            auto& tx = state.transaction;
+            int64_t start_offset = -1;
+            if (tx && tx->begin_offset >= model::offset{0}) {
+                start_offset = partition->get_offset_translator_state()
+                                 ->from_log_offset(tx->begin_offset);
+            }
+            int64_t last_timetamp = -1;
+            if (tx) {
+                auto time_since_last_update = model::timeout_clock::now()
+                                              - tx->last_update;
+                auto last_update_ts
+                  = (model::timestamp_clock::now() - time_since_last_update);
+                last_timetamp = last_update_ts.time_since_epoch() / 1ms;
+            }
+            response.active_producers.push_back({
+              .producer_id = id,
+              .producer_epoch = state.epoch,
+              .last_sequence = tx ? tx->tx_seq : -1,
+              .last_timestamp = last_timetamp,
+              .coordinator_epoch = -1,
+              .current_txn_start_offset = start_offset,
+            });
+        }
+    }
+    return response;
 }
 
 ss::future<std::vector<deletable_group_result>> group_manager::delete_groups(

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -204,6 +204,9 @@ public:
 
     size_t attached_partitions_count() const { return _partitions.size(); }
 
+    ss::future<cluster::get_producers_reply>
+      get_group_producers_locally(cluster::get_producers_request);
+
 public:
     error_code validate_group_status(
       const model::ntp& ntp, const group_id& group, api_key api);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -26,6 +26,7 @@
 #include "kafka/protocol/offset_delete.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "kafka/protocol/schemata/delete_groups_response.h"
+#include "kafka/protocol/schemata/describe_producers_response.h"
 #include "kafka/protocol/schemata/list_groups_response.h"
 #include "kafka/protocol/sync_group.h"
 #include "kafka/protocol/txn_offset_commit.h"
@@ -183,6 +184,9 @@ public:
     list_groups(const list_groups_filter_data& filter_data = {}) const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);
+
+    using partition_producers = partition_response;
+    partition_response describe_partition_producers(const model::ntp&);
 
     ss::future<std::vector<deletable_group_result>>
       delete_groups(std::vector<std::pair<model::ntp, group_id>>);

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -71,7 +71,8 @@ ss::future<> group_recovery_consumer::handle_fence_v1(
       pid.get_epoch(),
       data.tx_seq,
       data.transaction_timeout_ms,
-      model::partition_id(0));
+      model::partition_id(0),
+      header.base_offset);
     co_return;
 }
 
@@ -92,7 +93,8 @@ ss::future<> group_recovery_consumer::handle_fence(
       pid.get_epoch(),
       data.tx_seq,
       data.transaction_timeout_ms,
-      data.tm_partition);
+      data.tm_partition,
+      header.base_offset);
     co_return;
 }
 

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -167,17 +167,18 @@ void group_recovery_consumer::handle_record(model::record r) {
 }
 
 void group_recovery_consumer::handle_group_metadata(group_metadata_kv md) {
-    vlog(klog.trace, "[group: {}] recovered group metadata", md.key.group_id);
-
     if (md.value) {
         // until we switch over to a compacted topic or use raft snapshots,
         // always take the latest entry in the log.
+        vlog(
+          klog.trace, "[group: {}] recovered group metadata", md.key.group_id);
 
         auto [group_it, _] = _state.groups.try_emplace(
           md.key.group_id, group_stm());
         group_it->second.overwrite_metadata(std::move(*md.value));
     } else {
         // tombstone
+        vlog(klog.trace, "[group: {}] recovered tombstone", md.key.group_id);
         _state.groups.erase(md.key.group_id);
     }
 }

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -80,6 +80,18 @@ ss::future<> group_recovery_consumer::handle_fence(
   model::record_batch_header header, kafka::group_tx::fence_metadata data) {
     auto pid = model::producer_identity{
       header.producer_id, header.producer_epoch};
+    auto group_it = _state.groups.find(data.group_id);
+    if (group_it == _state.groups.end()) {
+        vlog(
+          klog.trace,
+          "[group: {}] group does not exist, ignoring tx fence version: {} for "
+          "producer: {} - {}",
+          data.group_id,
+          group::fence_control_record_version,
+          pid,
+          data);
+        co_return;
+    }
     vlog(
       klog.trace,
       "[group: {}] recovered tx fence version: {} for producer: {} - {}",
@@ -87,7 +99,6 @@ ss::future<> group_recovery_consumer::handle_fence(
       group::fence_control_record_version,
       pid,
       data);
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
     group_it->second.try_set_fence(
       pid.get_id(),
       pid.get_epoch(),
@@ -100,24 +111,43 @@ ss::future<> group_recovery_consumer::handle_fence(
 
 ss::future<> group_recovery_consumer::handle_abort(
   model::record_batch_header header, kafka::group_tx::abort_metadata data) {
+    auto pid = model::producer_identity{
+      header.producer_id, header.producer_epoch};
+    auto group_it = _state.groups.find(data.group_id);
+    if (group_it == _state.groups.end()) {
+        vlog(
+          klog.trace,
+          "[group: {}] group does not exist, ignoring abort for "
+          "producer: {} - sequence {}",
+          data.group_id,
+          pid,
+          data.tx_seq);
+        co_return;
+    }
     vlog(
       klog.trace,
       "[group: {}] recovered abort tx_seq: {}",
       data.group_id,
       data.tx_seq);
-    auto pid = model::producer_identity{
-      header.producer_id, header.producer_epoch};
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
     group_it->second.abort(pid, data.tx_seq);
     co_return;
 }
 
 ss::future<> group_recovery_consumer::handle_commit(
   model::record_batch_header header, kafka::group_tx::commit_metadata data) {
-    vlog(klog.trace, "[group: {}] recovered commit tx", data.group_id);
     auto pid = model::producer_identity{
       header.producer_id, header.producer_epoch};
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
+    auto group_it = _state.groups.find(data.group_id);
+    if (group_it == _state.groups.end()) {
+        vlog(
+          klog.trace,
+          "[group: {}] group does not exist, ignoring commit for "
+          "producer: {}",
+          data.group_id,
+          pid);
+        co_return;
+    }
+    vlog(klog.trace, "[group: {}] recovered commit tx", data.group_id);
     group_it->second.commit(pid);
     co_return;
 }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -104,7 +104,8 @@ void group_stm::try_set_fence(
   model::producer_epoch epoch,
   model::tx_seq txseq,
   model::timeout_clock::duration transaction_timeout_ms,
-  model::partition_id tm_partition) {
+  model::partition_id tm_partition,
+  model::offset fence_offset) {
     auto [it, _] = _producers.try_emplace(id, epoch);
     if (it->second.epoch <= epoch) {
         it->second.epoch = epoch;
@@ -112,6 +113,7 @@ void group_stm::try_set_fence(
           .tx_seq = txseq,
           .tm_partition = tm_partition,
           .timeout = transaction_timeout_ms,
+          .begin_offset = fence_offset,
           .offsets = {},
         });
     }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -31,7 +31,7 @@ void group_stm::update_tx_offset(
       it == _producers.end() || it->second.tx == nullptr
       || offset_md.pid.epoch != it->second.epoch) {
         vlog(
-          cluster::txlog.warn,
+          cluster::txlog.debug,
           "producer {} not found, skipping offsets update",
           offset_md.pid);
         return;
@@ -58,7 +58,7 @@ void group_stm::commit(model::producer_identity pid) {
       || pid.epoch != it->second.epoch) {
         // missing prepare may happen when the consumer log gets truncated
         vlog(
-          cluster::txlog.warn,
+          cluster::txlog.debug,
           "unable to find ongoing transaction for producer: {}, skipping "
           "commit",
           pid);

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -35,6 +35,7 @@ public:
         model::tx_seq tx_seq;
         model::partition_id tm_partition;
         model::timeout_clock::duration timeout;
+        model::offset begin_offset{-1};
         chunked_hash_map<model::topic_partition, group::offset_metadata>
           offsets;
     };
@@ -57,7 +58,8 @@ public:
       model::producer_epoch epoch,
       model::tx_seq txseq,
       model::timeout_clock::duration transaction_timeout_ms,
-      model::partition_id tm_partition);
+      model::partition_id tm_partition,
+      model::offset fence_offset);
 
     bool has_data() const {
         return !_is_removed && (_is_loaded || _offsets.size() > 0);

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -117,12 +117,14 @@ model::offset group_tx_tracker_stm::max_collectible_offset() {
     return result;
 }
 
-ss::future<> group_tx_tracker_stm::apply_local_snapshot(
+ss::future<raft::local_snapshot_applied>
+group_tx_tracker_stm::apply_local_snapshot(
   raft::stm_snapshot_header, iobuf&& snap_buf) {
     auto holder = _gate.hold();
     iobuf_parser parser(std::move(snap_buf));
     auto snap = co_await serde::read_async<snapshot>(parser);
     _all_txs = std::move(snap.transactions);
+    co_return raft::local_snapshot_applied::yes;
 }
 
 ss::future<raft::stm_snapshot>

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -119,8 +119,12 @@ model::offset group_tx_tracker_stm::max_collectible_offset() {
 
 ss::future<raft::local_snapshot_applied>
 group_tx_tracker_stm::apply_local_snapshot(
-  raft::stm_snapshot_header, iobuf&& snap_buf) {
+  raft::stm_snapshot_header header, iobuf&& snap_buf) {
     auto holder = _gate.hold();
+    if (header.version != supported_local_snapshot_version) {
+        // fall back to applying from the log
+        co_return raft::local_snapshot_applied::no;
+    }
     iobuf_parser parser(std::move(snap_buf));
     auto snap = co_await serde::read_async<snapshot>(parser);
     _all_txs = std::move(snap.transactions);
@@ -137,8 +141,8 @@ group_tx_tracker_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     iobuf snap_buf;
     apply_units.return_all();
     co_await serde::write_async(snap_buf, snap);
-    // snapshot versioning handled via serde.
-    co_return raft::stm_snapshot::create(0, offset, std::move(snap_buf));
+    co_return raft::stm_snapshot::create(
+      supported_local_snapshot_version, offset, std::move(snap_buf));
 }
 
 ss::future<> group_tx_tracker_stm::apply_raft_snapshot(const iobuf&) {

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -22,7 +22,33 @@ group_tx_tracker_stm::group_tx_tracker_stm(
   : raft::persisted_stm<>("group_tx_tracker_stm.snapshot", logger, raft)
   , group_data_parser<group_tx_tracker_stm>()
   , _feature_table(feature_table)
-  , _serializer(make_consumer_offsets_serializer()) {}
+  , _serializer(make_consumer_offsets_serializer()) {
+    _stale_tx_fence_gc_timer.set_callback([this] {
+        ssx::spawn_with_gate(
+          _gate, [this] { return gc_expired_tx_fence_transactions(); });
+    });
+    _stale_tx_fence_gc_timer.arm_periodic(tx_fence_gc_frequency);
+}
+
+ss::future<> group_tx_tracker_stm::gc_expired_tx_fence_transactions() {
+    auto holder = _gate.hold();
+    auto it = _all_txs.begin();
+    while (it != _all_txs.end()) {
+        it->second.gc_expired_tx_fence_transactions();
+        ++it;
+        if (ss::need_preempt() && it != _all_txs.end()) {
+            auto key_checkpoint = it->first;
+            co_await ss::yield();
+            it = _all_txs.lower_bound(key_checkpoint);
+        }
+    }
+}
+
+ss::future<> group_tx_tracker_stm::stop() {
+    vlog(klog.trace, "stopping...");
+    _stale_tx_fence_gc_timer.cancel();
+    return raft::persisted_stm<>::stop();
+}
 
 void group_tx_tracker_stm::maybe_add_tx_begin_offset(
   model::record_batch_type fence_type,
@@ -280,6 +306,24 @@ void group_tx_tracker_stm::per_group_state::maybe_add_tx_begin(
         begin_offsets.emplace(offset);
         producer_states[pid] = p_state;
         producer_to_begin_deprecated[pid] = offset;
+    }
+}
+
+void group_tx_tracker_stm::per_group_state::gc_expired_tx_fence_transactions() {
+    auto it = producer_states.begin();
+    while (it != producer_states.end()) {
+        if (it->second.expired_deprecated_fence_tx()) {
+            vlog(
+              klog.warn,
+              "Expiring stale tx_fence based begin tx at offset: {} for "
+              "producer: {}",
+              it->second.begin_offset,
+              it->first);
+            begin_offsets.erase(it->second.begin_offset);
+            it = producer_states.erase(it);
+            continue;
+        }
+        ++it;
     }
 }
 

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -71,27 +71,46 @@ public:
     ss::future<> handle_version_fence(features::feature_table::version_fence);
 
 private:
+    struct producer_tx_state
+      : serde::envelope<
+          producer_tx_state,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        model::record_batch_type fence_type;
+        model::offset begin_offset;
+        model::timestamp batch_ts;
+        model::timeout_clock::duration timeout;
+
+        auto serde_fields() {
+            return std::tie(fence_type, begin_offset, batch_ts, timeout);
+        }
+    };
     struct per_group_state
       : serde::envelope<
           per_group_state,
-          serde::version<0>,
+          serde::version<1>,
           serde::compat_version<0>> {
         per_group_state() = default;
 
-        per_group_state(model::producer_identity pid, model::offset offset) {
-            maybe_add_tx_begin(pid, offset);
-        }
-
-        void
-        maybe_add_tx_begin(model::producer_identity pid, model::offset offset);
+        void maybe_add_tx_begin(
+          model::record_batch_type fence_type,
+          model::producer_identity pid,
+          model::offset offset,
+          model::timestamp begin_ts,
+          model::timeout_clock::duration tx_timeout);
 
         absl::btree_set<model::offset> begin_offsets;
 
+        // deprecated
         absl::btree_map<model::producer_identity, model::offset>
-          producer_to_begin;
+          producer_to_begin_deprecated;
+
+        absl::btree_map<model::producer_identity, producer_tx_state>
+          producer_states;
 
         auto serde_fields() {
-            return std::tie(begin_offsets, producer_to_begin);
+            return std::tie(
+              begin_offsets, producer_to_begin_deprecated, producer_states);
         }
     };
     using all_txs_t = absl::btree_map<kafka::group_id, per_group_state>;
@@ -105,9 +124,14 @@ private:
     void handle_group_metadata(group_metadata_kv);
 
     void maybe_add_tx_begin_offset(
-      kafka::group_id, model::producer_identity, model::offset);
+      model::record_batch_type fence_type,
+      kafka::group_id,
+      model::producer_identity,
+      model::offset,
+      model::timestamp begin_ts,
+      model::timeout_clock::duration tx_timeout);
 
-    void maybe_end_tx(kafka::group_id, model::producer_identity);
+    void maybe_end_tx(kafka::group_id, model::producer_identity, model::offset);
 
     all_txs_t _all_txs;
 

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -102,6 +102,8 @@ private:
         auto serde_fields() { return std::tie(transactions); }
     };
 
+    void handle_group_metadata(group_metadata_kv);
+
     void maybe_add_tx_begin_offset(
       kafka::group_id, model::producer_identity, model::offset);
 
@@ -110,6 +112,7 @@ private:
     all_txs_t _all_txs;
 
     ss::sharded<features::feature_table>& _feature_table;
+    group_metadata_serializer _serializer;
 };
 
 class group_tx_tracker_stm_factory : public cluster::state_machine_factory {

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -96,7 +96,7 @@ public:
 
     model::offset max_collectible_offset() override;
 
-    ss::future<>
+    ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;
 
     ss::future<raft::stm_snapshot>

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -81,6 +81,8 @@ private:
         model::timestamp batch_ts;
         model::timeout_clock::duration timeout;
 
+        bool expired_deprecated_fence_tx() const;
+
         auto serde_fields() {
             return std::tie(fence_type, begin_offset, batch_ts, timeout);
         }
@@ -93,6 +95,7 @@ private:
         per_group_state() = default;
 
         void maybe_add_tx_begin(
+          const kafka::group_id&,
           model::record_batch_type fence_type,
           model::producer_identity pid,
           model::offset offset,

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -123,6 +123,7 @@ public:
     const all_txs_t& inflight_transactions() const { return _all_txs; }
 
 private:
+    static constexpr int8_t supported_local_snapshot_version = 1;
     struct snapshot
       : serde::envelope<snapshot, serde::version<0>, serde::compat_version<0>> {
         all_txs_t transactions;

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -24,7 +24,8 @@ class group_tx_tracker_stm final
 public:
     static constexpr std::string_view name = "group_tx_tracker_stm";
 
-    group_tx_tracker_stm(ss::logger&, raft::consensus*);
+    group_tx_tracker_stm(
+      ss::logger&, raft::consensus*, ss::sharded<features::feature_table>&);
 
     storage::stm_type type() override {
         return storage::stm_type::consumer_offsets_transactional;
@@ -107,13 +108,19 @@ private:
     void maybe_end_tx(kafka::group_id, model::producer_identity);
 
     all_txs_t _all_txs;
+
+    ss::sharded<features::feature_table>& _feature_table;
 };
 
 class group_tx_tracker_stm_factory : public cluster::state_machine_factory {
 public:
-    group_tx_tracker_stm_factory() = default;
+    explicit group_tx_tracker_stm_factory(
+      ss::sharded<features::feature_table>&);
     bool is_applicable_for(const storage::ntp_config&) const final;
     void create(raft::state_machine_manager_builder&, raft::consensus*) final;
+
+private:
+    ss::sharded<features::feature_table>& _feature_table;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -497,4 +497,13 @@ rm_group_frontend::abort_group_tx_locally(cluster::abort_group_tx_request req) {
     co_return reply;
 }
 
+ss::future<cluster::get_producers_reply>
+rm_group_frontend::get_group_producers_locally(
+  cluster::get_producers_request request) {
+    return _group_router.local()
+      .get_group_manager()
+      .local()
+      .get_group_producers_locally(std::move(request));
+}
+
 } // namespace kafka

--- a/src/v/kafka/server/rm_group_frontend.h
+++ b/src/v/kafka/server/rm_group_frontend.h
@@ -59,6 +59,8 @@ public:
       model::timeout_clock::duration);
     ss::future<cluster::abort_group_tx_reply>
       abort_group_tx_locally(cluster::abort_group_tx_request);
+    ss::future<cluster::get_producers_reply>
+      get_group_producers_locally(cluster::get_producers_request);
 
 private:
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
@@ -136,6 +138,11 @@ public:
     ss::future<cluster::abort_group_tx_reply>
     abort_group_tx_locally(cluster::abort_group_tx_request req) override {
         return _target.local().abort_group_tx_locally(std::move(req));
+    }
+
+    ss::future<cluster::get_producers_reply> get_group_producers_locally(
+      cluster::get_producers_request request) override {
+        return _target.local().get_group_producers_locally(std::move(request));
     }
 
 private:

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -209,7 +209,7 @@ struct cg_recovery_test_fixture : seastar_test {
     model::record_batch make_tx_fence_batch(
       const model::producer_identity& pid, group_tx::fence_metadata cmd) {
         return make_tx_batch(
-          model::record_batch_type::tx_fence,
+          model::record_batch_type::group_fence_tx,
           group::fence_control_record_version,
           pid,
           std::move(cmd));

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -22,16 +22,17 @@ static model::ntp offsets_ntp{
   model::kafka_consumer_offsets_nt.tp,
   model::partition_id{0}};
 
-struct disabled_compaction_fixture {
-    disabled_compaction_fixture() {
+struct custom_configs_fixture {
+    custom_configs_fixture() {
         // compaction is run manually in this test.
         cfg.get("log_disable_housekeeping_for_tests").set_value(true);
+        cfg.get("group_initial_rebalance_delay").set_value(0ms);
     }
     scoped_config cfg;
 };
 
 struct group_manager_fixture
-  : public disabled_compaction_fixture
+  : public custom_configs_fixture
   , public redpanda_thread_fixture
   , public seastar_test {
     ss::future<> SetUpAsync() override {
@@ -49,6 +50,18 @@ struct group_manager_fixture
                    && gm.local().attached_partitions_count() == 1;
         });
         co_await wait_for_version_fence();
+    }
+
+    auto join_group(kafka::join_group_request request) {
+        return app._group_manager.local().join_group(std::move(request)).result;
+    }
+
+    auto sync_group(kafka::sync_group_request request) {
+        return app._group_manager.local().sync_group(std::move(request)).result;
+    }
+
+    auto describe_group(kafka::group_id& group) {
+        return app._group_manager.local().describe_group(offsets_ntp, group);
     }
 
     auto begin_tx(cluster::begin_group_tx_request request) {
@@ -122,6 +135,40 @@ struct group_manager_fixture
 struct executable_op {
     virtual ~executable_op() = default;
     virtual ss::future<> execute(group_manager_fixture*) = 0;
+};
+
+struct join_group_op : public executable_op {
+    explicit join_group_op(kafka::group_id group)
+      : group(std::move(group)) {}
+
+    ss::future<> execute(group_manager_fixture* fixture) override {
+        vlog(logger.trace, "Executing join_group_op: {}", group);
+
+        kafka::join_group_request request;
+        request.data = kafka::join_group_request_data{
+          .group_id = group,
+          .session_timeout_ms = 300s,
+          .member_id = kafka::unknown_member_id,
+          .protocol_type = kafka::protocol_type{"test"},
+          .protocols = chunked_vector<kafka::join_group_request_protocol>{
+            {kafka::protocol_name("test"), bytes()}}};
+        request.ntp = offsets_ntp;
+        auto result = co_await fixture->join_group(std::move(request));
+        ASSERT_EQ_CORO(result.data.error_code, kafka::error_code::none);
+
+        kafka::sync_group_request sync_request;
+        sync_request.ntp = offsets_ntp;
+        sync_request.data = kafka::sync_group_request_data{
+          .group_id = group,
+          .generation_id = result.data.generation_id,
+          .member_id = result.data.member_id,
+        };
+
+        auto sync_result = co_await fixture->sync_group(
+          std::move(sync_request));
+        ASSERT_EQ_CORO(sync_result.data.error_code, kafka::error_code::none);
+    }
+    kafka::group_id group;
 };
 
 struct begin_tx_op : public executable_op {
@@ -220,6 +267,7 @@ random_ops generate_workload(workload_parameters params) {
     for (int i = 0; i < params.num_groups; i++) {
         std::queue<executable_op_ptr> group_ops;
         kafka::group_id id = next_group_id();
+        group_ops.emplace(ss::make_shared<join_group_op>(id));
         auto pid = model::random_producer_identity();
         for (int j = 0; j < params.num_tx_per_group; j++) {
             auto seq = model::tx_seq{j};
@@ -367,7 +415,7 @@ TEST_P_CORO(group_basic_workload_fixture, test_group_tx_stm_tracking) {
     auto log = consumer_offsets_log();
     // Generate a commit transaction.
     auto ops = generate_workload(GetParam());
-    ASSERT_EQ_CORO(ops.size(), 3);
+    ASSERT_EQ_CORO(ops.size(), 4);
 
     auto wait_until_stm_apply = [&] {
         return tests::cooperative_spin_wait_with_timeout(5s, [log, stm] {
@@ -380,19 +428,22 @@ TEST_P_CORO(group_basic_workload_fixture, test_group_tx_stm_tracking) {
           [&]() { return wait_until_stm_apply(); });
     };
 
+    // prep the group
+    co_await execute_op(0);
+
     co_await wait_until_stm_apply();
     // no transactions in flight
     ASSERT_EQ_CORO(
       stm->max_collectible_offset(), log->offsets().committed_offset);
     auto before = stm->max_collectible_offset();
     // begin transaction.
-    co_await execute_op(0);
-    ASSERT_EQ_CORO(stm->max_collectible_offset(), before);
-    // tx offset commit
     co_await execute_op(1);
     ASSERT_EQ_CORO(stm->max_collectible_offset(), before);
-    // end transaction
+    // tx offset commit
     co_await execute_op(2);
+    ASSERT_EQ_CORO(stm->max_collectible_offset(), before);
+    // end transaction
+    co_await execute_op(3);
     // ensure max collectible offset moved.
     ASSERT_GT_CORO(stm->max_collectible_offset(), before);
     ASSERT_EQ_CORO(

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -96,6 +96,10 @@ inline timestamp_clock::duration duration_since_epoch(timestamp ts) {
       std::chrono::milliseconds{ts.value()});
 }
 
+inline timestamp_clock::time_point to_time_point(timestamp ts) {
+    return timestamp_clock::time_point(std::chrono::milliseconds(ts.value()));
+}
+
 inline timestamp to_timestamp(timestamp_clock::time_point ts) {
     return timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
                        ts.time_since_epoch())

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -30,6 +30,9 @@ namespace raft {
 static constexpr const int8_t stm_snapshot_version_v0 = 0;
 static constexpr const int8_t stm_snapshot_version = 1;
 
+using local_snapshot_applied
+  = ss::bool_class<struct local_snapshot_applied_tag>;
+
 struct stm_snapshot_header {
     int8_t version{0};
     int32_t snapshot_size{0};
@@ -228,9 +231,12 @@ protected:
     virtual ss::future<> do_apply(const model::record_batch& b) = 0;
 
     /**
-     * Called when local snapshot is applied to the state machine
+     * Called when local snapshot is applied to the state machine. The state
+     * machine may choose to reject the snapshot if it wishes to in which case
+     * it will be hydrated from the log.
      */
-    virtual ss::future<> apply_local_snapshot(stm_snapshot_header, iobuf&&) = 0;
+    virtual ss::future<local_snapshot_applied>
+    apply_local_snapshot(stm_snapshot_header, iobuf&&) = 0;
 
     /**
      * Called when a local snapshot is taken. Apply fiber is stalled until

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -124,9 +124,11 @@ struct kv_state
 class persisted_kv : public persisted_stm<> {
 public:
     static constexpr std::string_view name = "persited_kv_stm";
-    explicit persisted_kv(raft_node_instance& rn)
+    explicit persisted_kv(
+      raft_node_instance& rn, bool reject_local_snapshots = false)
       : persisted_stm<>("simple-kv", logger, rn.raft().get())
-      , raft_node(rn) {}
+      , raft_node(rn)
+      , reject_local_snapshots(reject_local_snapshots) {}
 
     ss::future<> start() override { return persisted_stm<>::start(); }
     ss::future<> stop() override { return persisted_stm<>::stop(); }
@@ -157,10 +159,13 @@ public:
     /**
      * Called when local snapshot is applied to the state machine
      */
-    ss::future<>
-    apply_local_snapshot(stm_snapshot_header header, iobuf&& buffer) final {
+    ss::future<raft::local_snapshot_applied>
+    apply_local_snapshot(stm_snapshot_header, iobuf&& buffer) final {
+        if (reject_local_snapshots) {
+            co_return raft::local_snapshot_applied::no;
+        }
         state = serde::from_iobuf<kv_state>(std::move(buffer));
-        co_return;
+        co_return raft::local_snapshot_applied::yes;
     };
 
     /**
@@ -274,6 +279,7 @@ public:
     kv_state state;
     kv_operation last_operation;
     raft_node_instance& raft_node;
+    bool reject_local_snapshots = false;
 };
 
 class other_persisted_kv : public persisted_kv {
@@ -392,7 +398,8 @@ struct persisted_stm_test_fixture : state_machine_fixture {
         return ops;
     }
 
-    ss::future<> restart_cluster() {
+    ss::future<>
+    restart_cluster(bool reject_local_snapshots_after_restart = false) {
         absl::flat_hash_map<model::node_id, ss::sstring> data_directories;
         for (auto& [id, node] : nodes()) {
             data_directories[id]
@@ -407,7 +414,8 @@ struct persisted_stm_test_fixture : state_machine_fixture {
         for (auto& [_, node] : nodes()) {
             co_await node->initialise(all_vnodes());
             raft::state_machine_manager_builder builder;
-            auto stm = builder.create_stm<persisted_kv>(*node);
+            auto stm = builder.create_stm<persisted_kv>(
+              *node, reject_local_snapshots_after_restart);
             co_await node->start(std::move(builder));
             node_stms.emplace(node->get_vnode(), std::move(stm));
         }
@@ -475,10 +483,10 @@ public:
         co_return iobuf{};
     }
 
-    ss::future<>
-    apply_local_snapshot(stm_snapshot_header header, iobuf&& buffer) override {
+    ss::future<raft::local_snapshot_applied>
+    apply_local_snapshot(stm_snapshot_header, iobuf&& buffer) override {
         _last_stm_applied = serde::from_iobuf<model::offset>(std::move(buffer));
-        co_return;
+        co_return raft::local_snapshot_applied::yes;
     }
 
     ss::future<> validate_applied_offsets(model::offset before) {
@@ -593,6 +601,32 @@ TEST_F_CORO(persisted_stm_test_fixture, test_local_snapshot) {
     co_await wait_for_committed_offset(committed, 30s);
     co_await wait_for_apply();
 
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+}
+
+TEST_F_CORO(persisted_stm_test_fixture, test_skipping_local_snapshot_on_start) {
+    co_await initialize_state_machines();
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+    // take local snapshot on every node
+    co_await take_local_snapshot_on_every_node();
+
+    auto committed = node(model::node_id(0)).raft()->committed_offset();
+    // Reject snapshot loading
+    co_await restart_cluster(true);
+    co_await wait_for_committed_offset(committed, 30s);
+    co_await wait_for_apply();
+
+    // Ensure everything loaded from the log tallies
     for (const auto& [_, stm] : node_stms) {
         ASSERT_EQ_CORO(stm->state, expected);
     }

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -381,6 +381,46 @@
             ]
         },
         {
+            "path": "/v1/debug/producers/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get low level debug information about producers producing to the input partition, queried from the leader of the partition.",
+                    "type": "partition_producers",
+                    "nickname": "get_partition_producers",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "limit",
+                            "in": "query",
+                            "required": false,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/debug/set_storage_failure_injection_enabled",
             "operations": [
                 {
@@ -1168,6 +1208,101 @@
                         "type": "partition_replica_state"
                     },
                     "description": "All replicas of this partition"
+                }
+            }
+        },
+        "idempotent_producer_request_state": {
+            "id": "idempotent_producer_request_state",
+            "description": "Debug state of an idempotent producer request to a partition.",
+            "properties": {
+                "first_sequence": {
+                    "type": "int",
+                    "description": "Kafka first sequence of the request"
+                },
+                "last_sequence": {
+                    "type": "int",
+                    "description": "Kafka last sequence of the request"
+                },
+                "term": {
+                    "type": "long",
+                    "description": "Raft term of the idempotent request"
+                }
+            }
+        },
+        "partition_producer_state": {
+            "id": "partition_producer_state",
+            "description": "Debug state of a single producer producing to a partition ",
+            "properties": {
+                "id" : {
+                    "type": "long",
+                    "description": "ID of the producer, assigned by Redpanda."
+                },
+                "epoch": {
+                    "type": "int",
+                    "description": "Epoch of the producer, assigned by Redpanda."
+                },
+                "inflight_idempotent_requests": {
+                    "type": "array",
+                    "items": {
+                        "type": "idempotent_producer_request_state"
+                    },
+                    "description": "List of requests currently in flight."
+                },
+                "finished_idempotent_requests": {
+                    "type": "array",
+                    "items": {
+                        "type": "idempotent_producer_request_state"
+                    },
+                    "description": "List of finished requests."
+                },
+                "last_update_timestamp": {
+                    "type": "long",
+                    "description": "Last update timestamp for this producer."
+                },
+                "transaction_begin_offset": {
+                    "type": "long",
+                    "description": "First offset of the transaction."
+                },
+                "transaction_last_offset": {
+                    "type": "long",
+                    "description": "Last offset of the transaction."
+                },
+                "transaction_sequence": {
+                    "type": "int",
+                    "description": "Sequence number of the transaction."
+                },
+                "transaction_timeout_ms": {
+                    "type": "long",
+                    "description": "Transaction timeout in ms."
+                },
+                "transaction_coordinator_partition": {
+                    "type": "int",
+                    "description": "Transaction coordinator partition coordinating the transaction."
+                },
+                "transaction_group_id": {
+                    "type": "string",
+                    "description": "Group id of transaction, only relevant for group partitions."
+                }
+            }
+        },
+        "partition_producers": {
+            "id": "partition_producers",
+            "description": "Debug information about producers producing to a partition.",
+            "properties": {
+                "ntp": {
+                    "type": "string",
+                    "description": "Partition that is queried"
+                },
+                "total_producer_count": {
+                    "type": "long",
+                    "description": "Total number of producers as tracked by the partition."
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "type": "partition_producer_state"
+                    },
+                    "description": "Producers to this partition, a limit is enforced to avoid fetching too many producers. total_producer_count denotes actual number of producers tracked by the partition."
                 }
             }
         },

--- a/src/v/redpanda/admin/api-doc/transaction.json
+++ b/src/v/redpanda/admin/api-doc/transaction.json
@@ -92,6 +92,46 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/transaction/unsafe_abort_group_transaction/{group_id}",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Unsafely abort a transaction from a group, only for debugging",
+                    "type": "void",
+                    "nickname": "unsafe_abort_group_transaction",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "group_id",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "producer_id",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "producer_epoch",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "sequence",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -550,6 +550,8 @@ private:
       delete_partition_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       find_tx_coordinator_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      unsafe_abort_group_transaction(std::unique_ptr<ss::http::request>);
 
     /// Cluster routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -615,6 +615,8 @@ private:
     ss::future<ss::json::json_return_type>
       get_partition_state_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      get_producers_state_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       get_local_storage_usage_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       get_disk_stat_handler(std::unique_ptr<ss::http::request>);

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -11,6 +11,8 @@
 #include "cluster/partition_manager.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "container/lw_shared_container.h"
+#include "kafka/server/coordinator_ntp_mapper.h"
+#include "kafka/server/server.h"
 #include "redpanda/admin/api-doc/transaction.json.hh"
 #include "redpanda/admin/server.h"
 #include "redpanda/admin/util.h"
@@ -35,6 +37,12 @@ void admin_server::register_transaction_routes() {
       ss::httpd::transaction_json::find_coordinator,
       [this](std::unique_ptr<ss::http::request> req) {
           return find_tx_coordinator_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::unsafe_abort_group_transaction,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return unsafe_abort_group_transaction(std::move(req));
       });
 }
 
@@ -211,5 +219,79 @@ admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
     auto res = co_await _tx_gateway_frontend.local().delete_partition_from_tx(
       tid, partition_for_delete);
     co_await throw_on_error(*req, res, ntp);
+    co_return ss::json::json_return_type(ss::json::json_void());
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::unsafe_abort_group_transaction(
+  std::unique_ptr<ss::http::request> request) {
+    if (!_tx_gateway_frontend.local_is_initialized()) {
+        throw ss::httpd::bad_request_exception("Transaction are disabled");
+    }
+
+    auto group_id = request->get_path_param("group_id");
+    auto pid_str = request->get_query_param("producer_id");
+    auto epoch_str = request->get_query_param("producer_epoch");
+    auto sequence_str = request->get_query_param("sequence");
+
+    if (group_id.empty()) {
+        throw ss::httpd::not_found_exception("group_id cannot be empty");
+    }
+
+    if (pid_str.empty() || epoch_str.empty() || sequence_str.empty()) {
+        throw ss::httpd::bad_param_exception(fmt::format(
+          "invalid producer_id({})/epoch({})/sequence({}), should be integers "
+          ">= 0",
+          pid_str,
+          epoch_str,
+          sequence_str));
+    }
+
+    std::optional<model::producer_id> pid;
+    try {
+        auto parsed_pid = boost::lexical_cast<model::producer_id::type>(
+          pid_str);
+        pid = model::producer_id{parsed_pid};
+    } catch (const boost::bad_lexical_cast& e) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("invalid producer_id: {}, should be >= 0", pid_str));
+    }
+
+    std::optional<model::producer_epoch> epoch;
+    try {
+        auto parsed_epoch = boost::lexical_cast<model::producer_epoch::type>(
+          epoch_str);
+        epoch = model::producer_epoch{parsed_epoch};
+    } catch (const boost::bad_lexical_cast& e) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("invalid producer_epoch {}, should be >= 0", epoch_str));
+    }
+
+    std::optional<model::tx_seq> seq;
+    try {
+        auto parsed_seq = boost::lexical_cast<model::tx_seq::type>(
+          sequence_str);
+        seq = model::tx_seq{parsed_seq};
+    } catch (const boost::bad_lexical_cast& e) {
+        throw ss::httpd::bad_param_exception(fmt::format(
+          "invalid transaction sequence {}, should be >= 0", sequence_str));
+    }
+
+    auto& mapper = _kafka_server.local().coordinator_mapper();
+    auto kafka_gid = kafka::group_id{group_id};
+    auto group_ntp = mapper.ntp_for(kafka::group_id{group_id});
+    if (!group_ntp) {
+        throw ss::httpd::server_error_exception(
+          "consumer_offsets topic not found");
+    }
+
+    auto result
+      = co_await _tx_gateway_frontend.local().unsafe_abort_group_transaction(
+        std::move(kafka_gid),
+        model::producer_identity{pid.value(), epoch.value()},
+        seq.value(),
+        5s);
+
+    co_await throw_on_error(*request, result, group_ntp.value());
     co_return ss::json::json_return_type(ss::json::json_void());
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2748,7 +2748,8 @@ void application::start_runtime_services(
             cloud_storage_api,
             feature_table,
             controller->get_topics_state());
-          pm.register_factory<kafka::group_tx_tracker_stm_factory>();
+          pm.register_factory<kafka::group_tx_tracker_stm_factory>(
+            feature_table);
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -478,7 +478,7 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         split_str = res.split("\n")
         info_str = split_str[0]
         info_key = info_str.strip().split("\t")
-        assert info_key == expected_columns, f"{info_key}"
+        assert info_key == expected_columns, f"{info_key} vs {expected_columns}"
 
         assert split_str[-1] == ""
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -945,7 +945,7 @@ class RpkTool:
 
     def group_delete(self, group):
         cmd = ["delete", group]
-        self._run_group(cmd)
+        return self._run_group(cmd)
 
     def group_list(self, states: list[str] = []) -> list[RpkListGroup]:
         cmd = ['list']

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1709,3 +1709,15 @@ class Admin:
 
         path = f"migrations/{migration_id}"
         return self._request("DELETE", path, node=node)
+
+    def unsafe_abort_group_transaction(self, group_id: str, *, pid: int,
+                                       epoch: int, sequence: int):
+        params = {
+            "producer_id": pid,
+            "producer_epoch": epoch,
+            "sequence": sequence,
+        }
+        params = "&".join([f"{k}={v}" for k, v in params.items()])
+        return self._request(
+            'POST',
+            f"transaction/unsafe_abort_group_transaction/{group_id}?{params}")

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1478,6 +1478,10 @@ class Admin:
         path = f"debug/partition/{namespace}/{topic}/{partition}"
         return self._request("GET", path, node=node).json()
 
+    def get_producers_state(self, namespace, topic, partition, node=None):
+        path = f"debug/producers/{namespace}/{topic}/{partition}"
+        return self._request("GET", path, node=node).json()
+
     def get_local_storage_usage(self, node=None):
         """
         Get the local storage usage report.

--- a/tests/rptest/tests/describe_producers_test.py
+++ b/tests/rptest/tests/describe_producers_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import random
+import string
 import time
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
@@ -18,6 +19,8 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.rpk import parse_rpk_table
 from rptest.util import wait_until_result
+from ducktape.mark import matrix
+from confluent_kafka import TopicPartition
 
 
 class DescribeProducersTest(RedpandaTest):
@@ -31,23 +34,49 @@ class DescribeProducersTest(RedpandaTest):
 
         self.kafka_cli = KafkaCliTools(self.redpanda, "3.0.0")
 
-    def _describe_all_producers(self):
+    def _describe_all_producers(self, include_group_partitions: bool):
         all_producers = []
         for topic in self.topics:
             for partition in range(topic.partition_count):
                 producers = self.kafka_cli.describe_producers(
                     topic.name, partition)
                 all_producers += producers
+        if include_group_partitions:
+            for partition in range(0, 16):
+                all_producers += self.kafka_cli.describe_producers(
+                    "__consumer_offsets", partition)
         return all_producers
 
     def _check_timestamp(self, producer_desc, range_start, range_end):
+        ts = int(producer_desc['LastTimestamp'])
         # convert to python representation of epoch
-        ts = int(producer_desc['LastTimestamp']) / 1000.0
-        assert ts >= range_start and ts <= range_end, \
+        ts_epoch = ts / 1000.0
+        assert ts == -1 or (ts_epoch >= range_start and ts_epoch <= range_end), \
             f"Producer timestamp must correspond to system clock. Returned timestamp: {ts}, range: [{range_start}, {range_end}]"
 
+    def _random_group_name(self):
+        return ''.join(
+            random.choice(string.ascii_uppercase) for _ in range(16))
+
     @cluster(num_nodes=3)
-    def test_describe_producer_with_tx(self):
+    @matrix(include_group_tx=[True, False])
+    def test_describe_producer_with_tx(self, include_group_tx):
+
+        consumers = []
+        if include_group_tx:
+            for _ in range(5):
+                c = ck.Consumer({
+                    'bootstrap.servers': self.redpanda.brokers(),
+                    'group.id': self._random_group_name(),
+                    'auto.offset.reset': 'earliest',
+                    'enable.auto.commit': False,
+                    'max.poll.interval.ms': 10000,
+                    'session.timeout.ms': 8000
+                })
+                c.subscribe([topic.name for topic in self.topics])
+                c.consume(1, 1)
+                consumers.append(c)
+
         before = time.time()
         producer_count = 20
         producers = []
@@ -59,7 +88,7 @@ class DescribeProducersTest(RedpandaTest):
             producer.init_transactions()
             producers.append(producer)
 
-        all_producers_desc = self._describe_all_producers()
+        all_producers_desc = self._describe_all_producers(include_group_tx)
 
         assert len(all_producers_desc
                    ) == 0, "Before producing data producers should be empty"
@@ -69,11 +98,23 @@ class DescribeProducersTest(RedpandaTest):
             producer.produce(self.topics[idx % len(self.topics)].name,
                              f'key-{idx}', f'value-{idx}',
                              idx % self.partition_count)
+
+            if include_group_tx:
+                assert consumers
+                c = random.choice(consumers)
+                dummy = [
+                    TopicPartition(topic.name, 0, 100) for topic in self.topics
+                ]
+                producer.send_offsets_to_transaction(
+                    dummy, c.consumer_group_metadata())
+
             producer.flush()
 
+        expected_producer_count = 2 * producer_count if include_group_tx else producer_count
+
         def _all_producers():
-            all = self._describe_all_producers()
-            if len(all) == producer_count:
+            all = self._describe_all_producers(include_group_tx)
+            if len(all) == expected_producer_count:
                 return (True, all)
             return (False, None)
 
@@ -82,7 +123,7 @@ class DescribeProducersTest(RedpandaTest):
         after = time.time()
         assert len(
             all_producers_desc
-        ) == producer_count, f"Unexpected size of producers list, expected: {producer_count}, current: {len(all_producers_desc)}"
+        ) == expected_producer_count, f"Unexpected size of producers list, expected: {expected_producer_count}, current: {len(all_producers_desc)}"
         for p in all_producers_desc:
             self.logger.info(f"producer state with transaction ongoing: {p}")
             self._check_timestamp(p, before, after)
@@ -95,11 +136,11 @@ class DescribeProducersTest(RedpandaTest):
             producer.commit_transaction()
             producer.flush()
 
-        all_producers_desc = self._describe_all_producers()
+        all_producers_desc = self._describe_all_producers(include_group_tx)
         after = time.time()
         assert len(
             all_producers_desc
-        ) == producer_count, f"Unexpected size of producers list, expected: {producer_count}, current: {len(all_producers_desc)}"
+        ) == expected_producer_count, f"Unexpected size of producers list, expected: {expected_producer_count}, current: {len(all_producers_desc)}"
         for p in all_producers_desc:
             self.logger.info(f"producer state with transaction committed: {p}")
             self._check_timestamp(p, before, after)
@@ -118,7 +159,7 @@ class DescribeProducersTest(RedpandaTest):
                         "test-msg",
                         partition=i % self.partition_count)
 
-        all_producers = self._describe_all_producers()
+        all_producers = self._describe_all_producers(False)
 
         after = time.time()
         assert len(

--- a/tests/rptest/transactions/consumer_offsets_test.py
+++ b/tests/rptest/transactions/consumer_offsets_test.py
@@ -1,0 +1,117 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.transactions.verifiers.consumer_offsets_verifier import ConsumerOffsetsVerifier
+from rptest.services.cluster import cluster
+from rptest.services.redpanda_installer import RedpandaInstaller
+from rptest.tests.redpanda_test import RedpandaTest
+from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
+
+
+class VerifyConsumerOffsets(RedpandaTest):
+    def __init__(self, test_context):
+        super(VerifyConsumerOffsets,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "group_topic_partitions": 1,
+                                 "log_segment_size": 1024 * 1024,
+                                 "log_segment_ms": 60000,
+                                 "log_compaction_interval_ms": 10,
+                                 "group_new_member_join_timeout": 3000,
+                                 "group_initial_rebalance_delay": 0
+                             })
+
+    @cluster(num_nodes=3)
+    def test_consumer_group_offsets(self):
+        verifier = ConsumerOffsetsVerifier(self.redpanda, self._client)
+        verifier.verify()
+
+
+class VerifyConsumerOffsetsThruUpgrades(RedpandaTest):
+    def __init__(self, test_context):
+        super(VerifyConsumerOffsetsThruUpgrades,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "group_topic_partitions": 1,
+                                 "log_segment_size": 1024 * 1024,
+                                 "log_segment_ms": 60000,
+                                 "log_compaction_interval_ms": 10,
+                                 "group_new_member_join_timeout": 3000,
+                                 "group_initial_rebalance_delay": 0
+                             })
+
+    def rp_install_version(self,
+                           num_previous: int,
+                           version=RedpandaInstaller.HEAD):
+        if num_previous == 0:
+            return version
+        previous = self.redpanda._installer.highest_from_prior_feature_version(
+            version)
+        return self.rp_install_version(num_previous=num_previous - 1,
+                                       version=previous)
+
+    def setUp(self):
+        pass
+
+    def ensure_compactible(self):
+        def consumer_offsets_is_compactible():
+            try:
+                state = self.redpanda._admin.get_partition_state(
+                    namespace="kafka", topic="__consumer_offsets", partition=0)
+                collectible = []
+                for replica in state["replicas"]:
+                    for stm in replica["raft_state"]["stms"]:
+                        if stm["name"] == "group_tx_tracker_stm.snapshot":
+                            collectible.append(stm["last_applied_offset"] ==
+                                               stm["max_collectible_offset"])
+                return len(collectible) == 3 and all(collectible)
+            except Exception as e:
+                self.redpanda.logger.debug(
+                    f"failed to get parition state: {e}")
+
+        wait_until(
+            consumer_offsets_is_compactible,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=
+            f"Timed out waiting for consumer offsets partition to be compactible"
+        )
+
+    @cluster(num_nodes=3)
+    @matrix(versions_to_upgrade=[1, 2, 3])
+    def test_consumer_group_offsets(self, versions_to_upgrade):
+        """This test ensures consumer offset state remains correct during the following upgrade cycles"""
+
+        # At the time of writing, this test checks the following version upgrades
+        # Each upgrade also rolls logs ensures it is compacted
+        # 24.3.x (initial_version) -> 25.1.x
+        # 24.2.x (initial version) -> 24.3.x -> 24.4.x
+        # 24.1.x (initial version) -> 24.2.x -> 24.3.x -> 24.4.x
+        #
+        # After the upgrade + compaction the following invariants are checked
+        # - The state of group offets is correct as snapshotted prior to all upgrades
+        # - The log is fully compactible.
+        initial_version = self.rp_install_version(
+            num_previous=versions_to_upgrade)
+        self.redpanda._installer.install(self.redpanda.nodes, initial_version)
+        super(VerifyConsumerOffsetsThruUpgrades, self).setUp()
+
+        verifier = ConsumerOffsetsVerifier(self.redpanda, self._client)
+        verifier.verify()
+
+        versions = self.load_version_range(initial_version)
+        for v in self.upgrade_through_versions(versions_in=versions,
+                                               already_running=True):
+            self.logger.info(f"Updated to {v}")
+            verifier.verify()
+
+        self.ensure_compactible()

--- a/tests/rptest/transactions/producers_api_test.py
+++ b/tests/rptest/transactions/producers_api_test.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import threading
+from time import sleep
+from rptest.transactions.verifiers.consumer_offsets_verifier import ConsumerOffsetsVerifier
+from rptest.services.admin import Admin
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+
+
+class ProducersAdminAPITest(RedpandaTest):
+    def __init__(self, test_context):
+        super(ProducersAdminAPITest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "group_topic_partitions": 1,
+                                 "group_new_member_join_timeout": 3000,
+                                 "enable_leader_balancer": False
+                             })
+        self._stop_scraping = threading.Event()
+
+    def get_producer_state(self, topic: str):
+        admin = self.redpanda._admin
+        return admin.get_producers_state(namespace="kafka",
+                                         topic=topic,
+                                         partition=0)
+
+    @cluster(num_nodes=3)
+    def test_producers_state_api_during_load(self):
+        verifier = ConsumerOffsetsVerifier(self.redpanda, self._client)
+        self.redpanda._admin.await_stable_leader(topic="__consumer_offsets")
+        self.redpanda._admin.await_stable_leader(topic=verifier._topic)
+
+        # Run a scraper in background as the verifier is running to ensure it doesn't
+        # interact with the workloads incorrectly
+        def scraper():
+            while not self._stop_scraping.isSet():
+                self.get_producer_state(verifier._topic)
+                self.get_producer_state("__consumer_offsets")
+                sleep(1)
+
+        bg_scraper = threading.Thread(target=scraper, daemon=True)
+        bg_scraper.start()
+        verifier.verify()
+        self._stop_scraping.set()
+        bg_scraper.join()
+
+        # Basic sanity checks
+        co_producers = self.get_producer_state("__consumer_offsets")
+        assert len(
+            co_producers["producers"]
+        ) == 10, "Not all producers states found in consumer_offsets partition"
+        expected_groups = set([f"group-{i}" for i in range(10)])
+        state_groups = set([
+            producer["transaction_group_id"]
+            for producer in co_producers["producers"]
+        ])
+        assert expected_groups == state_groups, f"Not all groups reported. expected: {expected_groups}, repoted: {state_groups}"
+
+        topic_producers = self.get_producer_state(verifier._topic)
+        assert len(
+            topic_producers["producers"]
+        ) == 10, "Not all producers states found in data topic partition"

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -268,6 +268,45 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             self.logger.info(f"Read {len(records)} from node {node.name}")
 
     @cluster(num_nodes=3)
+    def group_deletion_with_ongoing_transaction_test(self):
+        self.redpanda.set_cluster_config(
+            {"group_new_member_join_timeout": 5000})
+        self.generate_data(self.input_t, self.max_records)
+
+        group_name = "test_group"
+
+        producer = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': 'group_deletion_test_id',
+        })
+
+        group_name = "test"
+        consumer = ck.Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        consumer.subscribe([self.input_t])
+        _ = self.consume(consumer)
+        producer.init_transactions()
+        producer.begin_transaction()
+        producer.send_offsets_to_transaction(
+            consumer.position(consumer.assignment()),
+            consumer.consumer_group_metadata())
+        producer.flush()
+        # leave the consumer group
+        consumer.close()
+        # Attempt to delete the group, should fail
+        rpk = RpkTool(self.redpanda)
+        out = rpk.group_delete(group=group_name)
+        assert "NON_EMPTY_GROUP" in out, f"Group deletion should fail with inprogress transaction: {out}"
+        producer.commit_transaction()
+        out = rpk.group_delete(group=group_name)
+        assert "OK" in out, f"Group deletion expected to succeed after committing transaction: {out}"
+
+    @cluster(num_nodes=3)
     def rejoin_member_test(self):
         self.redpanda.set_cluster_config(
             {"group_new_member_join_timeout": 5000})

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -918,6 +918,92 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
 
         assert num_consumed == expected_records
 
+    @cluster(num_nodes=3)
+    def unsafe_abort_group_transaction_test(self):
+        def random_group_name():
+            return ''.join(
+                random.choice(string.ascii_uppercase) for _ in range(16))
+
+        def wait_for_active_producers(count: int):
+            def describe_active_producers():
+                active_producers = []
+                for partition in range(0, 16):
+                    desc = self.kafka_cli.describe_producers(
+                        "__consumer_offsets", partition)
+                    for producer in desc:
+                        tx_start_offset = producer[
+                            'CurrentTransactionStartOffset']
+                        if 'None' in tx_start_offset:
+                            continue
+                        if int(tx_start_offset) >= 0:
+                            active_producers.append(producer)
+                return active_producers
+
+            wait_until(
+                lambda: len(describe_active_producers()) == count,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=f"Timed out waiting for producer count to reach {count}"
+            )
+
+        group_name = random_group_name()
+        input_records = 10
+        self.generate_data(self.input_t, input_records)
+
+        # setup consumer offsets
+        rpk = RpkTool(self.redpanda)
+        rpk.consume(topic=self.input_t.name, n=1, group="test-group")
+
+        wait_for_active_producers(0)
+
+        # Setup a consumer to consume from ^^ topic and
+        # produce to a target topic.
+        producer_conf = {
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': 'test-repro',
+            # Large-ish timeout
+            'transaction.timeout.ms': 300000,
+        }
+        producer = ck.Producer(producer_conf)
+        consumer_conf = {
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': group_name,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        }
+        consumer = ck.Consumer(consumer_conf)
+        consumer.subscribe([self.input_t])
+
+        # Consume - identity transform - produce
+        producer.init_transactions()
+        _ = self.consume(consumer)
+        # Start a transaction and flush some offsets
+        producer.begin_transaction()
+        producer.send_offsets_to_transaction(
+            consumer.position(consumer.assignment()),
+            consumer.consumer_group_metadata())
+        producer.flush()
+
+        wait_until(lambda: len(self.admin.get_all_transactions()) == 1,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="Timed out waiting for transaction to appear")
+
+        wait_for_active_producers(1)
+
+        self.admin.unsafe_abort_group_transaction(group_id=group_name,
+                                                  pid=1,
+                                                  epoch=0,
+                                                  sequence=0)
+        wait_for_active_producers(0)
+        producer.commit_transaction()
+
+        wait_until(
+            lambda: self.no_running_transactions(),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timed out waiting for running transactions to wind down.")
+
 
 class TransactionsStreamsTest(RedpandaTest, TransactionsMixin):
     topics = (TopicSpec(partition_count=1, replication_factor=3),

--- a/tests/rptest/transactions/verifiers/consumer_offsets_verifier.py
+++ b/tests/rptest/transactions/verifiers/consumer_offsets_verifier.py
@@ -1,0 +1,214 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import threading
+import confluent_kafka as ck
+from confluent_kafka import TopicPartition
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from concurrent import futures
+from kafka import KafkaAdminClient
+import random
+from time import sleep
+from concurrent.futures import ThreadPoolExecutor
+from ducktape.utils.util import wait_until
+from rptest.clients.rpk import RpkTool
+
+
+class ConsumerOffsetsVerifier():
+    """
+    Populates consumer offsets topic with various transactional offset commits 
+    over multiple groups and verifies the final offset positions.
+    Assumes that there is only one consumer offset partition for simplicity since
+    the intention of this test is correctness.
+
+    The verifier does not use a real topic and consumer to generate offset commits,
+    instead dummy offsets are generated randomly to mimic consumption. A real consumer
+    only adds noise to the test and is not needed to validate correctness here. 
+    """
+    def __init__(self,
+                 redpanda,
+                 client,
+                 produce_topic: str = "topic_produce",
+                 source_topic: str = "topic_consume",
+                 num_producers: int = 10,
+                 num_src_partitions: int = 5,
+                 max_commits: int = 5000):
+
+        self._redpanda = redpanda
+        self._topic = produce_topic
+        self._source_topic = source_topic
+        self._logger = self._redpanda.logger
+        self._lock = threading.Lock()
+        self._tasks = []
+        self._num_producers = num_producers
+        self._num_src_partitions = num_src_partitions
+
+        produce_topic_spec = TopicSpec(name=produce_topic,
+                                       replication_factor=3,
+                                       partition_count=1)
+
+        consume_topic_spec = TopicSpec(name=source_topic,
+                                       replication_factor=3,
+                                       partition_count=5)
+        client.create_topic(produce_topic_spec)
+        client.create_topic(consume_topic_spec)
+
+        self.rpk = RpkTool(self._redpanda)
+
+        # Each producers uses a group and each group has offset positions
+        # for every source partition
+        self._committed_offsets: dict[str, list[TopicPartition]] = dict()
+        self._stop_ev = threading.Event()
+        for producer in range(num_producers):
+            self._committed_offsets[f"group-{producer}"] = [
+                TopicPartition(self._source_topic, p, -1)
+                for p in range(num_src_partitions)
+            ]
+
+        self._total_commits_so_far = 0
+        self._max_commits = max_commits
+        self._commits_done = threading.Event()
+        threading.Thread(target=self._start_producers, daemon=True).start()
+
+    def _start_producers(self):
+        with ThreadPoolExecutor(max_workers=self._num_producers) as executor:
+            for producer in range(self._num_producers):
+                self._tasks.append(
+                    executor.submit(lambda: self._start_one_producer(
+                        group_id=f"group-{producer}", tx_id=f"txid-{producer}")
+                                    ))
+
+    def _stop_all(self, timeout_sec: int = 30):
+        if self._stop_ev.isSet():
+            return
+        self._stop_ev.set()
+        futures.wait(self._tasks,
+                     timeout=timeout_sec,
+                     return_when=futures.ALL_COMPLETED)
+
+    def _current_committed_offsets(self, group_id: str, partitions: list[int]):
+        with self._lock:
+            return [
+                tp for tp in self._committed_offsets[group_id]
+                if tp.partition in partitions
+            ]
+
+    def _update_committed_offsets(self, group_id: str,
+                                  positions: list[TopicPartition]):
+        with self._lock:
+            for position in positions:
+                self._committed_offsets[group_id][
+                    position.partition] = position
+            self._total_commits_so_far += 1
+            if self._total_commits_so_far >= self._max_commits:
+                self._commits_done.set()
+
+    def _group_is_ready(self, group: str):
+        gr = self.rpk.group_describe(group=group, summary=True)
+        return gr.members == 1 and gr.state == "Stable"
+
+    def _start_one_producer(self, group_id: str, tx_id: str):
+
+        consumer = ck.Consumer({
+            'bootstrap.servers': self._redpanda.brokers(),
+            'group.id': group_id,
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        })
+
+        consumer.subscribe([self._source_topic])
+
+        wait_until(
+            lambda: self._group_is_ready(group=group_id),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Timed out waiting for group {group_id} to be stable")
+
+        producer = ck.Producer({
+            'bootstrap.servers': self._redpanda.brokers(),
+            'transactional.id': tx_id,
+            'transaction.timeout.ms': 10000
+        })
+        producer.init_transactions()
+
+        def generate_dummy_positions():
+            # pick a random list of partitions to update
+            partitions = random.sample(range(0, self._num_src_partitions), 3)
+            current_offsets = self._current_committed_offsets(
+                group_id=group_id, partitions=partitions)
+            # update positions
+            for tp in current_offsets:
+                tp.offset = tp.offset + random.randint(1, 5)
+            return current_offsets
+
+        i = 0
+        while not self._stop_ev.isSet():
+            new_positions = generate_dummy_positions()
+            self._logger.debug(
+                f"[{tx_id}] attempting to update positions to {new_positions}")
+            producer.begin_transaction()
+            producer.produce(self._topic, f"{tx_id}_{i}", f"{tx_id}_id")
+            producer.send_offsets_to_transaction(
+                new_positions, consumer.consumer_group_metadata())
+            producer.flush()
+
+            commit = random.choice([True, False])
+            if commit:
+                producer.commit_transaction()
+                self._update_committed_offsets(group_id, new_positions)
+                self._logger.debug(
+                    f"[{tx_id}] attempting to update positions to {new_positions} succeeded total commits: {self._total_commits_so_far}"
+                )
+            else:
+                producer.abort_transaction()
+                self._logger.debug(
+                    f"[{tx_id}] attempting to update positions to {new_positions} aborted"
+                )
+            sleep(0.05)
+
+    def verify(self, timeout_sec: int = 90):
+        self._logger.debug("waiting for commits done")
+        self._commits_done.wait(timeout_sec)
+        self._stop_all(timeout_sec)
+
+        self._logger.debug("Verifying offsets for all groups")
+
+        admin = KafkaAdminClient(
+            **{'bootstrap_servers': self._redpanda.brokers()})
+
+        def list_offsets(group_id: str):
+            offsets = admin.list_consumer_group_offsets(group_id)
+            result = []
+            for tp, md in offsets.items():
+                result.append(TopicPartition(tp.topic, tp.partition,
+                                             md.offset))
+            return sorted(result, key=lambda tp: tp.partition)
+
+        def offsets_are_consistent():
+            try:
+                group_results = []
+                for group in [
+                        f"group-{p}" for p in range(self._num_producers)
+                ]:
+                    offsets = list_offsets(group)
+                    expected = self._committed_offsets[group]
+                    self._logger.debug(
+                        f"group: {group}, offsets: {offsets}, expected: {expected}"
+                    )
+                    group_results.append(offsets == expected)
+                return all(group_results)
+            except Exception as e:
+                self._logger.debug(f"exception listing offsets: {e}")
+                return False
+
+        wait_until(
+            offsets_are_consistent,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"Timed out waiting group offsets to be consistent.")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24637
Fixes https://github.com/redpanda-data/redpanda/issues/24685

Note on omission of https://github.com/redpanda-data/redpanda/commit/3d65c3933dea98d53552582f067bc90545eddb70 

It exposed what seemed like a race condition in log reader. The commit just blocks the apply fiber that holds a reader instance to a log range. It remains in that state during the entire upgrade and the it turns out that in that state a competing log reader for the same range just times out, in this case it was recovery stm trying to move partitions and the decommission was blocked. Just removed the commit altogether since it was a conservative check added to avoid compaction in mixed mode and has not known correctness implication.s

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Fixes an issue that blocked the compaction of consumer offsets with group transactions.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
