### PR TITLE
CORE-8685 crash_tracker: crash signal handlers for crash recording

### DIFF
--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_library(
         "prepared_writer.cc",
         "recorder.cc",
         "service.cc",
+        "signals.cc",
         "types.cc",
     ],
     hdrs = [
@@ -16,6 +17,7 @@ redpanda_cc_library(
         "prepared_writer.h",
         "recorder.h",
         "service.h",
+        "signals.h",
         "types.h",
     ],
     implementation_deps = [

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     prepared_writer.cc
     recorder.cc
     service.cc
+    signals.cc
     types.cc
   DEPS
     Seastar::seastar

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <string_view>
 
 using namespace std::chrono_literals;
 
@@ -127,7 +128,50 @@ void print_skipping() {
     ss::print_safe(skipping.data(), skipping.size());
 }
 
+void record_message(crash_description& cd, std::string_view msg) {
+    auto& format_buf = cd.crash_message;
+    fmt::format_to_n(
+      format_buf.begin(),
+      format_buf.capacity(),
+      "{} on shard {}.",
+      msg,
+      ss::this_shard_id());
+}
+
 } // namespace
+
+/// Async-signal safe
+void recorder::record_crash_sighandler(recorded_signo signo) {
+    auto* cd_opt = _writer.fill();
+    if (!cd_opt) {
+        // The writer has already been consumed by another crash
+        print_skipping();
+        return;
+    }
+    auto& cd = *cd_opt;
+
+    record_backtrace(cd);
+
+    switch (signo) {
+    case recorded_signo::sigsegv: {
+        cd.type = crash_type::segfault;
+        record_message(cd, "Segmentation fault");
+        break;
+    }
+    case recorded_signo::sigabrt: {
+        cd.type = crash_type::abort;
+        record_message(cd, "Aborting");
+        break;
+    }
+    case recorded_signo::sigill: {
+        cd.type = crash_type::illegal_instruction;
+        record_message(cd, "Illegal instruction");
+        break;
+    }
+    }
+
+    _writer.write();
+}
 
 void recorder::record_crash_exception(std::exception_ptr eptr) {
     if (is_crash_loop_limit_reached(eptr)) {

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -41,6 +41,8 @@ public:
     using include_malformed_files
       = ss::bool_class<struct include_malformed_files_tag>;
 
+    enum class recorded_signo { sigsegv, sigabrt, sigill };
+
     /// Visible for testing
     ~recorder() = default;
 
@@ -48,7 +50,7 @@ public:
     ss::future<> stop();
 
     /// Async-signal safe
-    void record_crash_sighandler(int signo);
+    void record_crash_sighandler(recorded_signo signo);
 
     void record_crash_exception(std::exception_ptr eptr);
 

--- a/src/v/crash_tracker/signals.cc
+++ b/src/v/crash_tracker/signals.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "crash_tracker/recorder.h"
+
+#include <seastar/util/print_safe.hh>
+
+#include <atomic>
+
+namespace crash_tracker {
+
+namespace {
+
+// Installs handler for Signal which ensures that Func is invoked only once
+// in the whole program. After Func is invoked, the previously-installed signal
+// handler is restored and triggered.
+template<int Signal, void (*Func)()>
+void install_oneshot_signal_handler() {
+    static ss::util::spinlock lock{};
+
+    // Capture the original (seastar's or SIG_DFL) signal handler so we can
+    // run it after redpanda's signal handler
+    static struct sigaction original_sa;
+
+    struct sigaction sa;
+    sa.sa_sigaction = [](int sig, siginfo_t*, void*) {
+        std::lock_guard<ss::util::spinlock> g{lock};
+
+        Func();
+
+        // Reinstall the original signal handler after calling Func() to ensure
+        // that a concurrent signal on another thread does not terminate the
+        // process before Func() finishes
+        auto r = ::sigaction(sig, &original_sa, nullptr);
+        if (r == -1) {
+            // This should not be possible given the man page of sigaction
+            // but it is prudent to handle this case by reinstalling the
+            // default sighandler
+            constexpr static std::string_view sigaction_failure
+              = "Failed to reinstall original signal handler\n";
+            ss::print_safe(sigaction_failure.data(), sigaction_failure.size());
+
+            ::signal(sig, SIG_DFL);
+        }
+
+        // Reraise the signal to trigger the original signal handler
+        pthread_kill(pthread_self(), sig);
+    };
+    sigfillset(&sa.sa_mask);
+    sa.sa_flags = SA_SIGINFO | SA_RESTART;
+    if (Signal == SIGSEGV) {
+        sa.sa_flags |= SA_ONSTACK;
+    }
+    auto r = ::sigaction(Signal, &sa, &original_sa);
+    ss::throw_system_error_on(r == -1);
+
+    // Unblock the signal on all reactor threads to ensure that our handler is
+    // called
+    ss::smp::invoke_on_all([] {
+        auto mask = ss::make_sigset_mask(Signal);
+        ss::throw_pthread_error(::pthread_sigmask(SIG_UNBLOCK, &mask, nullptr));
+    }).get();
+}
+
+void sigsegv_action() {
+    constexpr auto signo = crash_tracker::recorder::recorded_signo::sigsegv;
+    crash_tracker::get_recorder().record_crash_sighandler(signo);
+}
+void sigabrt_action() {
+    constexpr auto signo = crash_tracker::recorder::recorded_signo::sigabrt;
+    crash_tracker::get_recorder().record_crash_sighandler(signo);
+}
+void sigill_action() {
+    constexpr auto signo = crash_tracker::recorder::recorded_signo::sigill;
+    crash_tracker::get_recorder().record_crash_sighandler(signo);
+}
+
+} // namespace
+
+void install_sighandlers() {
+    install_oneshot_signal_handler<SIGSEGV, sigsegv_action>();
+    install_oneshot_signal_handler<SIGABRT, sigabrt_action>();
+    install_oneshot_signal_handler<SIGILL, sigill_action>();
+}
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/signals.h
+++ b/src/v/crash_tracker/signals.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace crash_tracker {
+
+void install_sighandlers();
+
+} // namespace crash_tracker

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -86,6 +86,7 @@
 #include "config/node_config.h"
 #include "config/seed_server.h"
 #include "config/types.h"
+#include "crash_tracker/signals.h"
 #include "crypto/ossl_context_service.h"
 #include "datalake/cloud_data_io.h"
 #include "datalake/coordinator/catalog_factory.h"
@@ -1028,6 +1029,7 @@ void application::check_environment() {
 void application::init_crashtracker(::stop_signal& app_signal) {
     _crash_tracker_service = std::make_unique<crash_tracker::service>();
     _crash_tracker_service->start(app_signal.abort_source()).get();
+    crash_tracker::install_sighandlers();
 }
 
 void application::schedule_crash_tracker_file_cleanup() {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2554,8 +2554,6 @@ class RedpandaService(RedpandaServiceBase):
         # which can kill redpanda nodes.
         # This is a number to allow multiple callers to set it.
         self.tolerate_not_running = 0
-        # Do not fail test on crashes including asserts. This is useful when
-        # running with redpanda's fault injection enabled.
         self._tolerate_crashes = False
         self._rpk_node_config = rpk_node_config
 
@@ -5367,6 +5365,13 @@ class RedpandaService(RedpandaServiceBase):
         self._log_config.enable_finject_logging()
 
         self.logger.info(f"Set up failure injection config for nodes: {nodes}")
+
+    def set_tolerate_crashes(self, tolerate_crashes: bool):
+        """
+        Do not fail test on crashes including asserts. This is useful when
+        running with redpanda's fault injection enabled.
+        """
+        self._tolerate_crashes = tolerate_crashes
 
     def validate_controller_log(self):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1394,6 +1394,10 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         }
     }
 
+    # Thread name of shards to be used with redpanda_tid()
+    SHARD_0_THREAD_NAME = "redpanda"
+    SHARD_1_THREAD_NAME = "reactor-1"
+
     class FIPSMode(Enum):
         disabled = 0
         permissive = 1
@@ -3131,12 +3135,20 @@ class RedpandaService(RedpandaServiceBase):
 
         return all(self.for_nodes(self._started, check_node))
 
-    def signal_redpanda(self, node, signal=signal.SIGKILL, idempotent=False):
+    def signal_redpanda(self,
+                        node,
+                        signal=signal.SIGKILL,
+                        idempotent=False,
+                        thread=None):
         """
         :param idempotent: if true, then kill-like signals are ignored if
                            the process is already gone.
+        :param thread: if set, then the signal is sent to the given thread
         """
-        pid = self.redpanda_pid(node)
+        if thread is None:
+            pid = self.redpanda_pid(node)
+        else:
+            pid = self.redpanda_tid(node, thread)
         if pid is None:
             if idempotent and signal in {signal.SIGKILL, signal.SIGTERM}:
                 return
@@ -4187,6 +4199,20 @@ class RedpandaService(RedpandaServiceBase):
                 return None
 
             raise e
+
+    def redpanda_tid(self, node, thread):
+        """Return the thread ID of the given thread"""
+        cmd = "ps -C redpanda -T"
+        for line in node.account.ssh_capture(cmd, timeout_sec=10):
+            # Example line:
+            #     PID    SPID TTY          TIME CMD
+            # 2662879 2662879 pts/16   00:00:02 redpanda
+            self.logger.debug(f"ps output: {line}")
+            parts = line.split()
+            thread_name = parts[4]
+            if thread == thread_name:
+                return int(parts[1])
+        return None
 
     def started_nodes(self) -> List[ClusterNode]:
         return list(self._started)

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -46,6 +46,7 @@ class CrashLoopChecksTest(RedpandaTest):
             },
             log_config=LoggingConfig('info', logger_levels={'main': 'debug'}),
         )
+        self.broker = self.redpanda.nodes[0]
 
     def remove_crash_loop_tracker_file(self, broker):
         broker.account.ssh(
@@ -63,6 +64,10 @@ class CrashLoopChecksTest(RedpandaTest):
             self.redpanda.start_node(broker)
         self.redpanda.signal_redpanda(node=broker)
         self.redpanda.start_node(node=broker, expect_fail=True)
+
+    def expect_crash_count(self, expected):
+        crash_files = self.count_crash_files(self.broker)
+        assert crash_files == expected, f"Unexpected number of crashes: {crash_files} != {expected}"
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
     def test_crash_loop_checks_with_tracker_file(self):
@@ -144,18 +149,14 @@ class CrashLoopChecksTest(RedpandaTest):
     def test_crash_report_with_startup_exception(self):
         broker = self.redpanda.nodes[0]
 
-        def expect_crash_count(expected):
-            crash_files = self.count_crash_files(broker)
-            assert crash_files == expected, f"Unexpected number of crashes: {crash_files} != {expected}"
-
         # A SIGKILL'd broker will leave behind an empty crash report
         self.redpanda.signal_redpanda(broker)
-        expect_crash_count(1)
+        self.expect_crash_count(1)
 
         # A clean broker start+stop will not leave behind a crash report
         self.redpanda.start_node(broker)
         self.redpanda.stop_node(broker)
-        expect_crash_count(1)
+        self.expect_crash_count(1)
 
         # Exceptions during startup should generate crash reports
         invalid_conf = dict(
@@ -164,7 +165,7 @@ class CrashLoopChecksTest(RedpandaTest):
             self.redpanda.start_node(broker,
                                      override_cfg_params=invalid_conf,
                                      expect_fail=True)
-        expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
+        self.expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
 
         # No new crash report should be generated for when redpanda stops with the crash loop limit reached
         self.redpanda.start_node(broker,
@@ -176,7 +177,7 @@ class CrashLoopChecksTest(RedpandaTest):
             broker,
             "Crash #4 at 20.* UTC - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: 0x.*"
         )
-        expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
+        self.expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + HOSTNAME_ERRORS)
     def test_crash_report_parser(self):

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import signal
 from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
@@ -14,6 +15,8 @@ from rptest.services.redpanda import RedpandaService
 from rptest.util import expect_exception
 from rptest.services.redpanda import LoggingConfig
 from ducktape.errors import TimeoutError
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
 
 
 class CrashLoopChecksTest(RedpandaTest):
@@ -24,6 +27,12 @@ class CrashLoopChecksTest(RedpandaTest):
     CRASH_LOOP_LOG = [
         "Crash loop detected. Too many consecutive crashes.*",
         ".*Failure during startup: crash_tracker::crash_loop_limit_reached \(Crash loop detected, aborting startup.\).*"
+    ]
+
+    SIGNAL_CRASH_LOG = [
+        "Aborting on",
+        "Segmentation fault on",
+        "Illegal instruction on",
     ]
 
     # main - application.cc:348 - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)
@@ -68,6 +77,18 @@ class CrashLoopChecksTest(RedpandaTest):
     def expect_crash_count(self, expected):
         crash_files = self.count_crash_files(self.broker)
         assert crash_files == expected, f"Unexpected number of crashes: {crash_files} != {expected}"
+
+    def wait_for_redpanda_stop(self, broker, timeout=10):
+        '''
+        Wait for the redpanda process to terminate (e.g. after sending a crash signal)
+        '''
+        wait_until(
+            lambda: self.redpanda.redpanda_pid(broker) == None,
+            timeout_sec=timeout,
+            backoff_sec=0.2,
+            err_msg=
+            f"Redpanda processes did not terminate on {broker.name} in {timeout} sec"
+        )
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
     def test_crash_loop_checks_with_tracker_file(self):
@@ -198,3 +219,60 @@ class CrashLoopChecksTest(RedpandaTest):
         self.logger.debug(f'First report: {report}')
         assert 'Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)' == report[
             'crash_message'], f'Unexpected crash message: {report["crash_message"]}'
+
+    @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + SIGNAL_CRASH_LOG)
+    @matrix(signo=[signal.SIGSEGV, signal.SIGABRT, signal.SIGILL],
+            signal_shard=[0, 1])
+    def test_crash_report_with_signal(self, signo, signal_shard):
+        if signal_shard == 0:
+            signal_thread = RedpandaService.SHARD_0_THREAD_NAME
+        else:
+            signal_thread = RedpandaService.SHARD_1_THREAD_NAME
+
+        self.redpanda.set_tolerate_crashes(True)
+        broker = self.redpanda.nodes[0]
+
+        # Send a crash signal to redpanda CRASH_LOOP_LIMIT times
+        for _ in range(CrashLoopChecksTest.CRASH_LOOP_LIMIT):
+            self.redpanda.signal_redpanda(broker,
+                                          signal=signo,
+                                          thread=signal_thread)
+            self.wait_for_redpanda_stop(broker)
+            self.redpanda.start_node(broker)
+
+        # Expect to see a crash report for each crash + a new one for the last
+        # start_node
+        self.expect_crash_count(CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
+
+        # Sanity check the crash loop limit message has not been printed yet
+        assert not self.redpanda.search_log_node(
+            broker, "Too many consecutive crashes"
+        ), "The crash loop limit message should not have been printed yet"
+
+        # Send a crash signal + start again, now reaching the crash loop limit.
+        self.redpanda.signal_redpanda(broker,
+                                      signal=signo,
+                                      thread=signal_thread)
+        self.wait_for_redpanda_stop(broker)
+        self.redpanda.start_node(broker, expect_fail=True)
+
+        # Assert the crash loop limit message is printed with information about
+        # the crashes
+        assert self.redpanda.search_log_node(
+            broker, "Too many consecutive crashes"
+        ), "The crash loop limit should have been reached"
+
+        def signo_prefix():
+            if signo == signal.SIGSEGV:
+                return "Segmentation fault"
+            elif signo == signal.SIGABRT:
+                return "Aborting"
+            elif signo == signal.SIGILL:
+                return "Illegal instruction"
+            else:
+                assert False, "Test failure: not yet implemented"
+
+        assert self.redpanda.search_log_node(
+            broker,
+            f"Crash #4 at 20.* - {signo_prefix()} on shard {signal_shard}. Backtrace: "
+        )


### PR DESCRIPTION
This PR implements installing custom signal handlers for SIGSEGV and SIGABRT signals in redpanda using the `sigaction` system call. These signal handlers implement recording information about the crash for later debugging.

Seastar has support for handling signals on the reactor. However, seastar's `ss::engine::handle_signal` is designed for asynchronously handling user signals (e.g., SIGUSR1, SIGINT, SIGHUP) within the reactor framework. This approach is unsuitable for crash signals where the reactor won't run again after the signal handler is done. In such cases, synchronous signal handlers are required to perform minimal, safe actions (e.g., writing out crash data) immediately upon signal reception, without relying on the reactor's asynchronous scheduling.

This commit introduces synchronous, one-shot signal handlers for the main crash signals (SIGSEGV, SIGABRT, SIGILL). The implementation closely mirrors Seastar's existing signal handling mechanism for the above crash signals with the following difference:

- Wrapping the existing signal handler: The original signal handler is retrieved and stored before installing redpanda's handler, ensuring it can be restored and triggered after our handler executes. This is to continue to call seastar's handlers as well after our handler.

- Crash handler action: While seastar's signal handlers print to stderr, our signal handlers instead write a serde-serialized crash description to an open file descriptor.

Note that for SIGILL seastar did not have a custom handler, which means that while for SIGSEGV and SIGABRT the original handler is seastar's, for SIGILL it is the default signal handler SIG_DFL which just terminated the process without printing to stderr. A SIGILL handler is introduced to capture `vassert()` crashes, which (among other places) uses the `__builtin_trap()` primitive leading to a SIGILL signal being raised.

Fixes https://redpandadata.atlassian.net/browse/CORE-8685

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
