### PR TITLE
CORE-9028 crash_tracker: test no allocs in `record_crash_sighandler`

### DIFF
--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -28,6 +28,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ rp_test(
   BINARY_NAME recorder_test
   SOURCES
     recorder_test.cc
-  LIBRARIES v::gtest_main v::config v::crash_tracker
+  LIBRARIES v::gtest_main v::config v::crash_tracker Seastar::seastar
   ARGS "-- -c 1"
 )
 

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -12,6 +12,8 @@
 #include "crash_tracker/recorder.h"
 #include "test_utils/tmp_dir.h"
 
+#include <seastar/core/memory.hh>
+
 #include <gtest/gtest.h>
 
 #include <exception>
@@ -19,18 +21,25 @@
 
 namespace crash_tracker {
 
-class RecorderTest : public testing::Test {
+class RecorderTestHelper {
 public:
-    void SetUp() override {
-        config::node().data_directory.set_value(_dir.get_path());
-    }
-    void TearDown() override {
+    void SetUp() { config::node().data_directory.set_value(_dir.get_path()); }
+    void TearDown() {
         _dir.remove().get();
         config::node().data_directory.reset();
     }
 
 private:
     temporary_dir _dir{"recorder_test"};
+};
+
+class RecorderTest : public testing::Test {
+public:
+    void SetUp() override { _helper.SetUp(); }
+    void TearDown() override { _helper.TearDown(); }
+
+private:
+    RecorderTestHelper _helper;
 };
 
 TEST_F(RecorderTest, TestFileCleanup) {
@@ -54,5 +63,38 @@ TEST_F(RecorderTest, TestFileCleanup) {
     crashes = rec.get_recorded_crashes().get();
     ASSERT_EQ(crashes.size(), recorder::crash_files_to_keep);
 }
+
+class ParametrizedRecorderTest
+  : public testing::TestWithParam<recorder::recorded_signo> {
+public:
+    void SetUp() override { _helper.SetUp(); }
+    void TearDown() override { _helper.TearDown(); }
+
+private:
+    RecorderTestHelper _helper;
+};
+
+TEST_P(ParametrizedRecorderTest, TestNoAlloc) {
+    auto rec = get_test_recorder();
+    rec.start().get();
+
+    // Note: memory stats are only tracked in release mode
+    const auto stats = ss::memory::stats();
+    auto mallocs = [&]() {
+        return ss::memory::stats().mallocs() - stats.mallocs();
+    };
+
+    // Verify that writing out a crash report does not allocate
+    rec.record_crash_sighandler(GetParam());
+    ASSERT_EQ(mallocs(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  AllCrashSignals,
+  ParametrizedRecorderTest,
+  testing::Values(
+    recorder::recorded_signo::sigsegv,
+    recorder::recorded_signo::sigabrt,
+    recorder::recorded_signo::sigill));
 
 } // namespace crash_tracker


### PR DESCRIPTION
We should not heap-allocate in the signal handlers because calling malloc is not safe in signal handlers.

So this PR adds a test that checks that there are no allocations in the `recorder::record_crash_sighandler()` method which gets called in the signal handlers. This is so that any further changes that may introduce an allocation are caught automatically.

Eg. the test fails (in release mode) if I make this change which would lead to a heap-allocation in `recorder::record_crash_sighandler()`:
```
diff --git a/src/v/crash_tracker/prepared_writer.cc b/src/v/crash_tracker/prepared_writer.cc
index bc1213e37f..5acd441aa6 100644
--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -134,7 +134,7 @@ bool prepared_writer::try_write_crash() {
       "Sanity check to prevent overflowing the stack. Even though "
       "crash_description may contain a large amount of pre-allocated data, it "
       "should remain relatively small on the stack.");
- serde::write(_serde_output, std::move(_prepared_cd));
+ serde::write(_serde_output, crash_description{});

     for (const auto& frag : _serde_output) {
         size_t written = 0;
```

Fixes https://redpandadata.atlassian.net/browse/CORE-9028

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
