### PR TITLE
[CORE-8949] Incorporate datalake into space management accounting

### DIFF
--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -146,6 +146,10 @@ public:
         return data_directory().path / "cloud_storage_inventory";
     }
 
+    std::filesystem::path datalake_staging_path() const {
+        return data_directory().path / "datalake_staging";
+    }
+
     std::vector<model::broker_endpoint> advertised_kafka_api() const {
         if (_advertised_kafka_api().empty()) {
             std::vector<model::broker_endpoint> eps;

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -197,6 +197,7 @@ redpanda_cc_library(
         "//src/v/schema:registry",
         "//src/v/serde",
         "//src/v/ssx:semaphore",
+        "//src/v/utils:directory_walker",
         "@fmt",
         "@seastar",
     ],

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -14,6 +14,7 @@
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "datalake/backlog_controller.h"
 #include "datalake/catalog_schema_manager.h"
 #include "datalake/cloud_data_io.h"
@@ -104,7 +105,8 @@ datalake_manager::datalake_manager(
   , _iceberg_commit_interval(
       config::shard_local_cfg().iceberg_catalog_commit_interval_ms.bind())
   , _iceberg_invalid_record_action(
-      config::shard_local_cfg().iceberg_invalid_record_action.bind()) {
+      config::shard_local_cfg().iceberg_invalid_record_action.bind())
+  , _writer_scratch_space(config::node().datalake_staging_path()) {
     vassert(memory_limit > 0, "Memory limit must be greater than 0");
     auto max_parallel = static_cast<size_t>(
       std::floor(memory_limit / _effective_max_translator_buffered_data));
@@ -142,6 +144,25 @@ double datalake_manager::average_translation_backlog() {
 }
 
 ss::future<> datalake_manager::start() {
+    /*
+     * Ensure that datalake scratch space directory exists. This is run on each
+     * core (as opposed to only on core-0) because shard initialization happens
+     * in parallel, but the race is handled by ignoring EEXIST.
+     */
+    try {
+        co_await ss::make_directory(
+          config::node().datalake_staging_path().string());
+    } catch (const std::filesystem::filesystem_error& e) {
+        if (e.code() != std::errc::file_exists) {
+            vlog(
+              datalake_log.error,
+              "Could not create datalake staging directory: {}: {}",
+              config::node().datalake_staging_path(),
+              e);
+            throw;
+        }
+    }
+
     _catalog = co_await _catalog_factory->create_catalog();
     _schema_mgr = std::make_unique<catalog_schema_manager>(*_catalog);
     // partition managed notification, this is particularly
@@ -325,7 +346,8 @@ void datalake_manager::start_translator(
       _sg,
       _effective_max_translator_buffered_data,
       &_parallel_translations,
-      invalid_record_action);
+      invalid_record_action,
+      _writer_scratch_space);
     _translators.emplace(partition->ntp(), std::move(translator));
 }
 

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -25,6 +25,7 @@
 #include "datalake/record_translator.h"
 #include "raft/group_manager.h"
 #include "schema/registry.h"
+#include "utils/directory_walker.h"
 
 #include <memory>
 
@@ -368,6 +369,42 @@ void datalake_manager::stop_translator(const model::ntp& ntp) {
         auto* t_ptr = t.get();
         return t_ptr->stop().finally([_ = std::move(t)] {});
     });
+}
+
+ss::future<uint64_t> datalake_manager::disk_usage() {
+    const auto path = config::node().datalake_staging_path();
+
+    if (!co_await ss::file_exists(path.string())) {
+        co_return 0;
+    }
+
+    chunked_vector<std::filesystem::path> files;
+    co_await directory_walker::walk(
+      path.string(), [&files, path](const ss::directory_entry& de) {
+          if (de.type == ss::directory_entry_type::regular) {
+              files.push_back(path / std::filesystem::path(de.name));
+          }
+          return ss::now();
+      });
+
+    uint64_t total = 0;
+    co_await ss::max_concurrent_for_each(
+      files.begin(),
+      files.end(),
+      config::shard_local_cfg().space_management_max_log_concurrency(),
+      [&total](const std::filesystem::path& path) {
+          return ss::file_size(path.string())
+            .then([&total](uint64_t size) { total += size; })
+            .handle_exception([path](std::exception_ptr eptr) {
+                vlog(
+                  datalake_log.debug,
+                  "Stat failed for path: {}: {}",
+                  path,
+                  eptr);
+            });
+      });
+
+    co_return total;
 }
 
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -395,9 +395,20 @@ ss::future<uint64_t> datalake_manager::disk_usage() {
       [&total](const std::filesystem::path& path) {
           return ss::file_size(path.string())
             .then([&total](uint64_t size) { total += size; })
+            .handle_exception_type(
+              [path](const std::filesystem::filesystem_error& e) {
+                  if (e.code() == std::errc::no_such_file_or_directory) {
+                      vlog(
+                        datalake_log.debug,
+                        "Stat failed for path: {}: {}",
+                        path,
+                        e.code());
+                  }
+                  return ss::make_exception_future<>(e);
+              })
             .handle_exception([path](std::exception_ptr eptr) {
                 vlog(
-                  datalake_log.debug,
+                  datalake_log.warn,
                   "Stat failed for path: {}: {}",
                   path,
                   eptr);

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -113,6 +113,7 @@ private:
     config::binding<std::chrono::milliseconds> _iceberg_commit_interval;
     config::binding<model::iceberg_invalid_record_action>
       _iceberg_invalid_record_action;
+    std::filesystem::path _writer_scratch_space;
 
     // Translation requires buffering data batches in memory for efficient
     // output representation, this controls the maximum bytes buffered in memory

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -71,6 +71,14 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    /*
+     * Return the amount of disk space currently in use by the datalake
+     * subsystem (e.g. staged translated data on disk, etc...).
+     *
+     * This interface computes a global value, rather than shard local.
+     */
+    static ss::future<uint64_t> disk_usage();
+
 private:
     using translator = std::unique_ptr<translation::partition_translator>;
     using translator_map = chunked_hash_map<model::ntp, translator>;

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -169,7 +169,8 @@ partition_translator::partition_translator(
   ss::scheduling_group sg,
   size_t reader_max_bytes,
   std::unique_ptr<ssx::semaphore>* parallel_translations,
-  model::iceberg_invalid_record_action invalid_record_action)
+  model::iceberg_invalid_record_action invalid_record_action,
+  std::filesystem::path writer_scratch_space)
   : _term(partition->raft()->term())
   , _partition(std::move(partition))
   , _stm(_partition->raft()
@@ -192,7 +193,7 @@ partition_translator::partition_translator(
   , _max_bytes_per_reader(reader_max_bytes)
   , _parallel_translations(parallel_translations)
   , _invalid_record_action(invalid_record_action)
-  , _writer_scratch_space(std::filesystem::temp_directory_path())
+  , _writer_scratch_space(writer_scratch_space)
   , _logger(prefix_logger{
       datalake_log, fmt::format("{}-term-{}", _partition->ntp(), _term)}) {
     vassert(_stm, "No translation stm found for {}", _partition->ntp());

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -82,7 +82,8 @@ public:
       ss::scheduling_group sg,
       size_t reader_max_bytes,
       std::unique_ptr<ssx::semaphore>* parallel_translations,
-      model::iceberg_invalid_record_action invalid_record_action);
+      model::iceberg_invalid_record_action invalid_record_action,
+      std::filesystem::path writer_scratch_space);
     ~partition_translator();
 
     void start_translation_in_background(ss::scheduling_group);

--- a/src/v/resource_mgmt/BUILD
+++ b/src/v/resource_mgmt/BUILD
@@ -31,6 +31,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage",
         "//src/v/cluster",
         "//src/v/config",
+        "//src/v/datalake:manager",
         "//src/v/metrics",
         "//src/v/raft",
         "//src/v/ssx:semaphore",

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -21,6 +21,7 @@ v_cc_library(
     Seastar::seastar
     v::cloud_storage
     v::cluster
+    v::datalake_manager
   )
 
 add_subdirectory(tests)

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -15,8 +15,8 @@
 #include "cloud_storage/cache_service.h"
 #include "cluster/node/local_monitor.h"
 #include "cluster/partition_manager.h"
+#include "datalake/datalake_manager.h"
 #include "metrics/prometheus_sanitize.h"
-#include "storage/disk_log_impl.h"
 #include "utils/human.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -486,13 +486,33 @@ size_t eviction_policy::evict_until_active_segment(
       });
 }
 
+ss::future<storage::usage_report> disk_space_manager::disk_usage() {
+    /*
+     * log and kvstore usage.
+     */
+    auto report = co_await _storage->local().disk_usage();
+
+    /*
+     * datalake scratch space usage. from the perspective of space management
+     * the data used by datalake is not reclaimable. it is reported in the
+     * report as more "log data" the same way that kvstore data is reported.
+     */
+    const auto datalake_usage
+      = co_await datalake::datalake_manager::disk_usage();
+    vlog(rlog.debug, "Datalake usage: {}", human::bytes(datalake_usage));
+
+    report.usage.data += datalake_usage;
+
+    co_return report;
+}
+
 ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
     /*
      * query log storage usage across all cores
      */
     storage::usage_report usage;
     try {
-        usage = co_await _storage->local().disk_usage();
+        usage = co_await disk_usage();
     } catch (...) {
         vlog(
           rlog.info,

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -366,6 +366,7 @@ private:
     node::disk_space_info _data_disk_info{};
 
     ss::future<> manage_data_disk(uint64_t target_size);
+    ss::future<storage::usage_report> disk_usage();
     config::binding<std::optional<uint64_t>> _retention_target_capacity_bytes;
     config::binding<std::optional<double>> _retention_target_capacity_percent;
     config::binding<double> _disk_reservation_percent;


### PR DESCRIPTION
* Replaces https://github.com/redpanda-data/redpanda/pull/25048
* Adds account of disk usage by datalake in space management

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
