### PR TITLE
CORE-8616 redpanda: configurable sleep on crash loop

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -179,6 +179,16 @@ node_config::node_config() noexcept
       "broker-properties/#crash_loop_limit.",
       {.visibility = visibility::user},
       5) // default value
+  , crash_loop_sleep_sec(
+      *this,
+      "crash_loop_sleep_sec",
+      "The amount of time the broker sleeps before terminating the process "
+      "when it reaches the number of consecutive times a broker can crash. For "
+      "more information, see "
+      "https://docs.redpanda.com/current/reference/properties/"
+      "broker-properties/#crash_loop_limit.",
+      {.visibility = visibility::user},
+      std::nullopt)
   , upgrade_override_checks(
       *this,
       "upgrade_override_checks",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -70,6 +70,7 @@ public:
     deprecated_property enable_central_config;
 
     property<std::optional<uint32_t>> crash_loop_limit;
+    property<std::optional<std::chrono::seconds>> crash_loop_sleep_sec;
 
     // If true, permit any version of redpanda to start, even
     // if potentially incompatible with existing system state.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -157,6 +157,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/json/json_elements.hh>
@@ -501,7 +502,7 @@ int application::run(int ac, char** av) {
                 hydrate_config(cfg);
                 initialize();
                 check_environment();
-                check_for_crash_loop();
+                check_for_crash_loop(app_signal.abort_source());
                 setup_metrics();
                 wire_up_and_start(app_signal);
                 post_start_tasks();
@@ -1030,7 +1031,7 @@ void application::check_environment() {
 /// the broker last failed to start. This metadata is tracked in the
 /// tracker file. This is to prevent on disk state from piling up in
 /// each unclean run and creating more state to recover for the next run.
-void application::check_for_crash_loop() {
+void application::check_for_crash_loop(ss::abort_source& as) {
     if (config::node().developer_mode()) {
         // crash loop tracking has value only in long running clusters
         // that can potentially accumulate state across restarts.
@@ -1087,6 +1088,17 @@ void application::check_for_crash_loop() {
               config::node().crash_loop_limit.name(),
               limit.value(),
               file_path);
+
+            const auto crash_loop_sleep_val
+              = config::node().crash_loop_sleep_sec.value();
+            if (crash_loop_sleep_val) {
+                vlog(
+                  _log.info,
+                  "Sleeping for {} seconds before terminating...",
+                  *crash_loop_sleep_val / 1s);
+                ss::sleep_abortable(*crash_loop_sleep_val, as).get();
+            }
+
             throw std::runtime_error("Crash loop detected, aborting startup.");
         }
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -96,7 +96,7 @@ public:
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
     void post_start_tasks();
 
-    void check_for_crash_loop();
+    void check_for_crash_loop(ss::abort_source&);
     void schedule_crash_tracker_file_cleanup();
 
     explicit application(ss::sstring = "main");

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2657,6 +2657,10 @@ class RedpandaService(RedpandaServiceBase):
         assert node in self.nodes, f"Node {node.account.hostname} is not started"
         self._extra_node_conf[node] = conf
 
+    def add_extra_node_conf(self, node, conf):
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
+        self._extra_node_conf[node] = {**self._extra_node_conf[node], **conf}
+
     def set_security_settings(self, settings):
         self._security = settings
         self._init_tls()


### PR DESCRIPTION
When redpanda detects that it has reached the crash loop limit, instead of terminating immediately, it now sleeps for `crash_loop_sleep_sec` seconds before terminating. This sleeping occurs early on during startup before most components (e.g., storage, controller, admin API, etc.) are initialised.

`crash_loop_sleep_sec` is a node config. It is disabled by default in redpanda, but we plan to enable it by default in the Redpanda Kubernetes Helm Chart shortly.

This config is most useful in Kubernetes environments where setting this value allows customers to have ssh access into a crash looping pod for a short window of time.

Note that it may be pointless (though not harmful) to set `crash_loop_sleep_sec` to a value larger than the timeout specified in the Kubernetes [`startupProbe`](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#startup-probe) or [`livenessProbe`](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#liveness-probe). While the redpanda process is sleeping for `crash_loop_sleep_sec`, Kubernetes thinks that the pod is still starting up slowly. During this time Kubernetes assumes that the pod has not failed but is also not healthy (the admin API is not up, it hasn't joined the cluster, etc.). Therefore, if `crash_loop_sleep_sec` is larger than the configured `startupProbe` or `livenessProbe` timeout then Kubernetes will kill the pod after the configured `startupProbe`/`livenessProbe` expires before the full `crash_loop_sleep_sec` could elapse.

The Redpanda Helm Chart [currently specifies](https://docs.redpanda.com/current/reference/k-redpanda-helm-spec/#statefulset-startupprobe) a `startupProbe` with a timeout of `120s` by default, therefore it is recommended to set `crash_loop_sleep_sec` to a value below that.

Fixes https://redpandadata.atlassian.net/browse/CORE-8616

cc @mmaslankaprv @dotnwat @travisdowns for visibility

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

### Features

* Introduces the node config `crash_loop_sleep_sec`, which sets the time the broker sleeps before terminating the process when the limit on the number of consecutive times a broker can crash has been reached. This is most useful in Kubernetes environments where setting this value allows customers to have ssh access into a crash looping pod for a short window of time.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
