### PR TITLE
c/migration/table: when applying a snapshot update completed timestamp

### DIFF
--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -138,6 +138,7 @@ ss::future<> migrations_table::apply_snapshot(
                 continue;
             }
             it->second.state = migration.state;
+            it->second.completed_timestamp = migration.completed_timestamp;
         }
         affected_ids.push_back(id);
         updated.emplace_back(it->second);


### PR DESCRIPTION
When applying a snapshot we forgot to update completed timestamp. It may bring us into an incorrect state where state is finished but completed timestamp is not set.
https://redpandadata.atlassian.net/browse/CORE-8723

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
