### PR TITLE
CORE-8720 kafka/server: `chunked_hash_map` for response ordering

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -267,7 +267,7 @@ private:
     };
 
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
-    using map_t = absl::flat_hash_map<sequence_id, response_and_resources>;
+    using map_t = chunked_hash_map<sequence_id, response_and_resources>;
 
     /*
      * dispatch_method_once is the first stage processing of a request and


### PR DESCRIPTION
This is to avoid requiring large contiguous allocations for the response sequencing map.

This is in response to a recent crash where a node crashed while trying to allocate ~1MB for the response sequencing map even though there was plenty of free memory left.

It is not clear whether the response sequencing map consumed all the >1MB page spans or something else, but the failed 1MB allocation shows that large allocations are possible for the map and therefore it should be moved to a fragmented data structure.

According to the doc comment on `chunked_hash_map`, it is "Performance wise it's equal to the abseil hashmaps." so I am cc'ing the performance team only to be aware of this change. @travisdowns

Fixes: https://redpandadata.atlassian.net/browse/CORE-8720

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes
### Bug Fixes

* Avoid large allocations for the kafka response sequencing map.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
