### PR TITLE
Buffered protocol changes

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -489,7 +489,7 @@ configuration::configuration()
       "cannot change. When the total size of cached requests reaches the set "
       "limit, back pressure is applied to throttle producers.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5_MiB,
+      512_KiB,
       {.min = 0, .max = 100_MiB})
   , enable_usage(
       *this,

--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -283,6 +283,9 @@ ss::future<> append_entries_queue::do_dispatch(
   request_entry entry, ssx::semaphore_units inflight_units) {
     auto sent_ts = clock_type::now();
     _last_sent_timestamp = sent_ts;
+    // update timeout not to account for the time in a queue
+    entry.opts.timeout = rpc::timeout_spec::from_now(
+      entry.opts.timeout.timeout_period);
     return _base_protocol
       .append_entries(
         _target_node, std::move(entry.request), std::move(entry.opts))


### PR DESCRIPTION
When the request is buffered in the buffered protocol queue we do not
want to account that time for the overall timeout
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none