### PR TITLE
licenses: remove sasl2

### DIFF
--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -34,7 +34,6 @@ please keep this up to date with every new library use.
 | protobuf        | Apache License 2                   |
 | rapidjson       | MIT                                |
 | re2             | BSD 3-Clause                       |
-| sasl2           | <https://github.com/cyrusimap/cyrus-sasl/blob/master/COPYING> |
 | seastar         | Apache License 2                   |
 | snappy          | <https://github.com/google/snappy/blob/master/COPYING> |
 | unordered_dense | MIT                                |

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -16,7 +16,6 @@ please keep this up to date with every new library use.
 | CRoaring        | Apache License 2                   |
 | clang           | Apache License 2                   |
 | crc32c          | BSD 3                              |
-| DPDK            | BSD                                |
 | fmt             | BSD                                |
 | HdrHistogram    | BSD 2                              |
 | hwloc           | BSD                                |


### PR DESCRIPTION
We don't have this as a dependency anywhere anymore
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
