### PR TITLE
datalake: refactor schema manager to use table in public interface

### DIFF
--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -29,7 +29,8 @@ public:
     friend std::ostream& operator<<(std::ostream&, const errc&);
 
     virtual ss::future<checked<std::nullopt_t, errc>> ensure_table_schema(
-      const model::topic&, const iceberg::struct_type& desired_type)
+      const iceberg::table_identifier&,
+      const iceberg::struct_type& desired_type)
       = 0;
 
     struct table_info {
@@ -43,7 +44,7 @@ public:
     };
 
     virtual ss::future<checked<table_info, errc>>
-    get_table_info(const model::topic&) = 0;
+    get_table_info(const iceberg::table_identifier&) = 0;
 
     virtual ~schema_manager() = default;
 
@@ -55,13 +56,14 @@ class simple_schema_manager : public schema_manager {
 public:
     ss::future<checked<std::nullopt_t, schema_manager::errc>>
     ensure_table_schema(
-      const model::topic&, const iceberg::struct_type& desired_type) override;
+      const iceberg::table_identifier&,
+      const iceberg::struct_type& desired_type) override;
 
     ss::future<checked<table_info, schema_manager::errc>>
-    get_table_info(const model::topic&) override;
+    get_table_info(const iceberg::table_identifier&) override;
 
 private:
-    chunked_hash_map<model::topic, table_info> topic2table_;
+    chunked_hash_map<iceberg::table_identifier, table_info> table_info_by_id;
 };
 
 // Manages interactions with the catalog when reconciling the current schema of
@@ -78,11 +80,12 @@ public:
     // schema is updated to the desired type.
     ss::future<checked<std::nullopt_t, schema_manager::errc>>
     ensure_table_schema(
-      const model::topic&, const iceberg::struct_type& desired_type) override;
+      const iceberg::table_identifier&,
+      const iceberg::struct_type& desired_type) override;
 
     // Loads the table metadata for the given topic.
     ss::future<checked<table_info, schema_manager::errc>>
-    get_table_info(const model::topic&) override;
+    get_table_info(const iceberg::table_identifier&) override;
 
 private:
     // Attempts to fill the field ids in the given type with those from the

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -67,6 +67,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:manifest_entry",
         "//src/v/iceberg:manifest_io",
         "//src/v/iceberg:metadata_query",
+        "//src/v/iceberg:table_identifier",
         "//src/v/iceberg:transaction",
         "//src/v/iceberg:values_bytes",
         "//src/v/test_utils:gtest",

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -167,7 +167,8 @@ record_multiplexer::operator()(model::record_batch batch) {
                 co_return ss::stop_iteration::yes;
             }
 
-            auto load_res = co_await _schema_mgr.get_table_info(_ntp.tp.topic);
+            auto table_id = _schema_mgr.table_id_for_topic(_ntp.tp.topic);
+            auto load_res = co_await _schema_mgr.get_table_info(table_id);
             if (load_res.has_error()) {
                 auto e = load_res.error();
                 switch (e) {

--- a/src/v/datalake/table_creator.cc
+++ b/src/v/datalake/table_creator.cc
@@ -48,7 +48,7 @@ direct_table_creator::ensure_table(
 
     auto record_type = default_translator{}.build_type(std::move(val_type));
     auto ensure_res = co_await schema_mgr_.ensure_table_schema(
-      topic, record_type.type);
+      table_id, record_type.type);
     if (ensure_res.has_error()) {
         switch (ensure_res.error()) {
         case schema_manager::errc::not_supported:

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -716,6 +716,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/container:fragmented_vector",
+        "@boost//:container_hash",
         "@seastar",
     ],
 )

--- a/src/v/iceberg/table_identifier.h
+++ b/src/v/iceberg/table_identifier.h
@@ -7,10 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 #pragma once
+
 #include "base/seastarx.h"
 #include "container/fragmented_vector.h"
 
 #include <seastar/core/sstring.hh>
+
+#include <boost/container_hash/hash.hpp>
 
 namespace iceberg {
 struct table_identifier {
@@ -23,6 +26,24 @@ struct table_identifier {
           .table = table,
         };
     }
+
+    bool operator==(const table_identifier& other) const = default;
 };
 std::ostream& operator<<(std::ostream& o, const table_identifier& id);
 } // namespace iceberg
+
+namespace std {
+
+template<>
+struct hash<iceberg::table_identifier> {
+    size_t operator()(const iceberg::table_identifier& table_id) const {
+        size_t h = 0;
+        for (const auto& ns : table_id.ns) {
+            boost::hash_combine(h, std::hash<ss::sstring>()(ns));
+        }
+        boost::hash_combine(h, std::hash<ss::sstring>()(table_id.table));
+        return h;
+    };
+};
+
+} // namespace std


### PR DESCRIPTION
We want to use schema manager to manage multiple tables per topic. The first use-case is the DLQ / Dead-Letter-Table.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
