### PR TITLE
parquet: simplify stats tracking

### DIFF
--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -41,8 +41,7 @@ public:
     virtual ~impl() noexcept = default;
 
     virtual ss::future<> add(value, rep_level, def_level) = 0;
-    virtual size_t memory_usage() const = 0;
-    virtual size_t total_rows() const = 0;
+    virtual int64_t memory_usage() const = 0;
     virtual ss::future<flushed_pages> flush_pages() = 0;
 };
 
@@ -73,9 +72,7 @@ public:
         // A repetition level of zero means that it's the start of a new row and
         // not a repeated value within the same row.
         if (rl == rep_level(0)) {
-            // We can ONLY flush on row boundaries, so make sure this is the
-            // first thing we do.
-            if (_current_buffer_size > _opts.page_buffer_size) {
+            if (_page_memory_usage > _opts.page_buffer_size) {
                 co_await flush_page();
             }
             ++_num_rows;
@@ -112,25 +109,9 @@ public:
         // always use the full capacity in our value buffer, and eagerly
         // accounting that usage might cause callers to overagressively
         // flush pages/row groups.
-        _current_buffer_size += value_memory_usage
-                                + static_cast<int64_t>(
-                                  sizeof(rep_level) + sizeof(def_level));
-    }
-
-    size_t memory_usage() const override {
-        size_t size = _current_buffer_size;
-        for (const auto& page : _flushed_pages) {
-            size += page.serialized.size_bytes();
-        }
-        return size;
-    }
-
-    size_t total_rows() const override {
-        size_t total = _num_rows;
-        for (const auto& page : _flushed_pages) {
-            total += std::get<data_page_header>(page.header.type).num_rows;
-        }
-        return total;
+        _page_memory_usage += value_memory_usage
+                              + static_cast<int64_t>(
+                                sizeof(rep_level) + sizeof(def_level));
     }
 
     ss::future<> flush_page() {
@@ -211,7 +192,9 @@ public:
         full_page_data.append(std::move(encoded_def_levels));
         full_page_data.append(std::move(encoded_data));
         _current_page_stats.reset();
-        _current_buffer_size = 0;
+        _page_memory_usage = 0;
+        _total_memory_usage += static_cast<int32_t>(
+          full_page_data.size_bytes());
         _flushed_pages.push_back(data_page{
           .header = std::move(header),
           .serialized_header_size = header_size,
@@ -219,8 +202,12 @@ public:
         });
     }
 
+    int64_t memory_usage() const override {
+        return _total_memory_usage + _page_memory_usage;
+    }
+
     ss::future<flushed_pages> flush_pages() override {
-        if (_current_buffer_size > 0) {
+        if (_num_values > 0) {
             co_await flush_page();
         }
 
@@ -240,6 +227,7 @@ public:
               /*is_exact=*/true);
         }
         _flushed_stats.reset();
+        _total_memory_usage = 0;
         co_return flushed_pages{
           .pages = std::exchange(_flushed_pages, {}),
           .stats = std::move(full_stats),
@@ -249,7 +237,8 @@ public:
 private:
     column_stats_collector<value_type, comparator> _current_page_stats;
     column_stats_collector<value_type, comparator> _flushed_stats;
-    size_t _current_buffer_size = 0;
+    int64_t _page_memory_usage = 0;
+    int64_t _total_memory_usage = 0;
     chunked_vector<value_type> _value_buffer;
     chunked_vector<def_level> _def_levels;
     chunked_vector<rep_level> _rep_levels;
@@ -349,8 +338,7 @@ column_writer::add(value val, rep_level rep_level, def_level def_level) {
     return _impl->add(std::move(val), rep_level, def_level);
 }
 
-size_t column_writer::memory_usage() const { return _impl->memory_usage(); }
-size_t column_writer::total_rows() const { return _impl->total_rows(); }
+int64_t column_writer::memory_usage() const { return _impl->memory_usage(); }
 
 ss::future<flushed_pages> column_writer::flush_pages() {
     return _impl->flush_pages();

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -48,7 +48,7 @@ public:
         bool compress;
         // The target size for how much data we buffer before
         // flushing/encoding/compressing the data to a page.
-        size_t page_buffer_size;
+        int64_t page_buffer_size;
     };
 
     explicit column_writer(const schema_element&, options);
@@ -66,12 +66,12 @@ public:
     // nodes.
     //
     // Use `shred_record` to get the value and levels from an arbitrary value.
+    //
+    // Return the current information about the column after a value is written.
     ss::future<> add(value, rep_level, def_level);
 
-    // The current memory usage for this writer
-    size_t memory_usage() const;
-    // The current number of rows for this writer
-    size_t total_rows() const;
+    // The memory usage of this entire column.
+    int64_t memory_usage() const;
 
     // Flush the pages that have been accumulated so far in the column.
     //

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -75,21 +75,21 @@ public:
     }
 
     file_stats stats() const {
-        file_stats stats = _stats;
+        int64_t buffered = 0;
         for (const auto& [_, col] : _columns) {
-            // NOTE: total_rows is always the same for each column, as we push
-            // down NULLs to every column.
-            stats.current_row_group.rows = col.writer.total_rows();
-            stats.current_row_group.memory_usage += col.writer.memory_usage();
+            buffered += col.writer.memory_usage();
         }
-        return stats;
+        return {
+          .flushed_size = _flushed_bytes,
+          .buffered_size = buffered,
+        };
     }
 
     ss::future<> flush_row_group() {
         row_group rg{
           .total_byte_size = 0, // Computed incrementally below
           .num_rows = 0,        // computed below
-          .file_offset = static_cast<int64_t>(_stats.size),
+          .file_offset = _flushed_bytes,
           .total_compressed_size = 0, // Computed incrementally below
           .ordinal = static_cast<int16_t>(_row_groups.size()),
         };
@@ -108,7 +108,7 @@ public:
                   .total_uncompressed_size = 0, // computed below
                   .total_compressed_size = 0,   // computed below
                   .key_value_metadata = {},
-                  .data_page_offset = static_cast<int64_t>(_stats.size),
+                  .data_page_offset = _flushed_bytes,
                   .stats = std::move(flushed.stats),
                 },
             };
@@ -140,7 +140,6 @@ public:
         if (page_count == 0) {
             co_return;
         }
-        _stats.rows += rg.num_rows;
         _row_groups.push_back(std::move(rg));
     }
 
@@ -188,8 +187,8 @@ private:
     }
 
     ss::future<> write_iobuf(iobuf b) {
-        _stats.size += b.size_bytes();
-        co_await write_iobuf_to_output_stream(std::move(b), _output);
+        _flushed_bytes += static_cast<int64_t>(b.size_bytes());
+        return write_iobuf_to_output_stream(std::move(b), _output);
     }
 
     struct column {
@@ -201,7 +200,7 @@ private:
     ss::output_stream<char> _output;
     contiguous_range_map<int32_t, column> _columns;
     chunked_vector<row_group> _row_groups;
-    file_stats _stats;
+    int64_t _flushed_bytes = 0;
 };
 
 writer::writer(options opts, ss::output_stream<char> output)

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -20,28 +20,16 @@
 
 namespace serde::parquet {
 
-// Statistics about the current row group.
-//
-// These are mainly provided to limit memory usage.
-struct row_group_stats {
-    uint64_t rows = 0;
-    uint64_t memory_usage = 0;
-};
-
 // Statistics about the current file being built.
 struct file_stats {
-    // Note these are only the number of rows flushed
-    // to the output stream (so does not include the number
-    // in the current row group)
-    uint64_t rows = 0;
-
     // The size of the file flushed to the output stream - does not include the
     // current row group buffered in memory, nor the footer (until close is
     // called).
-    uint64_t size = 0;
+    int64_t flushed_size = 0;
 
-    // Additional information about the current row group buffered in memory.
-    row_group_stats current_row_group;
+    // The amount of memory currently buffered in the current row group.
+    // When calling flush_row_group, this is reset to 0.
+    int64_t buffered_size = 0;
 };
 
 // A parquet file writer for seastar.
@@ -62,8 +50,8 @@ public:
         // before flushing/encoding/compressing the data before a row group
         // being flushed (since columns can have multiple pages within a row
         // group). Ecosystem libraries tend to default between 256Kib-1MiB
-        static constexpr size_t default_page_size = 512_KiB;
-        size_t page_buffer_size = default_page_size;
+        static constexpr int64_t default_page_size = 512_KiB;
+        int64_t page_buffer_size = default_page_size;
     };
 
     // Create a new parquet file writer using the given options that


### PR DESCRIPTION
I don't think we ever care about the number of rows written and need
that information, it's all about memory usage. Removing row counts
from the API simplifies things a bit.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
