### PR TITLE
[v24.3.x] storage: always schedule adjacent segment compaction

### DIFF
--- a/src/v/model/offset_interval.h
+++ b/src/v/model/offset_interval.h
@@ -27,10 +27,19 @@ public:
     unchecked(model::offset min, model::offset max) noexcept {
         return {min, max};
     }
-
+    // Returns std::nullopt if the range is invalid (e.g. invalid start,
+    // invalid end, or end > start).
+    static std::optional<bounded_offset_interval>
+    optional(model::offset min, model::offset max) {
+        if (min < model::offset(0) || max < model::offset(0) || min > max) {
+            return std::nullopt;
+        }
+        return unchecked(min, max);
+    }
     static bounded_offset_interval
     checked(model::offset min, model::offset max) {
-        if (min < model::offset(0) || max < model::offset(0) || min > max) {
+        auto ret = optional(min, max);
+        if (!ret.has_value()) {
             throw std::invalid_argument(fmt::format(
               "Invalid arguments for constructing a non-empty bounded offset "
               "interval: min({}) <= max({})",
@@ -38,7 +47,7 @@ public:
               max));
         }
 
-        return {min, max};
+        return ret.value();
     }
 
     inline bool overlaps(const bounded_offset_interval& other) const noexcept {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1316,11 +1316,13 @@ ss::future<> disk_log_impl::do_compact(
         std::rethrow_exception(eptr);
     }
     bool compacted = did_compact_fut.get();
-    if (!compacted) {
-        // If sliding window compaction did not occur, we fall back to adjacent
-        // segment compaction.
-        co_await compact_adjacent_segments(compact_cfg);
-    }
+    vlog(
+      gclog.debug,
+      "Sliding compaction of {} did {}compact data, proceeding to adjacent "
+      "segment compaction",
+      config().ntp(),
+      compacted ? "" : "not ");
+    co_await compact_adjacent_segments(compact_cfg);
 }
 
 ss::future<> disk_log_impl::gc(gc_config cfg) {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4907,6 +4907,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
         BOOST_REQUIRE(result->on_disk_size >= target_size);
     }
 
+    info("Prefix truncating");
     auto new_start_offset = model::next_offset(first_segment_last_offset);
     log
       ->truncate_prefix(storage::truncate_prefix_config(
@@ -4918,6 +4919,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
 
     // Check that out of range access triggers exception.
 
+    info("Checking for null on out-of-range");
     BOOST_REQUIRE(
       log
         ->offset_range_size(
@@ -4959,6 +4961,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
         .get()
       == std::nullopt);
 
+    info("Checking the last batch");
     // Check that the last batch can be measured independently
     auto res = log
                  ->offset_range_size(
@@ -4980,6 +4983,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
     size_t tail_length = 5;
 
     for (size_t i = 0; i < tail_length; i++) {
+        info("Checking i = {}", i);
         auto ix_batch = c_summaries.size() - 1 - i;
         res = log
                 ->offset_range_size(
@@ -4997,6 +5001,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
     }
 
     // Check that the min_size is respected
+    info("Checking the back segment");
     BOOST_REQUIRE(
       log
         ->offset_range_size(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24874

Also pulls in https://github.com/redpanda-data/redpanda/pull/24880 which is a dependency of this change