### PR TITLE
dt: Double consumer count in test_max_partition

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -585,7 +585,10 @@ class OMBValidationTest(RedpandaCloudTest):
                             1)
         producer_rate = tier_limits.max_ingress // 2
         total_producers = self._producer_count(producer_rate)
-        total_consumers = self._consumer_count(producer_rate * subscriptions)
+        # double consumer count which is a bit more friendly and realistic in
+        # high partition scenarios
+        total_consumers = self._consumer_count(
+            producer_rate * subscriptions) * 2
 
         workload = self.WORKLOAD_DEFAULTS | {
             "name":


### PR DESCRIPTION
Makes the test a bit more friendly (and realistic) to high partition densities.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

