### PR TITLE
bazel: change benchmarks to binaries

### DIFF
--- a/src/v/compression/tests/BUILD
+++ b/src/v/compression/tests/BUILD
@@ -39,7 +39,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "zstd_stream_bench",
-    timeout = "short",
     srcs = [
         "zstd_stream_bench.cc",
     ],

--- a/src/v/container/tests/BUILD
+++ b/src/v/container/tests/BUILD
@@ -93,7 +93,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "vector_bench",
-    timeout = "short",
     srcs = [
         "vector_bench.cc",
     ],
@@ -108,7 +107,6 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "map_bench",
-    timeout = "short",
     srcs = [
         "map_bench.cc",
     ],

--- a/src/v/crypto/tests/BUILD
+++ b/src/v/crypto/tests/BUILD
@@ -115,7 +115,6 @@ common_env = {
 
 redpanda_cc_bench(
     name = "crypto_bench",
-    timeout = "short",
     srcs = ["crypto_bench.cc"],
     data = common_data_deps,
     env = common_env,
@@ -132,7 +131,6 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "crypto_bench_fips",
-    timeout = "short",
     srcs = ["crypto_bench.cc"],
     data = common_data_deps,
     defines = ["PERF_FIPS_MODE"],

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -639,7 +639,6 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "uri_bench",
-    timeout = "short",
     srcs = [
         "uri_bench.cc",
     ],
@@ -652,7 +651,6 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "compatibility_bench",
-    timeout = "short",
     srcs = [
         "compatibility_bench.cc",
     ],

--- a/src/v/rpc/test/BUILD
+++ b/src/v/rpc/test/BUILD
@@ -151,7 +151,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "rpc_bench",
-    timeout = "short",
     srcs = [
         "rpc_bench.cc",
     ],

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -216,7 +216,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "role_store_bench",
-    timeout = "moderate",
     srcs = [
         "role_store_bench.cc",
     ],

--- a/src/v/serde/test/BUILD
+++ b/src/v/serde/test/BUILD
@@ -2,7 +2,6 @@ load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest")
 
 redpanda_cc_bench(
     name = "serde_bench",
-    timeout = "short",
     srcs = [
         "bench.cc",
     ],

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -215,7 +215,6 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "thread_worker_bench",
-    timeout = "short",
     srcs = [
         "thread_worker_bench.cc",
     ],
@@ -229,7 +228,6 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "sformat_bench",
-    timeout = "short",
     srcs = [
         "sformat_bench.cc",
     ],

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -116,7 +116,6 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "vint_bench",
-    timeout = "short",
     srcs = [
         "vint_bench.cc",
     ],
@@ -260,7 +259,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "coro_bench",
-    timeout = "short",
     srcs = [
         "coro_bench.cc",
     ],
@@ -274,7 +272,6 @@ redpanda_cc_bench(
 
 redpanda_cc_bench(
     name = "seastar_histogram_bench",
-    timeout = "short",
     srcs = [
         "seastar_histogram_bench.cc",
     ],
@@ -484,7 +481,6 @@ redpanda_cc_btest(
 
 redpanda_cc_bench(
     name = "delta_for_bench",
-    timeout = "short",
     srcs = [
         "delta_for_bench.cc",
     ],

--- a/src/v/wasm/tests/BUILD
+++ b/src/v/wasm/tests/BUILD
@@ -260,7 +260,6 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "transform_bench",
-    timeout = "moderate",
     srcs = [
         "wasm_transform_bench.cc",
     ],


### PR DESCRIPTION
AFAIK this is standard practice in Bazel, we don't want to run these as
normal tests (we currently exclude them in CI), so just make them normal
binaries. We will need logic to schedule these, for example in CI we
don't run these with --overprovisioned, meaning they get pinned to a
core and if we run these in parallel we'll want to evenly distribute
these between cores. I'll leave the scheduling bit for another time, but
for now we just move the cc_bench rule to output a binary isntead of a
test.

Fixes: CORE-8747

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
