### PR TITLE
r/consensus: check if promotion is needed outside of coroutine

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -508,38 +508,37 @@ consensus::success_reply consensus::update_follower_index(
 }
 
 void consensus::maybe_promote_to_voter(vnode id) {
+    const auto& latest_cfg = _configuration_manager.get_latest();
+
+    // node is no longer part of current configuration, skip promotion
+    if (!latest_cfg.current_config().contains(id)) {
+        return;
+    }
+
+    // is voter already
+    if (latest_cfg.is_voter(id)) {
+        return;
+    }
+    auto it = _fstats.find(id);
+
+    // already removed
+    if (it == _fstats.end()) {
+        return;
+    }
+
+    // do not promote to voter, learner is not up to date
+    if (it->second.match_index < _flushed_offset) {
+        return;
+    }
+
+    // do not promote if the previous configuration is still uncommitted,
+    // otherwise we may add several new voters in quick succession, that the
+    // old voters will not know of, resulting in a possibility of
+    // non-intersecting quorums.
+    if (_configuration_manager.get_latest_offset() > _commit_index) {
+        return;
+    }
     ssx::spawn_with_gate(_bg, [this, id] {
-        const auto& latest_cfg = _configuration_manager.get_latest();
-
-        // node is no longer part of current configuration, skip promotion
-        if (!latest_cfg.current_config().contains(id)) {
-            return ss::now();
-        }
-
-        // is voter already
-        if (latest_cfg.is_voter(id)) {
-            return ss::now();
-        }
-        auto it = _fstats.find(id);
-
-        // already removed
-        if (it == _fstats.end()) {
-            return ss::now();
-        }
-
-        // do not promote to voter, learner is not up to date
-        if (it->second.match_index < _flushed_offset) {
-            return ss::now();
-        }
-
-        // do not promote if the previous configuration is still uncommitted,
-        // otherwise we may add several new voters in quick succession, that the
-        // old voters will not know of, resulting in a possibility of
-        // non-intersecting quorums.
-        if (_configuration_manager.get_latest_offset() > _commit_index) {
-            return ss::now();
-        }
-
         return _op_lock.get_units().then([this,
                                           id](ssx::semaphore_units u) mutable {
             // check once more under _op_lock to protect against races with


### PR DESCRIPTION
Processing append entries replies is very frequent task that leader executes. Making it faster to check if voter promotion is required by validating that before entering a coroutine context.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none