### PR TITLE
iceberg: serialize snapshot removals individually

### DIFF
--- a/src/v/iceberg/remove_snapshots_action.cc
+++ b/src/v/iceberg/remove_snapshots_action.cc
@@ -297,9 +297,12 @@ ss::future<action::action_outcome> remove_snapshots_action::build_updates() && {
         co_return ret;
     }
 
-    if (!snaps_to_remove.empty()) {
-        ret.updates.emplace_back(
-          table_update::remove_snapshots{std::move(snaps_to_remove)});
+    // NOTE: the Java implementation only allows a single snapshot per update,
+    // despite the spec allowing multiple. To be maximally supportive of the
+    // ecosystem, we will serialize one snapshot per update.
+    // https://github.com/apache/iceberg/blob/3e6da2e5437ffb3f643275927e5580cb9620256b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java#L550-L553
+    for (auto& s : snaps_to_remove) {
+        ret.updates.emplace_back(table_update::remove_snapshots{{s}});
     }
     for (auto& r : refs_to_remove) {
         ret.updates.emplace_back(

--- a/src/v/iceberg/tests/remove_snapshots_action_test.cc
+++ b/src/v/iceberg/tests/remove_snapshots_action_test.cc
@@ -81,6 +81,31 @@ add_tag(snapshot_id id, const ss::sstring& tag_name, table_metadata* table) {
     return table->refs->at(tag_name);
 }
 
+// Examines the updates from the transaction and checks that they match the
+// expected counts, also ensuring that snapshot removals are stored
+// individually, to match the expectations from Java implementations.
+// https://github.com/apache/iceberg/blob/3e6da2e5437ffb3f643275927e5580cb9620256b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java#L550-L553
+void check_expected_updates(
+  const transaction& txn,
+  size_t expected_snap_removals,
+  size_t expected_ref_removals) {
+    size_t snapshot_removals = 0;
+    size_t ref_removals = 0;
+    for (const auto& u : txn.updates().updates) {
+        if (std::holds_alternative<remove_snapshots>(u)) {
+            auto& r = std::get<remove_snapshots>(u);
+            EXPECT_EQ(1, r.snapshot_ids.size());
+            snapshot_removals++;
+        } else if (std::holds_alternative<remove_snapshot_ref>(u)) {
+            ref_removals++;
+        } else {
+            FAIL() << "Unexpected update: " << u.index();
+        }
+    }
+    EXPECT_EQ(expected_snap_removals, snapshot_removals);
+    EXPECT_EQ(ref_removals, expected_ref_removals);
+}
+
 static constexpr size_t default_total_snaps = 100;
 
 } // namespace
@@ -395,6 +420,10 @@ TEST_F(RemoveSnapshotsActionTest, TestRemoveSnapshotTransaction) {
     transaction txn(std::move(table));
     auto tx_outcome = txn.remove_expired_snapshots(now).get();
     ASSERT_FALSE(tx_outcome.has_error());
+
+    // Removed snapshots should be returned as individual updates.
+    ASSERT_NO_FATAL_FAILURE(
+      check_expected_updates(txn, default_total_snaps - 1, 0));
     ASSERT_EQ(
       txn.table().snapshots->size(),
       remove_snapshots_action::default_min_snapshots_retained);
@@ -417,6 +446,8 @@ TEST_F(RemoveSnapshotsActionTest, TestRemoveSnapshotReferenceTransaction) {
     transaction txn(std::move(table));
     auto tx_outcome = txn.remove_expired_snapshots(now).get();
     ASSERT_FALSE(tx_outcome.has_error());
+
+    ASSERT_NO_FATAL_FAILURE(check_expected_updates(txn, 1, 1));
     ASSERT_EQ(txn.table().snapshots->size(), 0);
     ASSERT_EQ(txn.table().refs->size(), 0);
 }

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -159,12 +159,13 @@ class DatalakeE2ETests(RedpandaTest):
             assert count_after_produce == count, f"{count_after_produce} rows, expected {count}"
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=supported_storage_types())
-    def test_remove_expired_snapshots(self, cloud_storage_type):
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_remove_expired_snapshots(self, cloud_storage_type, catalog_type):
         table_name = f"redpanda.{self.topic_name}"
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              catalog_type=filesystem_catalog_type(),
+                              catalog_type=catalog_type,
                               include_query_engines=[QueryEngineType.SPARK
                                                      ]) as dl:
             dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
@@ -182,8 +183,9 @@ class DatalakeE2ETests(RedpandaTest):
             spark = dl.spark()
 
             def num_snapshots() -> int:
+                # Example: [(2445569139027301708, 1739213500520), (2859411459768103060, 1739213495458), (1069851874616045025, 1739213485410), (5648673429948705023, 1739213475351), (7558202443004267034, 1739213465282)]
                 snapshots_out = spark.run_query_fetch_all(
-                    f"select * from {table_name}.snapshots")
+                    f"call system.ancestors_of('{table_name}')")
                 return len(snapshots_out)
 
             num_snaps = num_snapshots()


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
    The Java implementation expects snapshot removal updates to be
    serialized one at a time[1]. This meant that with Java REST catalogs, we
    could trigger catalog-side errors like:

    2025-02-10T19:09:53.865 WARN  [org.eclipse.jetty.server.HttpChannel] - /v1/namespaces/redpanda/tables/test
    java.lang.IllegalArgumentException: Invalid set of snapshot ids to remove.
    Expected one value but received: [2205058756266803285, 6389287107599228031, 837858603806954013, 8429544376017231169]
        at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)
        at org.apache.iceberg.MetadataUpdateParser.readRemoveSnapshots(MetadataUpdateParser.java:530)
        at org.apache.iceberg.MetadataUpdateParser.fromJson(MetadataUpdateParser.java:300)
        at org.apache.iceberg.rest.requests.UpdateTableRequestParser.lambda$fromJson$2(UpdateTableRequestParser.java:105)
        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
        at org.apache.iceberg.rest.requests.UpdateTableRequestParser.fromJson(UpdateTableRequestParser.java:105)
        at org.apache.iceberg.rest.RESTSerializers$UpdateTableRequestDeserializer.deserialize(RESTSerializers.java:354)
        at org.apache.iceberg.rest.RESTSerializers$UpdateTableRequestDeserializer.deserialize(RESTSerializers.java:349)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4825)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3785)
        at org.apache.iceberg.rest.RESTCatalogServlet$ServletRequestContext.from(RESTCatalogServlet.java:179)
        at org.apache.iceberg.rest.RESTCatalogServlet.doPost(RESTCatalogServlet.java:78)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:554)

    This updates the snapshot removal action to return its removed snapshots
    individually. Note that this doesn't mean there are multiple calls to
    the catalog for removal, only that we serialize multiple lists each with
    a single removal instead of a single list with multiple removals.

    [1] https://github.com/apache/iceberg/blob/3e6da2e5437ffb3f643275927e5580cb9620256b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java#L550-L553
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
