### PR TITLE
[CORE-8161] `storage`: add `min.cleanable.dirty.ratio`, schedule compaction by `dirty_ratio`

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -487,6 +487,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      tristate<double>{},
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -329,6 +329,11 @@ metadata_cache::get_default_iceberg_target_lag_ms() const {
     return config::shard_local_cfg().iceberg_target_lag_ms();
 }
 
+std::optional<double>
+metadata_cache::get_default_min_cleanable_dirty_ratio() const {
+    return config::shard_local_cfg().min_cleanable_dirty_ratio();
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -348,6 +353,8 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_retention_local_target_ms()};
     tp.delete_retention_ms = tristate<std::chrono::milliseconds>{
       get_default_delete_retention_ms()};
+    tp.min_cleanable_dirty_ratio = tristate<double>{
+      get_default_min_cleanable_dirty_ratio()};
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -205,6 +205,7 @@ public:
     std::optional<std::chrono::milliseconds>
     get_default_delete_retention_ms() const;
     std::chrono::milliseconds get_default_iceberg_target_lag_ms() const;
+    std::optional<double> get_default_min_cleanable_dirty_ratio() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -59,6 +59,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .iceberg_mode = properties.iceberg_mode,
             .cloud_topic_enabled = properties.cloud_topic_enabled,
             .tombstone_retention_ms = properties.delete_retention_ms,
+            .min_cleanable_dirty_ratio = properties.min_cleanable_dirty_ratio,
           });
     }
     return {

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -45,7 +45,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "iceberg_delete: {}, "
       "iceberg_partition_spec: {}, "
       "iceberg_invalid_record_action: {}, "
-      "iceberg_target_lag_ms: {}",
+      "iceberg_target_lag_ms: {}, "
+      "min_cleanable_dirty_ratio: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -85,7 +86,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.iceberg_delete,
       properties.iceberg_partition_spec,
       properties.iceberg_invalid_record_action,
-      properties.iceberg_target_lag_ms);
+      properties.iceberg_target_lag_ms,
+      properties.min_cleanable_dirty_ratio);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(
@@ -133,7 +135,8 @@ bool topic_properties::has_overrides() const {
         || leaders_preference.has_value() || delete_retention_ms.is_engaged()
         || iceberg_delete.has_value() || iceberg_partition_spec.has_value()
         || iceberg_invalid_record_action.has_value()
-        || iceberg_target_lag_ms.has_value();
+        || iceberg_target_lag_ms.has_value()
+        || min_cleanable_dirty_ratio.is_engaged();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -272,6 +275,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      tristate<double>{std::nullopt},
     };
 }
 

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -179,6 +179,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.iceberg_mode = iceberg_mode;
     ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.tombstone_retention_ms = delete_retention_ms;
+    ret.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio;
     return ret;
 }
 

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -80,7 +80,8 @@ struct topic_properties
       std::optional<ss::sstring> iceberg_partition_spec,
       std::optional<model::iceberg_invalid_record_action>
         iceberg_invalid_record_action,
-      std::optional<std::chrono::milliseconds> iceberg_target_lag_ms)
+      std::optional<std::chrono::milliseconds> iceberg_target_lag_ms,
+      tristate<double> min_cleanable_dirty_ratio)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -125,7 +126,8 @@ struct topic_properties
       , iceberg_delete(iceberg_delete)
       , iceberg_partition_spec(std::move(iceberg_partition_spec))
       , iceberg_invalid_record_action(iceberg_invalid_record_action)
-      , iceberg_target_lag_ms(iceberg_target_lag_ms) {}
+      , iceberg_target_lag_ms(iceberg_target_lag_ms)
+      , min_cleanable_dirty_ratio(min_cleanable_dirty_ratio) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -210,6 +212,8 @@ struct topic_properties
 
     std::optional<std::chrono::milliseconds> iceberg_target_lag_ms{};
 
+    tristate<double> min_cleanable_dirty_ratio{std::nullopt};
+
     bool is_compacted() const;
     bool has_overrides() const;
     bool requires_remote_erase() const;
@@ -259,7 +263,8 @@ struct topic_properties
           iceberg_delete,
           iceberg_partition_spec,
           iceberg_invalid_record_action,
-          iceberg_target_lag_ms);
+          iceberg_target_lag_ms,
+          min_cleanable_dirty_ratio);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1110,6 +1110,10 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(
       updated_properties.iceberg_target_lag_ms,
       overrides.iceberg_target_lag_ms);
+    incremental_update(
+      updated_properties.min_cleanable_dirty_ratio,
+      overrides.min_cleanable_dirty_ratio);
+
     return updated_properties;
 }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -644,6 +644,7 @@ struct incremental_topic_updates
     property_update<std::optional<ss::sstring>> iceberg_partition_spec;
     property_update<std::optional<model::iceberg_invalid_record_action>>
       iceberg_invalid_record_action;
+    property_update<tristate<double>> min_cleanable_dirty_ratio;
 
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_target_lag_ms;
@@ -689,7 +690,8 @@ struct incremental_topic_updates
           iceberg_delete,
           iceberg_partition_spec,
           iceberg_invalid_record_action,
-          iceberg_target_lag_ms);
+          iceberg_target_lag_ms,
+          min_cleanable_dirty_ratio);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -363,6 +363,7 @@ struct compat_check<cluster::topic_properties> {
           "iceberg_invalid_record_action",
           obj.iceberg_invalid_record_action);
         json_write(iceberg_target_lag_ms);
+        json_write(min_cleanable_dirty_ratio);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -401,6 +402,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(remote_topic_namespace_override);
         json_read(iceberg_invalid_record_action);
         json_read(iceberg_target_lag_ms);
+        json_read(min_cleanable_dirty_ratio);
         return obj;
     }
 
@@ -434,6 +436,7 @@ struct compat_check<cluster::topic_properties> {
         obj.remote_topic_namespace_override = std::nullopt;
         obj.iceberg_invalid_record_action = std::nullopt;
         obj.iceberg_target_lag_ms = std::nullopt;
+        obj.min_cleanable_dirty_ratio = tristate<double>{std::nullopt};
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -520,6 +523,8 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.mpx_virtual_cluster_id = std::nullopt;
 
         obj.properties.iceberg_invalid_record_action = std::nullopt;
+        obj.properties.min_cleanable_dirty_ratio = tristate<double>{
+          std::nullopt};
 
         obj.properties.iceberg_target_lag_ms = std::nullopt;
 

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -663,7 +663,9 @@ struct instance_generator<cluster::topic_properties> {
                 {model::iceberg_invalid_record_action::drop,
                  model::iceberg_invalid_record_action::dlq_table});
           }),
-          tests::random_optional([] { return tests::random_duration_ms(); })};
+          tests::random_optional([] { return tests::random_duration_ms(); }),
+          tristate<double>{disable_tristate},
+        };
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -631,6 +631,7 @@ inline void rjson_serialize(
     write_exceptional_member_type(
       w, "iceberg_invalid_record_action", tps.iceberg_invalid_record_action);
     write_member(w, "iceberg_target_lag_ms", tps.iceberg_target_lag_ms);
+    write_member(w, "min_cleanable_dirty_ratio", tps.min_cleanable_dirty_ratio);
     w.EndObject();
 }
 
@@ -706,6 +707,7 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
     read_member(
       rd, "iceberg_invalid_record_action", obj.iceberg_invalid_record_action);
     read_member(rd, "iceberg_target_lag_ms", obj.iceberg_target_lag_ms);
+    read_member(rd, "min_cleanable_dirty_ratio", obj.min_cleanable_dirty_ratio);
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -35,6 +35,10 @@ inline const char* to_str(const rapidjson::Type t) {
     return str[t];
 }
 
+inline void read_value(const json::Value& v, double& target) {
+    target = v.GetDouble();
+}
+
 inline void read_value(const json::Value& v, int64_t& target) {
     target = v.GetInt64();
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -993,6 +993,19 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt,
       validate_tombstone_retention_ms)
+  , min_cleanable_dirty_ratio(
+      *this,
+      "min_cleanable_dirty_ratio",
+      "The minimum ratio between the number of bytes in \"dirty\" segments and "
+      "the total number of bytes in closed segments that must be reached "
+      "before a partition's log is eligible for compaction in a compact topic. "
+      "The topic property `min.cleanable.dirty.ratio` overrides the value of "
+      "`min_cleanable_dirty_ratio` at the topic level.",
+      {.needs_restart = needs_restart::no,
+       .example = "0.5",
+       .visibility = visibility::user},
+      0.5,
+      {.min = 0.0, .max = 1.0})
   , log_disable_housekeeping_for_tests(
       *this,
       "log_disable_housekeeping_for_tests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -252,6 +252,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     // same as delete.retention.ms in kafka
     property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
+    bounded_property<std::optional<double>, numeric_bounds>
+      min_cleanable_dirty_ratio;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     // same as retention.size in kafka - TODO: size not implemented

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -83,7 +83,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 35,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 36,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -397,6 +397,14 @@ create_topic_properties_update(
                           v);
                       return std::chrono::milliseconds{parsed};
                   });
+                continue;
+            }
+            if (cfg.name == topic_property_min_cleanable_dirty_ratio) {
+                parse_and_set_tristate(
+                  update.properties.min_cleanable_dirty_ratio,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  min_cleanable_dirty_ratio_validator{});
                 continue;
             }
         } catch (const validation_error& e) {

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1037,6 +1037,18 @@ config_response_container_t make_topic_configs(
           describe_as_string<std::chrono::milliseconds>);
     }
 
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      topic_property_min_cleanable_dirty_ratio,
+      metadata_cache.get_default_min_cleanable_dirty_ratio(),
+      topic_property_min_cleanable_dirty_ratio,
+      topic_properties.min_cleanable_dirty_ratio,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().min_cleanable_dirty_ratio.desc()));
+
     return result;
 }
 

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <type_traits>
 
 namespace kafka {
 template<typename T>
@@ -795,7 +796,9 @@ void parse_and_set_tristate(
     }
     // set property value
     if (op == config_resource_operation::set) {
-        auto parsed = boost::lexical_cast<int64_t>(*value);
+        using config_t
+          = std::conditional_t<std::is_floating_point_v<T>, T, int64_t>;
+        auto parsed = boost::lexical_cast<config_t>(*value);
         if (parsed <= 0) {
             property.value = tristate<T>{};
         } else {

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -540,6 +540,25 @@ struct iceberg_target_lag_ms_validator {
     }
 };
 
+struct min_cleanable_dirty_ratio_validator {
+    std::optional<ss::sstring>
+    operator()(const ss::sstring&, const tristate<double>& value) {
+        double min = 0.0;
+        double max = 1.0;
+        if (value.has_optional_value()) {
+            if (value.value() < min || value.value() > max) {
+                return fmt::format(
+                  "min.cleanable.dirty.ratio {} is outside of allowed range "
+                  "[{}, {}]",
+                  value.value(),
+                  min,
+                  max);
+            }
+        }
+        return std::nullopt;
+    }
+};
+
 template<typename T, typename... ValidatorTypes>
 requires requires(
   model::topic_namespace_view tns,

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -79,7 +79,8 @@ bool is_supported(std::string_view name) {
        topic_property_iceberg_delete,
        topic_property_iceberg_partition_spec,
        topic_property_iceberg_invalid_record_action,
-       topic_property_iceberg_target_lag_ms});
+       topic_property_iceberg_target_lag_ms,
+       topic_property_min_cleanable_dirty_ratio});
 
     if (std::any_of(
           supported_configs.begin(),

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -397,7 +397,14 @@ create_topic_properties_update(
                   iceberg_target_lag_ms_validator{});
                 continue;
             }
-
+            if (cfg.name == topic_property_min_cleanable_dirty_ratio) {
+                parse_and_set_tristate(
+                  update.properties.min_cleanable_dirty_ratio,
+                  cfg.value,
+                  op,
+                  min_cleanable_dirty_ratio_validator{});
+                continue;
+            }
         } catch (const validation_error& e) {
             vlog(
               klog.debug,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -284,6 +284,9 @@ to_cluster_type(const creatable_topic& t) {
       = get_duration_value<std::chrono::milliseconds>(
         config_entries, topic_property_iceberg_target_lag_ms);
 
+    cfg.properties.min_cleanable_dirty_ratio = get_tristate_value<double>(
+      config_entries, topic_property_min_cleanable_dirty_ratio);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -26,6 +26,7 @@
 #include <boost/lexical_cast.hpp>
 
 #include <array>
+#include <type_traits>
 
 namespace kafka {
 
@@ -188,7 +189,9 @@ get_config_value(const config_map_t& config, std::string_view key) {
 template<typename T>
 tristate<T>
 get_tristate_value(const config_map_t& config, std::string_view key) {
-    auto v = get_config_value<int64_t>(config, key);
+    using config_t
+      = std::conditional_t<std::is_floating_point_v<T>, T, int64_t>;
+    auto v = get_config_value<config_t>(config, key);
     // no value set
     if (!v) {
         return tristate<T>(std::nullopt);

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -118,6 +118,9 @@ inline constexpr std::string_view topic_property_iceberg_invalid_record_action
 inline constexpr std::string_view topic_property_iceberg_target_lag_ms
   = "redpanda.iceberg.target.lag.ms";
 
+inline constexpr std::string_view topic_property_min_cleanable_dirty_ratio
+  = "min.cleanable.dirty.ratio";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
@@ -129,7 +132,6 @@ inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
   "segment.jitter.ms",
   "min.insync.replicas",
   "min.compaction.lag.ms",
-  "min.cleanable.dirty.ratio",
   "message.timestamp.difference.max.ms",
   "message.format.version",
   "max.compaction.lag.ms",

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -749,6 +749,7 @@ FIXTURE_TEST(
       "redpanda.iceberg.mode",
       "redpanda.leaders.preference",
       "delete.retention.ms",
+      "min.cleanable.dirty.ratio",
     };
 
     // All properties_request

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -248,4 +248,8 @@ ssize_t failure_injectable_log::closed_segment_bytes() const {
     return _underlying_log->closed_segment_bytes();
 }
 
+double failure_injectable_log::dirty_ratio() {
+    return _underlying_log->dirty_ratio();
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -132,8 +132,9 @@ public:
       retention_offset(storage::gc_config) const final;
 
     ssize_t dirty_segment_bytes() const final;
-
     ssize_t closed_segment_bytes() const final;
+
+    double dirty_ratio() final;
 
 private:
     ss::shared_ptr<storage::log> _underlying_log;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -267,7 +267,7 @@ public:
     // Returns the dirty ratio of the log.
     // The dirty ratio is the ratio of bytes in closed, dirty segments to the
     // total number of bytes in all closed segments in the log.
-    double dirty_ratio();
+    double dirty_ratio() final;
 
 private:
     friend class disk_log_appender; // for multi-term appends

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -225,6 +225,11 @@ public:
     virtual ssize_t dirty_segment_bytes() const = 0;
     virtual ssize_t closed_segment_bytes() const = 0;
 
+    // Returns the dirty ratio of the log. The dirty ratio is the ratio of bytes
+    // in closed, dirty segments to the total number of bytes in all closed
+    // segments in the log.
+    virtual double dirty_ratio() = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -20,6 +20,7 @@ struct log_housekeeping_meta {
         none = 0,
         compacted = 1U,
         lifetime_checked = 1U << 1U,
+        compaction_checked = 1U << 2U,
     };
     explicit log_housekeeping_meta(ss::shared_ptr<log> l) noexcept
       : handle(std::move(l)) {}

--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -21,6 +21,7 @@ struct log_housekeeping_meta {
         compacted = 1U,
         lifetime_checked = 1U << 1U,
         compaction_checked = 1U << 2U,
+        should_compact = 1U << 3U,
     };
     explicit log_housekeeping_meta(ss::shared_ptr<log> l) noexcept
       : handle(std::move(l)) {}

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -236,6 +236,9 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
      *   compaction is already sequential when this will be unified with
      *   compaction, the whole task could be made concurrent
      */
+    using compaction_heuristic_t = double;
+    absl::flat_hash_map<model::ntp, compaction_heuristic_t>
+      ntp_to_compaction_heuristic;
     while (!_logs_list.empty()
            && is_not_set(_logs_list.front().flags, bflags::lifetime_checked)) {
         if (_abort_source.abort_requested()) {
@@ -250,7 +253,60 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         // prevents the removal of the parent object. this makes awaiting
         // apply_segment_ms safe against removal of segments from _logs_list
         co_await current_log.handle->apply_segment_ms();
+
+        auto should_compact_log = [](ss::shared_ptr<log> l) {
+            // Consider the dirty ratio.
+            const auto min_cleanable_dirty_ratio
+              = l->config().min_cleanable_dirty_ratio().value_or(0.0);
+            const auto dirty_ratio = l->dirty_ratio();
+            if (dirty_ratio >= min_cleanable_dirty_ratio) {
+                return true;
+            }
+
+            return false;
+        };
+
+        const auto compact_log = should_compact_log(current_log.handle);
+
+        if (compact_log) {
+            // Order ntps by compaction heuristic.
+            // Currently, this is just the dirty ratio.
+            auto compute_compaction_heuristic =
+              [](ss::shared_ptr<log> l) -> compaction_heuristic_t {
+                return l->dirty_ratio();
+            };
+
+            auto compaction_heuristic_weight = compute_compaction_heuristic(
+              current_log.handle);
+            ntp_to_compaction_heuristic.emplace(
+              current_log.handle->config().ntp(), compaction_heuristic_weight);
+        }
     }
+
+    // If there are no partitions to compact, return early
+    if (ntp_to_compaction_heuristic.empty()) {
+        co_return;
+    }
+
+    auto sort_by_heuristic = [&ntp_to_compaction_heuristic](
+                               const log_housekeeping_meta& a,
+                               const log_housekeeping_meta& b) {
+        auto heuristic_it_a = ntp_to_compaction_heuristic.find(
+          a.handle->config().ntp());
+        compaction_heuristic_t heuristic_a
+          = (heuristic_it_a != ntp_to_compaction_heuristic.end())
+              ? heuristic_it_a->second
+              : 0.0;
+        auto heuristic_it_b = ntp_to_compaction_heuristic.find(
+          b.handle->config().ntp());
+        compaction_heuristic_t heuristic_b
+          = (heuristic_it_b != ntp_to_compaction_heuristic.end())
+              ? heuristic_it_b->second
+              : 0.0;
+        return heuristic_a > heuristic_b;
+    };
+
+    _logs_list.sort(sort_by_heuristic);
 
     if (
       config::shard_local_cfg().log_compaction_use_sliding_window.value()
@@ -274,6 +330,12 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _logs_list.shift_forward();
 
         current_log.flags |= bflags::compaction_checked;
+
+        if (!ntp_to_compaction_heuristic.contains(
+              current_log.handle->config().ntp())) {
+            continue;
+        }
+
         current_log.flags |= bflags::compacted;
         current_log.last_compaction = ss::lowres_clock::now();
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -220,7 +220,9 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     // algorithm is: mark the logs visited, rotate _logs_list, op, and loop
     // until empty or reaching a marked log
     for (auto& log_meta : _logs_list) {
-        log_meta.flags &= ~(bflags::compacted | bflags::lifetime_checked);
+        log_meta.flags &= ~(
+          bflags::compacted | bflags::lifetime_checked
+          | bflags::compaction_checked);
     }
 
     /*
@@ -260,8 +262,9 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         co_await compaction_map->initialize(compaction_mem_bytes);
         _compaction_hash_key_map = std::move(compaction_map);
     }
-    while (!_logs_list.empty()
-           && is_not_set(_logs_list.front().flags, bflags::compacted)) {
+    while (
+      !_logs_list.empty()
+      && is_not_set(_logs_list.front().flags, bflags::compaction_checked)) {
         if (_abort_source.abort_requested()) {
             co_return;
         }
@@ -270,6 +273,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         _logs_list.shift_forward();
 
+        current_log.flags |= bflags::compaction_checked;
         current_log.flags |= bflags::compacted;
         current_log.last_compaction = ss::lowres_clock::now();
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -222,7 +222,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     for (auto& log_meta : _logs_list) {
         log_meta.flags &= ~(
           bflags::compacted | bflags::lifetime_checked
-          | bflags::compaction_checked);
+          | bflags::compaction_checked | bflags::should_compact);
     }
 
     /*
@@ -236,9 +236,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
      *   compaction is already sequential when this will be unified with
      *   compaction, the whole task could be made concurrent
      */
-    using compaction_heuristic_t = double;
-    absl::flat_hash_map<model::ntp, compaction_heuristic_t>
-      ntp_to_compaction_heuristic;
     while (!_logs_list.empty()
            && is_not_set(_logs_list.front().flags, bflags::lifetime_checked)) {
         if (_abort_source.abort_requested()) {
@@ -253,7 +250,30 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         // prevents the removal of the parent object. this makes awaiting
         // apply_segment_ms safe against removal of segments from _logs_list
         co_await current_log.handle->apply_segment_ms();
+    }
 
+    if (
+      config::shard_local_cfg().log_compaction_use_sliding_window.value()
+      && !_compaction_hash_key_map && !_logs_list.empty()
+      && is_not_set(_logs_list.front().flags, bflags::compacted)) {
+        auto compaction_mem_bytes
+          = memory_groups().compaction_reserved_memory();
+        auto compaction_map = std::make_unique<hash_key_offset_map>();
+        co_await compaction_map->initialize(compaction_mem_bytes);
+        _compaction_hash_key_map = std::move(compaction_map);
+    }
+
+    using compaction_heuristic_t = uint64_t;
+
+    // There can be no scheduling points between here and the sorting done
+    // below, as we are holding pointers to log_housekeeping_meta in this
+    // btree_map.
+    // This needs to be sorted in ascending order, as we are pushing `log_meta`s
+    // to the front of the `_log_list`.
+    absl::
+      btree_map<compaction_heuristic_t, chunked_vector<log_housekeeping_meta*>>
+        compaction_heuristic_to_log_metas;
+    for (auto& log_meta : _logs_list) {
         auto should_compact_log = [](ss::shared_ptr<log> l) {
             // Consider the dirty ratio.
             const auto min_cleanable_dirty_ratio
@@ -266,58 +286,38 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             return false;
         };
 
-        const auto compact_log = should_compact_log(current_log.handle);
+        const auto compact_log = should_compact_log(log_meta.handle);
 
         if (compact_log) {
+            log_meta.flags |= bflags::should_compact;
+
             // Order ntps by compaction heuristic.
             // Currently, this is just the dirty ratio.
             auto compute_compaction_heuristic =
               [](ss::shared_ptr<log> l) -> compaction_heuristic_t {
-                return l->dirty_ratio();
+                auto res = (100.0 * l->dirty_ratio());
+                return static_cast<compaction_heuristic_t>(res);
             };
 
             auto compaction_heuristic_weight = compute_compaction_heuristic(
-              current_log.handle);
-            ntp_to_compaction_heuristic.emplace(
-              current_log.handle->config().ntp(), compaction_heuristic_weight);
+              log_meta.handle);
+            compaction_heuristic_to_log_metas[compaction_heuristic_weight]
+              .push_back(&log_meta);
         }
     }
 
     // If there are no partitions to compact, return early
-    if (ntp_to_compaction_heuristic.empty()) {
+    if (compaction_heuristic_to_log_metas.empty()) {
         co_return;
     }
 
-    auto sort_by_heuristic = [&ntp_to_compaction_heuristic](
-                               const log_housekeeping_meta& a,
-                               const log_housekeeping_meta& b) {
-        auto heuristic_it_a = ntp_to_compaction_heuristic.find(
-          a.handle->config().ntp());
-        compaction_heuristic_t heuristic_a
-          = (heuristic_it_a != ntp_to_compaction_heuristic.end())
-              ? heuristic_it_a->second
-              : 0.0;
-        auto heuristic_it_b = ntp_to_compaction_heuristic.find(
-          b.handle->config().ntp());
-        compaction_heuristic_t heuristic_b
-          = (heuristic_it_b != ntp_to_compaction_heuristic.end())
-              ? heuristic_it_b->second
-              : 0.0;
-        return heuristic_a > heuristic_b;
-    };
-
-    _logs_list.sort(sort_by_heuristic);
-
-    if (
-      config::shard_local_cfg().log_compaction_use_sliding_window.value()
-      && !_compaction_hash_key_map && !_logs_list.empty()
-      && is_not_set(_logs_list.front().flags, bflags::compacted)) {
-        auto compaction_mem_bytes
-          = memory_groups().compaction_reserved_memory();
-        auto compaction_map = std::make_unique<hash_key_offset_map>();
-        co_await compaction_map->initialize(compaction_mem_bytes);
-        _compaction_hash_key_map = std::move(compaction_map);
+    for (const auto& [weight, log_metas] : compaction_heuristic_to_log_metas) {
+        for (auto* meta_ptr : log_metas) {
+            meta_ptr->link.unlink();
+            _logs_list.push_front(*meta_ptr);
+        }
     }
+
     while (
       !_logs_list.empty()
       && is_not_set(_logs_list.front().flags, bflags::compaction_checked)) {
@@ -331,8 +331,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         current_log.flags |= bflags::compaction_checked;
 
-        if (!ntp_to_compaction_heuristic.contains(
-              current_log.handle->config().ntp())) {
+        if (is_not_set(current_log.flags, bflags::should_compact)) {
             continue;
         }
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -86,6 +86,8 @@ public:
         // properties.
         tristate<std::chrono::milliseconds> tombstone_retention_ms;
 
+        tristate<double> min_cleanable_dirty_ratio;
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };
@@ -363,6 +365,18 @@ public:
         }
         return _overrides ? _overrides->cloud_topic_enabled
                           : default_cloud_topic_enabled;
+    }
+
+    std::optional<double> min_cleanable_dirty_ratio() const {
+        if (_overrides) {
+            if (_overrides->min_cleanable_dirty_ratio.is_disabled()) {
+                return std::nullopt;
+            }
+            if (_overrides->min_cleanable_dirty_ratio.has_optional_value()) {
+                return _overrides->min_cleanable_dirty_ratio.value();
+            }
+        }
+        return config::shard_local_cfg().min_cleanable_dirty_ratio();
     }
 
     ntp_config copy() const {

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -564,6 +564,7 @@ redpanda_cc_btest(
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:directory_walker",
         "//src/v/utils:to_string",
+        "//src/v/utils:tristate",
         "@boost//:test",
         "@fmt",
         "@seastar",

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -19,5 +19,14 @@ public:
     static batch_cache& batch_cache(storage::log_manager& m) {
         return m._batch_cache;
     }
+
+    static ss::future<> housekeeping_scan(storage::log_manager& m) {
+        return m.housekeeping_scan(m.lowest_ts_to_retain());
+    }
+
+    static storage::log_manager::compaction_list_type&
+    logs_list(storage::log_manager& m) {
+        return m._logs_list;
+    }
 };
 } // namespace storage::testing_details

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -25,6 +25,7 @@
 #include "reflection/adl.h"
 #include "storage/batch_cache.h"
 #include "storage/disk_log_impl.h"
+#include "storage/log_housekeeping_meta.h"
 #include "storage/log_manager.h"
 #include "storage/log_reader.h"
 #include "storage/ntp_config.h"
@@ -40,6 +41,7 @@
 #include "test_utils/randoms.h"
 #include "test_utils/tmp_dir.h"
 #include "utils/directory_walker.h"
+#include "utils/tristate.h"
 
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/loop.hh>
@@ -5576,4 +5578,117 @@ FIXTURE_TEST(
 
     BOOST_REQUIRE_EQUAL(
       saved_closed_segment_bytes, disk_log.closed_segment_bytes());
+}
+
+FIXTURE_TEST(compaction_scheduling, storage_test_fixture) {
+    using log_manager_accessor = storage::testing_details::log_manager_accessor;
+    storage::log_manager mgr = make_log_manager();
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    std::vector<ss::shared_ptr<storage::log>> logs;
+
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    ov.min_cleanable_dirty_ratio = tristate<double>{0.2};
+
+    for (const auto& topic : {"tapioca", "cassava", "kudzu"}) {
+        auto ntp = model::ntp("kafka", topic, 0);
+        auto log
+          = mgr
+              .manage(storage::ntp_config(
+                ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+              .get();
+        logs.push_back(log);
+    }
+
+    auto& meta_list = log_manager_accessor::logs_list(mgr);
+
+    using bflags = storage::log_housekeeping_meta::bitflags;
+
+    static constexpr auto is_set = [](bflags var, auto flag) {
+        return (var & flag) == flag;
+    };
+
+    // Floating point comparison tolerance
+    static constexpr auto tol = 1.0e-6;
+
+    auto append_and_force_roll = [this](auto& log, int num_batches = 10) {
+        auto headers = append_random_batches<linear_int_kv_batch_generator>(
+          log, num_batches);
+        log->force_roll(ss::default_priority_class()).get();
+    };
+
+    // Attempt a housekeeping scan with no partitions to compact
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    for (const auto& meta : meta_list) {
+        BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+        BOOST_REQUIRE(!is_set(meta.flags, bflags::compacted));
+    }
+
+    // Append batches and force roll with first log- it should be the only one
+    // compacted
+    append_and_force_roll(logs[0], 30);
+    BOOST_REQUIRE_CLOSE(logs[0]->dirty_ratio(), 1.0, tol);
+
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    for (const auto& meta : meta_list) {
+        bool expect_compacted = meta.handle->config().ntp()
+                                == logs[0]->config().ntp();
+        BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+        BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+        BOOST_REQUIRE_EQUAL(
+          expect_compacted, is_set(meta.flags, bflags::compacted));
+        auto batches = read_and_validate_all_batches(logs[0]);
+        linear_int_kv_batch_generator::validate_post_compaction(
+          std::move(batches));
+    }
+
+    // Append fewer batches and force roll with second log- it should be the
+    // only one compacted
+    append_and_force_roll(logs[1], 20);
+    BOOST_REQUIRE_CLOSE(logs[1]->dirty_ratio(), 1.0, tol);
+
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    for (const auto& meta : meta_list) {
+        bool expect_compacted = meta.handle->config().ntp()
+                                == logs[1]->config().ntp();
+        BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+        BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+        BOOST_REQUIRE_EQUAL(
+          expect_compacted, is_set(meta.flags, bflags::compacted));
+        auto batches = read_and_validate_all_batches(logs[1]);
+        linear_int_kv_batch_generator::validate_post_compaction(
+          std::move(batches));
+    }
+
+    // Append batches and force roll all logs- all of them will be compacted
+    for (auto& log : logs) {
+        append_and_force_roll(log, 10);
+    }
+
+    BOOST_REQUIRE_GE(logs[0]->dirty_ratio(), 1.0 / 3.0);
+    BOOST_REQUIRE_GE(logs[1]->dirty_ratio(), 1.0 / 2.0);
+    BOOST_REQUIRE_CLOSE(logs[2]->dirty_ratio(), 1.0, tol);
+
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    // Logs in the meta list will be ordered w/r/t their dirty ratio
+    // (descending) post compaction
+    auto log_it = logs.rbegin();
+    for (const auto& meta : meta_list) {
+        BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+        BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+        BOOST_REQUIRE(is_set(meta.flags, bflags::compacted));
+        BOOST_REQUIRE_EQUAL(
+          meta.handle->config().ntp(), (*log_it)->config().ntp());
+        ++log_it;
+    }
+
+    for (auto& log : logs) {
+        auto batches = read_and_validate_all_batches(log);
+    }
 }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5682,6 +5682,7 @@ FIXTURE_TEST(compaction_scheduling, storage_test_fixture) {
     for (const auto& meta : meta_list) {
         BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
         BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+        BOOST_REQUIRE(is_set(meta.flags, bflags::should_compact));
         BOOST_REQUIRE(is_set(meta.flags, bflags::compacted));
         BOOST_REQUIRE_EQUAL(
           meta.handle->config().ntp(), (*log_it)->config().ntp());

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -247,13 +247,16 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
 
         assert configs is not None, "didn't find Configs: section"
 
-        def maybe_int(key: str, value: str):
+        def maybe_convert_value(key: str, value: str):
             if key in [
                     "retention_ms", "retention_bytes", 'segment_bytes',
                     'delete_retention_ms'
             ]:
                 return int(value)
-            return value
+            elif key in ['min_cleanable_dirty_ratio']:
+                return float(value)
+            else:
+                return value
 
         def fix_key(key: str):
             return key.replace(".", "_")
@@ -265,7 +268,10 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         ]
 
         configs = {fix_key(kv[0].strip()): kv[1].strip() for kv in configs}
-        configs = {kv[0]: maybe_int(kv[0], kv[1]) for kv in configs.items()}
+        configs = {
+            kv[0]: maybe_convert_value(kv[0], kv[1])
+            for kv in configs.items()
+        }
         configs["replication_factor"] = replication_factor
         configs["partition_count"] = partitions
         # The cast below is needed because a dict cannot be unpacked as keyword args

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -43,6 +43,7 @@ class TopicSpec:
     PROPERTY_DELETE_RETENTION_MS = "delete.retention.ms"
     PROPERTY_ICEBERG_INVALID_RECORD_ACTION = "redpanda.iceberg.invalid.record.action"
     PROPERTY_ICEBERG_TARGET_LAG_MS = "redpanda.iceberg.target.lag.ms"
+    PROPERTY_MIN_CLEANABLE_DIRTY_RATIO = "min.cleanable.dirty.ratio"
 
     class CompressionTypes(str, Enum):
         """
@@ -125,7 +126,8 @@ class TopicSpec:
             initial_retention_local_target_bytes: int | None = None,
             initial_retention_local_target_ms: int | None = None,
             virtual_cluster_id: str | None = None,
-            delete_retention_ms: int | None = None):
+            delete_retention_ms: int | None = None,
+            min_cleanable_dirty_ratio: float | None = None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -152,6 +154,7 @@ class TopicSpec:
         self.initial_retention_local_target_ms = initial_retention_local_target_ms
         self.virtual_cluster_id = virtual_cluster_id
         self.delete_retention_ms = delete_retention_ms
+        self.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -251,6 +251,53 @@ class AlterTopicConfiguration(RedpandaTest):
         assert altered_output["redpanda.remote.read"] == "false"
         assert altered_output["redpanda.remote.write"] == "false"
 
+    @cluster(num_nodes=3)
+    def test_min_cleanable_dirty_ratio_validation(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        self.redpanda.set_cluster_config({"min_cleanable_dirty_ratio": 0.5})
+        initial_spec = kafka_tools.describe_topic(topic)
+
+        # Check that a value outside valid range is rejected
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_MIN_CLEANABLE_DIRTY_RATIO: 1.01})
+        except subprocess.CalledProcessError as e:
+            assert "is outside of allowed range" in e.output
+
+        assert initial_spec.min_cleanable_dirty_ratio == kafka_tools.describe_topic(
+            topic
+        ).min_cleanable_dirty_ratio, "min.cleanable.dirty.ratio shouldn't be changed to invalid value"
+
+        # Check that a valid value is accepted
+        self.client().alter_topic_configs(
+            topic, {TopicSpec.PROPERTY_MIN_CLEANABLE_DIRTY_RATIO: 0.3})
+
+        assert kafka_tools.describe_topic(
+            topic).min_cleanable_dirty_ratio == 0.3
+
+        # Check that we can disable the tristate with -1
+        self.client().alter_topic_configs(
+            topic, {TopicSpec.PROPERTY_MIN_CLEANABLE_DIRTY_RATIO: -1})
+
+        assert kafka_tools.describe_topic(
+            topic).min_cleanable_dirty_ratio == -1
+
+        # Check that we can disable the tristate with any value < 0
+        self.client().alter_topic_configs(
+            topic, {TopicSpec.PROPERTY_MIN_CLEANABLE_DIRTY_RATIO: -123.456})
+
+        assert kafka_tools.describe_topic(
+            topic).min_cleanable_dirty_ratio == -1
+
+        # Check that deleting the topic config resets it back to cluster default
+        self.client().delete_topic_config(
+            topic, TopicSpec.PROPERTY_MIN_CLEANABLE_DIRTY_RATIO)
+
+        assert kafka_tools.describe_topic(
+            topic
+        ).min_cleanable_dirty_ratio == initial_spec.min_cleanable_dirty_ratio
+
 
 class ShadowIndexingGlobalConfig(RedpandaTest):
     topics = (TopicSpec(partition_count=1, replication_factor=3), )

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -35,7 +35,8 @@ class CompactionGapsTest(RedpandaTest):
                 "iceberg_enabled": "true",
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "datalake_coordinator_snapshot_max_delay_secs": 10,
-                "log_compaction_interval_ms": 5000
+                "log_compaction_interval_ms": 5000,
+                "min_cleanable_dirty_ratio": 0.0
             },
             *args,
             **kwargs)

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -313,6 +313,16 @@ class DescribeTopicsTest(RedpandaTest):
                 value="dlq_table",
                 doc_string=
                 "Action to take when an invalid record is encountered."),
+            "min.cleanable.dirty.ratio":
+            ConfigProperty(
+                config_type="DOUBLE",
+                value="0.5",
+                doc_string=
+                "The minimum ratio between the number of bytes in \"dirty\" segments and "
+                "the total number of bytes in closed segments that must be reached "
+                "before a partition's log is eligible for compaction in a compact topic. "
+                "The topic property `min.cleanable.dirty.ratio` overrides the value of "
+                "`min_cleanable_dirty_ratio` at the topic level."),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -77,7 +77,8 @@ class EndToEndShadowIndexingBase(EndToEndTest):
             cloud_storage_cluster_metadata_upload_interval_ms=1000,
             # Tests may configure spillover manually.
             cloud_storage_spillover_manifest_size=None,
-            controller_snapshot_max_age_sec=1)
+            controller_snapshot_max_age_sec=1,
+            min_cleanable_dirty_ratio=0.0)
         if extra_rp_conf:
             for k, v in conf.items():
                 extra_rp_conf[k] = v

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -34,7 +34,8 @@ class LogCompactionTest(PreallocNodesTest, PartitionMovementMixin):
             'log_segment_size': 2 * 1024**2,  # 2 MiB
             'retention_bytes': 25 * 1024**2,  # 25 MiB
             'compacted_log_segment_size': 1024**2,  # 1 MiB
-            'storage_compaction_key_map_memory': key_map_memory_kb * 1024
+            'storage_compaction_key_map_memory': key_map_memory_kb * 1024,
+            'min_cleanable_dirty_ratio': 0.0
         }
 
         # This environment variable is required to get around the map memory bounds

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -28,12 +28,11 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
         self.si_settings = SISettings(test_context,
                                       cloud_storage_max_connections=5,
                                       fast_uploads=True)
-        extra_rp_conf = dict(
-            enable_leader_balancer=False,
-            partition_autobalancing_mode="off",
-            group_initial_rebalance_delay=300,
-            compacted_log_segment_size=self.segment_size,
-        )
+        extra_rp_conf = dict(enable_leader_balancer=False,
+                             partition_autobalancing_mode="off",
+                             group_initial_rebalance_delay=300,
+                             compacted_log_segment_size=self.segment_size,
+                             min_cleanable_dirty_ratio=0.0)
         self.redpanda = make_redpanda_service(context=self.test_context,
                                               num_brokers=self.num_brokers,
                                               si_settings=self.si_settings,

--- a/tests/rptest/transactions/compaction_e2e_test.py
+++ b/tests/rptest/transactions/compaction_e2e_test.py
@@ -27,7 +27,7 @@ from rptest.services.metrics_check import MetricCheck
 
 class CompactionE2EIdempotencyTest(RedpandaTest):
     def __init__(self, test_context):
-        extra_rp_conf = {}
+        extra_rp_conf = {"min_cleanable_dirty_ratio": 0.0}
 
         self.segment_size = 5 * 1024 * 1024
         self.partition_count = 3
@@ -186,7 +186,8 @@ class CompactionWithRecoveryTest(RedpandaTest, PartitionMovementMixin):
         # keep read size low to ensure reads fall within a transaction
         extra_rp_conf = {
             "raft_recovery_default_read_size": 1024,
-            "log_compaction_interval_ms": 2000
+            "log_compaction_interval_ms": 2000,
+            "min_cleanable_dirty_ratio": 0.0
         }
         super(CompactionWithRecoveryTest,
               self).__init__(test_context=test_context,
@@ -254,7 +255,7 @@ class CompactionE2ERebootTest(RedpandaTest):
         self.segment_size = 5 * 1024 * 1024
         super(CompactionE2ERebootTest,
               self).__init__(test_context=test_context,
-                             extra_rp_conf={},
+                             extra_rp_conf={"min_cleanable_dirty_ratio": 0.0},
                              log_level="trace")
 
     @skip_debug_mode

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -152,6 +152,8 @@ def read_topic_properties_serde(rdr: Reader, version):
             rdr.read_optional(Reader.read_serde_enum),
             'iceberg_target_lag_ms':
             rdr.read_optional(Reader.read_int64),
+            'min_cleanable_dirty_ratio':
+            rdr.read_tristate(Reader.read_double),
         }
 
     return topic_properties

--- a/tools/offline_log_viewer/reader.py
+++ b/tools/offline_log_viewer/reader.py
@@ -78,6 +78,9 @@ class Reader:
     def read_uint64(self):
         return struct.unpack(self.with_endianness('Q'), self.stream.read(8))[0]
 
+    def read_double(self):
+        return struct.unpack(self.with_endianness('d'), self.stream.read(8))[0]
+
     def read_serde_enum(self):
         return self.read_int32()
 


### PR DESCRIPTION
Based on PR https://github.com/redpanda-data/redpanda/pull/24649.

Instead of unconditionally compacting all logs during a round of housekeeping, users may now optionally schedule log compaction in the `log_manager` using the cluster/topic property `min_cleanable_dirty_ratio`/`min.cleanable.dirty.ratio`.

As mentioned in the above PR,

> The dirty ratio of a log is defined as the ratio between the number of bytes in "dirty" segments and the total number of bytes in closed segments.
> Dirty segments are closed segments which have not yet been cleanly compacted- i.e, duplicates for keys in this segment could be found in the prefix of the log up to this segment.

By setting the `min.cleanable.dirty.ratio` on a per topic basis, users can avoid unnecessary read/write amplification during compaction as the log grows in size.

A housekeeping scan will still be performed every `log_compaction_interval_ms`, and the log's `dirty_ratio` will be tested against `min.cleanable.dirty.ratio` in determining it's eligibility for compaction. Additionally, logs are now compacted in descending order according to their dirty ratio, offering a better "bang for buck" heuristic for compaction scheduling.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Allow for optional scheduling of compaction via `min_cleanable_dirty_ratio`