### PR TITLE
[CORE-8754] Handle new TLS error codes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -212,7 +212,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "zmFP1dj5yRoCcdD3jInN9rQyUlbKJcvz7n2SHe4UgEY=",
+        "bzlTransitiveDigest": "HVHZRxHddAfQ0vBrAdVSY8sKmokWh0Mo4YHA2eYHDR4=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -399,9 +399,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "e9260699d5e912bb2284f68e217c2833a1ffc69acc2523fc118803d0ed717719",
-              "strip_prefix": "seastar-886d078e777a8f6e157c135af42021582045e45f",
-              "url": "https://github.com/redpanda-data/seastar/archive/886d078e777a8f6e157c135af42021582045e45f.tar.gz",
+              "sha256": "b9b4d5cd5bba1fb41ebdf6175bb91357753bd06d0e9f023e8dc7bf9894b1be2a",
+              "strip_prefix": "seastar-0fed8bea42680e63019bb36e747af5eb9ebf906e",
+              "url": "https://github.com/redpanda-data/seastar/archive/0fed8bea42680e63019bb36e747af5eb9ebf906e.tar.gz",
               "patches": [
                 "@@//bazel/thirdparty:seastar-fortify-source.patch"
               ],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,9 +167,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "e9260699d5e912bb2284f68e217c2833a1ffc69acc2523fc118803d0ed717719",
-        strip_prefix = "seastar-886d078e777a8f6e157c135af42021582045e45f",
-        url = "https://github.com/redpanda-data/seastar/archive/886d078e777a8f6e157c135af42021582045e45f.tar.gz",
+        sha256 = "b9b4d5cd5bba1fb41ebdf6175bb91357753bd06d0e9f023e8dc7bf9894b1be2a",
+        strip_prefix = "seastar-0fed8bea42680e63019bb36e747af5eb9ebf906e",
+        url = "https://github.com/redpanda-data/seastar/archive/0fed8bea42680e63019bb36e747af5eb9ebf906e.tar.gz",
         patches = ["//bazel/thirdparty:seastar-fortify-source.patch"],
         patch_args = ["-p1"],
     )

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -38,7 +38,10 @@ bool is_reconnect_error(const std::system_error& e) {
       ss::tls::ERROR_NO_CIPHER_SUITES,
       ss::tls::ERROR_PREMATURE_TERMINATION,
       ss::tls::ERROR_DECRYPTION_FAILED,
-      ss::tls::ERROR_MAC_VERIFY_FAILED};
+      ss::tls::ERROR_MAC_VERIFY_FAILED,
+      ss::tls::ERROR_WRONG_VERSION_NUMBER,
+      ss::tls::ERROR_HTTP_REQUEST,
+      ss::tls::ERROR_HTTPS_PROXY_REQUEST};
 
     if (e.code().category() == ss::tls::error_category()) {
         return absl::c_any_of(


### PR DESCRIPTION
Implement changes in Redpanda to handle new TLS error codes added by https://github.com/redpanda-data/seastar/pull/166.

These error codes provide more specificity about why connections failed to establish TLS connections.

   When a non TLS connection attempts to connect and send data to a Redpanda
    TLS enabled endpoint, OpenSSL may report different error codes depending on
    what it sees on the incoming packet:

* `ERROR_WRONG_VERSION_NUMBER` - reported when OpenSSL inspects the packet expecting to see a known TLS version but the one it sees is unknown.  This is distinct to seeing an unsupported version.
* `ERROR_HTTP_REQUEST` - similar to `ERROR_WRONG_VERSION_NUMBER`, however in this situation, the packet starts with a known HTTP verb (e.g. `GET`, or `POST`, etc).
* `ERROR_HTTPS_PROXY_REQUEST` - like `ERROR_HTTP_REQUEST`, however the packet starts with `CONNE`


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Improved TLS connection related error messages
