### PR TITLE
raft/tests: deflake truncation_detection_test

### DIFF
--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -226,6 +226,10 @@ void in_memory_test_protocol::on_dispatch(dispatch_callback_t f) {
     _on_dispatch_handlers.push_back(std::move(f));
 }
 
+void in_memory_test_protocol::reset_dispatch_handlers() {
+    _on_dispatch_handlers.clear();
+}
+
 ss::future<> in_memory_test_protocol::stop() {
     auto f = _gate.close();
     for (auto& [_, ch] : _channels) {
@@ -583,6 +587,10 @@ ss::future<model::offset> raft_node_instance::random_batch_base_offset(
 
 void raft_node_instance::on_dispatch(dispatch_callback_t f) {
     _protocol->on_dispatch(std::move(f));
+}
+
+void raft_node_instance::reset_dispatch_handlers() {
+    _protocol->reset_dispatch_handlers();
 }
 
 seastar::future<> raft_fixture::TearDownAsync() {

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -143,6 +143,8 @@ public:
 
     void on_dispatch(dispatch_callback_t f);
 
+    void reset_dispatch_handlers();
+
     ss::future<> stop();
 
 private:
@@ -258,6 +260,7 @@ public:
     //// \param f The callback function to be invoked when a message is
     /// dispatched.
     void on_dispatch(dispatch_callback_t);
+    void reset_dispatch_handlers();
 
     ss::shared_ptr<in_memory_test_protocol> get_protocol() { return _protocol; }
     ss::shared_ptr<buffered_protocol> get_buffered_protocol() {

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -12,6 +12,7 @@
 #include "test_utils/async.h"
 
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/util/defer.hh>
 
 using namespace raft;
 
@@ -57,6 +58,8 @@ public:
         co_await ss::sleep(500ms);
         ASSERT_FALSE_CORO(wait_futures.available());
 
+        chunked_vector<ss::deferred_action<std::function<void()>>> cleanup;
+
         for (auto& [id, node] : nodes()) {
             if (id == leader.get_vnode().id()) {
                 node->on_dispatch([](model::node_id, raft::msg_type mt) {
@@ -69,43 +72,33 @@ public:
                     }
                     return ss::now();
                 });
+                cleanup.emplace_back(
+                  [&node] { node->reset_dispatch_handlers(); });
             }
         }
 
-        std::vector<ss::future<>> enqueued;
         std::vector<ss::future<result<raft::replicate_result>>> replicated;
-
         for (size_t i = 0; i < num_waiters(); i++) {
             auto stages = raft->replicate_in_stages(
               make_batches({{"k", "v"}}),
-              replicate_options{raft::consistency_level::quorum_ack});
-            enqueued.push_back(std::move(stages.request_enqueued));
+              replicate_options{raft::consistency_level::leader_ack});
             replicated.push_back(std::move(stages.replicate_finished));
         }
-        auto enqueue_results = co_await ss::when_all(
-          enqueued.begin(), enqueued.end());
+
+        auto repl_results = co_await ss::when_all(
+          replicated.begin(), replicated.end());
+
         /**
          * block new leadership and step down, this forces one of the other
          * replicas to become a leader, since the current leader was not able to
          * deliver any append entries messages to the replicas its log must be
          * truncated by the new leader when it will try to replicate messages.
          */
-
         raft->block_new_leadership();
-        co_await raft->step_down(model::term_id(2), "test");
+        cleanup.emplace_back([raft] { raft->unblock_new_leadership(); });
+        co_await raft->step_down("test injected stepdown");
 
-        auto repl_results = co_await ss::when_all(
-          replicated.begin(), replicated.end());
-        for (auto& r : repl_results) {
-            auto res = r.get();
-            ASSERT_TRUE_CORO(res.has_error());
-            if (res.error() == errc::not_leader) {
-                throw raft_not_leader_exception();
-            }
-            ASSERT_EQ_CORO(res.error(), errc::replicated_entry_truncated);
-        }
-
-        co_await tests::cooperative_spin_wait_with_timeout(2s, [&] {
+        co_await tests::cooperative_spin_wait_with_timeout(10s, [&] {
             return wait_futures.available() && !wait_futures.failed();
         });
 
@@ -118,6 +111,7 @@ public:
               wait_results.at(i), errc::replicated_entry_truncated);
         }
     }
+
     ss::future<> replication_monitor_wait_test(raft_node_instance& leader) {
         auto raft = leader.raft();
 


### PR DESCRIPTION
The current logic to wait on `enqueued` stage seems incorrect and is causing the test to flake. `eneuqued` only guarantees that the request is enqueued in the raft layer and subsequent replication may still fail with not_leader error. So the sequence of flakiness is something like this.

1. wait for enqueued futures to resolve
2. force a step down
3. wait for replicated entry to be truncated.

If (2) happens before the entry is appended to the leader log, the replication future fails with a not leader resulting in a test retry. Effectively (1) is not a tight enough condition to wait on to force a step down.

This commit rewrites the test to replicate with a leader_ack and wait for the future to be resolved (which guarantees a lleader append) and then the replication monitor waiter should be resolved with a truncation error after leadership change.

Additionally the test seems to be missing some cleanup between retries, which is fixed

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
