### PR TITLE
Fix enum_values in config schema for optional property

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -903,8 +903,15 @@ public:
 
     std::vector<ss::sstring> enum_values() const final override {
         std::vector<ss::sstring> r;
+        r.reserve(_values.size());
         for (const auto& v : _values) {
-            r.push_back(ssx::sformat("{}", v));
+            if constexpr (reflection::is_std_optional<T>) {
+                if (v.has_value()) {
+                    r.push_back(ssx::sformat("{}", v.value()));
+                }
+            } else {
+                r.push_back(ssx::sformat("{}", v));
+            }
         }
 
         return r;
@@ -912,7 +919,16 @@ public:
 
 private:
     ss::sstring help_text() const {
-        return fmt::format("Must be one of {}", fmt::join(enum_values(), ","));
+        constexpr std::string_view or_null_str = [] {
+            if constexpr (reflection::is_std_optional<T>) {
+                return " or null";
+            } else {
+                return "";
+            }
+        }();
+
+        return fmt::format(
+          "Must be one of {}{}", fmt::join(enum_values(), ","), or_null_str);
     }
 
     std::vector<T> _values;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -912,18 +912,7 @@ public:
 
 private:
     ss::sstring help_text() const {
-        // String-ize the available values
-        std::vector<std::string> str_values;
-        str_values.reserve(_values.size());
-        std::transform(
-          _values.begin(),
-          _values.end(),
-          std::back_inserter(str_values),
-          [](const T& v) { return fmt::format("{}", v); });
-
-        return fmt::format(
-          "Must be one of {}",
-          fmt::join(str_values.begin(), str_values.end(), ","));
+        return fmt::format("Must be one of {}", fmt::join(enum_values(), ","));
     }
 
     std::vector<T> _values;

--- a/src/v/config/tests/enum_property_test.cc
+++ b/src/v/config/tests/enum_property_test.cc
@@ -59,8 +59,7 @@ SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
         verr = cfg.opt_enum_str.validate(YAML::Load(v));
         BOOST_REQUIRE(verr.has_value());
         BOOST_REQUIRE_EQUAL(
-          verr.value().error_message(),
-          "Must be one of {nullopt},{foo},{bar},{baz}");
+          verr.value().error_message(), "Must be one of foo,bar,baz or null");
     }
 
     // Optional variant should also always consider null to be valid.
@@ -78,11 +77,10 @@ SEASTAR_THREAD_TEST_CASE(enum_property_values) {
     BOOST_CHECK_EQUAL(values[2], "baz");
 
     auto opt_values = cfg.opt_enum_str.enum_values();
-    BOOST_CHECK_EQUAL(opt_values.size(), 4);
-    BOOST_CHECK_EQUAL(opt_values[0], "{nullopt}");
-    BOOST_CHECK_EQUAL(opt_values[1], "{foo}");
-    BOOST_CHECK_EQUAL(opt_values[2], "{bar}");
-    BOOST_CHECK_EQUAL(opt_values[3], "{baz}");
+    BOOST_CHECK_EQUAL(opt_values.size(), 3);
+    BOOST_CHECK_EQUAL(opt_values[0], "foo");
+    BOOST_CHECK_EQUAL(opt_values[1], "bar");
+    BOOST_CHECK_EQUAL(opt_values[2], "baz");
 }
 
 } // namespace

--- a/src/v/config/tests/enum_property_test.cc
+++ b/src/v/config/tests/enum_property_test.cc
@@ -52,17 +52,37 @@ SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
 
     for (const auto& v : invalid_values) {
         verr = cfg.enum_str.validate(YAML::Load(v));
-        BOOST_CHECK(verr.has_value());
-        BOOST_REQUIRE(
-          verr.value().error_message() == "Must be one of foo,bar,baz");
+        BOOST_REQUIRE(verr.has_value());
+        BOOST_REQUIRE_EQUAL(
+          verr.value().error_message(), "Must be one of foo,bar,baz");
 
         verr = cfg.opt_enum_str.validate(YAML::Load(v));
-        BOOST_CHECK(verr.has_value());
+        BOOST_REQUIRE(verr.has_value());
+        BOOST_REQUIRE_EQUAL(
+          verr.value().error_message(),
+          "Must be one of {nullopt},{foo},{bar},{baz}");
     }
 
     // Optional variant should also always consider null to be valid.
     verr = cfg.opt_enum_str.validate(YAML::Load("~"));
     BOOST_CHECK(!verr.has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(enum_property_values) {
+    auto cfg = test_config();
+
+    auto values = cfg.enum_str.enum_values();
+    BOOST_CHECK_EQUAL(values.size(), 3);
+    BOOST_CHECK_EQUAL(values[0], "foo");
+    BOOST_CHECK_EQUAL(values[1], "bar");
+    BOOST_CHECK_EQUAL(values[2], "baz");
+
+    auto opt_values = cfg.opt_enum_str.enum_values();
+    BOOST_CHECK_EQUAL(opt_values.size(), 4);
+    BOOST_CHECK_EQUAL(opt_values[0], "{nullopt}");
+    BOOST_CHECK_EQUAL(opt_values[1], "{foo}");
+    BOOST_CHECK_EQUAL(opt_values[2], "{bar}");
+    BOOST_CHECK_EQUAL(opt_values[3], "{baz}");
 }
 
 } // namespace

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -618,6 +618,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             'iceberg_rest_catalog_crl',
             'iceberg_rest_catalog_crl_file',
         ])
+        # Cloud storage and iceberg depend on properly configured cloud IO.
+        # Skip them to avoid breaking the test.
+        exclude_settings.add('cloud_storage_enabled')
+        exclude_settings.add('iceberg_enabled')
 
         # List of settings that must be odd
         odd_settings = [
@@ -691,10 +695,6 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Don't lock ourselves out of the admin API!
                 continue
 
-            if name == 'cloud_storage_enabled':
-                # Enabling cloud storage requires setting other properties too
-                continue
-
             if name == 'storage_strict_data_init':
                 # Enabling this property requires a file be manually added
                 # to RP's data dir for it to start
@@ -705,25 +705,11 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # cloud storage read/write properties.
                 continue
 
-            if name == 'record_key_subject_name_strategy' or name == 'record_value_subject_name_strategy':
-                valid_value = random.choice(
-                    [e for e in p['enum_values'] if e != initial_value])
-
-            if name == 'cloud_storage_recovery_topic_validation_mode':
-                valid_value = random.choice(
-                    [e for e in p['enum_values'] if e != initial_value])
-
-            if name == "tls_min_version":
-                valid_value = random.choice(
-                    [e for e in p['enum_values'] if e != initial_value])
-
-            if name == "iceberg_catalog_type":
-                valid_value = random.choice(
-                    [e for e in p['enum_values'] if e != initial_value])
-
-            if name == "iceberg_invalid_record_action":
-                valid_value = random.choice(
-                    [e for e in p['enum_values'] if e != initial_value])
+            if 'enum_values' in p:
+                valid_choices = p['enum_values']
+                if p['nullable']:
+                    valid_choices.append(None)
+                valid_value = random.choice(valid_choices)
 
             if name == "enable_consumer_group_metrics":
                 valid_value = random.choice([[], ["group"], ["partition"]])


### PR DESCRIPTION
Most interesting commit:

* config: fix enum values formatting for optional enum properties
```
According to our config JSON schema, "enum_values" should list the
possible property values in their actual string format. Previously,
optional enum properties were stringified using an optional formatter.
This meant values were wrapped in curly braces (e.g. {foo}, {nullopt}),
even when absent, which does not reflect the real, accepted values. As a
result, when a user attempted to set a config property using one of
these values, the request would fail.

This commit changes the behavior so that "enum_values" now contains only
the valid, accepted string representations for the property. The only
exception is the "null" value, which remains due to the limitation of
"enum_values" being a list of strings rather than arbitrary objects.
While we could remove "null"—since its status is also indicated by the
"is_nullable" field for the schema—this issue may also arise for more
complex config objects that require stringification.

This improvement ensures that the values are better aligned with both
human interpretation and automated tests.
```

---

Previous formatting is clearly wrong. Values wrapped with `{}` are not in fact accepted by the config subsystem. 
The outstanding question is the nullopt formatting. 
* How can let the user understand the difference between a possible (in the future who knows) `"null"` string and an actual `null` as-in configuration set to _empty_? Note that help text is more helpful to human as configs can be json (api)/yaml (config file)/something else (rpk cli values).
* "enum_values" is documented as "Possible values of the property (in string-ized form)" https://github.com/redpanda-data/redpanda/blob/4a83e99c5d361f1a7c7779279f7dfbf35693de86/src/v/redpanda/admin/api-doc/cluster_config.json#L212

Stumbled upon this as I tried to simplify tests/rptest/tests/cluster_config_test.py (also in this PR) and let it rely on enum values field.

---

This is technically a breaking change but the risk of breaking end users seems remote and lower than the benefit to us and future users so requesting review from @mattschumpert.

For Matt: This only affects end users relying on the admin endpoint `/v1/cluster_config/schema`. Before this change

```json
$ curl -s http://localhost:9644/v1/cluster_config/schema | jq .properties.cloud_storage_url_style
{
  "description": "Specifies the addressing style to use for Amazon S3 requests. This configuration determines how S3 bucket URLs are formatted. You can choose between: `virtual_host`, (for example, `<bucket-name>.s3.amazonaws.com`), `path`, (for example, `s3.amazonaws.com/<bucket-name>`), and `null`. Path style is supported for backward compatibility with legacy systems. When this property is not set or is `null`, the client tries to use `virtual_host` addressing. If the initial request fails, the client automatically tries the `path` style. If neither addressing style works, Redpanda terminates the startup, requiring manual configuration to proceed.",
  "nullable": true,
  "needs_restart": true,
  "visibility": "user",
  "is_secret": false,
  "example": "virtual_host",
  "type": "string",
  "enum_values": [
    "{virtual_host}",
    "{path}",
    "{nullopt}"
  ]
}
```

None of the values in "enum_values" are actually usable. They are for all other properties though. This one is the only optional enum property. You can also see that `example` is _rendered_ correctly.

_In retrospect, it could have been probably easier to have it default to "auto" rather than it being optional._

After:

```json
$ curl -s http://localhost:9644/v1/cluster_config/schema | jq .properties.cloud_storage_url_style
{
  "description": "Specifies the addressing style to use for Amazon S3 requests. This configuration determines how S3 bucket URLs are formatted. You can choose between: `virtual_host`, (for example, `<bucket-name>.s3.amazonaws.com`), `path`, (for example, `s3.amazonaws.com/<bucket-name>`), and `null`. Path style is supported for backward compatibility with legacy systems. When this property is not set or is `null`, the client tries to use `virtual_host` addressing. If the initial request fails, the client automatically tries the `path` style. If neither addressing style works, Redpanda terminates the startup, requiring manual configuration to proceed.",
  "nullable": true,
  "needs_restart": true,
  "visibility": "user",
  "is_secret": false,
  "example": "virtual_host",
  "type": "string",
  "enum_values": [
    "virtual_host",
    "path"
  ]
}
```

No more curly braces. We are not rendering "null" anymore as it wasn't usable anyway. There is `nullable` property which indicates that the config can be set to null.

I doubt anyone relies on that and if they do it certainly isn't in some hot path which can be critical so they can take time to adjust to the new behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
