### PR TITLE
gha/clang-format: don't update lockfile

### DIFF
--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -33,6 +33,7 @@ jobs:
           wget -O $HOME/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
           chmod +x $HOME/.local/bin/bazel
       - name: Run clang-format
+        # Don't update the lockfile for this
         run: |
-          bazel run //tools:clang_format
+          bazel run --lockfile_mode=off //tools:clang_format
           git diff --exit-code


### PR DESCRIPTION
Without this we can accidently update the lockfile, which we don't need
to do and causes false failures of this check.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
