### PR TITLE
crash_tracker: reduce size of crash_description

### DIFF
--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -128,6 +128,12 @@ void prepared_writer::write() {
 
 bool prepared_writer::try_write_crash() {
     bool success = true;
+
+    static_assert(
+      sizeof(crash_description) < 200,
+      "Sanity check to prevent overflowing the stack. Even though "
+      "crash_description may contain a large amount of pre-allocated data, it "
+      "should remain relatively small on the stack.");
     serde::write(_serde_output, std::move(_prepared_cd));
 
     for (const auto& frag : _serde_output) {

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_binary(
     name = "crash_report_generator",
+    testonly = True,
     srcs = ["report_generator.cc"],
     deps = [
         "//src/v/base",

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -40,7 +40,7 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
               "false != true at example.cc:123"};
         }
         return recorder::recorded_crash{
-          "", res, std::chrono::file_clock::time_point{}};
+          "", std::move(res), std::chrono::file_clock::time_point{}};
     };
 
     crashes.emplace_back(make_crash(with_additional_info::no));

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -18,6 +18,7 @@
 #include "serde/rw/envelope.h"
 #include "serde/rw/sstring.h"
 
+#include <memory>
 #include <ostream>
 
 namespace crash_tracker {
@@ -47,23 +48,23 @@ struct reserved_string {
           "String size {} exceeds reserved size {}",
           other.size(),
           Size);
-        std::copy(other.begin(), other.end(), _str.begin());
+        std::copy(other.begin(), other.end(), _str->begin());
     };
 
-    type* begin() { return _str.begin(); }
-    const type* c_str() const noexcept { return _str.data(); }
+    type* begin() { return _str->begin(); }
+    const type* c_str() const noexcept { return _str->data(); }
 
-    type& operator[](size_t i) { return _str[i]; }
-    const type& operator[](size_t i) const { return _str[i]; }
+    type& operator[](size_t i) { return (*_str)[i]; }
+    const type& operator[](size_t i) const { return (*_str)[i]; }
 
     /// The length of the populated, non-'\0' prefix of the string.
-    size_t length() const noexcept { return strlen(_str.data()); }
+    size_t length() const noexcept { return strlen(_str->data()); }
 
     /// The full capacity of the string, including the all-'\0' suffix.
     size_t capacity() const noexcept { return Size; }
 
 private:
-    underlying_t _str{};
+    std::unique_ptr<underlying_t> _str{std::make_unique<underlying_t>()};
 };
 
 template<std::size_t Size>


### PR DESCRIPTION
Move the large array inside reserved_string onto the heap to avoid
allocating large objects on the stack while writing out crashes.

It also makes the `crash_report_generator` test binary `testonly` to address this review comment: https://github.com/redpanda-data/redpanda/pull/24978#discussion_r1940424111

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
