### PR TITLE
bazel: use relative paths for debug symbols

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,7 +50,6 @@ build --@seastar//:debug=True
 # =================================
 build:sanitizer --copt -fsanitize=address,undefined,vptr,function
 build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function
-build:sanitizer --linkopt --rtlib=compiler-rt
 build:sanitizer --linkopt -fsanitize-link-c++-runtime
 build:sanitizer --copt -O1
 build:sanitizer --//bazel:has_sanitizers=True

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,11 @@ build --linkopt -stdlib=libc++
 # By default build without CGO
 build --@rules_go//go/config:pure
 
+# Improve caching and readability of filepaths that the compiler uses by not using
+# absolute paths, and instead use paths that are relative to the redpanda repo.
+# https://github.com/bazel-contrib/toolchains_llvm/pull/445#issuecomment-2605443516
+build --copt=-ffile-compilation-dir=. --host_copt=-ffile-compilation-dir=.
+
 common:clang-19 --extra_toolchains=@llvm_19_toolchain//:all
 
 build:system-clang --extra_toolchains=@local_config_cc_toolchains//:all


### PR DESCRIPTION
I've been using this for the past few days and it's been really great, I get paths that are now
something like the following and don't have my home directory in them anymore :tada:

```
#1 0x75f0296aa834 in iceberg::transaction::apply(std::__2::unique_ptr<iceberg::action, std::__2::default_delete<iceberg::action>>) src/v/iceberg/transaction.cc:22:14
```


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
