### PR TITLE
[24.2.x] redpanda: ensure correct version for protobuf includes

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -148,7 +148,12 @@
 #include <seastar/util/log.hh>
 
 #include <absl/log/globals.h>
+#if __has_include(<google/protobuf/runtime_version.h>)
+#include <google/protobuf/runtime_version.h>
+#endif
+#if __has_include(<google/protobuf/stubs/logging.h>)
 #include <google/protobuf/stubs/logging.h>
+#endif
 #include <sys/resource.h>
 #include <sys/utsname.h>
 


### PR DESCRIPTION
Signed-off-by: Noah Watkins <noahwatkins@gmail.com>

Backport of commit eed2b69c2fab9a202714bf9aac84727d67f02641
(cherry picked from commit eed2b69c2fab9a202714bf9aac84727d67f02641)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
