### PR TITLE
datalake: compress parquet files

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -527,16 +527,19 @@ redpanda_cc_library(
     hdrs = [
         "serde_parquet_writer.h",
     ],
-    include_prefix = "datalake",
-    visibility = [":__subpackages__"],
-    deps = [
+    implementation_deps = [
         ":logger",
         ":schema_parquet",
         ":values_parquet",
+        "//src/v/iceberg:values",
+        "//src/v/version",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
         ":writer",
         "//src/v/base",
         "//src/v/iceberg:datatypes",
-        "//src/v/iceberg:values",
         "//src/v/serde/parquet:writer",
         "@seastar",
     ],

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -4,6 +4,7 @@
 #include "datalake/logger.h"
 #include "datalake/schema_parquet.h"
 #include "datalake/values_parquet.h"
+#include "version/version.h"
 
 namespace datalake {
 
@@ -39,6 +40,8 @@ serde_parquet_writer_factory::create_writer(
   const iceberg::struct_type& schema, ss::output_stream<char> out) {
     serde::parquet::writer::options opts{
       .schema = schema_to_parquet(schema),
+      .version = ss::sstring(redpanda_git_version()),
+      .build = ss::sstring(redpanda_git_revision()),
       .compress = true,
     };
     serde::parquet::writer writer(std::move(opts), std::move(out));

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -37,7 +37,10 @@ ss::future<writer_error> serde_parquet_writer::finish() {
 ss::future<std::unique_ptr<parquet_ostream>>
 serde_parquet_writer_factory::create_writer(
   const iceberg::struct_type& schema, ss::output_stream<char> out) {
-    serde::parquet::writer::options opts{.schema = schema_to_parquet(schema)};
+    serde::parquet::writer::options opts{
+      .schema = schema_to_parquet(schema),
+      .compress = true,
+    };
     serde::parquet::writer writer(std::move(opts), std::move(out));
     co_await writer.init();
     co_return std::make_unique<serde_parquet_writer>(std::move(writer));


### PR DESCRIPTION
- **datalake: compress parquet files**
- **datalake: add version information to parquet files**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Generated parquet files for Iceberg Topics are now compressed with zstd compression.
