### PR TITLE
datalake: use a configurable scratch space

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -167,6 +167,12 @@ node_config::node_config() noexcept
       "scrubber",
       {.visibility = visibility::user},
       std::nullopt)
+  , datalake_staging_directory(
+      *this,
+      "datalake_staging_directory",
+      "Directory for datalake temporary storage.",
+      {.visibility = visibility::user},
+      std::nullopt)
   , enable_central_config(*this, "enable_central_config")
   , crash_loop_limit(
       *this,

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -67,6 +67,9 @@ public:
     // Path to store inventory file hashes for cloud storage scrubber
     property<std::optional<ss::sstring>> cloud_storage_inventory_hash_store;
 
+    // Datalake scratch space directory
+    property<std::optional<ss::sstring>> datalake_staging_directory;
+
     deprecated_property enable_central_config;
 
     property<std::optional<uint32_t>> crash_loop_limit;
@@ -144,6 +147,14 @@ public:
               cloud_storage_inventory_hash_store().value()};
         }
         return data_directory().path / "cloud_storage_inventory";
+    }
+
+    std::filesystem::path datalake_staging_path() const {
+        if (datalake_staging_directory().has_value()) {
+            return std::string(datalake_staging_directory().value());
+        } else {
+            return data_directory().path / "datalake_staging";
+        }
     }
 
     std::vector<model::broker_endpoint> advertised_kafka_api() const {

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -96,6 +96,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/cluster:notification",
+        "//src/v/config",
         "//src/v/datalake:cloud_data_io",
         "//src/v/datalake:local_parquet_file_writer",
         "//src/v/datalake:location",

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -13,6 +13,7 @@
 #include "cluster/archival/types.h"
 #include "cluster/notification.h"
 #include "cluster/partition.h"
+#include "config/node_config.h"
 #include "datalake/coordinator/frontend.h"
 #include "datalake/coordinator/translated_offset_range.h"
 #include "datalake/data_writer_interface.h"
@@ -192,7 +193,7 @@ partition_translator::partition_translator(
   , _max_bytes_per_reader(reader_max_bytes)
   , _parallel_translations(parallel_translations)
   , _invalid_record_action(invalid_record_action)
-  , _writer_scratch_space(std::filesystem::temp_directory_path())
+  , _writer_scratch_space(config::node().datalake_staging_path())
   , _logger(prefix_logger{
       datalake_log, fmt::format("{}-term-{}", _partition->ntp(), _term)}) {
     vassert(_stm, "No translation stm found for {}", _partition->ntp());


### PR DESCRIPTION
SEE: https://github.com/redpanda-data/redpanda/pull/25052

~Prior to this change the system temporary directory was used. Instead, we should use a scratch space under the configured data directory so that we can keep all redpanda data in one place and avoid accidental problems like filling up tmpfs or other things.~

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

