### PR TITLE
[CORE-9000] Tiered-Storage pause/resume

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -488,6 +488,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       tristate<double>{},
+      std::nullopt,
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1314,6 +1314,10 @@ model::offset archival_metadata_stm::max_collectible_offset() {
     // archival is enabled is authoritative.
     bool collect_all = !_raft->log_config().is_archival_enabled();
     bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
+    bool uploads_paused
+      = config::shard_local_cfg().cloud_storage_enable_segment_uploads()
+        == false;
+    bool gaps_allowed = _raft->log_config().is_remote_allow_gaps_enabled();
 
     // In earlier versions, we should assume every topic is archival enabled
     // if the global cloud_storage_enable_remote_write is true.
@@ -1323,7 +1327,7 @@ model::offset archival_metadata_stm::max_collectible_offset() {
         collect_all = false;
     }
 
-    if (collect_all || is_read_replica) {
+    if (collect_all || is_read_replica || (uploads_paused && gaps_allowed)) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
         // In read-replicas the state machine exists and stores segments

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -766,38 +766,47 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
           fence,
           _parent.archival_meta_stm()->get_insync_offset());
 
-        auto [non_compacted_upload_result, compacted_upload_result]
-          = co_await upload_next_candidates(archival_stm_fence{
-            .read_write_fence = fence,
-            // Only use the rw-fence if the feature is enabled which requires
-            // major version upgrade.
-            .emit_rw_fence_cmd = emit_read_write_fence(_feature_table),
-          });
-        if (non_compacted_upload_result.num_failed != 0) {
-            // The logic in class `remote` already does retries: if we get here,
-            // it means the upload failed after several retries, justifying
-            // a warning to the operator: something non-transient may be wrong,
-            // although we do also see this in practice on AWS S3 occasionally
-            // during normal operation.
-            vlog(
-              _rtclog.warn,
-              "Failed to upload {} segments out of {}",
-              non_compacted_upload_result.num_failed,
-              non_compacted_upload_result.num_succeeded
-                + non_compacted_upload_result.num_failed
-                + non_compacted_upload_result.num_cancelled);
-        } else if (non_compacted_upload_result.num_succeeded != 0) {
-            vlog(
-              _rtclog.debug,
-              "Successfully uploaded {} segments",
-              non_compacted_upload_result.num_succeeded);
+        bool uploads_paused
+          = !config::shard_local_cfg().cloud_storage_enable_segment_uploads();
+        std::optional<batch_result> result;
+        auto track_paused = _probe->register_archiver_on_hold(uploads_paused);
+        if (!uploads_paused) {
+            result = co_await upload_next_candidates(archival_stm_fence{
+              .read_write_fence = fence,
+              // Only use the rw-fence if the feature is enabled which requires
+              // major version upgrade.
+              .emit_rw_fence_cmd = emit_read_write_fence(_feature_table),
+            });
         }
+        if (result.has_value()) {
+            auto [compacted_upload_result, non_compacted_upload_result]
+              = result.value();
+            if (non_compacted_upload_result.num_failed != 0) {
+                // The logic in class `remote` already does retries: if we get
+                // here, it means the upload failed after several retries,
+                // justifying a warning to the operator: something non-transient
+                // may be wrong, although we do also see this in practice on AWS
+                // S3 occasionally during normal operation.
+                vlog(
+                  _rtclog.warn,
+                  "Failed to upload {} segments out of {}",
+                  non_compacted_upload_result.num_failed,
+                  non_compacted_upload_result.num_succeeded
+                    + non_compacted_upload_result.num_failed
+                    + non_compacted_upload_result.num_cancelled);
+            } else if (non_compacted_upload_result.num_succeeded != 0) {
+                vlog(
+                  _rtclog.debug,
+                  "Successfully uploaded {} segments",
+                  non_compacted_upload_result.num_succeeded);
+            }
 
-        if (non_compacted_upload_result.num_cancelled != 0) {
-            vlog(
-              _rtclog.debug,
-              "Cancelled upload of {} segments",
-              non_compacted_upload_result.num_cancelled);
+            if (non_compacted_upload_result.num_cancelled != 0) {
+                vlog(
+                  _rtclog.debug,
+                  "Cancelled upload of {} segments",
+                  non_compacted_upload_result.num_cancelled);
+            }
         }
 
         if (ss::lowres_clock::now() >= _next_housekeeping) {
@@ -832,7 +841,9 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
           "upload_until_term_change: released units (current {})",
           _uploads_active.current());
 
-        if (non_compacted_upload_result.num_succeeded == 0) {
+        if (
+          !result.has_value()
+          || result.value().non_compacted_upload_result.num_succeeded == 0) {
             // The backoff algorithm here is used to prevent high CPU
             // utilization when redpanda is not receiving any data and there
             // is nothing to update. Also, we want to limit amount of
@@ -3333,6 +3344,11 @@ ss::future<bool> ntp_archiver::do_upload_local(
     if (!may_begin_uploads()) {
         co_return false;
     }
+
+    if (!config::shard_local_cfg().cloud_storage_enable_segment_uploads()) {
+        co_return false;
+    }
+
     auto [upload, locks] = std::move(upload_locks);
 
     for (const auto& s : upload.sources) {

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1959,7 +1959,22 @@ ntp_archiver::wait_uploads_complete(
     result.checks_disabled
       = config::shard_local_cfg()
           .cloud_storage_disable_upload_consistency_checks.value();
-    if (!result.checks_disabled) {
+    auto skip_metadata_check = [this] {
+        // Special handling of the situation when the gap was created
+        // while the archiver was paused with 'redpanda.remote.allowgaps'
+        // set to 'true'.
+        // If the property is set to true and the local start offset
+        // doesn't match the last uploaded offset we should skip the
+        // check.
+        auto manifest_last = manifest().get_last_offset();
+        auto local_first = _parent.raft_start_offset();
+        model::offset manifest_next = model::next_offset(manifest_last);
+        bool gaps_allowed
+          = _parent.log()->config().is_remote_allow_gaps_enabled();
+        return gaps_allowed && !manifest().empty()
+               && manifest_next < local_first;
+    }();
+    if (!skip_metadata_check && !result.checks_disabled) {
         // With read-write-fence it's guaranteed that the concurrent
         // updates are not a problem. But we still need this check
         // to prevent certain bugs from corrupting the cloud storage

--- a/src/v/cluster/archival/probe.cc
+++ b/src/v/cluster/archival/probe.cc
@@ -150,6 +150,12 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
          sm::description(
            "Total size in bytes of the user-visible log for the topic"),
          labels)
+         .aggregate(aggregate_labels),
+       sm::make_gauge(
+         "paused_archivers",
+         [this] { return _num_paused_archivers; },
+         sm::description("Number of paused archivers"),
+         labels)
          .aggregate(aggregate_labels)});
 }
 

--- a/src/v/cluster/archival/probe.h
+++ b/src/v/cluster/archival/probe.h
@@ -16,6 +16,8 @@
 #include "model/fundamental.h"
 
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <cstdint>
 
@@ -67,6 +69,20 @@ public:
         _compacted_replaced_bytes = bytes;
     }
 
+    /// Increment metric and return an object which decrements it
+    /// upon destruction.
+    std::optional<ss::deferred_action<ss::noncopyable_function<void()>>>
+    register_archiver_on_hold(bool paused) {
+        if (!paused) {
+            return std::nullopt;
+        }
+        _num_paused_archivers++;
+        ss::noncopyable_function<void()> lmd = [this] {
+            _num_paused_archivers--;
+        };
+        return ss::defer(std::move(lmd));
+    }
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;
@@ -80,6 +96,9 @@ private:
     int64_t _segments_deleted = 0;
     /// cloud bytes "removed" due to compaction operation
     size_t _compacted_replaced_bytes = 0;
+
+    /// total number of paused ntp_archiver instances
+    size_t _num_paused_archivers = 0;
 
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -60,6 +60,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .cloud_topic_enabled = properties.cloud_topic_enabled,
             .tombstone_retention_ms = properties.delete_retention_ms,
             .min_cleanable_dirty_ratio = properties.min_cleanable_dirty_ratio,
+            .remote_allow_gaps = properties.remote_topic_allow_gaps,
           });
     }
     return {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -183,6 +183,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.tombstone_retention_ms = delete_retention_ms;
     ret.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio;
+    ret.remote_allow_gaps = remote_topic_allow_gaps;
     return ret;
 }
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -23,6 +23,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "read_replica: {}, read_replica_bucket: {}, "
       "remote_topic_namespace_override: {}, "
       "remote_topic_properties: {}, "
+      "remote_topic_allow_gaps: {}, "
       "batch_max_bytes: {}, retention_local_target_bytes: {}, "
       "retention_local_target_ms: {}, remote_delete: {}, segment_ms: {}, "
       "record_key_schema_id_validation: {}, "
@@ -60,6 +61,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.read_replica_bucket,
       properties.remote_topic_namespace_override,
       properties.remote_topic_properties,
+      properties.remote_topic_allow_gaps,
       properties.batch_max_bytes,
       properties.retention_local_target_bytes,
       properties.retention_local_target_ms,
@@ -136,7 +138,8 @@ bool topic_properties::has_overrides() const {
         || iceberg_delete.has_value() || iceberg_partition_spec.has_value()
         || iceberg_invalid_record_action.has_value()
         || iceberg_target_lag_ms.has_value()
-        || min_cleanable_dirty_ratio.is_engaged();
+        || min_cleanable_dirty_ratio.is_engaged()
+        || remote_topic_allow_gaps.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -277,6 +280,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       tristate<double>{std::nullopt},
+      std::nullopt,
     };
 }
 

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -81,7 +81,8 @@ struct topic_properties
       std::optional<model::iceberg_invalid_record_action>
         iceberg_invalid_record_action,
       std::optional<std::chrono::milliseconds> iceberg_target_lag_ms,
-      tristate<double> min_cleanable_dirty_ratio)
+      tristate<double> min_cleanable_dirty_ratio,
+      std::optional<bool> remote_topic_allow_gaps)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -95,6 +96,7 @@ struct topic_properties
       , read_replica_bucket(std::move(read_replica_bucket))
       , remote_topic_namespace_override(remote_topic_namespace_override)
       , remote_topic_properties(remote_topic_properties)
+      , remote_topic_allow_gaps(remote_topic_allow_gaps)
       , batch_max_bytes(batch_max_bytes)
       , retention_local_target_bytes(retention_local_target_bytes)
       , retention_local_target_ms(retention_local_target_ms)
@@ -148,6 +150,10 @@ struct topic_properties
     // Topic properties for a topic that already has remote data (e.g.
     // recovery topics).
     std::optional<remote_topic_properties> remote_topic_properties;
+
+    // The override that indicates that when tiered-storage is paused the local
+    // retention is allowed to work and potentially create a gap in the data.
+    std::optional<bool> remote_topic_allow_gaps;
 
     std::optional<uint32_t> batch_max_bytes;
     tristate<size_t> retention_local_target_bytes{std::nullopt};
@@ -264,7 +270,8 @@ struct topic_properties
           iceberg_partition_spec,
           iceberg_invalid_record_action,
           iceberg_target_lag_ms,
-          min_cleanable_dirty_ratio);
+          min_cleanable_dirty_ratio,
+          remote_topic_allow_gaps);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1113,7 +1113,8 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(
       updated_properties.min_cleanable_dirty_ratio,
       overrides.min_cleanable_dirty_ratio);
-
+    incremental_update(
+      updated_properties.remote_topic_allow_gaps, overrides.remote_allow_gaps);
     return updated_properties;
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -407,7 +407,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "remote_read: {}, remote_write: {}, iceberg_delete: {}, "
       "iceberg_partition_spec: {}, "
       "iceberg_invalid_record_action: {}, "
-      "iceberg_target_lag_ms: {}",
+      "iceberg_target_lag_ms: {}, "
+      "remote_allow_gaps: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -441,7 +442,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.iceberg_delete,
       i.iceberg_partition_spec,
       i.iceberg_invalid_record_action,
-      i.iceberg_target_lag_ms);
+      i.iceberg_target_lag_ms,
+      i.remote_allow_gaps);
     return o;
 }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -645,6 +645,7 @@ struct incremental_topic_updates
     property_update<std::optional<model::iceberg_invalid_record_action>>
       iceberg_invalid_record_action;
     property_update<tristate<double>> min_cleanable_dirty_ratio;
+    property_update<std::optional<bool>> remote_allow_gaps;
 
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_target_lag_ms;
@@ -691,7 +692,8 @@ struct incremental_topic_updates
           iceberg_partition_spec,
           iceberg_invalid_record_action,
           iceberg_target_lag_ms,
-          min_cleanable_dirty_ratio);
+          min_cleanable_dirty_ratio,
+          remote_allow_gaps);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -665,6 +665,7 @@ struct instance_generator<cluster::topic_properties> {
           }),
           tests::random_optional([] { return tests::random_duration_ms(); }),
           tristate<double>{disable_tristate},
+          std::nullopt,
         };
     }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2453,6 +2453,17 @@ configuration::configuration()
       "and shouldn't be set in production.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_enable_segment_uploads(
+      *this,
+      "cloud_storage_enable_segment_uploads",
+      "This property gates log segment upload in the Tiered-Storage subsystem. "
+      "It can be used to temporarily pause all segment uploads in the Redpanda "
+      "cluster. When the uploads are paused the "
+      "'cloud_storage_enable_remote_allow_gaps' cluster configuration or "
+      "'redpanda.remote.allowgaps' topic property determines how the local "
+      "retention should behave.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , cloud_storage_enable_remote_allow_gaps(
       *this,
       "cloud_storage_enable_remote_allow_gaps",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2453,6 +2453,20 @@ configuration::configuration()
       "and shouldn't be set in production.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_enable_remote_allow_gaps(
+      *this,
+      "cloud_storage_enable_remote_allow_gaps",
+      "This property affects the behavior of the Tiered-Storage during pause. "
+      "If 'false' (default value) Redpanda will evict from the local storage "
+      "only data which was already uploaded to the cloud storage. Eventually, "
+      "this will lead to a situation when the local volume is filled with data "
+      "which can't be evicted. When this will happen Redpanda will throttle "
+      "producers. To avoid this the property can be set to 'true'. In this "
+      "case Redpanda will allow segments that wasn't uploaded to the cloud "
+      "storage to be evicted from the local storage. The local storage "
+      "eviction may create a gap in offsets in this case.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2456,26 +2456,25 @@ configuration::configuration()
   , cloud_storage_enable_segment_uploads(
       *this,
       "cloud_storage_enable_segment_uploads",
-      "This property gates log segment upload in the Tiered-Storage subsystem. "
-      "It can be used to temporarily pause all segment uploads in the Redpanda "
-      "cluster. When the uploads are paused the "
-      "'cloud_storage_enable_remote_allow_gaps' cluster configuration or "
-      "'redpanda.remote.allowgaps' topic property determines how the local "
-      "retention should behave.",
+      "Controls the upload of log segments to Tiered Storage. "
+      "If set to false, this property temporarily pauses all log segment "
+      "uploads from the Redpanda cluster. When the uploads are paused, the "
+      "'cloud_storage_enable_remote_allow_gaps' cluster configuration and "
+      "'redpanda.remote.allowgaps' topic properties control local retention "
+      "behavior.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
   , cloud_storage_enable_remote_allow_gaps(
       *this,
       "cloud_storage_enable_remote_allow_gaps",
-      "This property affects the behavior of the Tiered-Storage during pause. "
-      "If 'false' (default value) Redpanda will evict from the local storage "
-      "only data which was already uploaded to the cloud storage. Eventually, "
-      "this will lead to a situation when the local volume is filled with data "
-      "which can't be evicted. When this will happen Redpanda will throttle "
-      "producers. To avoid this the property can be set to 'true'. In this "
-      "case Redpanda will allow segments that wasn't uploaded to the cloud "
-      "storage to be evicted from the local storage. The local storage "
-      "eviction may create a gap in offsets in this case.",
+      "Controls the eviction of locally-stored log segments when Tiered "
+      "Storage uploads are paused. "
+      "Set to `false` (default) to only evict data that has already been "
+      "uploaded to cloud storage. If the retained data fills the local volume, "
+      "Redpanda will throttle producers. "
+      "Set to `true` to allow the eviction of locally-stored log segments, "
+      "which "
+      "may create gaps in offsets. ",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , cloud_storage_azure_storage_account(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2474,7 +2474,7 @@ configuration::configuration()
       "Redpanda will throttle producers. "
       "Set to `true` to allow the eviction of locally-stored log segments, "
       "which "
-      "may create gaps in offsets. ",
+      "may create gaps in offsets.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , cloud_storage_azure_storage_account(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -475,6 +475,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
     property<bool> cloud_storage_disable_remote_labels_for_tests;
 
+    // Safe pause/resume functionality
+    property<bool> cloud_storage_enable_segment_uploads;
     property<bool> cloud_storage_enable_remote_allow_gaps;
 
     // Azure Blob Storage

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -475,6 +475,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
     property<bool> cloud_storage_disable_remote_labels_for_tests;
 
+    property<bool> cloud_storage_enable_remote_allow_gaps;
+
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;
     property<std::optional<ss::sstring>> cloud_storage_azure_container;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -83,7 +83,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 36,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 37,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/alter_configs_request.h"
 #include "kafka/protocol/schemata/alter_configs_response.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/handlers/configs/config_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
@@ -399,6 +400,7 @@ create_topic_properties_update(
                   });
                 continue;
             }
+
             if (cfg.name == topic_property_min_cleanable_dirty_ratio) {
                 parse_and_set_tristate(
                   update.properties.min_cleanable_dirty_ratio,
@@ -407,6 +409,15 @@ create_topic_properties_update(
                   min_cleanable_dirty_ratio_validator{});
                 continue;
             }
+
+            if (cfg.name == topic_property_remote_allow_gaps) {
+                parse_and_set_optional_bool_alpha(
+                  update.properties.remote_allow_gaps,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
+
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<
               alter_configs_resource_response>(

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1052,7 +1052,6 @@ config_response_container_t make_topic_configs(
     add_topic_config_if_requested(
       config_keys,
       result,
-
       config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps.name(),
       config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps(),
       topic_property_remote_allow_gaps,

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1049,6 +1049,21 @@ config_response_container_t make_topic_configs(
         include_documentation,
         config::shard_local_cfg().min_cleanable_dirty_ratio.desc()));
 
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+
+      config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps.name(),
+      config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps(),
+      topic_property_remote_allow_gaps,
+      topic_properties.remote_topic_allow_gaps,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg()
+          .cloud_storage_enable_remote_allow_gaps.desc()),
+      &describe_as_string<bool>);
+
     return result;
 }
 

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -80,7 +80,8 @@ bool is_supported(std::string_view name) {
        topic_property_iceberg_partition_spec,
        topic_property_iceberg_invalid_record_action,
        topic_property_iceberg_target_lag_ms,
-       topic_property_min_cleanable_dirty_ratio});
+       topic_property_min_cleanable_dirty_ratio,
+       topic_property_remote_allow_gaps});
 
     if (std::any_of(
           supported_configs.begin(),

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -387,6 +387,7 @@ create_topic_properties_update(
                   update.properties.iceberg_invalid_record_action,
                   cfg.value,
                   op);
+                continue;
             }
             if (cfg.name == topic_property_remote_allow_gaps) {
                 parse_and_set_optional_bool_alpha(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -387,6 +387,10 @@ create_topic_properties_update(
                   update.properties.iceberg_invalid_record_action,
                   cfg.value,
                   op);
+            }
+            if (cfg.name == topic_property_remote_allow_gaps) {
+                parse_and_set_optional_bool_alpha(
+                  update.properties.remote_allow_gaps, cfg.value, op);
                 continue;
             }
             if (cfg.name == topic_property_iceberg_target_lag_ms) {
@@ -397,6 +401,7 @@ create_topic_properties_update(
                   iceberg_target_lag_ms_validator{});
                 continue;
             }
+
             if (cfg.name == topic_property_min_cleanable_dirty_ratio) {
                 parse_and_set_tristate(
                   update.properties.min_cleanable_dirty_ratio,
@@ -485,7 +490,8 @@ static ss::future<chunked_vector<resp_resource_t>> alter_broker_configuration(
             //   compression.type=producer sensitive=false
             //   synonyms={DEFAULT_CONFIG:log_compression_type=producer}
             // (configuration.cc doesn't know `compression.type` but known
-            // `log_compression_type`) but for redpanda's properties it returns
+            // `log_compression_type`) but for redpanda's properties it
+            // returns
             //   redpanda.remote.read=false sensitive=false
             //   synonyms={DEFAULT_CONFIG:redpanda.remote.read=false}
             // which looks wrong because configuration.cc doesn't know

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -237,6 +237,9 @@ to_cluster_type(const creatable_topic& t) {
       = get_bool_value(config_entries, topic_property_remote_delete)
           .value_or(storage::ntp_config::default_remote_delete);
 
+    cfg.properties.remote_topic_allow_gaps = get_bool_value(
+      config_entries, topic_property_remote_allow_gaps);
+
     cfg.properties.segment_ms = get_tristate_value<std::chrono::milliseconds>(
       config_entries, topic_property_segment_ms);
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -53,6 +53,8 @@ inline constexpr std::string_view topic_property_remote_read
   = "redpanda.remote.read";
 inline constexpr std::string_view topic_property_read_replica
   = "redpanda.remote.readreplica";
+inline constexpr std::string_view topic_property_remote_allow_gaps
+  = "redpanda.remote.allowgaps";
 inline constexpr std::string_view topic_property_replication_factor
   = "replication.factor";
 inline constexpr std::string_view topic_property_remote_delete

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -750,6 +750,7 @@ FIXTURE_TEST(
       "redpanda.leaders.preference",
       "delete.retention.ms",
       "min.cleanable.dirty.ratio",
+      "redpanda.remote.allowgaps",
     };
 
     // All properties_request

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -87,6 +87,8 @@ public:
         tristate<std::chrono::milliseconds> tombstone_retention_ms;
 
         tristate<double> min_cleanable_dirty_ratio;
+        // Controls behavior during pause
+        std::optional<bool> remote_allow_gaps;
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
@@ -231,6 +233,15 @@ public:
     bool is_read_replica_mode_enabled() const {
         return _overrides != nullptr && _overrides->read_replica
                && _overrides->read_replica.value();
+    }
+
+    bool is_remote_allow_gaps_enabled() const {
+        auto cluster_default
+          = config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps();
+        if (_overrides == nullptr) {
+            return cluster_default;
+        }
+        return _overrides->remote_allow_gaps.value_or(cluster_default);
     }
 
     /**

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -114,7 +114,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
-      "flush_bytes: {} iceberg_mode: {} }}",
+      "flush_bytes: {} iceberg_mode: {}, remote_allow_gaps: {} }}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -130,7 +130,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.write_caching,
       v.flush_ms,
       v.flush_bytes,
-      v.iceberg_mode);
+      v.iceberg_mode,
+      v.remote_allow_gaps);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(o, ", cloud_topic_enabled: {}", v.cloud_topic_enabled);

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -328,15 +328,13 @@ class DescribeTopicsTest(RedpandaTest):
                 config_type="BOOLEAN",
                 value="false",
                 doc_string=
-                "This property affects the behavior of the Tiered-Storage during pause. "
-                "If 'false' (default value) Redpanda will evict from the local storage "
-                "only data which was already uploaded to the cloud storage. Eventually, "
-                "this will lead to a situation when the local volume is filled with data "
-                "which can't be evicted. When this will happen Redpanda will throttle "
-                "producers. To avoid this the property can be set to 'true'. In this "
-                "case Redpanda will allow segments that wasn't uploaded to the cloud "
-                "storage to be evicted from the local storage. The local storage "
-                "eviction may create a gap in offsets in this case."),
+                "controls the eviction of locally-stored log segments when "
+                "tiered storage uploads are paused. set to `false` (default) to "
+                "only evict data that has already been uploaded to cloud storage. "
+                "if the retained data fills the local volume, redpanda will "
+                "throttle producers. set to `true` to allow the eviction of "
+                "locally-stored log segments, which may create gaps in "
+                "offsets."),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -323,6 +323,20 @@ class DescribeTopicsTest(RedpandaTest):
                 "before a partition's log is eligible for compaction in a compact topic. "
                 "The topic property `min.cleanable.dirty.ratio` overrides the value of "
                 "`min_cleanable_dirty_ratio` at the topic level."),
+            "redpanda.remote.allowgaps":
+            ConfigProperty(
+                config_type="BOOLEAN",
+                value="false",
+                doc_string=
+                "This property affects the behavior of the Tiered-Storage during pause. "
+                "If 'false' (default value) Redpanda will evict from the local storage "
+                "only data which was already uploaded to the cloud storage. Eventually, "
+                "this will lead to a situation when the local volume is filled with data "
+                "which can't be evicted. When this will happen Redpanda will throttle "
+                "producers. To avoid this the property can be set to 'true'. In this "
+                "case Redpanda will allow segments that wasn't uploaded to the cloud "
+                "storage to be evicted from the local storage. The local storage "
+                "eviction may create a gap in offsets in this case."),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/tiered_storage_pause_test.py
+++ b/tests/rptest/tests/tiered_storage_pause_test.py
@@ -1,0 +1,330 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark import matrix
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import SISettings, MetricsEndpoint
+
+from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.utils.mode_checks import skip_debug_mode
+
+from collections import defaultdict
+from typing import Optional
+import time
+
+
+def gaps_allowed(cluster_level_allow_gaps: bool,
+                 topic_level_override: Optional[bool] = None):
+    """Return True if the gaps are allowed.
+    'topic_level_override' can be set to True, False, or None. The last
+    value means that the override is not set.
+    """
+    if topic_level_override is not None:
+        return topic_level_override
+    return cluster_level_allow_gaps
+
+
+class TestTieredStoragePause(PreallocNodesTest):
+    """Tiered storage can be put on 'pause' by setting
+    'cloud_storage_enable_segment_uploads' cluster config to 'True'.
+    There are two options there.
+    1. If 'cloud_storage_enable_remote_allow_gaps' is set to False (default)
+       the local retention is not allowed to remove segments which are not
+       uploaded to the cloud storage.
+    2. If 'cloud_storage_enable_remote_allow_gaps' is set to True the
+       tiered-storage is allowed to remove segments which are not uploaded
+       to the cloud storage yet.
+    3. The topic level override 'redpanda.remote.allowgaps' could be used
+       to enable or disable the no-gaps policy.
+    """
+    def __init__(self, test_context):
+        super().__init__(test_context,
+                         num_brokers=3,
+                         node_prealloc_count=1,
+                         si_settings=SISettings(
+                             test_context=test_context,
+                             cloud_storage_segment_max_upload_interval_sec=5,
+                             cloud_storage_enable_remote_read=True,
+                             cloud_storage_enable_remote_write=True,
+                             cloud_storage_housekeeping_interval_ms=500,
+                             fast_uploads=True))
+        self._msg_size = 128
+        # num messages to produce (50 MiB)
+        self._msg_count = 50 * int(1024 * 1024 / self._msg_size)
+        # amount of data to keep per partition
+        self._retention_bytes = 10 * 1024 * 1024
+
+    def get_metric(self, metric_name, endpoint):
+        res = defaultdict(int)
+        for n in self.redpanda.nodes:
+            if n in self.redpanda._started:
+                resp = self.redpanda.metrics(n, endpoint)
+                for family in resp:
+                    for sample in family.samples:
+                        res[sample.name] += sample.value
+        # should be safe due to GIL
+        if endpoint == MetricsEndpoint.PUBLIC_METRICS:
+            self.logger.info(f"Public metrics {res}")
+        else:
+            self.logger.info(f"Private metrics {res}")
+        return res.get(metric_name)
+
+    def start_producer(self):
+        self.logger.info(
+            f"starting kgo-verifier producer with {self._msg_count} messages of size {self._msg_size}, retention bytes {self._retention_bytes}"
+        )
+        self.producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self._topic,
+            self._msg_size,
+            self._msg_count,
+            # Limit tput to 1MiB per second
+            rate_limit_bps=2 * 1024 * 1024,
+            custom_node=self.preallocated_nodes)
+
+        self.producer.start(clean=False)
+
+        self.producer.wait_for_acks(
+            2 * self._retention_bytes // self._msg_size, 60, 1)
+
+    def start_producer_lite(self):
+        """Small scale producer"""
+        msg_cnt = 1024 * 1024 // self._msg_size
+        self.logger.info(
+            f"starting kgo-verifier producer with {msg_cnt} messages")
+        self.producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            self._topic,
+            self._msg_size,
+            msg_cnt,
+            custom_node=self.preallocated_nodes)
+
+        self.producer.start(clean=False)
+
+        self.producer.wait_for_acks(msg_cnt, 60, 1)
+
+    def wait_util_archivers_paused(self, expected_num_paused):
+        # Check that metric is showing that the ntp archiver is paused
+        def _archiver_paused():
+            num_paused = self.get_metric(
+                'redpanda_cloud_storage_paused_archivers',
+                MetricsEndpoint.PUBLIC_METRICS)
+            # only one partition is created
+            return num_paused == expected_num_paused
+
+        wait_until(
+            _archiver_paused,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"number of paused archivers is not {expected_num_paused}")
+
+    def get_uploaded_bytes(self):
+        uploaded_bytes = self.get_metric(
+            'vectorized_ntp_archiver_uploaded_bytes_total',
+            MetricsEndpoint.METRICS)
+        return uploaded_bytes
+
+    def expect_no_uploaded_bytes(self):
+        """Check that nothing is uploaded to the cloud storage"""
+        uploaded_bytes = self.get_uploaded_bytes()
+        assert uploaded_bytes == 0, f"{uploaded_bytes} bytes are uploaded, expected all uploads to be paused"
+
+    def expect_start_from_offset_zero(self, expected):
+        """If 'expected' set to True then the expectation is that the start offset is
+        zero. Otherwise the expectation is that start offset is greater than zero"""
+        rpk = RpkTool(self.redpanda)
+        partitions = rpk.describe_topic(self._topic)
+        for p in partitions:
+            if expected:
+                res = p.start_offset == 0
+            else:
+                res = p.start_offset > 0
+            assert res, f"local retention have unexpected value, expected to start from zero = {expected}, start offset = {p.start_offset}"
+
+    def wait_until_start_offset_advances(self):
+        """
+        Check that start offset moved forward because of the retention.
+        """
+        rpk = RpkTool(self.redpanda)
+
+        def _start_offset_updated():
+            partitions = rpk.describe_topic(self._topic)
+            return all([p.start_offset > 0 for p in partitions])
+
+        wait_until(_start_offset_updated,
+                   timeout_sec=120,
+                   backoff_sec=10,
+                   err_msg="timed out waiting for segments to be evicted")
+
+    def get_start_offset(self):
+        rpk = RpkTool(self.redpanda)
+        partitions = rpk.describe_topic(self._topic)
+        for p in partitions:
+            return p.start_offset
+
+    @cluster(num_nodes=4)
+    @skip_debug_mode
+    @matrix(allow_gaps_topic_level=[None, True, False],
+            allow_gaps_cluster_level=[True, False])
+    def test_safe_pause_resume(self, allow_gaps_cluster_level,
+                               allow_gaps_topic_level):
+        """
+        The test performs pause/resume operation. If the gaps are not allowed
+        it checks that the range is full. In this test we starts with paused
+        uploads. No segments should be uploaded to S3 so the Tiered storage
+        shouldn't be able to influence 'start_offset'. Because of that if the
+        local retention is allowed to run we will see 'start_offset' advancing
+        forward. So in case if the gaps are not allowed we just need to check
+        that the 'start_offset' is equal to zero while uploads are paused.
+
+        Otherwise it expects that the gap in the offset range is created. This
+        is checked by examining the 'start_offset' as well.
+        The test also validates the behavior of the 'paused_archivers' metric.
+        The metric is expected to be GT zero when some archivers are paused.
+        Otherwise it should be set to zero.
+        """
+        # create topic with tiered storage enabled
+        topic = TopicSpec(partition_count=1,
+                          segment_bytes=1024 * 1024,
+                          retention_bytes=self._retention_bytes)
+
+        self.client().create_topic(topic)
+        if allow_gaps_topic_level is not None:
+            value = 'true' if allow_gaps_topic_level else 'false'
+            self.client().alter_topic_config(topic.name,
+                                             "redpanda.remote.allowgaps",
+                                             value)
+        self._topic = topic.name
+
+        # Pause all segment uploads
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_segment_uploads": False})
+        self.redpanda.set_cluster_config({
+            "cloud_storage_enable_remote_allow_gaps":
+            allow_gaps_cluster_level
+        })
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_housekeeping_interval_ms": 1000})
+
+        gaps_expected = gaps_allowed(allow_gaps_cluster_level,
+                                     allow_gaps_topic_level)
+
+        self.start_producer()
+
+        # At this point retention.bytes x2 are produced to the partition.
+        # Nothing is uploaded yet so if local retention is allowed to remove
+        # data start_offset will move forward.
+        self.expect_start_from_offset_zero(not gaps_expected)
+
+        # Check that metric is showing that the ntp archiver is paused
+        self.wait_util_archivers_paused(expected_num_paused=1)
+
+        # Check that nothing is uploaded
+        self.expect_no_uploaded_bytes()
+
+        # Resume segment uploads
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_segment_uploads": True})
+        self.redpanda.wait_for_manifest_uploads()
+
+        # check that start offset moved forward because of the retention
+        self.wait_until_start_offset_advances()
+
+        # check that metric is showing that the ntp archiver is no longer paused
+        self.wait_util_archivers_paused(expected_num_paused=0)
+
+        # Wait until all messages are produced.
+        # This is not strictly necessary for the test. But uploading some more
+        # data may trigger some unexpected behavior.
+        self.producer.wait_for_acks(self._msg_count, 120, 1)
+
+    @cluster(num_nodes=4)
+    @skip_debug_mode
+    @matrix(allow_gaps_topic_level=[None],
+            allow_gaps_cluster_level=[True, False])
+    def test_resume(self, allow_gaps_cluster_level, allow_gaps_topic_level):
+        """
+        The test performs pause/resume operation. Unlike the previous test it
+        starts with some data in the cloud storage. Because of that if the gaps
+        are allowed during the pause the gap is actually created.
+        """
+        # create topic with tiered storage enabled
+        topic = TopicSpec(partition_count=1,
+                          segment_bytes=1024 * 1024,
+                          retention_bytes=self._retention_bytes)
+
+        self.client().create_topic(topic)
+        if allow_gaps_topic_level is not None:
+            value = 'true' if allow_gaps_topic_level else 'false'
+            self.client().alter_topic_config(topic.name,
+                                             "redpanda.remote.allowgaps",
+                                             value)
+        self._topic = topic.name
+
+        # Pre-populate the topic
+        self.start_producer()
+        self.producer.wait_for_acks(self._msg_count, 120, 1)
+        self.producer.free()
+
+        # save the start offset before pausing the uploads
+        start_offset = self.get_start_offset()
+
+        # Pause all segment uploads
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_segment_uploads": False})
+        self.redpanda.set_cluster_config({
+            "cloud_storage_enable_remote_allow_gaps":
+            allow_gaps_cluster_level
+        })
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_housekeeping_interval_ms": 1000})
+
+        gaps_expected = gaps_allowed(allow_gaps_cluster_level,
+                                     allow_gaps_topic_level)
+
+        # Wait until pending uploads are done
+        # We set upload interval to 5 seconds so it's guaranteed
+        # that final segment will be uploaded after short wait.
+        time.sleep(15)
+
+        # Start second round of producing.
+        # We don't need a lot of data here. Just need to check that
+        # uploads are not stalled.
+        self.start_producer_lite()
+
+        def _start_offset_advanced():
+            pause_start_offset = self.get_start_offset()
+            return pause_start_offset > start_offset
+
+        wait_until(_start_offset_advanced,
+                   timeout_sec=120,
+                   backoff_sec=10,
+                   err_msg="timed out waiting for segments to be evicted")
+
+        # Check that metric is showing that the ntp archiver is paused
+        self.wait_util_archivers_paused(expected_num_paused=1)
+
+        # Wait for local storage housekeeping to remove some local segments.
+        # The housekeeping interval is set to 1s.
+        time.sleep(15)
+
+        # Resume segment uploads.
+        # If the gaps are allowed we expect to see one.
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_segment_uploads": True})
+        self.redpanda.wait_for_manifest_uploads()
+
+        # check that metric is showing that the ntp archiver is no longer paused
+        self.wait_util_archivers_paused(expected_num_paused=0)

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -156,6 +156,11 @@ def read_topic_properties_serde(rdr: Reader, version):
             rdr.read_tristate(Reader.read_double),
         }
 
+    if version >= 11:
+        topic_properties |= {
+            'remote_topic_allow_gaps': rdr.read_optional(Reader.read_bool),
+        }
+
     return topic_properties
 
 


### PR DESCRIPTION
This PR adds pause/resume functionality to the Tiered Storage subsystem. 
Previously, the `redpanda.remote.write` was used to disable TS temporarily. The problem with this is that when the TS is disabled this way the `archival_metadata_stm` doesn't prevent segments which are not uploaded yet from being evicted from the local storage. As result the gap in the offset range might be created. If this is the case the `ntp_archiver` will get stuck when `redpanda.remote.write` will be reset back to `True`. This is by design because we don't want it to continue working without user intervention.

This PR doesn't change this behaviour. Instead, it adds an alternative pause/resume mechanism. The `cloud_storage_enable_segment_uploads` cluster config is added. By default it's set to `True`. When it's set to `False` all `ntp_archiver` instances in the cluster will pause uploading process. The gaps will not be created. Instead the disks will fill up and eventually the produce requests will get throttled.

It is possible to have the new pause with the old behaviour that allow gaps to be created. This behaviour can be enabled by setting `cloud_storage_enable_remote_allow_gaps` topic property. Alternatively, the `redpanda.remote.allowgaps` topic property could be used on the per-topic basis. When this mode is used Redpanda will not run out of disk space but the offset gaps might be created. If the gaps are created the resume will be seamless. No user intervention will be required as long as `allow-gaps` mode is enabled. If the `allow-gaps` mode is disabled before resuming and the gaps are created the resume will not be seamless and the user intervention will be required.

The user might want to disabled `allow-gaps` mode when the archivers are resumed. But first they need to make sure that the uploads resumed. In order to do so there is a new metric `redpanda_cloud_storage_paused_archivers`. When the uploads are paused using new mechanism this metric will be greater than zero. After uploads resumed it will eventually go back to zero. There might be some delay between the resume and metric update because it take some time for archivers to resume uploads.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Add cluster config `cloud_storage_enable_segment_uploads` that can be used to pause the Tiered Storage safely.
* New topic property `redpanda.remote.allow_gaps` is added. If it's set to `True` Redpanda is allowed to create gaps in the offset range when TS is paused.
* New cluster config `cloud_storage_enable_remote_allow_gaps` is added. If it's set to `True` Redpanda is allowed to create gaps in the offset range when TS is paused.
* New metric `redpanda_cloud_storage_paused_archivers` which tracks number of partitions with paused segment uploads is added.