### PR TITLE
pandaproxy/sr: protobuf rendering: refactor string rendering

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -27,6 +27,7 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
+#include <absl/strings/escaping.h>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/range/combine.hpp>
 #include <confluent/meta.pb.h>
@@ -76,6 +77,16 @@
 #include <ranges>
 #include <string_view>
 #include <unordered_set>
+
+namespace {
+
+// Protobuf string values need to be quoted and escaped
+// as they may contain characters like '\'
+auto pb_string_value(const std::string_view v) {
+    return fmt::format("\"{}\"", absl::CEscape(v));
+}
+
+} // namespace
 
 struct indent_formatter : fmt::formatter<std::string_view> {
     using Base = fmt::formatter<std::string_view>;
@@ -138,9 +149,9 @@ struct fmt::formatter<google::protobuf::UninterpretedOption>
                 if (option.has_string_value()) {
                     return fmt::format_to(
                       ctx.out(),
-                      "{} = {:?}",
+                      "{} = {}",
                       fmt::join(option.name(), "."),
-                      val);
+                      pb_string_value(val));
                 }
             }
             if (option.has_aggregate_value()) {
@@ -920,7 +931,8 @@ struct protobuf_schema_definition::impl {
         }
         if (field.has_json_name()) {
             maybe_print_seperator();
-            fmt::print(os, "json_name = {:?}", field.json_name());
+            fmt::print(
+              os, "json_name = {}", pb_string_value(field.json_name()));
         }
         if (field.has_options()) {
             const auto& options = field.options();
@@ -1076,11 +1088,12 @@ struct protobuf_schema_definition::impl {
 
         if (decl.has_full_name()) {
             maybe_print_seperator();
-            fmt::print(os, "{}: {:?}", "full_name", decl.full_name());
+            fmt::print(
+              os, "{}: {}", "full_name", pb_string_value(decl.full_name()));
         }
         if (decl.has_type()) {
             maybe_print_seperator();
-            fmt::print(os, "{}: {:?}", "type", decl.type());
+            fmt::print(os, "{}: {}", "type", pb_string_value(decl.type()));
         }
         if (decl.has_number()) {
             maybe_print_seperator();
@@ -1163,7 +1176,7 @@ struct protobuf_schema_definition::impl {
         auto reserved_names = maybe_sorted(message.reserved_name());
         if (!reserved_names.empty()) {
             const auto to_debug_string = [](const std::string_view strv) {
-                return fmt::format("{:?}", strv);
+                return fmt::format("{}", pb_string_value(strv));
             };
             fmt::print(
               os,
@@ -1292,7 +1305,12 @@ struct protobuf_schema_definition::impl {
             fmt::print(os, ";\n");
         }
         for (const auto& value : maybe_sorted(enum_proto.reserved_name())) {
-            fmt::print(os, "{:{}}reserved {:?};\n", "", indent + 2, value);
+            fmt::print(
+              os,
+              "{:{}}reserved {};\n",
+              "",
+              indent + 2,
+              pb_string_value(value));
         }
         if (enum_proto.options().has_allow_alias()) {
             fmt::print(
@@ -1434,7 +1452,7 @@ struct protobuf_schema_definition::impl {
             first_option = false;
         };
         auto prints = [&](std::string_view name, const auto& val) {
-            fmt::print(os, "option {} = {:?};\n", name, val);
+            fmt::print(os, "option {} = {};\n", name, pb_string_value(val));
             first_option = false;
         };
         if (options.has_cc_enable_arenas()) {
@@ -1551,7 +1569,7 @@ struct protobuf_schema_definition::impl {
 
         auto print_deps = [&](const auto& view, std::string_view type) {
             for (const auto& dep : view) {
-                fmt::print(os, "import {}{:?};\n", type, dep);
+                fmt::print(os, "import {}{};\n", type, pb_string_value(dep));
             }
         };
 
@@ -1569,9 +1587,12 @@ struct protobuf_schema_definition::impl {
             auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
             edition = syntax == "proto3" ? pb::Edition::EDITION_PROTO3
                                          : pb::Edition::EDITION_PROTO2;
-            fmt::print(os, "syntax = {:?};\n", syntax);
+            fmt::print(os, "syntax = {};\n", pb_string_value(syntax));
         } else {
-            fmt::print(os, "edition = {:?};\n", Edition_Name(fdp.edition()));
+            fmt::print(
+              os,
+              "edition = {};\n",
+              pb_string_value(Edition_Name(fdp.edition())));
         }
 
         if (fdp.has_package() && !fdp.package().empty()) {


### PR DESCRIPTION
Implements: [CORE-8906](https://redpandadata.atlassian.net/browse/CORE-8906)

Refactored string rendering to use `absl::CEscape` instead of fmt debug format.

It is done for 2 reasons:
1. Debug format is not supported in earlier versions of fmt that we still use.
2. Make the intent more explicit.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-8906]: https://redpandadata.atlassian.net/browse/CORE-8906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ