### PR TITLE
Adding error handling for get nodes or instances

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -84,7 +84,13 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
             '--query="Reservations[0].Instances[*].InstanceType"'
         ]
         res = subprocess.check_output(cmd)
-        resd = json.loads(res)
+        try:
+            resd = json.loads(res)
+        except json.JSONDecodeError as e:
+            self.logger.error(
+                f"Failed to parse AWS describe-instances response: {res}")
+            raise ValueError(
+                f"Failed to parse AWS describe-instances response: {e}")
 
         self.logger.debug(
             "asserting nodes_count: expected: {}, actual: {}".format(
@@ -107,6 +113,13 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         output = subprocess.check_output(cmd)
         self.logger.debug(f'nodes: {output}')
         nodes = json.loads(output)
+        try:
+            nodes = json.loads(nodes)
+        except json.JSONDecodeError as e:
+            self.logger.error(
+                f"Failed to parse kubectl get nodes response: {nodes}")
+            raise ValueError(
+                f"Failed to parse kubectl get nodes response: {e}")
 
         config_nodes_count = self._configProfile['nodes_count']
         actual_nodes_count = len(nodes)
@@ -123,7 +136,13 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
                 self._clusterId), '--format="json(name,machineType,disks)"'
         ]
         res = subprocess.check_output(cmd)
-        resd = json.loads(res)
+        try:
+            resd = json.loads(res)
+        except json.JSONDecodeError as e:
+            self.logger.error(
+                f"Failed to parse gcloud compute instances response: {res}")
+            raise ValueError(
+                f"Failed to parse gcloud compute instances response: {e}")
 
         self.logger.debug(
             "asserting machineType: expected: {}, actual: {}".format(


### PR DESCRIPTION
Adding a better error handling for cloud commands get node or describe instances. This would improve logs debugging.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
