### PR TITLE
bazel: extract test_utils:logs from test_utils

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -372,6 +372,7 @@ redpanda_cc_btest(
         "//src/v/model",
         "//src/v/random:generators",
         "//src/v/reflection:adl",
+        "//src/v/test_utils:logs",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar",

--- a/src/v/model/BUILD
+++ b/src/v/model/BUILD
@@ -90,3 +90,16 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "timeout_clock",
+    hdrs = [
+        "timeout_clock.h",
+    ],
+    include_prefix = "model",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/redpanda/tests/BUILD
+++ b/src/v/redpanda/tests/BUILD
@@ -14,5 +14,6 @@ redpanda_test_cc_library(
         "//src/v/redpanda:application",
         "//src/v/storage/tests:disk_log_builder",
         "//src/v/test_utils:fixture",
+        "//src/v/test_utils:logs",
     ],
 )

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -5,7 +5,6 @@ redpanda_test_cc_library(
     hdrs = [
         "async.h",
         "fixture.h",
-        "logs.h",
         "test_macros.h",
         "tmp_dir.h",
     ],
@@ -13,8 +12,8 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
-        "//src/v/model",
-        "//src/v/storage",
+        "//src/v/model:timeout_clock",
+        "//src/v/ssx:sformat",
         "@seastar//:testing",
     ],
 )
@@ -29,7 +28,6 @@ redpanda_test_cc_library(
         "async.h",
         "fixture.h",
         "gtest_utils.h",
-        "logs.h",
         "test.h",
         "test_macros.h",
         "tmp_dir.h",
@@ -54,7 +52,6 @@ redpanda_test_cc_library(
     hdrs = [
         "async.h",
         "fixture.h",
-        "logs.h",
         "test_macros.h",
         "tmp_dir.h",
     ],
@@ -155,6 +152,21 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/reflection:adl",
         "//src/v/serde",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "logs",
+    hdrs = [
+        "logs.h",
+    ],
+    include_prefix = "test_utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/model",
+        "//src/v/storage",
+        "@seastar",
     ],
 )
 


### PR DESCRIPTION
Tests depending on gtest or seastar_boost ended up building `//src/v/storage` as a dependency. Moved this dependency chain into a `test_utils:logs` target now.

Previous example:

```
 → bazel query --notool_deps "allpaths(//src/v/config/tests/..., //src/v/storage:storage)" --output graph
Another command (pid=2515496) is running. Waiting for it to complete on the server (server_pid=2512616)...
digraph mygraph {
  node [shape=box];
  "//src/v/config/tests:enterprise_property_test"
  "//src/v/config/tests:enterprise_property_test" -> "//src/v/test_utils:gtest"
  "//src/v/test_utils:gtest"
  "//src/v/test_utils:gtest" -> "//src/v/test_utils:fixture"
  "//src/v/config/tests:leaders_preference_test\n//src/v/config/tests:retention_property_test\n//src/v/config/tests:advertised_kafka_api_test\n//src/v/config/tests:bounded_property_test\n//src/v/config/tests:throughput_control_group_test\n//src/v/config/tests:tls_config_convert_test\n//src/v/config/tests:scoped_config_test\n//src/v/config/tests:config_store_test\n//src/v/config/tests:validator_test\n//src/v/config/tests:enum_property_test\n//src/v/config/tests:node_override_test\n...and 3 more items"
  "//src/v/config/tests:leaders_preference_test\n//src/v/config/tests:retention_property_test\n//src/v/config/tests:advertised_kafka_api_test\n//src/v/config/tests:bounded_property_test\n//src/v/config/tests:throughput_control_group_test\n//src/v/config/tests:tls_config_convert_test\n//src/v/config/tests:scoped_config_test\n//src/v/config/tests:config_store_test\n//src/v/config/tests:validator_test\n//src/v/config/tests:enum_property_test\n//src/v/config/tests:node_override_test\n...and 3 more items" -> "//src/v/test_utils:seastar_boost"
  "//src/v/test_utils:seastar_boost"
  "//src/v/test_utils:seastar_boost" -> "//src/v/test_utils:fixture"
  "//src/v/test_utils:fixture"
  "//src/v/test_utils:fixture" -> "//src/v/storage:storage"
  "//src/v/storage:storage"
}
```

After:

```
 → bazel query --notool_deps "allpaths(//src/v/config/tests/..., //src/v/storage:storage)" --output graph
digraph mygraph {
  node [shape=box];
}
INFO: Empty results
```

---

Spotted this while trying to iteration on `//src/v/config` and almost each modification ended up rebuilding hundreds of files instead of a couple because config tests depended on storage and storage depends on config header files ... and storage is pretty big library with dependency chain which also depends on config and has to be rebuilt.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
