### PR TITLE
kafka: return log offests for ooor error

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -80,20 +80,17 @@ make_partition_response_error(model::partition_id p_id, error_code error) {
  */
 static ss::future<read_result> read_from_partition(
   kafka::partition_proxy part,
+  model::offset lso,
   fetch_config config,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
-    auto lso = part.last_stable_offset();
-    if (unlikely(!lso)) {
-        co_return read_result(lso.error());
-    }
     auto hw = part.high_watermark();
     auto start_o = part.start_offset();
     // if we have no data read, return fast
     if (
       hw < config.start_offset || config.skip_read
       || config.start_offset > config.max_offset) {
-        co_return read_result(start_o, hw, lso.value());
+        co_return read_result(start_o, hw, lso);
     }
 
     storage::log_reader_config reader_config(
@@ -173,7 +170,7 @@ static ss::future<read_result> read_from_partition(
           ss::make_foreign<read_result::data_t>(std::move(data)),
           start_o,
           hw,
-          lso.value(),
+          lso,
           delta_from_tip_ms,
           std::move(aborted_transactions));
     }
@@ -182,7 +179,7 @@ static ss::future<read_result> read_from_partition(
       std::move(data),
       start_o,
       hw,
-      lso.value(),
+      lso,
       delta_from_tip_ms,
       std::move(aborted_transactions));
 }
@@ -345,15 +342,16 @@ static ss::future<read_result> do_read_from_ntp(
       ntp_config.cfg.read_from_follower,
       default_fetch_timeout + model::timeout_clock::now());
 
+    auto maybe_lso = kafka_partition->last_stable_offset();
+    if (unlikely(!maybe_lso)) {
+        // partition is still bootstrapping
+        co_return read_result(maybe_lso.error());
+    }
+
     if (config::shard_local_cfg().enable_transactions.value()) {
         if (
           ntp_config.cfg.isolation_level
           == model::isolation_level::read_committed) {
-            auto maybe_lso = kafka_partition->last_stable_offset();
-            if (unlikely(!maybe_lso)) {
-                // partition is still bootstrapping
-                co_return read_result(maybe_lso.error());
-            }
             ntp_config.cfg.max_offset = model::prev_offset(maybe_lso.value());
         }
     }
@@ -374,10 +372,6 @@ static ss::future<read_result> do_read_from_ntp(
         }
         auto p_info = std::move(p_info_res.value());
 
-        auto lso = kafka_partition->last_stable_offset();
-        if (unlikely(!lso)) {
-            co_return read_result(lso.error());
-        }
         auto preferred_replica = replica_selector.select_replica(
           consumer_info{
             .fetch_offset = ntp_config.cfg.start_offset,
@@ -392,12 +386,16 @@ static ss::future<read_result> do_read_from_ntp(
             co_return read_result(
               kafka_partition->start_offset(),
               kafka_partition->high_watermark(),
-              lso.value(),
+              maybe_lso.value(),
               preferred_replica);
         }
     }
     read_result result = co_await read_from_partition(
-      std::move(*kafka_partition), ntp_config.cfg, foreign_read, deadline);
+      std::move(*kafka_partition),
+      maybe_lso.value(),
+      ntp_config.cfg,
+      foreign_read,
+      deadline);
 
     adjust_memory_units(
       memory_sem, memory_fetch_sem, memory_units, result.data_size_bytes());

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -151,7 +151,8 @@ static ss::future<read_result> read_from_partition(
                 co_return read_result(
                   error_code::offset_out_of_range,
                   start_o,
-                  part.high_watermark());
+                  part.high_watermark(),
+                  lso);
             }
         }
 
@@ -360,7 +361,8 @@ static ss::future<read_result> do_read_from_ntp(
         co_return read_result(
           offset_ec,
           kafka_partition->start_offset(),
-          kafka_partition->high_watermark());
+          kafka_partition->high_watermark(),
+          maybe_lso.value());
     }
     if (
       config::shard_local_cfg().enable_rack_awareness.value()

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -71,6 +71,7 @@ make_partition_response_error(model::partition_id p_id, error_code error) {
       .error_code = error,
       .high_watermark = model::offset(-1),
       .last_stable_offset = model::offset(-1),
+      .log_start_offset = model::offset(-1),
       .records = batch_reader(),
     };
 }

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -250,7 +250,10 @@ struct read_result {
     };
 
     explicit read_result(error_code e)
-      : error(e) {}
+      : start_offset(-1)
+      , high_watermark(-1)
+      , last_stable_offset(-1)
+      , error(e) {}
 
     // special case for offset_out_of_range_error
     read_result(

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -254,9 +254,13 @@ struct read_result {
 
     // special case for offset_out_of_range_error
     read_result(
-      error_code e, model::offset start_offset, model::offset high_watermark)
+      error_code e,
+      model::offset start_offset,
+      model::offset hw,
+      model::offset lso)
       : start_offset(start_offset)
-      , high_watermark(high_watermark)
+      , high_watermark(hw)
+      , last_stable_offset(lso)
       , error(e) {}
 
     read_result(

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -829,3 +829,91 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
     BOOST_REQUIRE(
       fetch_one_byte.data.topics[0].partitions[0].records->size_bytes() > 0);
 }
+
+FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
+    model::topic topic("foo");
+    model::partition_id pid(0);
+    auto ntp = make_default_ntp(topic, pid);
+
+    wait_for_controller_leadership().get();
+
+    add_topic(model::topic_namespace_view(ntp)).get();
+    wait_for_partition_offset(ntp, model::offset(0)).get();
+    // append some data
+    auto shard = app.shard_table.local().shard_for(ntp);
+    app.partition_manager
+      .invoke_on(
+        *shard,
+        [ntp](cluster::partition_manager& mgr) {
+            return model::test::make_random_batches(model::offset(0), 20)
+              .then([ntp, &mgr](auto batches) {
+                  auto partition = mgr.get(ntp);
+                  return partition->raft()->replicate(
+                    chunked_vector<model::record_batch>(std::move(batches)),
+                    raft::replicate_options(
+                      raft::consistency_level::quorum_ack));
+              });
+        })
+      .get();
+
+    auto trunc_err = app.partition_manager
+                       .invoke_on(
+                         *shard,
+                         [ntp](cluster::partition_manager& mgr) {
+                             auto partition = mgr.get(ntp);
+                             auto k_trunc_offset = kafka::offset(5);
+                             auto rp_trunc_offset
+                               = partition->log()->to_log_offset(
+                                 model::offset(k_trunc_offset));
+                             return partition->prefix_truncate(
+                               rp_trunc_offset,
+                               k_trunc_offset,
+                               ss::lowres_clock::time_point::max());
+                         })
+                       .get();
+    BOOST_REQUIRE(!trunc_err);
+
+    auto hwm = app.partition_manager
+                 .invoke_on(
+                   *shard,
+                   [ntp](cluster::partition_manager& mgr) {
+                       auto partition = mgr.get(ntp);
+                       return partition->log()->from_log_offset(
+                         partition->high_watermark());
+                   })
+                 .get();
+
+    kafka::fetch_request req;
+    req.data.min_bytes = 1;
+    req.data.max_wait_ms = std::chrono::milliseconds(0);
+    req.data.session_id = kafka::invalid_fetch_session_id;
+    req.data.topics.emplace_back(kafka::fetch_topic{
+      .name = topic,
+      .fetch_partitions = {{
+        .partition_index = pid,
+        .fetch_offset = model::offset(0),
+      }},
+    });
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto fresp = client.dispatch(std::move(req), kafka::api_version(5));
+
+    auto resp = fresp.get();
+    client.stop().then([&client] { client.shutdown(); }).get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.topics[0].partitions[0].error_code,
+      kafka::error_code::offset_out_of_range);
+
+    // This is used by the clients to determine what should be done with the
+    // offset out of range error. See
+    // https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica
+    BOOST_REQUIRE_EQUAL(
+      resp.data.topics[0].partitions[0].log_start_offset, model::offset(5));
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions[0].high_watermark, hwm);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.topics[0].partitions[0].last_stable_offset, hwm);
+}


### PR DESCRIPTION
The commits in this PR came as result of investigating https://redpandadata.atlassian.net/browse/CORE-8770 (reading the ticket is advised too). Although this code does not fix the bug as it was reported I believe it makes sense to merge it.

* Out of range error response matches more closely AK response in which log offsets are returned to the client. Previously in redpanda the intention was there but the error mapping dropped the offsets (in `make_partition_response_error`) and never returned them to the client.
* Error handling seems nicer with this PR as in `fill_fetch_responses` `fetch_response::partition_response` is created only once but with an early exit in case of error. Before this PR it was created once by `make_partition_response_error` in case of error and independently in the body of `fill_fetch_responses`. `make_partition_response_error` is still kept as it is useful for creating error responses when log offsets shouldn't be present, i.e. in case of authorization errors.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
