### PR TITLE
kafka: add dedicated logger for authz failures

### DIFF
--- a/src/v/kafka/protocol/logger.cc
+++ b/src/v/kafka/protocol/logger.cc
@@ -11,4 +11,5 @@
 
 namespace kafka {
 ss::logger klog("kafka");
+ss::logger kauthzlog("kafka/authz");
 } // namespace kafka

--- a/src/v/kafka/protocol/logger.h
+++ b/src/v/kafka/protocol/logger.h
@@ -17,5 +17,6 @@
 namespace kafka {
 
 extern ss::logger klog;
+extern ss::logger kauthzlog;
 
 } // namespace kafka

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -312,10 +312,10 @@ private:
 
         template<typename... Args>
         void log(ss::log_level lvl, const char* format, Args&&... args) {
-            if (klog.is_enabled(lvl)) {
+            if (kauthzlog.is_enabled(lvl)) {
                 auto line_fmt = ss::sstring("{}:{} failed authorization - ")
                                 + format;
-                klog.log(
+                kauthzlog.log(
                   lvl,
                   line_fmt.c_str(),
                   _client_addr,


### PR DESCRIPTION
We currently log authz failures to the kafka log at info level, this
means we have per request possible log spam with no fine grained control
for them.

Rate limiting does not quite do the thing we want, rate limiting would
give us rate limiting at a global level, and what you would want is a
rate limit per principal or maybe per (principal, resource).

The simpler solution is to move the authz log to a dedicated logger so
that it can be controlled seperately, or temporarily disabled/enabled
for debugging.

Fixes: CORE-8666

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Move failed authorization log statements from the `kafka` logger to a new `kafka/authz` logger, allowing for fine grained control over log statements for failed authorization.

