### PR TITLE
CORE-8686 crash_tracker: remove old crash files

### DIFF
--- a/src/v/crash_tracker/limiter.cc
+++ b/src/v/crash_tracker/limiter.cc
@@ -24,6 +24,8 @@
 
 #include <fmt/chrono.h>
 
+#include <chrono>
+
 using namespace std::chrono_literals;
 
 namespace crash_tracker {
@@ -39,10 +41,10 @@ describe_crashes(const std::vector<recorder::recorded_crash>& crashes) {
         return "(No crash files have been recorded.)";
     }
 
-    constexpr auto format_time = [](model::timestamp ts_model) {
-        auto ts_chrono = model::to_time_point(ts_model);
-        return fmt::format("{:%Y-%m-%d %T} UTC", fmt::gmtime(ts_chrono));
-    };
+    constexpr auto format_time =
+      [](std::chrono::system_clock::time_point ts_chrono) {
+          return fmt::format("{:%Y-%m-%d %T} UTC", fmt::gmtime(ts_chrono));
+      };
 
     std::stringstream ss;
     ss << "The following crashes have been recorded:";
@@ -60,8 +62,8 @@ describe_crashes(const std::vector<recorder::recorded_crash>& crashes) {
           ss,
           "\nCrash #{} at {} - {}",
           i + 1,
-          format_time(crash.crash_time),
-          crash);
+          format_time(crashes[i].timestamp()),
+          crash ? fmt::format("{}", *crash) : "Crash reason not recorded");
     }
 
     return ss.str();

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -36,8 +36,7 @@ recorder& get_recorder() {
     return inst;
 }
 
-ss::future<> recorder::start() {
-    // Ensure that the crash report directory exists
+ss::future<> recorder::ensure_crashdir_exists() const {
     auto crash_report_dir = config::node().crash_report_dir_path();
     if (!co_await ss::file_exists(crash_report_dir.string())) {
         vlog(
@@ -50,6 +49,10 @@ ss::future<> recorder::start() {
           "Successfully created crash report directory {}",
           crash_report_dir.string());
     }
+}
+
+ss::future<std::filesystem::path> recorder::generate_crashfile_name() const {
+    auto crash_report_dir = config::node().crash_report_dir_path();
 
     // Loop a few times to avoid (very unlikely) collisions in the filename
     std::optional<std::filesystem::path> crash_file_name{};
@@ -64,16 +67,16 @@ ss::future<> recorder::start() {
             continue;
         }
 
-        crash_file_name = try_name;
-        break;
-    }
-    if (!crash_file_name) {
-        // The anti-collision above should ensure that we never reach this
-        throw std::runtime_error(
-          "Failed to create a unique crash recorder file");
+        co_return try_name;
     }
 
-    co_await _writer.initialize(*crash_file_name);
+    // The anti-collision above should ensure that we never reach this
+    throw std::runtime_error("Failed to create a unique crash recorder file");
+}
+
+ss::future<> recorder::start() {
+    co_await ensure_crashdir_exists();
+    co_await _writer.initialize(co_await generate_crashfile_name());
 }
 
 namespace {

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -24,6 +24,7 @@
 #include <seastar/util/print_safe.hh>
 
 #include <chrono>
+#include <filesystem>
 
 using namespace std::chrono_literals;
 
@@ -74,8 +75,26 @@ ss::future<std::filesystem::path> recorder::generate_crashfile_name() const {
     throw std::runtime_error("Failed to create a unique crash recorder file");
 }
 
+ss::future<> recorder::remove_old_crashfiles() const {
+    auto crash_files = co_await get_recorded_crashes(
+      recorder::include_malformed_files::yes);
+
+    if (crash_files.size() > crash_files_to_keep) {
+        // Delete the oldest crash reports to avoid filling up the disc with
+        // crash report files
+        for (size_t i = 0; i < crash_files.size() - crash_files_to_keep; ++i) {
+            const auto& fpath = crash_files[i].file_path.string();
+            vlog(ctlog.debug, "Deleting old crash report file {}", fpath);
+            co_await ss::remove_file(fpath);
+        }
+    }
+
+    co_return;
+}
+
 ss::future<> recorder::start() {
     co_await ensure_crashdir_exists();
+    co_await remove_old_crashfiles();
     co_await _writer.initialize(co_await generate_crashfile_name());
 }
 
@@ -137,8 +156,23 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
     _writer.write();
 }
 
+std::chrono::system_clock::time_point
+recorder::recorded_crash::timestamp() const {
+    auto recorded_timestamp_opt = crash
+                                    ? std::make_optional(
+                                        model::to_time_point(crash->crash_time))
+                                    : std::nullopt;
+    auto lwt_sys_timepoint = std::chrono::system_clock::time_point{
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        last_write_time.time_since_epoch())};
+
+    // Prefer the recorded timestamp, fall back to the last write time
+    return recorded_timestamp_opt.value_or(lwt_sys_timepoint);
+}
+
 ss::future<std::vector<recorder::recorded_crash>>
-recorder::get_recorded_crashes() const {
+recorder::get_recorded_crashes(
+  recorder::include_malformed_files incl_malformed) const {
     auto result = std::vector<recorded_crash>{};
     auto crash_report_dir = config::node().crash_report_dir_path();
     if (!co_await ss::file_exists(crash_report_dir.string())) {
@@ -156,12 +190,18 @@ recorder::get_recorded_crashes() const {
         try {
             auto crash_desc = serde::from_iobuf<crash_description>(
               std::move(buf));
-            result.emplace_back(std::move(crash_desc));
+            result.emplace_back(
+              entry.path(), std::move(crash_desc), entry.last_write_time());
         } catch (const serde::serde_exception&) {
-            vlog(
-              ctlog.warn,
-              "Ignoring malformed crash report file {}",
-              entry.path());
+            if (incl_malformed) {
+                result.emplace_back(
+                  entry.path(), std::nullopt, entry.last_write_time());
+            } else {
+                vlog(
+                  ctlog.warn,
+                  "Ignoring malformed crash report file {}",
+                  entry.path());
+            }
         }
     }
 
@@ -169,7 +209,7 @@ recorder::get_recorded_crashes() const {
       result.begin(),
       result.end(),
       [](const recorded_crash& a, const recorded_crash& b) {
-          return a.crash.crash_time < b.crash.crash_time;
+          return a.timestamp() < b.timestamp();
       });
 
     co_return result;

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -37,6 +37,8 @@ recorder& get_recorder() {
     return inst;
 }
 
+recorder get_test_recorder() { return recorder{}; }
+
 ss::future<> recorder::ensure_crashdir_exists() const {
     auto crash_report_dir = config::node().crash_report_dir_path();
     if (!co_await ss::file_exists(crash_report_dir.string())) {

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -44,6 +44,9 @@ private:
     recorder() = default;
     ~recorder() = default;
 
+    ss::future<> ensure_crashdir_exists() const;
+    ss::future<std::filesystem::path> generate_crashfile_name() const;
+
     prepared_writer _writer;
 
     friend recorder& get_recorder();

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -15,6 +15,10 @@
 #include "crash_tracker/prepared_writer.h"
 #include "crash_tracker/types.h"
 
+#include <seastar/util/bool_class.hh>
+
+#include <chrono>
+
 namespace crash_tracker {
 
 /// Thread-safe global singleton crash recorder
@@ -22,12 +26,20 @@ namespace crash_tracker {
 /// handlers which have to be static functions (/non-capturing lambdas).
 class recorder {
 public:
+    static constexpr auto crash_files_to_keep = 50;
+
     struct recorded_crash {
-        crash_description crash;
+        std::filesystem::path file_path;
+        std::optional<crash_description> crash;
+        std::filesystem::file_time_type last_write_time;
 
         ss::future<bool> is_uploaded() const;
         ss::future<> mark_uploaded() const;
+        std::chrono::system_clock::time_point timestamp() const;
     };
+
+    using include_malformed_files
+      = ss::bool_class<struct include_malformed_files_tag>;
 
     ss::future<> start();
     ss::future<> stop();
@@ -38,7 +50,9 @@ public:
     void record_crash_exception(std::exception_ptr eptr);
 
     /// Returns the list of recorded crashes in increasing crash_time order
-    ss::future<std::vector<recorded_crash>> get_recorded_crashes() const;
+    ss::future<std::vector<recorded_crash>> get_recorded_crashes(
+      include_malformed_files incl_malformed
+      = include_malformed_files::no) const;
 
 private:
     recorder() = default;
@@ -46,6 +60,7 @@ private:
 
     ss::future<> ensure_crashdir_exists() const;
     ss::future<std::filesystem::path> generate_crashfile_name() const;
+    ss::future<> remove_old_crashfiles() const;
 
     prepared_writer _writer;
 

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -41,6 +41,9 @@ public:
     using include_malformed_files
       = ss::bool_class<struct include_malformed_files_tag>;
 
+    /// Visible for testing
+    ~recorder() = default;
+
     ss::future<> start();
     ss::future<> stop();
 
@@ -56,7 +59,6 @@ public:
 
 private:
     recorder() = default;
-    ~recorder() = default;
 
     ss::future<> ensure_crashdir_exists() const;
     ss::future<std::filesystem::path> generate_crashfile_name() const;
@@ -65,9 +67,13 @@ private:
     prepared_writer _writer;
 
     friend recorder& get_recorder();
+    friend recorder get_test_recorder();
 };
 
 /// Singleton access to global static recorder
 recorder& get_recorder();
+
+/// Make a test instance of the recorder that is not a static singleton
+recorder get_test_recorder();
 
 } // namespace crash_tracker

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -16,6 +16,21 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "recorder_test",
+    timeout = "short",
+    srcs = [
+        "recorder_test.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/crash_tracker",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_binary(
     name = "crash_report_generator",
     srcs = ["report_generator.cc"],

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -8,6 +8,16 @@ rp_test(
   ARGS "-- -c 1"
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME recorder_test
+  SOURCES
+    recorder_test.cc
+  LIBRARIES v::gtest_main v::config v::crash_tracker
+  ARGS "-- -c 1"
+)
+
 add_executable(crash_report_generator report_generator.cc)
 set_property(TARGET crash_report_generator PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(crash_report_generator PUBLIC v::crash_tracker)

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -39,7 +39,8 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
             res.addition_info = crash_description::reserved_string_t{
               "false != true at example.cc:123"};
         }
-        return res;
+        return recorder::recorded_crash{
+          "", res, std::chrono::file_clock::time_point{}};
     };
 
     crashes.emplace_back(make_crash(with_additional_info::no));

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "config/node_config.h"
+#include "crash_tracker/recorder.h"
+#include "test_utils/tmp_dir.h"
+
+#include <gtest/gtest.h>
+
+#include <exception>
+#include <stdexcept>
+
+namespace crash_tracker {
+
+class RecorderTest : public testing::Test {
+public:
+    void SetUp() override {
+        config::node().data_directory.set_value(_dir.get_path());
+    }
+    void TearDown() override {
+        _dir.remove().get();
+        config::node().data_directory.reset();
+    }
+
+private:
+    temporary_dir _dir{"recorder_test"};
+};
+
+TEST_F(RecorderTest, TestFileCleanup) {
+    const auto test_eptr = std::make_exception_ptr(std::runtime_error{""});
+
+    // Observe no recorded crashes before the first start
+    auto crashes = get_test_recorder().get_recorded_crashes().get();
+    ASSERT_EQ(crashes.size(), 0);
+
+    // Simulate lots of crashed restarts to generate crash reports on disk
+    for (size_t i = 0; i < recorder::crash_files_to_keep + 5; i++) {
+        auto rec = get_test_recorder();
+        rec.start().get();
+        rec.record_crash_exception(test_eptr);
+    }
+
+    // Run one more restart and observe that old crash files are cleaned up
+    auto rec = get_test_recorder();
+    rec.start().get();
+
+    crashes = rec.get_recorded_crashes().get();
+    ASSERT_EQ(crashes.size(), recorder::crash_files_to_keep);
+}
+
+} // namespace crash_tracker


### PR DESCRIPTION
The broker will retain the 50 most recent crash files and delete all older crashes on startup. This is to ensure that crash report files do not fill up the disk.

Note that we remove files before creating them to ensure cleanup succeeds before we create new files. This means that technically we will have up to 51 crash reports on disk (50 kept + 1 created). This is acceptable since 50 is a loose limit.

A fixture test is added to verify this behaviour.

Fixes https://redpandadata.atlassian.net/browse/CORE-8686

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
