### PR TITLE
Fixing check azure instances output parsing

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -110,21 +110,27 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
             '--output', f'jsonpath-as-json="{jsonpath}"'
         ] # yapf: disable
 
-        output = subprocess.check_output(cmd)
-        self.logger.debug(f'nodes: {output}')
-        nodes = json.loads(output)
-        try:
-            nodes = json.loads(nodes)
-        except json.JSONDecodeError as e:
-            self.logger.error(
-                f"Failed to parse kubectl get nodes response: {nodes}")
-            raise ValueError(
-                f"Failed to parse kubectl get nodes response: {e}")
+        output = subprocess.check_output(cmd).decode("utf-8").strip()
 
+        self.logger.debug(f'Azure nodes raw output: {output}')
+
+        # Convert space separated output into a Python list
+        # Example: ["Standard_D2d_v5", "Standard_D2d_v5", "Standard_D2d_v5"]
+        nodes = output.split()
+
+        # Ensure we have nodes to validate
+        if not nodes:
+            self.logger.error(
+                "No nodes found with selector 'redpanda-node=true'")
+            raise ValueError(
+                "No nodes found with selector 'redpanda-node=true'")
+
+        # Validate the number of nodes
         config_nodes_count = self._configProfile['nodes_count']
         actual_nodes_count = len(nodes)
         assert actual_nodes_count == config_nodes_count, f"expected nodes_count: {config_nodes_count}, actual: {actual_nodes_count}"
 
+        # Validate machine type
         config_machine_type = self._configProfile['machine_type']
         actual_machine_type = nodes[0]
         assert actual_machine_type == config_machine_type, f"expected machineType: {config_machine_type}, actual: {actual_machine_type}"


### PR DESCRIPTION
```
kubectl get nodes --selector redpanda-node=true -o jsonpath='{..labels.node\.kubernetes\.io/instance-type}'
```

Doesn't return a valid json format, but returns a space-separated list like so:
```
Standard_D2d_v5 Standard_D2d_v5 Standard_D2d_v5
```

So this PR should fix the error from CI run:
```
TypeError: the JSON object must be str, bytes or bytearray, not list
```

  Fixes #DEVPROD-2618

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
