### PR TITLE
[CORE-8999] schema_registry/protobuf: Add test for legacy_map

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,6 +41,7 @@ single_version_override(
     # this patch is in upstream protobuf, so should be in an upcoming release.
     patches = [
         "//bazel/thirdparty:protobuf_capture_warning.patch",
+        "//bazel/thirdparty:0001-protobuf-handle-map-entry.patch",
     ],
 )
 

--- a/bazel/thirdparty/0001-protobuf-handle-map-entry.patch
+++ b/bazel/thirdparty/0001-protobuf-handle-map-entry.patch
@@ -1,0 +1,42 @@
+diff --git a/src/google/protobuf/compiler/parser.cc b/src/google/protobuf/compiler/parser.cc
+index bc17e7a70..5404bf5ce 100644
+--- a/src/google/protobuf/compiler/parser.cc
++++ b/src/google/protobuf/compiler/parser.cc
+@@ -552,21 +552,14 @@ void Parser::SkipRestOfBlock() {
+ 
+ // ===================================================================
+ 
+-bool Parser::ValidateMessage(const DescriptorProto* proto) {
++bool Parser::ValidateMessage(DescriptorProto* proto) {
+   for (int i = 0; i < proto->options().uninterpreted_option_size(); i++) {
+     const UninterpretedOption& option =
+         proto->options().uninterpreted_option(i);
+     if (option.name_size() > 0 && !option.name(0).is_extension() &&
+         option.name(0).name_part() == "map_entry") {
+-      int line = -1, col = 0;  // indicates line and column not known
+-      if (source_location_table_ != nullptr) {
+-        source_location_table_->Find(
+-            &option, DescriptorPool::ErrorCollector::OPTION_NAME, &line, &col);
+-      }
+-      RecordError(line, col,
+-                  "map_entry should not be set explicitly. "
+-                  "Use map<KeyType, ValueType> instead.");
+-      return false;
++      proto->mutable_options()->set_map_entry(true);
++      return true;
+     }
+   }
+   return true;
+diff --git a/src/google/protobuf/compiler/parser.h b/src/google/protobuf/compiler/parser.h
+index f1e709d1b..0d70f091a 100644
+--- a/src/google/protobuf/compiler/parser.h
++++ b/src/google/protobuf/compiler/parser.h
+@@ -549,7 +549,7 @@ class PROTOBUF_EXPORT Parser final {
+     return syntax_identifier_ == "proto3";
+   }
+ 
+-  bool ValidateMessage(const DescriptorProto* proto);
++  bool ValidateMessage(DescriptorProto* proto);
+   bool ValidateEnum(const EnumDescriptorProto* proto);
+ 
+   // =================================================================


### PR DESCRIPTION
The Confluent Schema Registry client renders maps in the expanded form demonstrated by the test, which is considered invalid by libprotobuf >= v25.

The patch required to fix this is: https://github.com/redpanda-data/vtools/pull/3434


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Schema Registry/Protobuf: Fix a regression with maps.
