### PR TITLE
[v24.2.x] [CORE-8754] Handle new TLS error codes

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -37,7 +37,10 @@ bool is_reconnect_error(const std::system_error& e) {
       ss::tls::ERROR_NO_CIPHER_SUITES,
       ss::tls::ERROR_PREMATURE_TERMINATION,
       ss::tls::ERROR_DECRYPTION_FAILED,
-      ss::tls::ERROR_MAC_VERIFY_FAILED};
+      ss::tls::ERROR_MAC_VERIFY_FAILED,
+      ss::tls::ERROR_WRONG_VERSION_NUMBER,
+      ss::tls::ERROR_HTTP_REQUEST,
+      ss::tls::ERROR_HTTPS_PROXY_REQUEST};
 
     if (e.code().category() == ss::tls::error_category()) {
         return absl::c_any_of(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24749

Fixes: #24758 
Fixes: CORE-8783

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None