### PR TITLE
pandaproxy/sr: Fix normalized rendering for custom options

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -28,6 +28,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/range/combine.hpp>
 #include <confluent/meta.pb.h>
 #include <confluent/types/decimal.pb.h>
 #include <fmt/core.h>
@@ -555,7 +556,8 @@ struct protobuf_schema_definition::impl {
         if (is_normalized) {
             pb::FileDescriptorProto tmp_fdp;
             fd->CopyTo(&tmp_fdp);
-            render_proto(osb.ostream(), std::move(tmp_fdp), *fd);
+            copy_uninterpreted_options(fdp, tmp_fdp);
+            render_proto(osb.ostream(), tmp_fdp, *fd);
         } else {
             render_proto(osb.ostream(), fdp, *fd);
         }
@@ -598,6 +600,89 @@ struct protobuf_schema_definition::impl {
 
         std::variant<Range, std::reference_wrapper<const Range>> _r;
     };
+
+    template<typename Proto>
+    void copy_options(const Proto& from, Proto& to) const {
+        if (!from.has_options()) {
+            return;
+        }
+        to.mutable_options()->CopyFrom(from.options());
+    }
+
+    void copy_uninterpreted_options(
+      const pb::DescriptorProto& from, pb::DescriptorProto& to) const {
+        copy_options(from, to);
+
+        for (auto&& [field_from, field_to] :
+             boost::combine(from.field(), *to.mutable_field())) {
+            copy_uninterpreted_options(field_from, field_to);
+        }
+
+        // oneof decl
+        for (auto&& [oneof_from, oneof_to] :
+             boost::combine(from.oneof_decl(), *to.mutable_oneof_decl())) {
+            copy_options(oneof_from, oneof_to);
+        }
+
+        // nested messages
+        for (auto&& [nested_from, nested_to] :
+             boost::combine(from.nested_type(), *to.mutable_nested_type())) {
+            copy_uninterpreted_options(nested_from, nested_to);
+        }
+
+        // nested enums
+        for (auto&& [enum_from, enum_to] :
+             boost::combine(from.enum_type(), *to.mutable_enum_type())) {
+            copy_uninterpreted_options(enum_from, enum_to);
+        }
+    }
+
+    void copy_uninterpreted_options(
+      const pb::EnumDescriptorProto& from, pb::EnumDescriptorProto& to) const {
+        copy_options(from, to);
+
+        for (auto&& [value_from, value_to] :
+             boost::combine(from.value(), *to.mutable_value())) {
+            copy_options(value_from, value_to);
+        }
+    }
+
+    void copy_uninterpreted_options(
+      const pb::ServiceDescriptorProto& from,
+      pb::ServiceDescriptorProto& to) const {
+        copy_options(from, to);
+
+        for (auto&& [method_from, method_to] :
+             boost::combine(from.method(), *to.mutable_method())) {
+            copy_options(method_from, method_to);
+        }
+    }
+
+    void copy_uninterpreted_options(
+      const pb::FieldDescriptorProto& from,
+      pb::FieldDescriptorProto& to) const {
+        copy_options(from, to);
+    }
+
+    void copy_uninterpreted_options(
+      const pb::FileDescriptorProto& from, pb::FileDescriptorProto& to) const {
+        copy_options(from, to);
+
+        for (auto&& [message_from, message_to] :
+             boost::combine(from.message_type(), *to.mutable_message_type())) {
+            copy_uninterpreted_options(message_from, message_to);
+        }
+
+        for (auto&& [enum_from, enum_to] :
+             boost::combine(from.enum_type(), *to.mutable_enum_type())) {
+            copy_uninterpreted_options(enum_from, enum_to);
+        }
+
+        for (auto&& [service_from, service_to] :
+             boost::combine(from.service(), *to.mutable_service())) {
+            copy_uninterpreted_options(service_from, service_to);
+        }
+    }
 
     template<
       std::ranges::random_access_range Range,

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -890,16 +890,25 @@ struct protobuf_schema_definition::impl {
         }
     }
 
-    void render_extension(
+    template<typename Descriptor>
+    void render_extensions(
       std::ostream& os,
       pb::Edition edition,
-      const google::protobuf::FieldDescriptorProto& field,
-      const google::protobuf::FieldDescriptor* descriptor,
+      const pb::RepeatedPtrField<pb::FieldDescriptorProto>& raw_extensions,
+      const Descriptor& descriptor,
       int indent) const {
-        // Render the field as an extension
-        fmt::print(os, "{:{}}extend {} {{\n", "", indent, field.extendee());
-        render_field(os, edition, field, descriptor, indent + 2);
-        fmt::print(os, "{:{}}}}\n", "", indent);
+        auto extensions = maybe_sorted(
+          raw_extensions, std::less{}, [](const auto& extension) {
+              return std::make_pair(extension.extendee(), extension.number());
+          });
+        for (const auto& extension : extensions) {
+            auto d = descriptor.FindExtensionByName(extension.name());
+
+            fmt::print(
+              os, "{:{}}extend {} {{\n", "", indent, extension.extendee());
+            render_field(os, edition, extension, d, indent + 2);
+            fmt::print(os, "{:{}}}}\n", "", indent);
+        }
     }
 
     // Render a message, including nested messages
@@ -1050,11 +1059,8 @@ struct protobuf_schema_definition::impl {
               range.end() - 1);
         }
 
-        // Render extensions
-        for (const auto& extension : message.extension()) {
-            auto d = descriptor->FindExtensionByName(extension.name());
-            render_extension(os, edition, extension, d, indent + 2);
-        }
+        render_extensions(
+          os, edition, message.extension(), *descriptor, indent + 2);
 
         auto nested_messages = std::views::filter(
           message.nested_type(),
@@ -1431,10 +1437,7 @@ struct protobuf_schema_definition::impl {
             render_enum(os, enum_proto, 0);
         }
 
-        for (const auto& extension : fdp.extension()) {
-            auto d = descriptor.FindExtensionByName(extension.name());
-            render_extension(os, edition, extension, d, 0);
-        }
+        render_extensions(os, edition, fdp.extension(), descriptor, 0);
 
         if ((fdp.message_type_size() + fdp.enum_type_size()) != 0) {
             fmt::print(os, "\n");

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -932,6 +932,15 @@ struct protobuf_schema_definition::impl {
         for (const int i : oneofs) {
             const auto& decl = message.oneof_decl(i);
             fmt::print(os, "{:{}}oneof {} {{\n", "", indent + 2, decl.name());
+            auto uninterpreted_options = maybe_sorted(
+              decl.options().uninterpreted_option(),
+              std::less{},
+              [](const pb::UninterpretedOption& o) {
+                  return fmt::format("{}", fmt::join(o.name(), ""));
+              });
+            for (const auto& option : uninterpreted_options) {
+                fmt::print(os, "{:{}}option {};\n", "", indent + 4, option);
+            }
             auto fields = maybe_sorted(
               message.field(),
               std::ranges::less{},

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -131,18 +131,18 @@ struct fmt::formatter<google::protobuf::UninterpretedOption>
         const auto fmt = [&](const auto& val) {
             if (option.has_string_value()) {
                 return fmt::format_to(
-                  ctx.out(), "{} = \"{}\"", fmt::join(option.name(), ""), val);
+                  ctx.out(), "{} = \"{}\"", fmt::join(option.name(), "."), val);
             } else if (option.has_aggregate_value()) {
                 return fmt::format_to(
                   ctx.out(),
                   "{} = {{{}\n{:{}}}}",
-                  fmt::join(option.name(), ""),
+                  fmt::join(option.name(), "."),
                   val,
                   "",
                   indent + 2);
             }
             return fmt::format_to(
-              ctx.out(), "{} = {}", fmt::join(option.name(), ""), val);
+              ctx.out(), "{} = {}", fmt::join(option.name(), "."), val);
         };
         if (option.has_identifier_value()) {
             return fmt(option.identifier_value());
@@ -786,7 +786,7 @@ struct protobuf_schema_definition::impl {
               options.uninterpreted_option(),
               std::less{},
               [](const auto& option) {
-                  return fmt::format("{}", fmt::join(option.name(), ""));
+                  return fmt::format("{}", fmt::join(option.name(), "."));
               });
             for (const auto& option : uninterpreted_options) {
                 maybe_print_seperator();
@@ -866,7 +866,7 @@ struct protobuf_schema_definition::impl {
           message.options().uninterpreted_option(),
           std::less{},
           [](const auto& option) {
-              return fmt::format("{}", fmt::join(option.name(), ""));
+              return fmt::format("{}", fmt::join(option.name(), "."));
           });
         for (const auto& option : uninterepreted_options) {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
@@ -1097,7 +1097,7 @@ struct protobuf_schema_definition::impl {
               service.options().uninterpreted_option(),
               std::less{},
               [](const pb::UninterpretedOption& o) {
-                  return fmt::format("{}", fmt::join(o.name(), ""));
+                  return fmt::format("{}", fmt::join(o.name(), "."));
               });
             for (const auto& option : uninterpreted_options) {
                 fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
@@ -1106,7 +1106,7 @@ struct protobuf_schema_definition::impl {
         for (const auto& method : service.method()) {
             fmt::print(
               os,
-              "{:{}}rpc {} ({}{}) returns ({}{});\n",
+              "{:{}}rpc {} ({}{}) returns ({}{})",
               "",
               indent + 2,
               method.name(),
@@ -1115,6 +1115,7 @@ struct protobuf_schema_definition::impl {
               method.server_streaming() ? "stream " : "",
               method.output_type());
             if (method.has_options()) {
+                fmt::print(os, " {{\n");
                 if (method.options().has_deprecated()) {
                     fmt::print(
                       os,
@@ -1136,11 +1137,14 @@ struct protobuf_schema_definition::impl {
                   method.options().uninterpreted_option(),
                   std::less{},
                   [](const pb::UninterpretedOption& o) {
-                      return fmt::format("{}", fmt::join(o.name(), ""));
+                      return fmt::format("{}", fmt::join(o.name(), "."));
                   });
                 for (const auto& option : uninterpreted_options) {
-                    fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
+                    fmt::print(os, "{:{}}option {};\n", "", indent + 4, option);
                 }
+                fmt::print(os, "{:{}}}}\n", "", indent + 2);
+            } else {
+                fmt::print(os, ";\n");
             }
         }
         fmt::print(os, "{:{}}}}\n", "", indent);
@@ -1218,7 +1222,7 @@ struct protobuf_schema_definition::impl {
           options.uninterpreted_option(),
           std::less{},
           [](const pb::UninterpretedOption& o) {
-              return fmt::format("{}", fmt::join(o.name(), ""));
+              return fmt::format("{}", fmt::join(o.name(), "."));
           });
         for (const auto& option : uninterpreted_options) {
             first_option = false;

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -635,6 +635,12 @@ struct protobuf_schema_definition::impl {
              boost::combine(from.enum_type(), *to.mutable_enum_type())) {
             copy_uninterpreted_options(enum_from, enum_to);
         }
+
+        // nested extentions
+        for (auto&& [extension_from, extension_to] :
+             boost::combine(from.extension(), *to.mutable_extension())) {
+            copy_uninterpreted_options(extension_from, extension_to);
+        }
     }
 
     void copy_uninterpreted_options(
@@ -676,6 +682,11 @@ struct protobuf_schema_definition::impl {
         for (auto&& [enum_from, enum_to] :
              boost::combine(from.enum_type(), *to.mutable_enum_type())) {
             copy_uninterpreted_options(enum_from, enum_to);
+        }
+
+        for (auto&& [extension_from, extension_to] :
+             boost::combine(from.extension(), *to.mutable_extension())) {
+            copy_uninterpreted_options(extension_from, extension_to);
         }
 
         for (auto&& [service_from, service_to] :

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -698,6 +698,14 @@ struct protobuf_schema_definition::impl {
         return range_proxy<Range>{std::move(copy)};
     }
 
+    auto maybe_sorted_uninterpreted_options(
+      const pb::RepeatedPtrField<pb::UninterpretedOption>& options) const {
+        return maybe_sorted(
+          options, std::less{}, [](const pb::UninterpretedOption& o) {
+              return fmt::format("{}", o);
+          });
+    }
+
     void render_field(
       std::ostream& os,
       pb::Edition edition,
@@ -867,12 +875,8 @@ struct protobuf_schema_definition::impl {
               },
               field_options());
 
-            auto uninterpreted_options = maybe_sorted(
-              options.uninterpreted_option(),
-              std::less{},
-              [](const auto& option) {
-                  return fmt::format("{}", fmt::join(option.name(), "."));
-              });
+            auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+              options.uninterpreted_option());
             for (const auto& option : uninterpreted_options) {
                 maybe_print_seperator();
                 fmt::print(os, "{}", option);
@@ -975,12 +979,8 @@ struct protobuf_schema_definition::impl {
                   message.options().no_standard_descriptor_accessor());
             }
         }
-        auto uninterepreted_options = maybe_sorted(
-          message.options().uninterpreted_option(),
-          std::less{},
-          [](const auto& option) {
-              return fmt::format("{}", fmt::join(option.name(), "."));
-          });
+        auto uninterepreted_options = maybe_sorted_uninterpreted_options(
+          message.options().uninterpreted_option());
         for (const auto& option : uninterepreted_options) {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
         }
@@ -1045,12 +1045,8 @@ struct protobuf_schema_definition::impl {
         for (const int i : oneofs) {
             const auto& decl = message.oneof_decl(i);
             fmt::print(os, "{:{}}oneof {} {{\n", "", indent + 2, decl.name());
-            auto uninterpreted_options = maybe_sorted(
-              decl.options().uninterpreted_option(),
-              std::less{},
-              [](const pb::UninterpretedOption& o) {
-                  return fmt::format("{}", fmt::join(o.name(), ""));
-              });
+            auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+              decl.options().uninterpreted_option());
             for (const auto& option : uninterpreted_options) {
                 fmt::print(os, "{:{}}option {};\n", "", indent + 4, option);
             }
@@ -1152,12 +1148,8 @@ struct protobuf_schema_definition::impl {
               indent + 2,
               enum_proto.options().deprecated());
         }
-        auto uninterpreted_options = maybe_sorted(
-          enum_proto.options().uninterpreted_option(),
-          std::less{},
-          [](const pb::UninterpretedOption& o) {
-              return fmt::format("{}", fmt::join(o.name(), ""));
-          });
+        auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+          enum_proto.options().uninterpreted_option());
         for (const auto& option : uninterpreted_options) {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
         }
@@ -1191,13 +1183,9 @@ struct protobuf_schema_definition::impl {
                 }
                 if (!value.options().uninterpreted_option().empty()) {
                     maybe_print_comma();
-                    auto uninterpreted_options = maybe_sorted(
-                      value.options().uninterpreted_option(),
-                      std::less{},
-                      [](const auto& option) {
-                          return fmt::format(
-                            "{}", fmt::join(option.name(), "."));
-                      });
+                    auto uninterpreted_options
+                      = maybe_sorted_uninterpreted_options(
+                        value.options().uninterpreted_option());
                     fmt::print(
                       os, "{}", fmt::join(uninterpreted_options, ", "));
                 }
@@ -1223,12 +1211,8 @@ struct protobuf_schema_definition::impl {
                   indent + 2,
                   service.options().deprecated());
             }
-            auto uninterpreted_options = maybe_sorted(
-              service.options().uninterpreted_option(),
-              std::less{},
-              [](const pb::UninterpretedOption& o) {
-                  return fmt::format("{}", fmt::join(o.name(), "."));
-              });
+            auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+              service.options().uninterpreted_option());
             for (const auto& option : uninterpreted_options) {
                 fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
             }
@@ -1263,12 +1247,8 @@ struct protobuf_schema_definition::impl {
                       pb::MethodOptions_IdempotencyLevel_Name(
                         method.options().idempotency_level()));
                 }
-                auto uninterpreted_options = maybe_sorted(
-                  method.options().uninterpreted_option(),
-                  std::less{},
-                  [](const pb::UninterpretedOption& o) {
-                      return fmt::format("{}", fmt::join(o.name(), "."));
-                  });
+                auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+                  method.options().uninterpreted_option());
                 for (const auto& option : uninterpreted_options) {
                     fmt::print(os, "{:{}}option {};\n", "", indent + 4, option);
                 }
@@ -1348,12 +1328,8 @@ struct protobuf_schema_definition::impl {
         if (options.has_py_generic_services()) {
             printv("py_generic_services", options.py_generic_services());
         }
-        auto uninterpreted_options = maybe_sorted(
-          options.uninterpreted_option(),
-          std::less{},
-          [](const pb::UninterpretedOption& o) {
-              return fmt::format("{}", fmt::join(o.name(), "."));
-          });
+        auto uninterpreted_options = maybe_sorted_uninterpreted_options(
+          options.uninterpreted_option());
         for (const auto& option : uninterpreted_options) {
             first_option = false;
             fmt::print(os, "option {};\n", option);

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -901,13 +901,32 @@ struct protobuf_schema_definition::impl {
           raw_extensions, std::less{}, [](const auto& extension) {
               return std::make_pair(extension.extendee(), extension.number());
           });
+
+        const auto start_section = [indent, &os](std::string_view ext) {
+            fmt::print(os, "{:{}}extend {} {{\n", "", indent, ext);
+        };
+        const auto close_section = [indent, &os]() {
+            fmt::print(os, "{:{}}}}\n", "", indent);
+        };
+
+        std::string active_extendee{};
+        bool open_section = false;
         for (const auto& extension : extensions) {
             auto d = descriptor.FindExtensionByName(extension.name());
 
-            fmt::print(
-              os, "{:{}}extend {} {{\n", "", indent, extension.extendee());
+            const auto& extendee = extension.extendee();
+            if (active_extendee != extendee) {
+                active_extendee = extendee;
+                if (open_section) {
+                    close_section();
+                }
+                start_section(extendee);
+                open_section = true;
+            }
             render_field(os, edition, extension, d, indent + 2);
-            fmt::print(os, "{:{}}}}\n", "", indent);
+        }
+        if (open_section) {
+            close_section();
         }
     }
 

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -1127,7 +1127,13 @@ struct protobuf_schema_definition::impl {
               indent + 2,
               enum_proto.options().deprecated());
         }
-        for (const auto& option : enum_proto.options().uninterpreted_option()) {
+        auto uninterpreted_options = maybe_sorted(
+          enum_proto.options().uninterpreted_option(),
+          std::less{},
+          [](const pb::UninterpretedOption& o) {
+              return fmt::format("{}", fmt::join(o.name(), ""));
+          });
+        for (const auto& option : uninterpreted_options) {
             fmt::print(os, "{:{}}option {};\n", "", indent + 2, option);
         }
         std::optional<std::decay_t<decltype(enum_proto.value())>> values;
@@ -1160,10 +1166,15 @@ struct protobuf_schema_definition::impl {
                 }
                 if (!value.options().uninterpreted_option().empty()) {
                     maybe_print_comma();
+                    auto uninterpreted_options = maybe_sorted(
+                      value.options().uninterpreted_option(),
+                      std::less{},
+                      [](const auto& option) {
+                          return fmt::format(
+                            "{}", fmt::join(option.name(), "."));
+                      });
                     fmt::print(
-                      os,
-                      "{}",
-                      fmt::join(value.options().uninterpreted_option(), ", "));
+                      os, "{}", fmt::join(uninterpreted_options, ", "));
                 }
                 fmt::print(os, "]");
             }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -597,7 +597,7 @@ message Bar {
       foobar_proto);
 }
 
-// proto file copied from
+// proto file heavily inspired from
 // https://protobuf.dev/programming-guides/proto2/#customoptions
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_custom_options) {
     auto schema = R"(import "google/protobuf/descriptor.proto";
@@ -609,6 +609,9 @@ extend google.protobuf.FileOptions {
 extend google.protobuf.MessageOptions {
   optional int32 my_message_option_b = 50009;
   optional int32 my_message_option_a = 50001;
+}
+extend google.protobuf.FileOptions {
+  optional string my_file_option_c = 50015;
 }
 extend google.protobuf.FieldOptions {
   optional float my_field_option_b = 50010;
@@ -712,50 +715,37 @@ enum MyEnum {
 }
 extend google.protobuf.FileOptions {
   optional string my_file_option_b = 50008;
-}
-extend google.protobuf.FileOptions {
   optional string my_file_option_a = 50000;
 }
 extend google.protobuf.MessageOptions {
   optional int32 my_message_option_b = 50009;
-}
-extend google.protobuf.MessageOptions {
   optional int32 my_message_option_a = 50001;
+}
+extend google.protobuf.FileOptions {
+  optional string my_file_option_c = 50015;
 }
 extend google.protobuf.FieldOptions {
   optional float my_field_option_b = 50010;
-}
-extend google.protobuf.FieldOptions {
   optional float my_field_option_a = 50002;
 }
 extend google.protobuf.OneofOptions {
   optional int64 my_oneof_option_b = 50011;
-}
-extend google.protobuf.OneofOptions {
   optional int64 my_oneof_option_a = 50003;
 }
 extend google.protobuf.EnumOptions {
   optional bool my_enum_option_b = 50012;
-}
-extend google.protobuf.EnumOptions {
   optional bool my_enum_option_a = 50004;
 }
 extend google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option_b = 50013;
-}
-extend google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option_a = 50005;
 }
 extend google.protobuf.ServiceOptions {
   optional MyEnum my_service_option_b = 50014;
-}
-extend google.protobuf.ServiceOptions {
   optional MyEnum my_service_option_a = 50006;
 }
 extend google.protobuf.MethodOptions {
   optional MyMessage my_method_option_b = 50015;
-}
-extend google.protobuf.MethodOptions {
   optional MyMessage my_method_option_a = 50007;
 }
 
@@ -806,50 +796,35 @@ enum MyEnum {
 }
 extend .google.protobuf.EnumOptions {
   optional bool my_enum_option_a = 50004;
-}
-extend .google.protobuf.EnumOptions {
   optional bool my_enum_option_b = 50012;
 }
 extend .google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option_a = 50005;
-}
-extend .google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option_b = 50013;
 }
 extend .google.protobuf.FieldOptions {
   optional float my_field_option_a = 50002;
-}
-extend .google.protobuf.FieldOptions {
   optional float my_field_option_b = 50010;
 }
 extend .google.protobuf.FileOptions {
   optional string my_file_option_a = 50000;
-}
-extend .google.protobuf.FileOptions {
   optional string my_file_option_b = 50008;
+  optional string my_file_option_c = 50015;
 }
 extend .google.protobuf.MessageOptions {
   optional int32 my_message_option_a = 50001;
-}
-extend .google.protobuf.MessageOptions {
   optional int32 my_message_option_b = 50009;
 }
 extend .google.protobuf.MethodOptions {
   optional .MyMessage my_method_option_a = 50007;
-}
-extend .google.protobuf.MethodOptions {
   optional .MyMessage my_method_option_b = 50015;
 }
 extend .google.protobuf.OneofOptions {
   optional int64 my_oneof_option_a = 50003;
-}
-extend .google.protobuf.OneofOptions {
   optional int64 my_oneof_option_b = 50011;
 }
 extend .google.protobuf.ServiceOptions {
   optional .MyEnum my_service_option_a = 50006;
-}
-extend .google.protobuf.ServiceOptions {
   optional .MyEnum my_service_option_b = 50014;
 }
 

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -804,53 +804,53 @@ enum MyEnum {
   FOO = 1 [(my_enum_value_option_a) = 321, (my_enum_value_option_b) = 432];
   BAR = 2;
 }
-extend .google.protobuf.FileOptions {
-  optional string my_file_option_b = 50008;
-}
-extend .google.protobuf.FileOptions {
-  optional string my_file_option_a = 50000;
-}
-extend .google.protobuf.MessageOptions {
-  optional int32 my_message_option_b = 50009;
-}
-extend .google.protobuf.MessageOptions {
-  optional int32 my_message_option_a = 50001;
-}
-extend .google.protobuf.FieldOptions {
-  optional float my_field_option_b = 50010;
-}
-extend .google.protobuf.FieldOptions {
-  optional float my_field_option_a = 50002;
-}
-extend .google.protobuf.OneofOptions {
-  optional int64 my_oneof_option_b = 50011;
-}
-extend .google.protobuf.OneofOptions {
-  optional int64 my_oneof_option_a = 50003;
+extend .google.protobuf.EnumOptions {
+  optional bool my_enum_option_a = 50004;
 }
 extend .google.protobuf.EnumOptions {
   optional bool my_enum_option_b = 50012;
 }
-extend .google.protobuf.EnumOptions {
-  optional bool my_enum_option_a = 50004;
+extend .google.protobuf.EnumValueOptions {
+  optional uint32 my_enum_value_option_a = 50005;
 }
 extend .google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option_b = 50013;
 }
-extend .google.protobuf.EnumValueOptions {
-  optional uint32 my_enum_value_option_a = 50005;
+extend .google.protobuf.FieldOptions {
+  optional float my_field_option_a = 50002;
 }
-extend .google.protobuf.ServiceOptions {
-  optional .MyEnum my_service_option_b = 50014;
+extend .google.protobuf.FieldOptions {
+  optional float my_field_option_b = 50010;
 }
-extend .google.protobuf.ServiceOptions {
-  optional .MyEnum my_service_option_a = 50006;
+extend .google.protobuf.FileOptions {
+  optional string my_file_option_a = 50000;
+}
+extend .google.protobuf.FileOptions {
+  optional string my_file_option_b = 50008;
+}
+extend .google.protobuf.MessageOptions {
+  optional int32 my_message_option_a = 50001;
+}
+extend .google.protobuf.MessageOptions {
+  optional int32 my_message_option_b = 50009;
+}
+extend .google.protobuf.MethodOptions {
+  optional .MyMessage my_method_option_a = 50007;
 }
 extend .google.protobuf.MethodOptions {
   optional .MyMessage my_method_option_b = 50015;
 }
-extend .google.protobuf.MethodOptions {
-  optional .MyMessage my_method_option_a = 50007;
+extend .google.protobuf.OneofOptions {
+  optional int64 my_oneof_option_a = 50003;
+}
+extend .google.protobuf.OneofOptions {
+  optional int64 my_oneof_option_b = 50011;
+}
+extend .google.protobuf.ServiceOptions {
+  optional .MyEnum my_service_option_a = 50006;
+}
+extend .google.protobuf.ServiceOptions {
+  optional .MyEnum my_service_option_b = 50014;
 }
 
 service MyService {
@@ -968,17 +968,17 @@ message MyMessage {
     BAR = 2;
   }
 }
-extend .google.protobuf.MessageOptions {
-  optional int32 my_message_option = 50001;
-}
-extend .google.protobuf.FieldOptions {
-  optional float my_field_option = 50002;
-}
 extend .google.protobuf.EnumOptions {
   optional bool my_enum_option = 50004;
 }
 extend .google.protobuf.EnumValueOptions {
   optional uint32 my_enum_value_option = 50005;
+}
+extend .google.protobuf.FieldOptions {
+  optional float my_field_option = 50002;
+}
+extend .google.protobuf.MessageOptions {
+  optional int32 my_message_option = 50001;
 }
 
 )";

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -603,48 +603,60 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_custom_options) {
     auto schema = R"(import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.FileOptions {
-  optional string my_file_option = 50000;
+  optional string my_file_option_b = 50008;
+  optional string my_file_option_a = 50000;
 }
 extend google.protobuf.MessageOptions {
-  optional int32 my_message_option = 50001;
+  optional int32 my_message_option_b = 50009;
+  optional int32 my_message_option_a = 50001;
 }
 extend google.protobuf.FieldOptions {
-  optional float my_field_option = 50002;
+  optional float my_field_option_b = 50010;
+  optional float my_field_option_a = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional int64 my_oneof_option = 50003;
+  optional int64 my_oneof_option_b = 50011;
+  optional int64 my_oneof_option_a = 50003;
 }
 extend google.protobuf.EnumOptions {
-  optional bool my_enum_option = 50004;
+  optional bool my_enum_option_b = 50012;
+  optional bool my_enum_option_a = 50004;
 }
 extend google.protobuf.EnumValueOptions {
-  optional uint32 my_enum_value_option = 50005;
+  optional uint32 my_enum_value_option_b = 50013;
+  optional uint32 my_enum_value_option_a = 50005;
 }
 extend google.protobuf.ServiceOptions {
-  optional MyEnum my_service_option = 50006;
+  optional MyEnum my_service_option_b = 50014;
+  optional MyEnum my_service_option_a = 50006;
 }
 extend google.protobuf.MethodOptions {
-  optional MyMessage my_method_option = 50007;
+  optional MyMessage my_method_option_b = 50015;
+  optional MyMessage my_method_option_a = 50007;
 }
 
-option (my_file_option) = "Hello world!";
+option (my_file_option_b) = "Some other string";
+option (my_file_option_a) = "Hello world!";
 
 message MyMessage {
-  option (my_message_option) = 1234;
+  option (my_message_option_b) = 2345;
+  option (my_message_option_a) = 1234;
 
-  optional int32 foo = 1 [(my_field_option) = 4.5];
+  optional int32 foo = 1 [(my_field_option_b) = 5.5, (my_field_option_a) = 4.5];
   optional string bar = 2;
   oneof qux {
-    option (my_oneof_option) = 42;
+    option (my_oneof_option_b) = 43;
+    option (my_oneof_option_a) = 42;
 
     string quux = 3;
   }
 }
 
 enum MyEnum {
-  option (my_enum_option) = true;
+  option (my_enum_option_b) = false;
+  option (my_enum_option_a) = true;
 
-  FOO = 1 [(my_enum_value_option) = 321];
+  FOO = 1 [(my_enum_value_option_b) = 432, (my_enum_value_option_a) = 321];
   BAR = 2;
 }
 
@@ -652,13 +664,16 @@ message RequestType {}
 message ResponseType {}
 
 service MyService {
-  option (my_service_option) = FOO;
+  option (my_service_option_b) = BAR;
+  option (my_service_option_a) = FOO;
 
   rpc MyMethod(RequestType) returns(ResponseType) {
-    // Note:  my_method_option has type MyMessage.  We can set each field
+    // Note:  my_method_option_a has type MyMessage.  We can set each field
     //   within it using a separate "option" line.
-    option (my_method_option).foo = 567;
-    option (my_method_option).bar = "Some string";
+    option (my_method_option_b).bar = "Some other string";
+    option (my_method_option_b).foo = 678;
+    option (my_method_option_a).foo = 567;
+    option (my_method_option_a).bar = "Some string";
   }
 }
 )";
@@ -667,15 +682,21 @@ service MyService {
 
 import "google/protobuf/descriptor.proto";
 
-option (my_file_option) = "Hello world!";
+option (my_file_option_b) = "Some other string";
+option (my_file_option_a) = "Hello world!";
 
 message MyMessage {
-  option (my_message_option) = 1234;
-  optional int32 foo = 1 [(my_field_option) = 4.5];
+  option (my_message_option_b) = 2345;
+  option (my_message_option_a) = 1234;
+  optional int32 foo = 1 [
+    (my_field_option_b) = 5.5,
+    (my_field_option_a) = 4.5
+  ];
   optional string bar = 2;
 
   oneof qux {
-    option (my_oneof_option) = 42;
+    option (my_oneof_option_b) = 43;
+    option (my_oneof_option_a) = 42;
     string quux = 3;
   }
 }
@@ -684,40 +705,68 @@ message RequestType {
 message ResponseType {
 }
 enum MyEnum {
-  option (my_enum_option) = true;
-  FOO = 1 [(my_enum_value_option) = 321];
+  option (my_enum_option_b) = false;
+  option (my_enum_option_a) = true;
+  FOO = 1 [(my_enum_value_option_b) = 432, (my_enum_value_option_a) = 321];
   BAR = 2;
 }
 extend google.protobuf.FileOptions {
-  optional string my_file_option = 50000;
+  optional string my_file_option_b = 50008;
+}
+extend google.protobuf.FileOptions {
+  optional string my_file_option_a = 50000;
 }
 extend google.protobuf.MessageOptions {
-  optional int32 my_message_option = 50001;
+  optional int32 my_message_option_b = 50009;
+}
+extend google.protobuf.MessageOptions {
+  optional int32 my_message_option_a = 50001;
 }
 extend google.protobuf.FieldOptions {
-  optional float my_field_option = 50002;
+  optional float my_field_option_b = 50010;
+}
+extend google.protobuf.FieldOptions {
+  optional float my_field_option_a = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional int64 my_oneof_option = 50003;
+  optional int64 my_oneof_option_b = 50011;
+}
+extend google.protobuf.OneofOptions {
+  optional int64 my_oneof_option_a = 50003;
 }
 extend google.protobuf.EnumOptions {
-  optional bool my_enum_option = 50004;
+  optional bool my_enum_option_b = 50012;
+}
+extend google.protobuf.EnumOptions {
+  optional bool my_enum_option_a = 50004;
 }
 extend google.protobuf.EnumValueOptions {
-  optional uint32 my_enum_value_option = 50005;
+  optional uint32 my_enum_value_option_b = 50013;
+}
+extend google.protobuf.EnumValueOptions {
+  optional uint32 my_enum_value_option_a = 50005;
 }
 extend google.protobuf.ServiceOptions {
-  optional MyEnum my_service_option = 50006;
+  optional MyEnum my_service_option_b = 50014;
+}
+extend google.protobuf.ServiceOptions {
+  optional MyEnum my_service_option_a = 50006;
 }
 extend google.protobuf.MethodOptions {
-  optional MyMessage my_method_option = 50007;
+  optional MyMessage my_method_option_b = 50015;
+}
+extend google.protobuf.MethodOptions {
+  optional MyMessage my_method_option_a = 50007;
 }
 
 service MyService {
-  option (my_service_option) = FOO;
+  option (my_service_option_b) = BAR;
+  option (my_service_option_a) = FOO;
   rpc MyMethod (RequestType) returns (ResponseType) {
-    option (my_method_option).foo = 567;
-    option (my_method_option).bar = "Some string";
+    option (my_method_option_b).bar = "Some other string";
+    option (my_method_option_b).foo = 678;
+    option (my_method_option_a).foo = 567;
+    option (my_method_option_a).bar = "Some string";
   }
 }
 
@@ -727,15 +776,21 @@ service MyService {
 
 import "google/protobuf/descriptor.proto";
 
-option (my_file_option) = "Hello world!";
+option (my_file_option_a) = "Hello world!";
+option (my_file_option_b) = "Some other string";
 
 message MyMessage {
-  option (my_message_option) = 1234;
-  optional int32 foo = 1 [(my_field_option) = 4.5];
+  option (my_message_option_a) = 1234;
+  option (my_message_option_b) = 2345;
+  optional int32 foo = 1 [
+    (my_field_option_a) = 4.5,
+    (my_field_option_b) = 5.5
+  ];
   optional string bar = 2;
 
   oneof qux {
-    option (my_oneof_option) = 42;
+    option (my_oneof_option_a) = 42;
+    option (my_oneof_option_b) = 43;
     string quux = 3;
   }
 }
@@ -744,40 +799,68 @@ message RequestType {
 message ResponseType {
 }
 enum MyEnum {
-  option (my_enum_option) = true;
-  FOO = 1 [(my_enum_value_option) = 321];
+  option (my_enum_option_a) = true;
+  option (my_enum_option_b) = false;
+  FOO = 1 [(my_enum_value_option_a) = 321, (my_enum_value_option_b) = 432];
   BAR = 2;
 }
 extend .google.protobuf.FileOptions {
-  optional string my_file_option = 50000;
+  optional string my_file_option_b = 50008;
+}
+extend .google.protobuf.FileOptions {
+  optional string my_file_option_a = 50000;
 }
 extend .google.protobuf.MessageOptions {
-  optional int32 my_message_option = 50001;
+  optional int32 my_message_option_b = 50009;
+}
+extend .google.protobuf.MessageOptions {
+  optional int32 my_message_option_a = 50001;
 }
 extend .google.protobuf.FieldOptions {
-  optional float my_field_option = 50002;
+  optional float my_field_option_b = 50010;
+}
+extend .google.protobuf.FieldOptions {
+  optional float my_field_option_a = 50002;
 }
 extend .google.protobuf.OneofOptions {
-  optional int64 my_oneof_option = 50003;
+  optional int64 my_oneof_option_b = 50011;
+}
+extend .google.protobuf.OneofOptions {
+  optional int64 my_oneof_option_a = 50003;
 }
 extend .google.protobuf.EnumOptions {
-  optional bool my_enum_option = 50004;
+  optional bool my_enum_option_b = 50012;
+}
+extend .google.protobuf.EnumOptions {
+  optional bool my_enum_option_a = 50004;
 }
 extend .google.protobuf.EnumValueOptions {
-  optional uint32 my_enum_value_option = 50005;
+  optional uint32 my_enum_value_option_b = 50013;
+}
+extend .google.protobuf.EnumValueOptions {
+  optional uint32 my_enum_value_option_a = 50005;
 }
 extend .google.protobuf.ServiceOptions {
-  optional .MyEnum my_service_option = 50006;
+  optional .MyEnum my_service_option_b = 50014;
+}
+extend .google.protobuf.ServiceOptions {
+  optional .MyEnum my_service_option_a = 50006;
 }
 extend .google.protobuf.MethodOptions {
-  optional .MyMessage my_method_option = 50007;
+  optional .MyMessage my_method_option_b = 50015;
+}
+extend .google.protobuf.MethodOptions {
+  optional .MyMessage my_method_option_a = 50007;
 }
 
 service MyService {
-  option (my_service_option) = FOO;
+  option (my_service_option_a) = FOO;
+  option (my_service_option_b) = BAR;
   rpc MyMethod (.RequestType) returns (.ResponseType) {
-    option (my_method_option).bar = "Some string";
-    option (my_method_option).foo = 567;
+    option (my_method_option_a).bar = "Some string";
+    option (my_method_option_a).foo = 567;
+    option (my_method_option_b).bar = "Some other string";
+    option (my_method_option_b).foo = 678;
   }
 }
 

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -603,7 +603,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_custom_options) {
     auto schema = R"(import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.FileOptions {
-  optional string my_file_option_b = 50008;
+  optional string my_file_option_b = 50008 [(my_field_option_b) = 5.5, (my_field_option_a) = 4.5];
   optional string my_file_option_a = 50000;
   repeated uint32 my_repeated_file_option = 60000;
 }
@@ -721,7 +721,10 @@ enum MyEnum {
   BAR = 2;
 }
 extend google.protobuf.FileOptions {
-  optional string my_file_option_b = 50008;
+  optional string my_file_option_b = 50008 [
+    (my_field_option_b) = 5.5,
+    (my_field_option_a) = 4.5
+  ];
   optional string my_file_option_a = 50000;
   repeated uint32 my_repeated_file_option = 60000;
 }
@@ -819,7 +822,10 @@ extend .google.protobuf.FieldOptions {
 }
 extend .google.protobuf.FileOptions {
   optional string my_file_option_a = 50000;
-  optional string my_file_option_b = 50008;
+  optional string my_file_option_b = 50008 [
+    (my_field_option_a) = 4.5,
+    (my_field_option_b) = 5.5
+  ];
   optional string my_file_option_c = 50015;
   repeated uint32 my_repeated_file_option = 60000;
 }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -605,6 +605,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_custom_options) {
 extend google.protobuf.FileOptions {
   optional string my_file_option_b = 50008;
   optional string my_file_option_a = 50000;
+  repeated uint32 my_repeated_file_option = 60000;
 }
 extend google.protobuf.MessageOptions {
   optional int32 my_message_option_b = 50009;
@@ -638,7 +639,10 @@ extend google.protobuf.MethodOptions {
   optional MyMessage my_method_option_a = 50007;
 }
 
+option (my_repeated_file_option) = 2;
 option (my_file_option_b) = "Some other string";
+option (my_repeated_file_option) = 1;
+option (my_repeated_file_option) = 3;
 option (my_file_option_a) = "Hello world!";
 
 message MyMessage {
@@ -685,7 +689,10 @@ service MyService {
 
 import "google/protobuf/descriptor.proto";
 
+option (my_repeated_file_option) = 2;
 option (my_file_option_b) = "Some other string";
+option (my_repeated_file_option) = 1;
+option (my_repeated_file_option) = 3;
 option (my_file_option_a) = "Hello world!";
 
 message MyMessage {
@@ -716,6 +723,7 @@ enum MyEnum {
 extend google.protobuf.FileOptions {
   optional string my_file_option_b = 50008;
   optional string my_file_option_a = 50000;
+  repeated uint32 my_repeated_file_option = 60000;
 }
 extend google.protobuf.MessageOptions {
   optional int32 my_message_option_b = 50009;
@@ -768,6 +776,9 @@ import "google/protobuf/descriptor.proto";
 
 option (my_file_option_a) = "Hello world!";
 option (my_file_option_b) = "Some other string";
+option (my_repeated_file_option) = 1;
+option (my_repeated_file_option) = 2;
+option (my_repeated_file_option) = 3;
 
 message MyMessage {
   option (my_message_option_a) = 1234;
@@ -810,6 +821,7 @@ extend .google.protobuf.FileOptions {
   optional string my_file_option_a = 50000;
   optional string my_file_option_b = 50008;
   optional string my_file_option_c = 50015;
+  repeated uint32 my_repeated_file_option = 60000;
 }
 extend .google.protobuf.MessageOptions {
   optional int32 my_message_option_a = 50001;


### PR DESCRIPTION
When calling CopyTo from `FileDescriptor` to `FileDescriptorProto`, custom options are discarded.

To fix it a manual pass has been added to copy the custom options from the old `FileDescriptorProto` to the new `FileDescriptorProto`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
