### PR TITLE
Use `chunked_vector` in `append_entries_request`

### DIFF
--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -324,7 +324,7 @@ struct instance_generator<raft::append_entries_request> {
           instance_generator<raft::vnode>::random(),
           instance_generator<raft::vnode>::random(),
           instance_generator<raft::protocol_metadata>::random(),
-          model::make_memory_record_batch_reader(
+          chunked_vector<model::record_batch>(
             model::test::make_random_batches(model::offset(0), 3, false).get()),
           0,
           raft::flush_after_append(tests::random_bool()),

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -708,13 +708,7 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
         }
         // prepare empty request
         append_entries_request req(
-          _self,
-          target,
-          meta(),
-          model::make_memory_record_batch_reader(
-            ss::circular_buffer<model::record_batch>{}),
-          0,
-          flush_after_append::yes);
+          _self, target, meta(), {}, 0, flush_after_append::yes);
         auto seq = next_follower_sequence(target);
         sequences.emplace(target, seq);
 
@@ -2000,7 +1994,7 @@ consensus::do_append_entries(append_entries_request&& r) {
     // section 1
     // For an entry to fit into our log, it must not leave a gap.
     if (request_metadata.prev_log_index > last_log_offset) {
-        if (!r.batches().is_end_of_stream()) {
+        if (!r.batches().empty()) {
             vlog(
               _ctxlog.debug,
               "Rejecting append entries. Would leave gap in log, last log "
@@ -2061,34 +2055,22 @@ consensus::do_append_entries(append_entries_request&& r) {
         // the request was delayed/duplicated). In this case we don't want to
         // truncate, otherwise we might lose already committed data.
 
-        struct find_mismatch_consumer {
-            const consensus& parent;
-            model::offset last_log_offset;
-            model::offset last_matched;
-
-            ss::future<ss::stop_iteration>
-            operator()(const model::record_batch& b) {
-                model::offset last_batch_offset
-                  = last_matched
-                    + model::offset(b.header().last_offset_delta + 1);
-                if (
-                  last_batch_offset > last_log_offset
-                  || parent.get_term(last_batch_offset) != b.term()) {
-                    co_return ss::stop_iteration::yes;
-                }
-                last_matched = last_batch_offset;
-                co_return ss::stop_iteration::no;
+        model::offset last_matched = adjusted_prev_log_index;
+        auto it = r.batches().begin();
+        for (; it != r.batches().end(); ++it) {
+            model::offset last_batch_offset
+              = last_matched
+                + model::offset(it->header().last_offset_delta + 1);
+            if (
+              last_batch_offset > last_log_offset
+              || get_term(last_batch_offset) != it->term()) {
+                break;
             }
-
-            model::offset end_of_stream() { return last_matched; }
-        };
-
-        model::offset last_matched = co_await r.batches().peek_each_ref(
-          find_mismatch_consumer{
-            .parent = *this,
-            .last_log_offset = last_log_offset,
-            .last_matched = adjusted_prev_log_index},
-          model::no_timeout); // no_timeout as the batches are already in memory
+            last_matched = last_batch_offset;
+        }
+        chunked_vector<model::record_batch> batches;
+        batches.reserve(std::distance(it, r.batches().end()));
+        std::move(it, r.batches().end(), std::back_inserter(batches));
         if (last_matched != adjusted_prev_log_index) {
             vlog(
               _ctxlog.info,
@@ -2099,12 +2081,13 @@ consensus::do_append_entries(append_entries_request&& r) {
               meta());
             adjusted_prev_log_index = last_matched;
         }
+        r.batches() = std::move(batches);
     }
 
     // special case for heartbeats and batches without new records.
     // we need to handle it early (before executing truncation)
     // as timeouts are asynchronous to append calls and can have stall data
-    if (r.batches().is_end_of_stream()) {
+    if (r.batches().empty()) {
         if (adjusted_prev_log_index < last_log_offset) {
             // do not truncate on heartbeat just response with false
             reply.result = reply_result::failure;
@@ -2693,18 +2676,17 @@ ss::future<std::error_code> consensus::replicate_configuration(
       _bg, [this, u = std::move(u), cfg = std::move(cfg)]() mutable {
           try_updating_configuration_version(cfg);
 
-          auto batches = details::serialize_configuration_as_batches(
+          auto batch = details::serialize_configuration_as_batch(
             std::move(cfg));
           size_t batches_size{0};
-          for (auto& b : batches) {
-              batches_size += b.size_bytes();
-              b.set_term(model::term_id(_term));
-          }
+          batches_size += batch.size_bytes();
+          batch.set_term(model::term_id(_term));
+
           auto seqs = next_followers_request_seq();
           append_entries_request req(
             _self,
             meta(),
-            model::make_memory_record_batch_reader(std::move(batches)),
+            chunked_vector<model::record_batch>::single(std::move(batch)),
             batches_size);
           /**
            * We use dispatch_replicate directly as we already hold the
@@ -2867,7 +2849,7 @@ void consensus::maybe_schedule_flush() {
 }
 
 ss::future<storage::append_result> consensus::disk_append(
-  model::record_batch_reader&& reader,
+  chunked_vector<model::record_batch> batches,
   update_last_quorum_index should_update_last_quorum_idx) {
     using ret_t = storage::append_result;
     auto cfg = storage::log_append_config{
@@ -2895,7 +2877,8 @@ ss::future<storage::append_result> consensus::disk_append(
 
     return details::for_each_ref_extract_configuration(
              _log->offsets().dirty_offset,
-             std::move(reader),
+             model::make_fragmented_memory_record_batch_reader(
+               std::move(batches)),
              consumer(_log->make_appender(cfg)),
              cfg.timeout)
       .then([this, should_update_last_quorum_idx](
@@ -4107,8 +4090,7 @@ ss::future<full_heartbeat_reply> consensus::full_heartbeat(
         .last_visible_index = hb_data.last_visible_index,
         .dirty_offset = hb_data.prev_log_index,
       },
-      model::make_memory_record_batch_reader(
-        ss::circular_buffer<model::record_batch>{}),
+      {},
       0,
       flush_after_append::no));
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -601,8 +601,8 @@ private:
 
     ss::future<result<replicate_result>> chain_stages(replicate_stages);
 
-    ss::future<storage::append_result>
-    disk_append(model::record_batch_reader&&, update_last_quorum_index);
+    ss::future<storage::append_result> disk_append(
+      chunked_vector<model::record_batch>, update_last_quorum_index);
 
     using success_reply = ss::bool_class<struct successfull_reply_tag>;
 

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -37,8 +37,7 @@ ss::future<std::vector<model::record_batch_reader>>
 foreign_share_n(model::record_batch_reader&&, std::size_t);
 
 /// serialize group configuration as config-type batch
-ss::circular_buffer<model::record_batch>
-serialize_configuration_as_batches(group_configuration cfg);
+model::record_batch serialize_configuration_as_batch(group_configuration cfg);
 
 iobuf serialize_configuration(group_configuration cfg);
 void write_configuration(group_configuration cfg, iobuf& out);

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -58,11 +58,12 @@ private:
       = std::variant<storage::snapshot_reader, on_demand_snapshot_reader>;
     ss::future<> recover();
     ss::future<> do_recover(ss::io_priority_class);
-    ss::future<std::optional<std::tuple<model::record_batch_reader, size_t>>>
+    ss::future<
+      std::optional<std::tuple<chunked_vector<model::record_batch>, size_t>>>
     read_range_for_recovery(model::offset, ss::io_priority_class, bool, size_t);
 
     ss::future<> replicate(
-      model::record_batch_reader&& batches,
+      chunked_vector<model::record_batch> batches,
       flush_after_append request_flush_after_append,
       ssx::semaphore_units recovery_memory_units,
       size_t batches_size);

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -200,7 +200,7 @@ ss::future<> replicate_batcher::flush(
 
         auto meta = _ptr->meta();
         const auto term = model::term_id(meta.term);
-        ss::circular_buffer<model::record_batch> data;
+        chunked_vector<model::record_batch> data;
         std::vector<item_ptr> notifications;
         ssx::semaphore_units item_memory_units(_max_batch_size_sem, 0);
         auto force_flush_requested = false;
@@ -251,7 +251,7 @@ ss::future<> replicate_batcher::flush(
         append_entries_request req(
           _ptr->_self,
           meta,
-          model::make_memory_record_batch_reader(std::move(data)),
+          std::move(data),
           item_memory_units.count(),
           needs_flush);
 

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -25,6 +25,7 @@
 #include "raft/raftgen_service.h"
 #include "raft/types.h"
 #include "rpc/types.h"
+#include "ssx/async_algorithm.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/semaphore.hh>
@@ -36,18 +37,17 @@
 namespace raft {
 using namespace std::chrono_literals;
 
-ss::future<model::record_batch_reader> replicate_entries_stm::share_batches() {
+ss::future<chunked_vector<model::record_batch>>
+replicate_entries_stm::share_batches() {
     // one extra copy is needed for retries
     auto u = co_await _share_mutex.get_units();
+    chunked_vector<model::record_batch> batches;
+    batches.reserve(_batches->size());
+    co_await ssx::async_for_each(*_batches, [&batches](model::record_batch& b) {
+        batches.push_back(b.share());
+    });
 
-    auto readers = co_await details::foreign_share_n(
-      std::move(_batches.value()), 2);
-
-    // keep a copy around until the end
-    _batches = std::move(readers.back());
-    readers.pop_back();
-
-    co_return std::move(readers.back());
+    co_return batches;
 }
 
 ss::future<> replicate_entries_stm::flush_log() {
@@ -65,7 +65,7 @@ clock_type::time_point replicate_entries_stm::append_entries_timeout() {
 
 ss::future<result<append_entries_reply>>
 replicate_entries_stm::send_append_entries_request(
-  vnode n, model::record_batch_reader batches) {
+  vnode n, chunked_vector<model::record_batch> batches) {
     _ptr->update_node_append_timestamp(n);
 
     vlog(_ctxlog.trace, "Sending append entries request {} to {}", _meta, n);
@@ -119,7 +119,7 @@ ss::future<> replicate_entries_stm::dispatch_remote_append_entries(vnode id) {
       "Incorrect remote entries dispatch for local node: {}",
       id);
     return share_batches()
-      .then([this, id](model::record_batch_reader batches) mutable {
+      .then([this, id](chunked_vector<model::record_batch> batches) mutable {
           return send_append_entries_request(id, std::move(batches));
       })
       .then([this, id](result<append_entries_reply> reply) {
@@ -143,7 +143,7 @@ ss::future<> replicate_entries_stm::dispatch_remote_append_entries(vnode id) {
 ss::future<result<storage::append_result>>
 replicate_entries_stm::append_to_self() {
     return share_batches()
-      .then([this](model::record_batch_reader batches) mutable {
+      .then([this](chunked_vector<model::record_batch> batches) mutable {
           vlog(_ctxlog.trace, "Self append entries - {}", _meta);
 
           _ptr->_last_write_flushed = _is_flush_required;
@@ -370,7 +370,8 @@ replicate_entries_stm::replicate_entries_stm(
   , _meta(r.metadata())
   , _is_flush_required(r.is_flush_required())
   , _batches_size(r.batches_size())
-  , _batches(std::move(r).release_batches())
+  , _batches(std::make_unique<chunked_vector<model::record_batch>>(
+      std::move(r).release_batches()))
   , _followers_seq(std::move(seqs))
   , _ctxlog(_ptr->_ctxlog) {}
 

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -40,7 +40,6 @@ using namespace std::chrono_literals;
 ss::future<chunked_vector<model::record_batch>>
 replicate_entries_stm::share_batches() {
     // one extra copy is needed for retries
-    auto u = co_await _share_mutex.get_units();
     chunked_vector<model::record_batch> batches;
     batches.reserve(_batches->size());
     co_await ssx::async_for_each(*_batches, [&batches](model::record_batch& b) {

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -14,7 +14,6 @@
 #include "base/outcome.h"
 #include "base/seastarx.h"
 #include "model/fundamental.h"
-#include "model/record_batch_reader.h"
 #include "raft/consensus.h"
 #include "raft/fwd.h"
 #include "raft/logger.h"
@@ -96,14 +95,14 @@ public:
     ss::future<> wait_for_shutdown();
 
 private:
-    ss::future<model::record_batch_reader> share_batches();
+    ss::future<chunked_vector<model::record_batch>> share_batches();
 
     ss::future<> dispatch_one(vnode);
     ss::future<> dispatch_remote_append_entries(vnode);
     ss::future<> flush_log();
 
     ss::future<result<append_entries_reply>>
-      send_append_entries_request(vnode, model::record_batch_reader);
+      send_append_entries_request(vnode, chunked_vector<model::record_batch>);
 
     result<replicate_result>
       process_result(raft::errc, model::offset, model::term_id);
@@ -119,7 +118,7 @@ private:
     protocol_metadata _meta;
     flush_after_append _is_flush_required;
     size_t _batches_size;
-    std::optional<model::record_batch_reader> _batches;
+    std::unique_ptr<chunked_vector<model::record_batch>> _batches;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     absl::flat_hash_map<vnode, consensus::inflight_appends_guard>
       _inflight_appends;

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -122,7 +122,6 @@ private:
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     absl::flat_hash_map<vnode, consensus::inflight_appends_guard>
       _inflight_appends;
-    mutex _share_mutex{"replicate_entries_stm::share"};
     ssx::semaphore _dispatch_sem{0, "raft/repl-dispatch"};
     ss::gate _req_bg;
     ctx_log _ctxlog;

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -173,7 +173,7 @@ public:
         return _probe.append_entries().then([this, r = std::move(r)]() mutable {
             auto gr = r.target_group();
             return dispatch_request(
-              append_entries_request::make_foreign(std::move(r)),
+              std::move(r),
               [gr]() { return make_missing_group_reply(gr); },
               [](append_entries_request&& r, consensus_ptr c) {
                   return c->append_entries(std::move(r));
@@ -187,7 +187,7 @@ public:
             auto request = std::move(r).release();
             const raft::group_id gr = request.target_group();
             return dispatch_request(
-              append_entries_request::make_foreign(std::move(request)),
+              std::move(request),
               [gr]() { return make_missing_group_reply(gr); },
               [](append_entries_request&& req, consensus_ptr c) {
                   return c->append_entries(std::move(req));
@@ -366,8 +366,7 @@ private:
           hb.node_id,
           hb.target_node_id,
           hb.meta,
-          model::make_memory_record_batch_reader(
-            ss::circular_buffer<model::record_batch>{}),
+          {},
           0,
           flush_after_append::no};
     }
@@ -388,8 +387,7 @@ private:
             // same
             .dirty_offset = hb.data->prev_log_index,
           },
-          model::make_memory_record_batch_reader(
-            ss::circular_buffer<model::record_batch>{}),
+          {},
           0,
           flush_after_append::no};
     }

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -99,10 +99,9 @@ SEASTAR_THREAD_TEST_CASE(roundtrip_raft_configuration_entry) {
         cfg.set_version(v);
 
         // serialize to entry
-        auto batches = raft::details::serialize_configuration_as_batches(cfg);
+        auto batch = raft::details::serialize_configuration_as_batch(cfg);
         // extract from entry
-        iobuf_parser parser(
-          batches.begin()->copy_records().begin()->release_value());
+        iobuf_parser parser(batch.copy_records().begin()->release_value());
         auto new_cfg = raft::details::deserialize_configuration(parser);
 
         BOOST_REQUIRE_EQUAL(new_cfg, cfg);
@@ -140,20 +139,24 @@ SEASTAR_THREAD_TEST_CASE(test_config_extracting_reader) {
     // serialize to batches
     // use adl
     cfg_1.set_version(raft::group_configuration::v_5);
-    auto cfg_batch_1 = raft::details::serialize_configuration_as_batches(cfg_1);
+    auto cfg_batch_1 = raft::details::serialize_configuration_as_batch(cfg_1);
+    ss::circular_buffer<model::record_batch> cfg_batches_1;
+    cfg_batches_1.push_back(std::move(cfg_batch_1));
     // use serde
     cfg_2.set_version(raft::group_configuration::v_6);
-    auto cfg_batch_2 = raft::details::serialize_configuration_as_batches(cfg_2);
+    auto cfg_batch_2 = raft::details::serialize_configuration_as_batch(cfg_2);
+    ss::circular_buffer<model::record_batch> cfg_batches_2;
+    cfg_batches_2.push_back(std::move(cfg_batch_2));
     auto batches
       = model::test::make_random_batches(model::offset(0), 10, true).get();
 
     std::vector<batches_t> ranges;
     ranges.reserve(4);
     // interleave config batches with data batches
-    ranges.push_back(std::move(cfg_batch_1));
+    ranges.push_back(std::move(cfg_batches_1));
     ranges.push_back(
       model::test::make_random_batches(model::offset(0), 10, true).get());
-    ranges.push_back(std::move(cfg_batch_2));
+    ranges.push_back(std::move(cfg_batches_2));
     ranges.push_back(
       model::test::make_random_batches(model::offset(0), 10, true).get());
 

--- a/src/v/raft/tests/simple_record_fixture.h
+++ b/src/v/raft/tests/simple_record_fixture.h
@@ -52,9 +52,7 @@ struct simple_record_fixture {
     }
     model::record_batch
     config_batch(raft::group_configuration::version_t version) {
-        auto batches = details::serialize_configuration_as_batches(
-          rand_config(version));
-        return std::move(batches.front());
+        return details::serialize_configuration_as_batch(rand_config(version));
     }
 
     iobuf rand_iobuf() const {

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -36,42 +36,42 @@
 #include <cstdint>
 #include <vector>
 
-struct checking_consumer {
-    using batches_t = ss::circular_buffer<model::record_batch>;
-
-    checking_consumer(ss::circular_buffer<model::record_batch> exp)
-      : expected(std::move(exp)) {}
-
-    ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
-        auto current_batch = std::move(expected.front());
-        expected.pop_front();
-        BOOST_REQUIRE_EQUAL(current_batch.base_offset(), batch.base_offset());
-        BOOST_REQUIRE_EQUAL(current_batch.last_offset(), batch.last_offset());
-        BOOST_REQUIRE_EQUAL(current_batch.header().crc, batch.header().crc);
-        BOOST_REQUIRE_EQUAL(current_batch.compressed(), batch.compressed());
-        BOOST_REQUIRE_EQUAL(current_batch.header().type, batch.header().type);
-        BOOST_REQUIRE_EQUAL(current_batch.size_bytes(), batch.size_bytes());
-        BOOST_REQUIRE_EQUAL(current_batch.record_count(), batch.record_count());
-        BOOST_REQUIRE_EQUAL(current_batch.term(), batch.term());
-        return ss::make_ready_future<ss::stop_iteration>(
-          ss::stop_iteration::no);
+void verify_batches(
+  const chunked_vector<model::record_batch>& expected,
+  const chunked_vector<model::record_batch>& current) {
+    BOOST_REQUIRE_EQUAL(expected.size(), current.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        auto& current_batch = current[i];
+        auto& expected_batch = current[i];
+        BOOST_REQUIRE_EQUAL(
+          current_batch.base_offset(), expected_batch.base_offset());
+        BOOST_REQUIRE_EQUAL(
+          current_batch.last_offset(), expected_batch.last_offset());
+        BOOST_REQUIRE_EQUAL(
+          current_batch.header().crc, expected_batch.header().crc);
+        BOOST_REQUIRE_EQUAL(
+          current_batch.compressed(), expected_batch.compressed());
+        BOOST_REQUIRE_EQUAL(
+          current_batch.header().type, expected_batch.header().type);
+        BOOST_REQUIRE_EQUAL(
+          current_batch.size_bytes(), expected_batch.size_bytes());
+        BOOST_REQUIRE_EQUAL(
+          current_batch.record_count(), expected_batch.record_count());
+        BOOST_REQUIRE_EQUAL(current_batch.term(), expected_batch.term());
     }
-
-    void end_of_stream() { BOOST_REQUIRE(expected.empty()); }
-
-    batches_t expected;
-};
+}
 
 SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
-    auto batches
-      = model::test::make_random_batches(model::offset(1), 3, false).get();
+    chunked_vector<model::record_batch> batches{
+      model::test::make_random_batches(model::offset(1), 3, false).get()};
+
+    chunked_vector<model::record_batch> reference_batches;
 
     for (auto& b : batches) {
         b.set_term(model::term_id(123));
+        reference_batches.push_back(b.share());
     }
 
-    auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    auto readers = raft::details::share_n(std::move(rdr), 2).get();
     auto meta = raft::protocol_metadata{
       .group = raft::group_id(1),
       .commit_index = model::offset(100),
@@ -85,10 +85,9 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
       raft::vnode(model::node_id(1), model::revision_id(10)),
       raft::vnode(model::node_id(10), model::revision_id(101)),
       meta,
-      std::move(readers.back()),
+      std::move(batches),
       0);
 
-    readers.pop_back();
     const auto target_node_id = req.target_node();
 
     iobuf buf;
@@ -108,13 +107,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
       d.metadata().last_visible_index, meta.last_visible_index);
     BOOST_REQUIRE_EQUAL(d.metadata().dirty_offset, meta.dirty_offset);
 
-    auto batches_result = model::consume_reader_to_memory(
-                            std::move(readers.back()), model::no_timeout)
-                            .get();
-    std::move(d)
-      .release_batches()
-      .consume(checking_consumer(std::move(batches_result)), model::no_timeout)
-      .get();
+    verify_batches(reference_batches, d.batches());
 }
 
 model::broker create_test_broker() {
@@ -558,16 +551,13 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_backward_compatibility) {
 }
 
 SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
-    auto batches
-      = model::test::make_random_batches(model::offset(1), 3, false).get();
-
+    chunked_vector<model::record_batch> batches{
+      model::test::make_random_batches(model::offset(1), 3, false).get()};
+    chunked_vector<model::record_batch> reference_batches;
     for (auto& b : batches) {
         b.set_term(model::term_id(123));
+        reference_batches.push_back(b.share());
     }
-
-    auto rdr = model::make_memory_record_batch_reader(std::move(batches));
-    // share readers to have a copy of data to compare
-    auto readers = raft::details::share_n(std::move(rdr), 2).get();
 
     auto meta = raft::protocol_metadata{
       .group = raft::group_id(1),
@@ -582,10 +572,8 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
       raft::vnode(model::node_id(1), model::revision_id(10)),
       raft::vnode(model::node_id(10), model::revision_id(101)),
       meta,
-      std::move(readers.back()),
+      std::move(batches),
       0);
-
-    readers.pop_back();
 
     const auto src_node = req.source_node();
     const auto target_node = req.target_node();
@@ -613,11 +601,5 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
       decoded_req.metadata().last_visible_index, meta.last_visible_index);
     BOOST_REQUIRE_EQUAL(decoded_req.metadata().dirty_offset, meta.dirty_offset);
 
-    auto batches_result = model::consume_reader_to_memory(
-                            std::move(readers.back()), model::no_timeout)
-                            .get();
-    std::move(decoded_req)
-      .release_batches()
-      .consume(checking_consumer(std::move(batches_result)), model::no_timeout)
-      .get();
+    verify_batches(reference_batches, decoded_req.batches());
 }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -220,7 +220,7 @@ struct append_entries_request
     append_entries_request(
       vnode src,
       protocol_metadata m,
-      model::record_batch_reader r,
+      chunked_vector<model::record_batch> r,
       size_t batches_size,
       flush_after_append f = flush_after_append::yes) noexcept;
 
@@ -228,7 +228,7 @@ struct append_entries_request
       vnode src,
       vnode target,
       protocol_metadata m,
-      model::record_batch_reader r,
+      chunked_vector<model::record_batch> r,
       size_t batches_size,
       flush_after_append f = flush_after_append::yes) noexcept;
 
@@ -247,14 +247,15 @@ struct append_entries_request
     const protocol_metadata& metadata() const { return _meta; }
     flush_after_append is_flush_required() const { return _flush; }
 
-    model::record_batch_reader release_batches() && {
+    chunked_vector<model::record_batch> release_batches() && {
         return std::move(_batches);
     }
 
-    model::record_batch_reader& batches() { return _batches; }
-    const model::record_batch_reader& batches() const { return _batches; }
+    chunked_vector<model::record_batch>& batches() { return _batches; }
 
-    static append_entries_request make_foreign(append_entries_request&& req);
+    const chunked_vector<model::record_batch>& batches() const {
+        return _batches;
+    }
 
     friend std::ostream&
     operator<<(std::ostream& o, const append_entries_request& r);
@@ -274,7 +275,7 @@ private:
     vnode _target_node_id;
     protocol_metadata _meta;
     flush_after_append _flush;
-    model::record_batch_reader _batches;
+    chunked_vector<model::record_batch> _batches;
 
     // not serialized field used for accounting in raft internals
     size_t _total_size;


### PR DESCRIPTION
`model::record_batch_reader` was not the best abstraction to represent
the batches in `append_entries_request`. Number of batches contained in
the request is known upfront and they are always materialized in memory.
Therefore it is more convenient and easier to store batches as a plain
`chunked_vector` instead of the reader.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none