### PR TITLE
CORE-8721 security: check `std::uncaught_exceptions()` in `~request_auth_result()`

### DIFF
--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -227,7 +227,14 @@ void request_auth_result::pass() { _checked = true; }
  * knowing that all our member objects have nothrow destructors.
  */
 request_auth_result::~request_auth_result() noexcept(false) {
-    if (!_checked && !std::current_exception()) {
+    // If another exception is already in flight (e.g., thrown during request
+    // handling between authenticate() and the check), it's acceptable that we
+    // didn't perform the check. We only log the error if there is no active
+    // exception, to avoid confusion where the log suggests an authentication
+    // issue when the real cause might be unrelated.
+    const auto another_exception_in_flight = std::current_exception()
+                                             || std::uncaught_exceptions() > 0;
+    if (!_checked && !another_exception_in_flight) {
         vlog(
           logger.error, "request_auth_result destroyed without being checked!");
 


### PR DESCRIPTION
We now check `std::uncaught_exceptions()` in the destructor to avoid throwing exceptions during stack unwinding. This ensures that if an exception is already in flight, no additional exceptions will be thrown, which would otherwise lead to a call to `std::terminate()`.

Example showing the difference in behaviour: https://godbolt.org/z/KevcEvo55

This fixes a recent crash scenario where the `~request_auth_result()` destructor threw a second exception while another one (caused by failing to audit an authentication event) was already in flight. See the attached ticket for details.

The comment I added about not throwing when an exception is in flight is based on context from the original PR that introduced the throwing destructor: https://github.com/redpanda-data/redpanda/pull/3819#discussion_r815759519

Fixes https://redpandadata.atlassian.net/browse/CORE-8721

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes
### Bug Fixes

* Fixes a bug where failing to audit an authentication event could lead to a broker crash.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
