### PR TITLE
[v24.2.x] [UX-78] rpk: fix incorrect parsing of ipv6 addresses #25029

### DIFF
--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1204,3 +1204,162 @@ func TestXSetDefaultsPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestConfig_fixSchemePorts(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		expect Config
+		errMsg string
+	}{
+		{
+			name: "fix missing ports in redpanda.yaml addresses",
+			config: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"broker1", "broker2:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"address1", "address2:2222"},
+						},
+					},
+				},
+			},
+			expect: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"broker1:9092", "broker2:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"address1:9644", "address2:2222"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fix missing ports in profile brokers",
+			config: Config{
+				rpkYaml: RpkYaml{
+					CurrentProfile: "default",
+					Profiles: []RpkProfile{
+						{
+							Name: "default",
+							KafkaAPI: RpkKafkaAPI{
+								Brokers: []string{"profile-broker1", "profile-broker2:9094"},
+							},
+							AdminAPI: RpkAdminAPI{
+								Addresses: []string{"address1", "address2:2222"},
+							},
+							SR: RpkSchemaRegistryAPI{
+								Addresses: []string{"address1", "address2", "address3:8088"},
+							},
+						},
+					},
+				},
+			},
+			expect: Config{
+				rpkYaml: RpkYaml{
+					CurrentProfile: "default",
+					Profiles: []RpkProfile{
+						{
+							Name: "default",
+							KafkaAPI: RpkKafkaAPI{
+								Brokers: []string{"profile-broker1:9092", "profile-broker2:9094"},
+							},
+							AdminAPI: RpkAdminAPI{
+								Addresses: []string{"address1:9644", "address2:2222"},
+							},
+							SR: RpkSchemaRegistryAPI{
+								Addresses: []string{"address1:8081", "address2:8081", "address3:8088"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fix missing ports in redpanda.yaml addresses",
+			config: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"broker1", "broker2:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"address1", "address2:2222"},
+						},
+					},
+				},
+			},
+			expect: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"broker1:9092", "broker2:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"address1:9644", "address2:2222"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fix missing ports in redpanda.yaml addresses with IPv6",
+			config: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"[2001:db8::1]", "[2001:db8::2]:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"[2001:db8::3]", "[2001:db8::4]:2222"},
+						},
+					},
+				},
+			},
+			expect: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{"[2001:db8::1]:9092", "[2001:db8::2]:9093"},
+						},
+						AdminAPI: RpkAdminAPI{
+							Addresses: []string{"[2001:db8::3]:9644", "[2001:db8::4]:2222"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid broker address",
+			config: Config{
+				redpandaYaml: RedpandaYaml{
+					Rpk: RpkNodeConfig{
+						KafkaAPI: RpkKafkaAPI{
+							Brokers: []string{":invalid"},
+						},
+					},
+				},
+			},
+			expect: Config{},
+			errMsg: "unable to fix broker address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.fixSchemePorts()
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expect, tt.config)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes a bug where we were adding double
brackets to IPV6 addresses.

Fixes #23363
Fixes #25028 
(cherry picked from commit 3607a3b9f2358b9542428d6451f711cdc14ac94a)

Manually edited as the RpkNodeConfig does not
have the SR struct in older versions.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* rpk: fixes a bug where rpk incorrectly handles IPv6 by adding extra brackets.
