### PR TITLE
Throttle requests if the translation backlog hits the limit

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -561,7 +561,7 @@ configuration::configuration()
       *this,
       "quota_manager_gc_sec",
       "Quota manager GC frequency in milliseconds.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(30000))
   , target_quota_byte_rate(*this, "target_quota_byte_rate")
   , target_fetch_quota_byte_rate(*this, "target_fetch_quota_byte_rate")

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4040,7 +4040,7 @@ configuration::configuration()
       "allow to run at a given time. If a translation is requested but the "
       "number of running translations exceeds this value, the request will be "
       "put to sleep temporarily, polling until capacity becomes available.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       4,
       {.min = 1, .max = 8})
   , datalake_scheduler_time_slice_ms(

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -436,4 +436,20 @@ ss::future<uint64_t> datalake_manager::disk_usage() {
     co_return total;
 }
 
+size_t datalake_manager::partitions_over_target_translation_backlog() const {
+    auto now = translation::scheduling::clock::now();
+    return std::ranges::count_if(
+      _scheduler.all_translators(), [now](const auto& entry) {
+          return entry.second.status().next_checkpoint_deadline < now;
+      });
+}
+/**
+ * Returns count of partitions that translation is blocked. This value
+ * should be 0 in normal conditions.
+ */
+size_t datalake_manager::partitions_with_translation_blocked() const {
+    //TODO: Return blocked if partition wasn't translated for a long time f.e. moret 
+    return 0;
+}
+
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -115,7 +115,7 @@ datalake_manager::datalake_manager(
       config::shard_local_cfg().datalake_scheduler_block_size_bytes(),
       translation::scheduling::scheduling_policy::make_default(
         config::shard_local_cfg()
-          .datalake_scheduler_max_concurrent_translations(),
+          .datalake_scheduler_max_concurrent_translations.bind(),
         std::chrono::duration_cast<translation::scheduling::clock::duration>(
           config::shard_local_cfg().datalake_scheduler_time_slice_ms())))
   , _queue(sg, [](const std::exception_ptr& ex) {
@@ -448,7 +448,8 @@ size_t datalake_manager::partitions_over_target_translation_backlog() const {
  * should be 0 in normal conditions.
  */
 size_t datalake_manager::partitions_with_translation_blocked() const {
-    //TODO: Return blocked if partition wasn't translated for a long time f.e. moret 
+    // TODO: Return blocked if partition wasn't translated for a long time f.e.
+    // moret
     return 0;
 }
 

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -82,6 +82,17 @@ public:
      */
     static ss::future<uint64_t> disk_usage();
 
+    /**
+     * Returns the number of partitions that the translator is not able to keep
+     * up with.
+     */
+    size_t partitions_over_target_translation_backlog() const;
+    /**
+     * Returns count of partitions that translation is blocked. This value
+     * should be 0 in normal conditions.
+     */
+    size_t partitions_with_translation_blocked() const;
+
 private:
     using translator = std::unique_ptr<translation::partition_translator>;
 

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -44,6 +44,7 @@ redpanda_cc_library(
     include_prefix = "datalake/translation",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:fragmented_vector",
         "//src/v/container:intrusive",

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -429,9 +429,10 @@ ss::future<> scheduler::main() {
 
 // temporary default until a proper scheduling policy is implemented.
 std::unique_ptr<scheduling_policy> scheduling_policy::make_default(
-  size_t max_concurrent_translators, clock::duration translation_time_quota) {
+  config::binding<size_t> max_concurrent_translators,
+  clock::duration translation_time_quota) {
     return std::make_unique<fair_scheduling_policy>(
-      max_concurrent_translators, translation_time_quota);
+      std::move(max_concurrent_translators), translation_time_quota);
 }
 
 std::unique_ptr<reservations_tracker> reservations_tracker::make_default(

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
@@ -316,7 +317,7 @@ public:
     on_resource_exhaustion(executor&, const reservations_tracker&) = 0;
 
     static std::unique_ptr<scheduling_policy> make_default(
-      size_t max_concurrent_translators,
+      config::binding<size_t> max_concurrent_translators,
       clock::duration translation_time_slice);
 };
 

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -23,14 +23,15 @@ static constexpr auto polling_interval = 1s;
 
 namespace datalake::translation::scheduling {
 simple_fcfs_scheduling_policy::simple_fcfs_scheduling_policy(
-  size_t max_concurrent_translators, clock::duration translation_time_quota)
-  : _max_concurrent_translations(max_concurrent_translators)
+  config::binding<size_t> max_concurrent_translators,
+  clock::duration translation_time_quota)
+  : _max_concurrent_translations(std::move(max_concurrent_translators))
   , _translation_time_quota(translation_time_quota) {
     vlog(
       datalake_log.info,
       "created simple_fcfs_scheduling_policy policy with {} translators "
       "and {} time quota",
-      max_concurrent_translators,
+      max_concurrent_translators(),
       std::chrono::duration_cast<std::chrono::milliseconds>(
         translation_time_quota));
 }
@@ -40,7 +41,7 @@ ss::future<> simple_fcfs_scheduling_policy::schedule_one_translation(
     // check the # of running translators
     while (!executor.as.abort_requested() && !executor.waiting.empty()
            && !mem_tracker.memory_exhausted()
-           && executor.running.size() >= _max_concurrent_translations) {
+           && executor.running.size() >= _max_concurrent_translations()) {
         co_await ss::sleep_abortable(polling_interval, executor.as);
     }
     if (executor.as.abort_requested() || mem_tracker.memory_exhausted()) {
@@ -66,14 +67,15 @@ ss::future<> simple_fcfs_scheduling_policy::on_resource_exhaustion(
 }
 
 fair_scheduling_policy::fair_scheduling_policy(
-  size_t max_concurrent_translators, clock::duration translation_time_quota)
-  : _max_concurrent_translations(max_concurrent_translators)
+  config::binding<size_t> max_concurrent_translators,
+  clock::duration translation_time_quota)
+  : _max_concurrent_translations(std::move(max_concurrent_translators))
   , _translation_time_quota(translation_time_quota) {
     vlog(
       datalake_log.info,
       "created fair_scheduling_policy policy with {} translators "
       "and {} time quota",
-      max_concurrent_translators,
+      max_concurrent_translators(),
       std::chrono::duration_cast<std::chrono::milliseconds>(
         translation_time_quota));
     initialize_group_shares();
@@ -142,7 +144,7 @@ ss::future<> fair_scheduling_policy::schedule_one_translation(
     // Wait until an empty slot frees up.
     while (!executor.as.abort_requested() && !executor.waiting.empty()
            && !mem_tracker.memory_exhausted()
-           && executor.running.size() >= _max_concurrent_translations) {
+           && executor.running.size() >= _max_concurrent_translations()) {
         co_await ss::sleep_abortable(polling_interval, executor.as);
     }
 

--- a/src/v/datalake/translation/scheduling_policies.h
+++ b/src/v/datalake/translation/scheduling_policies.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "config/property.h"
 #include "datalake/translation/scheduling.h"
 
 #include <absl/container/flat_hash_map.h>
@@ -23,7 +24,7 @@ namespace datalake::translation::scheduling {
 class simple_fcfs_scheduling_policy : public scheduling_policy {
 public:
     explicit simple_fcfs_scheduling_policy(
-      size_t max_concurrent_translators,
+      config::binding<size_t> max_concurrent_translators,
       clock::duration translation_time_quota);
 
     ss::future<> schedule_one_translation(
@@ -33,7 +34,7 @@ public:
       executor& executor, const reservations_tracker& mem_tracker) override;
 
 private:
-    size_t _max_concurrent_translations;
+    config::binding<size_t> _max_concurrent_translations;
     clock::duration _translation_time_quota;
 };
 
@@ -48,7 +49,7 @@ private:
 class fair_scheduling_policy : public scheduling_policy {
 public:
     explicit fair_scheduling_policy(
-      size_t max_concurrent_translators,
+      config::binding<size_t> max_concurrent_translators,
       clock::duration translation_time_quota);
 
     ss::future<>
@@ -117,7 +118,7 @@ private:
     group_intervals_t _group_intervals;
     void initialize_group_shares();
 
-    size_t _max_concurrent_translations;
+    config::binding<size_t> _max_concurrent_translations;
     clock::duration _translation_time_quota;
 };
 

--- a/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
+++ b/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
@@ -31,8 +31,8 @@ public:
         return std::get<0>(GetParam());
     }
 
-    [[nodiscard]] static size_t max_concurrent_translators() {
-        return std::get<1>(GetParam());
+    [[nodiscard]] static config::binding<size_t> max_concurrent_translators() {
+        return config::mock_binding<size_t>(std::get<1>(GetParam()));
     }
 
     [[nodiscard]] static size_t total_memory() {
@@ -110,7 +110,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 class simple_fair_scheduling_policy_fixture : public scheduler_fixture {
     std::unique_ptr<scheduling_policy> make_scheduling_policy() override {
-        return std::make_unique<fair_scheduling_policy>(max_translators, 10ms);
+        return std::make_unique<fair_scheduling_policy>(
+          config::mock_binding(max_translators), 10ms);
     }
 
 protected:

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -404,7 +404,7 @@ public:
     std::unique_ptr<scheduling::scheduling_policy>
     make_scheduling_policy() override {
         return scheduling::scheduling_policy::make_default(
-          max_concurrent_translators, task_quota);
+          config::mock_binding(max_concurrent_translators), task_quota);
     }
 
 protected:

--- a/src/v/datalake/translation/tests/scheduler_fixture.h
+++ b/src/v/datalake/translation/tests/scheduler_fixture.h
@@ -137,7 +137,7 @@ public:
 
     virtual std::unique_ptr<scheduling_policy> make_scheduling_policy() {
         return scheduling_policy::make_default(
-          max_concurrent_translators, task_time_quota);
+          config::mock_binding(max_concurrent_translators), task_time_quota);
     }
 
     ss::future<> SetUpAsync() override {

--- a/src/v/datalake/translation/tests/scheduler_tests.cc
+++ b/src/v/datalake/translation/tests/scheduler_tests.cc
@@ -20,7 +20,7 @@ class many_concurrent_translators : public scheduler_fixture {
 public:
     std::unique_ptr<scheduling_policy> make_scheduling_policy() override {
         return scheduling_policy::make_default(
-          max_concurrent_translators, task_time_quota);
+          config::mock_binding(max_concurrent_translators), task_time_quota);
     }
 
 protected:

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     server/consumer_group_lag_metrics_service.cc
     server/requests.cc
     server/member.cc
+    server/datalake_throttle_manager.cc
     server/group_stm.cc
     server/group.cc
     server/group_router.cc

--- a/src/v/kafka/protocol/BUILD
+++ b/src/v/kafka/protocol/BUILD
@@ -19,7 +19,6 @@ redpanda_cc_library(
         "batch_reader.cc",
         "errors.cc",
         "kafka_batch_adapter.cc",
-        "logger.cc",
         "types.cc",
     ],
     hdrs = [
@@ -30,7 +29,6 @@ redpanda_cc_library(
         "fwd.h",
         "kafka_batch_adapter.h",
         "legacy_message.h",
-        "logger.h",
         "timeout.h",
         "topic_properties.h",
         "types.h",
@@ -39,6 +37,7 @@ redpanda_cc_library(
     include_prefix = "kafka/protocol",
     visibility = ["//visibility:public"],
     deps = [
+        ":logger",
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
@@ -77,6 +76,22 @@ redpanda_cc_library(
         "//src/v/utils:vint",
         "@seastar",
     ] + MESSAGE_TYPES,
+)
+
+redpanda_cc_library(
+    name = "logger",
+    srcs = [
+        "logger.cc",
+    ],
+    hdrs = [
+        "logger.h",
+    ],
+    include_prefix = "kafka/protocol",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
 )
 
 generate_kafka_message_libs()

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -353,6 +353,28 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "datalake_throttle_manager",
+    srcs = [
+        "datalake_throttle_manager.cc",
+    ],
+    hdrs = [
+        "datalake_throttle_manager.h",
+    ],
+    include_prefix = "kafka/server",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":logger",
+        "//src/v/base",
+        "//src/v/config",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/metrics",
+        "//src/v/ssx:future_util",
+        "//src/v/utils:absl_sstring_hash",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "errors",
     hdrs = [
         "errors.h",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -188,6 +188,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":consumer_group_lag_metrics_rpc",
+        ":datalake_throttle_manager",
         ":logger",
         ":qdc_monitor_config",
         "//src/v/base",
@@ -401,6 +402,7 @@ redpanda_cc_library(
     include_prefix = "kafka/server",
     visibility = ["//src/v/redpanda:__pkg__"],
     deps = [
+        ":datalake_throttle_manager",
         ":qdc_monitor_config",
         "@seastar",
     ],

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -17,6 +17,24 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "logger",
+    srcs = [
+        "logger.cc",
+    ],
+    hdrs = [
+        "logger.h",
+    ],
+    include_prefix = "kafka/server",
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/v/base",
+        "//src/v/kafka/protocol:logger",
+        "//src/v/utils:truncating_logger",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "server",
     srcs = [
         "client_quota_translator.cc",
@@ -59,7 +77,6 @@ redpanda_cc_library(
         "handlers/topics/topic_utils.cc",
         "handlers/topics/types.cc",
         "handlers/txn_offset_commit.cc",
-        "logger.cc",
         "member.cc",
         "protocol_utils.cc",
         "quota_manager.cc",
@@ -150,7 +167,6 @@ redpanda_cc_library(
         "handlers/topics/validators.h",
         "handlers/txn_offset_commit.h",
         "kafka_probe.h",
-        "logger.h",
         "member.h",
         "protocol_utils.h",
         "queue_depth_monitor.h",
@@ -172,6 +188,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":consumer_group_lag_metrics_rpc",
+        ":logger",
         ":qdc_monitor_config",
         "//src/v/base",
         "//src/v/bytes",
@@ -225,6 +242,7 @@ redpanda_cc_library(
         "//src/v/kafka/protocol:list_offset",
         "//src/v/kafka/protocol:list_partition_reassignments",
         "//src/v/kafka/protocol:list_transactions",
+        "//src/v/kafka/protocol:logger",
         "//src/v/kafka/protocol:metadata",
         "//src/v/kafka/protocol:offset_commit",
         "//src/v/kafka/protocol:offset_delete",

--- a/src/v/kafka/server/app.cc
+++ b/src/v/kafka/server/app.cc
@@ -42,6 +42,7 @@ seastar::future<> server_app::init(
   seastar::sharded<cluster::security_frontend>& sec,
   seastar::sharded<cluster::controller_api>& ctrl,
   seastar::sharded<cluster::tx_gateway_frontend>& tx,
+  seastar::sharded<datalake_throttle_manager>& dtm,
   std::optional<qdc_monitor_config> qdc,
   ssx::singleton_thread_worker& worker,
   const std::unique_ptr<pandaproxy::schema_registry::api>& pp) {
@@ -71,6 +72,7 @@ seastar::future<> server_app::init(
       std::ref(sec),
       std::ref(ctrl),
       std::ref(tx),
+      std::ref(dtm),
       qdc,
       std::ref(worker),
       std::ref(pp));

--- a/src/v/kafka/server/app.h
+++ b/src/v/kafka/server/app.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "kafka/server/datalake_throttle_manager.h"
 #include "kafka/server/queue_depth_monitor_config.h"
 
 #include <seastar/core/future.hh>
@@ -103,6 +104,7 @@ public:
       seastar::sharded<cluster::security_frontend>&,
       seastar::sharded<cluster::controller_api>&,
       seastar::sharded<cluster::tx_gateway_frontend>&,
+      seastar::sharded<datalake_throttle_manager>&,
       std::optional<qdc_monitor_config>,
       ssx::singleton_thread_worker&,
       const std::unique_ptr<pandaproxy::schema_registry::api>&);

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -19,6 +19,7 @@
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/sasl_authenticate.h"
+#include "kafka/server/datalake_throttle_manager.h"
 #include "kafka/server/handlers/fetch.h"
 #include "kafka/server/handlers/handler_interface.h"
 #include "kafka/server/handlers/produce.h"
@@ -560,6 +561,12 @@ connection_context::record_tp_and_calculate_throttle(
         auto produce_delay
           = co_await _server.quota_mgr().record_produce_tp_and_throttle(
             r_data.client_id, request_size, now);
+        auto datalake_produce_delay
+          = co_await _server.get_datalake_producer_throttle(r_data.client_id);
+
+        produce_delay = std::max(
+          produce_delay,
+          std::chrono::duration_cast<clock::duration>(datalake_produce_delay));
         auto produce_enforced = _throttling_state.update_produce_delay(
           produce_delay, now);
         client_quota_delay = delay_t{

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "kafka/server/datalake_throttle_manager.h"
+
+#include "config/configuration.h"
+#include "kafka/server/logger.h"
+#include "ssx/future-util.h"
+namespace kafka {
+using namespace std::chrono_literals;
+namespace {
+
+static constexpr std::string_view anonymous_client_id = "";
+
+static constexpr std::chrono::milliseconds no_throttling{0};
+std::string_view
+get_effective_client_id(const std::optional<std::string_view>& client_id) {
+    if (client_id.has_value()) {
+        return *client_id;
+    }
+    return anonymous_client_id;
+}
+
+} // namespace
+void datalake_throttle_manager::merge_producer_maps(
+  producers_map_t& target, const producers_map_t& source) {
+    for (const auto& [client_id, state] : source) {
+        auto [it, emplaced] = target.try_emplace(client_id, state);
+        if (!emplaced) {
+            it->second.last_datalake_produce = std::max(
+              it->second.last_datalake_produce, state.last_datalake_produce);
+        }
+    }
+}
+
+datalake_throttle_manager::backlog_status
+datalake_throttle_manager::backlog_status::operator+(
+  const datalake_throttle_manager::backlog_status& o) const {
+    return datalake_throttle_manager::backlog_status{
+      .partitions_backlog_limit_breached
+      = partitions_backlog_limit_breached + o.partitions_backlog_limit_breached,
+      .partitions_translation_blocked = partitions_translation_blocked
+                                        + o.partitions_translation_blocked};
+}
+
+bool datalake_throttle_manager::backlog_status::has_no_issues() const {
+    return partitions_backlog_limit_breached == 0
+           && partitions_translation_blocked == 0;
+}
+
+std::ostream& operator<<(
+  std::ostream& o, const datalake_throttle_manager::backlog_status& s) {
+    fmt::print(
+      o,
+      "{{partitions_backlog_limit_breached: {}, "
+      "partitions_translation_blocked: {}}}",
+      s.partitions_backlog_limit_breached,
+      s.partitions_translation_blocked);
+    return o;
+}
+
+datalake_throttle_manager::datalake_throttle_manager(
+  status_provider_fn status_provider,
+  config::binding<std::chrono::milliseconds> producer_gc_threshold,
+  config::binding<std::chrono::milliseconds> max_kafka_throttle)
+  : _shard_status_provider(std::move(status_provider))
+  , _producer_gc_threshold(std::move(producer_gc_threshold))
+  , _max_kafka_throttle(std::move(max_kafka_throttle)) {
+    _update_timer.set_callback([this] {
+        ssx::spawn_with_gate(
+          _gate, [this] { return gc_and_update_global_producers_map(); });
+    });
+}
+
+void datalake_throttle_manager::start() {
+    using namespace std::chrono_literals;
+    setup_metrics();
+    /**
+     * Only run update timer on shard 0
+     */
+    if (ss::this_shard_id() == 0) {
+        _update_timer.arm_periodic(100ms);
+    }
+}
+
+ss::future<> datalake_throttle_manager::stop() {
+    _update_timer.cancel();
+    return _gate.close();
+}
+
+void datalake_throttle_manager::mark_datalake_producer(
+  const std::optional<std::string_view>& client_id,
+  clock_type::time_point now) {
+    _shard_local_producers.insert_or_assign(
+      ss::sstring(get_effective_client_id(client_id)),
+      producer_state{.last_datalake_produce = now});
+}
+
+ss::future<> datalake_throttle_manager::gc_and_update_global_producers_map() {
+    vassert(
+      ss::this_shard_id() == 0,
+      "Global producers map should be updated only on shard 0");
+
+    _translation_status = co_await container().map_reduce0(
+      [](datalake_throttle_manager& instance) {
+          return instance._shard_status_provider();
+      },
+      backlog_status{},
+      [](backlog_status acc, backlog_status shard_status) {
+          return acc + shard_status;
+      });
+    if (_translation_status.has_no_issues()) {
+        _last_no_issues_timestamp = clock_type::now();
+    }
+    /**
+     * Collect shard local maps and while iterating over the shards update the
+     * total backlog
+     */
+    auto shard_local_maps = co_await ssx::parallel_transform(
+      boost::irange(ss::smp::count), [this](auto shard_id) {
+          return container().invoke_on(
+            shard_id,
+            [status = _translation_status](datalake_throttle_manager& other) {
+                other._translation_status = status;
+                return std::exchange(other._shard_local_producers, {});
+            });
+      });
+
+    for (auto& shard_map : shard_local_maps) {
+        merge_producer_maps(_global_producers, shard_map);
+    }
+
+    std::erase_if(_global_producers, [this](const auto& p) {
+        return (clock_type::now() - p.second.last_datalake_produce)
+               > _producer_gc_threshold();
+    });
+}
+
+ss::future<std::chrono::milliseconds>
+datalake_throttle_manager::maybe_throttle_producer(
+  std::optional<std::string_view> client_id) {
+    // fast path, backlog is below the threshold
+
+    if (_translation_status.has_no_issues()) [[likely]] {
+        co_return no_throttling;
+    }
+
+    auto throttle_ms = co_await container().invoke_on(
+      0, [&client_id](datalake_throttle_manager& shard_0_manager) {
+          auto throttle_ms = shard_0_manager.get_producer_throttle(client_id);
+          if (throttle_ms > 0ms) {
+              vlog(
+                client_quota_log.debug,
+                "Throttling producer {} for {}ms, current "
+                "status: {}",
+                client_id,
+                throttle_ms,
+                shard_0_manager._translation_status);
+          }
+          return throttle_ms;
+      });
+    // record throttle for exposing a metric
+    _total_throttle += throttle_ms.count();
+    co_return throttle_ms;
+}
+
+std::chrono::milliseconds datalake_throttle_manager::get_producer_throttle(
+  const std::optional<std::string_view>& client_id) {
+    vassert(
+      ss::this_shard_id() == 0, "Throttle can only be calculate on shard 0");
+    if (_translation_status.has_no_issues()) [[likely]] {
+        return no_throttling;
+    }
+    auto effective_client_id = get_effective_client_id(client_id);
+
+    auto it = _global_producers.find(effective_client_id);
+    // do not throttle non datalake producers
+    if (it == _global_producers.end()) {
+        return no_throttling;
+    }
+
+    return calculate_throttle();
+}
+
+std::chrono::milliseconds
+datalake_throttle_manager::calculate_throttle() const {
+    vassert(
+      ss::this_shard_id() == 0, "Throttle can only be calculate on shard 0");
+    if (_translation_status.partitions_translation_blocked > 0) {
+        // if translation is blocked (this should never really be the case),
+        // use max throttle
+        return _max_kafka_throttle();
+    }
+    // Heuristic:
+    // we apply the incremental throttle based on time spent in the degraded
+    // translation state, the longer the time the more we throttle. The
+    // throttle is set to max after 5 minutes
+
+    if (_translation_status.partitions_backlog_limit_breached > 0) {
+        auto time_in_degraded_state
+          = std::chrono::duration_cast<std::chrono::milliseconds>(
+            ss::lowres_clock::now() - _last_no_issues_timestamp);
+
+        const auto max_throttle_ratio = std::min(
+          double(time_in_degraded_state.count()) / 300000, 1.0);
+
+        return std::chrono::milliseconds(static_cast<size_t>(
+          max_throttle_ratio * _max_kafka_throttle().count()));
+    }
+
+    return 0ms;
+}
+
+void datalake_throttle_manager::setup_metrics() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      "kafka:datalake:throttle",
+      {
+        sm::make_counter(
+          "total_throttle",
+          [this] { return _total_throttle; },
+          sm::description(
+            "Total datalake producer throttle time in milliseconds")),
+      });
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "base/seastarx.h"
+#include "config/property.h"
+#include "container/chunked_hash_map.h"
+#include "metrics/metrics.h"
+#include "utils/absl_sstring_hash.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sstring.hh>
+namespace kafka {
+
+/**
+ * Simple class responsible for tracking and throttling  producers thar are
+ * writing data to Iceberg enabled topics.
+ *
+ * Throttle manager has two parts one is the shard local map used to quickly
+ * update producer state when handling the producer requests. The state from the
+ * local maps is eventually merged in a global map on shard 0. The shard 0
+ * global map is queried only when Iceberg capabilites are enabled and the
+ * Iceberg backlog is over the threshold making x-shard access very rare.
+ */
+class datalake_throttle_manager
+  : public ss::peering_sharded_service<datalake_throttle_manager> {
+public:
+    struct backlog_status {
+        size_t partitions_backlog_limit_breached{0};
+        size_t partitions_translation_blocked{0};
+
+        bool has_no_issues() const;
+        backlog_status operator+(const backlog_status& o) const;
+
+        friend std::ostream& operator<<(std::ostream&, const backlog_status&);
+    };
+
+    using clock_type = ss::lowres_clock;
+    /**
+     * The function should return a number reflecting the current backlog of
+     * Iceberg translation on a shard.
+     */
+    using status_provider_fn
+      = ss::noncopyable_function<ss::future<backlog_status>()>;
+
+    datalake_throttle_manager(
+      status_provider_fn,
+      config::binding<std::chrono::milliseconds>,
+      config::binding<std::chrono::milliseconds>);
+
+    void start();
+    ss::future<> stop();
+
+    // This method can be called on any shard it will update the local producer
+    // state so it is marked as the datalake topic related producer.
+    void mark_datalake_producer(
+      const std::optional<std::string_view>& producer_id,
+      clock_type::time_point now = clock_type::now());
+
+    // This method can be called on any shard it will return the throttle time
+    // if the Iceberg translation backlog limit is breached.
+    ss::future<std::chrono::milliseconds>
+    maybe_throttle_producer(std::optional<std::string_view> client_id);
+
+private:
+    ss::future<> gc_and_update_global_producers_map();
+    struct producer_state {
+        clock_type::time_point last_datalake_produce = clock_type::now();
+    };
+    using producers_map_t
+      = chunked_hash_map<ss::sstring, producer_state, sstring_hash, sstring_eq>;
+    static void
+    merge_producer_maps(producers_map_t& target, const producers_map_t& source);
+
+    // must be called only on shard 0
+    std::chrono::milliseconds
+    get_producer_throttle(const std::optional<std::string_view>&);
+
+    std::chrono::milliseconds calculate_throttle() const;
+
+    void setup_metrics();
+
+    status_provider_fn _shard_status_provider;
+    config::binding<std::chrono::milliseconds> _producer_gc_threshold;
+    config::binding<std::chrono::milliseconds> _max_kafka_throttle;
+
+    // Timestamp marking a last time when the Iceberg translation reported no
+    // issues. This timestamp is used to calculate the throttle, the longer the
+    // issue persist the bigger the throttle.
+    ss::lowres_clock::time_point _last_no_issues_timestamp = clock_type::now();
+    // global producers are maintained only on shard 0.
+    producers_map_t _global_producers;
+    // backlog status, calculated on shard 0 but updated on every shard
+    backlog_status _translation_status;
+    // shard local producers map used to quickly update the state of producer.
+    // The global map is updated by the background task.
+    producers_map_t _shard_local_producers;
+    ss::timer<clock_type> _update_timer;
+    size_t _total_throttle{0};
+    metrics::internal_metric_groups _metrics;
+    ss::gate _gate;
+};
+} // namespace kafka

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -31,5 +31,6 @@ class server;
 class snc_quota_context;
 class snc_quota_manager;
 class usage_manager;
+class datalake_throttle_manager;
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -567,7 +567,8 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
         partitions_produced.push_back(std::move(pr.produced));
         partitions_dispatched.push_back(std::move(pr.dispatched));
     }
-
+    auto is_iceberg_enabled = topic_cfg.properties.iceberg_mode
+                              != model::iceberg_mode::disabled;
     // collect partition responses and build the topic response
     return topic_produce_stages{
       .dispatched = ss::when_all_succeed(
@@ -575,6 +576,15 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
       .produced
       = ss::when_all_succeed(
           partitions_produced.begin(), partitions_produced.end())
+          .then([&octx, is_iceberg_enabled](
+                  std::vector<produce_response::partition> parts) {
+              // if topic is iceberg enabled update iceberg throttle manager.
+              if (is_iceberg_enabled) {
+                  octx.rctx.server().local().mark_datalake_producer(
+                    octx.rctx.header().client_id);
+              }
+              return ssx::now(std::move(parts));
+          })
           .then([name = std::move(topic.name)](
                   std::vector<produce_response::partition> parts) mutable {
               return produce_response::topic{

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -160,7 +160,7 @@ quota_manager::quota_manager(
   , _replenish_threshold(
       config::shard_local_cfg().kafka_throughput_replenish_threshold.bind())
   , _translator{client_quota_store}
-  , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
+  , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec.bind())
   , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
     if (seastar::this_shard_id() == quotas_shard) {
         _global_map = global_map_t{};
@@ -182,7 +182,7 @@ ss::future<> quota_manager::start() {
     _probe = std::make_unique<client_quotas_probe>();
     _probe->setup_metrics();
     if (ss::this_shard_id() == quotas_shard) {
-        _gc_timer.arm_periodic(_gc_freq);
+        _gc_timer.arm(_gc_freq());
 
         auto update_quotas = [this]() { update_client_quotas(); };
         _translator.watch(update_quotas);
@@ -536,15 +536,23 @@ void quota_manager::gc() {
     auto full_window = _default_num_windows() * _default_window_width();
     auto expire_threshold = clock::now() - 10 * full_window;
     ssx::background
-      = ssx::spawn_with_gate_then(_gate, [this, expire_threshold]() {
-            return container()
-              .invoke_on_all([expire_threshold](quota_manager& qm) {
-                  return qm.do_local_gc(expire_threshold);
-              })
-              .then([this]() { return do_global_gc(); });
-        }).handle_exception([](const std::exception_ptr& e) {
-            vlog(klog.warn, "Error garbage collecting quotas - {}", e);
-        });
+      = ssx::spawn_with_gate_then(
+          _gate,
+          [this, expire_threshold]() {
+              return container()
+                .invoke_on_all([expire_threshold](quota_manager& qm) {
+                    return qm.do_local_gc(expire_threshold);
+                })
+                .then([this]() { return do_global_gc(); });
+          })
+          .handle_exception([](const std::exception_ptr& e) {
+              vlog(klog.warn, "Error garbage collecting quotas - {}", e);
+          })
+          .finally([this] {
+              if (!_gate.is_closed()) {
+                  _gc_timer.arm(_gc_freq());
+              }
+          });
 }
 
 ss::future<> quota_manager::do_global_gc() {

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -156,7 +156,7 @@ private:
     std::unique_ptr<client_quotas_probe> _probe;
 
     ss::timer<> _gc_timer;
-    clock::duration _gc_freq;
+    config::binding<std::chrono::milliseconds> _gc_freq;
     config::binding<std::chrono::milliseconds> _max_delay;
     ss::gate _gate;
     std::optional<mutex> _global_map_mutex; // Only on shard 0

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -24,6 +24,7 @@
 #include "kafka/protocol/schemata/list_groups_response.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
+#include "kafka/server/datalake_throttle_manager.h"
 #include "kafka/server/errors.h"
 #include "kafka/server/group.h"
 #include "kafka/server/group_manager.h"
@@ -142,6 +143,7 @@ server::server(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<kafka::datalake_throttle_manager>& datalake_throttle_manager,
   std::optional<qdc_monitor_config> qdc_config,
   ssx::singleton_thread_worker& tw,
   const std::unique_ptr<pandaproxy::schema_registry::api>& sr) noexcept
@@ -178,6 +180,7 @@ server::server(
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
+  , _datalake_throttle_manager(datalake_throttle_manager)
   , _mtls_principal_mapper(
       config::shard_local_cfg().kafka_mtls_principal_mapping_rules.bind())
   , _gssapi_principal_mapper(
@@ -457,6 +460,27 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
     }
 }
 
+void server::mark_datalake_producer(
+  const std::optional<std::string_view>& client_id) {
+    if (
+      !config::shard_local_cfg().iceberg_enabled()
+      || !_datalake_throttle_manager.local_is_initialized()) {
+        return;
+    }
+    _datalake_throttle_manager.local().mark_datalake_producer(client_id);
+}
+
+ss::future<std::chrono::milliseconds> server::get_datalake_producer_throttle(
+  std::optional<std::string_view> client_id) {
+    if (
+      !config::shard_local_cfg().iceberg_enabled()
+      || !_datalake_throttle_manager.local_is_initialized()) {
+        return ssx::now<std::chrono::milliseconds>(0ms);
+    }
+
+    return _datalake_throttle_manager.local().maybe_throttle_producer(
+      client_id);
+}
 template<>
 ss::future<response_ptr> heartbeat_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -78,6 +78,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<datalake_throttle_manager>&,
       std::optional<qdc_monitor_config>,
       ssx::singleton_thread_worker&,
       const std::unique_ptr<pandaproxy::schema_registry::api>&) noexcept;
@@ -231,6 +232,19 @@ public:
     // processing incoming requests.
     ss::scheduling_group get_request_handler_sg() const;
 
+    /**
+     * Returns a throttle for a producer that may be producing to datalake
+     * enabled topics.
+     */
+    ss::future<std::chrono::milliseconds>
+    get_datalake_producer_throttle(std::optional<std::string_view> client_id);
+    /**
+     * Marks producer as datalake producer. I.e. a producer that produced to the
+     * datalake enabled topics.
+     */
+    void
+    mark_datalake_producer(const std::optional<std::string_view>& client_id);
+
 private:
     void setup_metrics();
 
@@ -263,6 +277,7 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<kafka::datalake_throttle_manager>& _datalake_throttle_manager;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
     security::tls::principal_mapper _mtls_principal_mapper;

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -783,6 +783,26 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "datalake_throttle_manager_test",
+    timeout = "short",
+    srcs = [
+        "datalake_throttle_manager_test.cc",
+    ],
+    cpu = 3,
+    deps = [
+        "//src/v/config",
+        "//src/v/kafka/server:datalake_throttle_manager",
+        "//src/v/random:generators",
+        "//src/v/ssx:future_util",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_bench(
     name = "kafka_fetch_rpbench",
     timeout = "moderate",

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -1,0 +1,177 @@
+
+#include "config/mock_property.h"
+#include "kafka/server/datalake_throttle_manager.h"
+#include "random/generators.h"
+#include "ssx/future-util.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+using namespace testing;
+using namespace std::chrono_literals;
+
+struct shard_local_state {
+    size_t blocked_translation{0};
+    size_t not_keeping_up{0};
+    config::mock_property<std::chrono::milliseconds> producer_gc_threshold{
+      1min};
+    config::mock_property<std::chrono::milliseconds> max_throttle{30s};
+};
+
+struct IcebergThrottlingManagerTest : ::testing::Test {
+    void SetUp() override {
+        shard_state.start().get();
+        manager
+          .start(
+            [this] { return sample_backlog(); },
+            ss::sharded_parameter(
+              [this] { return shard_state.local().max_throttle.bind(); }),
+            ss::sharded_parameter([this] {
+                return shard_state.local().producer_gc_threshold.bind();
+            }))
+          .get();
+        manager.invoke_on_all(&kafka::datalake_throttle_manager::start).get();
+    }
+
+    void TearDown() override {
+        manager.stop().get();
+        shard_state.stop().get();
+    }
+
+    ss::future<kafka::datalake_throttle_manager::backlog_status>
+    sample_backlog() {
+        co_return kafka::datalake_throttle_manager::backlog_status{
+          .partitions_backlog_limit_breached
+          = shard_state.local().not_keeping_up,
+          .partitions_translation_blocked
+          = shard_state.local().blocked_translation};
+    }
+
+    ss::future<> wait_for_producer_throttling(
+      const std::optional<ss::sstring>& producer_id,
+      std::chrono::milliseconds throttle_time_ms) {
+        return tests::cooperative_spin_wait_with_timeout(
+          5s, [this, producer_id, throttle_time_ms] {
+              return manager.local()
+                .maybe_throttle_producer(producer_id)
+                .then([throttle_time_ms](std::chrono::milliseconds throttle) {
+                    return throttle >= throttle_time_ms;
+                });
+          });
+    }
+    ss::future<>
+    wait_for_no_throttling(const std::optional<ss::sstring>& producer_id) {
+        return tests::cooperative_spin_wait_with_timeout(
+          5s, [this, producer_id] {
+              return manager.local()
+                .maybe_throttle_producer(producer_id)
+                .then([](std::chrono::milliseconds throttle_time_ms) {
+                    return throttle_time_ms == 0ms;
+                });
+          });
+    }
+
+    ss::sharded<kafka::datalake_throttle_manager> manager;
+    ss::sharded<shard_local_state> shard_state;
+};
+
+ss::future<> mark_producers_on_random_shards(
+  ss::sharded<kafka::datalake_throttle_manager>& mgr, int producer_cnt) {
+    for (auto i : std::ranges::views::iota(0, producer_cnt)) {
+        auto shard = random_generators::get_int<uint32_t>(
+          0, ss::smp::count - 1);
+        co_await mgr.invoke_on(
+          shard, [i](kafka::datalake_throttle_manager& local_mgr) {
+              local_mgr.mark_datalake_producer(fmt::format("producer-{}", i));
+          });
+    }
+}
+
+TEST_F(IcebergThrottlingManagerTest, TestThrottlingIcebergEnabledProducer) {
+    mark_producers_on_random_shards(manager, 100).get();
+    // wait for a while for state to propagate across shards
+    ss::sleep(500ms).get();
+    ASSERT_EQ(
+      manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
+    // set the backlog above the threshold on one shards, the throttling should
+    // be applied
+    shard_state
+      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .get();
+    wait_for_producer_throttling("producer-20", 10ms).get();
+
+    // wait for some more time, the throttle should increase
+    wait_for_producer_throttling("producer-20", 100ms).get();
+
+    // // non iceberg producer should not be throttled
+    ASSERT_EQ(
+      manager.local().maybe_throttle_producer("producer-20-other").get(), 0ms);
+    // when translation status does not report any issues, the producer should
+    // not be throttled
+    shard_state
+      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up = 0; })
+      .get();
+    wait_for_no_throttling("producer-20").get();
+}
+
+TEST_F(IcebergThrottlingManagerTest, TestProducerEviction) {
+    mark_producers_on_random_shards(manager, 100).get();
+    // wait for state to propagate
+    ss::sleep(500ms).get();
+    shard_state
+      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .get();
+    wait_for_producer_throttling("producer-20", 10ms).get();
+    shard_state
+      .invoke_on_all([](shard_local_state& state) {
+          state.producer_gc_threshold.update(1s);
+      })
+      .get();
+    // backlog is still above threshold but the producer should be evicted so it
+    // should not be throttled
+    wait_for_no_throttling("producer-20").get();
+}
+
+TEST_F(IcebergThrottlingManagerTest, TestHandlingAnonymousProducers) {
+    // mark anonymous producer on random shard
+    auto shard = random_generators::get_int<uint32_t>(0, ss::smp::count - 1);
+    manager
+      .invoke_on(
+        shard,
+        [](kafka::datalake_throttle_manager& local_mgr) {
+            local_mgr.mark_datalake_producer(std::nullopt);
+        })
+      .get();
+
+    shard_state
+      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .get();
+    // check if anonymous producer is throttled
+    wait_for_producer_throttling(std::nullopt, 10ms).get();
+}
+
+TEST_F(IcebergThrottlingManagerTest, TestHandlingBlockedPartitions) {
+    mark_producers_on_random_shards(manager, 100).get();
+    // wait for a while for state to propagate across shards
+    ss::sleep(500ms).get();
+    ASSERT_EQ(
+      manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
+    // set the backlog above the threshold on one shards, the throttling should
+    // be applied
+    shard_state
+      .invoke_on(
+        0, [](shard_local_state& state) { state.blocked_translation++; })
+      .get();
+    // the max throttle should be applied,
+    wait_for_producer_throttling("producer-20", 30s).get();
+
+    // // non iceberg producer should not be throttled
+    ASSERT_EQ(
+      manager.local().maybe_throttle_producer("producer-20-other").get(), 0ms);
+    // when translation status does not report any issues, the producer should
+    // not be throttled
+    shard_state
+      .invoke_on(
+        0, [](shard_local_state& state) { state.blocked_translation = 0; })
+      .get();
+    wait_for_no_throttling("producer-20").get();
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1416,6 +1416,29 @@ void application::wire_up_runtime_services(
           .get();
         _datalake_manager.invoke_on_all(&datalake::datalake_manager::start)
           .get();
+
+        construct_service(
+          datalake_throttle_manager,
+          [&mgr = _datalake_manager] {
+              return ssx::now(kafka::datalake_throttle_manager::backlog_status{
+                .partitions_backlog_limit_breached
+                = mgr.local().partitions_over_target_translation_backlog(),
+                .partitions_translation_blocked
+                = mgr.local().partitions_with_translation_blocked(),
+              });
+          },
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg()
+                .max_kafka_throttle_delay_ms.bind();
+          }),
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg().quota_manager_gc_sec.bind();
+          }))
+          .get();
+
+        datalake_throttle_manager
+          .invoke_on_all(&kafka::datalake_throttle_manager::start)
+          .get();
     }
     construct_single_service(_monitor_unsafe, std::ref(feature_table));
 
@@ -2322,6 +2345,7 @@ void application::wire_up_redpanda_services(
         std::ref(controller->get_security_frontend()),
         std::ref(controller->get_api()),
         std::ref(tx_gateway_frontend),
+        std::ref(datalake_throttle_manager),
         qdc_config,
         std::ref(*thread_worker),
         std::ref(_schema_registry))

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -188,6 +188,7 @@ public:
     std::unique_ptr<ssx::singleton_thread_worker> thread_worker;
 
     ss::sharded<crypto::ossl_context_service> ossl_context_service;
+    ss::sharded<kafka::datalake_throttle_manager> datalake_throttle_manager;
 
     ss::sharded<kafka::consumer_group_lag_metrics_frontend>
       _consumer_group_lag_metrics_frontend;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -174,6 +174,7 @@ public:
             std::ref(app.controller->get_security_frontend()),
             std::ref(app.controller->get_api()),
             std::ref(app.tx_gateway_frontend),
+            std::ref(app.datalake_throttle_manager),
             std::nullopt,
             std::ref(*app.thread_worker),
             std::ref(app.schema_registry()))

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import datetime
+import re
+import time
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkTool, TopicSpec
+from rptest.services.cluster import cluster
+from random import randint
+
+from confluent_kafka import avro
+from confluent_kafka.avro import AvroProducer
+from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings, MetricsEndpoint
+from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types, filesystem_catalog_type
+from ducktape.mark import matrix, ignore
+from ducktape.utils.util import wait_until
+from rptest.services.metrics_check import MetricCheck
+from rptest.services.catalog_service import CatalogType
+
+
+class DatalakeThrottlingTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(DatalakeThrottlingTest, self).__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx),
+            extra_rp_conf={
+                "iceberg_enabled": "true",
+                "iceberg_catalog_commit_interval_ms": 5000
+            },
+            schema_registry_config=SchemaRegistryConfig(),
+            pandaproxy_config=PandaproxyConfig(),
+            environment={
+                "__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"
+            },
+            *args,
+            **kwargs)
+        self.test_ctx = test_ctx
+        self.topic_name = "test"
+
+    def setUp(self):
+        # redpanda will be started by DatalakeServices
+        pass
+
+    def _total_throttle(self):
+        total = 0
+        sample = self.redpanda.metrics_sample("total_throttle")
+        assert sample is not None, "total_throttle metric not found"
+        for s in sample.samples:
+            self.logger.debug(f"metrics sample: {s}")
+            total += s.value
+        return total
+
+    def producer_throttled(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.produce(self.topic_name, "key", "value")
+        throttle = self._total_throttle()
+        return throttle > 0
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_basic_throttling(self, cloud_storage_type, catalog_type):
+        msg_cnt = 100
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.TRINO],
+                              catalog_type=catalog_type) as dl:
+
+            non_iceberg_topic = TopicSpec(partition_count=1,
+                                          replication_factor=1)
+            rpk = RpkTool(self.redpanda)
+            dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
+            DefaultClient(self.redpanda).create_topic(non_iceberg_topic)
+            dl.produce_to_topic(self.topic_name, 1024, msg_cnt)
+            dl.wait_for_translation(self.topic_name, msg_count=msg_cnt)
+            assert self._total_throttle(
+            ) == 0, "There should be no throttling in baseline conditions"
+
+            # Block translation by setting the max number of translations to 0
+            self.redpanda.set_cluster_config(
+                {"datalake_scheduler_max_concurrent_translations": 0})
+            # Produce some more messages
+            dl.produce_to_topic(self.topic_name, 1024, msg_cnt)
+            wait_until(lambda: self.producer_throttled(), timeout_sec=30)
+
+            # Validate that non Iceberg related producers are not throttled
+            current_throttle = self._total_throttle()
+            dl.produce_to_topic(non_iceberg_topic.name, 1024, 10)
+            assert self._total_throttle(
+            ) == current_throttle, "Total throttle should not increase as the topic is not iceberg enabled"
+            # Enable translation back
+            self.redpanda.set_cluster_config(
+                {"datalake_scheduler_max_concurrent_translations": 4})
+            partitions = rpk.describe_topic(self.topic_name)
+            total_messages = 0
+            for p in partitions:
+                total_messages += p.high_watermark
+            self.logger.info(
+                f"waiting for translation of {total_messages} messages")
+            dl.wait_for_translation(self.topic_name, msg_count=total_messages)
+            dl.produce_to_topic(self.topic_name, 1024, msg_cnt)
+            assert self._total_throttle(
+            ) == current_throttle, "Total throttle should not increase as the translation is progressing"


### PR DESCRIPTION
Introduced a component that is responsible for throttling Iceberg
enabled producers when partition translation backlog target is not met.

The `datalake_throttle_manager` keeps track of all Iceberg related
producers. The producer is marked as iceberg enabled on any shard, then
the manager map reduces the state and throttling is always calculated on
shard 0.

In order to skip the x-shard call for non-iceberg producers and in case
the throttling is not required, every shard local manager can verify if
the throttling is required. Only if the translation backlog are over the
limit the x-shard call is required to verify if the producer is iceberg
enabled one. (shard 0 is the only one that has producer state from all
other shards).

The throttling is calculated based on the time since the translation
error was reported. Currently the max throttle will be applied after 5
minutes if translation problem persists.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none