### PR TITLE
[CORE-4268] Spill key optimizations

### DIFF
--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -97,7 +97,7 @@ private:
         return debug::AllocatedByteSize(_midx);
     }
 
-    size_t entry_mem_usage(const bytes& k) const {
+    static size_t entry_mem_usage(const bytes& k) {
         // One entry in a node hash map: key and value
         // are allocated together, and the key is a basic_sstring with
         // internal buffer that may be spilled if key was longer.

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -125,6 +125,22 @@ private:
     ss::future<> spill_some(size_t entry_size, size_t min_index_size);
     ss::future<> spill(compacted_index::entry_type, bytes_view, value_type);
 
+    // a buffer to collect multiple spilled keys
+    struct spill_payload {
+        iobuf data;
+        uint32_t keys{0};
+    };
+
+    // append a spilled key into the payload buffer
+    static void append_to_spill_payload(
+      spill_payload& payload,
+      compacted_index::entry_type type,
+      bytes_view b,
+      value_type v);
+
+    // append all the keys added to the given payload
+    ss::future<> spill(spill_payload);
+
     std::optional<ntp_sanitizer_config> _sanitizer_config;
     storage_resources& _resources;
     ss::io_priority_class _pc;

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -119,6 +119,10 @@ private:
     ss::future<> open();
     ss::future<> drain_all_keys();
     ss::future<> add_key(compaction_key, value_type);
+    // called during add_key if the index should have keys spilled into the
+    // backing file in order to free up capacity for new keys. see function for
+    // details on the exact spill policy.
+    ss::future<> spill_some(size_t entry_size, size_t min_index_size);
     ss::future<> spill(compacted_index::entry_type, bytes_view, value_type);
 
     std::optional<ntp_sanitizer_config> _sanitizer_config;

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -147,6 +147,7 @@ private:
     bool _truncate;
     std::optional<segment_appender> _appender;
     underlying_t _midx;
+    bytes _last_key_indexed;
 
     // Max memory we'll use for _midx, although we may spill earlier
     // if hinted to by storage_resources


### PR DESCRIPTION
This PR attempts to implement two suggestions by @travisdowns related to the spilling of compaction keys to disk. Both are taken from this discussion on @StephanDollberg's PR https://github.com/redpanda-data/redpanda/pull/19836/files#r1646331859.

> What if we just extract all the keys first, then loop over all of them and spill them? I guess the stopping condition would have to be somewhat different because currently we rely on release_entry_memory to be called once per extraction to update the memory usage estimate.

This one is implemented in this PR. We choose a starting point in the index, and then build up the buffer to be spilled to disk without a suspension point per key.

> Other option is just to maintain a separate vector-ish of compaction_keys in _midx: you can select randomly from this vector easily and erase that element from both. This solves the bias problem and probably ends up cheaper anyway because right now even the occasional begin() call is going to be very expensive over time as the map gets highly warped (all elements condensed on the right hand side of the bucket space). Of course, we won't want to duplicate the key itself.

This one is approximated not by generating a random sequence of keys to spill but rather by choosing a random location in the index from which to start spilling keys. That is, something other than the current fixed location `begin()`. So we may still get hot spots, but we try to move the hot spot around.

The approximation isn't particularly robust. We use the last inserted key as the "random" location. So a workload that skewed heavily towards a few keys would have a few hot spots. Still, perhaps better than always using `begin()`.

As @StephanDollberg pointed out, we don't currently have any great benchmarking tools for compaction so I can't provide any concrete numbers here. I think that's something we may be able to add but it kinda sounds like we were ready to move ahead with the previous PR attempt sans benchmarks?

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
