### PR TITLE
kafka: Add batch size histogram

### DIFF
--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -137,7 +137,7 @@ redpanda_cc_library(
         "handlers/topics/types.h",
         "handlers/topics/validators.h",
         "handlers/txn_offset_commit.h",
-        "latency_probe.h",
+        "kafka_probe.h",
         "logger.h",
         "member.h",
         "protocol_utils.h",

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -28,7 +28,7 @@
 #include "kafka/server/handlers/fetch/fetch_plan_executor.h"
 #include "kafka/server/handlers/fetch/fetch_planner.h"
 #include "kafka/server/handlers/fetch/replica_selector.h"
-#include "kafka/server/latency_probe.h"
+#include "kafka/server/kafka_probe.h"
 #include "kafka/server/read_distribution_probe.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -353,6 +353,7 @@ static partition_produce_stages produce_topic_partition(
     auto dispatch = std::make_unique<ss::promise<>>();
     auto dispatch_f = dispatch->get_future();
     auto m = octx.rctx.probe().auto_produce_measurement();
+    octx.rctx.probe().record_batch(batch_size);
     auto timeout = octx.request.data.timeout_ms;
     if (timeout < 0ms) {
         static constexpr std::chrono::milliseconds max_timeout{

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -21,16 +21,16 @@
 #include <chrono>
 
 namespace kafka {
-class latency_probe {
+class kafka_probe {
 public:
     using hist_t = log_hist_internal;
 
-    latency_probe() = default;
-    latency_probe(const latency_probe&) = delete;
-    latency_probe& operator=(const latency_probe&) = delete;
-    latency_probe(latency_probe&&) = delete;
-    latency_probe& operator=(latency_probe&&) = delete;
-    ~latency_probe() = default;
+    kafka_probe() = default;
+    kafka_probe(const kafka_probe&) = delete;
+    kafka_probe& operator=(const kafka_probe&) = delete;
+    kafka_probe(kafka_probe&&) = delete;
+    kafka_probe& operator=(kafka_probe&&) = delete;
+    ~kafka_probe() = default;
 
     void setup_metrics() {
         namespace sm = ss::metrics;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -118,7 +118,7 @@ public:
 
     protocol::decoder& reader() { return _reader; }
 
-    latency_probe& probe() { return _conn->server().latency_probe(); }
+    kafka_probe& probe() { return _conn->server().kafka_probe(); }
     sasl_probe& sasl_probe() { return _conn->server().sasl_probe(); }
 
     // used to reach for server_probe::produce_bad_timestamp

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -182,7 +182,7 @@ server::server(
         cfg->local().max_service_memory_per_core
         * config::shard_local_cfg().kafka_memory_share_for_fetch()),
       "kafka/server-mem-fetch")
-  , _probe(std::make_unique<class latency_probe>())
+  , _probe(std::make_unique<class kafka_probe>())
   , _sasl_probe(std::make_unique<class sasl_probe>())
   , _read_dist_probe(std::make_unique<read_distribution_probe>())
   , _thread_worker(tw)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -22,7 +22,7 @@
 #include "kafka/server/fwd.h"
 #include "kafka/server/handlers/fetch/replica_selector.h"
 #include "kafka/server/handlers/handler_probe.h"
-#include "kafka/server/latency_probe.h"
+#include "kafka/server/kafka_probe.h"
 #include "kafka/server/queue_depth_monitor.h"
 #include "kafka/server/queue_depth_monitor_config.h"
 #include "kafka/server/read_distribution_probe.h"
@@ -182,7 +182,7 @@ public:
         return _gssapi_principal_mapper;
     }
 
-    latency_probe& latency_probe() { return *_probe; }
+    kafka_probe& kafka_probe() { return *_probe; }
 
     sasl_probe& sasl_probe() { return *_sasl_probe; }
 
@@ -262,7 +262,7 @@ private:
 
     handler_probe_manager _handler_probes;
     metrics::internal_metric_groups _metrics;
-    std::unique_ptr<class latency_probe> _probe;
+    std::unique_ptr<class kafka_probe> _probe;
     std::unique_ptr<class sasl_probe> _sasl_probe;
     std::unique_ptr<read_distribution_probe> _read_dist_probe;
     ssx::singleton_thread_worker& _thread_worker;

--- a/src/v/utils/log_hist.cc
+++ b/src/v/utils/log_hist.cc
@@ -101,6 +101,16 @@ log_hist<number_of_buckets, first_bucket_upper_bound>::
     return seastar_histogram_logform<client_quota_config>();
 }
 
+template<int number_of_buckets, uint64_t first_bucket_upper_bound>
+seastar::metrics::histogram
+log_hist<number_of_buckets, first_bucket_upper_bound>::
+  batch_size_histogram_logform() const {
+    using batch_size_config
+      = logform_config<1l, first_bucket_upper_bound, number_of_buckets>;
+
+    return seastar_histogram_logform<batch_size_config>();
+}
+
 template<
   class duration_t,
   int number_of_buckets,
@@ -145,6 +155,8 @@ latency_log_hist<duration_t, number_of_buckets, first_bucket_upper_bound>::
     return _histo.client_quota_histogram_logform();
 }
 
+// Explicit instantiation for batch_size_hist
+template class log_hist<16, 32>;
 // Explicit instantiation for log_hist_public
 template class latency_log_hist<std::chrono::microseconds, 18, 256ul>;
 // Explicit instantiation for log_hist_internal

--- a/src/v/utils/log_hist.h
+++ b/src/v/utils/log_hist.h
@@ -125,10 +125,21 @@ public:
      */
     seastar::metrics::histogram client_quota_histogram_logform() const;
 
+    /*
+     * Histogram type used for the Kafka client quota distribution. Going from
+     * 128 bytes to 1MiB.
+     */
+    seastar::metrics::histogram batch_size_histogram_logform() const;
+
 private:
     std::array<uint64_t, number_of_buckets> _counts;
     uint64_t _sample_sum{0};
 };
+
+/*
+ * Histogram for kafka batch sizes - see kafka_probe
+ */
+using batch_size_hist = log_hist<16, 32>;
 
 template<
   class duration_t,


### PR DESCRIPTION
Adds a batch size histogram. There is no per topic or partition info as
that would cause a metric explosion due to the histogram.

The histogram goes from 128 bytes to 1MiB.

Ref CORE-8570

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
