### PR TITLE
iobuf: replace boost::intrusive_list with hand rolled implementation

### DIFF
--- a/src/v/base/vassert.h
+++ b/src/v/base/vassert.h
@@ -50,3 +50,15 @@ inline dummyassert g_assert_log;
             __builtin_trap();                                                  \
         }                                                                      \
     } while (0)
+
+/**
+ * same as vassert but only debug mode. Use over assert for better
+ * error messages.
+ */
+#ifndef NDEBUG
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define dassert(x, msg, args...) vassert(x, msg, ##args)
+#else
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define dassert(...)
+#endif

--- a/src/v/bytes/BUILD
+++ b/src/v/bytes/BUILD
@@ -18,7 +18,6 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
-        "//src/v/container:intrusive",
         "@fmt",
         "@seastar",
     ],

--- a/src/v/bytes/details/io_byte_iterator.h
+++ b/src/v/bytes/details/io_byte_iterator.h
@@ -19,9 +19,7 @@
 namespace details {
 class io_byte_iterator {
 public:
-    using io_const_iterator
-      = uncounted_intrusive_list<io_fragment, &io_fragment::hook>::
-        const_iterator;
+    using io_const_iterator = io_fragment_list::const_iterator;
 
     // iterator_traits
     using difference_type = void;

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -12,12 +12,16 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "base/vassert.h"
 #include "bytes/details/out_of_range.h"
-#include "container/intrusive_list_helpers.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
+#include <iterator>
+#include <utility>
+
 namespace details {
+
 class io_fragment {
 public:
     /**
@@ -38,7 +42,11 @@ public:
     io_fragment& operator=(io_fragment&& o) noexcept = delete;
     io_fragment(const io_fragment& o) = delete;
     io_fragment& operator=(const io_fragment& o) = delete;
-    ~io_fragment() noexcept = default;
+    ~io_fragment() noexcept {
+        dassert(
+          !_next && !_prev,
+          "io_fragment cleanup failure and possible memory leak");
+    }
 
     bool is_empty() const { return _used_bytes == 0; }
     size_t available_bytes() const { return _buf.size() - _used_bytes; }
@@ -94,12 +102,298 @@ public:
     char* get_current() { return _buf.get_write() + _used_bytes; }
     char* get_write() { return _buf.get_write(); }
 
-    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
-    safe_intrusive_list_hook hook;
-
 private:
+    friend class io_fragment_list;
+
+    io_fragment* _next = nullptr;
+    io_fragment* _prev = nullptr;
+
     ss::temporary_buffer<char> _buf;
     size_t _used_bytes;
+};
+
+/**
+ * A double-ly linked (intrusive) list of `io_fragment`.
+ *
+ * We use a hand rolled list instead of boost::intrusive_list to optimize
+ * certain codepaths, namely the move constructor was about 4x faster in the
+ * hand rolled implementation over boost.
+ *
+ * We're also able to enhance the list with features like iterator invalidation
+ * checking and the like.
+ *
+ * Note that this container does not own the memory for the io_fragments it
+ * contains, iobuf is responsible for that.
+ */
+class io_fragment_list {
+    template<bool Const, bool Forward>
+    class iter {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using container_type = typename std::
+          conditional_t<Const, const io_fragment_list, io_fragment_list>;
+        using value_type =
+          typename std::conditional_t<Const, const io_fragment, io_fragment>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+    private:
+        iter(container_type* container, pointer curr)
+          : _current(curr)
+#ifndef NDEBUG
+          , _my_generation(container->_generation)
+#endif
+          , _container(container) {
+        }
+
+    public:
+        iter() noexcept = default;
+        // Support conversion to const_iterator
+        // NOLINTNEXTLINE(hicpp-explicit-conversions)
+        operator iter<true, Forward>() const {
+            check_generation();
+            return {_container, _current};
+        }
+
+        reference operator*() const {
+            check_generation();
+            return *_current;
+        }
+        pointer operator->() const {
+            check_generation();
+            return _current;
+        }
+        iter& operator++() {
+            check_generation();
+            if constexpr (Forward) {
+                _current = _current->_next;
+            } else {
+                _current = _current->_prev;
+            }
+            return *this;
+        }
+        iter operator++(int) {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
+        iter& operator--() {
+            check_generation();
+            if constexpr (Forward) {
+                if (_current == nullptr) {
+                    _current = _container->_tail;
+                } else {
+                    _current = _current->_prev;
+                }
+            } else {
+                if (_current == nullptr) {
+                    _current = _container->_head;
+                } else {
+                    _current = _current->_next;
+                }
+            }
+            return *this;
+        }
+        iter operator--(int) {
+            auto tmp = *this;
+            --*this;
+            return tmp;
+        }
+        bool operator==(const iter& o) const {
+            check_generation();
+            return _current == o._current;
+        }
+
+    private:
+        friend class io_fragment_list;
+
+        inline void check_generation() const {
+            dassert(
+              _container->_generation == _my_generation,
+              "Attempting to use an invalidated iterator. The corresponding "
+              "iobuf has been mutated since this iterator was constructed.");
+        }
+
+        pointer _current = nullptr;
+#ifndef NDEBUG
+        size_t _my_generation = 0;
+#endif
+        container_type* _container = nullptr;
+    };
+
+public:
+    io_fragment_list() noexcept = default;
+    io_fragment_list(io_fragment_list&& o) noexcept
+      : _head(std::exchange(o._head, nullptr))
+      , _tail(std::exchange(o._tail, nullptr)) {
+        o.update_generation();
+    }
+    io_fragment_list(const io_fragment_list&) = delete;
+    io_fragment_list& operator=(io_fragment_list&&) = delete;
+    io_fragment_list& operator=(const io_fragment_list&) = delete;
+    ~io_fragment_list() noexcept {
+        dassert(
+          _head == nullptr && _tail == nullptr,
+          "io_fragment_list cleanup failure and possible memory leak");
+    };
+
+    using iterator = iter<false, true>;
+    using reverse_iterator = iter<false, false>;
+    using const_iterator = iter<true, true>;
+
+    bool empty() const {
+        check_consistency();
+        return _head == nullptr;
+    }
+
+    io_fragment& front() {
+        check_consistency();
+        return *_head;
+    }
+
+    void pop_front() {
+        check_consistency();
+        io_fragment* h = _head;
+        _head = h->_next;
+        h->_next = nullptr;
+        if (_head != nullptr) {
+            _head->_prev = nullptr;
+        } else {
+            _tail = nullptr;
+        }
+        update_generation();
+    }
+
+    void push_front(io_fragment& elem) {
+        check_consistency();
+        if (_head == nullptr) {
+            _tail = &elem;
+        } else {
+            _head->_prev = &elem;
+        }
+        elem._next = _head;
+        _head = &elem;
+        update_generation();
+    }
+
+    template<typename Func>
+    void pop_front_and_dispose(Func func) {
+        io_fragment* front = _head;
+        pop_front();
+        func(front);
+    }
+
+    io_fragment& back() {
+        check_consistency();
+        return *_tail;
+    }
+    const io_fragment& back() const {
+        check_consistency();
+        return *_tail;
+    }
+
+    void pop_back() {
+        check_consistency();
+        io_fragment* t = _tail;
+        _tail = _tail->_prev;
+        t->_prev = nullptr;
+        if (_tail != nullptr) {
+            _tail->_next = nullptr;
+        } else {
+            _head = nullptr;
+        }
+        update_generation();
+    }
+
+    void push_back(io_fragment& elem) {
+        dassert(
+          elem._prev == nullptr, "pushing back io_fragment in another iobuf");
+        dassert(
+          elem._next == nullptr, "pushing back io_fragment in another iobuf");
+        check_consistency();
+        if (_tail == nullptr) {
+            _head = &elem;
+        } else {
+            _tail->_next = &elem;
+        }
+        elem._prev = _tail;
+        _tail = &elem;
+        update_generation();
+    }
+
+    template<typename Func>
+    void pop_back_and_dispose(Func func) {
+        io_fragment* back = _tail;
+        pop_back();
+        func(back);
+    }
+
+    template<typename Func>
+    void clear_and_dispose(Func func) {
+        check_consistency();
+        io_fragment* current = _head;
+        while (current != nullptr) {
+            io_fragment* next = current->_next;
+            if (next != nullptr) {
+                dassert(
+                  next->_prev == current, "io_fragment_list inconsistency");
+                next->_prev = nullptr;
+            }
+            current->_next = nullptr;
+            func(current);
+            current = next;
+        }
+        _head = nullptr;
+        _tail = nullptr;
+        update_generation();
+    }
+
+    iterator begin() { return {this, _head}; }
+    iterator end() { return {this, nullptr}; }
+    reverse_iterator rbegin() { return {this, _tail}; }
+    reverse_iterator rend() { return {this, nullptr}; }
+    const_iterator cbegin() const { return {this, _head}; }
+    const_iterator cend() const { return {this, nullptr}; }
+
+private:
+    friend class iter<true, true>;
+    friend class iter<false, true>;
+    friend class iter<false, false>;
+    inline void update_generation() {
+#ifndef NDEBUG
+        ++_generation;
+#endif
+    }
+
+    inline void check_consistency() const {
+        // We don't check full consistency, just the head and tail elements, so
+        // we don't make debug mode *that* much slower.
+#ifndef NDEBUG
+        dassert(
+          (_head == nullptr) == (_tail == nullptr),
+          "head and tail consistency");
+        if (_head == nullptr) {
+            return;
+        }
+        dassert(!_head->_prev, "head must not have prev");
+        dassert(!_tail->_next, "tail must not have next");
+        dassert(
+          _head == _tail || _head->_next, "head must have next if size > 1");
+        dassert(
+          _head == _tail || _tail->_prev, "tail must have prev if size > 1");
+        dassert(
+          (_head->_next == _tail) == (_tail->_prev == _head),
+          "If head points to tail, then tail should point to head (size == 2 "
+          "consistency).");
+#endif
+    }
+
+    io_fragment* _head = nullptr;
+    io_fragment* _tail = nullptr;
+#ifndef NDEBUG
+    size_t _generation = 0;
+#endif
 };
 
 inline void __attribute__((noinline)) dispose_io_fragment(io_fragment* f) {

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -277,13 +277,6 @@ public:
         update_generation();
     }
 
-    template<typename Func>
-    void pop_front_and_dispose(Func func) {
-        io_fragment* front = _head;
-        pop_front();
-        func(front);
-    }
-
     io_fragment& back() {
         check_consistency();
         return *_tail;
@@ -320,13 +313,6 @@ public:
         elem._prev = _tail;
         _tail = &elem;
         update_generation();
-    }
-
-    template<typename Func>
-    void pop_back_and_dispose(Func func) {
-        io_fragment* back = _tail;
-        pop_back();
-        func(back);
     }
 
     template<typename Func>

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -129,7 +129,7 @@ class io_fragment_list {
     template<bool Const, bool Forward>
     class iter {
     public:
-        using iterator_category = std::bidirectional_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
         using container_type = typename std::
           conditional_t<Const, const io_fragment_list, io_fragment_list>;
         using value_type =
@@ -139,12 +139,13 @@ class io_fragment_list {
         using reference = value_type&;
 
     private:
-        iter(container_type* container, pointer curr)
+        iter([[maybe_unused]] container_type* container, pointer curr)
           : _current(curr)
 #ifndef NDEBUG
           , _my_generation(container->_generation)
+          , _container(container)
 #endif
-          , _container(container) {
+        {
         }
 
     public:
@@ -153,7 +154,11 @@ class io_fragment_list {
         // NOLINTNEXTLINE(hicpp-explicit-conversions)
         operator iter<true, Forward>() const {
             check_generation();
+#ifndef NDEBUG
             return {_container, _current};
+#else
+            return {nullptr, _current};
+#endif
         }
 
         reference operator*() const {
@@ -178,28 +183,6 @@ class io_fragment_list {
             ++*this;
             return tmp;
         }
-        iter& operator--() {
-            check_generation();
-            if constexpr (Forward) {
-                if (_current == nullptr) {
-                    _current = _container->_tail;
-                } else {
-                    _current = _current->_prev;
-                }
-            } else {
-                if (_current == nullptr) {
-                    _current = _container->_head;
-                } else {
-                    _current = _current->_next;
-                }
-            }
-            return *this;
-        }
-        iter operator--(int) {
-            auto tmp = *this;
-            --*this;
-            return tmp;
-        }
         bool operator==(const iter& o) const {
             check_generation();
             return _current == o._current;
@@ -218,8 +201,8 @@ class io_fragment_list {
         pointer _current = nullptr;
 #ifndef NDEBUG
         size_t _my_generation = 0;
-#endif
         container_type* _container = nullptr;
+#endif
     };
 
 public:

--- a/src/v/bytes/details/io_iterator_consumer.h
+++ b/src/v/bytes/details/io_iterator_consumer.h
@@ -46,9 +46,7 @@
 namespace details {
 class io_iterator_consumer {
 public:
-    using io_const_iterator
-      = uncounted_intrusive_list<io_fragment, &io_fragment::hook>::
-        const_iterator;
+    using io_const_iterator = io_fragment_list::const_iterator;
 
     io_iterator_consumer(
       const io_const_iterator& begin, const io_const_iterator& end) noexcept

--- a/src/v/bytes/details/io_placeholder.h
+++ b/src/v/bytes/details/io_placeholder.h
@@ -13,19 +13,17 @@
 
 #include "bytes/details/io_fragment.h"
 #include "bytes/details/out_of_range.h"
-#include "container/intrusive_list_helpers.h"
 
 namespace details {
 class io_placeholder {
 public:
-    using iterator
-      = uncounted_intrusive_list<io_fragment, &io_fragment::hook>::iterator;
+    using iterator = io_fragment_list::iterator;
 
     io_placeholder() noexcept = default;
 
     io_placeholder(
-      const iterator& iter, size_t initial_index, size_t max_size_to_write)
-      : _iter(iter)
+      io_fragment& iter, size_t initial_index, size_t max_size_to_write)
+      : _current(&iter)
       , _byte_index(initial_index)
       , _remaining_size(max_size_to_write) {}
 
@@ -47,13 +45,13 @@ public:
 
     // the first byte of the _current_ iterator + offset
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    const char* index() const { return _iter->get() + _byte_index; }
+    const char* index() const { return _current->get() + _byte_index; }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    char* mutable_index() { return _iter->get_write() + _byte_index; }
+    char* mutable_index() { return _current->get_write() + _byte_index; }
 
 private:
-    iterator _iter;
+    io_fragment* _current = nullptr;
     size_t _byte_index{0};
     size_t _remaining_size{0};
 };

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -237,8 +237,8 @@ iobuf::placeholder iobuf::reserve(size_t sz) {
     vassert(sz, "zero length reservations are unsupported");
     reserve_memory(sz);
     _size += sz;
-    auto it = std::prev(_frags.end());
-    placeholder p(it, it->size(), sz);
-    it->reserve(sz);
+    auto& back = _frags.back();
+    placeholder p(back, back.size(), sz);
+    back.reserve(sz);
     return p;
 }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -18,7 +18,6 @@
 #include "bytes/details/io_fragment.h"
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/details/io_placeholder.h"
-#include "bytes/details/out_of_range.h"
 #include "container/intrusive_list_helpers.h"
 
 #include <seastar/core/temporary_buffer.hh>
@@ -52,7 +51,7 @@
  */
 class iobuf {
     // Not a lightweight object.
-    // 16 bytes for std::list
+    // 16 bytes for io_fragment_list
     // 8  bytes for _size_bytes
     // -----------------------
     //
@@ -60,7 +59,7 @@ class iobuf {
 
     // Each fragment:
     // 24  of ss::temporary_buffer<>
-    // 16  for left,right pointers
+    // 16  for prev,next pointers
     // 8   for consumed capacity
     // -----------------------
     //
@@ -68,7 +67,7 @@ class iobuf {
 
 public:
     using fragment = details::io_fragment;
-    using container = uncounted_intrusive_list<fragment, &fragment::hook>;
+    using container = details::io_fragment_list;
     using iterator = typename container::iterator;
     using reverse_iterator = typename container::reverse_iterator;
     using const_iterator = typename container::const_iterator;
@@ -90,10 +89,8 @@ public:
     ~iobuf() noexcept;
     iobuf(iobuf&& x) noexcept
       : _frags(std::move(x._frags))
-      , _size(x._size) {
-        x._frags = container{};
-        x._size = 0;
-    }
+      , _size(std::exchange(x._size, 0)) {}
+
     iobuf& operator=(iobuf&& x) noexcept {
         if (this != &x) {
             this->~iobuf();

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -11,7 +11,6 @@
 
 #pragma once
 #include "base/likely.h"
-#include "base/oncore.h"
 #include "base/seastarx.h"
 #include "bytes/details/io_allocation_size.h"
 #include "bytes/details/io_byte_iterator.h"

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -325,10 +325,10 @@ iobuf::prepend(ss::temporary_buffer<char> b) {
 }
 [[gnu::always_inline]] inline void iobuf::prepend(iobuf b) {
     while (!b._frags.empty()) {
-        b._frags.pop_back_and_dispose([this](fragment* f) {
-            prepend(f->share());
-            details::dispose_io_fragment(f);
-        });
+        fragment* f = &b._frags.back();
+        b._frags.pop_back();
+        prepend(f->share());
+        details::dispose_io_fragment(f);
     }
 }
 /// append src + len into storage
@@ -392,29 +392,33 @@ iobuf::append(const uint8_t* src, size_t len) {
 /// appends the contents of buffer; might pack values into existing space
 inline void iobuf::append(iobuf o) {
     while (!o._frags.empty()) {
-        o._frags.pop_front_and_dispose([this](fragment* f) {
-            append(f->share());
-            details::dispose_io_fragment(f);
-        });
+        fragment* f = &o._frags.front();
+        o._frags.pop_front();
+        append(f->share());
+        details::dispose_io_fragment(f);
     }
 }
 
 inline void iobuf::append_fragments(iobuf o) {
     while (!o._frags.empty()) {
-        o._frags.pop_front_and_dispose([this](fragment* f) {
-            append(std::make_unique<fragment>(f->share()));
-            details::dispose_io_fragment(f);
-        });
+        fragment* f = &o._frags.front();
+        o._frags.pop_front();
+        append(std::make_unique<fragment>(f->share()));
+        details::dispose_io_fragment(f);
     }
 }
 /// used for iostreams
 inline void iobuf::pop_front() {
-    _size -= _frags.front().size();
-    _frags.pop_front_and_dispose(&details::dispose_io_fragment);
+    fragment* f = &_frags.front();
+    _size -= f->size();
+    _frags.pop_front();
+    details::dispose_io_fragment(f);
 }
 inline void iobuf::pop_back() {
-    _size -= _frags.back().size();
-    _frags.pop_back_and_dispose(&details::dispose_io_fragment);
+    fragment* f = &_frags.back();
+    _size -= f->size();
+    _frags.pop_back();
+    details::dispose_io_fragment(f);
 }
 inline void iobuf::trim_front(size_t n) {
     while (!_frags.empty()) {

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -18,7 +18,6 @@
 #include "bytes/details/io_fragment.h"
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/details/io_placeholder.h"
-#include "container/intrusive_list_helpers.h"
 
 #include <seastar/core/temporary_buffer.hh>
 

--- a/src/v/bytes/iostream.cc
+++ b/src/v/bytes/iostream.cc
@@ -19,7 +19,7 @@ ss::input_stream<char> make_iobuf_input_stream(iobuf io) {
             return get();
         }
         ss::future<ss::temporary_buffer<char>> get() final {
-            if (io.begin() == io.end()) {
+            if (io.empty()) {
                 return ss::make_ready_future<ss::temporary_buffer<char>>();
             }
             auto buf = io.begin()->share();

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -44,6 +44,22 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "iobuf_fragment_list_test",
+    timeout = "short",
+    srcs = [
+        "iobuf_fragment_list_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "iobuf_utils_test",
     timeout = "short",

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_fuzz_test", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_fuzz_test", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "iobuf_test",
@@ -89,5 +89,16 @@ redpanda_cc_fuzz_test(
         "//src/v/base",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:scattered_message",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "iobuf_rpbench",
+    srcs = ["iobuf_bench.cc"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/random:generators",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -1,0 +1,35 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/units.h"
+#include "bytes/iobuf.h"
+#include "random/generators.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+namespace {
+static constexpr size_t inner_iters = 1000;
+
+template<size_t Size>
+size_t move_bench() {
+    iobuf buffer = iobuf::from(random_generators::gen_alphanum_string(Size));
+    perf_tests::start_measuring_time();
+    for (auto i = inner_iters; i--;) {
+        iobuf moved = std::move(buffer);
+        perf_tests::do_not_optimize(moved);
+        buffer = std::move(moved);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters * 2;
+}
+} // namespace
+
+PERF_TEST(iobuf, move_bench_small) { return move_bench<71>(); }
+PERF_TEST(iobuf, move_bench_medium) { return move_bench<300_KiB>(); }
+PERF_TEST(iobuf, move_bench_large) { return move_bench<965_KiB>(); }

--- a/src/v/bytes/tests/iobuf_fragment_list_test.cc
+++ b/src/v/bytes/tests/iobuf_fragment_list_test.cc
@@ -1,0 +1,275 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/details/io_fragment.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include <list>
+#include <ranges>
+
+using namespace details;
+
+namespace {
+
+TEST(FragmentListTests, Back) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    EXPECT_TRUE(list.empty());
+    list.push_back(a);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_back(b);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &b);
+    EXPECT_FALSE(list.empty());
+    list.push_back(c);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &c);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &b);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(FragmentListTests, Front) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    EXPECT_TRUE(list.empty());
+    list.push_front(a);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_front(b);
+    EXPECT_EQ(&list.front(), &b);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_front(c);
+    EXPECT_EQ(&list.front(), &c);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_EQ(&list.front(), &b);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(FragmentListTests, FrontBack) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    EXPECT_TRUE(list.empty());
+    list.push_front(a);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_front(b);
+    EXPECT_EQ(&list.front(), &b);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_front(c);
+    EXPECT_EQ(&list.front(), &c);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_EQ(&list.front(), &c);
+    EXPECT_EQ(&list.back(), &b);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_EQ(&list.front(), &c);
+    EXPECT_EQ(&list.back(), &c);
+    EXPECT_FALSE(list.empty());
+    list.pop_back();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(FragmentListTests, BackFront) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    EXPECT_TRUE(list.empty());
+    list.push_back(a);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &a);
+    EXPECT_FALSE(list.empty());
+    list.push_back(b);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &b);
+    EXPECT_FALSE(list.empty());
+    list.push_back(c);
+    EXPECT_EQ(&list.front(), &a);
+    EXPECT_EQ(&list.back(), &c);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_EQ(&list.front(), &b);
+    EXPECT_EQ(&list.back(), &c);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_EQ(&list.front(), &c);
+    EXPECT_EQ(&list.back(), &c);
+    EXPECT_FALSE(list.empty());
+    list.pop_front();
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(FragmentListTests, IteratorIncrement) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+    std::list<io_fragment*> shadow = {&a, &b, &c};
+    while (!list.empty()) {
+        auto it = list.begin();
+        for (io_fragment* frag : shadow) {
+            ASSERT_NE(it, list.end());
+            EXPECT_EQ(&*it, frag);
+            ++it;
+        }
+        EXPECT_EQ(it, list.end());
+        auto rit = list.rbegin();
+        for (io_fragment* frag : std::ranges::reverse_view(shadow)) {
+            ASSERT_NE(rit, list.rend());
+            EXPECT_EQ(&*rit, frag);
+            ++rit;
+        }
+        EXPECT_EQ(rit, list.rend());
+        auto cit = list.cbegin();
+        for (io_fragment* frag : shadow) {
+            ASSERT_NE(cit, list.cend());
+            EXPECT_EQ(&*cit, frag);
+            ++cit;
+        }
+        EXPECT_EQ(cit, list.cend());
+        list.pop_back();
+        shadow.pop_back();
+    }
+    EXPECT_EQ(list.begin(), list.end());
+    EXPECT_EQ(list.cbegin(), list.cend());
+    EXPECT_EQ(list.rbegin(), list.rend());
+}
+
+TEST(FragmentListTests, IteratorDecrement) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+    std::list<io_fragment*> shadow = {&a, &b, &c};
+    while (!list.empty()) {
+        auto it = list.end();
+        for (io_fragment* frag : std::ranges::reverse_view(shadow)) {
+            --it;
+            ASSERT_NE(it, list.end());
+            EXPECT_EQ(&*it, frag);
+        }
+        EXPECT_EQ(it, list.begin());
+        auto rit = list.rend();
+        for (io_fragment* frag : shadow) {
+            --rit;
+            ASSERT_NE(rit, list.rend());
+            EXPECT_EQ(&*rit, frag);
+        }
+        EXPECT_EQ(rit, list.rbegin());
+        auto cit = list.cend();
+        for (io_fragment* frag : std::ranges::reverse_view(shadow)) {
+            --cit;
+            ASSERT_NE(cit, list.cend());
+            EXPECT_EQ(&*cit, frag);
+        }
+        EXPECT_EQ(cit, list.cbegin());
+        list.pop_back();
+        shadow.pop_back();
+    }
+    EXPECT_EQ(list.begin(), list.end());
+    EXPECT_EQ(list.cbegin(), list.cend());
+    EXPECT_EQ(list.rbegin(), list.rend());
+}
+
+TEST(FragmentListTests, Clear) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+    std::list<io_fragment*> shadow = {&a, &b, &c};
+    list.clear_and_dispose([&shadow](io_fragment* f) {
+        EXPECT_EQ(shadow.front(), f);
+        shadow.pop_front();
+    });
+    EXPECT_TRUE(shadow.empty());
+    EXPECT_TRUE(list.empty());
+}
+
+TEST(FragmentListTests, PopFront) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+    std::list<io_fragment*> shadow = {&a, &b, &c};
+    while (!list.empty()) {
+        EXPECT_EQ(&c, &list.back());
+        list.pop_front_and_dispose([&shadow](io_fragment* f) {
+            EXPECT_EQ(shadow.front(), f);
+            shadow.pop_front();
+        });
+    }
+    EXPECT_TRUE(shadow.empty());
+}
+
+TEST(FragmentListTests, PopBack) {
+    io_fragment_list list;
+    io_fragment a{0};
+    io_fragment b{0};
+    io_fragment c{0};
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+    std::list<io_fragment*> shadow = {&a, &b, &c};
+    while (!list.empty()) {
+        EXPECT_EQ(&a, &list.front());
+        list.pop_back_and_dispose([&shadow](io_fragment* f) {
+            EXPECT_EQ(shadow.back(), f);
+            shadow.pop_back();
+        });
+    }
+    EXPECT_TRUE(shadow.empty());
+}
+
+} // namespace

--- a/src/v/bytes/tests/iobuf_fragment_list_test.cc
+++ b/src/v/bytes/tests/iobuf_fragment_list_test.cc
@@ -234,42 +234,4 @@ TEST(FragmentListTests, Clear) {
     EXPECT_TRUE(list.empty());
 }
 
-TEST(FragmentListTests, PopFront) {
-    io_fragment_list list;
-    io_fragment a{0};
-    io_fragment b{0};
-    io_fragment c{0};
-    list.push_back(a);
-    list.push_back(b);
-    list.push_back(c);
-    std::list<io_fragment*> shadow = {&a, &b, &c};
-    while (!list.empty()) {
-        EXPECT_EQ(&c, &list.back());
-        list.pop_front_and_dispose([&shadow](io_fragment* f) {
-            EXPECT_EQ(shadow.front(), f);
-            shadow.pop_front();
-        });
-    }
-    EXPECT_TRUE(shadow.empty());
-}
-
-TEST(FragmentListTests, PopBack) {
-    io_fragment_list list;
-    io_fragment a{0};
-    io_fragment b{0};
-    io_fragment c{0};
-    list.push_back(a);
-    list.push_back(b);
-    list.push_back(c);
-    std::list<io_fragment*> shadow = {&a, &b, &c};
-    while (!list.empty()) {
-        EXPECT_EQ(&a, &list.front());
-        list.pop_back_and_dispose([&shadow](io_fragment* f) {
-            EXPECT_EQ(shadow.back(), f);
-            shadow.pop_back();
-        });
-    }
-    EXPECT_TRUE(shadow.empty());
-}
-
 } // namespace

--- a/src/v/bytes/tests/iobuf_fragment_list_test.cc
+++ b/src/v/bytes/tests/iobuf_fragment_list_test.cc
@@ -178,45 +178,6 @@ TEST(FragmentListTests, IteratorIncrement) {
     EXPECT_EQ(list.rbegin(), list.rend());
 }
 
-TEST(FragmentListTests, IteratorDecrement) {
-    io_fragment_list list;
-    io_fragment a{0};
-    io_fragment b{0};
-    io_fragment c{0};
-    list.push_back(a);
-    list.push_back(b);
-    list.push_back(c);
-    std::list<io_fragment*> shadow = {&a, &b, &c};
-    while (!list.empty()) {
-        auto it = list.end();
-        for (io_fragment* frag : std::ranges::reverse_view(shadow)) {
-            --it;
-            ASSERT_NE(it, list.end());
-            EXPECT_EQ(&*it, frag);
-        }
-        EXPECT_EQ(it, list.begin());
-        auto rit = list.rend();
-        for (io_fragment* frag : shadow) {
-            --rit;
-            ASSERT_NE(rit, list.rend());
-            EXPECT_EQ(&*rit, frag);
-        }
-        EXPECT_EQ(rit, list.rbegin());
-        auto cit = list.cend();
-        for (io_fragment* frag : std::ranges::reverse_view(shadow)) {
-            --cit;
-            ASSERT_NE(cit, list.cend());
-            EXPECT_EQ(&*cit, frag);
-        }
-        EXPECT_EQ(cit, list.cbegin());
-        list.pop_back();
-        shadow.pop_back();
-    }
-    EXPECT_EQ(list.begin(), list.end());
-    EXPECT_EQ(list.cbegin(), list.cend());
-    EXPECT_EQ(list.rbegin(), list.rend());
-}
-
 TEST(FragmentListTests, Clear) {
     io_fragment_list list;
     io_fragment a{0};

--- a/src/v/bytes/tests/iobuf_tests_mt.cc
+++ b/src/v/bytes/tests/iobuf_tests_mt.cc
@@ -12,6 +12,7 @@
 #include "test_utils/test.h"
 
 #include <seastar/core/loop.hh>
+#include <seastar/core/smp.hh>
 
 #include <boost/range/irange.hpp>
 

--- a/src/v/cloud_topics/core/BUILD
+++ b/src/v/cloud_topics/core/BUILD
@@ -45,6 +45,7 @@ redpanda_cc_library(
         ":serializer",
         "//src/v/base",
         "//src/v/cloud_topics:types",
+        "//src/v/container:intrusive",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/core/write_request.h
+++ b/src/v/cloud_topics/core/write_request.h
@@ -15,6 +15,7 @@
 #include "cloud_topics/core/pipeline_stage.h"
 #include "cloud_topics/core/serializer.h"
 #include "cloud_topics/errc.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/record.h"
 
 #include <seastar/core/lowres_clock.hh>

--- a/src/v/cluster/self_test/tests/BUILD
+++ b/src/v/cluster/self_test/tests/BUILD
@@ -1,0 +1,30 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "self_test_config_test",
+    timeout = "short",
+    srcs = ["self_test_config_test.cc"],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/json",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:math",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "self_test_request_test",
+    timeout = "short",
+    srcs = ["self_test_request_test.cc"],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cluster",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/cluster/self_test/tests/self_test_request_test.cc
+++ b/src/v/cluster/self_test/tests/self_test_request_test.cc
@@ -13,21 +13,20 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(test_make_netcheck_request) {
-    static const auto check_frags =
-      [](iobuf::const_iterator begin, iobuf::const_iterator end, size_t sz) {
-          vassert(
-            std::distance(begin, end) >= 2,
-            "check frags verifies constant fragment legnth up until final "
-            "fragment in iobuf");
-          /// Its expected for the final fragment to have a size < 'sz'
-          const auto final_equiv_frag = --(--end);
-          for (; begin != final_equiv_frag; ++begin) {
-              if (begin->size() != sz) {
-                  return false;
-              }
-          }
-          return true;
-      };
+    static const auto check_frags = [](iobuf& buf, size_t sz) {
+        vassert(
+          std::distance(buf.begin(), buf.end()) >= 2,
+          "check frags verifies constant fragment legnth up until final "
+          "fragment in iobuf");
+        auto it = buf.rbegin();
+        ++it; // Its expected for the final fragment to have a size < 'sz'
+        for (; it != buf.rend(); ++it) {
+            if (it->size() != sz) {
+                return false;
+            }
+        }
+        return true;
+    };
 
     auto req = cluster::make_netcheck_request(model::node_id{0}, 52).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), 52);
@@ -46,6 +45,6 @@ SEASTAR_THREAD_TEST_CASE(test_make_netcheck_request) {
     req = cluster::make_netcheck_request(model::node_id{0}, size).get().buf;
     BOOST_CHECK_EQUAL(req.size_bytes(), size);
     BOOST_CHECK_EQUAL(std::distance(req.cbegin(), req.cend()), 53);
-    BOOST_CHECK(check_frags(req.cbegin(), req.cend(), 8192));
-    BOOST_CHECK_EQUAL((--req.cend())->size(), 100);
+    BOOST_CHECK(check_frags(req, 8192));
+    BOOST_CHECK_EQUAL(req.rbegin()->size(), 100);
 }

--- a/src/v/container/tests/map_bench.cc
+++ b/src/v/container/tests/map_bench.cc
@@ -18,6 +18,8 @@
 #include <absl/container/btree_map.h>
 #include <boost/range/irange.hpp>
 
+#include <map>
+
 template<typename MapT, size_t KeySetSize, size_t FillPercent>
 class MapBenchTest {
     using key_t = typename MapT::key_type;

--- a/src/v/crash_tracker/signals.cc
+++ b/src/v/crash_tracker/signals.cc
@@ -11,9 +11,8 @@
 
 #include "crash_tracker/recorder.h"
 
+#include <seastar/core/smp.hh>
 #include <seastar/util/print_safe.hh>
-
-#include <atomic>
 
 namespace crash_tracker {
 

--- a/src/v/datalake/schema_registry.cc
+++ b/src/v/datalake/schema_registry.cc
@@ -71,7 +71,7 @@ get_proto_offsets_result get_schema_proto_offsets(iobuf& buf) noexcept {
 result<proto_offsets_message_data, get_schema_error>
 get_proto_offsets(iobuf& buf) noexcept {
     proto_offsets_message_data result;
-    iobuf_const_parser parser(buf.share(0, buf.size_bytes()));
+    iobuf_const_parser parser(buf);
 
     // The encoding is a length, followed by indexes into the file or message.
     // Each number is a zigzag encoded integer.

--- a/src/v/datalake/tests/datalake_parquet_tests.cc
+++ b/src/v/datalake/tests/datalake_parquet_tests.cc
@@ -591,12 +591,7 @@ static constexpr auto parquet_type(const T&) {
     __builtin_unreachable();
 }
 const auto values_equal = [](const auto& expected, const auto& current) {
-    if constexpr (std::
-                    is_same_v<decltype(current.val), std::unique_ptr<iobuf>>) {
-        return expected.val == *current.val;
-    } else {
-        return expected.val == current.val;
-    }
+    return expected.val == current.val;
 };
 
 template<typename IcebergPrimitive, typename Predicate>
@@ -648,7 +643,7 @@ AssertionResult validate_parquet_optional_primitive_value(
 bool decimals_equal(
   const iceberg::decimal_value& expected,
   const serde::parquet::fixed_byte_array_value& current) {
-    iobuf_parser parser(current.val->copy());
+    iobuf_parser parser(current.val.copy());
     auto high_part = ss::be_to_cpu(parser.consume_type<int64_t>());
     auto low_part = ss::be_to_cpu(parser.consume_type<uint64_t>());
     return expected.val == absl::MakeInt128(high_part, low_part);
@@ -657,7 +652,7 @@ bool decimals_equal(
 bool uuids_equal(
   const iceberg::uuid_value& expected,
   const serde::parquet::fixed_byte_array_value& current_bytes) {
-    iobuf_parser parser(current_bytes.val->copy());
+    iobuf_parser parser(current_bytes.val.copy());
     auto bytes = parser.read_bytes(16);
     std::vector<uint8_t> uuid_bytes(bytes.begin(), bytes.end());
     uuid_t current_uuid(uuid_bytes);

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -46,6 +46,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/container:chunked_hash_map",
         "//src/v/container:fragmented_vector",
+        "//src/v/container:intrusive",
         "//src/v/datalake:logger",
         "//src/v/model",
         "//src/v/random:generators",

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "container/chunked_hash_map.h"
-#include "container/fragmented_vector.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
 #include "ssx/semaphore.h"
 

--- a/src/v/datalake/values_parquet.cc
+++ b/src/v/datalake/values_parquet.cc
@@ -40,22 +40,18 @@ struct primitive_value_converting_visitor {
         return serde::parquet::int64_value{.val = v.val};
     }
     parquet_conversion_outcome operator()(iceberg::string_value v) {
-        return serde::parquet::byte_array_value{
-          .val = std::make_unique<iobuf>(std::move(v.val))};
+        return serde::parquet::byte_array_value{.val = std::move(v.val)};
     }
     parquet_conversion_outcome operator()(iceberg::uuid_value v) {
         iobuf buffer;
         buffer.append(v.val.uuid().data, v.val.uuid().size());
-        return serde::parquet::fixed_byte_array_value{
-          .val = std::make_unique<iobuf>(std::move(buffer))};
+        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
     }
     parquet_conversion_outcome operator()(iceberg::fixed_value v) {
-        return serde::parquet::fixed_byte_array_value{
-          .val = std::make_unique<iobuf>(std::move(v.val))};
+        return serde::parquet::fixed_byte_array_value{.val = std::move(v.val)};
     }
     parquet_conversion_outcome operator()(iceberg::binary_value v) {
-        return serde::parquet::byte_array_value{
-          .val = std::make_unique<iobuf>(std::move(v.val))};
+        return serde::parquet::byte_array_value{.val = std::move(v.val)};
     }
     parquet_conversion_outcome operator()(iceberg::decimal_value v) {
         iobuf buffer;
@@ -67,8 +63,7 @@ struct primitive_value_converting_visitor {
         buffer.append(
           reinterpret_cast<const char*>(&low_part), sizeof(uint64_t));
 
-        return serde::parquet::fixed_byte_array_value{
-          .val = std::make_unique<iobuf>(std::move(buffer))};
+        return serde::parquet::fixed_byte_array_value{.val = std::move(buffer)};
     }
 };
 struct value_converting_visitor {

--- a/src/v/iceberg/avro_utils.h
+++ b/src/v/iceberg/avro_utils.h
@@ -103,19 +103,21 @@ public:
         return true;
     }
 
+    // Allows for returning data in cur_frag_ *only*.
     void backup(size_t len) final {
         cur_pos_ -= len;
         if (cur_frag_ == buf_.end()) {
-            cur_frag_ = std::prev(buf_.end());
-            cur_frag_pos_ = cur_frag_->size();
+            throw std::runtime_error(
+              "invalid `backup` call in avro_iobuf_istream after `next` has "
+              "returned false");
         }
-        while (cur_frag_pos_ < len) {
-            len -= cur_frag_pos_;
-            if (cur_frag_ == buf_.begin()) {
-                return;
-            }
-            --cur_frag_;
-            cur_frag_pos_ = cur_frag_->size();
+        if (cur_frag_pos_ < len) {
+            throw std::runtime_error(fmt::format(
+              "invalid `backup` call in avro_iobuf_istream - trying to backup "
+              "more than the last call to `next` current_fragment_position: "
+              "{}, backup_len: {}",
+              cur_frag_pos_,
+              len));
         }
         cur_frag_pos_ -= len;
     }

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -673,6 +673,7 @@ redpanda_cc_gtest(
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/container:btree",
+        "@boost//:range",
         "@fmt",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -15,6 +15,7 @@
 #include "random/generators.h"
 
 #include <absl/container/btree_map.h>
+#include <boost/range/irange.hpp>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/src/v/json/iobuf_writer.h
+++ b/src/v/json/iobuf_writer.h
@@ -48,14 +48,17 @@ public:
 
 private:
     bool write_chunked_string(const iobuf& buf) {
-        const auto last_frag = [this]() {
-            return std::prev(this->os_->_impl.end());
-        };
+        const auto last_frag = [this]() { return this->os_->_impl.rbegin(); };
         using Ch = Base::Ch;
         this->Prefix(rapidjson::kStringType);
         const auto beg = buf.begin();
         const auto end = buf.end();
-        const auto last = std::prev(end);
+        if (beg == end) {
+            if (!Base::WriteString("", 0)) {
+                return false;
+            }
+            return this->EndValue(true);
+        }
         Ch stashed{};
         Ch* stash_pos{};
         // Base::WriteString is used to JSON encode the string, and requires a
@@ -73,7 +76,7 @@ private:
         //   3. Drop the final character
         // For each encoded fragment that is written (except the first one):
         //   4. Restore the stashed character over the prefix-quote
-        for (auto i = beg; i != end; ++i) {
+        for (auto i = beg;;) {
             if (!Base::WriteString(i->get(), i->size())) {
                 return false;
             }
@@ -81,23 +84,25 @@ private:
                 // 4. Restore the stashed character over the prefix-quote
                 *stash_pos = stashed;
             }
-            if (i != last) {
-                // 1. Trim the suffix quote
-                this->os_->_impl.trim_back(1);
-
-                // 2. Stash the final character, ...
-                auto last = last_frag();
-                stashed = *std::prev(last->get_current());
-                // 3. Drop the final character
-                this->os_->_impl.trim_back(1);
-
-                // Ensure a stable address to restore the stashed character
-                if (last != last_frag()) {
-                    this->os_->_impl.reserve_memory(1);
-                }
-                // 2. ...and where it is to be written.
-                stash_pos = last_frag()->get_current();
+            ++i;
+            if (i == end) {
+                break;
             }
+            // 1. Trim the suffix quote
+            this->os_->_impl.trim_back(1);
+
+            // 2. Stash the final character, ...
+            auto last = last_frag();
+            stashed = *std::prev(last->get_current());
+            // 3. Drop the final character
+            this->os_->_impl.trim_back(1);
+
+            // Ensure a stable address to restore the stashed character
+            if (last != last_frag()) {
+                this->os_->_impl.reserve_memory(1);
+            }
+            // 2. ...and where it is to be written.
+            stash_pos = last_frag()->get_current();
         }
         return this->EndValue(true);
     }

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -190,4 +190,15 @@ SEASTAR_THREAD_TEST_CASE(json_iobuf_writer_test) {
         BOOST_CHECK_EQUAL(out_buf, expected);
         BOOST_CHECK_EQUAL(to_string(out_buf), to_string(expected));
     }
+
+    {
+        json::chunked_buffer out;
+        json::iobuf_writer<json::chunked_buffer> os{out};
+        iobuf buf;
+        os.String(buf);
+        auto out_buf = std::move(out).as_iobuf();
+        auto expected = iobuf::from("\"\"");
+        BOOST_CHECK_EQUAL(out_buf, expected);
+        BOOST_CHECK_EQUAL(to_string(out_buf), to_string(expected));
+    }
 }

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "container/intrusive_list_helpers.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "model/fundamental.h"

--- a/src/v/serde/async.h
+++ b/src/v/serde/async.h
@@ -180,6 +180,7 @@ ss::future<> write_async(iobuf& out, T t) {
                                 sizeof(checksum_t));
                           });
                     } else {
+                        std::ignore = checksum_placeholder;
                         return ss::now();
                     }
                 });

--- a/src/v/serde/avro/BUILD
+++ b/src/v/serde/avro/BUILD
@@ -16,6 +16,7 @@ redpanda_cc_library(
         "//src/v/container:fragmented_vector",
         "//src/v/utils:vint",
         "@avro",
+        "@boost//:range",
         "@seastar",
     ],
 )

--- a/src/v/serde/avro/parser.cc
+++ b/src/v/serde/avro/parser.cc
@@ -15,6 +15,8 @@
 
 #include <seastar/util/defer.hh>
 
+#include <boost/range/irange.hpp>
+
 namespace serde::avro {
 // an arbitrary limit for nesting depth (number of levels in the schema tree)
 static constexpr int max_nested_depth = 100;

--- a/src/v/serde/avro/tests/BUILD
+++ b/src/v/serde/avro/tests/BUILD
@@ -84,6 +84,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:runfiles",
         "//src/v/utils:file_io",
         "@avro",
+        "@boost//:range",
         "@fmt",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/src/v/serde/avro/tests/parser_test.cc
+++ b/src/v/serde/avro/tests/parser_test.cc
@@ -24,8 +24,10 @@
 #include <avro/Encoder.hh>
 #include <avro/Generic.hh>
 #include <avro/Schema.hh>
+#include <boost/range/irange.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 using namespace testing;
 
 void parsed_to_avro(

--- a/src/v/serde/parquet/column_stats_collector.cc
+++ b/src/v/serde/parquet/column_stats_collector.cc
@@ -77,25 +77,25 @@ std::strong_ordering float64(const float64_value a, const float64_value b) {
 
 std::strong_ordering
 byte_array(const byte_array_value& a, const byte_array_value& b) {
-    return *a.val <=> *b.val;
+    return a.val <=> b.val;
 }
 
 std::strong_ordering fixed_byte_array(
   const fixed_byte_array_value& a, const fixed_byte_array_value& b) {
-    return *a.val <=> *b.val;
+    return a.val <=> b.val;
 }
 
 std::strong_ordering
 int128_be(const fixed_byte_array_value& a, const fixed_byte_array_value& b) {
     if (
-      a.val->size_bytes() != sizeof(absl::int128)
-      || b.val->size_bytes() != sizeof(absl::int128)) {
+      a.val.size_bytes() != sizeof(absl::int128)
+      || b.val.size_bytes() != sizeof(absl::int128)) {
         throw std::runtime_error("unable to convert input to int128");
     }
-    iobuf_const_parser ap(*a.val);
+    iobuf_const_parser ap(a.val);
     auto a_hi = ap.consume_be_type<int64_t>();
     auto a_lo = ap.consume_be_type<uint64_t>();
-    iobuf_const_parser bp(*b.val);
+    iobuf_const_parser bp(b.val);
     auto b_hi = bp.consume_be_type<int64_t>();
     auto b_lo = bp.consume_be_type<uint64_t>();
     // TODO: Switch to <=> on absl::int128 when
@@ -114,12 +114,12 @@ namespace internal {
 
 template<>
 byte_array_value copy(byte_array_value& v) {
-    return {std::make_unique<iobuf>(v.val->share(0, v.val->size_bytes()))};
+    return {v.val.share(0, v.val.size_bytes())};
 }
 
 template<>
 fixed_byte_array_value copy(fixed_byte_array_value& v) {
-    return {std::make_unique<iobuf>(v.val->share(0, v.val->size_bytes()))};
+    return {v.val.share(0, v.val.size_bytes())};
 }
 
 } // namespace internal

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -81,10 +81,10 @@ public:
         int64_t value_memory_usage = 0;
 
         ss::visit(
-          val,
+          std::move(val),
           [this, &value_memory_usage](value_type& v) {
               if constexpr (!std::is_trivially_copyable_v<value_type>) {
-                  value_memory_usage = v.val->size_bytes();
+                  value_memory_usage = v.val.size_bytes();
               } else {
                   value_memory_usage = sizeof(value_type);
               }

--- a/src/v/serde/parquet/encoding.cc
+++ b/src/v/serde/parquet/encoding.cc
@@ -77,10 +77,10 @@ iobuf encode_plain(const chunked_vector<float64_value>& vals) {
 iobuf encode_plain(chunked_vector<byte_array_value> vals) {
     iobuf buf;
     for (auto& v : vals) {
-        int32_t i = ss::cpu_to_le(static_cast<int32_t>(v.val->size_bytes()));
+        int32_t i = ss::cpu_to_le(static_cast<int32_t>(v.val.size_bytes()));
         // NOLINTNEXTLINE(*reinterpret-cast*)
         buf.append(reinterpret_cast<const uint8_t*>(&i), sizeof(int32_t));
-        buf.append(std::move(*v.val));
+        buf.append(std::move(v.val));
     }
     return buf;
 }
@@ -88,7 +88,7 @@ iobuf encode_plain(chunked_vector<byte_array_value> vals) {
 iobuf encode_plain(chunked_vector<fixed_byte_array_value> vals) {
     iobuf buf;
     for (auto& v : vals) {
-        buf.append(std::move(*v.val));
+        buf.append(std::move(v.val));
     }
     return buf;
 }
@@ -161,8 +161,6 @@ iobuf encode_for_stats(int32_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(int64_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(float32_value v) { return encode_plain({v}); }
 iobuf encode_for_stats(float64_value v) { return encode_plain({v}); }
-iobuf encode_for_stats(const byte_array_value& v) { return v.val->copy(); }
-iobuf encode_for_stats(const fixed_byte_array_value& v) {
-    return v.val->copy();
-}
+iobuf encode_for_stats(const byte_array_value& v) { return v.val.copy(); }
+iobuf encode_for_stats(const fixed_byte_array_value& v) { return v.val.copy(); }
 } // namespace serde::parquet

--- a/src/v/serde/parquet/tests/column_stats_collector_test.cc
+++ b/src/v/serde/parquet/tests/column_stats_collector_test.cc
@@ -67,10 +67,10 @@ TEST(ColumnStatsCollector, FloatingPoint) {
 
 TEST(ColumnStatsCollector, Binary) {
     column_stats_collector<byte_array_value, ordering::byte_array> collector;
-    auto empty = byte_array_value{std::make_unique<iobuf>(iobuf::from(""))};
-    auto bat = byte_array_value{std::make_unique<iobuf>(iobuf::from("bat"))};
-    auto cat = byte_array_value{std::make_unique<iobuf>(iobuf::from("cat"))};
-    auto zzzz = byte_array_value{std::make_unique<iobuf>(iobuf::from("zzzz"))};
+    auto empty = byte_array_value{iobuf::from("")};
+    auto bat = byte_array_value{iobuf::from("bat")};
+    auto cat = byte_array_value{iobuf::from("cat")};
+    auto zzzz = byte_array_value{iobuf::from("zzzz")};
     collector.record_value(bat);
     EXPECT_THAT(collector.min(), Optional(std::ref(bat)));
     EXPECT_THAT(collector.max(), Optional(std::ref(bat)));
@@ -86,14 +86,13 @@ TEST(ColumnStatsCollector, Binary) {
 TEST(ColumnStatsCollector, Decimal128) {
     column_stats_collector<fixed_byte_array_value, ordering::int128_be>
       collector;
-    auto negative_five = fixed_byte_array_value{
-      std::make_unique<iobuf>(iobuf::from(
-        {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE",
-         16}))};
-    auto one = fixed_byte_array_value{std::make_unique<iobuf>(
-      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", 16}))};
-    auto fourty_two = fixed_byte_array_value{std::make_unique<iobuf>(
-      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2A", 16}))};
+    auto negative_five = fixed_byte_array_value{iobuf::from(
+      {"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE",
+       16})};
+    auto one = fixed_byte_array_value{
+      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", 16})};
+    auto fourty_two = fixed_byte_array_value{
+      iobuf::from({"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x2A", 16})};
     collector.record_value(one);
     EXPECT_THAT(collector.min(), Optional(std::ref(one)));
     EXPECT_THAT(collector.max(), Optional(std::ref(one)));

--- a/src/v/serde/parquet/tests/encoding_test.cc
+++ b/src/v/serde/parquet/tests/encoding_test.cc
@@ -146,7 +146,7 @@ template<typename T>
 chunked_vector<T> buffers(std::initializer_list<iobuf> buffers) {
     chunked_vector<T> v;
     for (auto& b : buffers) {
-        v.push_back(T{std::make_unique<iobuf>(b.copy())});
+        v.push_back(T{b.copy()});
     }
     return v;
 }

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -16,6 +16,7 @@
 #include "json/iobuf_writer.h"
 #include "random/generators.h"
 #include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
 #include "serde/parquet/writer.h"
 #include "utils/base64.h"
 
@@ -30,10 +31,6 @@ using json_writer = json::iobuf_writer<json::chunked_buffer>;
 
 namespace serde::parquet {
 namespace {
-
-byte_array_value make_binary_value(std::string_view b) {
-    return {std::make_unique<iobuf>(iobuf::from(b))};
-}
 
 void json(json_writer& w, const schema_element& schema, const value& v) {
     ss::visit(
@@ -52,9 +49,9 @@ void json(json_writer& w, const schema_element& schema, const value& v) {
           auto str = fmt::format("{:.8f}", v.val);
           w.RawValue(str.data(), str.size(), rapidjson::kNumberType);
       },
-      [&w](const byte_array_value& v) { w.String(iobuf_to_base64(*v.val)); },
+      [&w](const byte_array_value& v) { w.String(iobuf_to_base64(v.val)); },
       [&w](const fixed_byte_array_value& v) {
-          w.String(iobuf_to_base64(*v.val));
+          w.String(iobuf_to_base64(v.val));
       },
       [&w, &schema](const group_value& v) {
           w.StartObject();
@@ -186,27 +183,27 @@ std::vector<value> dremel_paper_values() {
             /*Language*/
             record(
               /*Code*/
-              make_binary_value("en-us"),
+              byte_array_value(iobuf::from("en-us")),
               /*Country*/
-              make_binary_value("us")),
+              byte_array_value(iobuf::from("us"))),
             /*Language*/
-            record(make_binary_value("en"), null_value())),
+            record(byte_array_value(iobuf::from("en")), null_value())),
           /*Url*/
-          make_binary_value("http://A")),
+          byte_array_value(iobuf::from("http://A"))),
         /*Name*/
         record(
           list(),
           /*Url*/
-          make_binary_value("http://B")),
+          byte_array_value(iobuf::from("http://B"))),
         /*Name*/
         record(
           list(
             /*Language*/
             record(
               /*Code*/
-              make_binary_value("en-gb"),
+              byte_array_value(iobuf::from("en-gb")),
               /*Country*/
-              make_binary_value("gb"))),
+              byte_array_value(iobuf::from("gb")))),
           /*Url*/
           null_value()))));
     values.emplace_back(record(
@@ -220,7 +217,7 @@ std::vector<value> dremel_paper_values() {
         /*Language*/
         repeated_value(),
         /*Url*/
-        make_binary_value("http://C")))));
+        byte_array_value(iobuf::from("http://C"))))));
     return values;
 }
 
@@ -282,12 +279,12 @@ value generate_required(const schema_element& root) {
       },
       [](const byte_array_type& t) -> value {
           if (t.fixed_length) {
-              return fixed_byte_array_value{std::make_unique<iobuf>(iobuf::from(
-                random_generators::gen_alphanum_string(*t.fixed_length)))};
+              return fixed_byte_array_value{iobuf::from(
+                random_generators::gen_alphanum_string(*t.fixed_length))};
           }
           auto size = random_generators::get_int<size_t>(64);
-          return byte_array_value{std::make_unique<iobuf>(
-            iobuf::from(random_generators::gen_alphanum_string(size)))};
+          return byte_array_value{
+            iobuf::from(random_generators::gen_alphanum_string(size))};
       });
 }
 

--- a/src/v/serde/parquet/tests/shredder_test.cc
+++ b/src/v/serde/parquet/tests/shredder_test.cc
@@ -20,11 +20,6 @@
 
 namespace serde::parquet {
 namespace {
-
-byte_array_value make_binary_value(std::string_view b) {
-    return {std::make_unique<iobuf>(iobuf::from(b))};
-}
-
 template<typename... Args>
 schema_element
 group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
@@ -166,27 +161,27 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
             /*Language*/
             record(
               /*Code*/
-              make_binary_value("en-us"),
+              byte_array_value(iobuf::from("en-us")),
               /*Country*/
-              make_binary_value("us")),
+              byte_array_value(iobuf::from("us"))),
             /*Language*/
-            record(make_binary_value("en"), null_value())),
+            record(byte_array_value(iobuf::from("en")), null_value())),
           /*Url*/
-          make_binary_value("http://A")),
+          byte_array_value(iobuf::from("http://A"))),
         /*Name*/
         record(
           list(),
           /*Url*/
-          make_binary_value("http://B")),
+          byte_array_value(iobuf::from("http://B"))),
         /*Name*/
         record(
           list(
             /*Language*/
             record(
               /*Code*/
-              make_binary_value("en-gb"),
+              byte_array_value(iobuf::from("en-gb")),
               /*Country*/
-              make_binary_value("gb"))),
+              byte_array_value(iobuf::from("gb")))),
           /*Url*/
           null_value())));
     group_value r2 = record(
@@ -200,7 +195,7 @@ TEST(RecordShredding, ExampleFromDremelPaper) {
         /*Language*/
         repeated_value(),
         /*Url*/
-        make_binary_value("http://C"))));
+        byte_array_value(iobuf::from("http://C")))));
     index_schema(document_schema);
     value_collector collector(document_schema);
     shred_record(document_schema, std::move(r1), collector).get();
@@ -246,7 +241,9 @@ TEST(RecordShredding, ListOfStrings) {
       field_repetition_type::required,
       leaf_node("list", field_repetition_type::repeated, byte_array_type{}));
     group_value r = record(list(
-      make_binary_value("a"), make_binary_value("b"), make_binary_value("c")));
+      byte_array_value(iobuf::from("a")),
+      byte_array_value(iobuf::from("b")),
+      byte_array_value(iobuf::from("c"))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -267,8 +264,12 @@ TEST(RecordShredding, LogicalMap) {
         leaf_node(
           "value", field_repetition_type::optional, byte_array_type())));
     group_value r = record(list(
-      record(make_binary_value("AL"), make_binary_value("Alabama")),
-      record(make_binary_value("AK"), make_binary_value("Alaska"))));
+      record(
+        byte_array_value(iobuf::from("AL")),
+        byte_array_value(iobuf::from("Alabama"))),
+      record(
+        byte_array_value(iobuf::from("AK")),
+        byte_array_value(iobuf::from("Alaska")))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r), collector).get();
@@ -320,17 +321,19 @@ TEST(RecordShredding, RepetitionLevels) {
           "level2", field_repetition_type::repeated, byte_array_type())));
     group_value r1 = record(list(
       record(list(
-        make_binary_value("a"),
-        make_binary_value("b"),
-        make_binary_value("c"))),
+        byte_array_value(iobuf::from("a")),
+        byte_array_value(iobuf::from("b")),
+        byte_array_value(iobuf::from("c")))),
       record(list(
-        make_binary_value("d"),
-        make_binary_value("e"),
-        make_binary_value("f"),
-        make_binary_value("g")))));
+        byte_array_value(iobuf::from("d")),
+        byte_array_value(iobuf::from("e")),
+        byte_array_value(iobuf::from("f")),
+        byte_array_value(iobuf::from("g"))))));
     group_value r2 = record(list(
-      record(list(make_binary_value("h"))),
-      record(list(make_binary_value("i"), make_binary_value("j")))));
+      record(list(byte_array_value(iobuf::from("h")))),
+      record(list(
+        byte_array_value(iobuf::from("i")),
+        byte_array_value(iobuf::from("j"))))));
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();
@@ -378,15 +381,17 @@ TEST(RecordShredding, AddressBookExample) {
           byte_array_type(),
           string_type())));
     group_value r1 = record(
-      make_binary_value("Julien Le Dem"),
+      byte_array_value(iobuf::from("Julien Le Dem")),
       list(
-        make_binary_value("555 123 4567"), make_binary_value("555 666 1337")),
+        byte_array_value(iobuf::from("555 123 4567")),
+        byte_array_value(iobuf::from("555 666 1337"))),
       list(
         record(
-          make_binary_value("Dmitriy Ryaboy"),
-          make_binary_value("555 987 6543")),
-        record(make_binary_value("Chris Anizczyk"), null_value())));
-    group_value r2 = record(make_binary_value("A. Nonymous"), list(), list());
+          byte_array_value(iobuf::from("Dmitriy Ryaboy")),
+          byte_array_value(iobuf::from("555 987 6543"))),
+        record(byte_array_value(iobuf::from("Chris Anizczyk")), null_value())));
+    group_value r2 = record(
+      byte_array_value(iobuf::from("A. Nonymous")), list(), list());
     index_schema(schema);
     value_collector collector(schema);
     shred_record(schema, std::move(r1), collector).get();

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -21,12 +21,10 @@ value copy(const value& val) {
     return ss::visit(
       val,
       [](const byte_array_value& v) {
-          return value(
-            byte_array_value(std::make_unique<iobuf>(v.val->copy())));
+          return value(byte_array_value(v.val.copy()));
       },
       [](const fixed_byte_array_value& v) {
-          return value(
-            fixed_byte_array_value(std::make_unique<iobuf>(v.val->copy())));
+          return value(fixed_byte_array_value(v.val.copy()));
       },
       [](const group_value& v) {
           group_value clone;
@@ -73,7 +71,7 @@ auto fmt::formatter<serde::parquet::value>::format(
       },
       [&ctx](const byte_array_value& v) {
           auto out = ctx.out();
-          for (const auto& e : *v.val) {
+          for (const auto& e : v.val) {
               std::string_view s{e.get(), e.size()};
               out = fmt::format_to(out, "{}", absl::CEscape(s));
           }
@@ -81,7 +79,7 @@ auto fmt::formatter<serde::parquet::value>::format(
       },
       [&ctx](const fixed_byte_array_value& v) {
           auto out = ctx.out();
-          for (const auto& e : *v.val) {
+          for (const auto& e : v.val) {
               std::string_view s{e.get(), e.size()};
               out = fmt::format_to(out, "{}", absl::CEscape(s));
           }

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -15,7 +15,6 @@
 #include "container/fragmented_vector.h"
 
 #include <cstdint>
-#include <memory>
 #include <unistd.h>
 
 // A subset of parquet values that is needed for iceberg.
@@ -51,18 +50,14 @@ struct float64_value {
     bool operator==(const float64_value&) const = default;
 };
 struct byte_array_value {
-    std::unique_ptr<iobuf> val;
+    iobuf val;
 
-    bool operator==(const byte_array_value& other) const {
-        return *val == *other.val;
-    };
+    bool operator==(const byte_array_value&) const = default;
 };
 struct fixed_byte_array_value {
-    std::unique_ptr<iobuf> val;
+    iobuf val;
 
-    bool operator==(const fixed_byte_array_value& other) const {
-        return *val == *other.val;
-    };
+    bool operator==(const fixed_byte_array_value&) const = default;
 };
 
 struct repeated_element;

--- a/src/v/utils/tests/delta_for_bench.cc
+++ b/src/v/utils/tests/delta_for_bench.cc
@@ -14,7 +14,7 @@
 
 #include <seastar/testing/perf_tests.hh>
 
-#include <ranges>
+#include <map>
 #include <vector>
 
 using namespace cloud_storage;


### PR DESCRIPTION
A number of issues have cropped up in microbenchmark reports due to how expensive it is to move an iobuf. This has occurred at least three times to my knowledge:

* https://github.com/redpanda-data/redpanda/pull/25049
* https://github.com/redpanda-data/redpanda/pull/24794
* https://github.com/redpanda-data/redpanda/pull/24771

Let's fix the underlying problem and remove the usage of boost::intrusive_list from iobuf. The new handrolled implementation improves performance of the iceberg translation path by ~60% in one microbenchmark (with 35% less instructions). This benchmark heavily uses `iobuf` (being all the messages are smallish strings that get moved around a bunch).


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
