### PR TITLE
`config`: remove `shard_local_cfg` checks for `tombstone_retention_ms` validator

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -226,28 +226,6 @@ validate_api_endpoint(const std::optional<ss::sstring>& os) {
 std::optional<ss::sstring> validate_tombstone_retention_ms(
   const std::optional<std::chrono::milliseconds>& ms) {
     if (ms.has_value()) {
-        // For simplicity's sake, cloud storage enable/read/write permissions
-        // cannot be enabled at the same time as tombstone_retention_ms at the
-        // cluster level, to avoid the case in which redpanda refuses to create
-        // new, misconfigured topics due to cluster defaults
-        const auto& cloud_storage_enabled
-          = config::shard_local_cfg().cloud_storage_enabled;
-        const auto& cloud_storage_remote_write
-          = config::shard_local_cfg().cloud_storage_enable_remote_write;
-        const auto& cloud_storage_remote_read
-          = config::shard_local_cfg().cloud_storage_enable_remote_read;
-        if (
-          cloud_storage_enabled() || cloud_storage_remote_write()
-          || cloud_storage_remote_read()) {
-            return fmt::format(
-              "cannot set {} if any of ({}, {}, {}) are enabled at the cluster "
-              "level",
-              config::shard_local_cfg().tombstone_retention_ms.name(),
-              cloud_storage_enabled.name(),
-              cloud_storage_remote_write.name(),
-              cloud_storage_remote_read.name());
-        }
-
         if (ms.value() < 1ms || ms.value() > serde::max_serializable_ms) {
             return fmt::format(
               "tombstone_retention_ms should be in range: [1, {}]",


### PR DESCRIPTION
These checks are invalid, as cluster config changes are applied one by one. A user could edit multiple properties at once to a valid state, and be caught by this attempted validation with an outdated value in the `shard_local_cfg()`.

Multi-property validation of this cluster property is already handled in `server.cc`, see [`config_multi_property_validation()`](https://github.com/redpanda-data/redpanda/blob/2e3c1df93d1851439936ceb12b2044cb2b71d51e/src/v/redpanda/admin/server.cc#L1735-L1746).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

