### PR TITLE
bazel: bump buildifier

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,7 +55,7 @@ bazel_dep(name = "yaml-cpp", version = "0.8.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 bazel_dep(name = "zstd", version = "1.5.6")
 
-bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "1.0.0", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)


### PR DESCRIPTION
Bump to [v7.3.1](https://github.com/bazelbuild/buildtools/releases/tag/v7.3.1) to keep up-to-date with bug fixes in the bazel linter/formatter.

The [v8.0.0](https://github.com/bazelbuild/buildtools/releases/tag/v8.0.0) is newer, but will wait for it to bake.

Comparison of changes between releases: https://github.com/bazelbuild/buildtools/compare/v6.4.0...v7.3.1

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none