### PR TITLE
io: update interval tests and add bazel coverage helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+genhtml/
 
 # Translations
 *.mo

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -72,66 +72,71 @@ TEST(IntervalMap, InsertLeftAbut) {
     EXPECT_TRUE(res.second);
 }
 
-TEST(IntervalMap, InsertOverlapNoGap) {
+TEST(IntervalMap, InsertOverlapWithNoGapRejected) {
     imap map;
 
-    // [0, 10) [10, 20)
+    // [0, 10) [10, 20) [20, 21)
     EXPECT_TRUE(map.insert({0, 10}, 0).second);
     EXPECT_TRUE(map.insert({10, 10}, 0).second);
+    EXPECT_TRUE(map.insert({20, 1}, 0).second);
 
-    // overlap left
+    // overlap first rejected
     for (unsigned int i = 0; i < 10; ++i) {
         auto res = map.insert({i, 1}, 0);
         EXPECT_EQ(res.first, map.find(0));
         EXPECT_FALSE(res.second);
     }
 
-    // overlap right
+    // overlap second rejected
     for (unsigned int i = 10; i < 20; ++i) {
         auto res = map.insert({i, 1}, 0);
         EXPECT_EQ(res.first, map.find(10));
         EXPECT_FALSE(res.second);
     }
 
+    // overlap third rejected
     auto res = map.insert({20, 1}, 0);
-    EXPECT_NE(res.first, map.find(0));
-    EXPECT_NE(res.first, map.find(10));
-    EXPECT_TRUE(res.second);
+    EXPECT_EQ(res.first, map.find(20));
+    EXPECT_FALSE(res.second);
 }
 
-TEST(IntervalMap, InsertOverlapWithGap) {
+TEST(IntervalMap, InsertWithSparseOverlaps) {
     imap map;
 
     // [0, 10) [20, 30)
     EXPECT_TRUE(map.insert({0, 10}, 0).second);
     EXPECT_TRUE(map.insert({20, 10}, 0).second);
 
-    // overlap left
+    // overlap left rejected
     for (unsigned int i = 0; i < 10; ++i) {
         auto res = map.insert({i, 1}, 0);
         EXPECT_EQ(res.first, map.find(0));
         EXPECT_FALSE(res.second);
     }
 
+    // intervals in between can be inserted
     for (unsigned int i = 10; i < 20; ++i) {
         auto res = map.insert({i, 1}, 0);
+        EXPECT_EQ(res.first, map.find(i));
         EXPECT_NE(res.first, map.find(0));
         EXPECT_NE(res.first, map.find(20));
         EXPECT_TRUE(res.second);
     }
 
-    // overlap right
+    // overlap right rejected
     for (unsigned int i = 20; i < 30; ++i) {
         auto res = map.insert({i, 1}, 0);
         EXPECT_EQ(res.first, map.find(20));
         EXPECT_FALSE(res.second);
     }
 
-    auto res = map.insert({30, 1}, 0);
+    // intervals to the right can be inserted
+    const auto res = map.insert({30, 1}, 0);
+    EXPECT_EQ(res.first, map.find(30));
+    EXPECT_TRUE(res.second);
     for (int i = 0; i < 30; ++i) {
         EXPECT_NE(res.first, map.find(i));
     }
-    EXPECT_TRUE(res.second);
 }
 
 TEST(IntervalMap, FindEmpty) {

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -139,7 +139,7 @@ TEST(IntervalMap, InsertWithSparseOverlaps) {
     }
 }
 
-TEST(IntervalMap, FindEmpty) {
+TEST(IntervalMap, FindInEmptyMapReturnsEnd) {
     const imap map;
     EXPECT_EQ(map.find(0), map.end());
 }
@@ -153,7 +153,7 @@ TEST(IntervalMap, FindPastLast) {
     EXPECT_EQ(map.find(11), map.end());
 }
 
-TEST(IntervalMap, FindExact) {
+TEST(IntervalMap, FindExactStartOffset) {
     imap map;
     EXPECT_TRUE(map.insert({0, 10}, 11).second);
     EXPECT_TRUE(map.insert({20, 5}, 12).second);
@@ -161,7 +161,7 @@ TEST(IntervalMap, FindExact) {
     EXPECT_EQ(map.find(20)->second, 12);
 }
 
-TEST(IntervalMap, FindBeforeFirst) {
+TEST(IntervalMap, FindBeforeFirstReturnsEnd) {
     imap map;
     EXPECT_TRUE(map.insert({2, 10}, 33).second);
     EXPECT_EQ(map.find(0), map.end());
@@ -178,6 +178,8 @@ TEST(IntervalMap, FindMiddleNoGap) {
     EXPECT_EQ(map.find(9)->second, 3);
     EXPECT_EQ(map.find(11)->second, 4);
     EXPECT_EQ(map.find(19)->second, 4);
+    EXPECT_EQ(map.find(21)->second, 5);
+    EXPECT_EQ(map.find(29)->second, 5);
 }
 
 TEST(IntervalMap, FindMiddleWithGap) {
@@ -196,7 +198,7 @@ TEST(IntervalMap, FindMiddleWithGap) {
     EXPECT_EQ(map.find(39), map.end());
 }
 
-TEST(IntervalMap, BeginEndEmpty) {
+TEST(IntervalMap, BeginEndAreEqualInEmptyMap) {
     const imap map;
     EXPECT_EQ(map.begin(), map.end());
 }
@@ -209,6 +211,7 @@ TEST(IntervalMap, Empty) {
 }
 
 TEST(IntervalMap, Erase) {
+    // erase 1 becomes empty
     {
         imap map;
         auto res = map.insert({0, 10}, 0);
@@ -217,6 +220,7 @@ TEST(IntervalMap, Erase) {
         EXPECT_TRUE(map.empty());
     }
 
+    // erase 2 becomes empty
     {
         imap map;
         EXPECT_TRUE(map.insert({0, 10}, 0).second);

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -29,12 +29,15 @@ TEST(IntervalMap, InsertZeroLengthInterval) {
     }
 }
 
-TEST(IntervalMap, InsertEmpty) {
+TEST(IntervalMap, InsertIntoEmptyMap) {
     for (unsigned int i = 0; i < 10; ++i) {
-        imap map;
-        auto res = map.insert({i, 10}, 0);
-        EXPECT_NE(res.first, map.end());
-        EXPECT_TRUE(res.second);
+        for (unsigned int len = 1; len < 10; ++len) {
+            imap map;
+            // start/length don't matter it should always succeed
+            auto res = map.insert({i, len}, 0);
+            EXPECT_NE(res.first, map.end());
+            EXPECT_TRUE(res.second);
+        }
     }
 }
 

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -20,9 +20,10 @@ namespace io = experimental::io;
 
 using imap = io::interval_map<uint64_t, uint64_t>;
 
-TEST(IntervalMap, InsertZeroLength) {
+TEST(IntervalMap, InsertZeroLengthInterval) {
     imap map;
     for (unsigned int i = 0; i < 10; ++i) {
+        // it doesn't matter where the interval starts
         const auto res = map.insert({i, 0}, 0);
         EXPECT_EQ(res, std::make_pair(map.end(), false));
     }

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -41,32 +41,33 @@ TEST(IntervalMap, InsertIntoEmptyMap) {
     }
 }
 
-TEST(IntervalMap, InsertOverlapWithLast) {
+TEST(IntervalMap, InsertOverlapRejected) {
+    imap map;
+    EXPECT_TRUE(map.insert({0, 10}, 0).second);
+
     for (unsigned int i = 0; i < 10; ++i) {
-        imap map;
-        EXPECT_TRUE(map.insert({0, 10}, 0).second);
         const auto res = map.insert({i, 10}, 0);
         EXPECT_EQ(res.first, map.find(0));
         EXPECT_FALSE(res.second);
     }
+}
+
+TEST(IntervalMap, InsertRightAbut) {
     imap map;
     EXPECT_TRUE(map.insert({0, 10}, 0).second);
+
     const auto res = map.insert({10, 10}, 0);
     EXPECT_NE(res.first, map.find(0));
+    EXPECT_EQ(res.first, map.find(10));
     EXPECT_TRUE(res.second);
 }
 
-TEST(IntervalMap, InsertOverlapWithFirst) {
-    for (unsigned int i = 0; i < 10; ++i) {
-        imap map;
-        EXPECT_TRUE(map.insert({10, 10}, 0).second);
-        const auto res = map.insert({10 - i, 10}, 0);
-        EXPECT_EQ(res.first, map.find(10));
-        EXPECT_FALSE(res.second);
-    }
+TEST(IntervalMap, InsertLeftAbut) {
     imap map;
     EXPECT_TRUE(map.insert({10, 10}, 0).second);
+
     const auto res = map.insert({0, 10}, 0);
+    EXPECT_EQ(res.first, map.find(0));
     EXPECT_NE(res.first, map.find(10));
     EXPECT_TRUE(res.second);
 }

--- a/tools/single_test_cov.sh
+++ b/tools/single_test_cov.sh
@@ -3,8 +3,6 @@
 # single_test_cov.sh
 # ==================
 #
-# Prerequisite: redpanda debug binaries built with RP_ENABLE_COV=true
-#
 # This script runs a single unit test with coverage profiling enabled
 # and processes the output into an html report.
 #
@@ -12,22 +10,10 @@
 # like to directly measure the coverage of the class they are testing.
 #
 # Usage (in your redpanda directory):
-#  single_test_cov.sh vbuild/debug/clang/bin/<your test> [... extra args to test ...]
-
+#
+#  single_test_cov.sh //src/v/path/to/test
 set -e
 
-BINARY=$1
-BINARY_BASENAME=$(basename $1)
-PROFRAW=/tmp/${BINARY_BASENAME}.profraw
-PROFDATA=/tmp/${BINARY_BASENAME}.profdata
-HTML_DIR=/tmp/${BINARY_BASENAME}_coverage
-
-export LLVM_PROFILE_FILE=$PROFRAW
-echo "${@:2}"
-$BINARY ${@:2}
-
-vbuild/llvm/install/bin/llvm-profdata merge -sparse $PROFRAW -o $PROFDATA
-
-vbuild/llvm/install/bin/llvm-cov show $BINARY -instr-profile=$PROFDATA -format=html -output-dir=$HTML_DIR
-
-echo Wrote to ${HTML_DIR}/index.html
+bazel coverage $*
+COVERAGE_REPORT="$(bazel info output_path)/_coverage/_coverage_report.dat"
+genhtml --branch-coverage --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"


### PR DESCRIPTION
io: update interval tests and add bazel coverage helper

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
