### PR TITLE
[CORE-8999] [v24.2.x] Schema Registry/protobuf: Allow older protobuf and add a test for map field.

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -774,7 +774,7 @@ struct protobuf_schema_definition::impl {
 
     void render_field(
       std::ostream& os,
-      pb::Edition edition,
+      std::string_view edition,
       const pb::FieldDescriptorProto& field,
       const pb::FieldDescriptor* descriptor,
       int indent,
@@ -834,7 +834,7 @@ struct protobuf_schema_definition::impl {
         };
 
         const auto label = [&]() {
-            bool is_proto2 = edition == pb::Edition::EDITION_PROTO2;
+            bool is_proto2 = edition == "proto2";
             if(descriptor && 
                 (descriptor->is_map() || descriptor->real_containing_oneof() ||
                 ((descriptor->is_optional() && !field.proto3_optional()) && !(is_proto2 && !descriptor->containing_oneof())))) {
@@ -963,7 +963,7 @@ struct protobuf_schema_definition::impl {
     template<typename Descriptor>
     void render_extensions(
       std::ostream& os,
-      pb::Edition edition,
+      std::string_view edition,
       const pb::RepeatedPtrField<pb::FieldDescriptorProto>& raw_extensions,
       const Descriptor& descriptor,
       int indent) const {
@@ -1100,7 +1100,7 @@ struct protobuf_schema_definition::impl {
     // Render a message, including nested messages
     void render_nested(
       std::ostream& os,
-      pb::Edition edition,
+      std::string_view edition,
       const std::optional<pb::FieldDescriptorProto>& field,
       const pb::FieldDescriptor* field_descriptor,
       const pb::DescriptorProto& message,
@@ -1557,15 +1557,9 @@ struct protobuf_schema_definition::impl {
       std::ostream& os,
       const pb::FileDescriptorProto& fdp,
       const pb::FileDescriptor& descriptor) const {
-        auto edition = fdp.edition();
-        if (edition == pb::Edition::EDITION_UNKNOWN) {
-            auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
-            edition = syntax == "proto3" ? pb::Edition::EDITION_PROTO3
-                                         : pb::Edition::EDITION_PROTO2;
-            fmt::print(os, "syntax = \"{}\";\n", syntax);
-        } else {
-            fmt::print(os, "edition = \"{}\";\n", Edition_Name(fdp.edition()));
-        }
+        auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
+        std::string_view edition = syntax;
+        fmt::print(os, "syntax = \"{}\";\n", syntax);
 
         if (fdp.has_package() && !fdp.package().empty()) {
             fmt::print(os, "package {};\n", fdp.package());

--- a/tests/protobuf/payload.proto
+++ b/tests/protobuf/payload.proto
@@ -48,6 +48,7 @@ message A {
                 message NestedPayload {
                     int32 val = 1;
                     google.protobuf.Timestamp timestamp = 2;
+                    map<string, string> properties = 3;
                 }
             }
         }


### PR DESCRIPTION
* Drop support for editions
* Add a test for a map field

The test is expected to fail until https://github.com/redpanda-data/vtools/pull/3429 is merged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Schema Registry: Fix a regression with protobuf map fields

