### PR TITLE
[v24.3.x] kafka: add dedicated logger for authz failures

### DIFF
--- a/src/v/kafka/protocol/logger.cc
+++ b/src/v/kafka/protocol/logger.cc
@@ -11,4 +11,5 @@
 
 namespace kafka {
 ss::logger klog("kafka");
+ss::logger kauthzlog("kafka/authz");
 } // namespace kafka

--- a/src/v/kafka/protocol/logger.h
+++ b/src/v/kafka/protocol/logger.h
@@ -17,5 +17,6 @@
 namespace kafka {
 
 extern ss::logger klog;
+extern ss::logger kauthzlog;
 
 } // namespace kafka

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -312,10 +312,10 @@ private:
 
         template<typename... Args>
         void log(ss::log_level lvl, const char* format, Args&&... args) {
-            if (klog.is_enabled(lvl)) {
+            if (kauthzlog.is_enabled(lvl)) {
                 auto line_fmt = ss::sstring("{}:{} failed authorization - ")
                                 + format;
-                klog.log(
+                kauthzlog.log(
                   lvl,
                   line_fmt.c_str(),
                   _client_addr,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24712
