### PR TITLE
[v24.3.x] c/migration/table: when applying a snapshot update completed timestamp

### DIFF
--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -138,6 +138,7 @@ ss::future<> migrations_table::apply_snapshot(
                 continue;
             }
             it->second.state = migration.state;
+            it->second.completed_timestamp = migration.completed_timestamp;
         }
         affected_ids.push_back(id);
         updated.emplace_back(it->second);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24709
