### PR TITLE
ci: add redpanda version in promote trigger

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,5 +24,5 @@ jobs:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"
           branch: dev
-          message: ":github: Promote redpanda packages"
+          message: ":github: Promote redpanda ${{ github.ref_name }} packages"
           build_env_vars: '{"PROMOTE_REDPANDA_FROM_STAGING": "1", "TARGET_VERSION": "${{ github.ref_name }}"}'


### PR DESCRIPTION
improve search-ability in bk UI by adding the redpanda version in the build message when the promote pipeline is being triggered

jira: [DEVPROD-2619]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

* none


[DEVPROD-2619]: https://redpandadata.atlassian.net/browse/DEVPROD-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ