### PR TITLE
Use string instead of string_view as key type in `record_generator`

### DIFF
--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -116,6 +116,7 @@ redpanda_test_cc_library(
         "//src/v/serde/avro/tests:data_generator",
         "//src/v/serde/protobuf/tests:data_generator",
         "//src/v/storage:record_batch_builder",
+        "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:named_type",
         "@seastar",
     ],

--- a/src/v/datalake/tests/record_generator.h
+++ b/src/v/datalake/tests/record_generator.h
@@ -17,6 +17,7 @@
 #include "serde/avro/tests/data_generator.h"
 #include "serde/protobuf/tests/data_generator.h"
 #include "storage/record_batch_builder.h"
+#include "utils/absl_sstring_hash.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/future.hh>
@@ -57,8 +58,12 @@ public:
       testing::protobuf_generator_config config = {});
 
 private:
-    chunked_hash_map<std::string_view, pandaproxy::schema_registry::schema_id>
-      _id_by_name;
+    chunked_hash_map<
+      std::string,
+      pandaproxy::schema_registry::schema_id,
+      sstring_hash,
+      sstring_eq>
+      _id_by_name{};
     schema::registry* _sr;
 };
 


### PR DESCRIPTION
If string_view is used then user's of `record_generator` would need to ensure that the lifetime of any string_view they register equals or exceeds that of the `record_generator`. Using string instead avoids the need to do that.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
