### PR TITLE
bazel: extend ca certificate duration

### DIFF
--- a/bazel/cert.bzl
+++ b/bazel/cert.bzl
@@ -60,6 +60,8 @@ def redpanda_selfsigned_cert(name, certificate, common_name, visibility = None):
             "req",
             "-new",
             "-x509",
+            "-days",
+            "1000",
             "-sha256",
             "-key",
             "$(execpath :{})".format(private_key),


### PR DESCRIPTION
extend ca certificate duration to 1000 days

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
