### PR TITLE
bazel: Update krb5

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -216,7 +216,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "megnA0tr48yY3gvcfY3nR2b69YDcQeYRIPf0EWPGFzU=",
+        "bzlTransitiveDigest": "RkWRFepGlzWcN5QUxvFfbakwxxP3/i5PG8X0wDNp6Qk=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -303,9 +303,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:krb5.BUILD",
-              "sha256": "ec3861c3bec29aa8da9281953c680edfdab1754d1b1db8761c1d824e4b25496a",
-              "strip_prefix": "krb5-krb5-1.20.1-final",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/krb5-krb5-1.20.1-final.tar.gz"
+              "sha256": "2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861",
+              "strip_prefix": "krb5-krb5-1.21.3-final",
+              "url": "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz"
             }
           },
           "libpciaccess": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -73,9 +73,9 @@ def data_dependency():
     http_archive(
         name = "krb5",
         build_file = "//bazel/thirdparty:krb5.BUILD",
-        sha256 = "ec3861c3bec29aa8da9281953c680edfdab1754d1b1db8761c1d824e4b25496a",
-        strip_prefix = "krb5-krb5-1.20.1-final",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/krb5-krb5-1.20.1-final.tar.gz",
+        sha256 = "2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861",
+        strip_prefix = "krb5-krb5-1.21.3-final",
+        url = "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Current version fails to build on Fedora 41.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


