### PR TITLE
bazel: add bench tag to benchmarks

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -384,6 +384,8 @@ def redpanda_cc_bench(
     if duration != None:
         binary_args.append("--duration={}".format(duration))
 
+    tags = tags + ["bench"]
+
     native.cc_binary(
         name = name,
         srcs = srcs,


### PR DESCRIPTION
In case someone wants to filter them out.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
