### PR TITLE
Partition `replicate` API changes, follow up

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -402,7 +402,7 @@ kafka_stages stages_with_units(
 
 kafka_stages partition::replicate_in_stages(
   model::batch_identity bid,
-  chunked_vector<model::record_batch> batches,
+  model::record_batch batch,
   raft::replicate_options opts) {
     using ret_t = result<kafka_result>;
 
@@ -430,13 +430,12 @@ kafka_stages partition::replicate_in_stages(
       hold_writes_enabled(),
       [this,
        bid = std::move(bid),
-       batches = std::move(batches),
+       batch = std::move(batch),
        opts = std::move(opts)]() mutable {
           if (_rm_stm) {
-              return _rm_stm->replicate_in_stages(
-                bid, std::move(batches), opts);
+              return _rm_stm->replicate_in_stages(bid, std::move(batch), opts);
           }
-          auto res = _raft->replicate_in_stages(std::move(batches), opts);
+          auto res = _raft->replicate_in_stages(std::move(batch), opts);
           auto replicate_finished = res.replicate_finished.then(
             [this](result<raft::replicate_result> r) {
                 if (!r) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -90,7 +90,7 @@ public:
 
     kafka_stages replicate_in_stages(
       model::batch_identity,
-      chunked_vector<model::record_batch> batches,
+      model::record_batch batch,
       raft::replicate_options);
 
     /**

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -197,12 +197,12 @@ public:
 
     kafka_stages replicate_in_stages(
       model::batch_identity,
-      chunked_vector<model::record_batch> batches,
+      model::record_batch batch,
       raft::replicate_options);
 
     ss::future<result<kafka_result>> replicate(
       model::batch_identity,
-      chunked_vector<model::record_batch> batches,
+      model::record_batch batch,
       raft::replicate_options);
 
     ss::future<ss::basic_rwlock<>::holder> prepare_transfer_leadership();
@@ -274,28 +274,28 @@ private:
 
     ss::future<result<kafka_result>> do_replicate(
       model::batch_identity,
-      chunked_vector<model::record_batch>,
+      model::record_batch,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>);
 
-    ss::future<result<kafka_result>> transactional_replicate(
-      model::batch_identity, chunked_vector<model::record_batch>);
+    ss::future<result<kafka_result>>
+      transactional_replicate(model::batch_identity, model::record_batch);
 
     ss::future<result<kafka_result>> transactional_replicate(
       model::term_id,
       tx::producer_ptr,
       model::batch_identity,
-      chunked_vector<model::record_batch>);
+      model::record_batch);
 
     ss::future<result<kafka_result>> do_transactional_replicate(
       model::term_id,
       tx::producer_ptr,
       model::batch_identity,
-      chunked_vector<model::record_batch>);
+      model::record_batch);
 
     ss::future<result<kafka_result>> idempotent_replicate(
       model::batch_identity,
-      chunked_vector<model::record_batch>,
+      model::record_batch,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>);
 
@@ -303,7 +303,7 @@ private:
       model::term_id,
       tx::producer_ptr,
       model::batch_identity,
-      chunked_vector<model::record_batch>,
+      model::record_batch,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>,
       ssx::semaphore_units&,
@@ -313,14 +313,14 @@ private:
       model::term_id,
       tx::producer_ptr,
       model::batch_identity,
-      chunked_vector<model::record_batch>,
+      model::record_batch,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>,
       ssx::semaphore_units,
       producer_previously_known);
 
     ss::future<result<kafka_result>> replicate_msg(
-      chunked_vector<model::record_batch>,
+      model::record_batch,
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>);
 

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -41,14 +41,14 @@ FIXTURE_TEST(
     wait_for_meta_initialized();
 
     auto count = 5;
-    auto batches1 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(0),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .producer_id = -1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch_1 = model::test::make_random_batch(
+      model::test::record_batch_spec{
+        .offset = model::offset(0),
+        .allow_compression = true,
+        .count = count,
+        .producer_id = -1,
+        .producer_epoch = 0,
+        .base_sequence = 0});
     auto bid1 = model::batch_identity{
       .pid = model::producer_identity{-1, 0},
       .first_seq = 0,
@@ -56,20 +56,20 @@ FIXTURE_TEST(
     auto r1 = stm
                 .replicate(
                   bid1,
-                  std::move(batches1),
+                  std::move(batch_1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE((bool)r1);
 
-    auto batches2 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(count),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = -1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch_2 = model::test::make_random_batch(
+      model::test::record_batch_spec{
+        .offset = model::offset(count),
+        .allow_compression = true,
+        .count = count,
+        .enable_idempotence = true,
+        .producer_id = -1,
+        .producer_epoch = 0,
+        .base_sequence = 0});
     auto bid2 = model::batch_identity{
       .pid = model::producer_identity{-1, 0},
       .first_seq = 0,
@@ -77,7 +77,7 @@ FIXTURE_TEST(
     auto r2 = stm
                 .replicate(
                   bid2,
-                  std::move(batches2),
+                  std::move(batch_2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE((bool)r2);
@@ -95,15 +95,15 @@ FIXTURE_TEST(
     wait_for_meta_initialized();
 
     auto count = 5;
-    auto batches1 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(0),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch1 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = 0});
+
     auto bid1 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = 0,
@@ -111,20 +111,19 @@ FIXTURE_TEST(
     auto r1 = stm
                 .replicate(
                   bid1,
-                  std::move(batches1),
+                  std::move(batch1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE((bool)r1);
 
-    auto batches2 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(count),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = count})
-                      .get();
+    auto batch2 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = count});
     auto bid2 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = count,
@@ -132,7 +131,7 @@ FIXTURE_TEST(
     auto r2 = stm
                 .replicate(
                   bid2,
-                  std::move(batches2),
+                  std::move(batch2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE((bool)r2);
@@ -155,15 +154,15 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
     auto count = 5;
 
     for (int i = 0; i < 10; i++) {
-        auto batches = random_batches(model::test::record_batch_spec{
-                                        .offset = model::offset(i * count),
-                                        .allow_compression = true,
-                                        .count = count,
-                                        .enable_idempotence = true,
-                                        .producer_id = 1,
-                                        .producer_epoch = 0,
-                                        .base_sequence = i * count})
-                         .get();
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(i * count),
+            .allow_compression = true,
+            .count = count,
+            .enable_idempotence = true,
+            .producer_id = 1,
+            .producer_epoch = 0,
+            .base_sequence = i * count});
         auto bid = model::batch_identity{
           .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
@@ -171,7 +170,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
         auto r1 = stm
                     .replicate(
                       bid,
-                      std::move(batches),
+                      std::move(batch),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
                     .get();
@@ -179,19 +178,19 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
         offsets.push_back(r1.value().last_offset);
     }
 
-    // replicate caches only metadata so as long as batches have the same
-    // pid and seq numbers the duplicated request should yield the same
-    // offsets
+    // Replica last five batches with the same identity once again, the state
+    // machine should deduplicate them as it caches results for last five
+    // replicate requests.
     for (int i = 5; i < 10; i++) {
-        auto batches = random_batches(model::test::record_batch_spec{
-                                        .offset = model::offset(i * count),
-                                        .allow_compression = true,
-                                        .count = count,
-                                        .enable_idempotence = true,
-                                        .producer_id = 1,
-                                        .producer_epoch = 0,
-                                        .base_sequence = i * count})
-                         .get();
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(i * count),
+            .allow_compression = true,
+            .count = count,
+            .enable_idempotence = true,
+            .producer_id = 1,
+            .producer_epoch = 0,
+            .base_sequence = i * count});
         auto bid = model::batch_identity{
           .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
@@ -199,7 +198,7 @@ FIXTURE_TEST(test_rm_stm_caches_last_5_offsets, rm_stm_test_fixture) {
         auto r1 = stm
                     .replicate(
                       bid,
-                      std::move(batches),
+                      std::move(batch),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
                     .get();
@@ -221,15 +220,15 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
     auto count = 5;
 
     for (int i = 0; i < 6; i++) {
-        auto batches = random_batches(model::test::record_batch_spec{
-                                        .offset = model::offset(i * count),
-                                        .allow_compression = true,
-                                        .count = count,
-                                        .enable_idempotence = true,
-                                        .producer_id = 1,
-                                        .producer_epoch = 0,
-                                        .base_sequence = i * count})
-                         .get();
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(i * count),
+            .allow_compression = true,
+            .count = count,
+            .enable_idempotence = true,
+            .producer_id = 1,
+            .producer_epoch = 0,
+            .base_sequence = i * count});
         auto bid = model::batch_identity{
           .pid = model::producer_identity{1, 0},
           .first_seq = i * count,
@@ -237,7 +236,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
         auto r1 = stm
                     .replicate(
                       bid,
-                      std::move(batches),
+                      std::move(batch),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
                     .get();
@@ -246,15 +245,15 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
     }
 
     {
-        auto batches = random_batches(model::test::record_batch_spec{
-                                        .offset = model::offset(0),
-                                        .allow_compression = true,
-                                        .count = count,
-                                        .enable_idempotence = true,
-                                        .producer_id = 1,
-                                        .producer_epoch = 0,
-                                        .base_sequence = 0})
-                         .get();
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(0),
+            .allow_compression = true,
+            .count = count,
+            .enable_idempotence = true,
+            .producer_id = 1,
+            .producer_epoch = 0,
+            .base_sequence = 0});
         auto bid = model::batch_identity{
           .pid = model::producer_identity{1, 0},
           .first_seq = 0,
@@ -262,7 +261,7 @@ FIXTURE_TEST(test_rm_stm_doesnt_cache_6th_offset, rm_stm_test_fixture) {
         auto r1 = stm
                     .replicate(
                       bid,
-                      std::move(batches),
+                      std::move(batch),
                       raft::replicate_options(
                         raft::consistency_level::quorum_ack))
                     .get();
@@ -283,15 +282,14 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
     wait_for_meta_initialized();
 
     auto count = 5;
-    auto batches1 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(0),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch1 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = 0});
     auto bid1 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = 0,
@@ -299,20 +297,20 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
     auto r1 = stm
                 .replicate(
                   bid1,
-                  std::move(batches1),
+                  std::move(batch1),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE((bool)r1);
 
-    auto batches2 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(count),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = count + 1})
-                      .get();
+    auto batch2 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = count + 1});
+
     auto bid2 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = count + 1,
@@ -320,7 +318,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, rm_stm_test_fixture) {
     auto r2 = stm
                 .replicate(
                   bid2,
-                  std::move(batches2),
+                  std::move(batch2),
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get();
     BOOST_REQUIRE(
@@ -338,32 +336,30 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, rm_stm_test_fixture) {
     wait_for_meta_initialized();
 
     auto count = 5;
-    auto batches1 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(0),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch1 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = 0});
     auto bid1 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = 0,
       .last_seq = count - 1};
 
-    // replicate caches only metadata so as long as batches have the same
+    // replicate caches only metadata so as long as batch have the same
     // pid and seq numbers the duplicated request should yield the same
     // offsets
-    auto batches2 = random_batches(model::test::record_batch_spec{
-                                     .offset = model::offset(0),
-                                     .allow_compression = true,
-                                     .count = count,
-                                     .enable_idempotence = true,
-                                     .producer_id = 1,
-                                     .producer_epoch = 0,
-                                     .base_sequence = 0})
-                      .get();
+    auto batch2 = model::test::make_random_batch(model::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .producer_id = 1,
+      .producer_epoch = 0,
+      .base_sequence = 0});
     auto bid2 = model::batch_identity{
       .pid = model::producer_identity{1, 0},
       .first_seq = 0,
@@ -371,11 +367,11 @@ FIXTURE_TEST(test_rm_stm_passes_immediate_retry, rm_stm_test_fixture) {
 
     auto f1 = stm.replicate(
       bid1,
-      std::move(batches1),
+      std::move(batch1),
       raft::replicate_options(raft::consistency_level::quorum_ack));
     auto f2 = stm.replicate(
       bid2,
-      std::move(batches2),
+      std::move(batch2),
       raft::replicate_options(raft::consistency_level::quorum_ack));
     auto r2 = f2.get();
     auto r1 = f1.get();

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -42,7 +42,7 @@ struct batches_with_identity {
     chunked_vector<model::record_batch> batches;
 };
 
-static batches_with_identity make_rreader(
+static batches_with_identity make_batches(
   model::producer_identity pid,
   int first_seq,
   int count,
@@ -94,6 +94,21 @@ void check_snapshot_sizes(cluster::rm_stm& stm, raft::consensus* c) {
     BOOST_REQUIRE_EQUAL(stm.get_local_snapshot_size(), snapshots_size);
 }
 
+ss::future<result<cluster::kafka_result>>
+replicate_all(cluster::rm_stm& stm, batches_with_identity batches) {
+    result<cluster::kafka_result> result(cluster::kafka_result{});
+    for (auto& batch : batches.batches) {
+        result = co_await stm.replicate(
+          batches.id,
+          std::move(batch),
+          raft::replicate_options(raft::consistency_level::quorum_ack));
+        if (result.has_error()) {
+            co_return result;
+        }
+    }
+    co_return result;
+}
+
 // tests:
 //   - a simple tx execution succeeds
 //   - last_stable_offset doesn't advance past an ongoing transaction
@@ -111,14 +126,9 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
+
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
@@ -141,13 +151,9 @@ FIXTURE_TEST(test_tx_happy_tx, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
-    rreader = make_rreader(pid2, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid2, 0, 5, true);
+
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
@@ -188,14 +194,8 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
@@ -218,13 +218,8 @@ FIXTURE_TEST(test_tx_aborted_tx_1, rm_stm_test_fixture) {
     BOOST_REQUIRE((bool)term_op);
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
 
-    rreader = make_rreader(pid2, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid2, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
     tests::cooperative_spin_wait_with_timeout(10s, [&stm, first_offset]() {
@@ -275,14 +270,8 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     auto max_offset = model::offset(std::numeric_limits<int64_t>::max());
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
@@ -305,13 +294,8 @@ FIXTURE_TEST(test_tx_aborted_tx_2, rm_stm_test_fixture) {
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)term_op);
 
-    rreader = make_rreader(pid2, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid2, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE_EQUAL(stm.highest_producer_id(), pid2.get_id());
     BOOST_REQUIRE((bool)offset_r);
     auto tx_offset = offset_r.value().last_offset();
@@ -357,26 +341,15 @@ FIXTURE_TEST(test_tx_unknown_produce, rm_stm_test_fixture) {
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid2 = model::producer_identity{2, 0};
-    rreader = make_rreader(pid2, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid2, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
     RPTEST_REQUIRE_EVENTUALLY(
       1s, [&] { return stm.highest_producer_id() == pid1.get_id(); });
@@ -442,14 +415,8 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
@@ -474,13 +441,8 @@ FIXTURE_TEST(test_tx_begin_fences_produce, rm_stm_test_fixture) {
                 .get();
     BOOST_REQUIRE((bool)term_op);
 
-    rreader = make_rreader(pid20, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid20, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE(!(bool)offset_r);
 
     check_snapshot_sizes(stm, _raft.get());
@@ -500,14 +462,8 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
     wait_for_meta_initialized();
 
     auto pid1 = model::producer_identity{1, 0};
-    auto rreader = make_rreader(pid1, 0, 5, false);
-    auto offset_r = stm
-                      .replicate(
-                        rreader.id,
-                        std::move(rreader.batches),
-                        raft::replicate_options(
-                          raft::consistency_level::quorum_ack))
-                      .get();
+    auto rreader = make_batches(pid1, 0, 5, false);
+    auto offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{2, 0};
@@ -521,25 +477,15 @@ FIXTURE_TEST(test_tx_post_aborted_produce, rm_stm_test_fixture) {
                      .get();
     BOOST_REQUIRE((bool)term_op);
 
-    rreader = make_rreader(pid20, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid20, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE((bool)offset_r);
 
     auto op = stm.abort_tx(pid20, tx_seq, 2'000ms).get();
     BOOST_REQUIRE_EQUAL(op, cluster::tx::errc::none);
 
-    rreader = make_rreader(pid20, 0, 5, true);
-    offset_r = stm
-                 .replicate(
-                   rreader.id,
-                   std::move(rreader.batches),
-                   raft::replicate_options(raft::consistency_level::quorum_ack))
-                 .get();
+    rreader = make_batches(pid20, 0, 5, true);
+    offset_r = replicate_all(stm, std::move(rreader)).get();
     BOOST_REQUIRE(offset_r == invalid_producer_epoch);
 
     check_snapshot_sizes(stm, _raft.get());
@@ -567,8 +513,6 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
     const auto tx_seq = model::tx_seq(0);
     const auto timeout = std::chrono::milliseconds(
       std::numeric_limits<int32_t>::max());
-    const auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack);
     size_t segment_count = 1;
 
     auto& segments = disk_log->segments();
@@ -603,9 +547,9 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
         auto pid = model::producer_identity{pid_counter++, 0};
         BOOST_REQUIRE(
           stm.begin_tx(pid, tx_seq, timeout, model::partition_id(0)).get());
-        auto rreader = make_rreader(pid, 0, 5, true);
-        BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.batches), opts).get());
+
+        auto result = replicate_all(stm, make_batches(pid, 0, 5, true)).get();
+        BOOST_REQUIRE(result.has_value());
         return pid;
     };
 
@@ -615,9 +559,8 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
     };
 
     auto abort_tx = [&](auto pid) {
-        auto rreader = make_rreader(pid, 5, 5, true);
-        BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.batches), opts).get());
+        auto result = replicate_all(stm, make_batches(pid, 5, 5, true)).get();
+        BOOST_REQUIRE(result.has_value());
         BOOST_REQUIRE_EQUAL(
           stm.abort_tx(pid, tx_seq, timeout).get(), cluster::tx::errc::none);
     };
@@ -718,10 +661,11 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
         auto pid = start_tx();
         roll_log();
         // replicate some non transactional data batches.
-        auto rreader = make_rreader(
-          model::producer_identity{-1, -1}, 0, 5, false);
-        BOOST_REQUIRE(
-          stm.replicate(rreader.id, std::move(rreader.batches), opts).get());
+        auto result
+          = replicate_all(
+              stm, make_batches(model::producer_identity{-1, -1}, 0, 5, false))
+              .get();
+        BOOST_REQUIRE(result.has_value());
 
         // roll and abort.
         roll_log();

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -322,8 +322,7 @@ public:
 
             auto result = co_await _ctx._stm->replicate(
               bid,
-              chunked_vector<model::record_batch>::single(
-                std::move(batches[0])),
+              std::move(batches[0]),
               raft::replicate_options(raft::consistency_level::quorum_ack));
             if (!result.has_value()) {
                 vlog(clusterlog.error, "Error {}", result.error());

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -360,9 +360,7 @@ raft::replicate_stages replicated_partition::replicate(
             make_error_code(kafka::error_code::invalid_topic_exception))};
     }
     auto res = _partition->replicate_in_stages(
-      batch_id,
-      chunked_vector<model::record_batch>::single(std::move(batch)),
-      opts);
+      batch_id, std::move(batch), opts);
 
     raft::replicate_stages out(raft::errc::success);
     out.request_enqueued = std::move(res.request_enqueued);

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -355,7 +355,7 @@ public:
         co_return valid;
     }
 
-    ss::future<result> operator()(std::unique_ptr<model::record_batch> batch) {
+    ss::future<kafka::error_code> operator()(const model::record_batch& batch) {
         if (!_api) {
             // If Schema Registry is not enabled, the safe default is to reject
             co_return kafka::error_code::invalid_record;
@@ -363,16 +363,16 @@ public:
         if (
           config::shard_local_cfg().enable_schema_id_validation()
           == pandaproxy::schema_registry::schema_id_validation_mode::none) {
-            co_return std::move(batch);
+            co_return kafka::error_code::none;
         }
 
-        auto valid = co_await validate(*batch);
+        auto valid = co_await validate(batch);
 
         if (!valid) {
             // It's possible that the schema registry doesn't have a newly
             // written schema, update and retry.
             co_await _api->_sequencer.local().read_sync();
-            valid = co_await validate(*batch);
+            valid = co_await validate(batch);
         }
 
         if (!valid) {
@@ -390,7 +390,7 @@ public:
             co_return kafka::error_code::invalid_record;
         }
 
-        co_return std::move(batch);
+        co_return kafka::error_code::none;
     }
 
 private:
@@ -447,19 +447,19 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
     return std::nullopt;
 }
 
-ss::future<schema_id_validator::result> schema_id_validator::operator()(
-  std::unique_ptr<model::record_batch> batch, cluster::partition_probe* probe) {
-    using futurator = ss::futurize<schema_id_validator::result>;
-    return (*_impl)(std::move(batch))
+ss::future<kafka::error_code> schema_id_validator::operator()(
+  const model::record_batch& batch, cluster::partition_probe* probe) {
+    using futurator = ss::futurize<kafka::error_code>;
+    return (*_impl)(batch)
       .handle_exception([](std::exception_ptr e) {
           vlog(plog.warn, "Invalid record due to exception: {}", e);
           return futurator::convert(kafka::error_code::invalid_record);
       })
       .then([probe](futurator::value_type res) {
-          if (!res.has_value()) {
+          if (res != kafka::error_code::none) {
               probe->add_schema_id_validation_failed();
           }
-          return futurator::convert(std::move(res));
+          return res;
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -42,9 +42,10 @@ public:
     schema_id_validator& operator=(const schema_id_validator&) = delete;
     ~schema_id_validator() noexcept;
 
-    using result = ::result<model::record_batch, kafka::error_code>;
-    ss::future<result>
-    operator()(model::record_batch, cluster::partition_probe* probe);
+    using result
+      = ::result<std::unique_ptr<model::record_batch>, kafka::error_code>;
+    ss::future<result> operator()(
+      std::unique_ptr<model::record_batch>, cluster::partition_probe* probe);
 
 private:
     std::unique_ptr<impl> _impl;
@@ -57,7 +58,7 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
 
 inline ss::future<schema_id_validator::result> maybe_validate_schema_id(
   std::optional<schema_id_validator> validator,
-  model::record_batch batch,
+  std::unique_ptr<model::record_batch> batch,
   cluster::partition_probe* probe) {
     if (validator) {
         co_return co_await (*validator)(std::move(batch), probe);

--- a/src/v/pandaproxy/schema_registry/validation.h
+++ b/src/v/pandaproxy/schema_registry/validation.h
@@ -42,10 +42,8 @@ public:
     schema_id_validator& operator=(const schema_id_validator&) = delete;
     ~schema_id_validator() noexcept;
 
-    using result
-      = ::result<std::unique_ptr<model::record_batch>, kafka::error_code>;
-    ss::future<result> operator()(
-      std::unique_ptr<model::record_batch>, cluster::partition_probe* probe);
+    ss::future<kafka::error_code>
+    operator()(const model::record_batch&, cluster::partition_probe* probe);
 
 private:
     std::unique_ptr<impl> _impl;
@@ -56,14 +54,14 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
   const model::topic& topic,
   const cluster::topic_properties& props);
 
-inline ss::future<schema_id_validator::result> maybe_validate_schema_id(
+inline ss::future<kafka::error_code> maybe_validate_schema_id(
   std::optional<schema_id_validator> validator,
-  std::unique_ptr<model::record_batch> batch,
+  const model::record_batch& batch,
   cluster::partition_probe* probe) {
     if (validator) {
-        co_return co_await (*validator)(std::move(batch), probe);
+        co_return co_await (*validator)(batch, probe);
     }
-    co_return std::move(batch);
+    co_return kafka::error_code::none;
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -847,10 +847,26 @@ replicate_stages consensus::replicate_in_stages(
 }
 
 replicate_stages consensus::replicate_in_stages(
+  model::record_batch batch, replicate_options opts) {
+    return do_replicate(
+      {}, chunked_vector<model::record_batch>::single(std::move(batch)), opts);
+}
+
+replicate_stages consensus::replicate_in_stages(
   model::term_id expected_term,
   chunked_vector<model::record_batch> batches,
   replicate_options opts) {
     return do_replicate(expected_term, std::move(batches), opts);
+}
+
+replicate_stages consensus::replicate_in_stages(
+  model::term_id expected_term,
+  model::record_batch batch,
+  replicate_options opts) {
+    return do_replicate(
+      expected_term,
+      chunked_vector<model::record_batch>::single(std::move(batch)),
+      opts);
 }
 
 replicate_stages

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -253,6 +253,8 @@ public:
       replicate(model::record_batch, replicate_options);
     replicate_stages replicate_in_stages(
       chunked_vector<model::record_batch>, replicate_options);
+    replicate_stages
+      replicate_in_stages(model::record_batch, replicate_options);
     uint64_t get_snapshot_size() const { return _snapshot_size; }
 
     std::optional<state_machine_manager>& stm_manager() { return _stm_manager; }
@@ -286,7 +288,8 @@ public:
       replicate(model::term_id, model::record_batch, replicate_options);
     replicate_stages replicate_in_stages(
       model::term_id, chunked_vector<model::record_batch>, replicate_options);
-
+    replicate_stages replicate_in_stages(
+      model::term_id, model::record_batch, replicate_options);
     ss::future<model::record_batch_reader> make_reader(
       storage::log_reader_config,
       std::optional<clock_type::time_point> = std::nullopt);

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -152,14 +152,11 @@ replicate_batcher::do_cache_with_backpressure(
     }
 
     size_t record_count = 0;
-    chunked_vector<model::record_batch> data;
-    data.reserve(batches.size());
     for (auto& b : batches) {
         record_count += b.record_count();
-        data.push_back(std::move(b));
     }
     auto i = ss::make_lw_shared<item>(
-      record_count, std::move(data), std::move(u), expected_term, opts);
+      record_count, std::move(batches), std::move(u), expected_term, opts);
 
     _item_cache.emplace_back(i);
     co_return i;


### PR DESCRIPTION
This PR contains another set of changes simplifying the `partition` replicate API. Using a single batch API is convenient and makes replicating batches from Kafka API easier. 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
