### PR TITLE
dt: Increase message size in MPT TS warmup

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -415,8 +415,10 @@ class ManyPartitionsTest(PreallocNodesTest):
         # Because segments are rolled after a write we need to size messages
         # such that actual segment size is as close as possible to the desired
         # size. In default configuration we run with `log_segment_size_jitter_percent=5`
-        # adjust the messages size to always be larger than that.
-        warmup_message_size = math.ceil(scale.segment_size * 0.06)
+        # We use a message size of 0.53 * segment_size to ensure that with two
+        # messages we are always just about above the max possible segment size (2*0.53 > 1.05).
+        # We want decently sized messages to not make this warmup phase slower than needed.
+        warmup_message_size = math.ceil(scale.segment_size * 0.53)
         target_cloud_segments = 24 * 7 * scale.partition_limit
 
         # Enough data to generate the desired number of segments plus few more


### PR DESCRIPTION
This speeds up the TS warmup which is one of the major contributors time
wise with increasing partition count.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none

