### PR TITLE
[v24.3.x] tests/gtest_raft_rpunit: monitor_test_fixture to honour leadership changes

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -250,3 +250,417 @@ redpanda_cc_gtest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "foreign_entry_test",
+    timeout = "short",
+    srcs = [
+        "foreign_entry_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/random:generators",
+        "//src/v/resource_mgmt:io_priority",
+        "//src/v/storage",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:copy_range",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "configuration_serialization_test",
+    timeout = "short",
+    srcs = [
+        "configuration_serialization_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/raft:broker_compat",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "type_serialization_tests",
+    timeout = "short",
+    srcs = [
+        "type_serialization_tests.cc",
+    ],
+    deps = [
+        "//src/v/compression",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:rpc",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "term_assigning_reader_test",
+    timeout = "short",
+    srcs = [
+        "term_assigning_reader_test.cc",
+    ],
+    deps = [
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "membership_test",
+    timeout = "short",
+    srcs = [
+        "membership_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:stm_raft_fixture",
+        "//src/v/storage",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "leadership_test",
+    timeout = "short",
+    srcs = [
+        "leadership_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/finjector",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:stm_raft_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "state_removal_test",
+    timeout = "short",
+    srcs = [
+        "state_removal_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/raft",
+        "//src/v/raft/tests:stm_raft_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:directory_walker",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "append_entries_test",
+    timeout = "short",
+    srcs = [
+        "append_entries_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:random",
+        "//src/v/finjector",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/raft/tests:stm_raft_fixture",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/storage/tests:disk_log_builder",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "offset_monitor_test",
+    timeout = "short",
+    srcs = [
+        "offset_monitor_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/base",
+        "//src/v/raft",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "mutex_buffer_test",
+    timeout = "short",
+    srcs = [
+        "mutex_buffer_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/raft",
+        "//src/v/ssx:sformat",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:mutex",
+        "@boost//:test",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "configuration_manager_test",
+    timeout = "short",
+    srcs = [
+        "configuration_manager_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/base",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "coordinated_recovery_throttle_test",
+    timeout = "short",
+    srcs = [
+        "coordinated_recovery_throttle_test.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/raft",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "basic_raft_fixture_test",
+    timeout = "moderate",
+    srcs = [
+        "basic_raft_fixture_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixiture_retry_policy",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/raft/tests:stm_raft_fixture_gtest",
+        "//src/v/random:generators",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "stm_manager_test",
+    timeout = "moderate",
+    srcs = [
+        "stm_manager_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/raft/tests:raft_fixiture_retry_policy",
+        "//src/v/raft/tests:stm_raft_fixture_gtest",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_test_cc_library(
+    name = "stm_test_fixture",
+    hdrs = [
+        "raft_group_fixture.h",
+        "stm_test_fixture.h",
+    ],
+    include_prefix = "raft/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":raft_fixiture_retry_policy",
+        ":raft_fixture",
+        "//src/v/base",
+        "//src/v/bytes:random",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/raft",
+        "//src/v/random:generators",
+        "//src/v/rpc",
+        "//src/v/serde",
+        "//src/v/storage",
+        "//src/v/test_utils:random",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "raft_reconfiguration_test",
+    timeout = "long",
+    srcs = [
+        "raft_reconfiguration_test.cc",
+    ],
+    cpu = 4,
+    memory = "2GiB",
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixiture_retry_policy",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/random:generators",
+        "//src/v/serde",
+        "//src/v/ssx:future_util",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "persisted_stm_test",
+    timeout = "short",
+    srcs = [
+        "persisted_stm_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixiture_retry_policy",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/raft/tests:stm_raft_fixture_gtest",
+        "//src/v/random:generators",
+        "//src/v/serde",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "replication_monitor_tests",
+    timeout = "short",
+    srcs = [
+        "replication_monitor_tests.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/model",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/raft/tests:stm_raft_fixture_gtest",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "mux_state_machine_test",
+    timeout = "short",
+    srcs = [
+        "mux_state_machine_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/base",
+        "//src/v/model",
+        "//src/v/raft",
+        "//src/v/raft/tests:raft_fixiture_retry_policy",
+        "//src/v/raft/tests:raft_fixture",
+        "//src/v/raft/tests:simple_raft_fixture_gtest",
+        "//src/v/reflection:adl",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/storage/tests:disk_log_builder",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:gtest",
+        "@boost//:range",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -19,6 +19,7 @@
 #include "model/timeout_clock.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/coordinated_recovery_throttle.h"
+#include "raft/errc.h"
 #include "raft/fwd.h"
 #include "raft/heartbeat_manager.h"
 #include "raft/recovery_memory_quota.h"
@@ -39,6 +40,7 @@
 #include <boost/range/irange.hpp>
 
 #include <ranges>
+#include <system_error>
 namespace raft {
 
 inline constexpr raft::group_id test_group(123);
@@ -526,6 +528,7 @@ public:
                 .then([&state] { return state.result; });
           });
     }
+
     template<typename Func>
     auto
     retry_with_leader(model::timeout_clock::time_point deadline, Func&& f) {

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -59,20 +59,32 @@ public:
 
         for (auto& [id, node] : nodes()) {
             if (id == leader.get_vnode().id()) {
-                node->on_dispatch(
-                  [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
+                node->on_dispatch([](model::node_id, raft::msg_type mt) {
+                    if (mt == raft::msg_type::append_entries) {
+                        throw std::runtime_error("dropping_append_entries");
+                    }
+                    return ss::now();
+                });
             }
         }
 
-        std::vector<ss::future<result<replicate_result>>> replicate_f;
-        replicate_f.reserve(num_waiters());
-        for (size_t i = 0; i < num_waiters(); i++) {
-            replicate_f.push_back(raft->replicate(
+        std::vector<ss::future<>> enqueued;
+        std::vector<ss::future<result<raft::replicate_result>>> replicated;
+
+        for (auto i = 0; i < num_waiters(); i++) {
+            auto stages = raft->replicate_in_stages(
               make_batches({{"k", "v"}}),
-              replicate_options{raft::consistency_level::quorum_ack}));
+              replicate_options{raft::consistency_level::quorum_ack});
+            enqueued.push_back(std::move(stages.request_enqueued));
+            replicated.push_back(std::move(stages.replicate_finished));
         }
+        auto enqueue_results = co_await ss::when_all(
+          enqueued.begin(), enqueued.end());
+        // block new leadership and step down
+        raft->block_new_leadership();
+        co_await raft->step_down(model::term_id(2), "test");
         auto repl_results = co_await ss::when_all(
-          replicate_f.begin(), replicate_f.end());
+          replicated.begin(), replicated.end());
         for (auto& r : repl_results) {
             auto res = r.get();
             ASSERT_TRUE_CORO(res.has_error());

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -7,19 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/fundamental.h"
 #include "raft/tests/raft_fixture.h"
-#include "raft/tests/raft_group_fixture.h"
 #include "test_utils/async.h"
 
-using namespace raft;
+#include <seastar/core/lowres_clock.hh>
 
-class monitor_test_fixture
-  : public raft_fixture
-  , public ::testing::WithParamInterface<std::tuple<bool, size_t>> {
-public:
-    static bool write_caching() { return std::get<0>(GetParam()); }
-    static size_t num_waiters() { return std::get<1>(GetParam()); }
-};
+using namespace raft;
 
 namespace {
 
@@ -49,75 +43,103 @@ auto populate_waiters(
     return ss::when_all_succeed(futures.begin(), futures.end());
 }
 
+class monitor_test_fixture
+  : public raft_fixture
+  , public ::testing::WithParamInterface<std::tuple<bool, size_t>> {
+public:
+    static bool write_caching() { return std::get<0>(GetParam()); }
+    static size_t num_waiters() { return std::get<1>(GetParam()); }
+
+    ss::future<> truncation_detection_test(raft_node_instance& leader) {
+        auto raft = leader.raft();
+        auto all = ::populate_waiters(raft, write_caching(), num_waiters());
+        co_await ss::sleep(500ms);
+        ASSERT_FALSE_CORO(all.available());
+
+        for (auto& [id, node] : nodes()) {
+            if (id == leader.get_vnode().id()) {
+                node->on_dispatch(
+                  [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
+            }
+        }
+
+        std::vector<ss::future<result<replicate_result>>> replicate_f;
+        replicate_f.reserve(num_waiters());
+        for (size_t i = 0; i < num_waiters(); i++) {
+            replicate_f.push_back(raft->replicate(
+              make_batches({{"k", "v"}}),
+              replicate_options{raft::consistency_level::quorum_ack}));
+        }
+        auto results = co_await ss::when_all(
+          replicate_f.begin(), replicate_f.end());
+        for (auto& r : results) {
+            auto res = r.get();
+            ASSERT_TRUE_CORO(res.has_error());
+            if (res.error() == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(res.error(), errc::replicated_entry_truncated);
+        }
+
+        co_await tests::cooperative_spin_wait_with_timeout(
+          2s, [&] { return all.available() && !all.failed(); });
+
+        auto result = all.get();
+        for (size_t i = 0; i < num_waiters(); i++) {
+            if (result.at(i) == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(result.at(i), errc::replicated_entry_truncated);
+        }
+    }
+    ss::future<> replication_monitor_wait_test(raft_node_instance& leader) {
+        auto raft = leader.raft();
+
+        auto all = ::populate_waiters(raft, write_caching(), num_waiters());
+        co_await ss::sleep(500ms);
+        ASSERT_FALSE_CORO(all.available());
+
+        for (size_t i = 0; i < num_waiters(); i++) {
+            auto result = co_await raft->replicate(
+              make_batches({{"k", "v"}}),
+              replicate_options{raft::consistency_level::quorum_ack});
+            if (result.has_error() && result.error() == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_TRUE_CORO(result.has_value()) << result.error();
+        }
+
+        co_await tests::cooperative_spin_wait_with_timeout(
+          2s, [&] { return all.available() && !all.failed(); });
+
+        auto result = all.get();
+        for (size_t i = 0; i < num_waiters(); i++) {
+            if (result.at(i) == errc::not_leader) {
+                throw raft_not_leader_exception();
+            }
+            ASSERT_EQ_CORO(result.at(i), errc::success);
+        }
+    }
+};
 } // namespace
 
 TEST_P_CORO(monitor_test_fixture, replication_monitor_wait) {
     co_await create_simple_group(5);
 
     co_await set_write_caching(write_caching());
-    auto leader = co_await wait_for_leader(10s);
-    auto raft = node(leader).raft();
 
-    auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(500ms);
-    ASSERT_FALSE_CORO(all.available());
-
-    for (auto i = 0; i < num_waiters(); i++) {
-        auto result = co_await raft->replicate(
-          make_batches({{"k", "v"}}),
-          replicate_options{raft::consistency_level::quorum_ack});
-        ASSERT_TRUE_CORO(result.has_value()) << result.error();
-    }
-
-    co_await tests::cooperative_spin_wait_with_timeout(
-      2s, [&] { return all.available() && !all.failed(); });
-
-    auto result = all.get();
-    for (auto i = 0; i < num_waiters(); i++) {
-        ASSERT_EQ_CORO(result.at(i), errc::success);
-    }
+    co_await test_with_leader(
+      60s, &monitor_test_fixture::replication_monitor_wait_test);
 }
 
 TEST_P_CORO(monitor_test_fixture, truncation_detection) {
     set_enable_longest_log_detection(false);
     co_await create_simple_group(3);
-    auto leader = co_await wait_for_leader(10s);
+
     co_await set_write_caching(write_caching());
 
-    auto raft = node(leader).raft();
-    auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(500ms);
-    ASSERT_FALSE_CORO(all.available());
-
-    for (auto& [id, node] : nodes()) {
-        if (id == leader) {
-            node->on_dispatch(
-              [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
-        }
-    }
-
-    std::vector<ss::future<result<replicate_result>>> replicate_f;
-    replicate_f.reserve(num_waiters());
-    for (auto i = 0; i < num_waiters(); i++) {
-        replicate_f.push_back(raft->replicate(
-          make_batches({{"k", "v"}}),
-          replicate_options{raft::consistency_level::quorum_ack}));
-    }
-    auto results = co_await ss::when_all(
-      replicate_f.begin(), replicate_f.end());
-    for (auto& r : results) {
-        auto res = r.get();
-        ASSERT_TRUE_CORO(res.has_error());
-        ASSERT_EQ_CORO(res.error(), errc::replicated_entry_truncated);
-    }
-
-    co_await tests::cooperative_spin_wait_with_timeout(
-      2s, [&] { return all.available() && !all.failed(); });
-
-    auto result = all.get();
-    for (auto i = 0; i < num_waiters(); i++) {
-        ASSERT_EQ_CORO(result.at(i), errc::replicated_entry_truncated);
-    }
+    co_await test_with_leader(
+      60s, &monitor_test_fixture::truncation_detection_test);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -91,31 +91,20 @@ TEST_P_CORO(monitor_test_fixture, truncation_detection) {
 
     for (auto& [id, node] : nodes()) {
         if (id == leader) {
-            node->on_dispatch([](model::node_id, raft::msg_type mt) {
-                if (mt == raft::msg_type::append_entries) {
-                    throw std::runtime_error("dropping_append_entries");
-                }
-                return ss::now();
-            });
+            node->on_dispatch(
+              [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
         }
     }
 
-    std::vector<ss::future<>> enqueued;
-    std::vector<ss::future<result<raft::replicate_result>>> replicated;
-
+    std::vector<ss::future<result<replicate_result>>> replicate_f;
+    replicate_f.reserve(num_waiters());
     for (auto i = 0; i < num_waiters(); i++) {
-        auto stages = raft->replicate_in_stages(
+        replicate_f.push_back(raft->replicate(
           make_batches({{"k", "v"}}),
-          replicate_options{raft::consistency_level::quorum_ack});
-        enqueued.push_back(std::move(stages.request_enqueued));
-        replicated.push_back(std::move(stages.replicate_finished));
+          replicate_options{raft::consistency_level::quorum_ack}));
     }
-    auto enqueue_results = co_await ss::when_all(
-      enqueued.begin(), enqueued.end());
-    // block new leadership and step down
-    raft->block_new_leadership();
-    co_await raft->step_down(model::term_id(2), "test");
-    auto results = co_await ss::when_all(replicated.begin(), replicated.end());
+    auto results = co_await ss::when_all(
+      replicate_f.begin(), replicate_f.end());
     for (auto& r : results) {
         auto res = r.get();
         ASSERT_TRUE_CORO(res.has_error());


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/23398 