### PR TITLE
CORE-8937 admin: swagger docs for patch cluster config body

### DIFF
--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -14,6 +14,9 @@ seastar_cc_swagger_library(
 seastar_cc_swagger_library(
     name = "cluster_config",
     src = "api-doc/cluster_config.json",
+    definitions = [
+        "api-doc/cluster_config.def.json",
+    ],
 )
 
 seastar_cc_swagger_library(

--- a/src/v/redpanda/admin/api-doc/cluster_config.def.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.def.json
@@ -1,0 +1,24 @@
+"patch_cluster_config_request": {
+    "description": "Request body of patch cluster config request",
+    "type": "object",
+    "properties": {
+        "upsert": {
+            "description": "Cluster configuration property key-value pairs to add or update.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "remove": {
+            "description": "Cluster configuration property keys to reset to their default.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "upsert",
+        "remove"
+    ]
+}

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -29,6 +29,13 @@
               "schema": {"type": "integer"},
               "required": false,
               "description": "If nonzero, do not apply any changes (but still do validation and return 400 on errors)"
+            },
+            {
+              "in": "body",
+              "required": true,
+              "schema": {
+                "$ref": "#/definitions/patch_cluster_config_request"
+              }
             }
           ],
           "responses": {


### PR DESCRIPTION
Add the missing swagger api docs for the request body of the patch cluster configs endpoint.

For reviewers, the relevant admin api handler is here: https://github.com/redpanda-data/redpanda/blob/eed03d316bd276045a42fa8a2088c17c7135bc2c/src/v/redpanda/admin/server.cc#L1812-L1839

Fixes https://redpandadata.atlassian.net/browse/CORE-8937

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
