### PR TITLE
dt: Actually set resource limits in OMB MPT

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -768,7 +768,20 @@ class ManyPartitionsTest(PreallocNodesTest):
             self.redpanda,
             replication_factor=3,
             mib_per_partition=DEFAULT_MIB_PER_PARTITION,
-            topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD)
+            topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD,
+            partition_memory_reserve_percentage=
+            DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
+        )
+
+        self.redpanda.add_extra_rp_conf({
+            'topic_partitions_per_shard':
+            DEFAULT_PARTITIONS_PER_SHARD,
+            'topic_memory_per_partition':
+            DEFAULT_MIB_PER_PARTITION * 1024 * 1024,
+            'topic_partitions_memory_allocation_percent':
+            DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
+        })
+
         self.redpanda.start()
 
         # We have other OMB benchmark tests, but this one runs at the


### PR DESCRIPTION
The OMB MPT was not passing any of the calculated resource limits so it
would just use all available memory.

Fix this and also pass the partition reservation percentage.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
