### PR TITLE
pp/sr/proto: disable unused alias warning

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/protobuf/CMakeLists.txt
@@ -29,6 +29,9 @@ v_cc_library(
   DEPS protobuf::libprotobuf
 )
 
+# Disable clang tidy
+set_target_properties(v_pandaproxy_schema_registry_protobuf  PROPERTIES CXX_CLANG_TIDY "")
+
 target_include_directories(v_pandaproxy_schema_registry_protobuf
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
The latest version of protobuf has some unused aliases, disable the warning because we don't control the output of protoc.

(cherry picked from commit 93c06d2198a12d804f948ec7a971eaf259f776f1)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
