### PR TITLE
crash_tracker: add shared object name to stacktrace

### DIFF
--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -105,20 +105,30 @@ namespace {
 
 void record_backtrace(crash_description& cd) {
     size_t pos = 0;
-    ss::backtrace([&cd, &pos](ss::frame f) {
+    auto printer = [&pos, &cd](auto fmt, auto&&... args) {
         if (pos >= cd.stacktrace.capacity()) {
             return; // Prevent buffer overflow
         }
 
-        const bool first = pos == 0;
         auto result = fmt::format_to_n(
           cd.stacktrace.begin() + pos,
           cd.stacktrace.capacity() - pos,
-          "{}{:#x}",
-          first ? "" : " ",
-          f.addr);
+          fmt,
+          std::forward<decltype(args)...>(args)...);
+        pos = std::min(pos + result.size, cd.stacktrace.capacity());
+    };
 
-        pos += result.size;
+    ss::backtrace([&pos, &printer](ss::frame f) {
+        const bool first = pos == 0;
+        if (!first) {
+            printer(FMT_STRING(" "), " ");
+        }
+
+        if (!f.so->name.empty()) {
+            printer(FMT_STRING("{}+"), f.so->name.c_str());
+        }
+
+        printer(FMT_STRING("{:#x}"), f.addr);
     });
 }
 

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -238,7 +238,12 @@ recorder::get_recorded_crashes(
               std::move(buf));
             result.emplace_back(
               entry.path(), std::move(crash_desc), entry.last_write_time());
-        } catch (const serde::serde_exception&) {
+        } catch (const serde::serde_exception& e) {
+            vlog(
+              ctlog.debug,
+              "Exception while deserializing a crash report file {}: {}",
+              entry.path(),
+              e);
             if (incl_malformed) {
                 result.emplace_back(
                   entry.path(), std::nullopt, entry.last_write_time());

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -32,6 +32,20 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "types_test",
+    timeout = "short",
+    srcs = [
+        "types_test.cc",
+    ],
+    deps = [
+        "//src/v/crash_tracker",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_binary(
     name = "crash_report_generator",
     testonly = True,

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -18,6 +18,16 @@ rp_test(
   ARGS "-- -c 1"
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME crash_recorder_types_test
+  SOURCES
+    types_test.cc
+  LIBRARIES v::gtest_main v::crash_tracker
+  ARGS "-- -c 1"
+)
+
 add_executable(crash_report_generator report_generator.cc)
 set_property(TARGET crash_report_generator PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(crash_report_generator PUBLIC v::crash_tracker)

--- a/src/v/crash_tracker/tests/types_test.cc
+++ b/src/v/crash_tracker/tests/types_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "crash_tracker/types.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace crash_tracker {
+
+class TestReservedStringSerde : public testing::Test {};
+
+auto run_test_case(std::string_view print_str, std::string_view limited_str) {
+    // Write print_str into the reserved_string, it may be more or less than the
+    // capacity of the reserved_string, so limited_str is what fits into the
+    // reserved_string
+    auto rs_in = reserved_string<5>{};
+    auto res = fmt::format_to_n(
+      rs_in.begin(), rs_in.capacity(), "{}", print_str);
+    ASSERT_EQ(res.size, print_str.size());
+    ASSERT_EQ(rs_in.c_str(), limited_str);
+
+    // Round trip serde (expect no exception)
+    iobuf buf;
+    serde::write(buf, std::move(rs_in));
+    auto parser = iobuf_parser{std::move(buf)};
+    auto rs_out = serde::read<decltype(rs_in)>(parser);
+
+    // Assert that the result is the same as rs_in was
+    ASSERT_EQ(rs_out.c_str(), limited_str);
+}
+
+TEST_F(TestReservedStringSerde, AtCapacity) {
+    constexpr auto five_char_string = "12345";
+    run_test_case(five_char_string, five_char_string);
+}
+
+TEST_F(TestReservedStringSerde, BelowCapacity) {
+    constexpr auto three_char_string = "123";
+    run_test_case(three_char_string, three_char_string);
+}
+
+TEST_F(TestReservedStringSerde, AboveCapacity) {
+    run_test_case("123456", "12345");
+}
+
+} // namespace crash_tracker

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -89,7 +89,7 @@ void tag_invoke(
     using Type = typename reserved_string<Size>::type;
     const auto size = serde::read_nested<serde::serde_size_t>(
       in, bytes_left_limit);
-    if (unlikely(size >= t.capacity())) {
+    if (unlikely(size > t.capacity())) {
         throw serde::serde_exception(fmt::format(
           "reading reserved_string, size {} exceeds reserved size {}",
           size,

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -90,6 +90,15 @@ class CrashLoopChecksTest(RedpandaTest):
             f"Redpanda processes did not terminate on {broker.name} in {timeout} sec"
         )
 
+    def read_first_crash_report(self):
+        viewer = OfflineLogViewer(self.redpanda)
+        crash_reports = viewer.read_crash_reports(self.broker)
+        self.logger.debug(f'Crash reports: {crash_reports}')
+        assert len(crash_reports) > 0, "No crash reports found"
+        report = next(iter(crash_reports.values()))
+        self.logger.debug(f'First report: {report}')
+        return report
+
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
     def test_crash_loop_checks_with_tracker_file(self):
         broker = self.redpanda.nodes[0]
@@ -196,7 +205,7 @@ class CrashLoopChecksTest(RedpandaTest):
                                              "Too many consecutive crashes")
         assert self.redpanda.search_log_node(
             broker,
-            "Crash #4 at 20.* UTC - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: 0x.*"
+            "Crash #4 at 20.* UTC - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: .*"
         )
         self.expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
 
@@ -211,14 +220,11 @@ class CrashLoopChecksTest(RedpandaTest):
                                  override_cfg_params=invalid_conf,
                                  expect_fail=True)
 
-        viewer = OfflineLogViewer(self.redpanda)
-        crash_reports = viewer.read_crash_reports(broker)
-        self.logger.debug(f'Crash reports: {crash_reports}')
-        assert len(crash_reports) > 0, "No crash reports found"
-        report = next(iter(crash_reports.values()))
-        self.logger.debug(f'First report: {report}')
+        report = self.read_first_crash_report()
         assert 'Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)' == report[
             'crash_message'], f'Unexpected crash message: {report["crash_message"]}'
+        assert len(report['stacktrace']) > 0, \
+            f'Unexpected empty stacktrace for report: {report}'
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + SIGNAL_CRASH_LOG)
     @matrix(signo=[signal.SIGSEGV, signal.SIGABRT, signal.SIGILL],
@@ -276,3 +282,7 @@ class CrashLoopChecksTest(RedpandaTest):
             broker,
             f"Crash #4 at 20.* - {signo_prefix()} on shard {signal_shard}. Backtrace: "
         )
+
+        report = self.read_first_crash_report()
+        assert len(report['stacktrace']) > 0, \
+            f'Unexpected empty stacktrace for report: {report}'


### PR DESCRIPTION
* [crash_tracker: fix reserved_string serde at capacity](https://github.com/redpanda-data/redpanda/commit/1128cdffcf27b5e7c57903504fe4dd9606900bc7) 

Fixes a bug where a full (ie. length() == capacity()) reserved_string
was not handled correctly. It could be serialized correctly but it would
raise a serde exception on deserialization due to an off by one bug.

* [crash_tracker: add shared object name to stacktrace](https://github.com/redpanda-data/redpanda/commit/09778ea809e2c6fa57fdbdb213d7549f6f7b6fe0) 

This adds to the recorded stacktrace the name of the shared object each
frame is in. This matches the output of `ss::current_backtrace()` and is
necessary to be able to decode the stacktrace properly.

Example recorded stacktrace:
```
0x551bab2 0x554a432 /lib/x86_64-linux-gnu/libc.so.6+0x4251f /lib/x86_64-linux-gnu/libc.so.6+0x11e88c 0xab9eb3d 0xab8e66e 0xaaf458d 0xaaf1416 0xa9d99f4 0xa9d78f0 0x3619533 0xb13b019 /lib/x86_64-linux-gnu/libc.so.6+0x29d8f /lib/x86_64-linux-gnu/libc.so.6+0x29e3f 0x3611d64
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
