### PR TITLE
kafka-probe: remove latency label on batch_size

### DIFF
--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -40,7 +40,7 @@ public:
             return;
         }
 
-        std::vector<sm::label_instance> labels{
+        std::vector<sm::label_instance> latency_labels{
           sm::label("latency_metric")("microseconds")};
 
         _metrics.add_group(
@@ -49,12 +49,12 @@ public:
             sm::make_histogram(
               "fetch_latency_us",
               sm::description("Fetch Latency"),
-              labels,
+              latency_labels,
               [this] { return _fetch_latency.internal_histogram_logform(); }),
             sm::make_histogram(
               "produce_latency_us",
               sm::description("Produce Latency"),
-              labels,
+              latency_labels,
               [this] { return _produce_latency.internal_histogram_logform(); }),
           },
           {},
@@ -67,7 +67,7 @@ public:
               "batch_size",
               sm::description(
                 "Batch size across all topics measured at the kafka layer."),
-              labels,
+              {},
               [this] { return _batch_size.batch_size_histogram_logform(); }),
           },
           {},


### PR DESCRIPTION
We added a batch_size metric but it has a lantecy_metric label which doesn't make sense for this metric. Remove it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
