### PR TITLE
Bumping replicas timeout for Operator v1 back as it was before

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -997,7 +997,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         return self.redpanda.kubectl.cmd([
             'wait', 'cluster', cluster_name, '-n=redpanda',
             "--for=jsonpath='{.status.readyReplicas}'=" + str(ready_replicas),
-            '--timeout=900s'
+            '--timeout=1200s'
         ])
 
     # operator V2


### PR DESCRIPTION
Increasing ready replicas timeout to 1200 seconds for Operator v1 (as it was before)
There is a failure in https://buildkite.com/redpanda/vtools/builds/20056
`Add a new node and then decommission it while under load.`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
