### PR TITLE
kafka/server: add metrics and config for consumer lag reporting

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -14,6 +14,7 @@
 #include "config/base_property.h"
 #include "config/bounded_property.h"
 #include "config/node_config.h"
+#include "config/types.h"
 #include "config/validators.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -596,6 +597,14 @@ configuration::configuration()
       "sense by the shard and/or partition labels.",
       {.needs_restart = needs_restart::no},
       false)
+  , enable_consumer_group_metrics(
+      *this,
+      "enable_consumer_group_metrics",
+      "List of enabled consumer group metrics. Accepted "
+      "Values: `group`, `partition`",
+      {.needs_restart = needs_restart::no},
+      std::vector<ss::sstring>{"group", "partition"},
+      validate_consumer_group_metrics)
   , group_min_session_timeout_ms(
       *this,
       "group_min_session_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -601,7 +601,7 @@ configuration::configuration()
       *this,
       "enable_consumer_group_metrics",
       "List of enabled consumer group metrics. Accepted "
-      "Values: `group`, `partition`",
+      "Values: `group`, `partition`, `consumer_lag`",
       {.needs_restart = needs_restart::no},
       std::vector<ss::sstring>{"group", "partition"},
       validate_consumer_group_metrics)

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -196,6 +196,7 @@ struct configuration final : public config_store {
     property<bool> disable_metrics;
     property<bool> disable_public_metrics;
     property<bool> aggregate_metrics;
+    property<std::vector<ss::sstring>> enable_consumer_group_metrics;
     property<std::chrono::milliseconds> group_min_session_timeout_ms;
     property<std::chrono::milliseconds> group_max_session_timeout_ms;
     property<std::chrono::milliseconds> group_initial_rebalance_delay;

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -292,4 +292,20 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring>
+validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics) {
+    constexpr auto supported = std::to_array<std::string_view>(
+      {"group", "partition"});
+
+    // Validate results
+    for (const auto& m : metrics) {
+        if (std::ranges::none_of(
+              supported, [&m](const auto& s) { return s == m; })) {
+            return ssx::sformat("'{}' is not a valid consumer group metric", m);
+        }
+    }
+
+    return std::nullopt;
+}
+
 }; // namespace config

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -295,7 +295,7 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
 std::optional<ss::sstring>
 validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics) {
     constexpr auto supported = std::to_array<std::string_view>(
-      {"group", "partition"});
+      {"group", "partition", "consumer_lag"});
 
     // Validate results
     for (const auto& m : metrics) {

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -63,4 +63,7 @@ validate_iceberg_partition_spec(const ss::sstring& spec);
 std::optional<ss::sstring>
 validate_iceberg_rest_catalog_auth_mode(const configuration& config);
 
+std::optional<ss::sstring>
+validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics);
+
 }; // namespace config

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -134,9 +134,7 @@ group::group(
                          .abort_timed_out_transactions_interval_ms.value())
   , _tx_frontend(tx_frontend)
   , _feature_table(feature_table) {
-    if (_enable_group_metrics) {
-        _probe.setup_public_metrics(_id);
-    }
+    setup_metrics();
 
     start_abort_timer();
 }
@@ -193,9 +191,7 @@ group::group(
     // update when restoring from metadata value
     update_subscriptions();
 
-    if (_enable_group_metrics) {
-        _probe.setup_public_metrics(_id);
-    }
+    setup_metrics();
 
     start_abort_timer();
 }
@@ -3618,6 +3614,13 @@ group::delete_offsets(std::vector<model::topic_partition> offsets) {
     }
 
     return deleted_offsets;
+}
+
+void group::setup_metrics() {
+    if (!_enable_group_metrics) {
+        return;
+    }
+    _probe.setup_public_metrics(_id);
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -17,6 +17,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/tx_utils.h"
 #include "config/configuration.h"
+#include "config/types.h"
 #include "container/fragmented_vector.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/heartbeat.h"
@@ -30,6 +31,7 @@
 #include "kafka/protocol/wire.h"
 #include "kafka/server/errors.h"
 #include "kafka/server/group_metadata.h"
+#include "kafka/server/group_probe.h"
 #include "kafka/server/logger.h"
 #include "kafka/server/member.h"
 #include "model/fundamental.h"
@@ -48,6 +50,8 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
+
+#include <functional>
 
 namespace kafka {
 
@@ -113,8 +117,7 @@ group::group(
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  group_metadata_serializer serializer,
-  enable_group_metrics group_metrics)
+  group_metadata_serializer serializer)
   : _id(std::move(id))
   , _state(s)
   , _state_timestamp(model::timestamp::now())
@@ -129,7 +132,8 @@ group::group(
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
   , _term(term)
-  , _enable_group_metrics(group_metrics)
+  , _enable_group_metrics(conf.enable_consumer_group_metrics.bind(
+      std::function{enabled_metrics::from_vector}))
   , _abort_interval_ms(config::shard_local_cfg()
                          .abort_timed_out_transactions_interval_ms.value())
   , _tx_frontend(tx_frontend)
@@ -148,8 +152,7 @@ group::group(
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  group_metadata_serializer serializer,
-  enable_group_metrics group_metrics)
+  group_metadata_serializer serializer)
   : _id(std::move(id))
   , _state(md.members.empty() ? group_state::empty : group_state::stable)
   , _state_timestamp(
@@ -170,7 +173,8 @@ group::group(
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
   , _term(term)
-  , _enable_group_metrics(group_metrics)
+  , _enable_group_metrics(conf.enable_consumer_group_metrics.bind(
+      std::function{enabled_metrics::from_vector}))
   , _abort_interval_ms(config::shard_local_cfg()
                          .abort_timed_out_transactions_interval_ms.value())
   , _tx_frontend(tx_frontend)
@@ -3617,10 +3621,16 @@ group::delete_offsets(std::vector<model::topic_partition> offsets) {
 }
 
 void group::setup_metrics() {
-    if (!_enable_group_metrics) {
-        return;
-    }
-    _probe.setup_public_metrics(_id);
+    const auto metrics_registration = [this]() {
+        if (_enable_group_metrics().group) {
+            _probe.register_group_metrics(_id);
+        } else {
+            _probe.deregister_group_metrics();
+        }
+    };
+
+    _enable_group_metrics.watch(metrics_registration);
+    metrics_registration();
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -127,7 +127,7 @@ group::group(
   , _conf(conf)
   , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
-  , _probe(_members, _static_members, _offsets)
+  , _probe(_members, _static_members, _offsets, _lag_metrics)
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
@@ -168,7 +168,7 @@ group::group(
   , _conf(conf)
   , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
-  , _probe(_members, _static_members, _offsets)
+  , _probe(_members, _static_members, _offsets, _lag_metrics)
   , _ctxlog(klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
@@ -3626,6 +3626,12 @@ void group::setup_metrics() {
             _probe.register_group_metrics(_id);
         } else {
             _probe.deregister_group_metrics();
+        }
+
+        if (_enable_group_metrics().consumer_lag) {
+            _probe.register_consumer_lag_metrics(_id);
+        } else {
+            _probe.deregister_consumer_lag_metrics();
         }
     };
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -922,6 +922,8 @@ private:
 
     cluster::tx::errc map_tx_replication_error(std::error_code ec);
 
+    void setup_metrics();
+
     kafka::group_id _id;
     group_state _state;
     std::optional<model::timestamp> _state_timestamp;
@@ -965,6 +967,7 @@ private:
     chunked_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
     enable_group_metrics _enable_group_metrics;
+    config::binding<bool> _enable_consumer_lag_metrics;
 
     ss::gate _gate;
     ss::timer<clock_type> _auto_abort_timer;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -15,6 +15,9 @@
 #include "cluster/simple_batch_builder.h"
 #include "cluster/tx_protocol_types.h"
 #include "cluster/tx_utils.h"
+#include "config/configuration.h"
+#include "config/property.h"
+#include "config/types.h"
 #include "container/chunked_hash_map.h"
 #include "container/fragmented_vector.h"
 #include "features/feature_table.h"
@@ -103,8 +106,6 @@ enum class group_state {
     /// Transient state as the group is being removed.
     dead,
 };
-
-using enable_group_metrics = ss::bool_class<struct enable_gr_metrics_tag>;
 
 std::ostream& operator<<(std::ostream&, group_state gs);
 
@@ -227,18 +228,28 @@ public:
     struct offset_metadata_with_probe {
         offset_metadata metadata;
         group_offset_probe probe;
+        metrics_conversion_binding enable_group_metrics;
 
         offset_metadata_with_probe(
           offset_metadata _metadata,
           const kafka::group_id& group_id,
           const model::topic_partition& tp,
-          enable_group_metrics enable_metrics)
+          metrics_conversion_binding _enable_group_metrics)
           : metadata(std::move(_metadata))
-          , probe(metadata.offset) {
-            if (enable_metrics) {
-                probe.setup_metrics(group_id, tp);
-                probe.setup_public_metrics(group_id, tp);
-            }
+          , probe(metadata.offset)
+          , enable_group_metrics(std::move(_enable_group_metrics)) {
+            const auto metrics_registration = [this, group_id, tp]() {
+                if (enable_group_metrics().partition) {
+                    probe.register_metrics(group_id, tp);
+                    probe.register_public_metrics(group_id, tp);
+                } else {
+                    probe.deregister_metrics();
+                    probe.deregister_public_metrics();
+                }
+            };
+
+            enable_group_metrics.watch(metrics_registration);
+            metrics_registration();
         }
     };
 
@@ -257,8 +268,7 @@ public:
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
-      group_metadata_serializer,
-      enable_group_metrics);
+      group_metadata_serializer);
 
     // constructor used when loading state from log
     group(
@@ -270,8 +280,7 @@ public:
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
-      group_metadata_serializer,
-      enable_group_metrics);
+      group_metadata_serializer);
 
     ~group() noexcept;
 
@@ -633,7 +642,11 @@ public:
             _offsets.emplace(
               std::move(tp),
               std::make_unique<offset_metadata_with_probe>(
-                std::move(md), _id, tp, _enable_group_metrics));
+                std::move(md),
+                _id,
+                tp,
+                _conf.enable_consumer_group_metrics.bind(
+                  std::function{enabled_metrics::from_vector})));
         }
     }
 
@@ -648,7 +661,11 @@ public:
             _offsets.emplace(
               std::move(tp),
               std::make_unique<offset_metadata_with_probe>(
-                std::move(md), _id, tp, _enable_group_metrics));
+                std::move(md),
+                _id,
+                tp,
+                _conf.enable_consumer_group_metrics.bind(
+                  std::function{enabled_metrics::from_vector})));
             return true;
         }
     }
@@ -966,8 +983,7 @@ private:
     producers_map _producers;
     chunked_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
-    enable_group_metrics _enable_group_metrics;
-    config::binding<bool> _enable_consumer_lag_metrics;
+    metrics_conversion_binding _enable_group_metrics;
 
     ss::gate _gate;
     ss::timer<clock_type> _auto_abort_timer;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -963,6 +963,7 @@ private:
       model::topic_partition,
       std::unique_ptr<offset_metadata_with_probe>>
       _offsets;
+    consumer_lag_metrics _lag_metrics;
     group_probe<
       model::topic_partition,
       std::unique_ptr<offset_metadata_with_probe>>

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -69,8 +69,7 @@ group_manager::group_manager(
   ss::sharded<cluster::topic_table>& topic_table,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  group_metadata_serializer_factory serializer_factory,
-  enable_group_metrics enable_metrics)
+  group_metadata_serializer_factory serializer_factory)
   : _tp_ns(std::move(tp_ns))
   , _gm(gm)
   , _pm(pm)
@@ -80,7 +79,6 @@ group_manager::group_manager(
   , _serializer_factory(std::move(serializer_factory))
   , _conf(config::shard_local_cfg())
   , _self(cluster::make_self_broker(config::node()))
-  , _enable_group_metrics(enable_metrics)
   , _offset_retention_check(_conf.group_offset_retention_check_ms.bind()) {}
 
 ss::future<> group_manager::start() {
@@ -950,8 +948,7 @@ ss::future<> group_manager::do_recover_group(
               term,
               _tx_frontend,
               _feature_table,
-              _serializer_factory(),
-              _enable_group_metrics);
+              _serializer_factory());
             _groups.emplace(group_id, group);
             group->reschedule_all_member_heartbeats();
         }
@@ -1160,8 +1157,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
           it->second->term,
           _tx_frontend,
           _feature_table,
-          _serializer_factory(),
-          _enable_group_metrics);
+          _serializer_factory());
         _groups.emplace(r.data.group_id, group);
         _groups.rehash(0);
         is_new_group = true;
@@ -1313,8 +1309,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 p->term,
                 _tx_frontend,
                 _feature_table,
-                _serializer_factory(),
-                _enable_group_metrics);
+                _serializer_factory());
               _groups.emplace(r.data.group_id, group);
               _groups.rehash(0);
           }
@@ -1409,8 +1404,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 p->term,
                 _tx_frontend,
                 _feature_table,
-                _serializer_factory(),
-                _enable_group_metrics);
+                _serializer_factory());
               _groups.emplace(r.group_id, group);
               _groups.rehash(0);
           }
@@ -1484,8 +1478,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               p->term,
               _tx_frontend,
               _feature_table,
-              _serializer_factory(),
-              _enable_group_metrics);
+              _serializer_factory());
             _groups.emplace(r.data.group_id, group);
             _groups.rehash(0);
         } else {

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -132,8 +132,7 @@ public:
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
-      group_metadata_serializer_factory,
-      enable_group_metrics group_metrics);
+      group_metadata_serializer_factory);
 
     ss::future<> start();
     ss::future<> stop();
@@ -318,7 +317,6 @@ private:
     //
 
     model::broker _self;
-    enable_group_metrics _enable_group_metrics;
     config::binding<std::chrono::milliseconds> _offset_retention_check;
 };
 

--- a/src/v/kafka/server/group_probe.h
+++ b/src/v/kafka/server/group_probe.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/configuration.h"
+#include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "kafka/server/member.h"
 #include "metrics/metrics.h"
@@ -23,7 +24,26 @@
 
 #include <absl/container/node_hash_map.h>
 
+#include <algorithm>
+
 namespace kafka {
+
+struct enabled_metrics {
+    bool group;
+    bool partition;
+
+    static auto from_vector(const std::vector<ss::sstring>& metrics) {
+        return enabled_metrics{
+          .group = std::ranges::contains(metrics, "group"),
+          .partition = std::ranges::contains(metrics, "partition")};
+    }
+
+    constexpr auto operator<=>(const enabled_metrics&) const = default;
+};
+
+using metrics_conversion_binding
+  = config::conversion_binding<enabled_metrics, std::vector<ss::sstring>>;
+
 class group_offset_probe {
 public:
     explicit group_offset_probe(model::offset& offset) noexcept
@@ -34,7 +54,30 @@ public:
     group_offset_probe& operator=(group_offset_probe&&) = delete;
     ~group_offset_probe() = default;
 
-    void setup_metrics(
+    void register_metrics(
+      const kafka::group_id& group_id, const model::topic_partition& tp) {
+        if (_internal_metrics.has_value()) {
+            return;
+        }
+
+        _internal_metrics.emplace();
+        _setup_metrics(group_id, tp);
+    }
+    void deregister_metrics() { _internal_metrics.reset(); }
+
+    void register_public_metrics(
+      const kafka::group_id& group_id, const model::topic_partition& tp) {
+        if (_public_metrics.has_value()) {
+            return;
+        }
+
+        _public_metrics.emplace();
+        _setup_public_metrics(group_id, tp);
+    }
+    void deregister_public_metrics() { _public_metrics.reset(); }
+
+private:
+    void _setup_metrics(
       const kafka::group_id& group_id, const model::topic_partition& tp) {
         namespace sm = ss::metrics;
 
@@ -49,7 +92,7 @@ public:
           group_label(group_id()),
           topic_label(tp.topic()),
           partition_label(tp.partition())};
-        _metrics.add_group(
+        _internal_metrics.value().add_group(
           prometheus_sanitize::metrics_name("kafka:group"),
           {sm::make_gauge(
             "offset",
@@ -58,7 +101,7 @@ public:
             labels)});
     }
 
-    void setup_public_metrics(
+    void _setup_public_metrics(
       const kafka::group_id& group_id, const model::topic_partition& tp) {
         namespace sm = ss::metrics;
 
@@ -74,7 +117,7 @@ public:
           topic_label(tp.topic()),
           partition_label(tp.partition())};
 
-        _public_metrics.add_group(
+        _public_metrics.value().add_group(
           prometheus_sanitize::metrics_name("kafka:consumer:group"),
           {sm::make_gauge(
             "committed_offset",
@@ -83,10 +126,14 @@ public:
             labels)});
     }
 
-private:
+    struct metric_groups {
+        metrics::internal_metric_groups internal_metrics;
+        metrics::public_metric_groups public_metrics;
+    };
+
     model::offset& _offset;
-    metrics::internal_metric_groups _metrics;
-    metrics::public_metric_groups _public_metrics;
+    std::optional<metrics::internal_metric_groups> _internal_metrics;
+    std::optional<metrics::public_metric_groups> _public_metrics;
 };
 
 template<typename KeyType, typename ValType>
@@ -111,7 +158,19 @@ public:
     group_probe& operator=(group_probe&&) = delete;
     ~group_probe() = default;
 
-    void setup_public_metrics(const kafka::group_id& group_id) {
+    void register_group_metrics(const kafka::group_id& group_id) {
+        if (_public_group_metrics.has_value()) {
+            return;
+        }
+
+        _public_group_metrics.emplace();
+        _setup_public_metrics(group_id);
+    }
+
+    void deregister_group_metrics() { _public_group_metrics.reset(); }
+
+private:
+    void _setup_public_metrics(const kafka::group_id& group_id) {
         namespace sm = ss::metrics;
 
         if (config::shard_local_cfg().disable_public_metrics()) {
@@ -122,7 +181,7 @@ public:
 
         std::vector<sm::label_instance> labels{group_label(group_id())};
 
-        _public_metrics.add_group(
+        _public_group_metrics.value().add_group(
           prometheus_sanitize::metrics_name("kafka:consumer:group"),
           {sm::make_gauge(
              "consumers",
@@ -137,11 +196,10 @@ public:
              labels)});
     }
 
-private:
     member_map& _members;
     static_member_map& _static_members;
     offsets_map& _offsets;
-    metrics::public_metric_groups _public_metrics;
+    std::optional<metrics::public_metric_groups> _public_group_metrics;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/group_probe.h
+++ b/src/v/kafka/server/group_probe.h
@@ -31,11 +31,13 @@ namespace kafka {
 struct enabled_metrics {
     bool group;
     bool partition;
+    bool consumer_lag;
 
     static auto from_vector(const std::vector<ss::sstring>& metrics) {
         return enabled_metrics{
           .group = std::ranges::contains(metrics, "group"),
-          .partition = std::ranges::contains(metrics, "partition")};
+          .partition = std::ranges::contains(metrics, "partition"),
+          .consumer_lag = std::ranges::contains(metrics, "consumer_lag")};
     }
 
     constexpr auto operator<=>(const enabled_metrics&) const = default;
@@ -136,6 +138,11 @@ private:
     std::optional<metrics::public_metric_groups> _public_metrics;
 };
 
+struct consumer_lag_metrics {
+    size_t sum{};
+    size_t max{};
+};
+
 template<typename KeyType, typename ValType>
 class group_probe {
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
@@ -147,10 +154,12 @@ public:
     explicit group_probe(
       member_map& members,
       static_member_map& static_members,
-      offsets_map& offsets) noexcept
+      offsets_map& offsets,
+      consumer_lag_metrics& _lag_metrics) noexcept
       : _members(members)
       , _static_members(static_members)
-      , _offsets(offsets) {}
+      , _offsets(offsets)
+      , _lag_metrics(_lag_metrics) {}
 
     group_probe(const group_probe&) = delete;
     group_probe& operator=(const group_probe&) = delete;
@@ -168,6 +177,19 @@ public:
     }
 
     void deregister_group_metrics() { _public_group_metrics.reset(); }
+
+    void register_consumer_lag_metrics(const kafka::group_id& group_id) {
+        if (_public_consumer_lag_metrics.has_value()) {
+            return;
+        }
+
+        _public_consumer_lag_metrics.emplace();
+        _setup_consumer_lag_metrics(group_id);
+    }
+
+    void deregister_consumer_lag_metrics() {
+        _public_consumer_lag_metrics.reset();
+    }
 
 private:
     void _setup_public_metrics(const kafka::group_id& group_id) {
@@ -196,10 +218,38 @@ private:
              labels)});
     }
 
+    void _setup_consumer_lag_metrics(const kafka::group_id& group_id) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_public_metrics()) {
+            return;
+        }
+
+        auto group_label = metrics::make_namespaced_label("group");
+        std::vector<sm::label_instance> labels{group_label(group_id())};
+
+        _public_consumer_lag_metrics.value().add_group(
+          prometheus_sanitize::metrics_name("kafka:consumer:group"),
+          {sm::make_gauge(
+             "lag_sum",
+             [this] { return _lag_metrics.sum; },
+             sm::description(
+               "Sum of consumer group lag for all topic-partitions"),
+             labels),
+           sm::make_gauge(
+             "lag_max",
+             [this] { return _lag_metrics.max; },
+             sm::description(
+               "Maximum consumer group lag across topic-partitions"),
+             labels)});
+    }
+
     member_map& _members;
     static_member_map& _static_members;
     offsets_map& _offsets;
+    consumer_lag_metrics& _lag_metrics;
     std::optional<metrics::public_metric_groups> _public_group_metrics;
+    std::optional<metrics::public_metric_groups> _public_consumer_lag_metrics;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/partition.h"
 #include "config/configuration.h"
+#include "config/types.h"
 #include "container/fragmented_vector.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/group.h"
@@ -51,6 +52,7 @@ static bool is_uuid(const ss::sstring& uuid) {
  */
 static group get() {
     static config::configuration conf;
+    conf.enable_consumer_group_metrics.set_value(std::vector<ss::sstring>{});
     ss::sharded<cluster::tx_gateway_frontend> fr;
     ss::sharded<features::feature_table> feature_table;
     return group(
@@ -62,8 +64,7 @@ static group get() {
       model::term_id(),
       fr,
       feature_table,
-      make_consumer_offsets_serializer(),
-      enable_group_metrics::no);
+      make_consumer_offsets_serializer());
 }
 
 static const std::vector<member_protocol> test_group_protos = {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1984,8 +1984,7 @@ void application::wire_up_redpanda_services(
       std::ref(controller->get_topics_state()),
       std::ref(tx_gateway_frontend),
       std::ref(controller->get_feature_table()),
-      &kafka::make_consumer_offsets_serializer,
-      kafka::enable_group_metrics::yes)
+      &kafka::make_consumer_offsets_serializer)
       .get();
     construct_service(
       offsets_recoverer,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -716,6 +716,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 valid_value = random.choice(
                     [e for e in p['enum_values'] if e != initial_value])
 
+            if name == "enable_consumer_group_metrics":
+                valid_value = random.choice([[], ["group"], ["partition"]])
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -22,11 +22,11 @@ from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.kafka_cli_consumer import KafkaCliConsumer
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService, MetricsEndpoint
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import wait_until_result
+from rptest.util import expect_exception, wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 
 from ducktape.utils.util import wait_until
@@ -657,6 +657,94 @@ class ConsumerGroupTest(RedpandaTest):
 
         self.producer.wait()
         self.producer.free()
+
+    @cluster(num_nodes=6)
+    @parametrize(enabled_group_metrics=[])
+    @parametrize(enabled_group_metrics=["group"])
+    @parametrize(enabled_group_metrics=["partition"])
+    @parametrize(enabled_group_metrics=["group", "partition"])
+    def test_group_metrics(self, enabled_group_metrics):
+        """
+        Test validating the behavior of group metrics
+        """
+        def flip_option(option):
+            if option in enabled_group_metrics:
+                enabled_group_metrics.remove(option)
+            else:
+                enabled_group_metrics.append(option)
+
+        self.redpanda.set_cluster_config(
+            {"enable_consumer_group_metrics": enabled_group_metrics})
+
+        self.create_topic(20)
+        group = 'test-gr-1'
+        # use 2 consumers
+        consumers = self.create_consumers(2,
+                                          self.topic_spec.name,
+                                          group,
+                                          static_members=False)
+
+        self.start_producer()
+        # wait for some messages
+        wait_until(
+            lambda: ConsumerGroupTest.group_consumed_at_least(
+                consumers, 50 * len(consumers)), 30, 2,
+            "Test setup failed. Waiting on consumers timed out.")
+        self.validate_group_state(group,
+                                  expected_state="Stable",
+                                  static_members=False)
+
+        metrics = {
+            "group": [
+                "redpanda_kafka_consumer_group_consumers",
+                "redpanda_kafka_consumer_group_topics"
+            ],
+            "partition": ["redpanda_kafka_consumer_group_committed_offset"],
+        }
+
+        def get_group_metrics_from_nodes(patterns):
+            samples = self.redpanda.metrics_samples(
+                patterns, self.redpanda.started_nodes(),
+                MetricsEndpoint.PUBLIC_METRICS)
+            success = samples is not None and set(
+                samples.keys()) == set(patterns)
+            return success
+
+        for option, patterns in metrics.items():
+            expected_value = option in enabled_group_metrics
+            wait_until(
+                lambda: get_group_metrics_from_nodes(patterns
+                                                     ) == expected_value,
+                30,
+                1,
+                err_msg=
+                f"Looking for metrics in '{option}'. Timed-out while expecting value '{expected_value}'"
+            )
+
+        for option in metrics.keys():
+            flip_option(option)
+
+        self.redpanda.set_cluster_config(
+            {"enable_consumer_group_metrics": enabled_group_metrics})
+
+        for option, patterns in metrics.items():
+            expected_value = option in enabled_group_metrics
+            wait_until(
+                lambda: get_group_metrics_from_nodes(patterns
+                                                     ) == expected_value,
+                30,
+                1,
+                err_msg=
+                f"Looking for metrics in '{option}'. Timed-out while expecting value '{expected_value}'"
+            )
+
+        self.producer.wait()
+        self.producer.free()
+
+        for c in consumers:
+            c.stop()
+            c.wait()
+            c.free()
 
 
 @dataclass

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -662,7 +662,11 @@ class ConsumerGroupTest(RedpandaTest):
     @parametrize(enabled_group_metrics=[])
     @parametrize(enabled_group_metrics=["group"])
     @parametrize(enabled_group_metrics=["partition"])
+    @parametrize(enabled_group_metrics=["consumer_lag"])
     @parametrize(enabled_group_metrics=["group", "partition"])
+    @parametrize(enabled_group_metrics=["group", "consumer_lag"])
+    @parametrize(enabled_group_metrics=["partition", "consumer_lag"])
+    @parametrize(enabled_group_metrics=["group", "partition", "consumer_lag"])
     def test_group_metrics(self, enabled_group_metrics):
         """
         Test validating the behavior of group metrics
@@ -700,6 +704,10 @@ class ConsumerGroupTest(RedpandaTest):
                 "redpanda_kafka_consumer_group_topics"
             ],
             "partition": ["redpanda_kafka_consumer_group_committed_offset"],
+            "consumer_lag": [
+                "redpanda_kafka_consumer_group_lag_max",
+                "redpanda_kafka_consumer_group_lag_sum"
+            ]
         }
 
         def get_group_metrics_from_nodes(patterns):


### PR DESCRIPTION
Implements: [https://redpandadata.atlassian.net/browse/CORE-8914](https://redpandadata.atlassian.net/browse/CORE-8914)

Introduce "enable_consumer_group_metrics" which controls whether the group, partition and consumer lag metrics are active. This can be changed without needing a restart.

Introduce the metrics scaffolding needed to have metrics that can be enabled/disabled at runtime.

| Metric | Type | Description | Labels | Aggregation labels |
| -- | -- | -- | -- | -- |
| `redpanda_kafka_consumer_group_lag_max` | gauge | Maximum consumer group lag across topic-partitions | `group`, `shard` |  |
| `redpanda_kafka_consumer_group_lag_sum` | gauge | Sum of consumer group lag for all topic-partitions | `group`, `shard` |  |
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
