### PR TITLE
c/topic_table: notify ntp delta waiters in batches

### DIFF
--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -672,7 +672,7 @@ private:
         uint64_t id;
     };
 
-    void notify_waiters();
+    ss::future<> notify_waiters();
 
     void change_partition_replicas(
       model::ntp ntp,
@@ -684,7 +684,7 @@ private:
 
     class snapshot_applier;
 
-    std::error_code do_local_delete(
+    ss::future<std::error_code> do_local_delete(
       model::topic_namespace nt, model::offset offset, bool ignore_migration);
     ss::future<std::error_code>
       do_apply(update_partition_replicas_cmd_data, model::offset);


### PR DESCRIPTION
When installing a controller snapshot or creating a topic with many partitions, the number of pending deltas can grow quite large. Notify waiters in batches to avoid stalls. This should also fix the problem with controller_backend notification handler that will spawn a lot of ready tasks if the task quota is exceeded.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
* none