### PR TITLE
CORE-8618 crash_tracker: record uncaught startup exceptions

### DIFF
--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -122,6 +122,10 @@ public:
         return data_directory().path / "startup_log";
     }
 
+    std::filesystem::path crash_report_dir_path() const {
+        return data_directory().path / "crash_reports";
+    }
+
     /**
      * Return the configured cache path if set, otherwise a default
      * path within the data directory.

--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -7,6 +7,7 @@ redpanda_cc_library(
         "logger.cc",
         "recorder.cc",
         "service.cc",
+        "types.cc",
     ],
     hdrs = [
         "limiter.h",

--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -5,6 +5,7 @@ redpanda_cc_library(
     srcs = [
         "limiter.cc",
         "logger.cc",
+        "prepared_writer.cc",
         "recorder.cc",
         "service.cc",
         "types.cc",
@@ -12,6 +13,7 @@ redpanda_cc_library(
     hdrs = [
         "limiter.h",
         "logger.h",
+        "prepared_writer.h",
         "recorder.h",
         "service.h",
         "types.h",

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   SRCS
     limiter.cc
     logger.cc
+    prepared_writer.cc
     recorder.cc
     service.cc
     types.cc

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     logger.cc
     recorder.cc
     service.cc
+    types.cc
   DEPS
     Seastar::seastar
     v::base

--- a/src/v/crash_tracker/limiter.cc
+++ b/src/v/crash_tracker/limiter.cc
@@ -97,7 +97,7 @@ ss::future<> limiter::check_for_crash_loop(ss::abort_source& as) const {
                 co_await ss::sleep_abortable(*crash_loop_sleep_val, as);
             }
 
-            throw std::runtime_error("Crash loop detected, aborting startup.");
+            throw crash_loop_limit_reached();
         }
 
         vlog(

--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "crash_tracker/prepared_writer.h"
+
+#include "crash_tracker/logger.h"
+#include "crash_tracker/types.h"
+#include "hashing/xx.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/file-types.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/print_safe.hh>
+
+#include <fmt/chrono.h>
+
+#include <chrono>
+#include <fcntl.h>
+#include <system_error>
+#include <unistd.h>
+
+using namespace std::chrono_literals;
+
+namespace crash_tracker {
+
+std::ostream& operator<<(std::ostream& os, prepared_writer::state s) {
+    switch (s) {
+    case prepared_writer::state::uninitialized:
+        return os << "uninitialized";
+    case prepared_writer::state::initialized:
+        return os << "initialized";
+    case prepared_writer::state::filled:
+        return os << "filled";
+    case prepared_writer::state::written:
+        return os << "written";
+    case prepared_writer::state::released:
+        return os << "released";
+    }
+}
+
+ss::future<>
+prepared_writer::initialize(std::filesystem::path crash_file_path) {
+    vassert(_state == state::uninitialized, "Unexpected state: {}", _state);
+    _crash_report_file_name = std::move(crash_file_path);
+
+    _serde_output.reserve_memory(crash_description::serde_size_overestimate);
+
+    // Create the crash recorder file
+    auto f = co_await ss::open_file_dma(
+      _crash_report_file_name.c_str(),
+      ss::open_flags::create | ss::open_flags::rw | ss::open_flags::truncate
+        | ss::open_flags::exclusive);
+    co_await f.close();
+
+    // Open the crash recorder file using ::open().
+    // We need to use the low level open() function here instead of the seastar
+    // API or higher-level C++ primitives because we need to be able to
+    // manipulate the file using async-signal-safe, allocation-free functions
+    // inside signal handlers.
+    _fd = ::open(_crash_report_file_name.c_str(), O_WRONLY);
+    if (_fd == -1) {
+        throw std::system_error(
+          errno,
+          std::system_category(),
+          fmt::format(
+            "Failed to open {} to record crash reason",
+            _crash_report_file_name));
+    }
+
+    // Update _state as the last step in initialize() to make earlier changes
+    // visible across threads.
+    _state = state::initialized;
+}
+
+crash_description* prepared_writer::fill() {
+    // Note: this CAS serves two purposes:
+    // 1. Ensures the visibility of the changes made in initialize()
+    // 2. Ensures only a single owner can win the race for the prepared_writer
+    //    with competing calls of fill() and release() across threads.
+    auto before = state::initialized;
+    auto success = _state.compare_exchange_strong(before, state::filled);
+    if (!success) {
+        // The old value of _state could have been anything but uninitialized
+        // because of competing calls of fill(), write() or release() on other
+        // threads. These competing calls are unlikely but possible. Example: a
+        // sigabrt signal handler calls fill() on thread T3 while a segfault
+        // signal handler calls fill() on thread T2.
+        vassert(
+          before != state::uninitialized,
+          "fill() must be called after initialize(). Unexpected state: {}",
+          before);
+        return nullptr;
+    }
+    _prepared_cd.crash_time = model::timestamp::now();
+
+    return &_prepared_cd;
+}
+
+void prepared_writer::write() {
+    auto before = state::filled;
+    auto success = _state.compare_exchange_strong(before, state::written);
+    vassert(
+      success,
+      "write() must be called after a fill() that returned a non-null value. "
+      "Unexpected state: {}",
+      before);
+
+    if (try_write_crash()) {
+        constexpr static std::string_view success
+          = "Recorded crash reason to crash file.\n";
+        ss::print_safe(success.data(), success.size());
+    } else {
+        constexpr static std::string_view failure
+          = "Failed to record crash reason to crash file.\n";
+        ss::print_safe(failure.data(), failure.size());
+    }
+}
+
+bool prepared_writer::try_write_crash() {
+    bool success = true;
+    serde::write(_serde_output, std::move(_prepared_cd));
+
+    for (const auto& frag : _serde_output) {
+        size_t written = 0;
+        while (written < frag.size()) {
+            auto res = ::write(
+              _fd, frag.get() + written, frag.size() - written);
+            if (res == -1 && errno == EINTR) {
+                // EINTR is retriable
+                continue;
+            } else if (res == -1) {
+                // Return that writing the crash failed but try to continue to
+                // write later fragments as much information as possible
+                success = false;
+                break;
+            } else {
+                written += res;
+            }
+        }
+    }
+
+    ::fsync(_fd);
+
+    return success;
+}
+
+ss::future<> prepared_writer::release() {
+    // Note: this CAS ensures only a single owner can win the race for the
+    // prepared_writer with competing calls of fill() and release() across
+    // threads.
+    auto before = state::initialized;
+    auto success = _state.compare_exchange_strong(before, state::released);
+    if (!success) {
+        // Sanity check that the CAS was unsuccessful because of a race with
+        // fill() and not because the prepared_writer was not initialized.
+        vassert(
+          before != state::uninitialized,
+          "release() must be called after initialize(). Unexpected state: {}",
+          before);
+
+        // If another call to fill() won the race, release() is a noop
+        co_return;
+    }
+
+    ::close(_fd);
+    co_await ss::remove_file(_crash_report_file_name.c_str());
+    vlog(ctlog.debug, "Deleted crash report file: {}", _crash_report_file_name);
+
+    _state = state::released;
+
+    co_return;
+}
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "crash_tracker/types.h"
+
+namespace crash_tracker {
+
+// prepared_writer is a thread-safe helper for writing a crash_description to a
+// file in an async-signal safe way. The state transition diagram for the object
+// is below. Note that fill() may race with other calls of fill() or with
+// release(), and the class safely breaks this race. Calling fill() returns a
+// nullptr if it lost the race (i.e. if the object is already in
+// filled/written/released state). Calling release() is a noop if it lost the
+// race (i.e. if the object is already in filled/written state).
+//
+// clang-format off
+// +---------------+  initialize()   +-------------+  fill()   +--------+  write()   +---------+
+// | uninitialized +---------------->| initialized +---------->| filled +----------->| written |
+// +---------------+                 +------+------+           +--------+            +---------+
+//                                          |
+//                                          |
+//                                          |
+//                                          |
+//                                          |
+//                                          |                        release()      +----------+
+//                                          +-------------------------------------->| released |
+//                                                                                  +----------+
+// clang-format on
+class prepared_writer {
+public:
+    ss::future<> initialize(std::filesystem::path);
+    ss::future<> release();
+
+    /// Async-signal safe
+    /// May return nullptr if the prepared_writer has already been consumed
+    crash_description* fill();
+
+    /// Async-signal safe
+    /// Must be called after a fill() that returned a non-null value
+    void write();
+
+private:
+    enum class state { uninitialized, initialized, filled, written, released };
+    friend std::ostream& operator<<(std::ostream&, state);
+
+    // Returns true on success, false on failure
+    bool try_write_crash();
+
+    std::atomic<state> _state{state::uninitialized};
+
+    // We want to avoid taking locks during signal handling. An atomic enum with
+    // a few states should be lock-free implementable on the platforms redpanda
+    // supports, but if this check ever fails we could change the type of the
+    // enum class to an enum or integer.
+    static_assert(std::atomic<state>::is_always_lock_free);
+
+    crash_description _prepared_cd;
+    iobuf _serde_output;
+    std::filesystem::path _crash_report_file_name;
+    int _fd{0};
+};
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -11,11 +11,75 @@
 
 #include "crash_tracker/recorder.h"
 
+#include "config/node_config.h"
+#include "crash_tracker/logger.h"
+#include "model/timestamp.h"
+#include "random/generators.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace crash_tracker {
+
+static constexpr std::string_view crash_report_suffix = ".crash";
 
 recorder& get_recorder() {
     static recorder inst;
     return inst;
+}
+
+ss::future<> recorder::start() {
+    // Ensure that the crash report directory exists
+    auto crash_report_dir = config::node().crash_report_dir_path();
+    if (!co_await ss::file_exists(crash_report_dir.string())) {
+        vlog(
+          ctlog.info,
+          "Creating crash report directory {}",
+          crash_report_dir.string());
+        co_await ss::recursive_touch_directory(crash_report_dir.string());
+        vlog(
+          ctlog.debug,
+          "Successfully created crash report directory {}",
+          crash_report_dir.string());
+    }
+
+    // Loop a few times to avoid (very unlikely) collisions in the filename
+    std::optional<std::filesystem::path> crash_file_name{};
+    for (int i = 0; i < 10; ++i) {
+        auto time_now = model::timestamp::now().value();
+        auto random_int = random_generators::get_int(0, 10000);
+        auto try_name = crash_report_dir
+                        / fmt::format(
+                          "{}_{}{}", time_now, random_int, crash_report_suffix);
+        if (co_await ss::file_exists(try_name.string())) {
+            // Try again in the rare case of a collision
+            continue;
+        }
+
+        crash_file_name = try_name;
+        break;
+    }
+    if (!crash_file_name) {
+        // The anti-collision above should ensure that we never reach this
+        throw std::runtime_error(
+          "Failed to create a unique crash recorder file");
+    }
+
+    co_await _writer.initialize(*crash_file_name);
+}
+
+ss::future<> recorder::stop() {
+    std::unique_lock<ss::util::spinlock> g(_writer_lock, std::try_to_lock);
+    vassert(
+      g.owns_lock(),
+      "stop() runs after all previous calls have completed, so we must have "
+      "been able to take the _writer_lock");
+    co_await _writer.release();
 }
 
 } // namespace crash_tracker

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "crash_tracker/prepared_writer.h"
 #include "crash_tracker/types.h"
 
 namespace crash_tracker {
@@ -41,6 +42,8 @@ public:
 private:
     recorder() = default;
     ~recorder() = default;
+
+    prepared_writer _writer;
 
     friend recorder& get_recorder();
 };

--- a/src/v/crash_tracker/service.cc
+++ b/src/v/crash_tracker/service.cc
@@ -23,8 +23,12 @@ service::service() noexcept
 
 ss::future<> service::start(ss::abort_source& as) {
     co_await _limiter.check_for_crash_loop(as);
+    co_await get_recorder().start();
 }
 
-ss::future<> service::stop() { co_await _limiter.record_clean_shutdown(); }
+ss::future<> service::stop() {
+    co_await _limiter.record_clean_shutdown();
+    co_await get_recorder().stop();
+}
 
 } // namespace crash_tracker

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "crash_tracker/types.h"
+
+namespace crash_tracker {
+
+bool is_crash_loop_limit_reached(std::exception_ptr eptr) {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const crash_loop_limit_reached&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -62,4 +62,12 @@ struct crash_tracker_metadata
     }
 };
 
+class crash_loop_limit_reached : public std::runtime_error {
+public:
+    explicit crash_loop_limit_reached()
+      : std::runtime_error("Crash loop detected, aborting startup.") {}
+};
+
+bool is_crash_loop_limit_reached(std::exception_ptr);
+
 } // namespace crash_tracker

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -31,7 +31,15 @@ enum class crash_type {
 struct crash_description
   : serde::
       envelope<crash_description, serde::version<0>, serde::compat_version<0>> {
-    crash_type type;
+    // We pre-allocate the memory necessary for the buffers needed to fill a
+    // crash_description and overestimate its serialized size to be able to
+    // pre-allocate a sufficiently large iobuf to write it to
+    constexpr static size_t string_buffer_reserve = 4096;
+    constexpr static size_t overhead_overestimate = 1024;
+    constexpr static size_t serde_size_overestimate
+      = overhead_overestimate + 3 * string_buffer_reserve;
+
+    crash_type type{};
     model::timestamp crash_time;
     ss::sstring crash_message;
     ss::sstring stacktrace;
@@ -41,6 +49,12 @@ struct crash_description
     /// verbose for telemetry.
     /// Eg. top-N allocations
     ss::sstring addition_info;
+
+    crash_description()
+      : crash_time{}
+      , crash_message(string_buffer_reserve, '\0')
+      , stacktrace(string_buffer_reserve, '\0')
+      , addition_info(string_buffer_reserve, '\0') {}
 
     auto serde_fields() {
         return std::tie(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -520,6 +520,10 @@ int application::run(int ac, char** av) {
                   _log.error,
                   "Failure during startup: {}",
                   std::current_exception());
+                if (_crash_tracker_service) {
+                    _crash_tracker_service->get_recorder()
+                      .record_crash_exception(std::current_exception());
+                }
                 return 1;
             }
             return 0;

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -143,7 +143,7 @@ def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
     for ns in safe_listdir(data_dir):
         if not safe_isdir(ns):
             continue
-        if ns.name == "cloud_storage_cache":
+        if ns.name in ["cloud_storage_cache", "crash_reports"]:
             continue
         ns_output = {}
         for topic in safe_listdir(ns):

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -22,7 +22,7 @@ class CrashLoopChecksTest(RedpandaTest):
 
     CRASH_LOOP_LOG = [
         "Crash loop detected. Too many consecutive crashes.*",
-        ".*Failure during startup: std::runtime_error \(Crash loop detected, aborting startup.\).*"
+        ".*Failure during startup: crash_tracker::crash_loop_limit_reached \(Crash loop detected, aborting startup.\).*"
     ]
 
     # main - application.cc:348 - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -33,6 +33,7 @@ class CrashLoopChecksTest(RedpandaTest):
     ]
 
     CRASH_LOOP_TRACKER_FILE = f"{RedpandaService.DATA_DIR}/startup_log"
+    CRASH_REPORTS_DIR = f"{RedpandaService.DATA_DIR}/crash_reports"
 
     def __init__(self, test_context):
         super(CrashLoopChecksTest, self).__init__(
@@ -48,6 +49,12 @@ class CrashLoopChecksTest(RedpandaTest):
     def remove_crash_loop_tracker_file(self, broker):
         broker.account.ssh(
             f"rm -f {CrashLoopChecksTest.CRASH_LOOP_TRACKER_FILE}")
+
+    def count_crash_files(self, broker):
+        return int(
+            broker.account.ssh_output(
+                f"find \"{CrashLoopChecksTest.CRASH_REPORTS_DIR}\" -type f | wc -l",
+                combine_stderr=False).strip())
 
     def get_broker_to_crash_loop_state(self, broker):
         for _ in range(CrashLoopChecksTest.CRASH_LOOP_LIMIT):
@@ -131,3 +138,37 @@ class CrashLoopChecksTest(RedpandaTest):
                                              "Too many consecutive crashes")
         assert self.redpanda.search_log_node(
             broker, "Sleeping for 3 seconds before terminating...")
+
+    @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + HOSTNAME_ERRORS)
+    def test_crash_report_file_create(self):
+        broker = self.redpanda.nodes[0]
+
+        def expect_crash_count(expected):
+            crash_files = self.count_crash_files(broker)
+            assert crash_files == expected, f"Unexpected number of crashes: {crash_files} != {expected}"
+
+        # A SIGKILL'd broker will leave behind an empty crash report
+        self.redpanda.signal_redpanda(broker)
+        expect_crash_count(1)
+
+        # A clean broker start+stop will not leave behind a crash report
+        self.redpanda.start_node(broker)
+        self.redpanda.stop_node(broker)
+        expect_crash_count(1)
+
+        # Exceptions during startup should generate crash reports
+        invalid_conf = dict(
+            kafka_api=dict(address="unreachable_host.com", port=9092))
+        for _ in range(CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1):
+            self.redpanda.start_node(broker,
+                                     override_cfg_params=invalid_conf,
+                                     expect_fail=True)
+        expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
+
+        # No new crash report should be generated for when redpanda stops with the crash loop limit reached
+        self.redpanda.start_node(broker,
+                                 override_cfg_params=invalid_conf,
+                                 expect_fail=True)
+        assert self.redpanda.search_log_node(broker,
+                                             "Too many consecutive crashes")
+        expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)


### PR DESCRIPTION
This PR adds functionality to record crashes caused by an exception during startup as crash reports to disk. This is the first step to implement the core crash recording project which aims to persist information about redpanda broker crashes to disk to help debugging.

The PR implements the core functionality of preparing state to allow writing crash reports in an async-signal-safe way, so that this code can be reused in signal handlers in follow-up PRs.

The crash reports are going to be stored under the data directory. The filenames are constructed as: `${datadir}/crash_reports/${broker_start_time_ms}_${random}.crash`.

Reports are serialized using `serde` and `iobuf` (with pre-reserved) memory, and the implementation relies on their allocation-free behaviour to ensure that writing crash files in signal handlers is reliable even in OOM scenarios. (This will become important in a follow-up PR when the signal handlers are actually hooked up.)

To write to the crash reports, we need to use the low-level `open()` function here instead of the seastar API or higher-level C++ primitives because we need to be able to manipulate the file using async-signal-safe, allocation-free functions inside signal handlers. Ref: https://man7.org/linux/man-pages/man7/signal-safety.7.html

Fixes https://redpandadata.atlassian.net/browse/CORE-8618

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
