### PR TITLE
[v24.2.x] CORE-8804 Make brokers field no longer require

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -24,8 +24,9 @@ configuration::configuration()
   : brokers(
     *this,
     "brokers",
-    "List of address and port of the brokers",
-    {.required = config::required::yes},
+    "Network addresses of the Kafka API servers to which the HTTP Proxy "
+    "client should connect.",
+    {},
     std::vector<net::unresolved_address>({{"127.0.0.1", 9092}}))
   , broker_tls(
       *this,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24891

Fixes: #24902
Fixes: CORE-8889