### PR TITLE
ducktape: bump spark version

### DIFF
--- a/tests/docker/ducktape-deps/spark
+++ b/tests/docker/ducktape-deps/spark
@@ -5,7 +5,7 @@ mkdir /opt/spark
 
 SPARK_VERSION=3.5.4
 SPARK_FILE=spark-$SPARK_VERSION-bin-hadoop3.tgz
-SPARK_URL=https://dlcdn.apache.org/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz
+SPARK_URL=https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz
 
 wget ${SPARK_URL}
 tar xvf ${SPARK_FILE} -C /opt/spark --strip-components 1

--- a/tests/docker/ducktape-deps/spark
+++ b/tests/docker/ducktape-deps/spark
@@ -3,7 +3,7 @@ set -e
 
 mkdir /opt/spark
 
-SPARK_VERSION=3.5.3
+SPARK_VERSION=3.5.4
 SPARK_FILE=spark-$SPARK_VERSION-bin-hadoop3.tgz
 SPARK_URL=https://dlcdn.apache.org/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz
 


### PR DESCRIPTION
Looks like spark 3.5.3 is no longer available.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
