### PR TITLE
kafka/server|hashing: bazelize benchmarks

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -11,3 +11,10 @@ config_setting(
         ":has_sanitizers": "true",
     },
 )
+
+config_setting(
+    name = "optimized_build",
+    values = {
+        "compilation_mode": "opt",
+    },
+)

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -335,7 +335,8 @@ def redpanda_cc_bench(
         runs = None,
         duration = None,
         data = [],
-        tags = []):
+        tags = [],
+        target_compatible_with = []):
     """
     Create a seastar benchmark target
 
@@ -353,6 +354,7 @@ def redpanda_cc_bench(
       data: any data files available to the benchmark as runfiles
       tags: custom tags for the test
       timeout: the timeout for smoke testing the benchmark
+      target_compatible_with: constraints for the test target
     """
     args = [
         "--blocked-reactor-notify-ms 2000000",
@@ -417,4 +419,5 @@ def redpanda_cc_bench(
         data = [
             ":" + name,
         ] + data,
+        target_compatible_with = target_compatible_with,
     )

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -332,6 +332,8 @@ def redpanda_cc_bench(
         env = {},
         cpu = 1,
         memory = "1GiB",
+        runs = None,
+        duration = None,
         data = [],
         tags = []):
     """
@@ -346,6 +348,8 @@ def redpanda_cc_bench(
       env: any custom environment variables for the binary
       cpu: the number of cores the benchmark needs
       memory: the amount of RAM needed for the benchmark
+      runs: number of runs
+      duration: duration of a single run in seconds
       data: any data files available to the benchmark as runfiles
       tags: custom tags for the test
       timeout: the timeout for smoke testing the benchmark
@@ -359,6 +363,10 @@ def redpanda_cc_bench(
         fail("Use `memory=\"XGiB\"` test parameter instead of -m/--memory")
     if has_flags(args, "-c", "--smp"):
         fail("Use `cpu=N` test parameter instead of -c/--smp")
+    if has_flags(args, "--runs"):
+        fail("Use `runs=N` test parameter instead of --runs")
+    if has_flags(args, "--duration"):
+        fail("Use `duration=N` test parameter instead of --duration")
 
     args.append("-m{}".format(memory))
     args.append("-c{}".format(cpu))
@@ -368,6 +376,12 @@ def redpanda_cc_bench(
         "resources:memory:{}".format(parse_bytes(memory) / (1 << 20)),
     ]
 
+    binary_args = []
+    if runs != None:
+        binary_args.append("--runs={}".format(runs))
+    if duration != None:
+        binary_args.append("--duration={}".format(duration))
+
     native.cc_binary(
         name = name,
         srcs = srcs,
@@ -375,7 +389,7 @@ def redpanda_cc_bench(
         deps = deps,
         testonly = True,
         copts = redpanda_copts(),
-        args = args,
+        args = args + binary_args,
         features = [
             "layering_check",
         ],

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_btest_no_seastar")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_btest_no_seastar")
 
 redpanda_cc_btest(
     name = "secure_hash_test",
@@ -22,5 +22,23 @@ redpanda_cc_btest_no_seastar(
     deps = [
         "//src/v/hashing:xx",
         "//src/v/utils:named_type",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "hashing_bench_rpbench",
+    srcs = [
+        "hash_bench.cc",
+    ],
+    deps = [
+        "//src/v/hashing:crc32c",
+        "//src/v/hashing:xx",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/strings",
+        "@boost//:crc",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -801,3 +801,25 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_bench(
+    name = "kafka_produce_partition_rpbench",
+    srcs = [
+        "produce_partition_bench.cc",
+    ],
+    duration = 1,
+    memory = "4GiB",
+    runs = 1,
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/kafka/protocol/schemata:produce_request",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/redpanda/tests:fixture",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -777,3 +777,27 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_bench(
+    name = "kafka_fetch_plan_rpbench",
+    srcs = [
+        "fetch_plan_bench.cc",
+    ],
+    duration = 1,
+    memory = "4GiB",
+    runs = 1,
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/base",
+        "//src/v/kafka/client",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:fetch",
+        "//src/v/kafka/protocol/schemata:fetch_request",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/redpanda/tests:fixture",
+        "@boost//:test",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "config_response_utils_test_help",
@@ -747,5 +747,33 @@ redpanda_cc_gtest(
         "@fmt",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "kafka_fetch_rpbench",
+    timeout = "moderate",
+    srcs = [
+        "fetch_bench.cc",
+    ],
+    cpu = 2,
+    duration = 1,
+    memory = "4GiB",
+    runs = 1,
+    tags = ["exclusive"],
+    target_compatible_with = select({
+        "//bazel:optimized_build": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":kafka_test_utils",
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:scoped_config",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -823,3 +823,22 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_bench(
+    name = "quota_manager_rpbench",
+    srcs = [
+        "quota_manager_bench.cc",
+    ],
+    cpu = 2,
+    duration = 1,
+    memory = "4GiB",
+    runs = 1,
+    deps = [
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/kafka/server",
+        "@fmt",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/kafka/server/tests/produce_partition_bench.cc
+++ b/src/v/kafka/server/tests/produce_partition_bench.cc
@@ -9,29 +9,17 @@
  * by the Apache License, Version 2.0
  */
 #include "container/fragmented_vector.h"
-#include "kafka/client/types.h"
-#include "kafka/protocol/fetch.h"
 #include "kafka/protocol/schemata/produce_request.h"
-#include "kafka/protocol/types.h"
 #include "kafka/server/handlers/produce.h"
 #include "model/fundamental.h"
-#include "model/record.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
-#include "test_utils/fixture.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/testing/perf_tests.hh>
-#include <seastar/testing/thread_test_case.hh>
 
-#include <boost/range/iterator_range_core.hpp>
-#include <boost/test/tools/interface.hpp>
-#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test_log.hpp>
-#include <fmt/ostream.h>
-
-#include <tuple>
 
 using namespace std::chrono_literals; // NOLINT
 


### PR DESCRIPTION
implements:
- [CORE-7484](https://redpandadata.atlassian.net/browse/CORE-7484): `hashing/tests/hash_bench.cc`
- [CORE-7502](https://redpandadata.atlassian.net/browse/CORE-7502): `kafka/server/tests/fetch_bench.cc`
- [CORE-7503](https://redpandadata.atlassian.net/browse/CORE-7503): `kafka/server/tests/fetch_plan_bench.cc`
- [CORE-7521](https://redpandadata.atlassian.net/browse/CORE-7521): `kafka/server/tests/produce_partition_bench.cc`
- [CORE-7522](https://redpandadata.atlassian.net/browse/CORE-7522): `kafka/server/tests/quota_manager_bench.cc`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-7484]: https://redpandadata.atlassian.net/browse/CORE-7484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7502]: https://redpandadata.atlassian.net/browse/CORE-7502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7503]: https://redpandadata.atlassian.net/browse/CORE-7503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7521]: https://redpandadata.atlassian.net/browse/CORE-7521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-7522]: https://redpandadata.atlassian.net/browse/CORE-7522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ