### PR TITLE
CORE-8619 crash_tracker: print recorded crash reports

### DIFF
--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -17,3 +17,5 @@ v_cc_library(
     v::hashing
     v::random
 )
+
+add_subdirectory(tests)

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     types.cc
   DEPS
     Seastar::seastar
+    v::config
     v::base
     v::bytes
     v::model

--- a/src/v/crash_tracker/limiter.cc
+++ b/src/v/crash_tracker/limiter.cc
@@ -116,16 +116,19 @@ ss::future<> limiter::check_for_crash_loop(ss::abort_source& as) const {
                              || tracking_reset;
 
         if (!ok_to_proceed) {
+            auto crashes = co_await _recorder.get_recorded_crashes();
             vlog(
               ctlog.error,
               "Crash loop detected. Too many consecutive crashes {}, exceeded "
               "{} configured value {}. To recover Redpanda from this state, "
               "manually remove file at path {}. Crash loop automatically "
-              "resets 1h after last crash or with node configuration changes.",
+              "resets 1h after last crash or with node configuration changes. "
+              "{}",
               crash_md.crash_count,
               config::node().crash_loop_limit.name(),
               limit.value(),
-              file_path);
+              file_path,
+              impl::describe_crashes(crashes));
 
             const auto crash_loop_sleep_val
               = config::node().crash_loop_sleep_sec.value();

--- a/src/v/crash_tracker/limiter.h
+++ b/src/v/crash_tracker/limiter.h
@@ -41,4 +41,9 @@ private:
     const recorder& _recorder [[maybe_unused]];
 };
 
+namespace impl {
+std::string
+describe_crashes(const std::vector<recorder::recorded_crash>& crashes);
+}
+
 } // namespace crash_tracker

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -80,14 +80,14 @@ namespace {
 void record_backtrace(crash_description& cd) {
     size_t pos = 0;
     ss::backtrace([&cd, &pos](ss::frame f) {
-        if (pos >= cd.stacktrace.size()) {
+        if (pos >= cd.stacktrace.capacity()) {
             return; // Prevent buffer overflow
         }
 
         const bool first = pos == 0;
         auto result = fmt::format_to_n(
           cd.stacktrace.begin() + pos,
-          cd.stacktrace.size() - pos,
+          cd.stacktrace.capacity() - pos,
           "{}{:#x}",
           first ? "" : " ",
           f.addr);
@@ -126,7 +126,7 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
     auto& format_buf = cd.crash_message;
     fmt::format_to_n(
       format_buf.begin(),
-      format_buf.size(),
+      format_buf.capacity(),
       "Failure during startup: {}",
       eptr);
 

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -16,6 +16,7 @@
 #include "crash_tracker/types.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
+#include "utils/file_io.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
@@ -131,6 +132,44 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
       eptr);
 
     _writer.write();
+}
+
+ss::future<std::vector<recorder::recorded_crash>>
+recorder::get_recorded_crashes() const {
+    auto result = std::vector<recorded_crash>{};
+    auto crash_report_dir = config::node().crash_report_dir_path();
+    if (!co_await ss::file_exists(crash_report_dir.string())) {
+        co_return result;
+    }
+
+    for (const auto& entry :
+         std::filesystem::directory_iterator(crash_report_dir)) {
+        if (!entry.path().string().ends_with(crash_report_suffix)) {
+            // Filter only for crash files
+            continue;
+        }
+
+        auto buf = co_await read_fully(entry.path());
+        try {
+            auto crash_desc = serde::from_iobuf<crash_description>(
+              std::move(buf));
+            result.emplace_back(std::move(crash_desc));
+        } catch (const serde::serde_exception&) {
+            vlog(
+              ctlog.warn,
+              "Ignoring malformed crash report file {}",
+              entry.path());
+        }
+    }
+
+    std::sort(
+      result.begin(),
+      result.end(),
+      [](const recorded_crash& a, const recorded_crash& b) {
+          return a.crash.crash_time < b.crash.crash_time;
+      });
+
+    co_return result;
 }
 
 ss::future<> recorder::stop() { co_await _writer.release(); }

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -37,6 +37,7 @@ public:
 
     void record_crash_exception(std::exception_ptr eptr);
 
+    /// Returns the list of recorded crashes in increasing crash_time order
     ss::future<std::vector<recorded_crash>> get_recorded_crashes() const;
 
 private:

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -1,0 +1,16 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "limiter_test",
+    timeout = "short",
+    srcs = [
+        "limiter_test.cc",
+    ],
+    deps = [
+        "//src/v/crash_tracker",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME limiter_test
+  SOURCES
+    limiter_test.cc
+  LIBRARIES v::gtest_main v::crash_tracker Seastar::seastar
+  ARGS "-- -c 1"
+)

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "crash_tracker/limiter.h"
+#include "crash_tracker/recorder.h"
+#include "crash_tracker/types.h"
+#include "model/timestamp.h"
+
+#include <seastar/util/bool_class.hh>
+
+#include <gtest/gtest.h>
+
+namespace crash_tracker {
+
+struct LimiterTest : public testing::Test {};
+
+TEST_F(LimiterTest, TestDescribeCrashes) {
+    auto crashes = std::vector<recorder::recorded_crash>{};
+    EXPECT_EQ(
+      crash_tracker::impl::describe_crashes(crashes),
+      "(No crash files have been recorded.)");
+
+    using with_additional_info
+      = ss::bool_class<struct with_additional_info_tag>;
+    auto make_crash = [](with_additional_info wai) {
+        auto res = crash_description{};
+        res.crash_message = ss::sstring{"Assertion error"};
+        res.stacktrace = ss::sstring{"0xaaaaaaaa 0xbbbbbbbb"};
+        if (wai) {
+            res.addition_info = ss::sstring{"false != true at example.cc:123"};
+        }
+        return res;
+    };
+
+    crashes.emplace_back(make_crash(with_additional_info::no));
+
+    EXPECT_EQ(
+      crash_tracker::impl::describe_crashes(crashes),
+      // clang-format off
+      "The following crashes have been recorded:"
+      "\nCrash #1 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb."
+      // clang-format on
+    );
+
+    for (int i = 0; i < 10; i++) {
+        crashes.emplace_back(make_crash(with_additional_info::yes));
+    }
+
+    EXPECT_EQ(
+      crash_tracker::impl::describe_crashes(crashes),
+      // clang-format off
+      "The following crashes have been recorded:"
+      "\nCrash #1 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb."
+      "\nCrash #2 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #3 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #4 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #5 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\n    ..."
+      "\nCrash #7 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #8 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #9 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #10 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      "\nCrash #11 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
+      // clang-format on
+    );
+}
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -13,6 +13,24 @@
 
 namespace crash_tracker {
 
+std::ostream& operator<<(std::ostream& os, const crash_description& cd) {
+    fmt::print(os, "{}", cd.crash_message.c_str());
+
+    const auto opt_stacktrace = cd.stacktrace.c_str();
+    const auto has_stacktrace = strlen(opt_stacktrace) > 0;
+    if (has_stacktrace) {
+        fmt::print(os, " Backtrace: {}.", opt_stacktrace);
+    }
+
+    const auto opt_add_info = cd.addition_info.c_str();
+    const auto has_add_info = strlen(opt_add_info) > 0;
+    if (has_add_info) {
+        fmt::print(os, " {}", opt_add_info);
+    }
+
+    return os;
+}
+
 bool is_crash_loop_limit_reached(std::exception_ptr eptr) {
     try {
         std::rethrow_exception(eptr);

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -18,6 +18,8 @@
 #include "serde/rw/envelope.h"
 #include "serde/rw/sstring.h"
 
+#include <ostream>
+
 namespace crash_tracker {
 
 enum class crash_type {
@@ -92,6 +94,8 @@ struct crash_description
         return std::tie(
           type, crash_time, crash_message, stacktrace, addition_info);
     }
+
+    friend std::ostream& operator<<(std::ostream&, const crash_description&);
 };
 
 struct crash_tracker_metadata

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -140,7 +140,7 @@ class CrashLoopChecksTest(RedpandaTest):
             broker, "Sleeping for 3 seconds before terminating...")
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + HOSTNAME_ERRORS)
-    def test_crash_report_file_create(self):
+    def test_crash_report_with_startup_exception(self):
         broker = self.redpanda.nodes[0]
 
         def expect_crash_count(expected):
@@ -171,4 +171,8 @@ class CrashLoopChecksTest(RedpandaTest):
                                  expect_fail=True)
         assert self.redpanda.search_log_node(broker,
                                              "Too many consecutive crashes")
+        assert self.redpanda.search_log_node(
+            broker,
+            "Crash #4 at 20.* UTC - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: 0x.*"
+        )
         expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)


### PR DESCRIPTION
The PR implements reading recorded crash reports and extending the crash loop limit reached log message with a description of the recorded crashes.

To limit the length of the output, up to the 5 earliest and 5 latest recorded crashes are printed only. A unit test is added to test this logic and the output format.

A ducktape test is added to verify that information about recorded startup exceptions is correctly printed to the logs when the crash loop limit is reached. Through this we test that both:
 * Startup crash information is correctly recorded
 * The recorded crash information is correctly printed

Fixes: https://redpandadata.atlassian.net/browse/CORE-8619

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
