### PR TITLE
[CORE-8848] `rptest`: adjust compaction settings in `datalake/compaction_test`

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -146,7 +146,9 @@ def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
     for ns in safe_listdir(data_dir):
         if not safe_isdir(ns):
             continue
-        if ns.name in ["cloud_storage_cache", "crash_reports"]:
+        if ns.name in [
+                "cloud_storage_cache", "crash_reports", "datalake_staging"
+        ]:
             continue
         ns_output = {}
         for topic in safe_listdir(ns):

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -69,7 +69,7 @@ class SegmentReader:
 
 def safe_isdir(p: Path) -> bool:
     """
-    It's valid for files to be deleted at any time, 
+    It's valid for files to be deleted at any time,
     in that case that the file is missing, just return
     that it's not a directory
     """
@@ -81,10 +81,13 @@ def safe_isdir(p: Path) -> bool:
 
 def safe_listdir(p: Path) -> list[Path]:
     """
-    It's valid for directories to be deleted at any time, 
+    It's valid for directories to be deleted at any time,
     in that case that the directory is missing, just return
     that there are no files.
     """
+    if not safe_isdir(p):
+        return []
+
     try:
         return [f for f in p.iterdir()]
     except FileNotFoundError:

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -35,7 +35,7 @@ class CompactionGapsTest(RedpandaTest):
                 "iceberg_enabled": "true",
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "datalake_coordinator_snapshot_max_delay_secs": 10,
-                "log_compaction_interval_ms": 2000
+                "log_compaction_interval_ms": 5000
             },
             *args,
             **kwargs)
@@ -61,12 +61,12 @@ class CompactionGapsTest(RedpandaTest):
     def wait_until_segment_count(self, count):
         wait_until(
             lambda: self.partition_segments() == count,
-            timeout_sec=30,
+            timeout_sec=120,
             backoff_sec=3,
             err_msg=f"Timed out waiting for segment count to reach {count}")
 
     def produce_until_segment_count(self, count):
-        timeout_sec = 30
+        timeout_sec = 60
         deadline = time() + timeout_sec
         while True:
             current_segment_count = self.partition_segments()


### PR DESCRIPTION
[Because we now schedule adjacent segment compaction after sliding window compaction](https://redpandadata.atlassian.net/browse/CORE-8848), this test was having trouble trying to reach the desired number of segments while producing.

Increase the timeout as well as the `log_compaction_interval_ms` to allow the test to reach the desired number of segments.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
