### PR TITLE
bazel: more sanitizer fixes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -129,4 +129,11 @@ test --test_output=errors
 # warn if a timeout is much longer than actual runtime
 test --test_verbose_timeout_warnings
 
+# Use --config=lldb to run a test under lldb
+# to connect run `gdb-remote 7654` in an lldb session
+test:lldb --run_under='@llvm_18_toolchain_llvm//:bin/lldb-server g :7654 --'
+# Bump timeout to 1h
+test:lldb --test_timeout=3600
+test:lldb --strategy=TestRunner=local
+
 try-import %workspace%/user.bazelrc

--- a/BUILD
+++ b/BUILD
@@ -42,3 +42,17 @@ alias(
     name = "cc_gen",
     actual = "//bazel/compilation_database_generator",
 )
+
+filegroup(
+    name = "lsan_suppressions",
+    testonly = True,
+    srcs = ["lsan_suppressions.txt"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ubsan_suppressions",
+    testonly = True,
+    srcs = ["ubsan_suppressions.txt"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -9,7 +9,7 @@ running tests, like setting a reasonable number of cores and amount of memory.
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(":internal.bzl", "redpanda_copts")
 
-def has_flags(args, *flags):
+def _has_flags(args, *flags):
     """
     Check if flags are present in a set of arguments.
 
@@ -26,7 +26,7 @@ def has_flags(args, *flags):
                 return True
     return False
 
-def parse_bytes(value):
+def _parse_bytes(value):
     """
     Convert a string into bytes number. Does not respect SI standard.
 
@@ -48,10 +48,25 @@ def parse_bytes(value):
             break
     return int(value) * factor
 
-# TODO(bazel)
-# - Make log level configurable (e.g. CI)
-# - Set --overprovisioned in CI context
-# - Other ASAN settings used in cmake_test.py
+def _test_options():
+    data = [
+        "//:ubsan_suppressions",
+        "//:lsan_suppressions",
+        "@llvm_18_toolchain//:llvm-symbolizer",
+    ]
+    env = {
+        "BOOST_TEST_LOG_LEVEL": "test_suite",
+        "BOOST_TEST_COLOR_OUTPUT": "0",
+        "BOOST_TEST_CATCH_SYSTEM_ERRORS": "no",
+        "BOOST_TEST_REPORT_LEVEL": "no",
+        "BOOST_LOGGER": "HRF,test_suite",
+        "ASAN_OPTIONS": "disable_coredump=0:abort_on_error=1",
+        "ASAN_SYMBOLIZER_PATH": "$(rootpath @llvm_18_toolchain//:llvm-symbolizer)",
+        "LSAN_OPTIONS": "suppressions=$(rootpath //:lsan_suppressions)",
+        "UBSAN_OPTIONS": "halt_on_error=1:abort_on_error=1:report_error_type=1:suppressions=$(rootpath //:ubsan_suppressions)",
+    }
+    return data, env
+
 def _redpanda_cc_test(
         name,
         timeout,
@@ -96,9 +111,9 @@ def _redpanda_cc_test(
 
     args = common_args + extra_args + custom_args
 
-    if has_flags(args, "-m", "--memory"):
+    if _has_flags(args, "-m", "--memory"):
         fail("Use `memory=\"XGiB\"` test parameter instead of -m/--memory")
-    if has_flags(args, "-c", "--smp"):
+    if _has_flags(args, "-c", "--smp"):
         fail("Use `cpu=N` test parameter instead of -c/--smp")
 
     args.append("-m{}".format(memory))
@@ -106,12 +121,14 @@ def _redpanda_cc_test(
     resource_tags = [
         "resources:cpu:{}".format(cpu),
         # This is always defined in MiB for Bazel
-        "resources:memory:{}".format(parse_bytes(memory) / (1 << 20)),
+        "resources:memory:{}".format(_parse_bytes(memory) / (1 << 20)),
     ]
 
     # Google test / benchmarks don't understand the "--" protocol
     if args and dash_dash_protocol:
         args = ["--"] + args
+
+    test_data, test_env = _test_options()
 
     native.cc_test(
         name = name,
@@ -125,9 +142,9 @@ def _redpanda_cc_test(
             "layering_check",
         ],
         tags = resource_tags + tags,
-        env = env,
+        env = env | test_env,
         target_compatible_with = target_compatible_with,
-        data = data,
+        data = data + test_data,
         local_defines = local_defines,
     )
 
@@ -284,7 +301,7 @@ def redpanda_cc_btest_no_seastar(
         timeout = timeout,
         tags = [
             "resources:cpu:{}".format(cpu),
-            "resources:memory:{}".format(parse_bytes(memory) / (2 << 20)),
+            "resources:memory:{}".format(_parse_bytes(memory) / (2 << 20)),
         ],
         srcs = srcs,
         defines = defines,
@@ -361,13 +378,13 @@ def redpanda_cc_bench(
         "--abort-on-seastar-bad-alloc",
     ] + args
 
-    if has_flags(args, "-m", "--memory"):
+    if _has_flags(args, "-m", "--memory"):
         fail("Use `memory=\"XGiB\"` test parameter instead of -m/--memory")
-    if has_flags(args, "-c", "--smp"):
+    if _has_flags(args, "-c", "--smp"):
         fail("Use `cpu=N` test parameter instead of -c/--smp")
-    if has_flags(args, "--runs"):
+    if _has_flags(args, "--runs"):
         fail("Use `runs=N` test parameter instead of --runs")
-    if has_flags(args, "--duration"):
+    if _has_flags(args, "--duration"):
         fail("Use `duration=N` test parameter instead of --duration")
 
     args.append("-m{}".format(memory))
@@ -375,7 +392,7 @@ def redpanda_cc_bench(
     resource_tags = [
         "resources:cpu:{}".format(cpu),
         # This is always defined in MiB for Bazel
-        "resources:memory:{}".format(parse_bytes(memory) / (1 << 20)),
+        "resources:memory:{}".format(_parse_bytes(memory) / (1 << 20)),
     ]
 
     binary_args = []

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -69,13 +69,17 @@ redpanda_test_cc_library(
     srcs = [
         "boost_result_redirect.cc",
     ],
-    include_prefix = "test_utils",
-    visibility = ["//visibility:public"],
-    deps = [
+    implementation_deps = [
+        "//src/v/thirdparty/libxml2",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/time",
         "@boost//:config",
         "@boost//:core",
         "@boost//:test",
     ],
+    include_prefix = "test_utils",
+    visibility = ["//visibility:public"],
 )
 
 redpanda_test_cc_library(

--- a/src/v/test_utils/boost_result_redirect.cc
+++ b/src/v/test_utils/boost_result_redirect.cc
@@ -7,12 +7,94 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include <boost/test/detail/global_typedef.hpp>
-#include <boost/test/unit_test_log.hpp>
+#include "thirdparty/libxml2/xmlwriter.h"
+
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_replace.h>
+#include <absl/time/time.h>
+#include <boost/test/results_collector.hpp>
+#include <boost/test/tree/traverse.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_suite.hpp>
 
-#include <fstream>
-#include <iomanip>
+#include <stdexcept>
+
+namespace {
+
+class xml_writer {
+public:
+    explicit xml_writer(const std::string& path)
+      : _writer(xmlNewTextWriterFilename(path.c_str(), 0)) {
+        if (!_writer) {
+            throw std::runtime_error("unable to create writer");
+        }
+        if (
+          xmlTextWriterStartDocument(_writer, nullptr, "UTF-8", nullptr) < 0) {
+            throw std::runtime_error("unable to start doc");
+        }
+        if (xmlTextWriterSetIndent(_writer, 2) < 0) {
+            throw std::runtime_error("unable to use indent for doc");
+        }
+    }
+    xml_writer(const xml_writer&) = delete;
+    xml_writer(xml_writer&&) = delete;
+    xml_writer& operator=(const xml_writer&) = delete;
+    xml_writer& operator=(xml_writer&&) = delete;
+    ~xml_writer() {
+        if (_writer) {
+            xmlFreeTextWriter(_writer);
+        }
+    }
+
+    void start_element(const std::string& name) {
+        int res = xmlTextWriterStartElement(_writer, BAD_CAST name.c_str());
+        if (res < 0) {
+            throw std::runtime_error("unable to start element");
+        }
+        ++_unclosed_elements;
+    }
+    void add_attr(const std::string& name, size_t value) {
+        add_attr(name, absl::StrFormat("%d", value));
+    }
+    void add_attr(const std::string& name, double value) {
+        // use fixed format to avoid scientific notation for
+        // https://github.com/bazelbuild/bazel/issues/24605
+        add_attr(name, absl::StrFormat("%.6f", value));
+    }
+    void
+    add_attr(const std::string& name, boost::unit_test::const_string value) {
+        add_attr(name, std::string{value.begin(), value.size()});
+    }
+    void add_attr(const std::string& name, const std::string& value) {
+        int res = xmlTextWriterWriteAttribute(
+          _writer, BAD_CAST name.c_str(), BAD_CAST value.c_str());
+        if (res < 0) {
+            throw std::runtime_error("unable to write attribute");
+        }
+    }
+    void end_element() {
+        int res = xmlTextWriterEndElement(_writer);
+        if (res < 0) {
+            throw std::runtime_error("unable to end element");
+        }
+        --_unclosed_elements;
+    }
+
+    void close() {
+        for (int i = 0; i < _unclosed_elements; ++i) {
+            end_element();
+        }
+        if (xmlTextWriterEndDocument(_writer) < 0) {
+            throw std::runtime_error("unable to end doc");
+        }
+    }
+
+private:
+    int _unclosed_elements = 0;
+    xmlTextWriterPtr _writer;
+};
+
+using namespace boost::unit_test;
 
 /**
  * This test configuration object is used to redirect the JUNIT result output
@@ -21,20 +103,98 @@
  * writes the results in a local that bazel can subsequently consume.
  * Ref: CORE-8013.
  */
-struct bazel_result_handler_for_boost {
-    bazel_result_handler_for_boost() {
-        using namespace boost::unit_test;
+class bazel_test_observer : public test_observer {
+    class reporter : public test_tree_visitor {
+    public:
+        explicit reporter(xml_writer* writer)
+          : _writer(writer) {}
+
+        void visit(const test_case& tc) override {
+            const auto& results = results_collector.results(tc.p_id);
+            _writer->start_element("testcase");
+            const auto& suite = framework::get(
+              tc.p_parent_id, test_unit_type::TUT_SUITE);
+            _writer->add_attr(
+              "classname", absl::StrReplaceAll(suite.full_name(), {{" ", ""}}));
+            _writer->add_attr("name", tc.p_name);
+            _writer->add_attr("file", tc.p_file_name);
+            _writer->add_attr("line", tc.p_line_num);
+            _writer->add_attr(
+              "time",
+              absl::ToDoubleSeconds(
+                absl::Microseconds(results.p_duration_microseconds.get())));
+            if (results.aborted()) {
+                _writer->start_element("error");
+                _writer->end_element();
+            } else if (results.skipped()) {
+                _writer->start_element("skipped");
+                _writer->end_element();
+            } else if (!results.passed()) {
+                _writer->start_element("failure");
+                _writer->end_element();
+            }
+            _writer->end_element();
+        }
+        bool test_suite_start(const test_suite& suite) override {
+            _writer->start_element("testsuite");
+            _writer->add_attr(
+              "name", absl::StrReplaceAll(suite.p_name.get(), {{" ", ""}}));
+            const auto& results = results_collector.results(suite.p_id);
+            _writer->add_attr(
+              "tests",
+              results.p_test_cases_passed + results.p_test_cases_failed
+                + results.p_test_cases_aborted + results.p_test_cases_skipped);
+            _writer->add_attr("failures", results.p_test_cases_failed);
+            _writer->add_attr("errors", results.p_test_cases_aborted);
+            _writer->add_attr("skipped", results.p_test_cases_skipped);
+            _writer->add_attr(
+              "time",
+              absl::ToDoubleSeconds(
+                absl::Microseconds(results.p_duration_microseconds.get())));
+            return true;
+        }
+        void test_suite_finish(const test_suite&) override {
+            _writer->end_element();
+        }
+
+    private:
+        xml_writer* _writer;
+    };
+
+public:
+    bazel_test_observer() { framework::register_observer(*this); }
+    bazel_test_observer(const bazel_test_observer&) = delete;
+    bazel_test_observer(bazel_test_observer&&) = delete;
+    bazel_test_observer& operator=(const bazel_test_observer&) = delete;
+    bazel_test_observer& operator=(bazel_test_observer&&) = delete;
+    ~bazel_test_observer() override { framework::deregister_observer(*this); }
+    void test_finish() override { generate_output_file(); }
+    void test_aborted() override { generate_output_file(); }
+    int priority() override {
+        // Just needs to be higher than 3, the test collector priority.
+        constexpr int my_priority = 10;
+        return my_priority;
+    }
+
+private:
+    void generate_output_file() {
+        if (_done) {
+            return;
+        }
+        _done = true;
         if (auto xml_path = std::getenv("XML_OUTPUT_FILE")) {
-            // use fixed format to avoid scientific notation as a
-            // work-around to
-            // https://github.com/bazelbuild/bazel/issues/24605
-            _out = std::ofstream(xml_path)
-                   << std::fixed << std::setprecision(6);
-            unit_test_log.add_format(OF_JUNIT);
-            unit_test_log.set_stream(OF_JUNIT, *_out);
+            xml_writer w(xml_path);
+            w.start_element("testsuites");
+            reporter r{&w};
+            traverse_test_tree(framework::master_test_suite(), r);
+            w.end_element();
+            w.close();
         }
     }
-    static inline std::optional<std::ofstream> _out;
+
+    bool _done = false;
 };
 
-BOOST_TEST_GLOBAL_CONFIGURATION(bazel_result_handler_for_boost);
+} // namespace
+
+BOOST_TEST_GLOBAL_CONFIGURATION(bazel_test_observer);

--- a/src/v/thirdparty/libxml2/BUILD
+++ b/src/v/thirdparty/libxml2/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "libxml2",
     hdrs = [
         "parser.h",
+        "xmlwriter.h",
     ],
     include_prefix = "thirdparty/libxml2",
     visibility = ["//visibility:public"],

--- a/src/v/thirdparty/libxml2/xmlwriter.h
+++ b/src/v/thirdparty/libxml2/xmlwriter.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <libxml/xmlwriter.h>


### PR DESCRIPTION
Details in the commits, a lot of tests work with the sanitizer now, I'm just tracking down the final issues between cmake and bazel.

It's really nice to have the symbolizer there now to decode backtraces :) 

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
