### PR TITLE
`rptest`: add `nessie` catalog and smoke testing 

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -239,6 +239,13 @@ RUN /ocsf-server && rm /ocsf-server
 FROM base AS polaris
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/polaris /
 RUN /polaris && rm /polaris
+
+#################################
+
+FROM base AS nessie
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/nessie /
+RUN /nessie && rm /nessie
+
 #################################
 
 FROM base AS iceberg-rest
@@ -351,6 +358,7 @@ COPY --from=wasi-transforms /opt/transforms/ /opt/transforms/
 COPY --from=ocsf /opt/ocsf-schema/ /opt/ocsf-schema/
 COPY --from=ocsf /opt/ocsf-server/ /opt/ocsf-server/
 COPY --from=polaris /opt/polaris/ /opt/polaris/
+COPY --from=nessie /opt/nessie/ /opt/nessie/
 COPY --from=flink /opt/flink/ /opt/flink/
 COPY --from=iceberg-rest /opt/iceberg-rest-catalog /opt/iceberg-rest-catalog
 COPY --from=trino /opt/trino /opt/trino

--- a/tests/docker/ducktape-deps/nessie
+++ b/tests/docker/ducktape-deps/nessie
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+git -C /opt clone https://github.com/projectnessie/nessie
+cd /opt/nessie
+git reset --hard 25bd982ca37802123f328c066ddce517138779ef
+ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH)
+JAVA_HOME="/usr/lib/jvm/java-21-openjdk-${ARCH}" ./gradlew --no-daemon --info :nessie-quarkus:quarkusBuild
+mkdir -p deployments
+
+mv servers/quarkus-server/build/quarkus-app/lib/ deployments/lib/
+mv servers/quarkus-server/build/quarkus-app/*.jar deployments/
+mv servers/quarkus-server/build/quarkus-app/app/ deployments/app/
+mv servers/quarkus-server/build/quarkus-app/quarkus/ deployments/quarkus/

--- a/tests/java/spark-iceberg-dependencies/pom.xml
+++ b/tests/java/spark-iceberg-dependencies/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>iceberg-gcp-bundle</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.projectnessie.nessie-integrations</groupId>
+      <artifactId>nessie-spark-extensions-3.5_2.12</artifactId>
+      <version>0.102.2</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/tests/rptest/services/apache_iceberg_catalog.py
+++ b/tests/rptest/services/apache_iceberg_catalog.py
@@ -15,20 +15,17 @@ import jinja2
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
-from pyiceberg.catalog import load_catalog
 
 from rptest.context import cloud_storage
+from rptest.services.catalog_service import CatalogType, CatalogService
 
 
-class IcebergRESTCatalog(Service):
-    """A Iceberg REST service compatible with minio. This service is a thin REST wrapper over 
+class IcebergRESTCatalog(CatalogService):
+    """A Iceberg REST service compatible with minio. This service is a thin REST wrapper over
     a catalog IO implementation controlled via CATALOG_IO__IMPL. Out of the box, it defaults
     to org.apache.iceberg.jdbc.JdbcCatalog over a temporary sqlite db. It can also wrap over a
     S3 based (minio) implementaion by setting org.apache.iceberg.aws.s3.S3FileIO.
     """
-
-    # Available after start. Use catalog_url property to access.
-    _catalog_url: Optional[str] = None
 
     PERSISTENT_ROOT = "/var/lib/iceberg_rest/"
     LOG_FILE = os.path.join(PERSISTENT_ROOT, "iceberg_rest_server.log")
@@ -70,20 +67,15 @@ class IcebergRESTCatalog(Service):
 {{extra_config}}
 </configuration>""")
 
-    def __init__(
-            self,
-            ctx,
-            cloud_storage_bucket: str,
-            cloud_storage_catalog_prefix: str = 'redpanda-iceberg-catalog',
-            filesystem_wrapper_mode: bool = False,
-            node: ClusterNode | None = None):
-        super(IcebergRESTCatalog, self).__init__(ctx,
-                                                 num_nodes=0 if node else 1)
-        self.credentials = cloud_storage.Credentials.from_context(ctx)
+    def __init__(self,
+                 ctx,
+                 cloud_storage_bucket: str,
+                 warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME,
+                 filesystem_wrapper_mode: bool = False,
+                 node: ClusterNode | None = None):
+        super(IcebergRESTCatalog, self).__init__(ctx, cloud_storage_bucket,
+                                                 warehouse_name, node)
 
-        self.cloud_storage_bucket = cloud_storage_bucket
-        self.cloud_storage_catalog_prefix = cloud_storage_catalog_prefix
-        self.dedicated_nodes = ctx.globals.get("dedicated_nodes", False)
         self.set_filesystem_wrapper_mode(filesystem_wrapper_mode)
         # This REST server can operate in two modes.
         # 1. filesystem wrapper mode
@@ -99,10 +91,25 @@ class IcebergRESTCatalog(Service):
         #
         # Trino <-> REST server (HadoopCatalog) <-> S3
         # Trino <-> REST server (JDBC Catalog) <-> local sqllite DB.
-        self._catalog_url = None
         self.db_file = None
 
+    def catalog_name(self) -> str:
+        return self.catalog_type().value
+
+    def catalog_type(self) -> CatalogType:
+        if self.filesystem_wrapper_mode:
+            return CatalogType.REST_HADOOP
+        else:
+            return CatalogType.REST_JDBC
+
+    def set_filesystem_wrapper_mode(self, mode: bool):
+        self.filesystem_wrapper_mode = mode
+        self.compute_warehouse_path()
+
     def compute_warehouse_path(self):
+        """
+        Overridden to support Hadoop catalog case with `s3a` prefix.
+        """
         if isinstance(self.credentials,
                       cloud_storage.S3Credentials) or isinstance(
                           self.credentials,
@@ -111,20 +118,19 @@ class IcebergRESTCatalog(Service):
             if self.filesystem_wrapper_mode:
                 # For hadoop catalog compatibility
                 s3_prefix = "s3a"
-            self.cloud_storage_warehouse = f"{s3_prefix}://{self.cloud_storage_bucket}/{self.cloud_storage_catalog_prefix}"
+            self.cloud_storage_warehouse = f"{s3_prefix}://{self.cloud_storage_bucket}/{self.warehouse_name}"
         elif isinstance(self.credentials,
                         cloud_storage.GCPInstanceMetadataCredentials):
-            self.cloud_storage_warehouse = f"gs://{self.cloud_storage_bucket}/{self.cloud_storage_catalog_prefix}"
+            self.cloud_storage_warehouse = f"gs://{self.cloud_storage_bucket}/{self.warehouse_name}"
         elif isinstance(self.credentials,
                         cloud_storage.ABSSharedKeyCredentials):
-            self.cloud_storage_warehouse = f"abfss://{self.cloud_storage_bucket}@{self.credentials.endpoint}/{self.cloud_storage_catalog_prefix}"
+            self.cloud_storage_warehouse = f"abfss://{self.cloud_storage_bucket}@{self.credentials.endpoint}/{self.warehouse_name}"
         else:
             raise ValueError(
                 f"Unsupported credential type: {type(self.credentials)}")
 
-    def set_filesystem_wrapper_mode(self, mode: bool):
-        self.filesystem_wrapper_mode = mode
-        self.compute_warehouse_path()
+    def client(self, catalog_name: str = 'default'):
+        return self._client(catalog_name=catalog_name)
 
     def _make_env(self):
         env = dict()
@@ -169,35 +175,6 @@ class IcebergRESTCatalog(Service):
         env = " ".join(f"{k}={v}" for k, v in envs.items())
         return f"{env} {java} -jar  {IcebergRESTCatalog.JAR_PATH} \
             1>> {IcebergRESTCatalog.LOG_FILE} 2>> {IcebergRESTCatalog.LOG_FILE} &"
-
-    def client(self, catalog_name="default"):
-        conf = dict()
-        conf["uri"] = self.catalog_url
-
-        if isinstance(self.credentials, cloud_storage.S3Credentials):
-            conf["s3.endpoint"] = self.credentials.endpoint
-            conf["s3.access-key-id"] = self.credentials.access_key
-            conf["s3.secret-access-key"] = self.credentials.secret_key
-            conf["s3.region"] = self.credentials.region
-        elif isinstance(self.credentials,
-                        cloud_storage.AWSInstanceMetadataCredentials):
-            pass
-        elif isinstance(self.credentials,
-                        cloud_storage.GCPInstanceMetadataCredentials):
-            pass
-        elif isinstance(self.credentials,
-                        cloud_storage.ABSSharedKeyCredentials):
-            # Legancy pyiceberg https://github.com/apache/iceberg-python/issues/866
-            conf["adlfs.account-name"] = self.credentials.account_name
-            conf["adlfs.account-key"] = self.credentials.account_key
-            # Modern pyiceberg https://github.com/apache/iceberg-python/issues/866
-            conf["adls.account-name"] = self.credentials.account_name
-            conf["alds.account-key"] = self.credentials.account_key
-        else:
-            raise ValueError(
-                f"Unsupported credential type: {type(self.credentials)}")
-
-        return load_catalog(catalog_name, **conf)
 
     def start_node(self, node, timeout_sec=60, **kwargs):
         node.account.ssh("mkdir -p %s" % IcebergRESTCatalog.PERSISTENT_ROOT,
@@ -287,11 +264,6 @@ class IcebergRESTCatalog(Service):
         self.stop_node(node, allow_fail=True)
         node.account.remove(IcebergRESTCatalog.PERSISTENT_ROOT,
                             allow_fail=True)
-
-    @property
-    def catalog_url(self) -> str:
-        assert self._catalog_url, "URL not available because service is not started"
-        return self._catalog_url
 
     @staticmethod
     def dict_to_xml_properties(d: dict[str, Optional[str | bool]]):

--- a/tests/rptest/services/catalog_service.py
+++ b/tests/rptest/services/catalog_service.py
@@ -21,6 +21,7 @@ class CatalogType(str, Enum):
     REST_JDBC = 'rest_jdbc'
     REST_HADOOP = 'rest_hadoop'
     POLARIS = 'polaris'
+    NESSIE = 'nessie'
 
 
 def catalog_type_to_config_string(catalog_type: CatalogType) -> str:

--- a/tests/rptest/services/catalog_service.py
+++ b/tests/rptest/services/catalog_service.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.services.service import Service
+from ducktape.cluster.cluster import ClusterNode
+from rptest.context import cloud_storage
+
+from typing import Optional, Any
+from enum import Enum
+
+from pyiceberg.catalog import load_catalog
+
+
+class CatalogType(str, Enum):
+    REST_JDBC = 'rest_jdbc'
+    REST_HADOOP = 'rest_hadoop'
+    POLARIS = 'polaris'
+
+
+def catalog_type_to_config_string(catalog_type: CatalogType) -> str:
+    """
+    Query engines expect iceberg.catalog.type to be a configured property.
+    This value is dictated by the catalog and not the implementation,
+    which is why e.g. both JdbcCatalog and HadoopCatalog map to 'rest'.
+    """
+    if catalog_type in [CatalogType.REST_JDBC, CatalogType.REST_HADOOP]:
+        return 'rest'
+    elif catalog_type == CatalogType.POLARIS:
+        return 'polaris'
+    elif catalog_type == CatalogType.NESSIE:
+        return 'nessie'
+
+
+class CatalogService(Service):
+    # Expected to be available after initialization of derived class.
+    # Use catalog_url property to access.
+    _catalog_url: Optional[str] = None
+    DEFAULT_WAREHOUSE_NAME = 'redpanda-iceberg-catalog'
+
+    def __init__(self,
+                 ctx,
+                 cloud_storage_bucket: str,
+                 warehouse_name: str = DEFAULT_WAREHOUSE_NAME,
+                 node: ClusterNode | None = None):
+        super(CatalogService, self).__init__(ctx, num_nodes=0 if node else 1)
+        self.dedicated_nodes = ctx.globals.get("dedicated_nodes", False)
+        self.credentials = cloud_storage.Credentials.from_context(ctx)
+
+        self.cloud_storage_bucket = cloud_storage_bucket
+        self.warehouse_name = warehouse_name
+        self._catalog_url = None
+
+    @property
+    def catalog_url(self) -> str:
+        assert self._catalog_url, "URL not available because service is not started"
+        return self._catalog_url
+
+    def compute_warehouse_path(self):
+        """
+        Provides the physical location of the Iceberg warehouse in storage.
+        This function can be overridden in child classes of CatalogService
+        if needed for a specific catalog implementation.
+        """
+        if isinstance(self.credentials,
+                      cloud_storage.S3Credentials) or isinstance(
+                          self.credentials,
+                          cloud_storage.AWSInstanceMetadataCredentials):
+            s3_prefix = "s3"
+            self.cloud_storage_warehouse = f"{s3_prefix}://{self.cloud_storage_bucket}/{self.warehouse_name}"
+        elif isinstance(self.credentials,
+                        cloud_storage.GCPInstanceMetadataCredentials):
+            self.cloud_storage_warehouse = f"gs://{self.cloud_storage_bucket}/{self.warehouse_name}"
+        elif isinstance(self.credentials,
+                        cloud_storage.ABSSharedKeyCredentials):
+            self.cloud_storage_warehouse = f"abfss://{self.cloud_storage_bucket}@{self.credentials.endpoint}/{self.warehouse_name}"
+        else:
+            raise ValueError(
+                f"Unsupported credential type: {type(self.credentials)}")
+
+    def _client(self,
+                catalog_name: str = 'default',
+                catalog_url: Optional[str] = None):
+        if not catalog_url:
+            catalog_url = self.catalog_url
+
+        conf = dict()
+        conf["uri"] = catalog_url
+        conf["warehouse"] = self.cloud_storage_warehouse
+
+        if isinstance(self.credentials, cloud_storage.S3Credentials):
+            conf["s3.endpoint"] = self.credentials.endpoint
+            conf["s3.access-key-id"] = self.credentials.access_key
+            conf["s3.secret-access-key"] = self.credentials.secret_key
+            conf["s3.region"] = self.credentials.region
+        elif isinstance(self.credentials,
+                        cloud_storage.AWSInstanceMetadataCredentials):
+            pass
+        elif isinstance(self.credentials,
+                        cloud_storage.GCPInstanceMetadataCredentials):
+            pass
+        elif isinstance(self.credentials,
+                        cloud_storage.ABSSharedKeyCredentials):
+            # Legancy pyiceberg https://github.com/apache/iceberg-python/issues/866
+            conf["adlfs.account-name"] = self.credentials.account_name
+            conf["adlfs.account-key"] = self.credentials.account_key
+            # Modern pyiceberg https://github.com/apache/iceberg-python/issues/866
+            conf["adls.account-name"] = self.credentials.account_name
+            conf["alds.account-key"] = self.credentials.account_key
+        else:
+            raise ValueError(
+                f"Unsupported credential type: {type(self.credentials)}")
+
+        return load_catalog(catalog_name, **conf)

--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -1,0 +1,196 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import json
+import collections
+import re
+import time
+from typing import Optional, Any
+
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster import ClusterNode
+
+import requests
+
+from rptest.services.tls import TLSCertManager
+from rptest.services.catalog_service import CatalogType, CatalogService
+from rptest.context import cloud_storage
+
+
+class NessieCatalog(CatalogService):
+    """Nessie Catalog service
+
+    The nessie catalog service maintain lifecycle of catalog process on the nodes.
+    The service deploys nessie in a test mode with in-memory storage which is intended
+    to be used for dev/test purposes.
+    """
+    PERSISTENT_ROOT = "/var/lib/nessie"
+    INSTALL_PATH = "/opt/nessie"
+    JAR = "quarkus-run.jar"
+    JAR_PATH = f"/opt/nessie/deployments/{JAR}"
+    NESSIE_PORT = 19120
+    # Trino currently lacks SQL support for Nessie management:
+    # https://projectnessie.org/iceberg/trino/.
+    # Spark supports Nessie management via SQL, but uses the v1
+    # API at time of writing: https://projectnessie.org/iceberg/spark/
+    # Bump this API version to 'v2' when these catalog services better
+    # support it.
+    NESSIE_API_VERSION = "v1"
+
+    # This should be kept up to date with version set in docker/ducktape-deps
+    NESSIE_VERSION = "0.102.2"
+    NESSIE_DEFAULT_WAREHOUSE = 'main'
+
+    LOG_FILE = os.path.join(PERSISTENT_ROOT, "nessie.log")
+    logs = {
+        "nessie_logs": {
+            "path": LOG_FILE,
+            "collect_default": True
+        },
+    }
+
+    def __init__(self,
+                 ctx,
+                 cloud_storage_bucket: str,
+                 warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME,
+                 node: ClusterNode | None = None):
+        super(NessieCatalog, self).__init__(ctx, cloud_storage_bucket,
+                                            warehouse_name, node)
+
+        self._ctx = ctx
+        self._current_reference = "main"
+        self.compute_warehouse_path()
+
+    # The endpoint that directly accesses the iceberg catalog.
+    _iceberg_url: Optional[str] = None
+
+    @property
+    def iceberg_url(self) -> str:
+        assert self._iceberg_url, "URL not available because service is not started"
+        return self._iceberg_url
+
+    def catalog_name(self) -> str:
+        return self.catalog_type().value
+
+    def catalog_type(self) -> CatalogType:
+        return CatalogType.NESSIE
+
+    def client(self, catalog_name: str = 'default'):
+        return self._client(catalog_name=catalog_name,
+                            catalog_url=self._iceberg_url)
+
+    def _java_home(self, node):
+        return node.account.ssh_output(
+            "echo /usr/lib/jvm/java-21-openjdk-$(dpkg-architecture -q DEB_BUILD_ARCH)"
+        ).decode('utf-8').strip()
+
+    def _java_bin(self, node):
+        java_home = self._java_home(node)
+        return f"{java_home}/bin/java"
+
+    def _make_env(self):
+        env = dict()
+        env["NESSIE_CATALOG_DEFAULT_WAREHOUSE"] = NessieCatalog.NESSIE_DEFAULT_WAREHOUSE
+        env[f"NESSIE_CATALOG_WAREHOUSES_{NessieCatalog.NESSIE_DEFAULT_WAREHOUSE.upper()}_LOCATION"] = self.cloud_storage_warehouse
+
+        if isinstance(self.credentials, cloud_storage.S3Credentials):
+            env["NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_REGION"] = self.credentials.region
+            env["NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_ENDPOINT"] = self.credentials.endpoint
+            env["NESSIE_CATALOG_VALIDATE_SECRETS"] = "true"
+        elif isinstance(self.credentials,
+                        cloud_storage.ABSSharedKeyCredentials):
+            env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_AUTH_TYPE"] = "STORAGE_SHARED_KEY"
+            env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_ACCOUNT_NAME"] = self.credentials.account_name
+            env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_ACCOUNT_SECRET"] = self.credentials.account_key
+        return env
+
+    def _make_java_properties(self):
+        """
+        These options don't work nicely with conversion to env variable format.
+        Specify them as Java -D properties instead.
+        """
+        d_flags = ""
+        d_flags += "-Dnessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:my-secrets-default "
+        d_flags += f"-Dmy-secrets-default.name={self.credentials.access_key} "
+        d_flags += f"-Dmy-secrets-default.secret={self.credentials.secret_key} "
+        d_flags += "-Dnessie.catalog.validate-secrets=true"
+        return d_flags
+
+    def _java_cmd(self, node):
+        java_home = self._java_home(node)
+        java_bin = self._java_bin(node)
+        envs = self._make_env()
+        env = " ".join(f"{k}={v}" for k, v in envs.items())
+        d_props = self._make_java_properties()
+        return f"{env} JAVA_HOME={java_home} nohup {java_bin} {d_props} -jar {NessieCatalog.JAR_PATH} \
+        1>> {NessieCatalog.LOG_FILE} 2>> {NessieCatalog.LOG_FILE} & echo $!"
+
+    def _nessie_base_path(self, node):
+        return f"http://{node.account.hostname}:{NessieCatalog.NESSIE_PORT}"
+
+    def _http_request_path_from_node(self, node, endpoint):
+        return f"{self._nessie_base_path(node)}/api/{endpoint}"
+
+    def _nessie_iceberg_path(self, node):
+        return f"{self._nessie_base_path(node)}/iceberg"
+
+    def start_node(self, node, timeout_sec=60, **kwargs):
+        node.account.ssh("mkdir -p %s" % NessieCatalog.PERSISTENT_ROOT,
+                         allow_fail=False)
+
+        cmd = self._java_cmd(node)
+        self.logger.info(
+            f"Starting nessie catalog service on {node.name} with command {cmd}"
+        )
+
+        node.account.ssh(cmd, allow_fail=False)
+
+        # wait for the config endpoint to return 200
+        def _nessie_ready():
+            config_path = self._http_request_path_from_node(
+                node, f"{NessieCatalog.NESSIE_API_VERSION}/config")
+            self.logger.debug(f"Querying nessie healthcheck on {config_path}")
+            r = requests.get(config_path, timeout=10)
+
+            self.logger.info(
+                f"health check result status code: {r.status_code}")
+            return r.status_code == 200
+
+        wait_until(_nessie_ready,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=0.4,
+                   err_msg="Error waiting for nessie catalog to start",
+                   retry_on_exc=True)
+
+        self._iceberg_url = self._nessie_iceberg_path(node)
+        self._catalog_url = self._http_request_path_from_node(
+            node, NessieCatalog.NESSIE_API_VERSION)
+
+    def wait_node(self, node, timeout_sec=None):
+        ## unused as there is nothing to wait for here
+        return False
+
+    def stop_node(self, node, allow_fail=False, **_):
+        node.account.kill_java_processes(NessieCatalog.JAR,
+                                         allow_fail=allow_fail)
+
+        def _stopped():
+            out = node.account.ssh_output("jcmd").decode('utf-8')
+            return NessieCatalog.JAR not in out
+
+        wait_until(_stopped,
+                   timeout_sec=10,
+                   backoff_sec=1,
+                   err_msg="Error stopping Nessie")
+
+    def clean_node(self, node, **_):
+        self.stop_node(node, allow_fail=True)
+        node.account.remove(NessieCatalog.PERSISTENT_ROOT, allow_fail=True)

--- a/tests/rptest/services/spark_service.py
+++ b/tests/rptest/services/spark_service.py
@@ -15,6 +15,8 @@ from pyhive import hive
 
 from rptest.context import cloud_storage
 from rptest.tests.datalake.query_engine_base import QueryEngineBase, QueryEngineType
+from rptest.services.catalog_service import CatalogType
+from rptest.services.nessie_catalog import NessieCatalog
 
 
 class SparkService(Service, QueryEngineBase):
@@ -26,9 +28,17 @@ class SparkService(Service, QueryEngineBase):
 
     logs = {"spark_sql_logs": {"path": LOGS_DIR, "collect_default": True}}
 
-    def __init__(self, ctx, iceberg_catalog_rest_uri: str):
+    def __init__(self,
+                 ctx,
+                 iceberg_catalog_uri: str,
+                 default_warehouse_dir: str,
+                 catalog_type: CatalogType,
+                 catalog_name: str = 'spark-catalog'):
         super(SparkService, self).__init__(ctx, num_nodes=1)
-        self.iceberg_catalog_rest_uri = iceberg_catalog_rest_uri
+        self.iceberg_catalog_uri = iceberg_catalog_uri
+        self.default_warehouse_dir = default_warehouse_dir
+        self.catalog_type = catalog_type
+        self.catalog_name = catalog_name
 
         self.credentials = cloud_storage.Credentials.from_context(ctx)
         self.spark_host: Optional[SparkService] = None
@@ -57,48 +67,69 @@ class SparkService(Service, QueryEngineBase):
         return " ".join([f"{k}={v}" for k, v in env.items()])
 
     def start_cmd(self):
-        conf_args: dict[str, Optional[str | bool]] = {
+        conf_args: dict[str, Optional[str | bool]] = {}
+
+        conf_args.update({
             "spark.sql.extensions":
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
-            "spark.sql.defaultCatalog":
-            "redpanda-iceberg-catalog",
-            "spark.sql.catalog.redpanda-iceberg-catalog":
+            f"spark.sql.catalog.{self.catalog_name}":
             "org.apache.iceberg.spark.SparkCatalog",
-            "spark.sql.catalog.redpanda-iceberg-catalog.type":
-            "rest",
-            "spark.sql.catalog.redpanda-iceberg-catalog.cache-enabled":
+            f"spark.sql.catalog.{self.catalog_name}.cache-enabled":
             False,
-            "spark.sql.catalog.redpanda-iceberg-catalog.uri":
-            self.iceberg_catalog_rest_uri,
-        }
+            f"spark.sql.catalog.{self.catalog_name}.uri":
+            self.iceberg_catalog_uri,
+            "spark.sql.defaultCatalog":
+            f"{self.catalog_name}",
+        })
+
+        if self.catalog_type == CatalogType.NESSIE:
+            conf_args.update({
+                "spark.jars.packages":
+                f"org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1,org.projectnessie.nessie-integrations:nessie-spark-extensions-3.5_2.12:{NessieCatalog.NESSIE_VERSION}",
+                "spark.sql.extensions":
+                "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions",
+                f"spark.sql.catalog.{self.catalog_name}.catalog-impl":
+                "org.apache.iceberg.nessie.NessieCatalog",
+                f"spark.sql.catalog.{self.catalog_name}.ref":
+                "main",
+                f"spark.sql.catalog.{self.catalog_name}.authentication.type":
+                "NONE",
+                f"spark.sql.catalog.{self.catalog_name}.warehouse":
+                self.default_warehouse_dir,
+            })
+        else:
+            conf_args.update({
+                f"spark.sql.catalog.{self.catalog_name}.type":
+                "rest",
+            })
 
         if isinstance(self.credentials, cloud_storage.S3Credentials):
             conf_args.update({
-                "spark.sql.catalog.redpanda-iceberg-catalog.io-impl":
+                f"spark.sql.catalog.{self.catalog_name}.io-impl":
                 "org.apache.iceberg.aws.s3.S3FileIO",
-                "spark.sql.catalog.redpanda-iceberg-catalog.s3.endpoint":
+                f"spark.sql.catalog.{self.catalog_name}.s3.endpoint":
                 self.credentials.endpoint,
             })
         elif isinstance(self.credentials,
                         cloud_storage.AWSInstanceMetadataCredentials):
             conf_args.update({
-                "spark.sql.catalog.redpanda-iceberg-catalog.io-impl":
+                f"spark.sql.catalog.{self.catalog_name}.io-impl":
                 "org.apache.iceberg.aws.s3.S3FileIO",
             })
         elif isinstance(self.credentials,
                         cloud_storage.GCPInstanceMetadataCredentials):
             conf_args.update({
-                "spark.sql.catalog.redpanda-iceberg-catalog.io-impl":
+                f"spark.sql.catalog.{self.catalog_name}.io-impl":
                 "org.apache.iceberg.gcp.gcs.GCSFileIO",
             })
         elif isinstance(self.credentials,
                         cloud_storage.ABSSharedKeyCredentials):
             conf_args.update({
-                "spark.sql.catalog.redpanda-iceberg-catalog.io-impl":
+                f"spark.sql.catalog.{self.catalog_name}.io-impl":
                 "org.apache.iceberg.azure.adlsv2.ADLSFileIO",
-                "spark.sql.catalog.redpanda-iceberg-catalog.adls.auth.shared-key.account.name":
+                f"spark.sql.catalog.{self.catalog_name}.adls.auth.shared-key.account.name":
                 self.credentials.account_name,
-                "spark.sql.catalog.redpanda-iceberg-catalog.adls.auth.shared-key.account.key":
+                f"spark.sql.catalog.{self.catalog_name}.adls.auth.shared-key.account.key":
                 self.credentials.account_key,
             })
         else:
@@ -151,7 +182,9 @@ class SparkService(Service, QueryEngineBase):
 
     def make_client(self):
         assert self.spark_host
-        return hive.connect(host=self.spark_host, port=self.spark_port)
+        return hive.connect(host=self.spark_host,
+                            port=self.spark_port,
+                            database=self.catalog_name)
 
     @staticmethod
     def dict_to_conf_args(conf: dict[str, Optional[str | bool]]) -> str:

--- a/tests/rptest/services/trino_service.py
+++ b/tests/rptest/services/trino_service.py
@@ -18,6 +18,8 @@ from pyhive import trino
 from rptest.context import cloud_storage
 from rptest.services.spark_service import QueryEngineBase
 from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.services.catalog_service import CatalogType, catalog_type_to_config_string
+from rptest.services.nessie_catalog import NessieCatalog
 
 
 class TrinoService(Service, QueryEngineBase):
@@ -33,14 +35,24 @@ class TrinoService(Service, QueryEngineBase):
     REDPANDA_CATALOG_PATH = "/opt/trino/etc/catalog/redpanda.properties"
     REDPANDA_CATALOG_CONF = jinja2.Template("""
 connector.name=iceberg
-iceberg.catalog.type=rest
-iceberg.rest-catalog.uri={{ catalog_rest_uri }}
-{{extra_conf}}
+iceberg.catalog.type={{ catalog_type }}
+iceberg.{{ catalog_type }}-catalog.uri={{ catalog_uri }}
+{{cloud_storage_conf}}
+{{ extra_connector_conf }}
 """)
 
-    def __init__(self, ctx, iceberg_catalog_rest_uri: str):
+    def __init__(self,
+                 ctx,
+                 iceberg_catalog_uri: str,
+                 default_warehouse_dir: str,
+                 catalog_type: CatalogType,
+                 catalog_name: str = 'trino-catalog'):
         super(TrinoService, self).__init__(ctx, num_nodes=1)
-        self.iceberg_catalog_rest_uri = iceberg_catalog_rest_uri
+        self.iceberg_catalog_uri = iceberg_catalog_uri
+        self.default_warehouse_dir = default_warehouse_dir
+        self.catalog_type = catalog_type
+        self.catalog_name = catalog_name
+
         self.credentials = cloud_storage.Credentials.from_context(ctx)
         self.trino_host: Optional[str] = None
         self.trino_port = 8083
@@ -49,9 +61,9 @@ iceberg.rest-catalog.uri={{ catalog_rest_uri }}
         node.account.ssh(f"mkdir -p {TrinoService.PERSISTENT_ROOT}")
         node.account.ssh(f"rm -f {TrinoService.REDPANDA_CATALOG_PATH}")
 
-        extra_conf = ""
+        cloud_storage_conf = ""
         if isinstance(self.credentials, cloud_storage.S3Credentials):
-            extra_conf = self.dict_to_conf({
+            cloud_storage_conf = self.dict_to_conf({
                 "fs.native-s3.enabled":
                 True,
                 "s3.region":
@@ -67,13 +79,15 @@ iceberg.rest-catalog.uri={{ catalog_rest_uri }}
             })
         elif isinstance(self.credentials,
                         cloud_storage.AWSInstanceMetadataCredentials):
-            extra_conf = self.dict_to_conf({"fs.native-s3.enabled": True})
+            cloud_storage_conf = self.dict_to_conf(
+                {"fs.native-s3.enabled": True})
         elif isinstance(self.credentials,
                         cloud_storage.GCPInstanceMetadataCredentials):
-            extra_conf = self.dict_to_conf({"fs.native-gcs.enabled": True})
+            cloud_storage_conf = self.dict_to_conf(
+                {"fs.native-gcs.enabled": True})
         elif isinstance(self.credentials,
                         cloud_storage.ABSSharedKeyCredentials):
-            extra_conf = self.dict_to_conf({
+            cloud_storage_conf = self.dict_to_conf({
                 "fs.native-azure.enabled":
                 True,
                 "azure.auth-type":
@@ -85,8 +99,21 @@ iceberg.rest-catalog.uri={{ catalog_rest_uri }}
             raise NotImplementedError(
                 f"Unsupported cloud storage credentials: {self.credentials}")
 
-        connector_config = dict(catalog_rest_uri=self.iceberg_catalog_rest_uri,
-                                extra_conf=extra_conf)
+        extra_connector_conf = ""
+        if self.catalog_type == CatalogType.NESSIE:
+            # https://trino.io/docs/current/object-storage/metastores.html#nessie-catalog
+            extra_connector_conf = self.dict_to_conf({
+                f"iceberg.nessie-catalog.default-warehouse-dir":
+                self.default_warehouse_dir,
+                f"iceberg.nessie-catalog.client-api-version":
+                NessieCatalog.NESSIE_API_VERSION
+            })
+
+        connector_config = dict(catalog_uri=self.iceberg_catalog_uri,
+                                catalog_type=catalog_type_to_config_string(
+                                    self.catalog_type),
+                                cloud_storage_conf=cloud_storage_conf,
+                                extra_connector_conf=extra_connector_conf)
         config_str = TrinoService.REDPANDA_CATALOG_CONF.render(
             connector_config)
         self.logger.debug(f"Using connector config: {config_str}")

--- a/tests/rptest/tests/datalake/catalog_service_factory.py
+++ b/tests/rptest/tests/datalake/catalog_service_factory.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.catalog_service import CatalogType, CatalogService
+from rptest.services.nessie_catalog import NessieCatalog
+from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
+
+from typing import List
+
+# TODO: Nessie is not supported here yet. Add it back once
+# required datalake authentication changes have been made.
+SUPPORTED_CATALOG_TYPES = [CatalogType.REST_JDBC, CatalogType.REST_HADOOP]
+
+
+def filesystem_catalog_type() -> CatalogType:
+    return CatalogType.REST_HADOOP
+
+
+def supported_catalog_types() -> List[CatalogType]:
+    return SUPPORTED_CATALOG_TYPES
+
+
+def make_catalog_service_for_type(catalog_type: CatalogType, test_ctx,
+                                  cloud_storage_bucket: str,
+                                  warehouse_name: str) -> CatalogService:
+    if catalog_type not in SUPPORTED_CATALOG_TYPES:
+        raise NotImplementedError(f"No catalog of type {catalog_type}")
+    if catalog_type == CatalogType.REST_JDBC:
+        return IcebergRESTCatalog(test_ctx,
+                                  cloud_storage_bucket=cloud_storage_bucket,
+                                  warehouse_name=warehouse_name)
+    elif catalog_type == CatalogType.REST_HADOOP:
+        return IcebergRESTCatalog(test_ctx,
+                                  cloud_storage_bucket=cloud_storage_bucket,
+                                  warehouse_name=warehouse_name,
+                                  filesystem_wrapper_mode=True)

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -22,6 +22,7 @@ from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types
 
 
 class CompactionGapsTest(RedpandaTest):
@@ -113,12 +114,13 @@ class CompactionGapsTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     @skip_debug_mode
-    @matrix(cloud_storage_type=supported_storage_types())
-    def test_translation_no_gaps(self, cloud_storage_type):
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_translation_no_gaps(self, cloud_storage_type, catalog_type):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              include_query_engines=[QueryEngineType.TRINO
-                                                     ]) as dl:
+                              include_query_engines=[QueryEngineType.TRINO],
+                              catalog_type=catalog_type) as dl:
             self.do_test_no_gaps(dl)
 
 
@@ -234,12 +236,12 @@ class CompactionTest(RedpandaTest):
             self.verify_log_and_table(dl)
 
     @cluster(num_nodes=4)
-    #@skip_debug_mode
-    @matrix(cloud_storage_type=supported_storage_types())
-    def test_compaction(self, cloud_storage_type):
+    @skip_debug_mode
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_compaction(self, cloud_storage_type, catalog_type):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
-                              include_query_engines=[QueryEngineType.TRINO
-                                                     ]) as dl:
+                              include_query_engines=[QueryEngineType.TRINO],
+                              catalog_type=catalog_type) as dl:
             self.do_test_compaction(dl)

--- a/tests/rptest/tests/datalake/coordinator_retention_test.py
+++ b/tests/rptest/tests/datalake/coordinator_retention_test.py
@@ -90,6 +90,5 @@ class CoordinatorRetentionTest(RedpandaTest):
     def test_retention(self, cloud_storage_type):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[]) as dl:
             self.do_test_retention(dl)

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -25,6 +25,7 @@ from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types
 
 
 class DatalakeCustomPartitioningConfigTest(RedpandaTest):
@@ -127,11 +128,11 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[False, True])
-    def test_basic(self, cloud_storage_type, filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_basic(self, cloud_storage_type, catalog_type):
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=catalog_type,
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
             # Create an iceberg topic with a custom partition spec and produce

--- a/tests/rptest/tests/datalake/datalake_dlq_test.py
+++ b/tests/rptest/tests/datalake/datalake_dlq_test.py
@@ -27,6 +27,7 @@ from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type, supported_catalog_types
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import expect_exception
 
@@ -191,7 +192,7 @@ class DatalakeDLQTest(RedpandaTest):
         """
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")
@@ -221,7 +222,7 @@ class DatalakeDLQTest(RedpandaTest):
         """
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name,
                                             iceberg_mode="key_value")
@@ -236,10 +237,9 @@ class DatalakeDLQTest(RedpandaTest):
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
             query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
-            filesystem_catalog_mode=[True, False])
+            catalog_type=supported_catalog_types())
     def test_dlq_table_for_invalid_records(self, cloud_storage_type,
-                                           query_engine,
-                                           filesystem_catalog_mode):
+                                           query_engine, catalog_type):
         """
         Produce records with no schema to `value_schema_id_prefix` mode topic.
         These records will fail translate and should be written to DLQ table.
@@ -252,7 +252,7 @@ class DatalakeDLQTest(RedpandaTest):
 
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=catalog_type,
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")
@@ -301,10 +301,9 @@ class DatalakeDLQTest(RedpandaTest):
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
             query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
-            filesystem_catalog_mode=[True, False])
+            catalog_type=supported_catalog_types())
     def test_dlq_table_for_mixed_records(self, cloud_storage_type,
-                                         query_engine,
-                                         filesystem_catalog_mode):
+                                         query_engine, catalog_type):
         """
         Produce a mix of valid and invalid records to a `value_schema_id_prefix`
         mode topic. Valid records should be written to the main table and
@@ -316,7 +315,7 @@ class DatalakeDLQTest(RedpandaTest):
         """
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")
@@ -370,7 +369,7 @@ class DatalakeDLQTest(RedpandaTest):
 
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name,
@@ -420,7 +419,7 @@ class DatalakeDLQTest(RedpandaTest):
                                                   use_topic_property):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -19,9 +19,11 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types, filesystem_catalog_type
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.services.metrics_check import MetricCheck
+from rptest.services.catalog_service import CatalogType
 
 avro_schema_str = """
 {
@@ -60,32 +62,32 @@ class DatalakeE2ETests(RedpandaTest):
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
             query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
-            filesystem_catalog_mode=[False, True])
-    def test_e2e_basic(self, cloud_storage_type, query_engine,
-                       filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_e2e_basic(self, cloud_storage_type, query_engine, catalog_type):
         # Create a topic
         # Produce some events
         # Ensure they end up in datalake
         count = 100
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
-                              include_query_engines=[query_engine]) as dl:
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=10)
             dl.produce_to_topic(self.topic_name, 1024, count)
             dl.wait_for_translation(self.topic_name, msg_count=count)
 
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=supported_storage_types(),
-            query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO])
-    def test_avro_schema(self, cloud_storage_type, query_engine):
+            query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
+            catalog_type=supported_catalog_types())
+    def test_avro_schema(self, cloud_storage_type, query_engine, catalog_type):
         count = 100
         table_name = f"redpanda.{self.topic_name}"
 
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
-                              include_query_engines=[query_engine]) as dl:
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")
 
@@ -131,14 +133,15 @@ class DatalakeE2ETests(RedpandaTest):
                     spark_describe_out)
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=supported_storage_types())
-    def test_upload_after_external_update(self, cloud_storage_type):
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_upload_after_external_update(self, cloud_storage_type,
+                                          catalog_type):
         table_name = f"redpanda.{self.topic_name}"
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
-                              include_query_engines=[QueryEngineType.SPARK
-                                                     ]) as dl:
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=catalog_type) as dl:
             count = 100
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
             dl.produce_to_topic(self.topic_name, 1024, count)
@@ -161,7 +164,7 @@ class DatalakeE2ETests(RedpandaTest):
         table_name = f"redpanda.{self.topic_name}"
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
@@ -198,15 +201,13 @@ class DatalakeE2ETests(RedpandaTest):
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[True, False])
-    def test_topic_lifecycle(self, cloud_storage_type,
-                             filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_topic_lifecycle(self, cloud_storage_type, catalog_type):
         count = 100
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
-                              include_query_engines=[QueryEngineType.SPARK
-                                                     ]) as dl:
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=catalog_type) as dl:
             rpk = RpkTool(self.redpanda)
 
             # produce some data then delete the topic
@@ -252,9 +253,8 @@ class DatalakeE2ETests(RedpandaTest):
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[False, True])
-    def test_iceberg_files_location(self, cloud_storage_type,
-                                    filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_iceberg_files_location(self, cloud_storage_type, catalog_type):
         """
         Test that redpanda writes data files to the correct location
         as directed by the catalog.
@@ -262,7 +262,7 @@ class DatalakeE2ETests(RedpandaTest):
         count = 100
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=catalog_type,
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=2)
@@ -330,11 +330,10 @@ class DatalakeMetricsTest(RedpandaTest):
     @cluster(num_nodes=5)
     @matrix(cloud_storage_type=supported_storage_types())
     def test_lag_metrics(self, cloud_storage_type):
-
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
-                              include_query_engines=[]) as dl:
+                              include_query_engines=[],
+                              catalog_type=supported_catalog_types()[0]) as dl:
 
             # Stop the catalog to halt the translation flow
             dl.catalog_service.stop()

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from typing import Any
+from typing import Any, Tuple, Optional
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool, TopicSpec
@@ -19,6 +19,9 @@ from rptest.services.trino_service import TrinoService
 from rptest.tests.datalake.query_engine_base import QueryEngineBase, QueryEngineType
 from rptest.services.redpanda_connect import RedpandaConnectService
 from rptest.tests.datalake.query_engine_factory import get_query_engine_by_type
+from rptest.services.catalog_service import CatalogType, CatalogService
+from rptest.services.nessie_catalog import NessieCatalog
+from rptest.tests.datalake.catalog_service_factory import make_catalog_service_for_type
 
 
 class DatalakeServices():
@@ -27,18 +30,22 @@ class DatalakeServices():
     def __init__(self,
                  test_ctx,
                  redpanda: RedpandaService,
-                 filesystem_catalog_mode=True,
                  include_query_engines: list[QueryEngineType] = [
                      QueryEngineType.SPARK, QueryEngineType.TRINO
-                 ]):
+                 ],
+                 catalog_type: CatalogType = CatalogType.REST_JDBC,
+                 warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME):
         self.test_ctx = test_ctx
         self.redpanda = redpanda
         si_settings = self.redpanda.si_settings
         assert si_settings
-        self.catalog_service = IcebergRESTCatalog(
-            test_ctx,
+
+        self.warehouse_name = warehouse_name
+        self.catalog_service = make_catalog_service_for_type(
+            catalog_type=catalog_type,
+            test_ctx=test_ctx,
             cloud_storage_bucket=si_settings.cloud_storage_bucket,
-            filesystem_wrapper_mode=filesystem_catalog_mode)
+            warehouse_name=warehouse_name)
         self.included_query_engines = include_query_engines
         # To be populated later once we have the URI of the catalog
         # available
@@ -53,7 +60,7 @@ class DatalakeServices():
 
         self.catalog_service.start()
 
-        if not self.catalog_service.filesystem_wrapper_mode:
+        if not self.catalog_service.catalog_type() == CatalogType.REST_HADOOP:
             # REST catalog mode
             self.redpanda.add_extra_rp_conf({
                 "iceberg_catalog_type":
@@ -65,11 +72,20 @@ class DatalakeServices():
                 "iceberg_rest_catalog_client_secret":
                 "panda-secret",
             })
+        if self.catalog_service.catalog_type() == CatalogType.NESSIE:
+            self.redpanda.add_extra_rp_conf({
+                "iceberg_rest_catalog_prefix":
+                NessieCatalog.NESSIE_DEFAULT_WAREHOUSE
+            })
         self.redpanda.start(start_si=False)
 
         for engine in self.included_query_engines:
             svc_cls = get_query_engine_by_type(engine)
-            svc = svc_cls(self.test_ctx, self.catalog_service.catalog_url)
+            svc = svc_cls(self.test_ctx,
+                          iceberg_catalog_uri=self.catalog_service.catalog_url,
+                          default_warehouse_dir=self.catalog_service.
+                          cloud_storage_warehouse,
+                          catalog_type=self.catalog_service.catalog_type())
             svc.start()
             self.query_engines.append(svc)
 
@@ -156,7 +172,7 @@ class DatalakeServices():
         rpk.alter_topic_config(topic, "redpanda.iceberg.mode", mode)
 
     def catalog_client(self):
-        return self.catalog_service.client("redpanda-iceberg-catalog")
+        return self.catalog_service.client(self.warehouse_name)
 
     def table_exists(self, table, namespace="redpanda", client=None):
         if client is None:

--- a/tests/rptest/tests/datalake/datalake_upgrade_test.py
+++ b/tests/rptest/tests/datalake/datalake_upgrade_test.py
@@ -15,6 +15,7 @@ from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from ducktape.mark import matrix
+from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
 
 
 class DatalakeUpgradeTest(RedpandaTest):
@@ -51,7 +52,7 @@ class DatalakeUpgradeTest(RedpandaTest):
         versions = self.load_version_range(self.initial_version)[1:]
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
+                              catalog_type=filesystem_catalog_type(),
                               include_query_engines=[query_engine]) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=10)
 

--- a/tests/rptest/tests/datalake/datalake_verifier_test.py
+++ b/tests/rptest/tests/datalake/datalake_verifier_test.py
@@ -59,7 +59,6 @@ class DatalakeVerifierTest(RedpandaTest):
         topic_name = "ducky_topic"
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[QueryEngineType.TRINO
                                                      ]) as dl:
             self._prepare_test_data(topic_name, dl)
@@ -81,7 +80,6 @@ class DatalakeVerifierTest(RedpandaTest):
         topic_name = "ducky_topic"
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[QueryEngineType.TRINO
                                                      ]) as dl:
             self._prepare_test_data(topic_name, dl)

--- a/tests/rptest/tests/datalake/iceberg_rest_catalog_smoke_test.py
+++ b/tests/rptest/tests/datalake/iceberg_rest_catalog_smoke_test.py
@@ -7,7 +7,11 @@ from pyiceberg.types import (
     TimestampType,
     FloatType,
     DoubleType,
+    IntegerType,
+    LongType,
     StringType,
+    BinaryType,
+    ListType,
     NestedField,
     StructType,
 )
@@ -76,3 +80,67 @@ class IcebergRESTCatalogSmokeTest(IcebergRESTCatalogTest):
         self.logger.info(f">>> {table}")
 
         assert "bids" in [t[1] for t in catalog.list_tables(namespace)]
+
+    @cluster(num_nodes=2)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            filesystem_catalog_mode=[True, False])
+    def test_redpanda_schema(self, cloud_storage_type,
+                             filesystem_catalog_mode):
+        self.catalog_service.set_filesystem_wrapper_mode(
+            filesystem_catalog_mode)
+        super().setUp()
+
+        warehouse = self.catalog_service.cloud_storage_warehouse
+        catalog = self.catalog_service.client()
+        namespace = "test_ns"
+        catalog.create_namespace(namespace)
+        catalog.list_tables(namespace)
+
+        headers_kv = StructType(
+            NestedField(field_id=7,
+                        name="key",
+                        field_type=BinaryType(),
+                        required=False),
+            NestedField(field_id=8,
+                        name="value",
+                        field_type=BinaryType(),
+                        required=False))
+
+        system_fields = StructType(
+            NestedField(field_id=2,
+                        name="partition",
+                        field_type=IntegerType(),
+                        required=True),
+            NestedField(field_id=3,
+                        name="offset",
+                        field_type=LongType(),
+                        required=True),
+            NestedField(field_id=4,
+                        name="timestamp",
+                        field_type=TimestampType(),
+                        required=True),
+            NestedField(field_id=5,
+                        name="headers",
+                        field_type=ListType(element_id=6,
+                                            element=headers_kv,
+                                            element_required=True),
+                        required=False),
+            NestedField(field_id=9,
+                        name="key",
+                        field_type=BinaryType(),
+                        required=False))
+
+        schema = Schema(
+            NestedField(field_id=1,
+                        name="test_schema",
+                        field_type=system_fields,
+                        required=True))
+        partition_spec = PartitionSpec(
+            PartitionField(source_id=4,
+                           field_id=1000,
+                           transform=DayTransform(),
+                           name="datetime_day"))
+        table = catalog.create_table(identifier=f"{namespace}.key",
+                                     schema=schema,
+                                     partition_spec=partition_spec)
+        self.logger.info(f">>> {table}")

--- a/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
+++ b/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
@@ -1,0 +1,268 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.services.nessie_catalog import NessieCatalog
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
+from rptest.services.trino_service import TrinoService
+from rptest.services.spark_service import SparkService
+from rptest.tests.datalake.utils import supported_storage_types
+
+from ducktape.mark import matrix
+import pynessie
+
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    TimestampType,
+    FloatType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    StringType,
+    BinaryType,
+    ListType,
+    NestedField,
+    StructType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import DayTransform
+
+
+class NessieCatalogSmokeTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        self.test_ctx = test_ctx
+        si_settings = SISettings(test_context=test_ctx)
+        super(NessieCatalogSmokeTest, self).__init__(test_ctx,
+                                                     si_settings=si_settings,
+                                                     *args,
+                                                     **kwargs)
+        self.catalog_service = NessieCatalog(
+            test_ctx, cloud_storage_bucket=si_settings.cloud_storage_bucket)
+
+    def setUp(self):
+        self.catalog_service.start()
+        return super().setUp()
+
+    def tearDown(self):
+        self.catalog_service.stop()
+        return super().tearDown()
+
+    @cluster(num_nodes=5)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_nessie_with_trino(self, cloud_storage_type):
+        """
+        Trino currently doesn't support Nessie management through SQL.
+        For that reason, pynessie is used here. Pynessie is considered
+        deprecated in favour of the CLI, so its use here should also be
+        limited/eventually replaced. Unfortunately, Trino also doesn't
+        support switching branches (references) without modifying the
+        catalog property iceberg.nessie-catalog.ref, which requires a
+        change to the redpanda.properties file and a restart.
+        """
+        self.trino = TrinoService(self.test_ctx,
+                                  self.catalog_service.catalog_url,
+                                  self.catalog_service.cloud_storage_warehouse,
+                                  self.catalog_service.catalog_type())
+        self.trino.start()
+        client = self.trino.make_client()
+
+        nessie_client_conf = {"endpoint": self.catalog_service.catalog_url}
+        nessie_client = pynessie.init(config_dict=nessie_client_conf)
+        try:
+            cursor = client.cursor()
+            try:
+                cursor.execute("CREATE SCHEMA redpanda")
+                cursor.fetchall()
+                cursor.execute(
+                    "CREATE TABLE redpanda.test (year INTEGER NOT NULL, name VARCHAR NOT NULL, age INTEGER, address VARCHAR)"
+                )
+                cursor.fetchall()
+
+                cursor.execute(
+                    "INSERT into redpanda.test values(2024, 'John', 60, 'Wick')"
+                )
+                cursor.fetchall()
+
+                cursor.execute(f"SELECT * from redpanda.test")
+                row = cursor.fetchall()
+                assert len(row) == 1
+                assert row == [(2024, 'John', 60, 'Wick')]
+
+                main_branch = "main"
+                dev_branch = "dev"
+
+                main_branch_ref = nessie_client.get_reference(None)
+                nessie_client.create_branch(dev_branch, main_branch,
+                                            main_branch_ref.hash_)
+                refs = nessie_client.list_references()
+                assert len(refs.references) == 2
+
+            finally:
+                cursor.close()
+        finally:
+            client.close()
+            self.trino.stop()
+
+    @cluster(num_nodes=5)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_nessie_with_spark(self, cloud_storage_type):
+        self.spark = SparkService(self.test_ctx,
+                                  self.catalog_service.catalog_url,
+                                  self.catalog_service.cloud_storage_warehouse,
+                                  self.catalog_service.catalog_type())
+        self.spark.start()
+        client = self.spark.make_client()
+        try:
+            cursor = client.cursor()
+            try:
+                cursor.execute(
+                    "CREATE SCHEMA IF NOT EXISTS `spark-catalog`.redpanda")
+                cursor.execute(
+                    "CREATE TABLE IF NOT EXISTS `spark-catalog`.redpanda.test(id bigint, data string) USING iceberg"
+                )
+                cursor.execute(
+                    "INSERT INTO `spark-catalog`.redpanda.test VALUES (1, 'Alice'), (2, 'Bob')"
+                )
+
+                main_branch = "main"
+                dev_branch = "dev"
+
+                cursor.execute(f"CREATE BRANCH IF NOT EXISTS {dev_branch}")
+
+                cursor.execute(
+                    f"INSERT INTO `spark-catalog`.redpanda.`test@{dev_branch}` VALUES (3, 'Carol'), (4, 'Doris')"
+                )
+
+                cursor.execute(
+                    f"SELECT * from `spark-catalog`.redpanda.`test@{dev_branch}` ORDER BY id"
+                )
+                row = cursor.fetchall()
+                assert len(row) == 4
+                assert row == [(1, 'Alice'), (2, 'Bob'), (3, 'Carol'),
+                               (4, 'Doris')]
+
+                cursor.execute(
+                    f"SELECT * from `spark-catalog`.redpanda.`test@{main_branch}` ORDER BY id"
+                )
+                row = cursor.fetchall()
+                assert len(row) == 2
+                assert row == [(1, 'Alice'), (2, 'Bob')]
+
+            finally:
+                cursor.close()
+        finally:
+            client.close()
+            self.spark.stop()
+
+    @cluster(num_nodes=2)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_basic(self, cloud_storage_type):
+        warehouse = self.catalog_service.cloud_storage_warehouse
+        catalog = self.catalog_service.client()
+        namespace = "test_ns"
+        catalog.create_namespace(namespace)
+        catalog.list_tables(namespace)
+        schema = Schema(
+            NestedField(field_id=1,
+                        name="datetime",
+                        field_type=TimestampType(),
+                        required=True),
+            NestedField(field_id=2,
+                        name="symbol",
+                        field_type=StringType(),
+                        required=True),
+            NestedField(field_id=3,
+                        name="bid",
+                        field_type=FloatType(),
+                        required=False),
+            NestedField(field_id=4,
+                        name="ask",
+                        field_type=DoubleType(),
+                        required=False),
+            NestedField(
+                field_id=5,
+                name="details",
+                field_type=StructType(
+                    NestedField(field_id=4,
+                                name="created_by",
+                                field_type=StringType(),
+                                required=False), ),
+                required=False,
+            ),
+        )
+        partition_spec = PartitionSpec(
+            PartitionField(source_id=1,
+                           field_id=1000,
+                           transform=DayTransform(),
+                           name="datetime_day"))
+        table = catalog.create_table(identifier=f"{namespace}.bids",
+                                     schema=schema,
+                                     partition_spec=partition_spec)
+        self.logger.info(f">>> {table}")
+
+        assert "bids" in [t[1] for t in catalog.list_tables(namespace)]
+
+    @cluster(num_nodes=2)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_redpanda_schema(self, cloud_storage_type):
+        warehouse = self.catalog_service.cloud_storage_warehouse
+        catalog = self.catalog_service.client()
+        namespace = "test_ns"
+        catalog.create_namespace(namespace)
+        catalog.list_tables(namespace)
+
+        headers_kv = StructType(
+            NestedField(field_id=7,
+                        name="key",
+                        field_type=BinaryType(),
+                        required=False),
+            NestedField(field_id=8,
+                        name="value",
+                        field_type=BinaryType(),
+                        required=False))
+
+        system_fields = StructType(
+            NestedField(field_id=2,
+                        name="partition",
+                        field_type=IntegerType(),
+                        required=True),
+            NestedField(field_id=3,
+                        name="offset",
+                        field_type=LongType(),
+                        required=True),
+            NestedField(field_id=4,
+                        name="timestamp",
+                        field_type=TimestampType(),
+                        required=True),
+            NestedField(field_id=5,
+                        name="headers",
+                        field_type=ListType(element_id=6,
+                                            element=headers_kv,
+                                            element_required=True),
+                        required=False),
+            NestedField(field_id=9,
+                        name="key",
+                        field_type=BinaryType(),
+                        required=False))
+
+        schema = Schema(
+            NestedField(field_id=1,
+                        name="test_schema",
+                        field_type=system_fields,
+                        required=True))
+        partition_spec = PartitionSpec(
+            PartitionField(source_id=4,
+                           field_id=1000,
+                           transform=DayTransform(),
+                           name="datetime_day"))
+        table = catalog.create_table(identifier=f"{namespace}.key",
+                                     schema=schema,
+                                     partition_spec=partition_spec)
+        self.logger.info(f">>> {table}")

--- a/tests/rptest/tests/datalake/partition_movement_test.py
+++ b/tests/rptest/tests/datalake/partition_movement_test.py
@@ -55,7 +55,6 @@ class PartitionMovementTest(PartitionMovementMixin, RedpandaTest):
 
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[QueryEngineType.TRINO
                                                      ]) as dl:
             dl.create_iceberg_enabled_topic(topic)

--- a/tests/rptest/tests/datalake/recovery_mode_test.py
+++ b/tests/rptest/tests/datalake/recovery_mode_test.py
@@ -22,6 +22,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types
 
 
 class DatalakeRecoveryModeTest(RedpandaTest):
@@ -43,11 +44,11 @@ class DatalakeRecoveryModeTest(RedpandaTest):
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[True, False])
-    def test_recovery_mode(self, cloud_storage_type, filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_recovery_mode(self, cloud_storage_type, catalog_type):
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=catalog_type,
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
             count = 1000
@@ -90,12 +91,11 @@ class DatalakeRecoveryModeTest(RedpandaTest):
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
-            filesystem_catalog_mode=[True, False])
-    def test_disabled_partitions(self, cloud_storage_type,
-                                 filesystem_catalog_mode):
+            catalog_type=supported_catalog_types())
+    def test_disabled_partitions(self, cloud_storage_type, catalog_type):
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=filesystem_catalog_mode,
+                              catalog_type=catalog_type,
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
 

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -24,6 +24,7 @@ from rptest.services.redpanda_connect import RedpandaConnectService
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.util import expect_exception
@@ -393,8 +394,10 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                        compat_level: str = "NONE"):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=True,
-                              include_query_engines=[query_engine]) as dl:
+                              catalog_type=filesystem_catalog_type(),
+                              include_query_engines=[
+                                  query_engine,
+                              ]) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name,
                 iceberg_mode="value_schema_id_prefix",

--- a/tests/rptest/tests/datalake/simple_connect_test.py
+++ b/tests/rptest/tests/datalake/simple_connect_test.py
@@ -123,7 +123,6 @@ class RedpandaConnectIcebergTest(RedpandaTest, DataMigrationTestMixin):
                                                  scenario):
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[
                                   QueryEngineType.SPARK,
                               ]) as datalake:

--- a/tests/rptest/tests/datalake/spark_sql_server_smoke_test.py
+++ b/tests/rptest/tests/datalake/spark_sql_server_smoke_test.py
@@ -30,7 +30,9 @@ class SparkSmokeTest(IcebergRESTCatalogTest):
     def setUp(self):
         super().setUp()
         self.spark = SparkService(self.test_ctx,
-                                  self.catalog_service.catalog_url)
+                                  self.catalog_service.catalog_url,
+                                  self.catalog_service.cloud_storage_warehouse,
+                                  self.catalog_service.catalog_type())
         self.spark.start()
 
     def tearDown(self):

--- a/tests/rptest/tests/datalake/transactions_test.py
+++ b/tests/rptest/tests/datalake/transactions_test.py
@@ -75,7 +75,6 @@ class DatalakeTransactionTests(RedpandaTest):
         min_num_records = 1000
         with DatalakeServices(self.test_context,
                               redpanda=self.redpanda,
-                              filesystem_catalog_mode=False,
                               include_query_engines=[QueryEngineType.TRINO
                                                      ]) as dl:
             topic_config = dict()

--- a/tests/rptest/tests/datalake/trino_smoke_test.py
+++ b/tests/rptest/tests/datalake/trino_smoke_test.py
@@ -28,7 +28,9 @@ class TrinoSmokeTest(IcebergRESTCatalogTest):
     def setUp(self):
         super().setUp()
         self.trino = TrinoService(self.test_ctx,
-                                  self.catalog_service.catalog_url)
+                                  self.catalog_service.catalog_url,
+                                  self.catalog_service.cloud_storage_warehouse,
+                                  self.catalog_service.catalog_type())
         self.trino.start()
 
     def tearDown(self):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -54,6 +54,7 @@ setup(
         "thrift==0.21.0",
         "thrift-sasl==0.4.3",
         "pyhive==0.7.0",
+        "pynessie",
     ],
     scripts=[],
 )


### PR DESCRIPTION
This PR adds the [`nessie`](https://projectnessie.org/) catalog as a ducktape dependency, wires it up as a ducktape service, and makes other changes to the Iceberg catalog service layer in ducktape.

Some notable changes:

* The addition of the `NessieCatalog` service.
* The addition of a `CatalogService` base class from which `IcebergRESTCatalog` and `NessieCatalog` now inherit
* Support for `nessie` configuration in the `SparkService` and `TrinoService` query engine classes
* Addition of the `CatalogType` enum, which specifies the catalog implementation to be used (Currently `rest_jdbc`, `rest_hadoop`).
* The addition of `catalog_service_factory.py`, which specifies valid catalog types. This also marks the removal of `filesystem_wrapper_mode` in place of parameterization via `supported_catalog_types()`.

This PR does NOT contain any integration tests between `nessie` and `redpanda`, as there are required changes to how we perform Iceberg authentication that must be made before we can perform this testing. The reason for this is that `nessie` [does not implement the deprecated `/v1/oauth/tokens` endpoint](https://github.com/apache/iceberg/blob/2fa6cd855b4e43b383df7b72776eb554b60d8c06/open-api/rest-catalog-open-api.yaml#L184-L185), which we currently [use by default for obtaining a valid bearer token](https://github.com/redpanda-data/redpanda/blob/73e5de9b9751585c3709053576fdd9d10a9be82a/src/v/iceberg/rest_client/catalog_client.cc#L106-L110) in our HTTP requests [made to the catalog](https://github.com/redpanda-data/redpanda/blob/73e5de9b9751585c3709053576fdd9d10a9be82a/src/v/iceberg/rest_client/catalog_client.cc#L310-L317).

There will be 2 more follow up PRs after this one:

1. Changes to Iceberg Authentication per the outcome of the RFC document written
2. Parameterized ducktape testing for `datalake` related tests/`redpanda` integration tests with the `nessie` catalog.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
