### PR TITLE
kvstore: remove partial snapshots at startup

### DIFF
--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -459,6 +459,8 @@ ss::future<> kvstore::load_snapshot() {
     if (ex) {
         std::rethrow_exception(ex);
     }
+
+    co_await _snap.remove_partial_snapshots();
 }
 
 ss::future<> kvstore::load_snapshot_from_reader(snapshot_reader& reader) {


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-8409

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

### Bug Fixes

* Remove partial kvstore snapshots at startup.
