### PR TITLE
[v24.1.x] CORE-8616 redpanda: configurable sleep on crash loop

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -146,6 +146,16 @@ node_config::node_config() noexcept
       "enforced in developer mode.",
       {.visibility = visibility::user},
       5)
+  , crash_loop_sleep_sec(
+      *this,
+      "crash_loop_sleep_sec",
+      "The amount of time the broker sleeps before terminating the process "
+      "when it reaches the number of consecutive times a broker can crash. For "
+      "more information, see "
+      "https://docs.redpanda.com/current/reference/properties/"
+      "broker-properties/#crash_loop_limit.",
+      {.visibility = visibility::user},
+      std::nullopt)
   , upgrade_override_checks(
       *this,
       "upgrade_override_checks",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -67,6 +67,7 @@ public:
     deprecated_property enable_central_config;
 
     property<std::optional<uint32_t>> crash_loop_limit;
+    property<std::optional<std::chrono::seconds>> crash_loop_sleep_sec;
 
     // If true, permit any version of redpanda to start, even
     // if potentially incompatible with existing system state.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -136,6 +136,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/json/json_elements.hh>
@@ -461,7 +462,7 @@ int application::run(int ac, char** av) {
                 hydrate_config(cfg);
                 initialize();
                 check_environment();
-                check_for_crash_loop();
+                check_for_crash_loop(app_signal.abort_source());
                 setup_metrics();
                 wire_up_and_start(app_signal);
                 post_start_tasks();
@@ -922,7 +923,7 @@ void application::check_environment() {
 /// the broker last failed to start. This metadata is tracked in the
 /// tracker file. This is to prevent on disk state from piling up in
 /// each unclean run and creating more state to recover for the next run.
-void application::check_for_crash_loop() {
+void application::check_for_crash_loop(ss::abort_source& as) {
     if (config::node().developer_mode()) {
         // crash loop tracking has value only in long running clusters
         // that can potentially accumulate state across restarts.
@@ -979,6 +980,17 @@ void application::check_for_crash_loop() {
               config::node().crash_loop_limit.name(),
               limit.value(),
               file_path);
+
+            const auto crash_loop_sleep_val
+              = config::node().crash_loop_sleep_sec.value();
+            if (crash_loop_sleep_val) {
+                vlog(
+                  _log.info,
+                  "Sleeping for {} seconds before terminating...",
+                  *crash_loop_sleep_val / 1s);
+                ss::sleep_abortable(*crash_loop_sleep_val, as).get();
+            }
+
             throw std::runtime_error("Crash loop detected, aborting startup.");
         }
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -91,7 +91,7 @@ public:
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
     void post_start_tasks();
 
-    void check_for_crash_loop();
+    void check_for_crash_loop(ss::abort_source&);
     void schedule_crash_tracker_file_cleanup();
 
     explicit application(ss::sstring = "main");

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2310,6 +2310,10 @@ class RedpandaService(RedpandaServiceBase):
         assert node in self.nodes, f"Node {node.account.hostname} is not started"
         self._extra_node_conf[node] = conf
 
+    def add_extra_node_conf(self, node, conf):
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
+        self._extra_node_conf[node] = {**self._extra_node_conf[node], **conf}
+
     def set_security_settings(self, settings):
         self._security = settings
         self._init_tls()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24787 

The conflict was in the surrounding code in `node_config.cc` because v24.2.x didn't have the `// default value` comment at the end of the creation of `crash_loop_limit`.

Fixes https://github.com/redpanda-data/redpanda/issues/24827
Fixes https://redpandadata.atlassian.net/browse/CORE-8826