### PR TITLE
r/buffered_protocol: run dispatch loop in raft scheduling group

### DIFF
--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -72,9 +72,11 @@ ss::future<result<Ret>> apply_with_gate(
 
 buffered_protocol::buffered_protocol(
   consensus_client_protocol base,
+  ss::scheduling_group scheduling_group,
   config::binding<size_t> max_inflight_requests,
   config::binding<size_t> max_buffered_bytes)
   : _base_protocol(std::move(base))
+  , _scheduling_group(scheduling_group)
   , _max_inflight_requests(std::move(max_inflight_requests))
   , _max_buffered_bytes(std::move(max_buffered_bytes))
   , _gc_timer([this] { garbage_collect_unused_queues(); }) {
@@ -113,6 +115,7 @@ ss::future<result<append_entries_reply>> buffered_protocol::append_entries(
                   target_node,
                   _base_protocol,
                   _gate.hold(),
+                  _scheduling_group,
                   _max_inflight_requests,
                   _max_buffered_bytes));
           }
@@ -230,11 +233,13 @@ append_entries_queue::append_entries_queue(
   model::node_id target_node,
   consensus_client_protocol base_protocol,
   ss::gate::holder gate_holder,
+  ss::scheduling_group scheduling_group,
   config::binding<size_t> max_inflight_requests,
   config::binding<size_t> max_buffered_bytes)
   : _target_node(target_node)
   , _base_protocol(std::move(base_protocol))
   , _logger(raftlog, fmt::format("[node: {}]", _target_node))
+  , _scheduling_group(scheduling_group)
   , _current_max_inflight_requests(max_inflight_requests())
   , _max_inflight_requests(std::move(max_inflight_requests))
   , _max_buffered_bytes(std::move(max_buffered_bytes))
@@ -256,8 +261,10 @@ append_entries_queue::append_entries_queue(
     setup_internal_metrics();
     // start dispatch loop
     ssx::repeat_until_gate_closed(
-      _gate,
-      [this, gate_holder = std::move(gate_holder)] { return dispatch_loop(); });
+      _gate, [this, gate_holder = std::move(gate_holder)] {
+          return ss::with_scheduling_group(
+            _scheduling_group, [this] { return dispatch_loop(); });
+      });
 };
 
 ss::future<> append_entries_queue::dispatch_loop() {

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -35,6 +35,7 @@ public:
       model::node_id,
       consensus_client_protocol,
       ss::gate::holder,
+      ss::scheduling_group scheduling_group,
       config::binding<size_t> max_inflight_requests,
       config::binding<size_t> max_buffered_bytes);
     append_entries_queue(append_entries_queue&&) = delete;
@@ -87,6 +88,7 @@ private:
     ss::condition_variable _new_requests;
     ss::condition_variable _dispatched;
 
+    ss::scheduling_group _scheduling_group;
     size_t _current_max_inflight_requests;
     config::binding<size_t> _max_inflight_requests;
     config::binding<size_t> _max_buffered_bytes;
@@ -122,6 +124,7 @@ public:
      */
     buffered_protocol(
       consensus_client_protocol base,
+      ss::scheduling_group scheduling_group,
       config::binding<size_t> max_inflight_requests,
       config::binding<size_t> max_buffered_bytes);
 
@@ -162,8 +165,10 @@ private:
       _append_entries_queues;
 
     consensus_client_protocol _base_protocol;
+    ss::scheduling_group _scheduling_group;
     config::binding<size_t> _max_inflight_requests;
     config::binding<size_t> _max_buffered_bytes;
+
     ss::gate _gate;
     ss::timer<> _gc_timer;
 };

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -39,6 +39,7 @@ group_manager::group_manager(
   , _configuration(cfg())
   , _buffered_protocol(ss::make_shared<buffered_protocol>(
       make_rpc_client_protocol(self, clients),
+      raft_sg,
       _configuration.max_inflight_requests_per_node,
       _configuration.max_buffered_bytes_per_node))
   , _heartbeats(

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -388,6 +388,7 @@ raft_node_instance::raft_node_instance(
   , _protocol(ss::make_shared<in_memory_test_protocol>(node_map, _logger))
   , _buffered_protocol(ss::make_shared<buffered_protocol>(
       consensus_client_protocol(_protocol),
+      ss::default_scheduling_group(),
       _max_inflight_requests.bind(),
       _max_queued_bytes.bind()))
   , _features(feature_table)


### PR DESCRIPTION
Changed buffered protocol to run in Raft scheduling group instead of the default one.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none