### PR TITLE
rpk/connect: print download message to stderr

### DIFF
--- a/src/go/rpk/pkg/cli/connect/connect.go
+++ b/src/go/rpk/pkg/cli/connect/connect.go
@@ -11,6 +11,7 @@ package connect
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -68,7 +69,7 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 					cmd.Help()
 					return
 				}
-				fmt.Println("Downloading latest Redpanda Connect")
+				fmt.Fprintln(os.Stderr, "Downloading latest Redpanda Connect")
 				path, _, err := installConnect(cmd.Context(), fs, "latest")
 				out.MaybeDie(err, "unable to install Redpanda Connect: %v; if running on an air-gapped environment you may install 'redpanda-connect' with your package manager.", err)
 				pluginPath = path


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/connect/issues/3101

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
