### PR TITLE
parquet: improve performance

### DIFF
--- a/src/v/datalake/tests/datalake_parquet_tests.cc
+++ b/src/v/datalake/tests/datalake_parquet_tests.cc
@@ -591,7 +591,12 @@ static constexpr auto parquet_type(const T&) {
     __builtin_unreachable();
 }
 const auto values_equal = [](const auto& expected, const auto& current) {
-    return expected.val == current.val;
+    if constexpr (std::
+                    is_same_v<decltype(current.val), std::unique_ptr<iobuf>>) {
+        return expected.val == *current.val;
+    } else {
+        return expected.val == current.val;
+    }
 };
 
 template<typename IcebergPrimitive, typename Predicate>
@@ -643,7 +648,7 @@ AssertionResult validate_parquet_optional_primitive_value(
 bool decimals_equal(
   const iceberg::decimal_value& expected,
   const serde::parquet::fixed_byte_array_value& current) {
-    iobuf_parser parser(current.val.copy());
+    iobuf_parser parser(current.val->copy());
     auto high_part = ss::be_to_cpu(parser.consume_type<int64_t>());
     auto low_part = ss::be_to_cpu(parser.consume_type<uint64_t>());
     return expected.val == absl::MakeInt128(high_part, low_part);
@@ -652,7 +657,7 @@ bool decimals_equal(
 bool uuids_equal(
   const iceberg::uuid_value& expected,
   const serde::parquet::fixed_byte_array_value& current_bytes) {
-    iobuf_parser parser(current_bytes.val.copy());
+    iobuf_parser parser(current_bytes.val->copy());
     auto bytes = parser.read_bytes(16);
     std::vector<uint8_t> uuid_bytes(bytes.begin(), bytes.end());
     uuid_t current_uuid(uuid_bytes);

--- a/src/v/datalake/values_parquet.cc
+++ b/src/v/datalake/values_parquet.cc
@@ -40,18 +40,22 @@ struct primitive_value_converting_visitor {
         return serde::parquet::int64_value{.val = v.val};
     }
     parquet_conversion_outcome operator()(iceberg::string_value v) {
-        return serde::parquet::byte_array_value{.val = std::move(v.val)};
+        return serde::parquet::byte_array_value{
+          .val = std::make_unique<iobuf>(std::move(v.val))};
     }
     parquet_conversion_outcome operator()(iceberg::uuid_value v) {
         iobuf buffer;
         buffer.append(v.val.uuid().data, v.val.uuid().size());
-        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
+        return serde::parquet::fixed_byte_array_value{
+          .val = std::make_unique<iobuf>(std::move(buffer))};
     }
     parquet_conversion_outcome operator()(iceberg::fixed_value v) {
-        return serde::parquet::fixed_byte_array_value{.val = std::move(v.val)};
+        return serde::parquet::fixed_byte_array_value{
+          .val = std::make_unique<iobuf>(std::move(v.val))};
     }
     parquet_conversion_outcome operator()(iceberg::binary_value v) {
-        return serde::parquet::byte_array_value{.val = std::move(v.val)};
+        return serde::parquet::byte_array_value{
+          .val = std::make_unique<iobuf>(std::move(v.val))};
     }
     parquet_conversion_outcome operator()(iceberg::decimal_value v) {
         iobuf buffer;
@@ -63,7 +67,8 @@ struct primitive_value_converting_visitor {
         buffer.append(
           reinterpret_cast<const char*>(&low_part), sizeof(uint64_t));
 
-        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
+        return serde::parquet::fixed_byte_array_value{
+          .val = std::make_unique<iobuf>(std::move(buffer))};
     }
 };
 struct value_converting_visitor {

--- a/src/v/serde/parquet/column_stats_collector.cc
+++ b/src/v/serde/parquet/column_stats_collector.cc
@@ -77,25 +77,25 @@ std::strong_ordering float64(const float64_value a, const float64_value b) {
 
 std::strong_ordering
 byte_array(const byte_array_value& a, const byte_array_value& b) {
-    return a.val <=> b.val;
+    return *a.val <=> *b.val;
 }
 
 std::strong_ordering fixed_byte_array(
   const fixed_byte_array_value& a, const fixed_byte_array_value& b) {
-    return a.val <=> b.val;
+    return *a.val <=> *b.val;
 }
 
 std::strong_ordering
 int128_be(const fixed_byte_array_value& a, const fixed_byte_array_value& b) {
     if (
-      a.val.size_bytes() != sizeof(absl::int128)
-      || b.val.size_bytes() != sizeof(absl::int128)) {
+      a.val->size_bytes() != sizeof(absl::int128)
+      || b.val->size_bytes() != sizeof(absl::int128)) {
         throw std::runtime_error("unable to convert input to int128");
     }
-    iobuf_const_parser ap(a.val);
+    iobuf_const_parser ap(*a.val);
     auto a_hi = ap.consume_be_type<int64_t>();
     auto a_lo = ap.consume_be_type<uint64_t>();
-    iobuf_const_parser bp(b.val);
+    iobuf_const_parser bp(*b.val);
     auto b_hi = bp.consume_be_type<int64_t>();
     auto b_lo = bp.consume_be_type<uint64_t>();
     // TODO: Switch to <=> on absl::int128 when
@@ -114,12 +114,12 @@ namespace internal {
 
 template<>
 byte_array_value copy(byte_array_value& v) {
-    return {v.val.share(0, v.val.size_bytes())};
+    return {std::make_unique<iobuf>(v.val->share(0, v.val->size_bytes()))};
 }
 
 template<>
 fixed_byte_array_value copy(fixed_byte_array_value& v) {
-    return {v.val.share(0, v.val.size_bytes())};
+    return {std::make_unique<iobuf>(v.val->share(0, v.val->size_bytes()))};
 }
 
 } // namespace internal

--- a/src/v/serde/parquet/column_stats_collector.h
+++ b/src/v/serde/parquet/column_stats_collector.h
@@ -63,7 +63,7 @@ public:
     using bound_ref_type = std::conditional_t<
       std::is_trivially_copyable_v<value_type>,
       std::optional<value_type>,
-      const std::optional<value_type>&>;
+      std::optional<value_type>&>;
 
     // Record a value in the collector
     void record_value(ref_type v) {
@@ -106,13 +106,11 @@ public:
 
     int64_t null_count() const { return _null_count; }
 
-    bound_ref_type min() const { return view(_min, true); }
-    std::optional<value_type> take_min() { return take(_min, true); }
-    bound_ref_type max() const { return view(_max, false); }
-    std::optional<value_type> take_max() { return take(_max, false); }
+    bound_ref_type min() { return normalize(_min, true); }
+    bound_ref_type max() { return normalize(_max, false); }
 
 private:
-    bound_ref_type view(const std::optional<value_type>& v, bool min) const {
+    bound_ref_type normalize(bound_ref_type v, bool min) {
         if constexpr (std::is_floating_point_v<decltype(v->val)>) {
             // min floats are always written as -0 and max as 0
             if (v && v->val == 0.0) {
@@ -120,15 +118,6 @@ private:
             }
         }
         return v;
-    }
-    std::optional<value_type> take(std::optional<value_type>& v, bool min) {
-        if constexpr (std::is_floating_point_v<decltype(v->val)>) {
-            // min floats are always written as -0 and max as 0
-            if (v && v->val == 0.0) {
-                return std::make_optional<value_type>(min ? -0.0 : 0.0);
-            }
-        }
-        return std::exchange(v, {});
     }
 
     std::optional<value_type> _min;

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -81,10 +81,10 @@ public:
         int64_t value_memory_usage = 0;
 
         ss::visit(
-          std::move(val),
+          val,
           [this, &value_memory_usage](value_type& v) {
               if constexpr (!std::is_trivially_copyable_v<value_type>) {
-                  value_memory_usage = v.val.size_bytes();
+                  value_memory_usage = v.val->size_bytes();
               } else {
                   value_memory_usage = sizeof(value_type);
               }

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -40,8 +40,10 @@ public:
     impl& operator=(impl&&) noexcept = default;
     virtual ~impl() noexcept = default;
 
-    virtual ss::future<> add(value, rep_level, def_level) = 0;
+    virtual void add(value, rep_level, def_level) = 0;
     virtual int64_t memory_usage() const = 0;
+    virtual int64_t current_page_memory_usage() const = 0;
+    virtual ss::future<> next_page() = 0;
     virtual ss::future<flushed_pages> flush_pages() = 0;
 };
 
@@ -68,13 +70,10 @@ public:
       , _max_def_level(schema_element.max_definition_level)
       , _opts(opts) {}
 
-    ss::future<> add(value val, rep_level rl, def_level dl) override {
+    void add(value val, rep_level rl, def_level dl) override {
         // A repetition level of zero means that it's the start of a new row and
         // not a repeated value within the same row.
         if (rl == rep_level(0)) {
-            if (_page_memory_usage > _opts.page_buffer_size) {
-                co_await flush_page();
-            }
             ++_num_rows;
         }
         ++_num_values;
@@ -109,9 +108,9 @@ public:
         // always use the full capacity in our value buffer, and eagerly
         // accounting that usage might cause callers to overagressively
         // flush pages/row groups.
-        _page_memory_usage += value_memory_usage
-                              + static_cast<int64_t>(
-                                sizeof(rep_level) + sizeof(def_level));
+        _current_page_memory_usage += value_memory_usage
+                                      + static_cast<int64_t>(
+                                        sizeof(rep_level) + sizeof(def_level));
     }
 
     ss::future<> flush_page() {
@@ -148,8 +147,9 @@ public:
         size_t compressed_page_size = encoded_def_levels.size_bytes()
                                       + encoded_rep_levels.size_bytes()
                                       + encoded_data.size_bytes();
+        using bound_type = decltype(_flushed_stats)::bound_ref_type;
         std::optional<statistics::bound> max_bound;
-        if (auto max = _current_page_stats.take_max()) {
+        if (bound_type max = _current_page_stats.max()) {
             // TODO: consider truncating large values instead of writing them
             // (is_exact=false)
             max_bound.emplace(
@@ -158,7 +158,7 @@ public:
             _flushed_stats.record_value(*max);
         }
         std::optional<statistics::bound> min_bound;
-        if (auto min = _current_page_stats.take_min()) {
+        if (bound_type min = _current_page_stats.min()) {
             // TODO: consider truncating large values instead of writing them
             // (is_exact=false)
             min_bound.emplace(
@@ -192,7 +192,7 @@ public:
         full_page_data.append(std::move(encoded_def_levels));
         full_page_data.append(std::move(encoded_data));
         _current_page_stats.reset();
-        _page_memory_usage = 0;
+        _current_page_memory_usage = 0;
         _total_memory_usage += static_cast<int32_t>(
           full_page_data.size_bytes());
         _flushed_pages.push_back(data_page{
@@ -203,8 +203,14 @@ public:
     }
 
     int64_t memory_usage() const override {
-        return _total_memory_usage + _page_memory_usage;
+        return _total_memory_usage + _current_page_memory_usage;
     }
+
+    int64_t current_page_memory_usage() const override {
+        return _current_page_memory_usage;
+    }
+
+    ss::future<> next_page() override { return flush_page(); }
 
     ss::future<flushed_pages> flush_pages() override {
         if (_num_values > 0) {
@@ -216,12 +222,13 @@ public:
           .max = {},
           .min = {},
         };
-        if (auto max = _flushed_stats.take_max()) {
+        using bound_type = decltype(_flushed_stats)::bound_ref_type;
+        if (bound_type max = _flushed_stats.max()) {
             full_stats.max.emplace(
               /*value=*/encode_for_stats(*max),
               /*is_exact=*/true);
         }
-        if (auto min = _flushed_stats.take_min()) {
+        if (bound_type min = _flushed_stats.min()) {
             full_stats.min.emplace(
               /*value=*/encode_for_stats(*min),
               /*is_exact=*/true);
@@ -237,7 +244,7 @@ public:
 private:
     column_stats_collector<value_type, comparator> _current_page_stats;
     column_stats_collector<value_type, comparator> _flushed_stats;
-    int64_t _page_memory_usage = 0;
+    int64_t _current_page_memory_usage = 0;
     int64_t _total_memory_usage = 0;
     chunked_vector<value_type> _value_buffer;
     chunked_vector<def_level> _def_levels;
@@ -333,12 +340,16 @@ column_writer::column_writer(column_writer&&) noexcept = default;
 column_writer& column_writer::operator=(column_writer&&) noexcept = default;
 column_writer::~column_writer() noexcept = default;
 
-ss::future<>
-column_writer::add(value val, rep_level rep_level, def_level def_level) {
-    return _impl->add(std::move(val), rep_level, def_level);
+void column_writer::add(value val, rep_level rep_level, def_level def_level) {
+    _impl->add(std::move(val), rep_level, def_level);
 }
 
 int64_t column_writer::memory_usage() const { return _impl->memory_usage(); }
+int64_t column_writer::current_page_memory_usage() const {
+    return _impl->current_page_memory_usage();
+}
+
+ss::future<> column_writer::next_page() { return _impl->next_page(); }
 
 ss::future<flushed_pages> column_writer::flush_pages() {
     return _impl->flush_pages();

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -46,9 +46,6 @@ public:
     struct options {
         // If true, use zstd compression for the column data.
         bool compress;
-        // The target size for how much data we buffer before
-        // flushing/encoding/compressing the data to a page.
-        int64_t page_buffer_size;
     };
 
     explicit column_writer(const schema_element&, options);
@@ -68,10 +65,15 @@ public:
     // Use `shred_record` to get the value and levels from an arbitrary value.
     //
     // Return the current information about the column after a value is written.
-    ss::future<> add(value, rep_level, def_level);
+    void add(value, rep_level, def_level);
 
     // The memory usage of this entire column.
     int64_t memory_usage() const;
+
+    // The memory usage of the current page being built.
+    int64_t current_page_memory_usage() const;
+
+    ss::future<> next_page();
 
     // Flush the pages that have been accumulated so far in the column.
     //

--- a/src/v/serde/parquet/encoding.cc
+++ b/src/v/serde/parquet/encoding.cc
@@ -77,10 +77,10 @@ iobuf encode_plain(const chunked_vector<float64_value>& vals) {
 iobuf encode_plain(chunked_vector<byte_array_value> vals) {
     iobuf buf;
     for (auto& v : vals) {
-        int32_t i = ss::cpu_to_le(static_cast<int32_t>(v.val.size_bytes()));
+        int32_t i = ss::cpu_to_le(static_cast<int32_t>(v.val->size_bytes()));
         // NOLINTNEXTLINE(*reinterpret-cast*)
         buf.append(reinterpret_cast<const uint8_t*>(&i), sizeof(int32_t));
-        buf.append(std::move(v.val));
+        buf.append(std::move(*v.val));
     }
     return buf;
 }
@@ -88,7 +88,7 @@ iobuf encode_plain(chunked_vector<byte_array_value> vals) {
 iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals) {
     iobuf buf;
     for (auto& v : vals) {
-        buf.append(std::move(v.val));
+        buf.append(std::move(*v.val));
     }
     return buf;
 }
@@ -161,6 +161,8 @@ iobuf encode_for_stats(int32_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(int64_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(float32_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(float64_value v) { return encode_plain({v}); }
-iobuf encode_for_stats(const byte_array_value& v) { return v.val.copy(); }
-iobuf encode_for_stats(const fixed_byte_array_value& v) { return v.val.copy(); }
+iobuf encode_for_stats(const byte_array_value& v) { return v.val->copy(); }
+iobuf encode_for_stats(const fixed_byte_array_value& v) {
+    return v.val->copy();
+}
 } // namespace serde::parquet

--- a/src/v/serde/parquet/tests/column_stats_collector_test.cc
+++ b/src/v/serde/parquet/tests/column_stats_collector_test.cc
@@ -67,10 +67,10 @@ TEST(ColumnStatsCollector, FloatingPoint) {
 
 TEST(ColumnStatsCollector, Binary) {
     column_stats_collector<byte_array_value, ordering::byte_array> collector;
-    auto empty = byte_array_value{iobuf::from("")};
-    auto bat = byte_array_value{iobuf::from("bat")};
-    auto cat = byte_array_value{iobuf::from("cat")};
-    auto zzzz = byte_array_value{iobuf::from("zzzz")};
+    auto empty = byte_array_value{std::make_unique<iobuf>(iobuf::from(""))};
+    auto bat = byte_array_value{std::make_unique<iobuf>(iobuf::from("bat"))};
+    auto cat = byte_array_value{std::make_unique<iobuf>(iobuf::from("cat"))};
+    auto zzzz = byte_array_value{std::make_unique<iobuf>(iobuf::from("zzzz"))};
     collector.record_value(bat);
     EXPECT_THAT(collector.min(), Optional(std::ref(bat)));
     EXPECT_THAT(collector.max(), Optional(std::ref(bat)));
@@ -86,13 +86,14 @@ TEST(ColumnStatsCollector, Binary) {
 TEST(ColumnStatsCollector, Decimal128) {
     column_stats_collector<fixed_byte_array_value, ordering::int128_be>
       collector;
-    auto negative_five = fixed_byte_array_value{iobuf::from(
-      {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE",
-       16})};
-    auto one = fixed_byte_array_value{
-      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", 16})};
-    auto fourty_two = fixed_byte_array_value{
-      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2A", 16})};
+    auto negative_five = fixed_byte_array_value{
+      std::make_unique<iobuf>(iobuf::from(
+        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE",
+         16}))};
+    auto one = fixed_byte_array_value{std::make_unique<iobuf>(
+      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", 16}))};
+    auto fourty_two = fixed_byte_array_value{std::make_unique<iobuf>(
+      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2A", 16}))};
     collector.record_value(one);
     EXPECT_THAT(collector.min(), Optional(std::ref(one)));
     EXPECT_THAT(collector.max(), Optional(std::ref(one)));

--- a/src/v/serde/parquet/tests/encoding_test.cc
+++ b/src/v/serde/parquet/tests/encoding_test.cc
@@ -146,7 +146,7 @@ template<typename T>
 chunked_vector<T> buffers(std::initializer_list<iobuf> buffers) {
     chunked_vector<T> v;
     for (auto& b : buffers) {
-        v.push_back(T{b.copy()});
+        v.push_back(T{std::make_unique<iobuf>(b.copy())});
     }
     return v;
 }

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -16,7 +16,6 @@
 #include "json/iobuf_writer.h"
 #include "random/generators.h"
 #include "serde/parquet/schema.h"
-#include "serde/parquet/value.h"
 #include "serde/parquet/writer.h"
 #include "utils/base64.h"
 
@@ -31,6 +30,10 @@ using json_writer = json::iobuf_writer<json::chunked_buffer>;
 
 namespace serde::parquet {
 namespace {
+
+byte_array_value make_binary_value(std::string_view b) {
+    return {std::make_unique<iobuf>(iobuf::from(b))};
+}
 
 void json(json_writer& w, const schema_element& schema, const value& v) {
     ss::visit(
@@ -49,9 +52,9 @@ void json(json_writer& w, const schema_element& schema, const value& v) {
           auto str = fmt::format("{:.8f}", v.val);
           w.RawValue(str.data(), str.size(), rapidjson::kNumberType);
       },
-      [&w](const byte_array_value& v) { w.String(iobuf_to_base64(v.val)); },
+      [&w](const byte_array_value& v) { w.String(iobuf_to_base64(*v.val)); },
       [&w](const fixed_byte_array_value& v) {
-          w.String(iobuf_to_base64(v.val));
+          w.String(iobuf_to_base64(*v.val));
       },
       [&w, &schema](const group_value& v) {
           w.StartObject();
@@ -183,27 +186,27 @@ std::vector<value> dremel_paper_values() {
             /*Language*/
             record(
               /*Code*/
-              byte_array_value(iobuf::from("en-us")),
+              make_binary_value("en-us"),
               /*Country*/
-              byte_array_value(iobuf::from("us"))),
+              make_binary_value("us")),
             /*Language*/
-            record(byte_array_value(iobuf::from("en")), null_value())),
+            record(make_binary_value("en"), null_value())),
           /*Url*/
-          byte_array_value(iobuf::from("http://A"))),
+          make_binary_value("http://A")),
         /*Name*/
         record(
           list(),
           /*Url*/
-          byte_array_value(iobuf::from("http://B"))),
+          make_binary_value("http://B")),
         /*Name*/
         record(
           list(
             /*Language*/
             record(
               /*Code*/
-              byte_array_value(iobuf::from("en-gb")),
+              make_binary_value("en-gb"),
               /*Country*/
-              byte_array_value(iobuf::from("gb")))),
+              make_binary_value("gb"))),
           /*Url*/
           null_value()))));
     values.emplace_back(record(
@@ -217,7 +220,7 @@ std::vector<value> dremel_paper_values() {
         /*Language*/
         repeated_value(),
         /*Url*/
-        byte_array_value(iobuf::from("http://C"))))));
+        make_binary_value("http://C")))));
     return values;
 }
 
@@ -279,12 +282,12 @@ value generate_required(const schema_element& root) {
       },
       [](const byte_array_type& t) -> value {
           if (t.fixed_length) {
-              return fixed_byte_array_value{iobuf::from(
-                random_generators::gen_alphanum_string(*t.fixed_length))};
+              return fixed_byte_array_value{std::make_unique<iobuf>(iobuf::from(
+                random_generators::gen_alphanum_string(*t.fixed_length)))};
           }
           auto size = random_generators::get_int<size_t>(64);
-          return byte_array_value{
-            iobuf::from(random_generators::gen_alphanum_string(size))};
+          return byte_array_value{std::make_unique<iobuf>(
+            iobuf::from(random_generators::gen_alphanum_string(size)))};
       });
 }
 

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -20,6 +20,11 @@
 
 namespace serde::parquet {
 namespace {
+
+byte_array_value make_binary_value(std::string_view b) {
+    return {std::make_unique<iobuf>(iobuf::from(b))};
+}
+
 template<typename... Args>
 schema_element
 group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
@@ -161,27 +166,27 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
             /*Language*/
             record(
               /*Code*/
-              byte_array_value(iobuf::from("en-us")),
+              make_binary_value("en-us"),
               /*Country*/
-              byte_array_value(iobuf::from("us"))),
+              make_binary_value("us")),
             /*Language*/
-            record(byte_array_value(iobuf::from("en")), null_value())),
+            record(make_binary_value("en"), null_value())),
           /*Url*/
-          byte_array_value(iobuf::from("http://A"))),
+          make_binary_value("http://A")),
         /*Name*/
         record(
           list(),
           /*Url*/
-          byte_array_value(iobuf::from("http://B"))),
+          make_binary_value("http://B")),
         /*Name*/
         record(
           list(
             /*Language*/
             record(
               /*Code*/
-              byte_array_value(iobuf::from("en-gb")),
+              make_binary_value("en-gb"),
               /*Country*/
-              byte_array_value(iobuf::from("gb")))),
+              make_binary_value("gb"))),
           /*Url*/
           null_value())));
     group_value r2 = record(
@@ -195,7 +200,7 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
         /*Language*/
         repeated_value(),
         /*Url*/
-        byte_array_value(iobuf::from("http://C")))));
+        make_binary_value("http://C"))));
     index_schema(document_schema);
     value_collector collector(document_schema);
     shred_record(document_schema, std::move(r1), collector).get();
@@ -241,9 +246,7 @@ TEST(RecordShredding, ListOfStrings) {
       field_repetition_type::required,
       leaf_node("list", field_repetition_type::repeated, byte_array_type{}));
     group_value r = record(list(
-      byte_array_value(iobuf::from("a")),
-      byte_array_value(iobuf::from("b")),
-      byte_array_value(iobuf::from("c"))));
+      make_binary_value("a"), make_binary_value("b"), make_binary_value("c")));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -264,12 +267,8 @@ TEST(RecordShredding, LogicalMap) {
         leaf_node(
           "value", field_repetition_type::optional, byte_array_type())));
     group_value r = record(list(
-      record(
-        byte_array_value(iobuf::from("AL")),
-        byte_array_value(iobuf::from("Alabama"))),
-      record(
-        byte_array_value(iobuf::from("AK")),
-        byte_array_value(iobuf::from("Alaska")))));
+      record(make_binary_value("AL"), make_binary_value("Alabama")),
+      record(make_binary_value("AK"), make_binary_value("Alaska"))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -321,19 +320,17 @@ TEST(RecordShredding, RepetitionLevels) {
           "level2", field_repetition_type::repeated, byte_array_type())));
     group_value r1 = record(list(
       record(list(
-        byte_array_value(iobuf::from("a")),
-        byte_array_value(iobuf::from("b")),
-        byte_array_value(iobuf::from("c")))),
+        make_binary_value("a"),
+        make_binary_value("b"),
+        make_binary_value("c"))),
       record(list(
-        byte_array_value(iobuf::from("d")),
-        byte_array_value(iobuf::from("e")),
-        byte_array_value(iobuf::from("f")),
-        byte_array_value(iobuf::from("g"))))));
+        make_binary_value("d"),
+        make_binary_value("e"),
+        make_binary_value("f"),
+        make_binary_value("g")))));
     group_value r2 = record(list(
-      record(list(byte_array_value(iobuf::from("h")))),
-      record(list(
-        byte_array_value(iobuf::from("i")),
-        byte_array_value(iobuf::from("j"))))));
+      record(list(make_binary_value("h"))),
+      record(list(make_binary_value("i"), make_binary_value("j")))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();
@@ -381,17 +378,15 @@ TEST(RecordShredding, AddressBookExample) {
           byte_array_type(),
           string_type())));
     group_value r1 = record(
-      byte_array_value(iobuf::from("Julien Le Dem")),
+      make_binary_value("Julien Le Dem"),
       list(
-        byte_array_value(iobuf::from("555 123 4567")),
-        byte_array_value(iobuf::from("555 666 1337"))),
+        make_binary_value("555 123 4567"), make_binary_value("555 666 1337")),
       list(
         record(
-          byte_array_value(iobuf::from("Dmitriy Ryaboy")),
-          byte_array_value(iobuf::from("555 987 6543"))),
-        record(byte_array_value(iobuf::from("Chris Anizczyk")), null_value())));
-    group_value r2 = record(
-      byte_array_value(iobuf::from("A. Nonymous")), list(), list());
+          make_binary_value("Dmitriy Ryaboy"),
+          make_binary_value("555 987 6543")),
+        record(make_binary_value("Chris Anizczyk"), null_value())));
+    group_value r2 = record(make_binary_value("A. Nonymous"), list(), list());
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -21,10 +21,12 @@ value copy(const value& val) {
     return ss::visit(
       val,
       [](const byte_array_value& v) {
-          return value(byte_array_value(v.val.copy()));
+          return value(
+            byte_array_value(std::make_unique<iobuf>(v.val->copy())));
       },
       [](const fixed_byte_array_value& v) {
-          return value(fixed_byte_array_value(v.val.copy()));
+          return value(
+            fixed_byte_array_value(std::make_unique<iobuf>(v.val->copy())));
       },
       [](const group_value& v) {
           group_value clone;
@@ -71,7 +73,7 @@ auto fmt::formatter<serde::parquet::value>::format(
       },
       [&ctx](const byte_array_value& v) {
           auto out = ctx.out();
-          for (const auto& e : v.val) {
+          for (const auto& e : *v.val) {
               std::string_view s{e.get(), e.size()};
               out = fmt::format_to(out, "{}", absl::CEscape(s));
           }
@@ -79,7 +81,7 @@ auto fmt::formatter<serde::parquet::value>::format(
       },
       [&ctx](const fixed_byte_array_value& v) {
           auto out = ctx.out();
-          for (const auto& e : v.val) {
+          for (const auto& e : *v.val) {
               std::string_view s{e.get(), e.size()};
               out = fmt::format_to(out, "{}", absl::CEscape(s));
           }

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -15,6 +15,7 @@
 #include "container/fragmented_vector.h"
 
 #include <cstdint>
+#include <memory>
 #include <unistd.h>
 
 // A subset of parquet values that is needed for iceberg.
@@ -50,14 +51,18 @@ struct float64_value {
     bool operator==(const float64_value&) const = default;
 };
 struct byte_array_value {
-    iobuf val;
+    std::unique_ptr<iobuf> val;
 
-    bool operator==(const byte_array_value&) const = default;
+    bool operator==(const byte_array_value& other) const {
+        return *val == *other.val;
+    };
 };
 struct fixed_byte_array_value {
-    iobuf val;
+    std::unique_ptr<iobuf> val;
 
-    bool operator==(const fixed_byte_array_value&) const = default;
+    bool operator==(const fixed_byte_array_value& other) const {
+        return *val == *other.val;
+    };
 };
 
 struct repeated_element;

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -59,7 +59,6 @@ public:
                   element,
                   {
                     .compress = _opts.compress,
-                    .page_buffer_size = _opts.page_buffer_size,
                   }),
               });
         });
@@ -72,6 +71,12 @@ public:
           _opts.schema, std::move(row), [this](shredded_value sv) {
               return write_value(std::move(sv));
           });
+        for (auto& [_, col] : _columns) {
+            int64_t usage = col.writer.current_page_memory_usage();
+            if (usage > _opts.page_buffer_size) {
+                co_await col.writer.next_page();
+            }
+        }
     }
 
     file_stats stats() const {
@@ -183,7 +188,8 @@ private:
 
     ss::future<> write_value(shredded_value sv) {
         auto& col = _columns.at(sv.schema_element_position);
-        co_await col.writer.add(std::move(sv.val), sv.rep_level, sv.def_level);
+        col.writer.add(std::move(sv.val), sv.rep_level, sv.def_level);
+        return ss::now();
     }
 
     ss::future<> write_iobuf(iobuf b) {


### PR DESCRIPTION
See commits and https://redpandadata.slack.com/archives/C06HM5UTWRW/p1738735548932669

- **parquet: move page flushing up to parquet writer**
- **parquet: move binary parquet values behind std::unique_ptr**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
