### PR TITLE
[UX-66] rpk: save crash information in rpk debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -249,6 +249,9 @@ COMMON FILES
  - Broker metrics: The broker's Prometheus metrics, fetched through its
    admin API (/metrics and /public_metrics).
 
+ - Crash information: Both startup_log and crash_reports will be collected if
+   present in the configured data directory.
+
 BARE-METAL
 
  - Kernel: The kernel logs ring buffer (syslog) and parameters (sysctl).

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -79,6 +79,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),
 		saveResourceUsageData(ps, bp.y),
+		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
 		saveUname(ctx, ps),
 	}

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -70,6 +70,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveCmdLine(ps),
 		saveConfig(ps, bp.yActual),
 		saveControllerLogDir(ps, bp.y, bp.controllerLogLimitBytes),
+		saveCrashReports(ps, bp.y),
 		saveDataDirStructure(ps, bp.y),
 		saveDiskUsage(ctx, ps, bp.y),
 		saveInterrupts(ps),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -152,6 +152,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveResourceUsageData(ps, bp.y),
 		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.cpuProfilerWait),
 		saveMetricsAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.metricsInterval, bp.metricsSampleCount),
+		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
 		saveSocketData(ctx, ps),
 		saveSysctl(ctx, ps),
@@ -1016,6 +1017,31 @@ func saveControllerLogDir(ps *stepParams, y *config.RedpandaYaml, logLimitBytes 
 			if err != nil {
 				return fmt.Errorf("unable to save controller logs: %v", err)
 			}
+		}
+		return nil
+	}
+}
+
+func saveStartupLog(ps *stepParams, y *config.RedpandaYaml) step {
+	return func() error {
+		if y.Redpanda.Directory == "" {
+			return fmt.Errorf("failed to save startup_log: 'redpanda.data_directory' is empty on the provided configuration file")
+		}
+		path := filepath.Join(y.Redpanda.Directory, "startup_log")
+		exists, err := afero.Exists(ps.fs, path)
+		if err != nil {
+			return fmt.Errorf("failed to save startup_log: unable to check existence of startup_log: %v", err)
+		}
+		if !exists {
+			return fmt.Errorf("skipping startup_log collection: unable to find file %q", path)
+		}
+		content, err := afero.ReadFile(ps.fs, path)
+		if err != nil {
+			return fmt.Errorf("failed to save startup_log: unable to read startup_log: %v", err)
+		}
+		err = writeFileToZip(ps, "startup_log", content)
+		if err != nil {
+			return fmt.Errorf("failed to save startup_log: %v", err)
 		}
 		return nil
 	}

--- a/tests/rptest/tests/rpk_debug_bundle_test.py
+++ b/tests/rptest/tests/rpk_debug_bundle_test.py
@@ -70,6 +70,13 @@ class RpkDebugBundleTest(RedpandaTest):
                 continue
             if re.match(r".* error querying .*\.ntp\..* i\/o timeout", l):
                 self.logger.error(f"Non-fatal transitory NTP error: {l}")
+            if re.match(
+                    r".*skipping\s+(startup_log collection|crash_reports collection):\s*(unable to find file|directory).*",
+                    l):
+                # this tests runs a development container, it will not have a
+                # startup_log and we don't expect a crash_reports dir to be
+                # in the data_directory as the container is new.
+                continue
             else:
                 self.logger.error(f"Bad output line: {l}")
                 filtered_errors.append(l)


### PR DESCRIPTION
This PR adds the capability to rpk to collect both the `startup_log` file and the `crash_reports` directory if it's present in the data directory, otherwise it will skip the step and move forward with the bundle collection.

Fixes UX-66

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Features

* rpk debug bundle will now collect the `startup_log` file and `crash_reports` directory if they are present in the data directory.