### PR TITLE
Fixed checking if `append_entries_request` batches are already present in follower log

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2079,6 +2079,25 @@ consensus::do_append_entries(append_entries_request&& r) {
               last_matched,
               meta());
             adjusted_prev_log_index = last_matched;
+            // all batches match, we can skip the append and inform the leader
+            // about the last matching index
+            if (batches.empty()) {
+                vlog(
+                  _ctxlog.info,
+                  "all records in received append entries request are already "
+                  "present. "
+                  "Last matching offset: {}, current protocol state: {}",
+                  adjusted_prev_log_index,
+                  meta());
+
+                reply.last_dirty_log_index = adjusted_prev_log_index;
+                // limit the last flushed offset as the adjusted_prev_log_index
+                // may have not yet been flushed.
+                reply.last_flushed_log_index = std::min(
+                  adjusted_prev_log_index, _flushed_offset);
+                reply.result = reply_result::success;
+                co_return reply;
+            }
         }
         r.batches() = std::move(batches);
     }

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2058,8 +2058,8 @@ consensus::do_append_entries(append_entries_request&& r) {
         auto it = r.batches().begin();
         for (; it != r.batches().end(); ++it) {
             model::offset last_batch_offset
-              = last_matched
-                + model::offset(it->header().last_offset_delta + 1);
+              = model::offset(it->header().last_offset_delta)
+                + model::next_offset(last_matched);
             if (
               last_batch_offset > last_log_offset
               || get_term(last_batch_offset) != it->term()) {

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -862,3 +862,109 @@ TEST_F_CORO(raft_fixture, test_no_stepdown_on_append_entries_timeout) {
     ASSERT_EQ_CORO(term_before, new_leader_node.raft()->term());
     ASSERT_TRUE_CORO(new_leader_node.raft()->is_leader());
 }
+
+/**
+ * This synthetic test is there to trigger a situation in which follower
+ * receives an append entries request which contains only batches that matches
+ * its log. This trigger a condition in which the follower should reply with
+ * success to the leader so the leader can continue recovery process.
+ *
+ * The test uses reply interception to 'trick' the leader to send the append
+ * entries with the batches that the follower already has.
+ */
+TEST_F_CORO(raft_fixture, test_redelivery_of_matching_logs) {
+    co_await create_simple_group(3);
+    auto term_1_leader_id = co_await wait_for_leader(10s);
+    for (auto& [id, n] : nodes()) {
+        n->set_default_recovery_read_size(1);
+    }
+    auto term_1_follower_id = random_follower_id().value();
+    auto& t1_leader_node = node(term_1_leader_id);
+    /**
+     * Replicate data to all nodes
+     */
+    auto r = co_await t1_leader_node.raft()->replicate(
+      make_batches(200, 1, 10),
+      replicate_options(consistency_level::quorum_ack, 10s));
+    co_await wait_for_committed_offset(r.value().last_offset, 5s);
+    auto term_1_match_offset = node(term_1_follower_id).raft()->dirty_offset();
+
+    /**
+     * Prevent any nodes from receiveing append entry requests from the leader
+     */
+    t1_leader_node.on_dispatch([](model::node_id, raft::msg_type mt) {
+        if (mt == raft::msg_type::append_entries) {
+            throw std::runtime_error("error");
+        }
+        return ss::now();
+    });
+
+    /**
+     * Replicate some data with the leader ack consistency level so the current
+     * leader has the longest log
+     */
+    r = co_await t1_leader_node.raft()->replicate(
+      make_batches(20, 1, 10),
+      replicate_options(consistency_level::leader_ack, 10s));
+
+    ASSERT_FALSE_CORO(r.has_error());
+    // leader has longest log, prevent follower from sending vote requests to
+    // term 1 leader.
+    node(term_1_follower_id)
+      .on_dispatch([term_1_leader_id](model::node_id id, raft::msg_type) {
+          if (term_1_leader_id == id) {
+              throw std::runtime_error("error");
+          }
+          return ss::now();
+      });
+
+    // stepdown to trigger another leader election
+    t1_leader_node.raft()->block_new_leadership();
+    co_await t1_leader_node.raft()->step_down(
+      model::term_id(2), "test step down");
+
+    auto new_leader_id = co_await wait_for_leader(10s);
+    // this is the only candidate as the other one will receive information from
+    // term 1 leader that it has the longest log.
+    ASSERT_EQ_CORO(new_leader_id, term_1_follower_id);
+
+    auto& new_leader_node = node(new_leader_id);
+    logger().info(
+      "new leader offsets: {}, term_1_match: {}",
+      new_leader_node.raft()->log()->offsets(),
+      term_1_match_offset);
+
+    /**
+     * Trick the leader right at the offset where the leader and follower log
+     * would match
+     */
+    ss::condition_variable reply_intercepted;
+    size_t intercept_count = 0;
+    new_leader_node.set_reply_interceptor(
+      [&, term_1_match_offset](reply_variant reply, model::node_id) {
+          return ss::visit(
+            std::move(reply),
+            [&, term_1_match_offset](append_entries_reply& a_r) {
+                if (
+                  a_r.last_dirty_log_index
+                  == model::next_offset(term_1_match_offset)) {
+                    a_r.result = reply_result::failure;
+                    intercept_count++;
+                    reply_intercepted.signal();
+                }
+                return ss::make_ready_future<reply_variant>(a_r);
+            },
+            [](auto& r) {
+                return ss::make_ready_future<reply_variant>(std::move(r));
+            });
+      });
+    /**
+     * Recover communication and wait for the intercept to trigger
+     */
+    new_leader_node.reset_dispatch_handlers();
+    co_await reply_intercepted.wait([&] { return intercept_count > 5; });
+    new_leader_node.reset_reply_interceptor();
+
+    co_await wait_for_committed_offset(
+      new_leader_node.raft()->dirty_offset(), 5s);
+}

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -746,7 +746,7 @@ ss::future<> raft_fixture::create_simple_group(size_t number_of_nodes) {
 
 ss::future<> raft_fixture::wait_for_committed_offset(
   model::offset offset, std::chrono::milliseconds timeout) {
-    RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, [this, offset] {
+    return tests::cooperative_spin_wait_with_timeout(timeout, [this, offset] {
         return std::all_of(
           nodes().begin(), nodes().end(), [offset](auto& pair) {
               return pair.second->raft()->committed_offset() >= offset;
@@ -755,7 +755,7 @@ ss::future<> raft_fixture::wait_for_committed_offset(
 }
 ss::future<> raft_fixture::wait_for_visible_offset(
   model::offset offset, std::chrono::milliseconds timeout) {
-    RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, [this, offset] {
+    return tests::cooperative_spin_wait_with_timeout(timeout, [this, offset] {
         return std::all_of(
           nodes().begin(), nodes().end(), [offset](auto& pair) {
               return pair.second->raft()->last_visible_index() >= offset;

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -395,11 +395,11 @@ raft_node_instance::raft_node_instance(
       _max_inflight_requests.bind(),
       _max_queued_bytes.bind()))
   , _features(feature_table)
-  , _recovery_mem_quota([] {
+  , _recovery_mem_quota([this] {
       return raft::recovery_memory_quota::configuration{
         .max_recovery_memory = config::mock_binding<std::optional<size_t>>(
           200_MiB),
-        .default_read_buffer_size = config::mock_binding<size_t>(128_KiB),
+        .default_read_buffer_size = _default_recovery_read_size.bind(),
       };
   })
   , _recovery_scheduler(

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -297,7 +297,14 @@ ss::future<result<RespT>> in_memory_test_protocol::dispatch(
         auto resp = co_await ss::with_timeout(
           opts.timeout.timeout_at(), std::move(f));
         iobuf_parser parser(std::move(resp));
-        co_return co_await serde::read_async<RespT>(parser);
+        RespT reply = co_await serde::read_async<RespT>(parser);
+        // intercept the reply if the interceptor is set
+        if (_reply_interceptor) {
+            auto intercepted = co_await (*_reply_interceptor)(
+              reply_variant{std::move(reply)}, id);
+            co_return std::get<RespT>(std::move(intercepted));
+        }
+        co_return reply;
     } catch (const ss::timed_out_error&) {
         co_return rpc::errc::client_request_timeout;
     } catch (const seastar::gate_closed_exception&) {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -701,6 +701,21 @@ raft_fixture::wait_for_leader(model::timeout_clock::time_point deadline) {
     co_return get_leader().value();
 }
 
+std::optional<model::node_id> raft_fixture::random_follower_id() const {
+    auto leader_id = get_leader();
+    std::vector<model::node_id> followers;
+    std::ranges::copy_if(
+      _nodes | std::views::keys,
+      std::back_inserter(followers),
+      [leader_id](model::node_id id) { return id != leader_id; });
+
+    if (followers.empty()) {
+        return std::nullopt;
+    }
+
+    return random_generators::random_choice(followers);
+}
+
 ss::future<model::node_id> raft_fixture::wait_for_leader_change(
   model::timeout_clock::time_point deadline, model::term_id term) {
     auto has_new_leader = [this, term] {

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -273,6 +273,10 @@ public:
 
     service_t& get_service() { return _service; }
 
+    void set_default_recovery_read_size(size_t bytes) {
+        _default_recovery_read_size.update(std::move(bytes));
+    }
+
 private:
     model::node_id _id;
     model::revision_id _revision;
@@ -280,6 +284,7 @@ private:
     ss::sstring _base_directory;
     config::mock_property<size_t> _max_inflight_requests{16};
     config::mock_property<size_t> _max_queued_bytes{1_MiB};
+    config::mock_property<size_t> _default_recovery_read_size{128_KiB};
     ss::shared_ptr<in_memory_test_protocol> _protocol;
     ss::shared_ptr<buffered_protocol> _buffered_protocol;
     ss::sharded<storage::api> _storage;

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -104,6 +104,18 @@ struct raft_node_map {
       node_for(model::node_id) = 0;
 };
 
+using reply_variant = std::variant<
+  vote_reply,
+  append_entries_reply,
+  heartbeat_reply,
+  heartbeat_reply_v2,
+  install_snapshot_reply,
+  timeout_now_reply,
+  transfer_leadership_reply>;
+
+using reply_interceptor_t = ss::noncopyable_function<ss::future<reply_variant>(
+  reply_variant, model::node_id)>;
+
 using dispatch_callback_t
   = ss::noncopyable_function<ss::future<>(model::node_id, msg_type)>;
 
@@ -145,6 +157,12 @@ public:
 
     void reset_dispatch_handlers();
 
+    void set_reply_interceptor(reply_interceptor_t interceptor) {
+        _reply_interceptor.emplace(std::move(interceptor));
+    }
+
+    void reset_reply_interceptor() { _reply_interceptor.reset(); }
+
     ss::future<> stop();
 
 private:
@@ -156,6 +174,7 @@ private:
     std::vector<dispatch_callback_t> _on_dispatch_handlers;
     raft_node_map& _nodes;
     prefix_logger& _logger;
+    std::optional<reply_interceptor_t> _reply_interceptor;
 };
 
 inline model::timeout_clock::time_point default_timeout() {
@@ -261,6 +280,17 @@ public:
     /// dispatched.
     void on_dispatch(dispatch_callback_t);
     void reset_dispatch_handlers();
+
+    /**
+     * Sets the reply interceptor for this node, the interceptor will be called
+     * for each service reply on this node. It can be used to inject failures or
+     * modify the reply to trigger specific behaviors.
+     */
+    void set_reply_interceptor(reply_interceptor_t interceptor) {
+        _protocol->set_reply_interceptor(std::move(interceptor));
+    }
+
+    void reset_reply_interceptor() { _protocol->reset_reply_interceptor(); }
 
     ss::shared_ptr<in_memory_test_protocol> get_protocol() { return _protocol; }
     ss::shared_ptr<buffered_protocol> get_buffered_protocol() {

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -372,6 +372,8 @@ public:
     ss::future<model::node_id> wait_for_leader(std::chrono::milliseconds);
     ss::future<model::node_id>
       wait_for_leader(model::timeout_clock::time_point);
+
+    std::optional<model::node_id> random_follower_id() const;
     ss::future<model::node_id> wait_for_leader_change(
       model::timeout_clock::time_point deadline, model::term_id term);
     seastar::future<> TearDownAsync() override;


### PR DESCRIPTION
### Background
When follower receives an append entries request that `prev_log_index` is smaller than its own `prev_log_index` it validates if the batches from the request matches (by checking a batch offset and corresponding term) its own log. It that is the case the batches are skipped to prevent truncation of valid batches and avoid the data loss.


#### Negative `append_entries_request::prev_log_index`

The validation of already matching batches was broken if they happened to be at the beginning of the log. In this case the `prev_log_index` is not initialised. This case was not correctly handled by the logic calculating the next offset when checking matching batches.

#### Replying with success when all request batches match

When follower receives an append entries request with the vector of records that are all present in its own log and their offsets and terms match it should reply with success and correct `last_dirty_log_index`.
This way a leader instead of moving the follower `next_offset` backward can start recovery process and deliver batches which the follower is missing.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes a very rare situation in which Raft leader can enter into infinite loop trying to recover follower. 