### PR TITLE
CORE-2701 Quotas: use kafka quotas in tests

### DIFF
--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -99,7 +99,6 @@ public:
           cloud_cfg,
           use_node_id,
           empty_seed_starts_cluster_val,
-          std::nullopt,
           false,
           enable_legacy_upload_mode,
           iceberg_enabled);

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -242,10 +242,12 @@ redpanda_cc_btest(
     ],
     tags = ["exclusive"],
     deps = [
+        "//src/v/cluster",
         "//src/v/kafka/client",
         "//src/v/kafka/client/test:fixture",
         "//src/v/kafka/client/test:utils",
         "//src/v/kafka/protocol",
+        "//src/v/model",
         "//src/v/redpanda/tests:fixture_btest",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -22,24 +22,6 @@ public:
     kafka_client_fixture()
       : redpanda_thread_fixture() {}
 
-    kafka_client_fixture(std::optional<uint32_t> kafka_admin_topic_api_rate)
-      : redpanda_thread_fixture(
-          model::node_id(1),
-          9092,
-          33145,
-          8082,
-          8081,
-          {},
-          ssx::sformat("test.dir_{}", time(0)),
-          std::nullopt,
-          true,
-          std::nullopt,
-          std::nullopt,
-          std::nullopt,
-          configure_node_id::yes,
-          empty_seed_starts_cluster::yes,
-          kafka_admin_topic_api_rate) {}
-
     void restart(bool test_mode = false) {
         shutdown();
         app_signal = std::make_unique<::stop_signal>();

--- a/src/v/kafka/client/test/retry.cc
+++ b/src/v/kafka/client/test/retry.cc
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/client_quota_frontend.h"
 #include "kafka/client/client.h"
 #include "kafka/client/test/fixture.h"
 #include "kafka/client/test/utils.h"
 #include "kafka/protocol/exceptions.h"
+#include "model/timeout_clock.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -51,7 +53,30 @@ FIXTURE_TEST(test_retry_produce, kafka_client_fixture) {
 class kafka_client_create_topic_fixture : public kafka_client_fixture {
 public:
     kafka_client_create_topic_fixture()
-      : kafka_client_fixture(std::make_optional<uint32_t>(1)) {}
+      : kafka_client_fixture() {
+        using cluster::client_quota::alter_delta_cmd_data;
+        using cluster::client_quota::entity_key;
+        using cluster::client_quota::entity_value_diff;
+
+        const entity_key key0{entity_key::client_id_default_match{}};
+        auto cmd = alter_delta_cmd_data{
+            .ops = {
+            alter_delta_cmd_data::op{
+                .key = key0,
+                .diff = {
+                  .entries = {
+                    entity_value_diff::entry(
+                      entity_value_diff::key::controller_mutation_rate, 1),
+                    },
+                  },
+                },
+            },
+        };
+        app.controller->get_quota_frontend()
+          .local()
+          .alter_quotas(cmd, model::timeout_clock::now() + 10s)
+          .get();
+    }
 };
 
 FIXTURE_TEST(test_retry_create_topic, kafka_client_create_topic_fixture) {

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -104,7 +104,6 @@ public:
       configure_node_id use_node_id = configure_node_id::yes,
       const empty_seed_starts_cluster empty_seed_starts_cluster_val
       = empty_seed_starts_cluster::yes,
-      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt,
       bool enable_data_transforms = false,
       bool enable_legacy_upload_mode = true,
       bool iceberg_enabled = false)
@@ -125,7 +124,6 @@ public:
           std::move(cloud_cfg),
           use_node_id,
           empty_seed_starts_cluster_val,
-          kafka_admin_topic_api_rate,
           enable_data_transforms,
           enable_legacy_upload_mode,
           iceberg_enabled);
@@ -336,7 +334,6 @@ public:
       configure_node_id use_node_id = configure_node_id::yes,
       const empty_seed_starts_cluster empty_seed_starts_cluster_val
       = empty_seed_starts_cluster::yes,
-      std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt,
       bool data_transforms_enabled = false,
       bool legacy_upload_mode_enabled = true,
       bool iceberg_enabled = false) {
@@ -427,10 +424,6 @@ public:
                     static_cast<int16_t>(cloud_cfg->connection_limit()));
             }
 
-            if (kafka_admin_topic_api_rate) {
-                config.get("kafka_admin_topic_api_rate")
-                  .set_value(kafka_admin_topic_api_rate);
-            }
             config.get("data_transforms_enabled")
               .set_value(data_transforms_enabled);
             config.get("cloud_storage_disable_archiver_manager")

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1920,7 +1920,8 @@ class RpkTool:
                                 default=[],
                                 name=[],
                                 strict=False,
-                                output_format="json"):
+                                output_format="json",
+                                node: Optional[ClusterNode] = None):
         cmd = ["describe"]
 
         if strict:
@@ -1932,7 +1933,9 @@ class RpkTool:
         if len(name) > 0:
             cmd += ["--name", ",".join(name)]
 
-        return self._run_cluster_quotas(cmd, output_format=output_format)
+        return self._run_cluster_quotas(cmd,
+                                        output_format=output_format,
+                                        node=node)
 
     def alter_cluster_quotas(self,
                              add=[],

--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -45,20 +45,12 @@ class ClusterQuotaPartitionMutationTest(RedpandaTest):
     Ducktape tests for partition mutation quota
     """
     def __init__(self, *args, **kwargs):
-        additional_options = {'kafka_admin_topic_api_rate': 10}
-        super().__init__(*args,
-                         num_brokers=3,
-                         extra_rp_conf=additional_options,
-                         **kwargs)
-        # Cluster configs used to be per-shard and for backwards compatibility, when we made them node-wide,
-        # we started acting on the cluster configs at the "core count" * "per-shard cluster config" value to
-        # be backwards compatible with the existing configurations.
-        # To keep the tests simple, run the tests with 1 core / broker to have the per-shard cluster configs
-        # be the same as the node-wide limit after upscaling by the core count.
-        self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
+        super().__init__(*args, num_brokers=3, **kwargs)
 
         # Use kcl so the throttle_time_ms value in the response can be examined
         self.kcl = RawKCL(self.redpanda)
+
+        self.rpk = RpkTool(self.redpanda)
 
     @cluster(num_nodes=3)
     def test_partition_throttle_mechanism(self):
@@ -66,7 +58,11 @@ class ClusterQuotaPartitionMutationTest(RedpandaTest):
         Ensure the partition throttling mechanism (KIP-599) works
         """
 
-        # The kafka_admin_topic_api_rate quota is 10. This test will
+        res = self.rpk.alter_cluster_quotas(
+            default=["client-id"], add=["controller_mutation_rate=10"])
+        assert res['status'] == 'OK', f'Alter failed with result: {res}'
+
+        # The per-client-id controller_mutation_rate quota is 10. This test will
         # make 1 request within containing three topics to create, each containing
         # different number of partitions.
         #
@@ -155,9 +151,6 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.max_partition_fetch_bytes = self.message_size * 11
         additional_options = {
             "max_kafka_throttle_delay_ms": self.max_throttle_time,
-            "target_quota_byte_rate": self.target_default_quota_byte_rate,
-            "target_fetch_quota_byte_rate":
-            self.target_default_quota_byte_rate,
         }
         super().__init__(*args,
                          extra_rp_conf=additional_options,
@@ -165,12 +158,6 @@ class ClusterRateQuotaTest(RedpandaTest):
                              'info', logger_levels={'kafka': 'trace'}),
                          resource_settings=ResourceSettings(num_cpus=1),
                          **kwargs)
-        # Cluster configs used to be per-shard and for backwards compatibility, when we made them node-wide,
-        # we started acting on the cluster configs at the "core count" * "per-shard cluster config" value to
-        # be backwards compatible with the existing configurations.
-        # To keep the tests simple, run the tests with 1 core / broker to have the per-shard cluster configs
-        # be the same as the node-wide limit after upscaling by the core count.
-        self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
         self.rpk = RpkTool(self.redpanda)
 
     def init_test_data(self):
@@ -304,20 +291,12 @@ class ClusterRateQuotaTest(RedpandaTest):
         """
         self.init_test_data()
 
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_byte_rate_quota": [
-                {
-                    "group_name": "group_1",
-                    "clients_prefix": "producer_group_alone_producer",
-                    "quota": self.target_group_quota_byte_rate
-                },
-                {
-                    "group_name": "group_2",
-                    "clients_prefix": "producer_group_multiple",
-                    "quota": self.target_group_quota_byte_rate
-                },
-            ]
-        })
+        self.alter_quota(
+            name=["client-id-prefix=producer_group_alone_producer"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
+        self.alter_quota(
+            name=["client-id-prefix=producer_group_multiple"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
 
         producer = self.make_producer("producer_group_alone_producer")
 
@@ -344,13 +323,9 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.produce(producer_2, self.under_group_quota_message_amount)
         self.check_producer_throttled(producer_2)
 
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_byte_rate_quota": {
-                "group_name": "change_config_group",
-                "clients_prefix": "new_producer_group",
-                "quota": self.target_group_quota_byte_rate
-            }
-        })
+        self.alter_quota(
+            name=["client-id-prefix=new_producer_group"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
 
         producer = self.make_producer("new_producer_group_producer")
 
@@ -364,20 +339,12 @@ class ClusterRateQuotaTest(RedpandaTest):
         """
         self.init_test_data()
 
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_fetch_byte_rate_quota": [
-                {
-                    "group_name": "group_1",
-                    "clients_prefix": "consumer_alone",
-                    "quota": self.target_group_quota_byte_rate
-                },
-                {
-                    "group_name": "group_2",
-                    "clients_prefix": "consumer_multiple",
-                    "quota": self.target_group_quota_byte_rate
-                },
-            ]
-        })
+        self.alter_quota(
+            name=["client-id-prefix=consumer_alone"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
+        self.alter_quota(
+            name=["client-id-prefix=consumer_multiple"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
 
         producer = self.make_producer()
         self.produce(producer, self.break_group_quota_message_amount * 2)
@@ -403,13 +370,9 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.fetch(consumer_2, 10)
         self.check_consumer_throttled(consumer_2)
 
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_fetch_byte_rate_quota": {
-                "group_name": "change_config",
-                "clients_prefix": "new_consumer",
-                "quota": self.target_group_quota_byte_rate
-            }
-        })
+        self.alter_quota(
+            name=["client-id-prefix=new_consumer"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
 
         consumer = self.make_consumer("new_consumer")
 
@@ -422,6 +385,10 @@ class ClusterRateQuotaTest(RedpandaTest):
         Ensure response size rate throttle works
         """
         self.init_test_data()
+
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"consumer_byte_rate={self.target_default_quota_byte_rate}"])
 
         producer = self.make_producer("producer")
         consumer = self.make_consumer("consumer")
@@ -442,6 +409,10 @@ class ClusterRateQuotaTest(RedpandaTest):
         Ensure response size rate throttle applies on next request
         """
         self.init_test_data()
+
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"consumer_byte_rate={self.target_default_quota_byte_rate}"])
 
         producer = self.make_producer("producer")
 
@@ -466,18 +437,14 @@ class ClusterRateQuotaTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_client_response_and_produce_throttle_mechanism(self):
         self.init_test_data()
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_byte_rate_quota": {
-                "group_name": "producer_throttle_group",
-                "clients_prefix": "throttle_producer_only",
-                "quota": self.target_group_quota_byte_rate
-            },
-            "kafka_client_group_fetch_byte_rate_quota": {
-                "group_name": "producer_throttle_group",
-                "clients_prefix": "throttle_producer_only",
-                "quota": self.target_group_quota_byte_rate
-            }
-        })
+
+        self.alter_quota(
+            name=["client-id-prefix=throttle_producer_only"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
+        self.alter_quota(
+            name=["client-id-prefix=throttle_producer_only"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
+
         # Producer and Consumer same client_id
         producer = self.make_producer("throttle_producer_only")
         consumer = self.make_consumer("throttle_producer_only")
@@ -490,18 +457,13 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.fetch(consumer, 10)
         self.check_consumer_not_throttled(consumer)
 
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_byte_rate_quota": {
-                "group_name": "consumer_throttle_group",
-                "clients_prefix": "throttle_consumer_only",
-                "quota": self.target_group_quota_byte_rate
-            },
-            "kafka_client_group_fetch_byte_rate_quota": {
-                "group_name": "consumer_throttle_group",
-                "clients_prefix": "throttle_consumer_only",
-                "quota": self.target_group_quota_byte_rate
-            }
-        })
+        self.alter_quota(
+            name=["client-id-prefix=throttle_consumer_only"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
+        self.alter_quota(
+            name=["client-id-prefix=throttle_consumer_only"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
+
         # Producer and Consumer same client_id
         producer = self.make_producer("throttle_consumer_only")
         consumer = self.make_consumer("throttle_consumer_only")
@@ -519,8 +481,14 @@ class ClusterRateQuotaTest(RedpandaTest):
 
     @cluster(num_nodes=1)
     def test_throttling_ms_enforcement_is_per_connection(self):
-        # Start with a cluster that has a produce quota (see class configs)
         self.init_test_data()
+
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"producer_byte_rate={self.target_default_quota_byte_rate}"])
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"consumer_byte_rate={self.target_default_quota_byte_rate}"])
 
         # Set the max throttling delay to something larger to give us a chance
         # to send a request before the throttling delay from the previous
@@ -585,52 +553,42 @@ class ClusterRateQuotaTest(RedpandaTest):
     @cluster(num_nodes=1)
     def test_client_quota_metrics(self):
         self.init_test_data()
-        self.redpanda.set_cluster_config({
-            "kafka_client_group_byte_rate_quota": {
-                "group_name": "producer_with_group",
-                "clients_prefix": "producer_with_group",
-                "quota": self.target_group_quota_byte_rate,
-            },
-            "kafka_client_group_fetch_byte_rate_quota": {
-                "group_name": "consumer_with_group",
-                "clients_prefix": "consumer_with_group",
-                "quota": self.target_group_quota_byte_rate,
-            },
-            "target_quota_byte_rate":
-            self.target_default_quota_byte_rate,
-            "target_fetch_quota_byte_rate":
-            self.target_default_quota_byte_rate,
-        })
+
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"producer_byte_rate={self.target_default_quota_byte_rate}"])
+        self.alter_quota(
+            default=["client-id"],
+            add=[f"consumer_byte_rate={self.target_default_quota_byte_rate}"])
+
+        self.alter_quota(
+            name=["client-id-prefix=producer_with_group"],
+            add=[f"producer_byte_rate={self.target_group_quota_byte_rate}"])
+        self.alter_quota(
+            name=["client-id-prefix=consumer_with_group"],
+            add=[f"consumer_byte_rate={self.target_group_quota_byte_rate}"])
 
         producer_with_group = self.make_producer("producer_with_group")
         consumer_with_group = self.make_consumer("consumer_with_group")
         unknown_producer = self.make_producer("unknown_producer")
         unknown_consumer = self.make_consumer("unknown_consumer")
 
-        # When the test topic is created, throughput for this metric is recorded
-        expected_pm_metrics = ExpectedMetrics([
-            ExpectedMetric({
-                'redpanda_quota_rule': 'not_applicable',
-                'redpanda_quota_type': 'partition_mutation_quota',
-            }),
-        ])
-
         # When we produce/fetch to/from the cluster, the metrics with these label should update
         expected_tput_metrics = ExpectedMetrics([
             ExpectedMetric({
-                'redpanda_quota_rule': 'cluster_client_prefix',
+                'redpanda_quota_rule': 'kafka_client_prefix',
                 'redpanda_quota_type': 'produce_quota',
             }),
             ExpectedMetric({
-                'redpanda_quota_rule': 'cluster_client_prefix',
+                'redpanda_quota_rule': 'kafka_client_prefix',
                 'redpanda_quota_type': 'fetch_quota',
             }),
             ExpectedMetric({
-                'redpanda_quota_rule': 'cluster_client_default',
+                'redpanda_quota_rule': 'kafka_client_default',
                 'redpanda_quota_type': 'produce_quota',
             }),
             ExpectedMetric({
-                'redpanda_quota_rule': 'cluster_client_default',
+                'redpanda_quota_rule': 'kafka_client_default',
                 'redpanda_quota_type': 'fetch_quota',
             }),
         ])
@@ -653,9 +611,7 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.redpanda.logger.debug(
             "Assert that throughput is recorded with the expected labels")
         for sample in self.get_metrics("client_quota_throughput_sum"):
-            all_expected_metrics = ExpectedMetrics(
-                expected_pm_metrics.metrics + expected_tput_metrics.metrics)
-            if all_expected_metrics.has_matching(sample.labels):
+            if expected_tput_metrics.has_matching(sample.labels):
                 check_sample(sample, sample.value > 0)
             else:
                 check_sample(sample, sample.value == 0)


### PR DESCRIPTION
This PR prepares for the removal of the deprecated client quota cluster configs:
* [kafka_client_group_byte_rate_quota](https://docs.redpanda.com/current/reference/cluster-properties/#kafka_client_group_byte_rate_quota)
* [kafka_client_group_fetch_byte_rate_quota](https://docs.redpanda.com/current/reference/cluster-properties/#kafka_client_group_fetch_byte_rate_quota)
* [target_quota_byte_rate](https://docs.redpanda.com/current/reference/cluster-properties/#target_quota_byte_rate)
* [target_fetch_quota_byte_rate](https://docs.redpanda.com/current/reference/cluster-properties/#target_fetch_quota_byte_rate)
* [kafka_admin_topic_api_rate](https://docs.redpanda.com/current/reference/cluster-properties/#kafka_admin_topic_api_rate) 

This PR only contains test changes. It specifically changes the client quota-related unit and ducktape tests to use the kafka api to configure client quotas instead of the cluster configs. This is to simplify the next PR which removes the above cluster configs.

Fixes https://redpandadata.atlassian.net/browse/CORE-8710

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
