### PR TITLE
bazel/bench: add tests to benchmarks

### DIFF
--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -355,6 +355,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "record_multiplexer_rpbench",
+    timeout = "long",
     srcs = [
         "record_multiplexer_bench.cc",
     ],

--- a/src/v/wasm/tests/BUILD
+++ b/src/v/wasm/tests/BUILD
@@ -260,6 +260,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "wasm_transform_rpbench",
+    timeout = "moderate",
     srcs = [
         "wasm_transform_bench.cc",
     ],


### PR DESCRIPTION
Just to smoke test they work. In both debug and release so hopefully we
catch stuff in the sanitizer when we get that working.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
