### PR TITLE
Introduced separate scheduling group for produce

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -835,6 +835,12 @@ configuration::configuration()
       "Use a separate scheduler group for fetch processing.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , use_produce_scheduler_group(
+      *this,
+      "use_produce_scheduler_group",
+      "Use a separate scheduler group for kafka produce requests processing.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , metadata_status_wait_timeout_ms(
       *this,
       "metadata_status_wait_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -232,6 +232,7 @@ struct configuration final : public config_store {
     enum_property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
     property<bool> use_fetch_scheduler_group;
+    property<bool> use_produce_scheduler_group;
     property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
     property<std::chrono::seconds> kafka_tcp_keepalive_idle_timeout_seconds;
     property<std::chrono::seconds> kafka_tcp_keepalive_probe_interval_seconds;

--- a/src/v/kafka/server/app.cc
+++ b/src/v/kafka/server/app.cc
@@ -19,7 +19,8 @@ namespace kafka {
 seastar::future<> server_app::init(
   seastar::sharded<net::server_configuration>* conf,
   seastar::smp_service_group smp,
-  seastar::scheduling_group sched,
+  seastar::scheduling_group fetch_sched,
+  seastar::scheduling_group prod_sched,
   seastar::sharded<cluster::metadata_cache>& mdc,
   seastar::sharded<cluster::topics_frontend>& tf,
   seastar::sharded<cluster::config_frontend>& cf,
@@ -46,7 +47,8 @@ seastar::future<> server_app::init(
     return _server.start(
       conf,
       smp,
-      sched,
+      fetch_sched,
+      prod_sched,
       std::ref(mdc),
       std::ref(tf),
       std::ref(cf),

--- a/src/v/kafka/server/app.h
+++ b/src/v/kafka/server/app.h
@@ -81,6 +81,7 @@ public:
       seastar::sharded<net::server_configuration>*,
       seastar::smp_service_group,
       seastar::scheduling_group,
+      seastar::scheduling_group,
       seastar::sharded<cluster::metadata_cache>&,
       seastar::sharded<cluster::topics_frontend>&,
       seastar::sharded<cluster::config_frontend>&,

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -56,6 +56,7 @@ public:
       ss::sharded<net::server_configuration>*,
       ss::smp_service_group,
       ss::scheduling_group,
+      ss::scheduling_group,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::config_frontend>&,
@@ -101,6 +102,8 @@ public:
      * them with most other tasks in the default scheduling group.
      */
     ss::scheduling_group fetch_scheduling_group() const;
+
+    ss::scheduling_group produce_scheduling_group() const;
 
     cluster::topics_frontend& topics_frontend() {
         return _topics_frontend.local();
@@ -228,6 +231,7 @@ private:
 
     ss::smp_service_group _smp_group;
     ss::scheduling_group _fetch_scheduling_group;
+    ss::scheduling_group _produce_scheduling_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
     ss::sharded<cluster::config_frontend>& _config_frontend;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2255,6 +2255,7 @@ void application::wire_up_redpanda_services(
         &kafka_cfg,
         smp_service_groups.kafka_smp_sg(),
         sched_groups.fetch_sg(),
+        sched_groups.produce_sg(),
         std::ref(metadata_cache),
         std::ref(controller->get_topics_frontend()),
         std::ref(controller->get_config_frontend()),

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -150,6 +150,7 @@ public:
             &configs,
             app.smp_service_groups.kafka_smp_sg(),
             app.sched_groups.fetch_sg(),
+            app.sched_groups.produce_sg(),
             std::ref(app.metadata_cache),
             std::ref(app.controller->get_topics_frontend()),
             std::ref(app.controller->get_config_frontend()),

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -40,6 +40,7 @@ public:
         _fetch = co_await ss::create_scheduling_group("fetch", 1000);
         _transforms = co_await ss::create_scheduling_group("transforms", 100);
         _datalake = co_await ss::create_scheduling_group("datalake", 100);
+        _produce = co_await ss::create_scheduling_group("produce", 1000);
     }
 
     ss::future<> destroy_groups() {
@@ -56,6 +57,7 @@ public:
         co_await destroy_scheduling_group(_fetch);
         co_await destroy_scheduling_group(_transforms);
         co_await destroy_scheduling_group(_datalake);
+        co_await destroy_scheduling_group(_produce);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -85,6 +87,14 @@ public:
      * use all the CPU.
      */
     ss::scheduling_group fetch_sg() { return _fetch; }
+    /**
+     * Scheduling group for produce requests.
+     *
+     * We use separate scheduling group for produce requests to prevent them
+     * from negatively impacting other work executed in the default scheduling
+     * group.
+     */
+    ss::scheduling_group produce_sg() { return _produce; }
 
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
@@ -102,7 +112,8 @@ public:
           std::cref(_self_test),
           std::cref(_fetch),
           std::cref(_transforms),
-          std::cref(_datalake)};
+          std::cref(_datalake),
+          std::cref(_produce)};
     }
 
 private:
@@ -121,4 +132,5 @@ private:
     ss::scheduling_group _fetch;
     ss::scheduling_group _transforms;
     ss::scheduling_group _datalake;
+    ss::scheduling_group _produce;
 };


### PR DESCRIPTION
Introducing a separate scheduling group for produce requests will allow
the scheduler to fairly distribute the CPU cycles between tasks that are
executed in main group and handling the produce requests. This way we
'isolate' produce requests processing from other work.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none