### PR TITLE
iceberg: remove extraneous empty block in Avro files

### DIFF
--- a/src/v/iceberg/manifest_avro.cc
+++ b/src/v/iceberg/manifest_avro.cc
@@ -154,7 +154,6 @@ iobuf serialize_avro(const manifest& m) {
               entry_struct, entry_schema.root());
             writer.write(entry_datum);
         }
-        writer.flush();
         writer.close();
 
         // NOTE: ~DataFileWriter does a final sync which may write to the

--- a/src/v/iceberg/manifest_list_avro.cc
+++ b/src/v/iceberg/manifest_list_avro.cc
@@ -160,7 +160,6 @@ iobuf serialize_avro(const manifest_list& m) {
         for (const auto& f : m.files) {
             writer.write(file_to_avro(f));
         }
-        writer.flush();
         writer.close();
 
         // NOTE: ~DataFileWriter does a final sync which may write to the


### PR DESCRIPTION
Removes a needless flush from our manifest and manifest list serialization code that would previously leave behind an empty block in our Avro files. While an extra empty block isn't necessarily problematic with Avro's and Iceberg's specs, not all query engines will happily read them.

Notably, with Bigquery, we would see the following error:

```
Error while reading data, error message: The Apache Avro library failed to read data with the following error: EOF reached File: bigstore/redpanda-iceberg-bucket/redpanda-iceberg-catalog/redpanda/events_raw/metadata/snap-2304216884486420382-2bab43f5-e6a4-48ee-911b-3d5eed53949c-0.avro
```

Under the hood, in our Avro serialization code we were calling flush() _and_ close(), though we only needed to run close(). Avro's flush() will serialize one more block[1], and close() will call flush()[2], so calling both would leave us with an extra empty block.

[1] https://github.com/redpanda-data/avro/blob/8dccd0d0060ad6abd773207bee91d3c70aaaf764/lang/c%2B%2B/impl/DataFile.cc#L140-L144
[2] https://github.com/redpanda-data/avro/blob/8dccd0d0060ad6abd773207bee91d3c70aaaf764/lang/c%2B%2B/impl/DataFile.cc#L129-L132

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes Iceberg metadata serialization to avoid writing an extraneous empty Avro block. This would previously prevent some query engines (e.g. BigQuery) from reading tables created by Iceberg Topics.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
