### PR TITLE
[CORE-8999] [v24.3.x] Revert "Schema Registry/protobuf: Remove support for editions."

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -788,7 +788,7 @@ struct protobuf_schema_definition::impl {
 
     void render_field(
       std::ostream& os,
-      std::string_view edition,
+      pb::Edition edition,
       const pb::FieldDescriptorProto& field,
       const pb::FieldDescriptor* descriptor,
       int indent,
@@ -848,7 +848,7 @@ struct protobuf_schema_definition::impl {
         };
 
         const auto label = [&]() {
-            bool is_proto2 = edition == "proto2";
+            bool is_proto2 = edition == pb::Edition::EDITION_PROTO2;
             if(descriptor && 
                 (descriptor->is_map() || descriptor->real_containing_oneof() ||
                 ((descriptor->is_optional() && !field.proto3_optional()) && !(is_proto2 && !descriptor->containing_oneof())))) {
@@ -978,7 +978,7 @@ struct protobuf_schema_definition::impl {
     template<typename Descriptor>
     void render_extensions(
       std::ostream& os,
-      std::string_view edition,
+      pb::Edition edition,
       const pb::RepeatedPtrField<pb::FieldDescriptorProto>& raw_extensions,
       const Descriptor& descriptor,
       int indent) const {
@@ -1116,7 +1116,7 @@ struct protobuf_schema_definition::impl {
     // Render a message, including nested messages
     void render_nested(
       std::ostream& os,
-      std::string_view edition,
+      pb::Edition edition,
       const std::optional<pb::FieldDescriptorProto>& field,
       const pb::FieldDescriptor* field_descriptor,
       const pb::DescriptorProto& message,
@@ -1584,9 +1584,18 @@ struct protobuf_schema_definition::impl {
       std::ostream& os,
       const pb::FileDescriptorProto& fdp,
       const pb::FileDescriptor& descriptor) const {
-        auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
-        std::string_view edition = syntax;
-        fmt::print(os, "syntax = {};\n", pb_string_value(syntax));
+        auto edition = fdp.edition();
+        if (edition == pb::Edition::EDITION_UNKNOWN) {
+            auto syntax = fdp.has_syntax() ? fdp.syntax() : "proto2";
+            edition = syntax == "proto3" ? pb::Edition::EDITION_PROTO3
+                                         : pb::Edition::EDITION_PROTO2;
+            fmt::print(os, "syntax = {};\n", pb_string_value(syntax));
+        } else {
+            fmt::print(
+              os,
+              "edition = {};\n",
+              pb_string_value(Edition_Name(fdp.edition())));
+        }
 
         if (fdp.has_package() && !fdp.package().empty()) {
             fmt::print(os, "package {};\n", fdp.package());


### PR DESCRIPTION
This reverts commit b1514d8324381d3f59f6a7cbc58ce03fb3ab3eed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
