### PR TITLE
cluster: Also track batches produced

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -140,6 +140,11 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
           [this] { return _records_produced; },
           sm::description("Total number of records produced"),
           labels),
+        sm::make_gauge(
+          "batches_produced",
+          [this] { return _batches_produced; },
+          sm::description("Total number of batches produced"),
+          labels),
         sm::make_counter(
           "records_fetched",
           [this] { return _records_fetched; },

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -28,6 +28,7 @@ public:
         virtual void add_records_produced(uint64_t) = 0;
         virtual void add_records_fetched(uint64_t) = 0;
         virtual void add_bytes_produced(uint64_t) = 0;
+        virtual void add_batches_produced(uint64_t) = 0;
         virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void add_bytes_fetched_from_follower(uint64_t) = 0;
         virtual void add_schema_id_validation_failed() = 0;
@@ -54,6 +55,10 @@ public:
     }
     void add_bytes_produced(uint64_t bytes) {
         return _impl->add_bytes_produced(bytes);
+    }
+
+    void add_batches_produced(uint64_t batches) {
+        return _impl->add_batches_produced(batches);
     }
 
     void add_bytes_fetched(uint64_t bytes) {
@@ -94,6 +99,7 @@ public:
         _bytes_fetched_from_follower += cnt;
     }
     void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
+    void add_batches_produced(uint64_t cnt) final { _batches_produced += cnt; }
     void add_schema_id_validation_failed() final {
         ++_schema_id_validation_records_failed;
     };
@@ -124,6 +130,7 @@ private:
     uint64_t _records_produced{0};
     uint64_t _records_fetched{0};
     uint64_t _bytes_produced{0};
+    uint64_t _batches_produced{0};
     uint64_t _bytes_fetched{0};
     uint64_t _bytes_fetched_from_follower{0};
     uint64_t _schema_id_validation_records_failed{0};

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -188,6 +188,7 @@ static partition_produce_stages partition_append(
                     p.error_code = error_code::none;
                     partition->probe().add_records_produced(num_records);
                     partition->probe().add_bytes_produced(num_bytes);
+                    partition->probe().add_batches_produced(1);
                 } else {
                     p.error_code = map_produce_error_code(r.error());
                 }


### PR DESCRIPTION
This is arguably the more useful metric than records and allows us to
calculate avg batch size etc at the kafka API layer.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
