### PR TITLE
`config`: add `iceberg_rest_catalog_authentication_mode` 

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3812,6 +3812,15 @@ configuration::configuration()
       {.visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , iceberg_rest_catalog_oauth2_server_uri(
+      *this,
+      "iceberg_rest_catalog_oauth2_server_uri",
+      "The OAuth URI used to retrieve access tokens for Iceberg catalog "
+      "authentication. If left undefined, the deprecated Iceberg catalog "
+      "endpoint `/v1/oauth/tokens` is used instead.",
+      {.visibility = visibility::user},
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , iceberg_backlog_controller_p_coeff(
       *this,
       "iceberg_backlog_controller_p_coeff",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3821,6 +3821,24 @@ configuration::configuration()
       {.visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , iceberg_rest_catalog_authentication_mode(
+      *this,
+      "iceberg_rest_catalog_authentication_mode",
+      "The authentication mode for client requests made to the Iceberg "
+      "catalog. Choose from: `none`, `bearer`, and `oauth2`. In `bearer` mode, "
+      "the token specified in `iceberg_rest_catalog_token` is used "
+      "unconditonally, and no attempts are made to refresh the token. In "
+      "`oauth2` mode, the credentials specified in "
+      "`iceberg_rest_catalog_client_id` and "
+      "`iceberg_rest_catalog_client_secret` are used to obtain a bearer token "
+      "from the URI defined by `iceberg_rest_catalog_oauth2_server_uri.`",
+      {.needs_restart = needs_restart::yes,
+       .example = "none",
+       .visibility = visibility::user},
+      datalake_catalog_auth_mode::none,
+      {datalake_catalog_auth_mode::none,
+       datalake_catalog_auth_mode::bearer,
+       datalake_catalog_auth_mode::oauth2})
   , iceberg_backlog_controller_p_coeff(
       *this,
       "iceberg_backlog_controller_p_coeff",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -719,6 +719,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> iceberg_rest_catalog_trust_file;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl_file;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_prefix;
+    property<std::optional<ss::sstring>> iceberg_rest_catalog_oauth2_server_uri;
     property<double> iceberg_backlog_controller_p_coeff;
     bounded_property<uint32_t> iceberg_target_backlog_size;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -720,6 +720,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl_file;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_prefix;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_oauth2_server_uri;
+    enum_property<datalake_catalog_auth_mode>
+      iceberg_rest_catalog_authentication_mode;
     property<double> iceberg_backlog_controller_p_coeff;
     bounded_property<uint32_t> iceberg_target_backlog_size;
 

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -687,4 +687,36 @@ struct convert<model::iceberg_invalid_record_action> {
     }
 };
 
+template<>
+struct convert<config::datalake_catalog_auth_mode> {
+    static Node encode(const config::datalake_catalog_auth_mode& rhs) {
+        return Node(fmt::format("{}", rhs));
+    }
+
+    static bool
+    decode(const Node& node, config::datalake_catalog_auth_mode& rhs) {
+        static constexpr auto acceptable_values
+          = config::acceptable_datalake_catalog_auth_modes();
+        auto value = node.as<std::string>();
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        rhs = string_switch<config::datalake_catalog_auth_mode>(
+                std::string_view{value})
+                .match(
+                  to_string_view(config::datalake_catalog_auth_mode::none),
+                  config::datalake_catalog_auth_mode::none)
+                .match(
+                  to_string_view(config::datalake_catalog_auth_mode::bearer),
+                  config::datalake_catalog_auth_mode::bearer)
+                .match(
+                  to_string_view(config::datalake_catalog_auth_mode::oauth2),
+                  config::datalake_catalog_auth_mode::oauth2);
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -14,6 +14,7 @@
 #include "base/type_traits.h"
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
+#include "config/types.h"
 #include "container/intrusive_list_helpers.h"
 #include "features/enterprise_feature_messages.h"
 #include "json/stringbuffer.h"
@@ -690,6 +691,10 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::is_same_v<
                            type,
                            model::iceberg_invalid_record_action>) {
+        return "string";
+    } else if constexpr (std::is_same_v<
+                           type,
+                           config::datalake_catalog_auth_mode>) {
         return "string";
     } else {
         static_assert(

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -273,4 +273,9 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, config::datalake_catalog_auth_mode cam) {
+    stringize(w, cam);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -142,4 +142,7 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>&,
   const model::iceberg_invalid_record_action&);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, config::datalake_catalog_auth_mode);
+
 } // namespace json

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -151,4 +151,46 @@ inline std::istream& operator>>(std::istream& is, datalake_catalog_type& ct) {
     return is;
 }
 
+enum class datalake_catalog_auth_mode { none, bearer, oauth2 };
+
+constexpr std::string_view to_string_view(datalake_catalog_auth_mode cam) {
+    switch (cam) {
+    case datalake_catalog_auth_mode::none:
+        return "none";
+    case datalake_catalog_auth_mode::bearer:
+        return "bearer";
+    case datalake_catalog_auth_mode::oauth2:
+        return "oauth2";
+    }
+}
+
+static constexpr auto acceptable_datalake_catalog_auth_modes() {
+    return std::to_array(
+      {to_string_view(datalake_catalog_auth_mode::none),
+       to_string_view(datalake_catalog_auth_mode::bearer),
+       to_string_view(datalake_catalog_auth_mode::oauth2)});
+}
+
+inline std::ostream&
+operator<<(std::ostream& os, datalake_catalog_auth_mode cam) {
+    return os << to_string_view(cam);
+}
+
+inline std::istream&
+operator>>(std::istream& is, datalake_catalog_auth_mode& cam) {
+    ss::sstring s;
+    is >> s;
+    cam = string_switch<datalake_catalog_auth_mode>(s)
+            .match(
+              to_string_view(datalake_catalog_auth_mode::none),
+              datalake_catalog_auth_mode::none)
+            .match(
+              to_string_view(datalake_catalog_auth_mode::bearer),
+              datalake_catalog_auth_mode::bearer)
+            .match(
+              to_string_view(datalake_catalog_auth_mode::bearer),
+              datalake_catalog_auth_mode::bearer);
+    return is;
+}
+
 } // namespace config

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -12,6 +12,7 @@
 #include "config/validators.h"
 
 #include "config/configuration.h"
+#include "config/types.h"
 #include "datalake/partition_spec_parser.h"
 #include "model/namespace.h"
 #include "model/validation.h"
@@ -274,6 +275,41 @@ validate_iceberg_partition_spec(const ss::sstring& value) {
     if (!parsed.value().is_valid_for_default_spec()) {
         return fmt::format(
           "partition spec `{}' can't be used as a default spec", value);
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
+validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
+    auto auth_mode = config.iceberg_rest_catalog_authentication_mode();
+    switch (auth_mode) {
+    case datalake_catalog_auth_mode::none:
+        return std::nullopt;
+    case datalake_catalog_auth_mode::bearer: {
+        const auto& token = config.iceberg_rest_catalog_token;
+        if (!token().has_value()) {
+            return fmt::format(
+              "Must set {} when iceberg_rest_catalog_authentication_mode is "
+              "set to {}.",
+              token.name(),
+              auth_mode);
+        }
+        break;
+    }
+    case datalake_catalog_auth_mode::oauth2: {
+        const auto& client_id = config.iceberg_rest_catalog_client_id;
+        const auto& client_secret = config.iceberg_rest_catalog_client_secret;
+        if (!(client_id().has_value() && client_secret().has_value())) {
+            return fmt::format(
+              "Must set both of {} and {} when "
+              "iceberg_rest_catalog_authentication_mode is "
+              "set to {}.",
+              client_id.name(),
+              client_secret.name(),
+              auth_mode);
+        }
+        break;
+    }
     }
     return std::nullopt;
 }

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "config/configuration.h"
+#include "config/types.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -57,5 +59,8 @@ std::optional<ss::sstring> validate_tombstone_retention_ms(
 
 std::optional<ss::sstring>
 validate_iceberg_partition_spec(const ss::sstring& spec);
+
+std::optional<ss::sstring>
+validate_iceberg_rest_catalog_auth_mode(const configuration& config);
 
 }; // namespace config

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -132,6 +132,8 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/cloud_io:remote",
+        "//src/v/iceberg/rest_client:credentials",
+        "//src/v/iceberg/rest_client:oauth_token",
         "@seastar",
     ],
 )

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -10,6 +10,7 @@
 #include "datalake/coordinator/catalog_factory.h"
 
 #include "config/configuration.h"
+#include "config/types.h"
 #include "datalake/logger.h"
 #include "iceberg/catalog.h"
 #include "iceberg/filesystem_catalog.h"
@@ -137,12 +138,38 @@ filesystem_catalog_factory::create_catalog() {
 rest_catalog_factory::rest_catalog_factory(config::configuration& config)
   : config_(&config) {}
 
+rest_catalog_factory::credentials_and_token
+rest_catalog_factory::make_credentials_or_token() {
+    auto creds_and_token = credentials_and_token{};
+    const auto auth_mode = config_->iceberg_rest_catalog_authentication_mode();
+    switch (auth_mode) {
+    case config::datalake_catalog_auth_mode::none:
+        break;
+    case config::datalake_catalog_auth_mode::bearer: {
+        throw_if_not_present(config_->iceberg_rest_catalog_token);
+        creds_and_token.token
+          = std::make_optional<iceberg::rest_client::oauth_token>(
+            config_->iceberg_rest_catalog_token().value());
+        break;
+    }
+    case config::datalake_catalog_auth_mode::oauth2: {
+        throw_if_not_present(config_->iceberg_rest_catalog_client_id);
+        throw_if_not_present(config_->iceberg_rest_catalog_client_secret);
+        creds_and_token.credentials
+          = std::make_optional<iceberg::rest_client::credentials>(
+            config_->iceberg_rest_catalog_client_id().value(),
+            config_->iceberg_rest_catalog_client_secret().value(),
+            config_->iceberg_rest_catalog_oauth2_server_uri());
+        break;
+    }
+    }
+    return creds_and_token;
+}
+
 ss::future<std::unique_ptr<iceberg::catalog>>
 rest_catalog_factory::create_catalog() {
     // TODO: add config level validation
     throw_if_not_present(config_->iceberg_rest_catalog_endpoint);
-    throw_if_not_present(config_->iceberg_rest_catalog_client_secret);
-    throw_if_not_present(config_->iceberg_rest_catalog_client_id);
 
     auto endpoint_information = endpoint_to_address(
       config_->iceberg_rest_catalog_endpoint().value());
@@ -161,10 +188,9 @@ rest_catalog_factory::create_catalog() {
           ? std::make_optional<iceberg::rest_client::prefix_path>(
               config_->iceberg_rest_catalog_prefix().value())
           : std::nullopt;
-    auto token = config_->iceberg_rest_catalog_token()
-                   ? std::make_optional<iceberg::rest_client::oauth_token>(
-                       config_->iceberg_rest_catalog_token().value())
-                   : std::nullopt;
+
+    auto creds_and_token = make_credentials_or_token();
+
     vlog(
       datalake_log.info,
       "Creating rest Iceberg catalog connected to: {}, with base path: {} and "
@@ -176,15 +202,13 @@ rest_catalog_factory::create_catalog() {
     auto client = std::make_unique<iceberg::rest_client::catalog_client>(
       std::move(http_client),
       config_->iceberg_rest_catalog_endpoint().value(),
-      // TODO: make credentials optional, we should provide either
-      // credentials or token
-      iceberg::rest_client::credentials{
-        .client_id = config_->iceberg_rest_catalog_client_id().value(),
-        .client_secret = config_->iceberg_rest_catalog_client_secret().value()},
-      std::move(endpoint_information.base_path), // base_path
-      std::move(prefix_path),                    // prefix
-      std::nullopt,                              // api_version
-      std::move(token)                           // token
+      std::move(creds_and_token.credentials),
+      std::move(endpoint_information.base_path),          // base_path
+      std::move(prefix_path),                             // prefix
+      std::nullopt,                                       // api_version
+      std::move(creds_and_token.token),                   // token
+      nullptr,                                            // retry_policy
+      config_->iceberg_rest_catalog_authentication_mode() // auth_mode
     );
 
     co_return std::make_unique<iceberg::rest_catalog>(

--- a/src/v/datalake/coordinator/catalog_factory.h
+++ b/src/v/datalake/coordinator/catalog_factory.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 #include "cloud_io/remote.h"
+#include "iceberg/rest_client/credentials.h"
+#include "iceberg/rest_client/oauth_token.h"
 
 namespace iceberg {
 class catalog;
@@ -34,6 +36,14 @@ public:
     ss::future<std::unique_ptr<iceberg::catalog>> create_catalog() final;
 
 private:
+    struct credentials_and_token {
+        std::optional<iceberg::rest_client::credentials> credentials{
+          std::nullopt};
+        std::optional<iceberg::rest_client::oauth_token> token{std::nullopt};
+    };
+
+    credentials_and_token make_credentials_or_token();
+
     config::configuration* config_;
 };
 /**

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -119,6 +119,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/http",
         "//src/v/http:request_builder",
+        "//src/v/http:rest_entity",
         "//src/v/http:utils",
         "//src/v/iceberg:json_writer",
         "//src/v/iceberg:logger",

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -61,6 +61,7 @@ redpanda_cc_library(
         "credentials.h",
     ],
     include_prefix = "iceberg/rest_client",
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
         "@seastar",
@@ -73,6 +74,7 @@ redpanda_cc_library(
         "oauth_token.h",
     ],
     include_prefix = "iceberg/rest_client",
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
         "@seastar",
@@ -114,6 +116,7 @@ redpanda_cc_library(
         ":retry_policy",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:streambuf",
+        "//src/v/config",
         "//src/v/http",
         "//src/v/http:request_builder",
         "//src/v/http:utils",

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -13,6 +13,7 @@
 #include "bytes/streambuf.h"
 #include "config/types.h"
 #include "http/request_builder.h"
+#include "http/rest_client/rest_entity.h"
 #include "http/utils.h"
 #include "iceberg/json_writer.h"
 #include "iceberg/rest_client/entities.h"
@@ -155,6 +156,35 @@ catalog_client::ensure_token(retry_chain_node& rtc) {
     co_return _oauth_token->access_token;
 }
 
+ss::future<expected<std::monostate>> catalog_client::maybe_add_bearer_auth(
+  http::request_builder& request, retry_chain_node& rtc) {
+    switch (_auth_mode) {
+    case config::datalake_catalog_auth_mode::none: {
+        break;
+    }
+    case config::datalake_catalog_auth_mode::bearer: {
+        // Use provided token.
+        vassert(
+          _oauth_token.has_value(),
+          "_oauth_token should have a value in auth mode {}",
+          _auth_mode);
+        request.with_bearer_auth(_oauth_token->access_token);
+        break;
+    }
+    case config::datalake_catalog_auth_mode::oauth2: {
+        // Ensure bearer token is still valid, may require acquiring a fresh one
+        // with OAuth2 credentials.
+        auto token = co_await ensure_token(rtc);
+        if (!token.has_value()) {
+            co_return tl::unexpected(token.error());
+        }
+
+        request.with_bearer_auth(token.value());
+    }
+    }
+    co_return std::monostate{};
+}
+
 ss::future<expected<iobuf>> catalog_client::perform_request(
   retry_chain_node& rtc,
   http::request_builder request_builder,
@@ -201,14 +231,13 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
 ss::future<expected<create_namespace_response>>
 catalog_client::create_namespace(
   create_namespace_request req, retry_chain_node& rtc) {
-    auto token = co_await ensure_token(rtc);
-    if (!token.has_value()) {
-        co_return tl::unexpected(token.error());
+    auto http_request = namespaces{root_path()}.create().with_content_type(
+      json_content_type);
+
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
     }
-    auto http_request = namespaces{root_path()}
-                          .create()
-                          .with_bearer_auth(token.value())
-                          .with_content_type(json_content_type);
 
     co_return (co_await perform_request(
                  rtc, http_request, serialize_payload_as_json(req)))
@@ -221,14 +250,13 @@ ss::future<expected<load_table_result>> catalog_client::create_table(
   const chunked_vector<ss::sstring>& ns,
   create_table_request req,
   retry_chain_node& rtc) {
-    auto token = co_await ensure_token(rtc);
-    if (!token.has_value()) {
-        co_return tl::unexpected(token.error());
+    auto http_request = table{root_path(), ns}.create().with_content_type(
+      json_content_type);
+
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
     }
-    auto http_request = table{root_path(), ns}
-                          .create()
-                          .with_bearer_auth(token.value())
-                          .with_content_type(json_content_type);
 
     co_return (co_await perform_request(
                  rtc, http_request, serialize_payload_as_json(req)))
@@ -240,13 +268,12 @@ ss::future<expected<load_table_result>> catalog_client::load_table(
   const chunked_vector<ss::sstring>& ns,
   const ss::sstring& table_name,
   retry_chain_node& rtc) {
-    auto token = co_await ensure_token(rtc);
-    if (!token.has_value()) {
-        co_return tl::unexpected(token.error());
-    }
+    auto http_request = table(root_path(), ns).get(table_name);
 
-    auto http_request
-      = table(root_path(), ns).get(table_name).with_bearer_auth(token.value());
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
+    }
 
     co_return (co_await perform_request(rtc, http_request))
       .and_then(parse_json)
@@ -258,11 +285,6 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
   const ss::sstring& table_name,
   std::optional<bool> purge_requested,
   retry_chain_node& rtc) {
-    auto token = co_await ensure_token(rtc);
-    if (!token.has_value()) {
-        co_return tl::unexpected(token.error());
-    }
-
     http::rest_client::rest_entity::optional_query_params params;
     if (purge_requested.has_value()) {
         params.emplace();
@@ -270,8 +292,12 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
     }
 
     auto http_request = table(root_path(), ns)
-                          .delete_(table_name, std::nullopt, std::move(params))
-                          .with_bearer_auth(token.value());
+                          .delete_(table_name, std::nullopt, std::move(params));
+
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
+    }
 
     co_return (co_await perform_request(rtc, http_request)).map([](iobuf&&) {
         // we expect empty response, discard it
@@ -281,15 +307,14 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
 
 ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
   commit_table_request commit_request, retry_chain_node& rtc) {
-    auto token = co_await ensure_token(rtc);
-    if (!token.has_value()) {
-        co_return tl::unexpected(token.error());
-    }
-
     auto http_request = table(root_path(), commit_request.identifier.ns)
                           .update(commit_request.identifier.table)
-                          .with_bearer_auth(token.value())
                           .with_content_type(json_content_type);
+
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
+    }
 
     co_return (co_await perform_request(
                  rtc, http_request, serialize_payload_as_json(commit_request)))

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -11,6 +11,7 @@
 #include "iceberg/rest_client/catalog_client.h"
 
 #include "bytes/streambuf.h"
+#include "config/types.h"
 #include "http/request_builder.h"
 #include "http/utils.h"
 #include "iceberg/json_writer.h"
@@ -87,23 +88,30 @@ expected<json::Document> parse_json(iobuf&& raw_response) {
 catalog_client::catalog_client(
   std::unique_ptr<http::abstract_client> http_client,
   ss::sstring endpoint,
-  credentials credentials,
+  std::optional<credentials> credentials,
   std::optional<base_path> base_path,
   std::optional<prefix_path> prefix,
   std::optional<api_version> api_version,
   std::optional<oauth_token> token,
-  std::unique_ptr<retry_policy> retry_policy)
+  std::unique_ptr<retry_policy> retry_policy,
+  config::datalake_catalog_auth_mode auth_mode)
   : _http_client(std::move(http_client))
   , _endpoint{std::move(endpoint)}
   , _credentials{std::move(credentials)}
   , _path_components{std::move(base_path), std::move(prefix), std::move(api_version)}
   , _oauth_token{std::move(token)}
-  , _retry_policy{
-      retry_policy ? std::move(retry_policy)
-                   : std::make_unique<default_retry_policy>()} {}
+  , _retry_policy{retry_policy ? std::move(retry_policy) : std::make_unique<default_retry_policy>()}
+  , _auth_mode(auth_mode) {}
 
 ss::future<expected<oauth_token>>
 catalog_client::acquire_token(retry_chain_node& rtc) {
+    vassert(
+      _credentials.has_value(),
+      "_credentials should have a value in auth mode {}",
+      _auth_mode);
+
+    const auto& creds = _credentials.value();
+
     const auto token_request
       = http::request_builder{}
           .method(boost::beast::http::verb::post)
@@ -111,8 +119,8 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
           .header("content-type", "application/x-www-form-urlencoded");
     auto payload = http::form_encode_data({
       {"grant_type", "client_credentials"},
-      {"client_id", _credentials.client_id},
-      {"client_secret", _credentials.client_secret},
+      {"client_id", creds.client_id},
+      {"client_secret", creds.client_secret},
       // TODO - parameterize this scope, the principal_role should be an input
       // to the catalog client
       {"scope", "PRINCIPAL_ROLE:ALL"},

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -46,6 +46,7 @@ iobuf serialize_payload_as_json(const T& payload) {
     return std::move(buf).as_iobuf();
 }
 static constexpr std::string_view json_content_type = "application/json";
+static constexpr std::string_view oauth_token_endpoint = "oauth/tokens";
 } // namespace
 
 namespace iceberg::rest_client {
@@ -112,10 +113,15 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
 
     const auto& creds = _credentials.value();
 
+    // Use the specified OAuth2 server uri if it has a value.
+    // Otherwise, fall back to the deprecated /oauth/tokens catalog endpoint.
+    ss::sstring token_path = creds.oauth2_server_uri.value_or(
+      _path_components.token_api_path());
+
     const auto token_request
       = http::request_builder{}
           .method(boost::beast::http::verb::post)
-          .path(_path_components.token_api_path())
+          .path(token_path)
           .header("content-type", "application/x-www-form-urlencoded");
     auto payload = http::form_encode_data({
       {"grant_type", "client_credentials"},
@@ -322,7 +328,7 @@ ss::sstring path_components::token_api_path() const {
     }
 
     parts.push_back(_api_version());
-    return absl::StrJoin(parts, "/") + "/oauth/tokens";
+    return absl::StrJoin(parts, "/") + "/" + std::string{oauth_token_endpoint};
 }
 
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -171,6 +171,14 @@ private:
     // expired. Acquired token is cached for future calls.
     ss::future<expected<ss::sstring>> ensure_token(retry_chain_node& rtc);
 
+    // Depending on the _auth_mode used in the catalog_client, authentication
+    // may be added to the http request.
+    //
+    // Returns an error if the authentication was unable to be added for any
+    // reason.
+    ss::future<expected<std::monostate>> maybe_add_bearer_auth(
+      http::request_builder& request, retry_chain_node& rtc);
+
     // Builds the request from supplied builder after validating it, performs
     // the request with optional payload, and takes care of retrying according
     // to policy

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "config/types.h"
 #include "http/client.h"
 #include "http/request_builder.h"
 #include "iceberg/rest_client/credentials.h"
@@ -77,17 +78,22 @@ public:
     /// \param api_version api version used to construct URLs,
     /// defaults to v1
     /// \param token an optional oauth token which will be used
-    /// if valid. If expired, a new one will be acquired \param retry_policy a
-    /// retry policy used to determine how failing calls will be retried
+    /// if valid. If expired, a new one will be acquired
+    /// \param retry_policy a retry policy used to determine how failing calls
+    /// will be retried
+    /// \param auth_mode the authentication mode to be used for obtaining an
+    /// oauth token used for API calls
     catalog_client(
       std::unique_ptr<http::abstract_client> client,
       ss::sstring endpoint,
-      credentials credentials,
+      std::optional<credentials> credentials = std::nullopt,
       std::optional<base_path> base_path = std::nullopt,
       std::optional<prefix_path> prefix = std::nullopt,
       std::optional<api_version> api_version = std::nullopt,
       std::optional<oauth_token> token = std::nullopt,
-      std::unique_ptr<retry_policy> retry_policy = nullptr);
+      std::unique_ptr<retry_policy> retry_policy = nullptr,
+      config::datalake_catalog_auth_mode auth_mode
+      = config::datalake_catalog_auth_mode::none);
     /**
      * The REST client allows interaction with Iceberg REST catalog implementing
      * the Iceberg Catalog OpenApi Specification as stated here:
@@ -175,10 +181,11 @@ private:
 
     std::unique_ptr<http::abstract_client> _http_client;
     ss::sstring _endpoint;
-    credentials _credentials;
+    std::optional<credentials> _credentials;
     path_components _path_components;
     std::optional<oauth_token> _oauth_token{std::nullopt};
     std::unique_ptr<retry_policy> _retry_policy;
+    config::datalake_catalog_auth_mode _auth_mode;
 
     friend class catalog_client_tester;
 };

--- a/src/v/iceberg/rest_client/credentials.h
+++ b/src/v/iceberg/rest_client/credentials.h
@@ -19,6 +19,7 @@ namespace iceberg::rest_client {
 struct credentials {
     ss::sstring client_id;
     ss::sstring client_secret;
+    std::optional<ss::sstring> oauth2_server_uri;
 };
 
 }; // namespace iceberg::rest_client

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -622,6 +622,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/config",
         "//src/v/iceberg:json_writer",
         "//src/v/iceberg:partition_json",
         "//src/v/iceberg:rest_catalog",

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -11,6 +11,7 @@
 #include "bytes/iobuf_parser.h"
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_io/tests/scoped_remote.h"
+#include "config/types.h"
 #include "iceberg/json_writer.h"
 #include "iceberg/rest_catalog.h"
 #include "iceberg/rest_client/catalog_client.h"
@@ -67,7 +68,10 @@ struct RestCatalogTest
           get_credentials(),
           iceberg::rest_client::base_path{"/catalog"},
           std::nullopt,
-          iceberg::rest_client::api_version("v1"));
+          iceberg::rest_client::api_version("v1"),
+          std::nullopt,
+          nullptr,
+          config::datalake_catalog_auth_mode::oauth2);
     }
     std::unique_ptr<cloud_io::scoped_remote> sr;
     iceberg::manifest_io io;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -49,6 +49,7 @@
 #include "config/base_property.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
+#include "config/validators.h"
 #include "container/fragmented_vector.h"
 #include "container/lw_shared_container.h"
 #include "features/enterprise_features.h"
@@ -1743,6 +1744,15 @@ void config_multi_property_validation(
           updated_config.cloud_storage_enabled.name(),
           updated_config.cloud_storage_enable_remote_read.name(),
           updated_config.cloud_storage_enable_remote_write.name());
+    }
+
+    // Validate iceberg authentication mode properties
+    auto opt_err = config::validate_iceberg_rest_catalog_auth_mode(
+      updated_config);
+    if (opt_err.has_value()) {
+        errors[ss::sstring{
+          updated_config.iceberg_rest_catalog_authentication_mode.name()}]
+          = opt_err.value();
     }
 }
 } // namespace

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1705,6 +1705,55 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         for prop, value in out_of_bound_properties.items():
             self._check_value_everywhere(prop, value)
 
+    @cluster(num_nodes=1)
+    def test_iceberg_authentication_properties(self):
+        """
+        Tests that the Iceberg authentication properties are properly validated when set.
+        """
+        validated_auth_modes = ["bearer", "oauth2"]
+
+        # Check that setting the authentication mode to anything other than "none" alone returns an error.
+        for mode in validated_auth_modes:
+            with expect_exception(requests.exceptions.HTTPError,
+                                  lambda e: e.response.status_code == 400):
+                self.redpanda.set_cluster_config(
+                    {'iceberg_rest_catalog_authentication_mode': mode},
+                    expect_restart=True)
+
+        # Bearer mode needs catalog_token set, oauth2 mode needs both client_id/secret set.
+        invalid_auth_mode_props = [{
+            'iceberg_rest_catalog_authentication_mode':
+            'bearer',
+        }, {
+            'iceberg_rest_catalog_authentication_mode':
+            'oauth2',
+            'iceberg_rest_catalog_client_id':
+            'panda_id',
+        }]
+
+        for invalid_props in invalid_auth_mode_props:
+            # These should fail.
+            with expect_exception(requests.exceptions.HTTPError,
+                                  lambda e: e.response.status_code == 400):
+                self.redpanda.set_cluster_config(invalid_props,
+                                                 expect_restart=True)
+
+        valid_auth_mode_props = [{
+            'iceberg_rest_catalog_authentication_mode': 'bearer',
+            'iceberg_rest_catalog_token': 'panda_token'
+        }, {
+            'iceberg_rest_catalog_authentication_mode':
+            'oauth2',
+            'iceberg_rest_catalog_client_id':
+            'panda_id',
+            'iceberg_rest_catalog_client_secret':
+            'panda_secret'
+        }]
+
+        for valid_props in valid_auth_mode_props:
+            # These should succeed.
+            self.redpanda.set_cluster_config(valid_props, expect_restart=True)
+
 
 """
 PropertyAliasData:

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -77,6 +77,8 @@ class PolarisCatalogSmokeTest(RedpandaTest):
             "rest",
             "iceberg_rest_catalog_endpoint":
             self.polaris.catalog_url,
+            "iceberg_rest_catalog_authentication_mode":
+            "oauth2",
             "iceberg_rest_catalog_client_id":
             client_id,
             "iceberg_rest_catalog_client_secret":


### PR DESCRIPTION
Add `iceberg_rest_catalog_authentication_mode` and `iceberg_rest_catalog_oauth2_server_uri` configuration options.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none