### PR TITLE
[CORE-9064] `rptest`: add credentials type check in `NessieService`

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -118,10 +118,11 @@ class NessieCatalog(CatalogService):
         Specify them as Java -D properties instead.
         """
         d_flags = ""
-        d_flags += "-Dnessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:my-secrets-default "
-        d_flags += f"-Dmy-secrets-default.name={self.credentials.access_key} "
-        d_flags += f"-Dmy-secrets-default.secret={self.credentials.secret_key} "
-        d_flags += "-Dnessie.catalog.validate-secrets=true"
+        if isinstance(self.credentials, cloud_storage.S3Credentials):
+            d_flags += "-Dnessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:my-secrets-default "
+            d_flags += f"-Dmy-secrets-default.name={self.credentials.access_key} "
+            d_flags += f"-Dmy-secrets-default.secret={self.credentials.secret_key} "
+            d_flags += "-Dnessie.catalog.validate-secrets=true"
         return d_flags
 
     def _java_cmd(self, node):


### PR DESCRIPTION
We were missing a type check in `_make_java_properties()` that would cause CDT to fail for `GCP`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none