### PR TITLE
Updating search filter based on new naming conventions

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -79,7 +79,7 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
     def _check_aws_nodes(self):
         cmd = self.redpanda.kubectl._ssh_prefix() + [
             'aws', 'ec2', 'describe-instances',
-            '--filters="Name=tag:Name, Values=redpanda-{}-rp"'.format(
+            '--filters="Name=tag:Name, Values=redpanda-{}-rp-*"'.format(
                 self._clusterId),
             '--query="Reservations[0].Instances[*].InstanceType"'
         ]


### PR DESCRIPTION
There was a recent change in nodes naming by adding a flag to use ec2 instance name as k8s node name

Currently, our tests filter by `redpanda-{}-rp` where {} is redpanda cluster id.

New names also have - and letetrs at the end, which might be random
Example: `redpanda-cud8i8b6oe39rec1u8cg-rp-mnbc`


```
aws ec2 describe-instances \
    --region us-west-2 \
    --query "Reservations[*].Instances[*].[InstanceId, Tags[?Key=='Name'].Value | [0], InstanceType]" \
    --output table

---------------------------------------------------------------------------------
|                               DescribeInstances                               |
+----------------------+-----------------------------------------+--------------+
|  i-0f74e029d3b9bf9cb |  redpanda-cud8i8b6oe39rec1u8cg-util     |  m5.large    |
|  i-09d1c1e3bea7ffe2f |  redpanda-cud8i8b6oe39rec1u8cg-util     |  m5.large    |
|  i-016a37f7fd14d847d |  redpanda-cud8i8b6oe39rec1u8cg-connect  |  c5.large    |
|  i-08894e03745894651 |  redpanda-cud8i8b6oe39rec1u8cg          |  t3.small    |

>>>
|  i-0583f3515bc7f30a9 |  redpanda-cud8i8b6oe39rec1u8cg-rp-mnbc  |  i3en.xlarge |
|  i-03a8294a06fe8ab24 |  redpanda-cud8i8b6oe39rec1u8cg-rp-mnbc  |  i3en.xlarge |
|  i-03f248f3b68416fce |  redpanda-cud8i8b6oe39rec1u8cg-rp-mnbc  |  i3en.xlarge |
+----------------------+-----------------------------------------+--------------+
>>>
```

This PR is ONLY for AWS and fixing #Jira:DEVPROD-2566 #DEVPROD-2566

## Backports Required

- [ x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
