### PR TITLE
r/heartbeat_mgr: run raft heartbeat manager in raft scheduling group

### DIFF
--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -42,6 +42,7 @@ group_manager::group_manager(
       _configuration.max_inflight_requests_per_node,
       _configuration.max_buffered_bytes_per_node))
   , _heartbeats(
+      _raft_sg,
       _configuration.heartbeat_interval,
       consensus_client_protocol(_buffered_protocol),
       _self,

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -213,13 +213,15 @@ bool heartbeat_manager::needs_full_heartbeat(
 }
 
 heartbeat_manager::heartbeat_manager(
+  ss::scheduling_group scheduling_group,
   config::binding<std::chrono::milliseconds> interval,
   consensus_client_protocol proto,
   model::node_id self,
   config::binding<std::chrono::milliseconds> heartbeat_timeout,
   config::binding<bool> enable_lw_heartbeat,
   features::feature_table& ft)
-  : _heartbeat_interval(std::move(interval))
+  : _scheduling_group(scheduling_group)
+  , _heartbeat_interval(std::move(interval))
   , _heartbeat_timeout(std::move(heartbeat_timeout))
   , _client_protocol(std::move(proto))
   , _self(self)
@@ -606,18 +608,20 @@ void heartbeat_manager::process_reply(
 }
 
 void heartbeat_manager::dispatch_heartbeats() {
-    ssx::background = ssx::spawn_with_gate_then(_bghbeats, [this] {
-                          return _lock.with([this] {
-                              return do_dispatch_heartbeats().finally([this] {
-                                  if (!_bghbeats.is_closed()) {
-                                      _heartbeat_timer.arm(
-                                        next_heartbeat_timeout());
-                                  }
-                              });
-                          });
-                      }).handle_exception([](const std::exception_ptr& e) {
-        vlog(hbeatlog.warn, "Error dispatching heartbeats - {}", e);
-    });
+    ssx::background
+      = ssx::spawn_with_gate_then(_bghbeats, [this] {
+            return ss::with_scheduling_group(_scheduling_group, [this] {
+                return _lock.with([this] {
+                    return do_dispatch_heartbeats().finally([this] {
+                        if (!_bghbeats.is_closed()) {
+                            _heartbeat_timer.arm(next_heartbeat_timeout());
+                        }
+                    });
+                });
+            });
+        }).handle_exception([](const std::exception_ptr& e) {
+            vlog(hbeatlog.warn, "Error dispatching heartbeats - {}", e);
+        });
     // update last
     _hbeat = clock_type::now();
 }

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -124,6 +124,7 @@ public:
     };
 
     heartbeat_manager(
+      ss::scheduling_group scheduling_group,
       config::binding<std::chrono::milliseconds> heartbeat_interval,
       consensus_client_protocol client_protocol,
       model::node_id self_node_id,
@@ -192,6 +193,7 @@ private:
 
     mutex _lock{"heartbeat_manager"};
     clock_type::time_point _hbeat = clock_type::now();
+    ss::scheduling_group _scheduling_group;
     config::binding<std::chrono::milliseconds> _heartbeat_interval;
     config::binding<std::chrono::milliseconds> _heartbeat_timeout;
     timer_type _heartbeat_timer;

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -419,6 +419,7 @@ ss::future<>
 raft_node_instance::initialise(std::vector<raft::vnode> initial_nodes) {
     co_await _group_manager.start_single();
     _hb_manager = std::make_unique<heartbeat_manager>(
+      ss::default_scheduling_group(),
       _heartbeat_interval,
       consensus_client_protocol(_buffered_protocol),
       _id,

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -219,6 +219,7 @@ struct raft_node {
           .get();
         server.invoke_on_all(&rpc::rpc_server::start).get();
         hbeats = std::make_unique<raft::heartbeat_manager>(
+          ss::default_scheduling_group(),
           config::mock_binding<std::chrono::milliseconds>(
             std::chrono::milliseconds(heartbeat_interval)),
           raft::make_rpc_client_protocol(broker.id(), cache),


### PR DESCRIPTION
Heartbeats are critical part of Raft protocol as they serve as a failure detector. Changed the manager to dispatch heartbeats as a part of raft scheduling group.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
