### PR TITLE
[v24.2.x] CORE-8720 kafka/server: `chunked_hash_map` for response ordering

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -268,7 +268,7 @@ private:
     };
 
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
-    using map_t = absl::flat_hash_map<sequence_id, response_and_resources>;
+    using map_t = chunked_hash_map<sequence_id, response_and_resources>;
 
     /*
      * dispatch_method_once is the first stage processing of a request and


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24725
