### PR TITLE
ct: Fix unit-tests in cloud topics

### DIFF
--- a/src/v/cloud_topics/core/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/core/tests/event_filter_test.cc
@@ -63,6 +63,7 @@ get_serialized_size(const ss::circular_buffer<model::record_batch>& batches) {
 
 template<class Fn>
 ss::future<> do_until(Fn&& fn, int retries = 100) {
+    co_await ss::sleep(1ms);
     for (int i = 0; i < retries; i++) {
         if (fn()) {
             co_return;

--- a/src/v/cloud_topics/throttler/tests/throttler_test.cc
+++ b/src/v/cloud_topics/throttler/tests/throttler_test.cc
@@ -91,6 +91,7 @@ struct write_pipeline_accessor {
 
 ss::future<> sleep(std::chrono::milliseconds delta, int retry_limit = 100) {
     ss::manual_clock::advance(delta);
+    co_await ss::sleep(1ms);
     for (int i = 0; i < retry_limit; i++) {
         co_await ss::yield();
     }
@@ -101,6 +102,7 @@ template<class Fn>
 ss::future<>
 sleep_until(std::chrono::milliseconds delta, Fn&& fn, int retry_limit = 100) {
     ss::manual_clock::advance(delta);
+    co_await ss::sleep(1ms);
     for (int i = 0; i < retry_limit; i++) {
         co_await ss::yield();
         if (fn()) {


### PR DESCRIPTION
Some tests which relying on manual clock do not work correctly with debug seastar build without the explicit sleep.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none