### PR TITLE
ducktape: Increase partition density to 3k per shard in the MPT

### DIFF
--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -333,7 +333,7 @@ class KgoRepeaterService(Service):
 
     def _get_status_reports(self):
         for node in self.nodes:
-            r = requests.get(self._remote_url(node, "status"), timeout=10)
+            r = requests.get(self._remote_url(node, "status"), timeout=30)
             r.raise_for_status()
             node_status = r.json()
             for worker_status in node_status:


### PR DESCRIPTION
Increase the partition density in the MPT to 3k per shard and use the new memory group aware config.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
