### PR TITLE
rm_stm: fix a race during partition shutdown

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -180,6 +180,7 @@ rm_stm::maybe_create_producer(model::producer_identity pid) {
             return std::make_pair(producer, producer_previously_known::yes);
         }
     }
+    vlog(_ctx_log.trace, "creating producer for pid: {}", pid);
     auto producer = ss::make_lw_shared<producer_state>(
       _ctx_log, pid, _raft->group(), [this](model::producer_identity pid) {
           cleanup_producer_state(pid);
@@ -238,6 +239,7 @@ void rm_stm::cleanup_producer_state(model::producer_identity pid) noexcept {
 };
 
 ss::future<> rm_stm::reset_producers() {
+    vlog(_ctx_log.trace, "reseting producers");
     // note: must always be called under exlusive write lock to
     // avoid concurrrent state changes to _producers.
     co_await ss::max_concurrent_for_each(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1676,6 +1676,7 @@ void rm_stm::apply_fence(model::producer_identity pid, model::record_batch b) {
 }
 
 ss::future<> rm_stm::do_apply(const model::record_batch& b) {
+    auto holder = _gate.hold();
     const auto& hdr = b.header();
     const auto bid = model::batch_identity::from(hdr);
 


### PR DESCRIPTION
Currently apply fiber can continue to run (and possibly add new producers to _producers map) as the state machine is shutting down.  This can manifest in weird crashes as the clean up destroys the _producers without deregistering properly.

First manifestation 

Iterator invalidation in reset_producers() as it loops thru _producers with scheduling points while state machine apply adds new producers

```
future<> rm_stm::stop() {
.....
    co_await _gate.close();
    co_await reset_producers();  <---- interferes with state machine apply 
    _metrics.clear();
    co_await raft::persisted_stm<>::stop();
```

Second manifestation

Crashes: every producer creation registers with an intrusive list in producer_state_manager using a safe link. Now, if a new producer is registered _after_ reset_producers, the map is destroyed in the state machine destructor without unlinking from the producer_state_manager and the safe_link fires an assert.

Note: since BOOST_ASSERT calls assert() which is a noop in release mode (with -NDEBUG), the crash stacks can be even weirder, they can be in producer_state_manager that tries to loop through the intrusive list (after the producers are cleaned up  incorrectly)

This bug has been there forever from what I can tell, perhaps gotten worse with recent changes that added more scheduling points.

https://redpandadata.atlassian.net/browse/CORE-8883
https://redpandadata.atlassian.net/browse/CORE-8843
https://redpandadata.atlassian.net/browse/CORE-8841
https://redpandadata.atlassian.net/browse/CORE-8845

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes

* Fixes a crash during partition shutdown. This can happen during partition moves (cross core/broker) or at broker shutdown.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
