### PR TITLE
Fix some oversized allocs during topic operations

### DIFF
--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -83,8 +83,8 @@ public:
     }
 
 private:
-    using in_progress_map = absl::
-      node_hash_map<model::partition_id, std::vector<model::broker_shard>>;
+    using in_progress_map
+      = chunked_hash_map<model::partition_id, std::vector<model::broker_shard>>;
     template<typename Cmd>
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd, model::offset);
 

--- a/src/v/container/chunked_hash_map.h
+++ b/src/v/container/chunked_hash_map.h
@@ -90,3 +90,18 @@ using chunked_hash_set = ankerl::unordered_dense::segmented_set<
   chunked_vector<Key>,
   ankerl::unordered_dense::bucket_type::standard,
   chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;
+
+template<typename K, typename V>
+std::ostream& operator<<(std::ostream& o, const chunked_hash_map<K, V>& r) {
+    o << "{";
+    bool first = true;
+    for (const auto& [k, v] : r) {
+        if (!first) {
+            o << ", ";
+        }
+        o << "{" << k << " -> " << v << "}";
+        first = false;
+    }
+    o << "}";
+    return o;
+}

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -14,6 +14,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
+#include "container/fragmented_vector.h"
 #include "metrics/metrics.h"
 #include "storage/fwd.h"
 #include "storage/ntp_config.h"
@@ -168,7 +169,7 @@ private:
      * when the segment reaches a threshold size a snapshot is saved a new
      * segment is created.
      */
-    std::vector<op> _ops;
+    chunked_vector<op> _ops;
     ss::timer<> _timer;
     ssx::semaphore _sem{0, "s/kvstore"};
     ss::lw_shared_ptr<segment> _segment;


### PR DESCRIPTION
Fix some medium sized oversized allocs during topic operations.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


