### PR TITLE
serde: fix c++23 enum handling

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -482,7 +482,7 @@ struct partition_assignment
       = default;
 };
 
-enum incremental_update_operation : int8_t { none, set, remove };
+enum class incremental_update_operation : int8_t { none, set, remove };
 
 inline std::string_view
 incremental_update_operation_as_string(incremental_update_operation op) {
@@ -496,6 +496,11 @@ incremental_update_operation_as_string(incremental_update_operation op) {
     default:
         vassert(false, "Unknown operation type passed: {}", int8_t(op));
     }
+}
+
+inline std::ostream&
+operator<<(std::ostream& os, const incremental_update_operation& op) {
+    return os << incremental_update_operation_as_string(op);
 }
 
 template<typename T>

--- a/src/v/serde/rw/enum.h
+++ b/src/v/serde/rw/enum.h
@@ -24,6 +24,7 @@ namespace serde {
 template<typename T>
 requires(serde_is_enum_v<std::decay_t<T>>)
 void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
+    static_assert(std::is_scoped_enum_v<std::decay_t<T>>);
     using Type = std::decay_t<T>;
     const auto val = static_cast<std::underlying_type_t<Type>>(t);
     if (unlikely(!std::in_range<serde_enum_serialized_t>(val))) {
@@ -41,6 +42,7 @@ template<typename T>
 requires serde_is_enum_v<std::decay_t<T>>
 void tag_invoke(
   tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
+    static_assert(std::is_scoped_enum_v<std::decay_t<T>>);
     using Type = std::decay_t<T>;
 
     const auto val = read_nested<serde_enum_serialized_t>(in, bytes_left_limit);

--- a/src/v/serde/rw/enum.h
+++ b/src/v/serde/rw/enum.h
@@ -24,7 +24,9 @@ namespace serde {
 template<typename T>
 requires(serde_is_enum_v<std::decay_t<T>>)
 void tag_invoke(tag_t<write_tag>, iobuf& out, T t) {
+#if defined(__cpp_lib_is_scoped_enum) && __cpp_lib_is_scoped_enum >= 202011L
     static_assert(std::is_scoped_enum_v<std::decay_t<T>>);
+#endif
     using Type = std::decay_t<T>;
     const auto val = static_cast<std::underlying_type_t<Type>>(t);
     if (unlikely(!std::in_range<serde_enum_serialized_t>(val))) {
@@ -42,7 +44,9 @@ template<typename T>
 requires serde_is_enum_v<std::decay_t<T>>
 void tag_invoke(
   tag_t<read_tag>, iobuf_parser& in, T& t, const std::size_t bytes_left_limit) {
+#if defined(__cpp_lib_is_scoped_enum) && __cpp_lib_is_scoped_enum >= 202011L
     static_assert(std::is_scoped_enum_v<std::decay_t<T>>);
+#endif
     using Type = std::decay_t<T>;
 
     const auto val = read_nested<serde_enum_serialized_t>(in, bytes_left_limit);

--- a/src/v/serde/serde_is_enum.h
+++ b/src/v/serde/serde_is_enum.h
@@ -16,13 +16,8 @@ namespace serde {
 using serde_enum_serialized_t = int32_t;
 
 template<typename T>
-inline constexpr bool serde_is_enum_v =
-#if defined(__cpp_lib_is_scoped_enum) && __cpp_lib_is_scoped_enum >= 202011L
-  std::is_scoped_enum_v<T>
-  && sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t);
-#else
-  std::is_enum_v<T>
-  && sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t);
-#endif
+inline constexpr bool serde_is_enum_v = std::is_enum_v<T>
+                                        && sizeof(std::decay_t<T>)
+                                             <= sizeof(serde_enum_serialized_t);
 
 } // namespace serde

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -174,13 +174,13 @@ public:
         // tests.
         const auto& prop_update = update.properties.batch_max_bytes;
         switch (prop_update.op) {
-        case cluster::none:
+        case cluster::incremental_update_operation::none:
             return;
-        case cluster::set:
+        case cluster::incremental_update_operation::set:
             config.properties.batch_max_bytes
               = update.properties.batch_max_bytes.value;
             break;
-        case cluster::remove:
+        case cluster::incremental_update_operation::remove:
             config.properties.batch_max_bytes.reset();
             break;
         }


### PR DESCRIPTION
See commit messages. Changes `cluster::incremental_update_operation` to use scoped enum.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
