### PR TITLE
Fix iceberg data migration test timeout

### DIFF
--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -92,6 +92,7 @@ class DatalakeVerifier():
         self._offline_mode_established = False
         self._consumer_positions = None  # set iff in offline mode
         self._partition_hwms = None  # set iff in offline mode
+        self._consumer_lock = threading.Lock()
 
         self._compacted = compacted
         # When consuming from a compacted topic, there may be records in the
@@ -116,25 +117,27 @@ class DatalakeVerifier():
         return c
 
     def update_and_get_fetch_positions(self):
-        if self._offline_mode_established:
-            assert self._consumer_positions is not None
-            return self._consumer_positions
+        with self._consumer_lock:
+            if self._offline_mode_established:
+                assert self._consumer_positions is not None
+                return self._consumer_positions
 
-        with self._lock:
-            partitions = [
-                TopicPartition(topic=self.topic, partition=p)
-                for p in self._consumed_messages.keys()
-            ]
-            positions = self._consumer.position(partitions)
-            for p in positions:
-                if p.error is not None:
-                    self.logger.warning(
-                        f"Error querying position for partition {p.partition}")
-                else:
-                    self.logger.debug(
-                        f"next position for {p.partition} is {p.offset}")
-                    self._next_positions[p.partition] = p.offset
-            return self._next_positions.copy()
+            with self._lock:
+                partitions = [
+                    TopicPartition(topic=self.topic, partition=p)
+                    for p in self._consumed_messages.keys()
+                ]
+                positions = self._consumer.position(partitions)
+                for p in positions:
+                    if p.error is not None:
+                        self.logger.warning(
+                            f"Error querying position for partition {p.partition}"
+                        )
+                    else:
+                        self.logger.debug(
+                            f"next position for {p.partition} is {p.offset}")
+                        self._next_positions[p.partition] = p.offset
+                return self._next_positions.copy()
 
     def partition_hwms(self) -> List[RpkPartition]:
         if self._offline_mode_established:
@@ -143,24 +146,45 @@ class DatalakeVerifier():
         return list(self._rpk.describe_topic(self.topic))
 
     # to be called no more than once
-    def go_offline(self):
+    def go_offline(self, timeout=60):
         assert not self._offline_mode_requested.is_set()
+        self.logger.debug(f"offline mode requested")
         self._offline_mode_requested.set()
-        self._consumer_stopped.wait()
-        # todo: send consumer thread stop, remember positions when it stopped
+        assert self._consumer_stopped.wait(timeout)
+        self.logger.debug(f"consistent state reached")
         self._consumer_positions = self.update_and_get_fetch_positions()
         self.logger.debug(f"remembered {self._consumer_positions=}")
         self._partition_hwms = self.partition_hwms()
-        self.logger.debug(f"remembered {self._partition_hwms=}")
-        self._consumer.close()
-        self._consumer = None
-        self._offline_mode_established = True
+        for p in self._partition_hwms:
+            self.logger.debug(
+                f"remembered partition {p.id=} hwm={p.high_watermark}, ")
+        with self._consumer_lock:
+            self._consumer.close()
+            self._consumer = None
+            self.logger.debug(f"offline mode established")
+            self._offline_mode_established = True
+
+    def _consumed_till_hwm(self, update: bool):
+        self.logger.debug("checking _consumed_till_hwm")
+        if update:
+            # reduce _lock contention
+            if not self._consumed_till_hwm(False):
+                return False
+            self.update_and_get_fetch_positions()
+        for p in self.partition_hwms():
+            if self._next_positions[p.id] < p.high_watermark:
+                self.logger.debug(
+                    f"partition {p.id} high watermark: {p.high_watermark} max offset: {self._next_positions[p.id]} has not been consumed fully"
+                )
+                return False
+        return True
 
     def _consumer_thread(self):
         try:
             self.logger.info("Starting consumer thread")
-            while not self._stop.is_set() \
-              and not self._offline_mode_requested.is_set():
+            while not self._stop.is_set() and not (
+                    self._offline_mode_requested.is_set()
+                    and self._consumed_till_hwm(update=True)):
                 self._msg_semaphore.acquire()
                 if self._stop.is_set():
                     break
@@ -295,16 +319,12 @@ class DatalakeVerifier():
     def _all_offsets_translated(self):
         partition_hwms = self.partition_hwms()
         with self._lock:
+            if not self._consumed_till_hwm(update=False):
+                return False
             for p in partition_hwms:
                 if p.id not in self._max_queried_offsets:
                     self.logger.debug(
                         f"partition {p.id} not found in max offsets: {self._max_queried_offsets}"
-                    )
-                    return False
-
-                if self._next_positions[p.id] < p.high_watermark:
-                    self.logger.debug(
-                        f"partition {p.id} high watermark: {p.high_watermark} max offset: {self._next_positions[p.id]} has not been consumed fully"
                     )
                     return False
                 # Ensure all the consumed messages are drained.
@@ -348,6 +368,7 @@ class DatalakeVerifier():
             self.stop()
 
     def stop(self):
+        self.logger.debug("stopping")
         try:
             self._stop.set()
             self._msg_semaphore.release()

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -343,6 +343,7 @@ class DatalakeVerifier():
             self.logger.debug(f"No errors around waiting")
         except Exception as e:
             self.logger.error(f"Error around waiting: {e}")
+            raise
         finally:
             self.stop()
 

--- a/tests/rptest/tests/datalake/datalake_verifier.py
+++ b/tests/rptest/tests/datalake/datalake_verifier.py
@@ -47,7 +47,8 @@ class DatalakeVerifier():
                  topic: str,
                  query_engine: QueryEngineBase,
                  compacted: bool = False,
-                 table_override: Optional[str] = None):
+                 table_override: Optional[str] = None,
+                 max_buffered_msgs=5000):
         self.redpanda = redpanda
         self.topic = topic
         self.table = table_override or topic
@@ -70,7 +71,7 @@ class DatalakeVerifier():
         self._lock = threading.Lock()
         self._stop = threading.Event()
         # number of messages buffered in memory
-        self._msg_semaphore = threading.Semaphore(5000)
+        self._msg_semaphore = threading.Semaphore(max_buffered_msgs)
         self._num_msgs_pending_verification = 0
         # Signalled when enough messages are batched so query
         # thread can perform verification. Larger batches results

--- a/tests/rptest/tests/datalake/mount_unmount_test.py
+++ b/tests/rptest/tests/datalake/mount_unmount_test.py
@@ -31,6 +31,12 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
     FAST_COMMIT_INTVL_S = 5
     SLOW_COMMIT_INTVL_S = 60
 
+    # Produce for as long as unmount takes until partitions get writes blocked.
+    # It may take a couple of minutes, so we limit messages count to avoid
+    # congestion in the verifier.
+    VERY_MANY_MESSAGES = 1000000
+    LOW_PRODUCTION_INTERVAL_MS = 1
+
     verifier_schema_avro = """
 {
     "type": "record",
@@ -73,14 +79,14 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
             redpanda=self.redpanda,
             include_query_engines=[QueryEngineType.SPARK])
 
-    def avro_stream_config(self, topic, subject, cnt=3000):
+    def avro_stream_config(self, topic, subject, cnt=3000, interval_ms=None):
         mapping = dict(
             ordinal="this",
             timestamp="timestamp_unix_milli()",
             verifier_string="uuid_v4()",
         )
         return counter_stream_config(self.redpanda, topic, subject, mapping,
-                                     cnt)
+                                     cnt, interval_ms)
 
     def setUp(self):
         self.dl.setUp()
@@ -102,12 +108,16 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
             config={"redpanda.iceberg.delete": "false"})
         connect = RedpandaConnectService(self.test_context, self.redpanda)
         connect.start()
-        verifier = DatalakeVerifier(self.redpanda, self.TOPIC_NAME,
-                                    self.dl.spark())
+        verifier = DatalakeVerifier(self.redpanda,
+                                    self.TOPIC_NAME,
+                                    self.dl.spark(),
+                                    max_buffered_msgs=50000)
 
         connect.start_stream(name="ducky_stream",
                              config=self.avro_stream_config(
-                                 self.TOPIC_NAME, "verifier_schema", 1000000))
+                                 self.TOPIC_NAME, "verifier_schema",
+                                 self.VERY_MANY_MESSAGES,
+                                 self.LOW_PRODUCTION_INTERVAL_MS))
         # todo make reasonable or just make sure something went through
         self.redpanda.set_cluster_config({
             "iceberg_catalog_commit_interval_ms":
@@ -127,8 +137,10 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
         # the topic goes read-only during this wait
         self.wait_for_migration_states(out_migration_id, ['executed'])
         connect.stop_stream("ducky_stream", should_finish=False)
-        time.sleep(1)  # just it case: let verifier consume remaining messages
-        verifier.go_offline()
+        # go_offline waits for consuming till migration blocking offset,
+        # consume thread waits for query thread as comparison buffer size is
+        # limited, and querying may lag due to translation lag
+        verifier.go_offline(600)
 
         self.admin.execute_data_migration_action(out_migration_id,
                                                  MigrationAction.finish)
@@ -147,15 +159,19 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
             iceberg_mode="value_schema_id_prefix")
         connect = RedpandaConnectService(self.test_context, self.redpanda)
         connect.start()
-        verifier = DatalakeVerifier(self.redpanda, self.TOPIC_NAME,
-                                    self.dl.spark())
+        verifier = DatalakeVerifier(self.redpanda,
+                                    self.TOPIC_NAME,
+                                    self.dl.spark(),
+                                    max_buffered_msgs=50000)
         self.redpanda.set_cluster_config({
             "iceberg_catalog_commit_interval_ms":
             self.SLOW_COMMIT_INTVL_S * 1000
         })
         connect.start_stream(name="ducky_stream",
                              config=self.avro_stream_config(
-                                 self.TOPIC_NAME, "verifier_schema", 100000))
+                                 self.TOPIC_NAME, "verifier_schema",
+                                 self.VERY_MANY_MESSAGES,
+                                 self.LOW_PRODUCTION_INTERVAL_MS))
         self.admin = Admin(self.redpanda)
         ns_topic = NamespacedTopic(self.TOPIC_NAME)
         self.logger.info(f"unmounting {self.TOPIC_NAME}")

--- a/tests/rptest/tests/datalake/mount_unmount_test.py
+++ b/tests/rptest/tests/datalake/mount_unmount_test.py
@@ -23,6 +23,7 @@ from ducktape.mark import matrix
 from rptest.services.admin import Admin, NamespacedTopic, InboundTopic, OutboundDataMigration, MigrationAction
 from rptest.clients.types import TopicSpec
 from rptest.utils.data_migrations import DataMigrationTestMixin
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
@@ -99,6 +100,7 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types())
+    @skip_debug_mode
     def test_simple_unmount(self, cloud_storage_type):
         self.dl.create_iceberg_enabled_topic(
             self.TOPIC_NAME,
@@ -151,6 +153,7 @@ class MountUnmountIcebergTest(RedpandaTest, DataMigrationTestMixin):
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types())
+    @skip_debug_mode
     def test_simple_remount(self, cloud_storage_type):
         self.dl.create_iceberg_enabled_topic(
             self.TOPIC_NAME,

--- a/tests/rptest/utils/rpcn_utils.py
+++ b/tests/rptest/utils/rpcn_utils.py
@@ -13,7 +13,8 @@ def counter_stream_config(redpanda: RedpandaService,
                           topic: str,
                           subject: str,
                           field_to_bloblang: dict[str, str] = {},
-                          cnt: int = 3000) -> dict:
+                          cnt: int = 3000,
+                          interval_ms: int | None = None) -> dict:
     """
     Creates a RPCN config where the input is a simple counter, and fields are
     mapped via the input mapping of bloblang functions.
@@ -39,7 +40,7 @@ def counter_stream_config(redpanda: RedpandaService,
         "input": {
             "generate": {
                 "mapping": "root = counter()",
-                "interval": "",
+                "interval": "" if interval_ms is None else f"{interval_ms}ms",
                 "count": cnt,
                 "batch_size": 1
             }


### PR DESCRIPTION
The test is broken: it swallows errors, timeout ones in particular.
Make it propagate errors. To avoid timeouts:
- make sure verifier offline mode only waits for consumption not for anything in the querying thread
- reduce production rate
- allow more time to complete

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
