### PR TITLE
ducktape: handle SIGABORT in Redpanda

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3716,7 +3716,7 @@ class RedpandaService(RedpandaServiceBase):
 
             crash_log = None
             for line in node.account.ssh_capture(
-                    f"grep -e SEGV -e Segmentation\\ fault -e [Aa]ssert -e Sanitizer {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
+                    f"grep -e SEGV -e Segmentation\\ fault -e [Aa]ssert -e Sanitizer -e 'Aborting on shard' {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
                     timeout_sec=30):
                 if 'SEGV' in line and any(
                     [h in line.lower() for h in cloud_header_strings]):


### PR DESCRIPTION
Currently on raise_on_crash we detect if Redpanda has crashed, in order to surface that as the failure reason instead of something like timeout or connection refused which invariably occurs when Redpanda dies during a test.

However we didn't include "Aborting on shard" in the crash regex, which what occurs when abort is triggered, which happening in various scenarios including OOM.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
