### PR TITLE
bazel: build seastar in debug mode by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,8 @@ build --incompatible_strict_action_env
 
 # Add stack guards by default for better debugging, we disable them in release builds
 build --@seastar//:stack_guards=True
+# Debug mode by default. Disabled in release builds.
+build --@seastar//:debug=True
 
 # =================================
 # Sanitizer
@@ -54,9 +56,6 @@ build:sanitizer --copt -O1
 build:sanitizer --//bazel:has_sanitizers=True
 # seastar has to be run with system allocator when using sanitizers
 build:sanitizer --@seastar//:system_allocator=True
-# This is currently required to get ASAN to work, but ideally in the future we can get
-# the sanitizers working in release mode
-build:sanitizer --@seastar//:debug=true
 # krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
 build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function
 
@@ -97,7 +96,7 @@ build:secure --config=relro
 build:release --compilation_mode opt
 build:release --config=secure
 build:release --copt -mllvm --copt -inline-threshold=2500
-build:release --@seastar//:stack_guards=False
+build:release --@seastar//:stack_guards=False --@seastar//:debug=False
 build:release --//src/v/redpanda:lto=True
 build:release --copt -flto=thin --copt -ffat-lto-objects
 


### PR DESCRIPTION
Found out today that a benchmark I run was actually run weeks ago was actually run in debug mode where I believed that we always run benchmarks in release mode. This might be surprising expectation for you but it wasn't for me as I'm used to the fact that we never build benchmarks in debug with cmake at all.

Anyway...

When seastar is built in debug mode there is a helpful message

```
WARNING: debug mode. Not for benchmarking or production
```

and I was surprised I could ignore it. Turns out I didn't. It wasn't printed because seastar wasn't being built in debug mode.

So I'm fixing that and making the bazel match more the cmake one.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
