### PR TITLE
cloud_storage_clients: skip lexical_cast on empty strings

### DIFF
--- a/src/v/cloud_storage_clients/s3_error.cc
+++ b/src/v/cloud_storage_clients/s3_error.cc
@@ -420,7 +420,9 @@ rest_error_response::rest_error_response(
   std::string_view message,
   std::string_view request_id,
   std::string_view resource)
-  : _code(boost::lexical_cast<s3_error_code>(code))
+  : _code(
+      code.empty() ? s3_error_code::_unknown
+                   : boost::lexical_cast<s3_error_code>(code))
   , _code_str(code)
   , _message(message)
   , _request_id(request_id)


### PR DESCRIPTION
`parse_rest_error_response` method tries to read fields from xml response and constructs `rest_error_response`. If a field is not found or is empty then it defaults to empty string.

https://github.com/redpanda-data/redpanda/blob/d3c2f00c4071c2cbce1e1babdfc2291e3c9898ba/src/v/cloud_storage_clients/s3_client.cc#L411

Google Cloud Storage gives one of these replies which we parse but the Error.Code path is not present in the response and we trip with a bad lexical cast which results in an error log line.

With this commit we'll default to unknown error code in that case. We already do the same for codes we don't recognize in the operator>>. lexical_cast does not call the operator>> at all for empty strings.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
