### PR TITLE
bazel: fix sanitizers in debug mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,9 @@ build:sanitizer --copt -O1
 build:sanitizer --//bazel:has_sanitizers=True
 # seastar has to be run with system allocator when using sanitizers
 build:sanitizer --@seastar//:system_allocator=True
+# This is currently required to get ASAN to work, but ideally in the future we can get
+# the sanitizers working in release mode
+build:sanitizer --@seastar//:debug=true
 # krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
 build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function
 

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -576,9 +576,19 @@ cc_library(
     }) + select({
         ":with_debug": [
             "SEASTAR_DEBUG",
+            "SEASTAR_DEBUG_PROMISE",
             "SEASTAR_DEBUG_SHARED_PTR",
+            "SEASTAR_TYPE_ERASE_MORE",
         ],
         "//conditions:default": [],
+    }) + select({
+        # This isn't the best way to check this, but is the only way I can
+        # currently think of to replicate this behavior in Bazel. In CMake
+        # seastar only enables this if CMAKE_BUILD_SHARED_LIBS is enabled.
+        "@//bazel:optimized_build": [],
+        "//conditions:default": [
+            "SEASTAR_BUILD_SHARED_LIBS",
+        ],
     }),
     includes = [
         "include",


### PR DESCRIPTION
- **bazel: fix some seastar compilation settings**
- **bazel: fix sanitizers in bazel debug build**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
