### PR TITLE
[v24.3.x] CORE-8804 Make brokers field no longer required

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -26,7 +26,7 @@ configuration::configuration()
       "brokers",
       "Network addresses of the Kafka API servers to which the HTTP Proxy "
       "client should connect.",
-      {.required = config::required::yes},
+      {},
       std::vector<net::unresolved_address>({{"127.0.0.1", 9092}}))
   , broker_tls(
       *this,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24891

Fixes: CORE-8890
