### PR TITLE
[CORE-8450] Schema Registry: Support normalize=true for protobuf

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -51,8 +51,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20240530-2db0eb3/MODULE.bazel": "d0405b762c5e87cd445b7015f2b8da5400ef9a8dbca0bfefa6c1cea79d528a97",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20240530-2db0eb3/source.json": "0d413869349e82e5d679802abe9ce23e0326bbf56daa97ae9e7dbdcec72982fc",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "37389c6b5a40c59410b4226d3bb54b08637f393d66e2fa57925c6fcf68e64bf4",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/source.json": "83eb01b197ed0b392f797860c9da5ed1bf95f4d0ded994d694a3d44731275916",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/7.3.1/MODULE.bazel": "537faf0ad9f5892910074b8e43b4c91c96f1d5d86b6ed04bdbe40cf68aa48b68",
+    "https://bcr.bazel.build/modules/buildifier_prebuilt/7.3.1/source.json": "55153a5e6ca9c8a7e266c4b46b951e8a010d25ec6062bc35d5d4f89925796bad",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/bzip2/1.0.8/MODULE.bazel": "83ee443b286b0b91566e5ee77e74ba6445895f3135467893871560f9e4ebc159",
@@ -913,8 +913,8 @@
     },
     "@@buildifier_prebuilt~//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "wCVIDn7TlLvw6PNyOj4qjCcL1dhRDKDOZKuBuxemVxY=",
-        "usagesDigest": "MbIuhDGRTlw07fpxjzM2N+5FUBehV3EnCmO7eEN86tc=",
+        "bzlTransitiveDigest": "lqH5eQXGrxGyrPzoegk5Mn6zC3A1P0h+QsA1O/QlXHc=",
+        "usagesDigest": "yt+GfSH6jiwv+nPT5fzdhb/zB+8RgR4U+dna3WGxrzU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -924,11 +924,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-darwin-amd64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
               ],
               "downloaded_file_path": "buildifier",
               "executable": true,
-              "sha256": "eeb47b2de27f60efe549348b183fac24eae80f1479e8b06cac0799c486df5bed"
+              "sha256": "375f823103d01620aaec20a0c29c6cbca99f4fd0725ae30b93655c6704f44d71"
             }
           },
           "buildifier_darwin_arm64": {
@@ -936,11 +936,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-darwin-arm64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
               ],
               "downloaded_file_path": "buildifier",
               "executable": true,
-              "sha256": "fa07ba0d20165917ca4cc7609f9b19a8a4392898148b7babdf6bb2a7dd963f05"
+              "sha256": "5a6afc6ac7a09f5455ba0b89bd99d5ae23b4174dc5dc9d6c0ed5ce8caac3f813"
             }
           },
           "buildifier_linux_amd64": {
@@ -948,11 +948,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-amd64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
               ],
               "downloaded_file_path": "buildifier",
               "executable": true,
-              "sha256": "be63db12899f48600bad94051123b1fd7b5251e7661b9168582ce52396132e92"
+              "sha256": "5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009"
             }
           },
           "buildifier_linux_arm64": {
@@ -960,11 +960,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-arm64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
               ],
               "downloaded_file_path": "buildifier",
               "executable": true,
-              "sha256": "18540fc10f86190f87485eb86963e603e41fa022f88a2d1b0cf52ff252b5e1dd"
+              "sha256": "0bf86c4bfffaf4f08eed77bde5b2082e4ae5039a11e2e8b03984c173c34a561c"
             }
           },
           "buildifier_windows_amd64": {
@@ -972,11 +972,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-windows-amd64.exe"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
               ],
               "downloaded_file_path": "buildifier.exe",
               "executable": true,
-              "sha256": "da8372f35e34b65fb6d997844d041013bb841e55f58b54d596d35e49680fe13c"
+              "sha256": "370cd576075ad29930a82f5de132f1a1de4084c784a82514bd4da80c85acf4a8"
             }
           },
           "buildozer_darwin_amd64": {
@@ -984,11 +984,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-darwin-amd64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-darwin-amd64"
               ],
               "downloaded_file_path": "buildozer",
               "executable": true,
-              "sha256": "d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e"
+              "sha256": "854c9583efc166602276802658cef3f224d60898cfaa60630b33d328db3b0de2"
             }
           },
           "buildozer_darwin_arm64": {
@@ -996,11 +996,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-darwin-arm64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-darwin-arm64"
               ],
               "downloaded_file_path": "buildozer",
               "executable": true,
-              "sha256": "9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d"
+              "sha256": "31b1bfe20d7d5444be217af78f94c5c43799cdf847c6ce69794b7bf3319c5364"
             }
           },
           "buildozer_linux_amd64": {
@@ -1008,11 +1008,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-linux-amd64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-linux-amd64"
               ],
               "downloaded_file_path": "buildozer",
               "executable": true,
-              "sha256": "8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119"
+              "sha256": "3305e287b3fcc68b9a35fd8515ee617452cd4e018f9e6886b6c7cdbcba8710d4"
             }
           },
           "buildozer_linux_arm64": {
@@ -1020,11 +1020,11 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-linux-arm64"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-linux-arm64"
               ],
               "downloaded_file_path": "buildozer",
               "executable": true,
-              "sha256": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa"
+              "sha256": "0b5a2a717ac4fc911e1fec8d92af71dbb4fe95b10e5213da0cc3d56cea64a328"
             }
           },
           "buildozer_windows_amd64": {
@@ -1032,18 +1032,18 @@
             "ruleClassName": "http_file",
             "attributes": {
               "urls": [
-                "https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-windows-amd64.exe"
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildozer-windows-amd64.exe"
               ],
               "downloaded_file_path": "buildozer.exe",
               "executable": true,
-              "sha256": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b"
+              "sha256": "58d41ce53257c5594c9bc86d769f580909269f68de114297f46284fbb9023dcf"
             }
           },
           "buildifier_prebuilt_toolchains": {
             "bzlFile": "@@buildifier_prebuilt~//:defs.bzl",
             "ruleClassName": "_buildifier_toolchain_setup",
             "attributes": {
-              "assets_json": "[{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"eeb47b2de27f60efe549348b183fac24eae80f1479e8b06cac0799c486df5bed\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"fa07ba0d20165917ca4cc7609f9b19a8a4392898148b7babdf6bb2a7dd963f05\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"be63db12899f48600bad94051123b1fd7b5251e7661b9168582ce52396132e92\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"18540fc10f86190f87485eb86963e603e41fa022f88a2d1b0cf52ff252b5e1dd\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"windows\",\"sha256\":\"da8372f35e34b65fb6d997844d041013bb841e55f58b54d596d35e49680fe13c\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"d29e347ecd6b5673d72cb1a8de05bf1b06178dd229ff5eb67fad5100c840cc8e\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"9b9e71bdbec5e7223871e913b65d12f6d8fa026684daf991f00e52ed36a6978d\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"8dfd6345da4e9042daa738d7fdf34f699c5dfce4632f7207956fceedd8494119\",\"version\":\"v6.4.0\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa\",\"version\":\"v6.4.0\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"windows\",\"sha256\":\"e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b\",\"version\":\"v6.4.0\"}]"
+              "assets_json": "[{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"375f823103d01620aaec20a0c29c6cbca99f4fd0725ae30b93655c6704f44d71\",\"version\":\"v7.3.1\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"5a6afc6ac7a09f5455ba0b89bd99d5ae23b4174dc5dc9d6c0ed5ce8caac3f813\",\"version\":\"v7.3.1\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"5474cc5128a74e806783d54081f581662c4be8ae65022f557e9281ed5dc88009\",\"version\":\"v7.3.1\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"0bf86c4bfffaf4f08eed77bde5b2082e4ae5039a11e2e8b03984c173c34a561c\",\"version\":\"v7.3.1\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"windows\",\"sha256\":\"370cd576075ad29930a82f5de132f1a1de4084c784a82514bd4da80c85acf4a8\",\"version\":\"v7.3.1\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"854c9583efc166602276802658cef3f224d60898cfaa60630b33d328db3b0de2\",\"version\":\"v7.3.1\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"31b1bfe20d7d5444be217af78f94c5c43799cdf847c6ce69794b7bf3319c5364\",\"version\":\"v7.3.1\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"3305e287b3fcc68b9a35fd8515ee617452cd4e018f9e6886b6c7cdbcba8710d4\",\"version\":\"v7.3.1\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"0b5a2a717ac4fc911e1fec8d92af71dbb4fe95b10e5213da0cc3d56cea64a328\",\"version\":\"v7.3.1\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"windows\",\"sha256\":\"58d41ce53257c5594c9bc86d769f580909269f68de114297f46284fbb9023dcf\",\"version\":\"v7.3.1\"}]"
             }
           }
         },

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3488,6 +3488,12 @@ configuration::configuration()
       "Normalize schemas as they are read from the topic on startup.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
+  , schema_registry_protobuf_renderer_v2(
+      *this,
+      "schema_registry_protobuf_renderer_v2",
+      "Enables experimental protobuf renderer to support normalize=true.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , pp_sr_smp_max_non_local_requests(
       *this,
       "pp_sr_smp_max_non_local_requests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -663,6 +663,7 @@ struct configuration final : public config_store {
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
     property<bool> schema_registry_normalize_on_startup;
+    property<bool> schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;
     bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;

--- a/src/v/pandaproxy/BUILD
+++ b/src/v/pandaproxy/BUILD
@@ -294,6 +294,7 @@ redpanda_cc_library(
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/container:inlined_vector",
         "@abseil-cpp//absl/container:node_hash_map",
+        "@abseil-cpp//absl/strings",
         "@avro",
         "@boost//:algorithm",
         "@boost//:container",

--- a/src/v/pandaproxy/BUILD
+++ b/src/v/pandaproxy/BUILD
@@ -296,6 +296,7 @@ redpanda_cc_library(
         "@abseil-cpp//absl/container:node_hash_map",
         "@avro",
         "@boost//:algorithm",
+        "@boost//:container",
         "@boost//:graph",
         "@boost//:lexical_cast",
         "@boost//:math",

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -17,6 +17,7 @@
 #include "pandaproxy/schema_registry/schema_id_cache.h"
 #include "pandaproxy/schema_registry/service.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/schema_registry/validation_metrics.h"
 
 #include <seastar/core/coroutine.hh>
@@ -44,7 +45,8 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>();
+    _store = std::make_unique<sharded_store>(protobuf_renderer_v2{
+      config::shard_local_cfg().schema_registry_protobuf_renderer_v2});
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -18,6 +18,7 @@
 #include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "src/v/pandaproxy/schema_registry/protobuf/confluent/meta.pb.h"
 #include "src/v/pandaproxy/schema_registry/protobuf/confluent/types/decimal.pb.h"
 #include "src/v/pandaproxy/schema_registry/protobuf/google/type/calendar_period.pb.h"
@@ -46,11 +47,15 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/container/flat_set.hpp>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/api.pb.h>
 #include <google/protobuf/compiler/parser.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor_database.h>
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/empty.pb.h>
 #include <google/protobuf/field_mask.pb.h>
@@ -488,6 +493,7 @@ struct protobuf_schema_definition::impl {
     pb::DescriptorPool _dp;
     const pb::FileDescriptor* fd{};
     pb::FileDescriptorProto fdp{};
+    normalize is_normalized{normalize::no};
     protobuf_renderer_v2 v2_renderer{protobuf_renderer_v2::no};
 
     /**
@@ -549,7 +555,13 @@ struct protobuf_schema_definition::impl {
             return canonical_schema_definition::raw_string{std::move(buf)};
         }
         iobuf_ostream osb;
-        render_proto(osb.ostream(), fdp, *fd);
+        if (is_normalized) {
+            pb::FileDescriptorProto tmp_fdp;
+            fd->CopyTo(&tmp_fdp);
+            render_proto(osb.ostream(), std::move(tmp_fdp), *fd);
+        } else {
+            render_proto(osb.ostream(), fdp, *fd);
+        }
         return canonical_schema_definition::raw_string{std::move(osb).buf()};
     }
 
@@ -589,6 +601,20 @@ struct protobuf_schema_definition::impl {
 
         std::variant<Range, std::reference_wrapper<const Range>> _r;
     };
+
+    template<
+      std::ranges::random_access_range Range,
+      typename Comp = std::ranges::less,
+      typename Proj = std::identity>
+    const range_proxy<Range> maybe_sorted(
+      const Range& range, Comp comp = Comp{}, Proj proj = Proj{}) const {
+        if (!is_normalized) {
+            return range_proxy<Range>{range};
+        }
+        std::decay_t<Range> copy = range;
+        std::ranges::sort(copy, comp, proj);
+        return range_proxy<Range>{std::move(copy)};
+    }
 
     void render_field(
       std::ostream& os,
@@ -664,9 +690,11 @@ struct protobuf_schema_definition::impl {
               [&](const pb::FieldDescriptor* fd) -> std::string_view {
                 switch (fd->type()) {
                 case pb::FieldDescriptor::TYPE_MESSAGE:
-                    return fd->message_type()->name();
+                    return is_normalized ? fd->message_type()->full_name()
+                                         : fd->message_type()->name();
                 case pb::FieldDescriptor::TYPE_ENUM:
-                    return fd->enum_type()->name();
+                    return is_normalized ? fd->enum_type()->full_name()
+                                         : fd->enum_type()->name();
                 default:
                     return fd->type_name();
                 };
@@ -751,7 +779,13 @@ struct protobuf_schema_definition::impl {
               },
               field_options());
 
-            for (const auto& option : options.uninterpreted_option()) {
+            auto uninterpreted_options = maybe_sorted(
+              options.uninterpreted_option(),
+              std::less{},
+              [](const auto& option) {
+                  return fmt::format("{}", fmt::join(option.name(), ""));
+              });
+            for (const auto& option : uninterpreted_options) {
                 maybe_print_seperator();
                 fmt::print(os, "{}", option);
             }
@@ -811,39 +845,52 @@ struct protobuf_schema_definition::impl {
                   message.options().no_standard_descriptor_accessor());
             }
         }
-        for (const auto& option : message.options().uninterpreted_option()) {
+        auto uninterepreted_options = maybe_sorted(
+          message.options().uninterpreted_option(),
+          std::less{},
+          [](const auto& option) {
+              return fmt::format("{}", fmt::join(option.name(), ""));
+          });
+        for (const auto& option : uninterepreted_options) {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
         }
 
-        for (const auto& value : message.reserved_range()) {
+        auto reserved_range = maybe_sorted(
+          message.reserved_range(),
+          std::less{},
+          &pb::DescriptorProto_ReservedRange::start);
+        for (const auto& value : reserved_range) {
             fmt::print(os, "{:{}}reserved {}", "", indent + 2, value.start());
             if (value.has_end() && value.end() != value.start() + 1) {
                 fmt::print(os, " to {}", value.end() - 1);
             }
             fmt::print(os, ";\n");
         }
-        if (message.reserved_name_size() != 0) {
+        auto reserved_names = maybe_sorted(message.reserved_name());
+        if (!reserved_names.empty()) {
             fmt::print(
               os,
               "{:{}}reserved \"{}\";\n",
               "",
               indent + 2,
-              fmt::join(message.reserved_name(), "\", \""));
+              fmt::join(reserved_names, "\", \""));
         }
-        if (
-          message.reserved_range_size() != 0
-          || message.reserved_name_size() != 0) {
+        if (!reserved_range.empty() || !reserved_names.empty()) {
             fmt::print(os, "\n");
         }
 
         bool has_fields = false;
+        auto fields = maybe_sorted(
+          message.field(),
+          std::ranges::less{},
+          &pb::FieldDescriptorProto::number);
 
         // Each oneof section needs to start with the lowest field number, which
         // may be different to the order of oneof_decl in the message.
         std::vector<int> oneofs;
 
         // Render non oneof fields, and record correct order of oneof indices.
-        for (const auto& field : message.field()) {
+        for (const auto& field : fields) {
             if (
               field.has_oneof_index()
               && !(field.has_proto3_optional() && field.proto3_optional())) {
@@ -918,14 +965,18 @@ struct protobuf_schema_definition::impl {
       const pb::EnumDescriptorProto& enum_proto,
       int indent) const {
         fmt::print(os, "{:{}}enum {} {{\n", "", indent, enum_proto.name());
-        for (const auto& value : enum_proto.reserved_range()) {
+        auto reserved_range = maybe_sorted(
+          enum_proto.reserved_range(),
+          std::less{},
+          &pb::EnumDescriptorProto_EnumReservedRange::start);
+        for (const auto& value : reserved_range) {
             fmt::print(os, "{:{}}reserved {}", "", indent + 2, value.start());
             if (value.has_end() && value.end() != value.start()) {
                 fmt::print(os, " to {}", value.end());
             }
             fmt::print(os, ";\n");
         }
-        for (const auto& value : enum_proto.reserved_name()) {
+        for (const auto& value : maybe_sorted(enum_proto.reserved_name())) {
             fmt::print(os, "{:{}}reserved \"{}\";\n", "", indent + 2, value);
         }
         if (enum_proto.options().has_allow_alias()) {
@@ -948,6 +999,12 @@ struct protobuf_schema_definition::impl {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
         }
         std::optional<std::decay_t<decltype(enum_proto.value())>> values;
+        if (is_normalized) {
+            values = enum_proto.value();
+            std::ranges::sort(values.value(), std::less{}, [](const auto& v) {
+                return std::pair<int, std::string_view>{v.number(), v.name()};
+            });
+        }
         for (const auto& value : values.value_or(enum_proto.value())) {
             fmt::print(
               os, "{:{}}{} = {}", "", indent + 2, value.name(), value.number());
@@ -998,8 +1055,13 @@ struct protobuf_schema_definition::impl {
                   indent + 2,
                   service.options().deprecated());
             }
-            for (const auto& option :
-                 service.options().uninterpreted_option()) {
+            auto uninterpreted_options = maybe_sorted(
+              service.options().uninterpreted_option(),
+              std::less{},
+              [](const pb::UninterpretedOption& o) {
+                  return fmt::format("{}", fmt::join(o.name(), ""));
+              });
+            for (const auto& option : uninterpreted_options) {
                 fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
             }
         }
@@ -1032,8 +1094,13 @@ struct protobuf_schema_definition::impl {
                       pb::MethodOptions_IdempotencyLevel_Name(
                         method.options().idempotency_level()));
                 }
-                for (const auto& option :
-                     method.options().uninterpreted_option()) {
+                auto uninterpreted_options = maybe_sorted(
+                  method.options().uninterpreted_option(),
+                  std::less{},
+                  [](const pb::UninterpretedOption& o) {
+                      return fmt::format("{}", fmt::join(o.name(), ""));
+                  });
+                for (const auto& option : uninterpreted_options) {
                     fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
                 }
             }
@@ -1109,7 +1176,13 @@ struct protobuf_schema_definition::impl {
         if (options.has_py_generic_services()) {
             printv("py_generic_services", options.py_generic_services());
         }
-        for (const auto& option : options.uninterpreted_option()) {
+        auto uninterpreted_options = maybe_sorted(
+          options.uninterpreted_option(),
+          std::less{},
+          [](const pb::UninterpretedOption& o) {
+              return fmt::format("{}", fmt::join(o.name(), ""));
+          });
+        for (const auto& option : uninterpreted_options) {
             first_option = false;
             fmt::print(os, "option {};\n", option);
         }
@@ -1136,16 +1209,32 @@ struct protobuf_schema_definition::impl {
         };
 
         // return a range that matches the predicate
-        constexpr auto partition = [](auto begin, auto end, auto pred) {
-            return std::ranges::subrange(
-              begin, std::stable_partition(begin, end, pred));
-        };
+        constexpr auto partition =
+          [](auto begin, auto end, auto pred, normalize norm) {
+              return std::ranges::subrange(
+                begin,
+                norm ? std::partition(begin, end, pred)
+                     : std::stable_partition(begin, end, pred));
+          };
 
         auto public_deps = partition(
-          all_deps.begin(), all_deps.end(), is_public);
-        auto weak_deps = partition(public_deps.end(), all_deps.end(), is_weak);
+          all_deps.begin(), all_deps.end(), is_public, is_normalized);
+        auto weak_deps = partition(
+          public_deps.end(), all_deps.end(), is_weak, is_normalized);
         auto private_deps = std::ranges::subrange(
           weak_deps.end(), all_deps.end());
+
+        if (is_normalized) {
+            constexpr auto sort_and_unique = [](auto& deps) {
+                std::ranges::sort(deps);
+                deps = std::ranges::subrange(
+                  deps.begin(), std::ranges::unique(deps).begin());
+            };
+
+            sort_and_unique(public_deps);
+            sort_and_unique(weak_deps);
+            sort_and_unique(private_deps);
+        }
 
         auto print_deps = [&](const auto& view, std::string_view type) {
             for (const auto& dep : view) {
@@ -1264,8 +1353,8 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
     return os;
 }
 
-ss::future<protobuf_schema_definition>
-make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
+ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
+  schema_getter& store, canonical_schema schema, normalize norm) {
     auto refs = schema.def().refs();
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     impl->fdp = co_await import_schema(impl->_dp, store, std::move(schema));
@@ -1273,18 +1362,24 @@ make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
     if (auto* s = dynamic_cast<const sharded_store*>(&store); s != nullptr) {
         impl->v2_renderer = s->protobuf_v2_renderer();
     }
+    impl->is_normalized = norm;
+    if (norm) {
+        std::sort(refs.begin(), refs.end());
+        auto uniq = std::ranges::unique(refs);
+        refs.erase(uniq.begin(), uniq.end());
+    }
     co_return protobuf_schema_definition{std::move(impl), std::move(refs)};
 }
 
-ss::future<canonical_schema_definition>
-validate_protobuf_schema(sharded_store& store, canonical_schema schema) {
+ss::future<canonical_schema_definition> validate_protobuf_schema(
+  sharded_store& store, canonical_schema schema, normalize norm) {
     auto res = co_await make_protobuf_schema_definition(
-      store, std::move(schema));
+      store, std::move(schema), norm);
     co_return canonical_schema_definition{std::move(res)};
 }
 
-ss::future<canonical_schema>
-make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
+ss::future<canonical_schema> make_canonical_protobuf_schema(
+  sharded_store& store, unparsed_schema schema, normalize norm) {
     auto [sub, unparsed] = std::move(schema).destructure();
     auto [def, type, refs] = std::move(unparsed).destructure();
     canonical_schema temp{
@@ -1295,7 +1390,7 @@ make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
 
     co_return canonical_schema{
       std::move(sub),
-      co_await validate_protobuf_schema(store, std::move(temp))};
+      co_await validate_protobuf_schema(store, std::move(temp), norm)};
 }
 
 namespace {

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -683,12 +683,12 @@ struct protobuf_schema_definition::impl {
             bool is_proto2 = edition == pb::Edition::EDITION_PROTO2;
             if(descriptor && 
                 (descriptor->is_map() || descriptor->real_containing_oneof() ||
-                (descriptor->is_optional() && !(is_proto2 && !descriptor->containing_oneof())))) {
+                ((descriptor->is_optional() && !field.proto3_optional()) && !(is_proto2 && !descriptor->containing_oneof())))) {
                 return "";
             }
             switch (field.label()) {
             case pb::FieldDescriptorProto::LABEL_OPTIONAL:
-                return is_proto2 ? "optional " : "";
+                return "optional ";
             case pb::FieldDescriptorProto::LABEL_REPEATED:
                 return "repeated ";
             case pb::FieldDescriptorProto::LABEL_REQUIRED:

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -52,6 +52,7 @@
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/api.pb.h>
 #include <google/protobuf/compiler/parser.h>
+#include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/empty.pb.h>
 #include <google/protobuf/field_mask.pb.h>
@@ -291,7 +292,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 ///
 /// Recursively import references into the DescriptorPool, building the
 /// files on stack unwind.
-ss::future<const pb::FileDescriptor*> build_file_with_refs(
+ss::future<pb::FileDescriptorProto> build_file_with_refs(
   pb::DescriptorPool& dp, schema_getter& store, canonical_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         if (dp.FindFileByName(ref.name)) {
@@ -306,12 +307,14 @@ ss::future<const pb::FileDescriptor*> build_file_with_refs(
     }
 
     parser p;
-    co_return build_file(dp, p.parse(schema));
+    auto new_fdp = p.parse(schema);
+    build_file(dp, new_fdp);
+    co_return new_fdp;
 }
 
 ///\brief Import a schema in the DescriptorPool and return the
 /// FileDescriptor.
-ss::future<const pb::FileDescriptor*> import_schema(
+ss::future<pb::FileDescriptorProto> import_schema(
   pb::DescriptorPool& dp, schema_getter& store, canonical_schema schema) {
     try {
         co_return co_await build_file_with_refs(dp, store, schema.share());
@@ -324,6 +327,7 @@ ss::future<const pb::FileDescriptor*> import_schema(
 struct protobuf_schema_definition::impl {
     pb::DescriptorPool _dp;
     const pb::FileDescriptor* fd{};
+    pb::FileDescriptorProto fdp;
     protobuf_renderer_v2 v2_renderer{protobuf_renderer_v2::no};
 
     /**
@@ -434,7 +438,8 @@ ss::future<protobuf_schema_definition>
 make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     auto refs = schema.def().refs();
-    impl->fd = co_await import_schema(impl->_dp, store, std::move(schema));
+    impl->fdp = co_await import_schema(impl->_dp, store, std::move(schema));
+    impl->fd = impl->_dp.FindFileByName(impl->fdp.name());
     if (auto* s = dynamic_cast<const sharded_store*>(&store); s != nullptr) {
         impl->v2_renderer = s->protobuf_v2_renderer();
     }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -46,6 +46,7 @@
 #include <seastar/util/variant_utils.hh>
 
 #include <absl/container/flat_hash_set.h>
+#include <absl/strings/ascii.h>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/container/flat_set.hpp>
 #include <fmt/core.h>
@@ -70,6 +71,7 @@
 #include <algorithm>
 #include <charconv>
 #include <functional>
+#include <optional>
 #include <ranges>
 #include <string_view>
 #include <unordered_set>
@@ -621,10 +623,20 @@ struct protobuf_schema_definition::impl {
       pb::Edition edition,
       const pb::FieldDescriptorProto& field,
       const pb::FieldDescriptor* descriptor,
-      int indent) const {
+      int indent,
+      bool is_group = false) const {
         const auto type_name = [&]() -> std::string_view {
             if (field.has_type_name()) {
-                return field.type_name();
+                std::string_view name{field.type_name()};
+                if (is_group) {
+                    // Remove the prefix, the type is always in the immediate
+                    // scope.
+                    size_t pos = name.find_last_of('.');
+                    if (pos != std::string::npos) {
+                        name = name.substr(pos + 1);
+                    }
+                }
+                return name;
             }
             switch (field.type()) {
             case pb::FieldDescriptorProto::TYPE_DOUBLE:
@@ -689,6 +701,7 @@ struct protobuf_schema_definition::impl {
             const auto name_for =
               [&](const pb::FieldDescriptor* fd) -> std::string_view {
                 switch (fd->type()) {
+                case pb::FieldDescriptor::TYPE_GROUP:
                 case pb::FieldDescriptor::TYPE_MESSAGE:
                     return is_normalized ? fd->message_type()->full_name()
                                          : fd->message_type()->name();
@@ -716,8 +729,8 @@ struct protobuf_schema_definition::impl {
               "",
               indent,
               label(),
-              type_name(),
-              field.name(),
+              is_group ? "group" : type_name(),
+              is_group ? type_name() : field.name(),
               field.number());
         }
 
@@ -740,11 +753,8 @@ struct protobuf_schema_definition::impl {
         bool first = true;
         auto maybe_print_seperator = [&]() {
             if (count > 1) {
-                if (first) {
-                    fmt::print(os, " [\n{:{}}", "", indent + 2);
-                } else {
-                    fmt::print(os, ",\n{:{}}", "", indent + 2);
-                }
+                const auto prefix = first ? " [" : ",";
+                fmt::print(os, "{}\n{:{}}", prefix, "", indent + 2);
                 first = false;
             } else if (first) {
                 fmt::print(os, " [");
@@ -795,7 +805,11 @@ struct protobuf_schema_definition::impl {
         } else if (count == 1) {
             fmt::print(os, "]");
         }
-        fmt::print(os, ";\n");
+        if (is_group) {
+            fmt::print(os, " {{\n");
+        } else {
+            fmt::print(os, ";\n");
+        }
     }
 
     void render_extension(
@@ -811,13 +825,23 @@ struct protobuf_schema_definition::impl {
     }
 
     // Render a message, including nested messages
-    void render_message(
+    void render_nested(
       std::ostream& os,
       pb::Edition edition,
+      const std::optional<pb::FieldDescriptorProto>& field,
+      const pb::FieldDescriptor* field_descriptor,
       const pb::DescriptorProto& message,
       const pb::Descriptor* descriptor,
       int indent) const {
-        fmt::print(os, "{:{}}message {} {{\n", "", indent, message.name());
+        auto type = field.has_value() ? field->type()
+                                      : pb::FieldDescriptorProto::TYPE_MESSAGE;
+        if (type == pb::FieldDescriptorProto::TYPE_MESSAGE) {
+            fmt::print(os, "{:{}}message {} {{\n", "", indent, message.name());
+        } else if (type == pb::FieldDescriptorProto::TYPE_GROUP) {
+            bool is_group = true;
+            render_field(
+              os, edition, *field, field_descriptor, indent, is_group);
+        }
 
         if (message.has_options()) {
             if (message.options().has_deprecated()) {
@@ -880,10 +904,13 @@ struct protobuf_schema_definition::impl {
         }
 
         bool has_fields = false;
-        auto fields = maybe_sorted(
+        auto fields_ = maybe_sorted(
           message.field(),
           std::ranges::less{},
           &pb::FieldDescriptorProto::number);
+        auto fields = std::views::filter(fields_, [](const auto& f) {
+            return f.type() != pb::FieldDescriptorProto::TYPE_GROUP;
+        });
 
         // Each oneof section needs to start with the lowest field number, which
         // may be different to the order of oneof_decl in the message.
@@ -947,8 +974,22 @@ struct protobuf_schema_definition::impl {
 
         // Render nested types
         for (const auto& nested : nested_messages) {
-            auto d = descriptor->FindNestedTypeByName(nested.name());
-            render_message(os, edition, nested, d, indent + 2);
+            auto it = std::ranges::find_if(
+              message.field(), [&nested](const auto& f) {
+                  return f.name() == absl::AsciiStrToLower(nested.name());
+              });
+
+            auto field = (it != message.field().end())
+                           ? std::optional<pb::FieldDescriptorProto>{*it}
+                           : std::nullopt;
+            render_nested(
+              os,
+              edition,
+              field,
+              field_descriptor,
+              nested,
+              descriptor->FindNestedTypeByName(nested.name()),
+              indent + 2);
         }
 
         // Render nested enums
@@ -1276,7 +1317,7 @@ struct protobuf_schema_definition::impl {
         // Render messages
         for (const auto& message : fdp.message_type()) {
             auto d = descriptor.FindMessageTypeByName(message.name());
-            render_message(os, edition, message, d, 0);
+            render_nested(os, edition, std::nullopt, nullptr, message, d, 0);
         }
 
         // Render enums

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -1231,9 +1231,9 @@ struct protobuf_schema_definition::impl {
                   deps.begin(), std::ranges::unique(deps).begin());
             };
 
-            sort_and_unique(public_deps);
             sort_and_unique(weak_deps);
             sort_and_unique(private_deps);
+            sort_and_unique(public_deps);
         }
 
         auto print_deps = [&](const auto& view, std::string_view type) {
@@ -1242,9 +1242,9 @@ struct protobuf_schema_definition::impl {
             }
         };
 
-        print_deps(public_deps, "public ");
-        print_deps(weak_deps, "weak ");
         print_deps(private_deps, "");
+        print_deps(weak_deps, "weak ");
+        print_deps(public_deps, "public ");
     }
 
     void render_proto(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -38,12 +38,11 @@
 #include "src/v/pandaproxy/schema_registry/protobuf/google/type/quaternion.pb.h"
 #include "src/v/pandaproxy/schema_registry/protobuf/google/type/timeofday.pb.h"
 #include "ssx/sformat.h"
-#include "thirdparty/protobuf/descriptor.h"
-#include "thirdparty/protobuf/descriptor.pb.h"
 #include "utils/base64.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <absl/container/flat_hash_set.h>
 #include <boost/algorithm/string/trim.hpp>
@@ -52,7 +51,6 @@
 #include <google/protobuf/any.pb.h>
 #include <google/protobuf/api.pb.h>
 #include <google/protobuf/compiler/parser.h>
-#include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/empty.pb.h>
 #include <google/protobuf/field_mask.pb.h>
@@ -64,12 +62,173 @@
 #include <google/protobuf/type.pb.h>
 #include <google/protobuf/wrappers.pb.h>
 
+#include <algorithm>
+#include <charconv>
+#include <functional>
+#include <ranges>
 #include <string_view>
 #include <unordered_set>
+
+struct indent_formatter : fmt::formatter<std::string_view> {
+    using Base = fmt::formatter<std::string_view>;
+    constexpr auto parse(fmt::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it == ':') {
+            ++it;
+        }
+        if (it != ctx.end() && *it == 'i') {
+            auto [ptr, ec] = std::from_chars(std::next(it), ctx.end(), indent);
+            if (ec == std::errc{}) {
+                it = ptr;
+            }
+        }
+        return Base::parse(ctx);
+    }
+
+    template<typename T>
+    auto
+    format(const T& t, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        if (indent > 0) {
+            fmt::format_to(ctx.out(), "{:{}}", "", indent);
+        }
+        return Base::format(t, ctx);
+    }
+
+    size_t indent{0};
+};
+
+template<>
+struct fmt::formatter<google::protobuf::UninterpretedOption_NamePart>
+  : formatter<std::string_view> {
+    using formatter<std::string_view>::format;
+    auto format(
+      const google::protobuf::UninterpretedOption_NamePart& np,
+      format_context& ctx) const {
+        if (np.has_is_extension() && np.is_extension()) {
+            return fmt::format_to(ctx.out(), "({})", np.name_part());
+        }
+        if (np.has_name_part()) {
+            return fmt::format_to(ctx.out(), "{}", np.name_part());
+        }
+
+        return ctx.out();
+    }
+};
+
+template<>
+struct fmt::formatter<google::protobuf::UninterpretedOption>
+  : indent_formatter {
+    using indent_formatter::format;
+    using indent_formatter::parse;
+    auto format(
+      const google::protobuf::UninterpretedOption& option,
+      format_context& ctx) const {
+        const auto fmt = [&](const auto& val) {
+            if (option.has_string_value()) {
+                return fmt::format_to(
+                  ctx.out(), "{} = \"{}\"", fmt::join(option.name(), ""), val);
+            } else if (option.has_aggregate_value()) {
+                return fmt::format_to(
+                  ctx.out(),
+                  "{} = {{{}\n{:{}}}}",
+                  fmt::join(option.name(), ""),
+                  val,
+                  "",
+                  indent + 2);
+            }
+            return fmt::format_to(
+              ctx.out(), "{} = {}", fmt::join(option.name(), ""), val);
+        };
+        if (option.has_identifier_value()) {
+            return fmt(option.identifier_value());
+        } else if (option.has_positive_int_value()) {
+            return fmt(option.positive_int_value());
+        } else if (option.has_negative_int_value()) {
+            return fmt(option.negative_int_value());
+        } else if (option.has_double_value()) {
+            return fmt(option.double_value());
+        } else if (option.has_string_value()) {
+            return fmt(option.string_value());
+        } else if (option.has_aggregate_value()) {
+            return fmt(option.aggregate_value());
+        }
+        return ctx.out();
+    }
+};
+
+template<>
+struct fmt::formatter<google::protobuf::FieldOptions::OptionRetention>
+  : indent_formatter {
+    auto format(
+      const google::protobuf::FieldOptions::OptionRetention& option,
+      format_context& ctx) const {
+        fmt::format_to(
+          ctx.out(),
+          "{}",
+          google::protobuf::FieldOptions::OptionRetention_Name(option));
+        return ctx.out();
+    }
+};
+
+template<>
+struct fmt::formatter<google::protobuf::FieldOptions::CType>
+  : indent_formatter {
+    auto format(
+      const google::protobuf::FieldOptions::CType& option,
+      format_context& ctx) const {
+        fmt::format_to(
+          ctx.out(), "{}", google::protobuf::FieldOptions::CType_Name(option));
+        return ctx.out();
+    }
+};
+template<>
+struct fmt::formatter<google::protobuf::FieldOptions::JSType>
+  : indent_formatter {
+    auto format(
+      const google::protobuf::FieldOptions::JSType& option,
+      format_context& ctx) const {
+        fmt::format_to(
+          ctx.out(), "{}", google::protobuf::FieldOptions::JSType_Name(option));
+        return ctx.out();
+    }
+};
 
 namespace pandaproxy::schema_registry {
 
 namespace pb = google::protobuf;
+
+template<typename T>
+struct field_option {
+    std::string_view name;
+    bool (pb::FieldOptions::*check)() const;
+    T (pb::FieldOptions::*field)() const;
+};
+
+auto field_options() {
+    return std::make_tuple(
+      field_option{
+        "debug_redact",
+        &pb::FieldOptions::has_debug_redact,
+        &pb::FieldOptions::debug_redact},
+      field_option{
+        "deprecated",
+        &pb::FieldOptions::has_deprecated,
+        &pb::FieldOptions::deprecated},
+      field_option{
+        "retention",
+        &pb::FieldOptions::has_retention,
+        &pb::FieldOptions::retention},
+      field_option{
+        "packed", &pb::FieldOptions::has_packed, &pb::FieldOptions::packed},
+      field_option{
+        "lazy", &pb::FieldOptions::has_lazy, &pb::FieldOptions::lazy},
+      field_option{
+        "weak", &pb::FieldOptions::has_weak, &pb::FieldOptions::weak},
+      field_option{
+        "ctype", &pb::FieldOptions::has_ctype, &pb::FieldOptions::ctype},
+      field_option{
+        "jstype", &pb::FieldOptions::has_jstype, &pb::FieldOptions::jstype});
+}
 
 struct descriptor_hasher {
     using is_transparent = void;
@@ -193,7 +352,7 @@ public:
           ss::sstring{message}});
     }
 
-    error_info error() const;
+    error_info error(std::string_view sub) const;
 
 private:
     enum class level {
@@ -285,7 +444,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
     if (auto fd = dp.BuildFileCollectingErrors(fdp, &dp_ec); fd) {
         return fd;
     }
-    throw as_exception(dp_ec.error());
+    throw as_exception(dp_ec.error(fdp.name()));
 }
 
 ///\brief Build a FileDescriptor and import references from the store.
@@ -319,7 +478,8 @@ ss::future<pb::FileDescriptorProto> import_schema(
     try {
         co_return co_await build_file_with_refs(dp, store, schema.share());
     } catch (const exception& e) {
-        vlog(plog.warn, "Failed to decode schema: {}", e.what());
+        vlog(
+          plog.warn, "Failed to decode schema {}: {}", schema.sub(), e.what());
         throw as_exception(invalid_schema(schema));
     }
 }
@@ -327,7 +487,7 @@ ss::future<pb::FileDescriptorProto> import_schema(
 struct protobuf_schema_definition::impl {
     pb::DescriptorPool _dp;
     const pb::FileDescriptor* fd{};
-    pb::FileDescriptorProto fdp;
+    pb::FileDescriptorProto fdp{};
     protobuf_renderer_v2 v2_renderer{protobuf_renderer_v2::no};
 
     /**
@@ -380,11 +540,681 @@ struct protobuf_schema_definition::impl {
         return ssx::sformat(
           "{}\n{}\n\n{}\n\n{}\n", header, package, imports, footer);
     }
+
+    canonical_schema_definition::raw_string raw() const {
+        if (!v2_renderer) {
+            iobuf buf;
+            auto proto = debug_string();
+            buf.append(proto.data(), proto.size());
+            return canonical_schema_definition::raw_string{std::move(buf)};
+        }
+        iobuf_ostream osb;
+        render_proto(osb.ostream(), fdp, *fd);
+        return canonical_schema_definition::raw_string{std::move(osb).buf()};
+    }
+
+    template<std::ranges::range Range>
+    struct range_proxy {
+    public:
+        explicit range_proxy(Range&& r)
+          : _r{std::forward<Range>(r)} {}
+        explicit range_proxy(const Range& r)
+          : _r{std::cref(r)} {}
+        auto begin() const { return range().begin(); }
+        auto end() const { return range().end(); }
+        auto empty() const { return range().empty(); }
+        auto size() const { return range().size(); }
+
+    private:
+        auto range() const {
+            return std::visit(
+              ss::make_visitor(
+                [](std::reference_wrapper<Range>& r) {
+                    return std::ranges::subrange(r.get());
+                },
+                [](const Range& r) { return std::ranges::subrange(r); }),
+              _r);
+        }
+        template<typename Func>
+        auto visit(Func&& func) const {
+            return std::visit(
+              _r,
+              [&func](std::reference_wrapper<const Range>& r) {
+                  return std::invoke(std::forward<Func>(func), r.get());
+              },
+              [&func](const Range& r) {
+                  return std::invoke(std::forward<Func>(func), r);
+              });
+        }
+
+        std::variant<Range, std::reference_wrapper<const Range>> _r;
+    };
+
+    void render_field(
+      std::ostream& os,
+      pb::Edition edition,
+      const pb::FieldDescriptorProto& field,
+      const pb::FieldDescriptor* descriptor,
+      int indent) const {
+        const auto type_name = [&]() -> std::string_view {
+            if (field.has_type_name()) {
+                return field.type_name();
+            }
+            switch (field.type()) {
+            case pb::FieldDescriptorProto::TYPE_DOUBLE:
+                return "double";
+            case pb::FieldDescriptorProto::TYPE_FLOAT:
+                return "float";
+            case pb::FieldDescriptorProto::TYPE_INT64:
+                return "int64";
+            case pb::FieldDescriptorProto::TYPE_UINT64:
+                return "uint64";
+            case pb::FieldDescriptorProto::TYPE_INT32:
+                return "int32";
+            case pb::FieldDescriptorProto::TYPE_FIXED64:
+                return "fixed64";
+            case pb::FieldDescriptorProto::TYPE_FIXED32:
+                return "fixed32";
+            case pb::FieldDescriptorProto::TYPE_BOOL:
+                return "bool";
+            case pb::FieldDescriptorProto::TYPE_STRING:
+                return "string";
+            case pb::FieldDescriptorProto::TYPE_GROUP:
+                return "group";
+            case pb::FieldDescriptorProto::TYPE_MESSAGE:
+                return "message";
+            case pb::FieldDescriptorProto::TYPE_BYTES:
+                return "bytes";
+            case pb::FieldDescriptorProto::TYPE_UINT32:
+                return "uint32";
+            case pb::FieldDescriptorProto::TYPE_ENUM:
+                return "enum";
+            case pb::FieldDescriptorProto::TYPE_SFIXED32:
+                return "sfixed32";
+            case pb::FieldDescriptorProto::TYPE_SFIXED64:
+                return "sfixed64";
+            case pb::FieldDescriptorProto::TYPE_SINT32:
+                return "sint32";
+            case pb::FieldDescriptorProto::TYPE_SINT64:
+                return "sint64";
+            }
+            return "unknown";
+        };
+
+        const auto label = [&]() {
+            bool is_proto2 = edition == pb::Edition::EDITION_PROTO2;
+            if(descriptor && 
+                (descriptor->is_map() || descriptor->real_containing_oneof() ||
+                (descriptor->is_optional() && !(is_proto2 && !descriptor->containing_oneof())))) {
+                return "";
+            }
+            switch (field.label()) {
+            case pb::FieldDescriptorProto::LABEL_OPTIONAL:
+                return is_proto2 ? "optional " : "";
+            case pb::FieldDescriptorProto::LABEL_REPEATED:
+                return "repeated ";
+            case pb::FieldDescriptorProto::LABEL_REQUIRED:
+                return is_proto2 ? "required " : "";
+            }
+            return "";
+        };
+
+        if (descriptor && descriptor->is_map()) {
+            const auto name_for =
+              [&](const pb::FieldDescriptor* fd) -> std::string_view {
+                switch (fd->type()) {
+                case pb::FieldDescriptor::TYPE_MESSAGE:
+                    return fd->message_type()->name();
+                case pb::FieldDescriptor::TYPE_ENUM:
+                    return fd->enum_type()->name();
+                default:
+                    return fd->type_name();
+                };
+            };
+            fmt::print(
+              os,
+              "{:{}}{}map<{}, {}> {} = {}",
+              "",
+              indent,
+              label(),
+              name_for(descriptor->message_type()->field(0)),
+              name_for(descriptor->message_type()->field(1)),
+              field.name(),
+              field.number());
+        } else {
+            fmt::print(
+              os,
+              "{:{}}{}{} {} = {}",
+              "",
+              indent,
+              label(),
+              type_name(),
+              field.name(),
+              field.number());
+        }
+
+        size_t count = [&field]() {
+            return static_cast<size_t>(field.has_default_value()) +
+                   static_cast<size_t>(field.has_json_name()) +
+                   (field.has_options()
+                     ? std::apply(
+                         [&field](const auto&... field_option) {
+                             return (
+                               static_cast<size_t>(
+                                 (field.options().*field_option.check)())
+                               + ...);
+                         },
+                         field_options())
+                         + field.options().uninterpreted_option_size()
+                     : 0);
+        }();
+
+        bool first = true;
+        auto maybe_print_seperator = [&]() {
+            if (count > 1) {
+                if (first) {
+                    fmt::print(os, " [\n{:{}}", "", indent + 2);
+                } else {
+                    fmt::print(os, ",\n{:{}}", "", indent + 2);
+                }
+                first = false;
+            } else if (first) {
+                fmt::print(os, " [");
+            }
+        };
+
+        if (field.has_default_value()) {
+            maybe_print_seperator();
+            fmt::print(os, "default = {}", field.default_value());
+        }
+        if (field.has_json_name()) {
+            maybe_print_seperator();
+            fmt::print(os, "json_name = \"{}\"", field.json_name());
+        }
+        if (field.has_options()) {
+            const auto& options = field.options();
+
+            std::apply(
+              [&](const auto&... field_option) {
+                  (
+                    [&](const auto& field_option) {
+                        if ((options.*(field_option.check))()) {
+                            maybe_print_seperator();
+                            fmt::print(
+                              os,
+                              "{} = {}",
+                              field_option.name,
+                              (options.*(field_option.field))());
+                        }
+                    }(field_option),
+                    ...);
+              },
+              field_options());
+
+            for (const auto& option : options.uninterpreted_option()) {
+                maybe_print_seperator();
+                fmt::print(os, "{}", option);
+            }
+        }
+        if (count > 1 && !first) {
+            fmt::print(os, "\n{:{}}]", "", indent);
+        } else if (count == 1) {
+            fmt::print(os, "]");
+        }
+        fmt::print(os, ";\n");
+    }
+
+    void render_extension(
+      std::ostream& os,
+      pb::Edition edition,
+      const google::protobuf::FieldDescriptorProto& field,
+      const google::protobuf::FieldDescriptor* descriptor,
+      int indent) const {
+        // Render the field as an extension
+        fmt::print(os, "{:{}}extend {} {{\n", "", indent, field.extendee());
+        render_field(os, edition, field, descriptor, indent + 2);
+        fmt::print(os, "{:{}}}}\n", "", indent);
+    }
+
+    // Render a message, including nested messages
+    void render_message(
+      std::ostream& os,
+      pb::Edition edition,
+      const pb::DescriptorProto& message,
+      const pb::Descriptor* descriptor,
+      int indent) const {
+        fmt::print(os, "{:{}}message {} {{\n", "", indent, message.name());
+
+        if (message.has_options()) {
+            if (message.options().has_deprecated()) {
+                fmt::print(
+                  os,
+                  "{:{}}option deprecated = {};\n",
+                  "",
+                  indent + 2,
+                  message.options().deprecated());
+            }
+            if (message.options().has_message_set_wire_format()) {
+                fmt::print(
+                  os,
+                  "{:{}}option message_set_wire_format = {};\n",
+                  "",
+                  indent + 2,
+                  message.options().message_set_wire_format());
+            }
+            if (message.options().has_no_standard_descriptor_accessor()) {
+                fmt::print(
+                  os,
+                  "{:{}}option no_standard_descriptor_accessor = {};\n",
+                  "",
+                  indent + 2,
+                  message.options().no_standard_descriptor_accessor());
+            }
+        }
+        for (const auto& option : message.options().uninterpreted_option()) {
+            fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
+        }
+
+        for (const auto& value : message.reserved_range()) {
+            fmt::print(os, "{:{}}reserved {}", "", indent + 2, value.start());
+            if (value.has_end() && value.end() != value.start() + 1) {
+                fmt::print(os, " to {}", value.end() - 1);
+            }
+            fmt::print(os, ";\n");
+        }
+        if (message.reserved_name_size() != 0) {
+            fmt::print(
+              os,
+              "{:{}}reserved \"{}\";\n",
+              "",
+              indent + 2,
+              fmt::join(message.reserved_name(), "\", \""));
+        }
+        if (
+          message.reserved_range_size() != 0
+          || message.reserved_name_size() != 0) {
+            fmt::print(os, "\n");
+        }
+
+        bool has_fields = false;
+
+        // Each oneof section needs to start with the lowest field number, which
+        // may be different to the order of oneof_decl in the message.
+        std::vector<int> oneofs;
+
+        // Render non oneof fields, and record correct order of oneof indices.
+        for (const auto& field : message.field()) {
+            if (
+              field.has_oneof_index()
+              && !(field.has_proto3_optional() && field.proto3_optional())) {
+                bool has_oneof = std::ranges::find(oneofs, field.oneof_index())
+                                 != oneofs.end();
+                if (!has_oneof) {
+                    oneofs.push_back(field.oneof_index());
+                }
+            } else {
+                has_fields = true;
+                auto d = descriptor->FindFieldByName(field.name());
+                render_field(os, edition, field, d, indent + 2);
+            }
+        }
+        if (has_fields && !oneofs.empty()) {
+            fmt::print(os, "\n");
+        }
+        // Render oneof fields
+        for (const int i : oneofs) {
+            const auto& decl = message.oneof_decl(i);
+            fmt::print(os, "{:{}}oneof {} {{\n", "", indent + 2, decl.name());
+            for (const auto& field : message.field()) {
+                if (field.has_oneof_index() && field.oneof_index() == i) {
+                    auto d = descriptor->FindFieldByName(field.name());
+                    render_field(os, edition, field, d, indent + 4);
+                }
+            }
+            fmt::print(os, "{:{}}}}\n", "", indent + 2);
+        }
+
+        // Render extension ranges
+        for (const auto& range : message.extension_range()) {
+            fmt::print(
+              os,
+              "{:{}}extensions {} to {};\n",
+              "",
+              indent + 2,
+              range.start(),
+              range.end() - 1);
+        }
+
+        // Render extensions
+        for (const auto& extension : message.extension()) {
+            auto d = descriptor->FindExtensionByName(extension.name());
+            render_extension(os, edition, extension, d, indent + 2);
+        }
+
+        auto nested_messages = std::views::filter(
+          message.nested_type(),
+          [](const auto& m) { return !m.options().has_map_entry(); });
+        if (!nested_messages.empty() || !message.enum_type().empty()) {
+            fmt::print(os, "\n");
+        }
+
+        // Render nested types
+        for (const auto& nested : nested_messages) {
+            auto d = descriptor->FindNestedTypeByName(nested.name());
+            render_message(os, edition, nested, d, indent + 2);
+        }
+
+        // Render nested enums
+        for (const auto& nested : message.enum_type()) {
+            render_enum(os, nested, indent + 2);
+        }
+
+        fmt::print(os, "{:{}}}}\n", "", indent);
+    }
+
+    // Render an enum
+    void render_enum(
+      std::ostream& os,
+      const pb::EnumDescriptorProto& enum_proto,
+      int indent) const {
+        fmt::print(os, "{:{}}enum {} {{\n", "", indent, enum_proto.name());
+        for (const auto& value : enum_proto.reserved_range()) {
+            fmt::print(os, "{:{}}reserved {}", "", indent + 2, value.start());
+            if (value.has_end() && value.end() != value.start()) {
+                fmt::print(os, " to {}", value.end());
+            }
+            fmt::print(os, ";\n");
+        }
+        for (const auto& value : enum_proto.reserved_name()) {
+            fmt::print(os, "{:{}}reserved \"{}\";\n", "", indent + 2, value);
+        }
+        if (enum_proto.options().has_allow_alias()) {
+            fmt::print(
+              os,
+              "{:{}}option allow_alias = {};\n",
+              "",
+              indent + 2,
+              enum_proto.options().allow_alias());
+        }
+        if (enum_proto.options().has_deprecated()) {
+            fmt::print(
+              os,
+              "{:{}}option deprecated = {};\n",
+              "",
+              indent + 2,
+              enum_proto.options().deprecated());
+        }
+        for (const auto& option : enum_proto.options().uninterpreted_option()) {
+            fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
+        }
+        std::optional<std::decay_t<decltype(enum_proto.value())>> values;
+        for (const auto& value : values.value_or(enum_proto.value())) {
+            fmt::print(
+              os, "{:{}}{} = {}", "", indent + 2, value.name(), value.number());
+            if (value.has_options()) {
+                fmt::print(os, " [");
+                bool first_option = true;
+                const auto maybe_print_comma = [&]() {
+                    if (!first_option) {
+                        fmt::print(os, ", ");
+                    }
+                    first_option = false;
+                };
+                if (value.options().has_deprecated()) {
+                    fmt::print(
+                      os, "deprecated = {}", value.options().deprecated());
+                }
+                if (value.options().has_debug_redact()) {
+                    maybe_print_comma();
+                    fmt::print(
+                      os, "debug_redact = {}", value.options().debug_redact());
+                }
+                if (!value.options().uninterpreted_option().empty()) {
+                    maybe_print_comma();
+                    fmt::print(
+                      os,
+                      "{}",
+                      fmt::join(value.options().uninterpreted_option(), ", "));
+                }
+                fmt::print(os, "]");
+            }
+            fmt::print(os, ";\n");
+        }
+        fmt::print(os, "{:{}}}}\n", "", indent);
+    }
+
+    // Render a service and its RPC methods
+    void render_service(
+      std::ostream& os,
+      const pb::ServiceDescriptorProto& service,
+      int indent) const {
+        fmt::print(os, "{:{}}service {} {{\n", "", indent, service.name());
+        if (service.has_options()) {
+            if (service.options().has_deprecated()) {
+                fmt::print(
+                  os,
+                  "{:{}}option deprecated = {};\n",
+                  "",
+                  indent + 2,
+                  service.options().deprecated());
+            }
+            for (const auto& option :
+                 service.options().uninterpreted_option()) {
+                fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
+            }
+        }
+        for (const auto& method : service.method()) {
+            fmt::print(
+              os,
+              "{:{}}rpc {} ({}{}) returns ({}{});\n",
+              "",
+              indent + 2,
+              method.name(),
+              method.client_streaming() ? "stream " : "",
+              method.input_type(),
+              method.server_streaming() ? "stream " : "",
+              method.output_type());
+            if (method.has_options()) {
+                if (method.options().has_deprecated()) {
+                    fmt::print(
+                      os,
+                      "{:{}}option deprecated = {};\n",
+                      "",
+                      indent + 4,
+                      method.options().deprecated());
+                }
+                if (method.options().has_idempotency_level()) {
+                    fmt::print(
+                      os,
+                      "{:{}}option idempotency_level = {};\n",
+                      "",
+                      indent + 4,
+                      pb::MethodOptions_IdempotencyLevel_Name(
+                        method.options().idempotency_level()));
+                }
+                for (const auto& option :
+                     method.options().uninterpreted_option()) {
+                    fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
+                }
+            }
+        }
+        fmt::print(os, "{:{}}}}\n", "", indent);
+    }
+
+    // Render the FileOptions (if any are set)
+    void render_file_options(
+      const pb::FileOptions& options, std::ostream& os) const {
+        bool first_option = true;
+        auto printv = [&](std::string_view name, const auto& val) {
+            fmt::print(os, "option {} = {};\n", name, val);
+            first_option = false;
+        };
+        auto prints = [&](std::string_view name, const auto& val) {
+            fmt::print(os, "option {} = \"{}\";\n", name, val);
+            first_option = false;
+        };
+        if (options.has_cc_enable_arenas()) {
+            printv("cc_enable_arenas", options.cc_enable_arenas());
+        }
+        if (options.has_cc_generic_services()) {
+            printv("cc_generic_services", options.cc_generic_services());
+        }
+        if (options.has_csharp_namespace()) {
+            prints("csharp_namespace", options.csharp_namespace());
+        }
+        if (options.has_deprecated()) {
+            printv("deprecated", options.deprecated());
+        }
+        if (options.has_go_package()) {
+            prints("go_package", options.go_package());
+        }
+        if (options.has_java_generic_services()) {
+            printv("java_generic_services", options.java_generic_services());
+        }
+        if (options.has_java_multiple_files()) {
+            printv("java_multiple_files", options.java_multiple_files());
+        }
+        if (options.has_java_outer_classname()) {
+            prints("java_outer_classname", options.java_outer_classname());
+        }
+        if (options.has_java_package()) {
+            prints("java_package", options.java_package());
+        }
+        if (options.has_java_string_check_utf8()) {
+            printv("java_string_check_utf8", options.java_string_check_utf8());
+        }
+        if (options.has_objc_class_prefix()) {
+            prints("objc_class_prefix", options.objc_class_prefix());
+        }
+        if (options.has_optimize_for()) {
+            printv(
+              "optimize_for",
+              FileOptions_OptimizeMode_Name(options.optimize_for()));
+        }
+        if (options.has_ruby_package()) {
+            prints("ruby_package", options.ruby_package());
+        }
+        if (options.has_swift_prefix()) {
+            prints("swift_prefix", options.swift_prefix());
+        }
+        if (options.has_php_class_prefix()) {
+            prints("php_class_prefix", options.php_class_prefix());
+        }
+        if (options.has_php_metadata_namespace()) {
+            prints("php_metadata_namespace", options.php_metadata_namespace());
+        }
+        if (options.has_php_namespace()) {
+            prints("php_namespace", options.php_namespace());
+        }
+        if (options.has_py_generic_services()) {
+            printv("py_generic_services", options.py_generic_services());
+        }
+        for (const auto& option : options.uninterpreted_option()) {
+            first_option = false;
+            fmt::print(os, "option {};\n", option);
+        }
+
+        if (!first_option) {
+            fmt::print(os, "\n");
+        }
+    }
+
+    void
+    render_imports(std::ostream& os, const pb::FileDescriptorProto& fdp) const {
+        std::vector<std::string_view> all_deps{
+          fdp.dependency().begin(), fdp.dependency().end()};
+
+        auto is_public = [&](const auto& dep) {
+            return std::ranges::any_of(fdp.public_dependency(), [&](int j) {
+                return fdp.dependency()[j] == dep;
+            });
+        };
+        auto is_weak = [&](const auto& dep) {
+            return std::ranges::any_of(fdp.weak_dependency(), [&](int j) {
+                return fdp.dependency()[j] == dep;
+            });
+        };
+
+        // return a range that matches the predicate
+        constexpr auto partition = [](auto begin, auto end, auto pred) {
+            return std::ranges::subrange(
+              begin, std::stable_partition(begin, end, pred));
+        };
+
+        auto public_deps = partition(
+          all_deps.begin(), all_deps.end(), is_public);
+        auto weak_deps = partition(public_deps.end(), all_deps.end(), is_weak);
+        auto private_deps = std::ranges::subrange(
+          weak_deps.end(), all_deps.end());
+
+        auto print_deps = [&](const auto& view, std::string_view type) {
+            for (const auto& dep : view) {
+                fmt::print(os, "import {}\"{}\";\n", type, dep);
+            }
+        };
+
+        print_deps(public_deps, "public ");
+        print_deps(weak_deps, "weak ");
+        print_deps(private_deps, "");
+    }
+
+    void render_proto(
+      std::ostream& os,
+      const pb::FileDescriptorProto& fdp,
+      const pb::FileDescriptor& descriptor) const {
+        auto edition = fdp.edition();
+        if (edition == pb::Edition::EDITION_UNKNOWN) {
+            auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
+            edition = syntax == "proto3" ? pb::Edition::EDITION_PROTO3
+                                         : pb::Edition::EDITION_PROTO2;
+            fmt::print(os, "syntax = \"{}\";\n", syntax);
+        } else {
+            fmt::print(os, "edition = \"{}\";\n", Edition_Name(fdp.edition()));
+        }
+
+        if (fdp.has_package() && !fdp.package().empty()) {
+            fmt::print(os, "package {};\n", fdp.package());
+        }
+        fmt::print(os, "\n");
+
+        if (!fdp.dependency().empty()) {
+            render_imports(os, fdp);
+            fmt::print(os, "\n");
+        }
+
+        render_file_options(fdp.options(), os);
+
+        // Render messages
+        for (const auto& message : fdp.message_type()) {
+            auto d = descriptor.FindMessageTypeByName(message.name());
+            render_message(os, edition, message, d, 0);
+        }
+
+        // Render enums
+        for (const auto& enum_proto : fdp.enum_type()) {
+            render_enum(os, enum_proto, 0);
+        }
+
+        for (const auto& extension : fdp.extension()) {
+            auto d = descriptor.FindExtensionByName(extension.name());
+            render_extension(os, edition, extension, d, 0);
+        }
+
+        if ((fdp.message_type_size() + fdp.enum_type_size()) != 0) {
+            fmt::print(os, "\n");
+        }
+
+        // Render services
+        for (const auto& service : fdp.service()) {
+            render_service(os, service, 0);
+            fmt::print(os, "\n");
+        }
+    }
 };
 
 canonical_schema_definition::raw_string
 protobuf_schema_definition::raw() const {
-    return canonical_schema_definition::raw_string{_impl->debug_string()};
+    return _impl->raw();
 }
 
 ::result<ss::sstring, kafka::error_code>
@@ -436,8 +1266,8 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
 
 ss::future<protobuf_schema_definition>
 make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
-    auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     auto refs = schema.def().refs();
+    auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     impl->fdp = co_await import_schema(impl->_dp, store, std::move(schema));
     impl->fd = impl->_dp.FindFileByName(impl->fdp.name());
     if (auto* s = dynamic_cast<const sharded_store*>(&store); s != nullptr) {
@@ -783,9 +1613,10 @@ error_info io_error_collector::error() const {
       error_code::schema_invalid, fmt::format("{}", fmt::join(_errors, "; "))};
 }
 
-error_info dp_error_collector::error() const {
+error_info dp_error_collector::error(std::string_view sub) const {
     return error_info{
-      error_code::schema_invalid, fmt::format("{}", fmt::join(_errors, "; "))};
+      error_code::schema_invalid,
+      fmt::format("{}:{}", sub, fmt::join(_errors, "; "))};
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -324,6 +324,7 @@ ss::future<const pb::FileDescriptor*> import_schema(
 struct protobuf_schema_definition::impl {
     pb::DescriptorPool _dp;
     const pb::FileDescriptor* fd{};
+    protobuf_renderer_v2 v2_renderer{protobuf_renderer_v2::no};
 
     /**
      * debug_string swaps the order of the import and package lines that
@@ -434,6 +435,9 @@ make_protobuf_schema_definition(schema_getter& store, canonical_schema schema) {
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     auto refs = schema.def().refs();
     impl->fd = co_await import_schema(impl->_dp, store, std::move(schema));
+    if (auto* s = dynamic_cast<const sharded_store*>(&store); s != nullptr) {
+        impl->v2_renderer = s->protobuf_v2_renderer();
+    }
     co_return protobuf_schema_definition{std::move(impl), std::move(refs)};
 }
 

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -20,14 +20,18 @@ class Descriptor;
 
 namespace pandaproxy::schema_registry {
 
-ss::future<protobuf_schema_definition>
-make_protobuf_schema_definition(schema_getter& store, canonical_schema schema);
+ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
+  schema_getter& store,
+  canonical_schema schema,
+  normalize norm = normalize::no);
 
-ss::future<canonical_schema_definition>
-validate_protobuf_schema(sharded_store& store, canonical_schema schema);
+ss::future<canonical_schema_definition> validate_protobuf_schema(
+  sharded_store& store,
+  canonical_schema schema,
+  normalize norm = normalize::no);
 
-ss::future<canonical_schema>
-make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema);
+ss::future<canonical_schema> make_canonical_protobuf_schema(
+  sharded_store& store, unparsed_schema schema, normalize norm = normalize::no);
 
 compatibility_result check_compatible(
   const protobuf_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -88,7 +88,7 @@ sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
     }
     case schema_type::protobuf:
         co_return co_await make_canonical_protobuf_schema(
-          *this, std::move(schema));
+          *this, std::move(schema), norm);
     case schema_type::json:
         co_return co_await make_canonical_json_schema(
           *this, std::move(schema), norm);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -25,6 +25,9 @@ class store;
 /// subject or schema_id
 class sharded_store final : public schema_getter {
 public:
+    explicit sharded_store(
+      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no)
+      : _v2_renderer(v2_renderer) {}
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -198,6 +201,10 @@ public:
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;
 
+    //// \brief Whether to use the experimental v2 protobuf renderer to support
+    //// normalize=true;
+    protobuf_renderer_v2 protobuf_v2_renderer() const { return _v2_renderer; }
+
 private:
     ss::future<compatibility_result> do_is_compatible(
       schema_version version, canonical_schema new_schema, verbose is_verbose);
@@ -228,6 +235,7 @@ private:
 
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
+    protobuf_renderer_v2 _v2_renderer;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -714,9 +714,9 @@ package foo;
 // sanitize should maintain relative ordering of imports per group,
 // normalize should sort them
 import "google/protobuf/timestamp.proto";
+import public "google/protobuf/duration.proto";
 import weak "google/protobuf/any.proto";
 import "google/protobuf/api.proto";
-import public "google/protobuf/duration.proto";
 )";
 
     BOOST_CHECK_EQUAL(
@@ -724,20 +724,20 @@ import public "google/protobuf/duration.proto";
       (R"(syntax = "proto3";
 package foo;
 
-import public "google/protobuf/duration.proto";
-import weak "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/api.proto";
+import weak "google/protobuf/any.proto";
+import public "google/protobuf/duration.proto";
 
 )"));
     BOOST_CHECK_EQUAL(
       normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto3";
 package foo;
 
-import public "google/protobuf/duration.proto";
-import weak "google/protobuf/any.proto";
 import "google/protobuf/api.proto";
 import "google/protobuf/timestamp.proto";
+import weak "google/protobuf/any.proto";
+import public "google/protobuf/duration.proto";
 
 )"));
 }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -857,6 +857,53 @@ message SearchResponse {
 )"));
 }
 
+SEASTAR_THREAD_TEST_CASE(test_protobuf_synthetic_oneof) {
+    auto schema = R"(syntax = "proto3";
+package foo;
+message WithSynthetic {
+  optional int32 int32 = 1;
+}
+
+message WithOneOf {
+  oneof some_int {
+    int32 int32 = 1;
+  }
+}
+
+)";
+    auto expected_sanitized = R"(syntax = "proto3";
+package foo;
+
+message WithSynthetic {
+  optional int32 int32 = 1;
+}
+message WithOneOf {
+  oneof some_int {
+    int32 int32 = 1;
+  }
+}
+
+)";
+    BOOST_CHECK_EQUAL(
+      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
+      expected_sanitized);
+    auto expected_normalized = R"(syntax = "proto3";
+package foo;
+
+message WithSynthetic {
+  optional int32 int32 = 1;
+}
+message WithOneOf {
+  oneof some_int {
+    int32 int32 = 1;
+  }
+}
+
+)";
+    BOOST_CHECK_EQUAL(
+      normalize(schema, pps::protobuf_renderer_v2::yes), expected_normalized);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize) {
     auto schema = R"(
 syntax = "proto3";

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -31,7 +31,9 @@ namespace pps = pp::schema_registry;
 namespace {
 
 struct simple_sharded_store {
-    simple_sharded_store() {
+    explicit simple_sharded_store(
+      pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::no)
+      : store{proto_v2} {
         store.start(pps::is_mutable::yes, ss::default_smp_service_group())
           .get();
     }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -37,6 +37,7 @@ using default_to_global = ss::bool_class<struct default_to_global_tag>;
 using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
+using protobuf_renderer_v2 = ss::bool_class<struct protobuf_renderer_v2_tag>;
 
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>


### PR DESCRIPTION
Support `?normalize=true` for protobuf

TODO:
* Split the big commit
* Add more tests
* Handle features (editions) when not using v2_renderer
* Manual tests with customer 2

*NOTES*:
Must enable this with the cluster config
```
rpk cluster config set schema_registry_protobuf_renderer_v2 true
```
To DOCS: Don't document this.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Features

* Schema Registry: Support `?normalize=true` for protobuf
