### PR TITLE
cluster: Make partition creation refusal more clear

### DIFF
--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -157,11 +157,10 @@ std::error_code partition_allocator::check_memory_limits(
     if (proposed_total_partitions > memory_limit) {
         vlog(
           clusterlog.warn,
-          "Refusing to create {} new partitions as total partition count "
-          "{} "
-          "would exceed memory limit of {} partitions. Cluster partition "
-          "memory: {} - "
-          "required memory per partition: {} - memory group aware: {}",
+          "Refusing to create {} new partition replicas as total partition "
+          "replica count {} would exceed memory limit of {} partition "
+          "replicas. Cluster partition memory: {} - "
+          "required memory per partition replica: {} - memory group aware: {}",
           new_partitions_replicas_requested,
           proposed_total_partitions,
           memory_limit,


### PR DESCRIPTION
Make it clear we are talking about replicas and not partitions.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none

