### PR TITLE
Replace `get0` with `get`

### DIFF
--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -941,7 +941,7 @@ FIXTURE_TEST(test_tx_expiration_without_data_batches, rm_stm_test_fixture) {
 FIXTURE_TEST(test_concurrent_producer_evictions, rm_stm_test_fixture) {
     create_stm_and_start_raft();
     auto& stm = *_stm;
-    stm.start().get0();
+    stm.start().get();
     stm.testing_only_disable_auto_abort();
 
     wait_for_confirmed_leader();

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -102,14 +102,14 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     batch_spec.records = record_count;
     batch_spec.count = batch_count;
     ss::circular_buffer<model::record_batch> batches
-      = model::test::make_random_batches(batch_spec).get0();
+      = model::test::make_random_batches(batch_spec).get();
 
     auto reader = model::make_generating_record_batch_reader(
       [batches = std::move(batches)]() mutable {
           return ss::make_ready_future<model::record_batch_reader::data_t>(
             std::move(batches));
       });
-    auto res = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+    auto res = reader.consume(std::move(multiplexer), model::no_timeout).get();
     ASSERT_TRUE(res.has_error());
     EXPECT_EQ(res.error(), datalake::writer_error::parquet_conversion_error);
 }
@@ -145,7 +145,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     batch_spec.count = batch_count;
     batch_spec.offset = model::offset{start_offset};
     ss::circular_buffer<model::record_batch> batches
-      = model::test::make_random_batches(batch_spec).get0();
+      = model::test::make_random_batches(batch_spec).get();
 
     auto reader = model::make_generating_record_batch_reader(
       [batches = std::move(batches)]() mutable {
@@ -154,7 +154,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
       });
 
     auto result
-      = reader.consume(std::move(multiplexer), model::no_timeout).get0();
+      = reader.consume(std::move(multiplexer), model::no_timeout).get();
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().data_files.size(), 1);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1047,7 +1047,7 @@ FIXTURE_TEST(append_concurrent_with_prefix_truncate, storage_test_fixture) {
     auto ntp = model::controller_ntp;
 
     storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
-    auto log = mgr.manage(std::move(ntp_cfg)).get0();
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     bool stop = false;
     size_t cnt = 0;


### PR DESCRIPTION
`get0` has been deprecated in seastar.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
