### PR TITLE
cluster: Jitter at the end of ntp reconcile loop

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -787,7 +787,6 @@ ss::future<> controller_backend::reconcile_ntp_fiber(
     co_await ss::coroutine::switch_to(ss::default_scheduling_group());
 
     while (true) {
-        co_await rs->wakeup_event.wait(_housekeeping_jitter.next_duration());
         if (_as.local().abort_requested()) {
             break;
         }
@@ -810,6 +809,10 @@ ss::future<> controller_backend::reconcile_ntp_fiber(
                   ex);
             }
         }
+
+        // Only wait after we have made it through the semaphore once to avoid
+        // mass wakeups after the entering the function for the first time
+        co_await rs->wakeup_event.wait(_housekeeping_jitter.next_duration());
     }
 }
 


### PR DESCRIPTION
`reconcile_ntp_fiber` is spawned into the background potentially many
many times concurrently.

Because of how `process_delta` and friends call `reconcile_ntp_fiber`
they mark the `wakeup_event` ready repeatedly so effectively all waiters
will be woken up in one tick. This causes a massive task queue.

Avoid this by making `reconcile_ntp_fiber` only at the end of the loop.
This means that all invocations will have to make it through the
`_reconciliation_sem` semaphore once first (which is concurrency
limited).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none


