### PR TITLE
`storage`: fixes for book keeping of `dirty` and `closed` bytes

### DIFF
--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -15,6 +15,7 @@
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/tests/service_fixture.h"
 #include "config/configuration.h"
+#include "storage/disk_log_impl.h"
 #include "storage/ntp_config.h"
 #include "test_utils/fixture.h"
 
@@ -153,6 +154,17 @@ struct reupload_fixture : public archiver_fixture {
 
     ss::shared_ptr<storage::log> disk_log_impl() {
         return get_local_storage_api().log_mgr().get(manifest_ntp);
+    }
+
+    // Need to call this when releasing an appender.
+    void add_segment_bytes(
+      ss::lw_shared_ptr<storage::segment> s, ssize_t size_bytes) {
+        static_cast<storage::disk_log_impl*>(disk_log_impl().get())
+          ->add_closed_segment_bytes(s->file_size());
+        if (!s->has_clean_compact_timestamp()) {
+            static_cast<storage::disk_log_impl*>(disk_log_impl().get())
+              ->add_dirty_segment_bytes(s->file_size());
+        }
     }
 
     cloud_storage::partition_manifest
@@ -523,6 +535,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     write_random_batches(last_segment, 20, 2);
     last_segment->appender().close().get();
     last_segment->release_appender();
+    add_segment_bytes(last_segment, last_segment->size_bytes());
 
     create_segment(
       {manifest_ntp,
@@ -592,6 +605,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     write_random_batches(last_segment, 20, 2);
     last_segment->appender().close().get();
     last_segment->release_appender();
+    add_segment_bytes(last_segment, last_segment->size_bytes());
 
     create_segment(
       {manifest_ntp,
@@ -780,6 +794,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
         write_random_batches(last_segment, 10, 2);
         last_segment->appender().close().get();
         last_segment->release_appender();
+        add_segment_bytes(last_segment, last_segment->size_bytes());
 
         create_segment(
           {manifest_ntp,

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -845,6 +845,10 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
         }
         auto seg = b.get_log_segments().back();
         seg->release_appender(&b.get_disk_log_impl().readers()).get();
+        b.add_closed_segment_bytes(seg->file_size());
+        if (!seg->has_clean_compact_timestamp()) {
+            b.add_dirty_segment_bytes(seg->file_size());
+        }
     }
 
     b | storage::add_segment(*first)

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -240,11 +240,11 @@ failure_injectable_log::retention_offset(storage::gc_config cfg) const {
     return _underlying_log->retention_offset(cfg);
 }
 
-uint64_t failure_injectable_log::dirty_segment_bytes() const {
+ssize_t failure_injectable_log::dirty_segment_bytes() const {
     return _underlying_log->dirty_segment_bytes();
 }
 
-uint64_t failure_injectable_log::closed_segment_bytes() const {
+ssize_t failure_injectable_log::closed_segment_bytes() const {
     return _underlying_log->closed_segment_bytes();
 }
 

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -240,4 +240,12 @@ failure_injectable_log::retention_offset(storage::gc_config cfg) const {
     return _underlying_log->retention_offset(cfg);
 }
 
+uint64_t failure_injectable_log::dirty_segment_bytes() const {
+    return _underlying_log->dirty_segment_bytes();
+}
+
+uint64_t failure_injectable_log::closed_segment_bytes() const {
+    return _underlying_log->closed_segment_bytes();
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -131,9 +131,9 @@ public:
     std::optional<model::offset>
       retention_offset(storage::gc_config) const final;
 
-    uint64_t dirty_segment_bytes() const final;
+    ssize_t dirty_segment_bytes() const final;
 
-    uint64_t closed_segment_bytes() const final;
+    ssize_t closed_segment_bytes() const final;
 
 private:
     ss::shared_ptr<storage::log> _underlying_log;

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -131,6 +131,10 @@ public:
     std::optional<model::offset>
       retention_offset(storage::gc_config) const final;
 
+    uint64_t dirty_segment_bytes() const final;
+
+    uint64_t closed_segment_bytes() const final;
+
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4099,23 +4099,28 @@ double disk_log_impl::dirty_ratio() const {
                  / static_cast<double>(_closed_segment_bytes);
 }
 
-void disk_log_impl::add_dirty_segment_bytes(uint64_t bytes) {
+void disk_log_impl::add_dirty_segment_bytes(ssize_t bytes) {
     _dirty_segment_bytes += bytes;
     _probe->set_dirty_segment_bytes(_dirty_segment_bytes);
 }
 
-void disk_log_impl::add_closed_segment_bytes(uint64_t bytes) {
+void disk_log_impl::add_closed_segment_bytes(ssize_t bytes) {
     _closed_segment_bytes += bytes;
     _probe->set_closed_segment_bytes(_closed_segment_bytes);
 }
 
-void disk_log_impl::subtract_dirty_segment_bytes(uint64_t bytes) {
-    _dirty_segment_bytes -= std::min(bytes, _dirty_segment_bytes);
+void disk_log_impl::subtract_dirty_segment_bytes(ssize_t bytes) {
+    _dirty_segment_bytes -= bytes;
+    dassert(
+      _dirty_segment_bytes >= 0, "_dirty_segment_bytes must not be negative.");
     _probe->set_dirty_segment_bytes(_dirty_segment_bytes);
 }
 
-void disk_log_impl::subtract_closed_segment_bytes(uint64_t bytes) {
-    _closed_segment_bytes -= std::min(bytes, _closed_segment_bytes);
+void disk_log_impl::subtract_closed_segment_bytes(ssize_t bytes) {
+    _closed_segment_bytes -= bytes;
+    dassert(
+      _closed_segment_bytes >= 0,
+      "_closed_segment_bytes must not be negative.");
     _probe->set_closed_segment_bytes(_closed_segment_bytes);
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -151,7 +151,7 @@ disk_log_impl::disk_log_impl(
         }
         if (s != _segs.back()) {
             auto seg_size_bytes = s->size_bytes();
-            if (!s->index().has_clean_compact_timestamp()) {
+            if (!s->has_clean_compact_timestamp()) {
                 add_dirty_segment_bytes(seg_size_bytes);
             }
             add_closed_segment_bytes(seg_size_bytes);
@@ -611,7 +611,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         }
 
         const auto removed_bytes = result.size_before - result.size_after;
-        if (!seg->index().has_clean_compact_timestamp()) {
+        if (!seg->has_clean_compact_timestamp()) {
             subtract_dirty_segment_bytes(removed_bytes);
         }
         subtract_closed_segment_bytes(removed_bytes);
@@ -627,7 +627,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     // Remove any of the segments that have already been cleanly compacted. They
     // would be no-ops to compact.
     while (!segs.empty()) {
-        if (segs.back()->index().has_clean_compact_timestamp()) {
+        if (segs.back()->has_clean_compact_timestamp()) {
             segs.pop_back();
         } else {
             break;
@@ -1326,7 +1326,7 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
           if (!s->may_have_compactible_records()) {
               return true;
           }
-          return s->index().has_clean_compact_timestamp();
+          return s->has_clean_compact_timestamp();
       });
 
     if (sliding_window_round_complete) {
@@ -1819,7 +1819,7 @@ ss::future<> disk_log_impl::new_segment(
                 if (!_segs.empty()) {
                     auto rolled_seg = _segs.back();
                     const auto closed_segment_size = rolled_seg->size_bytes();
-                    if (!rolled_seg->index().has_clean_compact_timestamp()) {
+                    if (!rolled_seg->has_clean_compact_timestamp()) {
                         add_dirty_segment_bytes(closed_segment_size);
                     }
                     add_closed_segment_bytes(closed_segment_size);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -149,13 +149,7 @@ disk_log_impl::disk_log_impl(
         if (_compaction_enabled) {
             s->mark_as_compacted_segment();
         }
-        if (s != _segs.back()) {
-            auto seg_size_bytes = s->size_bytes();
-            if (!s->has_clean_compact_timestamp()) {
-                add_dirty_segment_bytes(seg_size_bytes);
-            }
-            add_closed_segment_bytes(seg_size_bytes);
-        }
+        add_segment_bytes(s, s->size_bytes());
     }
     _probe->initial_segments_count(_segs.size());
     _probe->setup_metrics(this->config().ntp());
@@ -519,10 +513,9 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
         if (result.did_compact()) {
             segment->clear_cached_disk_usage();
             _compaction_ratio.update(result.compaction_ratio());
-            const auto removed_bytes = result.size_before - result.size_after;
-            subtract_dirty_segment_bytes(removed_bytes);
-            subtract_closed_segment_bytes(removed_bytes);
-
+            const ssize_t removed_bytes = ssize_t(result.size_before)
+                                          - ssize_t(result.size_after);
+            subtract_segment_bytes(segment, removed_bytes);
             co_return;
         }
     }
@@ -610,11 +603,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             continue;
         }
 
-        const auto removed_bytes = result.size_before - result.size_after;
-        if (!seg->has_clean_compact_timestamp()) {
-            subtract_dirty_segment_bytes(removed_bytes);
-        }
-        subtract_closed_segment_bytes(removed_bytes);
+        const ssize_t removed_bytes = result.size_before - result.size_after;
+        subtract_segment_bytes(seg, removed_bytes);
         vlog(
           gclog.debug,
           "[{}] segment {} self compaction result: {}",
@@ -847,9 +837,6 @@ disk_log_impl::compact_adjacent_segments(storage::compaction_config cfg) {
           r);
         if (r->did_compact()) {
             _compaction_ratio.update(r->compaction_ratio());
-            const auto removed_bytes = r->size_before - r->size_after;
-            subtract_dirty_segment_bytes(removed_bytes);
-            subtract_closed_segment_bytes(removed_bytes);
         }
     } else {
         vlog(
@@ -874,6 +861,22 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
 
     const bool all_segments_self_compacted = std::ranges::all_of(
       segments, &segment::finished_self_compaction);
+
+    const bool all_segments_cleanly_compacted = std::ranges::all_of(
+      segments, &segment::has_clean_compact_timestamp);
+
+    // In the case we are merging a cleanly compacted segment with a non-cleanly
+    // compacted segment, we need to consider the bytes of the cleanly compacted
+    // segment "dirty" again, since they will be deducted once the replacement
+    // segment has finally been marked clean.
+    ssize_t clean_turning_dirty_bytes = 0;
+    if (!all_segments_cleanly_compacted) {
+        for (const auto& seg : segments) {
+            if (seg->has_clean_compact_timestamp()) {
+                clean_turning_dirty_bytes += seg->size_bytes();
+            }
+        }
+    }
 
     if (unlikely(!all_segments_self_compacted)) {
         const auto total_size = std::accumulate(
@@ -989,6 +992,14 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     locks = co_await internal::transfer_segment(
       target, replacement, cfg, *_probe, std::move(locks));
 
+    auto segment_to_remove = segments.back();
+    // We are going to remove one of the segments, but its bytes have not
+    // technically been removed- just moved to the new segment, `target`.
+    // remove_segment_permanently() will remove bytes, so to make sure the
+    // book-keeping stays correct, we must first add them here to ensure a
+    // net zero change post adjacent merge.
+    add_segment_bytes(segment_to_remove, segment_to_remove->size_bytes());
+
     // remove the now redundant segments, if they haven't already been removed.
     // this could occur if racing with functions like truncate which manipulate
     // the segment set before acquiring segment locks. this also means that the
@@ -999,12 +1010,17 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     locks.clear();
     staging_to_clean.clear();
     vassert(segments.size() == 2, "Cannot compact more than two segments");
-    auto it = std::find(_segs.begin(), _segs.end(), segments.back());
+    auto it = std::find(_segs.begin(), _segs.end(), segment_to_remove);
     if (it != _segs.end()) {
         _segs.erase(it, std::next(it));
         co_await remove_segment_permanently(
-          segments.back(), "compact_adjacent_segments");
+          segment_to_remove, "compact_adjacent_segments");
     }
+
+    add_dirty_segment_bytes(clean_turning_dirty_bytes);
+    const ssize_t removed_bytes = ssize_t(ret.size_before)
+                                  - ssize_t(ret.size_after);
+    subtract_segment_bytes(target, removed_bytes);
 
     co_return ret;
 }
@@ -1473,13 +1489,15 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     seg->force_set_commit_offset_from_index();
     seg->release_batch_cache_index();
 
-    const auto removed_bytes = ssize_t(size_before) - ssize_t(size_after);
+    const ssize_t removed_bytes = ssize_t(size_before) - ssize_t(size_after);
 
     // We must deduct the removed bytes from the dirty segment bytes.
     // However, if the segment is marked as cleanly compacted below, the
     // entire seg size (before compaction) will instead be removed from dirty
     // segment bytes.
-    auto dirty_removed_bytes = removed_bytes;
+    ssize_t dirty_removed_bytes = seg->has_clean_compact_timestamp()
+                                    ? 0
+                                    : removed_bytes;
 
     if (is_finished_window_compaction) {
         // Mark the segment as completed window compaction, and possibly set the
@@ -1488,7 +1506,7 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
           = co_await internal::mark_segment_as_finished_window_compaction(
             seg, is_clean_compacted, *_probe);
         if (marked_as_cleanly_compacted) {
-            dirty_removed_bytes = size_before;
+            dirty_removed_bytes = ssize_t(size_before);
         }
     }
 
@@ -1816,14 +1834,6 @@ ss::future<> disk_log_impl::new_segment(
                 if (config().is_compacted()) {
                     h->mark_as_compacted_segment();
                 }
-                if (!_segs.empty()) {
-                    auto rolled_seg = _segs.back();
-                    const auto closed_segment_size = rolled_seg->size_bytes();
-                    if (!rolled_seg->has_clean_compact_timestamp()) {
-                        add_dirty_segment_bytes(closed_segment_size);
-                    }
-                    add_closed_segment_bytes(closed_segment_size);
-                }
                 _segs.add(std::move(h));
                 _probe->segment_created();
                 _stm_manager->make_snapshot_in_background();
@@ -1963,7 +1973,8 @@ ss::future<> disk_log_impl::force_roll(ss::io_priority_class iopc) {
         co_return co_await new_segment(next_offset, t, iopc);
     }
     co_return co_await ptr->release_appender(_readers_cache.get())
-      .then([this, next_offset, t, iopc] {
+      .then([this, ptr, next_offset, t, iopc] {
+          add_segment_bytes(ptr, ptr->size_bytes());
           return new_segment(next_offset, t, iopc);
       });
 }
@@ -1989,6 +2000,7 @@ ss::future<> disk_log_impl::maybe_roll_unlocked(
     }
     if (t != term() || size_should_roll) {
         co_await ptr->release_appender(_readers_cache.get());
+        add_segment_bytes(ptr, ptr->size_bytes());
         co_await new_segment(next_offset, t, iopc);
     }
 }
@@ -2064,6 +2076,7 @@ ss::future<> disk_log_impl::apply_segment_ms() {
                 .get_priority_class(); // note: has_appender is true, the
                                        // bouncer condition checked this
     co_await last->release_appender(_readers_cache.get());
+    add_segment_bytes(last, last->size_bytes());
     auto offsets = last->offsets();
     auto new_so = model::next_offset(offsets.get_committed_offset());
     co_await new_segment(new_so, offsets.get_term(), pc);
@@ -2798,11 +2811,10 @@ ss::future<> disk_log_impl::remove_segment_permanently(
     vlog(stlog.info, "Removing \"{}\" ({}, {})", s->filename(), ctx, s);
     // stats accounting must happen synchronously
     _probe->delete_segment(*s);
-    auto removed_segment_bytes = s->size_bytes();
-    if (!s->index().has_clean_compact_timestamp()) {
-        subtract_dirty_segment_bytes(removed_segment_bytes);
+    // Only deduct bytes if the segment was previously closed.
+    if (!s->has_appender()) {
+        subtract_segment_bytes(s, s->size_bytes());
     }
-    subtract_closed_segment_bytes(removed_segment_bytes);
     // background close
     s->tombstone();
     if (s->has_outstanding_locks()) {
@@ -3133,7 +3145,21 @@ ss::future<> disk_log_impl::do_truncate(
         co_return co_await remove_segment_permanently(
           last_ptr, "truncate[post-translation]");
     }
-    _probe->remove_partition_bytes(last_ptr->size_bytes() - file_position);
+
+    // In a compacted segment with an appender, last_ptr->truncate() will
+    // release_appender and force a segment roll. We need to add the file size
+    // to dirty and closed bytes here.
+    if (last_ptr->is_compacted_segment() && last_ptr->has_appender()) {
+        add_segment_bytes(last_ptr, last_ptr->size_bytes());
+    }
+
+    // But, we also have to remove the bytes according to truncation for a
+    // closed (or to-be-closed, in the case of a compacted) segment.
+    const ssize_t removed_bytes = last_ptr->size_bytes() - file_position;
+    _probe->remove_partition_bytes(removed_bytes);
+    if (!last_ptr->has_appender() || last_ptr->is_compacted_segment()) {
+        subtract_segment_bytes(last_ptr, removed_bytes);
+    }
     auto cache_lock = co_await _readers_cache->evict_truncate(cfg.base_offset);
 
     try {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4119,4 +4119,20 @@ void disk_log_impl::subtract_closed_segment_bytes(uint64_t bytes) {
     _probe->set_closed_segment_bytes(_closed_segment_bytes);
 }
 
+void disk_log_impl::add_segment_bytes(
+  ss::lw_shared_ptr<segment> s, ssize_t bytes) {
+    if (!s->has_clean_compact_timestamp()) {
+        add_dirty_segment_bytes(bytes);
+    }
+    add_closed_segment_bytes(bytes);
+}
+
+void disk_log_impl::subtract_segment_bytes(
+  ss::lw_shared_ptr<segment> s, ssize_t bytes) {
+    if (!s->has_clean_compact_timestamp()) {
+        subtract_dirty_segment_bytes(bytes);
+    }
+    subtract_closed_segment_bytes(bytes);
+}
+
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -259,9 +259,9 @@ public:
 
     size_t max_segment_size() const;
 
-    uint64_t dirty_segment_bytes() const final { return _dirty_segment_bytes; }
+    ssize_t dirty_segment_bytes() const final { return _dirty_segment_bytes; }
 
-    uint64_t closed_segment_bytes() const final { return _closed_segment_bytes; }
+    ssize_t closed_segment_bytes() const final { return _closed_segment_bytes; }
 
     // Returns the dirty ratio of the log.
     // The dirty ratio is the ratio of bytes in closed, dirty segments to the
@@ -465,8 +465,8 @@ private:
 
     size_t _reclaimable_size_bytes{0};
 
-    uint64_t _dirty_segment_bytes{0};
-    uint64_t _closed_segment_bytes{0};
+    ssize_t _dirty_segment_bytes{0};
+    ssize_t _closed_segment_bytes{0};
 
     // Update the number of bytes in dirty segments.
     //
@@ -479,8 +479,8 @@ private:
     // cleanly compacted, closed segments are evicted from the log, or when
     // bytes are removed by compaction. For that reason, one of the tags add_tag
     // or subtract_tag must be used.
-    void add_dirty_segment_bytes(uint64_t bytes);
-    void subtract_dirty_segment_bytes(uint64_t bytes);
+    void add_dirty_segment_bytes(ssize_t bytes);
+    void subtract_dirty_segment_bytes(ssize_t bytes);
 
     // Update the number of bytes in closed segments.
     //
@@ -488,8 +488,8 @@ private:
     // segment is rolled, and decreases when closed segments are evicted from
     // the log, or when bytes are removed by compaction. For that reason, one of
     // the tags add_tag or subtract_tag must be used.
-    void add_closed_segment_bytes(uint64_t bytes);
-    void subtract_closed_segment_bytes(uint64_t bytes);
+    void add_closed_segment_bytes(ssize_t bytes);
+    void subtract_closed_segment_bytes(ssize_t bytes);
 
     // Updates the number of closed & dirty bytes on segment roll (i.e when a
     // segment's appender is released) or when recovering existing segments from

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -259,9 +259,9 @@ public:
 
     size_t max_segment_size() const;
 
-    uint64_t dirty_segment_bytes() const { return _dirty_segment_bytes; }
+    uint64_t dirty_segment_bytes() const final { return _dirty_segment_bytes; }
 
-    uint64_t closed_segment_bytes() const { return _closed_segment_bytes; }
+    uint64_t closed_segment_bytes() const final { return _closed_segment_bytes; }
 
     // Returns the dirty ratio of the log.
     // The dirty ratio is the ratio of bytes in closed, dirty segments to the

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -28,6 +28,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include <absl/container/flat_hash_map.h>
 
@@ -489,6 +490,17 @@ private:
     // the tags add_tag or subtract_tag must be used.
     void add_closed_segment_bytes(uint64_t bytes);
     void subtract_closed_segment_bytes(uint64_t bytes);
+
+    // Updates the number of closed & dirty bytes on segment roll (i.e when a
+    // segment's appender is released) or when recovering existing segments from
+    // a set. The argument `bytes` is added to closed_segment_bytes, and
+    // conditionally added to dirty_segment_bytes.
+    void add_segment_bytes(ss::lw_shared_ptr<segment> s, ssize_t bytes);
+
+    // Updates the number of closed & dirty bytes on data removal, e.g
+    // compaction or truncation. The argument `bytes` is removed from
+    // closed_segment_bytes, and conditionally removed from dirty_segment_bytes.
+    void subtract_segment_bytes(ss::lw_shared_ptr<segment> s, ssize_t bytes);
 
     bool _compaction_enabled;
 };

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -33,6 +33,7 @@
 #include <absl/container/flat_hash_map.h>
 
 struct storage_e2e_fixture;
+struct reupload_fixture;
 namespace storage {
 
 /// \brief offset boundary type
@@ -272,6 +273,7 @@ private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
     friend ::storage_e2e_fixture;
+    friend ::reupload_fixture; // for tests
     friend std::ostream& operator<<(std::ostream& o, const disk_log_impl& d);
 
     /// Compute file offset of the batch inside the segment

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -222,8 +222,8 @@ public:
      */
     virtual std::optional<model::offset> retention_offset(gc_config) const = 0;
 
-    virtual uint64_t dirty_segment_bytes() const = 0;
-    virtual uint64_t closed_segment_bytes() const = 0;
+    virtual ssize_t dirty_segment_bytes() const = 0;
+    virtual ssize_t closed_segment_bytes() const = 0;
 
 private:
     ntp_config _config;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -222,6 +222,9 @@ public:
      */
     virtual std::optional<model::offset> retention_offset(gc_config) const = 0;
 
+    virtual uint64_t dirty_segment_bytes() const = 0;
+    virtual uint64_t closed_segment_bytes() const = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -166,8 +166,8 @@ private:
     uint64_t _num_rounds_window_compaction = 0;
     uint64_t _num_chunked_compaction_runs = 0;
 
-    uint64_t _dirty_segment_bytes = 0;
-    uint64_t _closed_segment_bytes = 0;
+    ssize_t _dirty_segment_bytes = 0;
+    ssize_t _closed_segment_bytes = 0;
 
     ssize_t _compaction_removed_bytes = 0;
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -191,6 +191,7 @@ public:
     bool finished_self_compaction() const;
     void mark_as_finished_windowed_compaction();
     bool finished_windowed_compaction() const;
+    bool has_clean_compact_timestamp() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
 
@@ -464,6 +465,9 @@ inline void segment::mark_as_finished_windowed_compaction() {
 inline bool segment::finished_windowed_compaction() const {
     return (_flags & bitflags::finished_windowed_compaction)
            == bitflags::finished_windowed_compaction;
+}
+inline bool segment::has_clean_compact_timestamp() const {
+    return index().has_clean_compact_timestamp();
 }
 inline std::optional<std::reference_wrapper<batch_cache_index>>
 segment::cache() {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -113,7 +113,7 @@ ss::future<model::offset> build_offset_map(
             cfg.asrc->check();
         }
         auto seg = *iter;
-        if (seg->index().has_clean_compact_timestamp()) {
+        if (seg->has_clean_compact_timestamp()) {
             // This segment has already been fully deduplicated, so building the
             // offset map for it would be pointless.
             vlog(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -910,7 +910,7 @@ make_concatenated_segment(
             // If even one segment in the set does not have a
             // clean_compact_timestamp, we must not mark the new index as having
             // one.
-            if (!seg->index().has_clean_compact_timestamp()) {
+            if (!seg->has_clean_compact_timestamp()) {
                 return std::nullopt;
             }
 
@@ -1183,7 +1183,7 @@ ss::future<bool> mark_segment_as_finished_window_compaction(
 bool is_past_tombstone_delete_horizon(
   ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
     if (
-      seg->index().has_clean_compact_timestamp()
+      seg->has_clean_compact_timestamp()
       && cfg.tombstone_retention_ms.has_value()) {
         auto tombstone_delete_horizon = model::timestamp(
           seg->index().clean_compact_timestamp()->value()

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -534,7 +534,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_btest(
     name = "storage_e2e_single_thread",
-    timeout = "moderate",
+    timeout = "long",
     srcs = [
         "storage_e2e_test.cc",
     ],

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -413,15 +413,15 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
 
     ASSERT_TRUE(segs[0]->finished_self_compaction());
     ASSERT_TRUE(segs[0]->finished_windowed_compaction());
-    ASSERT_FALSE(segs[0]->index().has_clean_compact_timestamp());
+    ASSERT_FALSE(segs[0]->has_clean_compact_timestamp());
 
     ASSERT_TRUE(segs[1]->finished_self_compaction());
     ASSERT_TRUE(segs[1]->finished_windowed_compaction());
-    ASSERT_FALSE(segs[1]->index().has_clean_compact_timestamp());
+    ASSERT_FALSE(segs[1]->has_clean_compact_timestamp());
 
     ASSERT_TRUE(segs[2]->finished_self_compaction());
     ASSERT_TRUE(segs[2]->finished_windowed_compaction());
-    ASSERT_TRUE(segs[2]->index().has_clean_compact_timestamp());
+    ASSERT_TRUE(segs[2]->has_clean_compact_timestamp());
 
     ASSERT_TRUE(disk_log.get_last_compaction_window_start_offset().has_value());
     ASSERT_EQ(
@@ -441,8 +441,8 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     ASSERT_TRUE(did_compact);
 
     // Now the first two segments should be marked as clean.
-    ASSERT_TRUE(segs[0]->index().has_clean_compact_timestamp());
-    ASSERT_TRUE(segs[1]->index().has_clean_compact_timestamp());
+    ASSERT_TRUE(segs[0]->has_clean_compact_timestamp());
+    ASSERT_TRUE(segs[1]->has_clean_compact_timestamp());
 
     ASSERT_FALSE(
       disk_log.get_last_compaction_window_start_offset().has_value());
@@ -495,14 +495,14 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
         auto& seg = segs[i];
         ASSERT_TRUE(seg->finished_windowed_compaction());
         ASSERT_TRUE(seg->finished_self_compaction());
-        ASSERT_TRUE(seg->index().has_clean_compact_timestamp());
+        ASSERT_TRUE(seg->has_clean_compact_timestamp());
     }
 
     // The last added segment should not have had any compaction operations
     // performed.
     ASSERT_FALSE(segs[segs.size() - 2]->finished_windowed_compaction());
     ASSERT_FALSE(segs[segs.size() - 2]->finished_self_compaction());
-    ASSERT_FALSE(segs[segs.size() - 2]->index().has_clean_compact_timestamp());
+    ASSERT_FALSE(segs[segs.size() - 2]->has_clean_compact_timestamp());
 
     // We should have compacted all the way down to the start of the log, and
     // reset the start offset.
@@ -515,7 +515,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
     // Now, these values should be set.
     ASSERT_TRUE(segs[segs.size() - 2]->finished_windowed_compaction());
     ASSERT_TRUE(segs[segs.size() - 2]->finished_self_compaction());
-    ASSERT_TRUE(segs[segs.size() - 2]->index().has_clean_compact_timestamp());
+    ASSERT_TRUE(segs[segs.size() - 2]->has_clean_compact_timestamp());
 
     auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
     ASSERT_LT(segments_compacted_2, segments_compacted_3);
@@ -851,7 +851,7 @@ TEST_F(CompactionFixtureTest, TestTombstones) {
     // clean_compact_timestamp set, since we fully indexed all of them.
     int num_clean_before = 0;
     for (const auto& seg : log->segments()) {
-        if (seg->index().has_clean_compact_timestamp()) {
+        if (seg->has_clean_compact_timestamp()) {
             ++num_clean_before;
         }
     }
@@ -872,7 +872,7 @@ TEST_F(CompactionFixtureTest, TestTombstones) {
     // Check that the clean_compact_timestamps got persisted in the index_state.
     int num_clean_again = 0;
     for (const auto& seg : log->segments()) {
-        if (seg->index().has_clean_compact_timestamp()) {
+        if (seg->has_clean_compact_timestamp()) {
             ++num_clean_again;
         }
     }
@@ -892,7 +892,7 @@ TEST_F(CompactionFixtureTest, TestTombstones) {
     // even after a restart.
     int num_clean_after = 0;
     for (const auto& seg : log->segments()) {
-        if (seg->index().has_clean_compact_timestamp()) {
+        if (seg->has_clean_compact_timestamp()) {
             ++num_clean_after;
         }
     }
@@ -971,7 +971,7 @@ TEST_P(CompactionFixtureTombstonesParamTest, TestTombstonesCompletelyEmptyLog) {
 
     ASSERT_TRUE(did_compact);
     for (size_t i = 0; i < num_segments; ++i) {
-        ASSERT_TRUE(log->segments()[i]->index().has_clean_compact_timestamp());
+        ASSERT_TRUE(log->segments()[i]->has_clean_compact_timestamp());
     }
 
     {
@@ -1237,7 +1237,7 @@ TEST_P(
 
         auto num_clean_compacted = 0;
         for (const auto& seg : log->segments()) {
-            if (seg->index().has_clean_compact_timestamp()) {
+            if (seg->has_clean_compact_timestamp()) {
                 ++num_clean_compacted;
             }
         }

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -70,6 +70,12 @@ void add_segments(
         if (seg->has_appender()) {
             seg->appender().close().get();
             seg->release_appender();
+            // Since we're "rolling" the segment manually here (releasing the
+            // appender), increment closed/dirty bytes in the log.
+            if (!seg->has_clean_compact_timestamp()) {
+                b.add_dirty_segment_bytes(seg->file_size());
+            }
+            b.add_closed_segment_bytes(seg->file_size());
         }
     }
 }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1236,7 +1236,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(log->offsets().dirty_offset, model::offset(6));
 }
 
-FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
+FIXTURE_TEST(test_compaction_preserve_state, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     auto ntp = model::ntp("default", "test", 0);
     // compacted topic

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1386,6 +1386,7 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
         // 1) append few single record batches in term 1
         append_single_record_batch(log, 14, model::term_id(1));
         log->flush().get();
+        check_dirty_and_closed_segment_bytes(log);
         // 2) truncate in the middle of segment
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
@@ -1396,9 +1397,11 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
         // 3) append some more batches to the same segment
         append_single_record_batch(log, 10, model::term_id(1));
         log->flush().get();
+        check_dirty_and_closed_segment_bytes(log);
         //  4) roll term by appending to new segment
         append_single_record_batch(log, 1, model::term_id(8));
         log->flush().get();
+        check_dirty_and_closed_segment_bytes(log);
     }
     // 5) restart log manager
     {
@@ -1447,6 +1450,7 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
           ss::default_priority_class(),
           as);
         log->flush().get();
+        check_dirty_and_closed_segment_bytes(log);
         model::offset truncate_at(7);
         info("Truncating at offset:{}", truncate_at);
         log
@@ -1456,11 +1460,14 @@ FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
         // roll segment
         append_single_record_batch(log, 10, model::term_id(2));
         log->flush().get();
+        check_dirty_and_closed_segment_bytes(log);
 
         // roll segment
         append_single_record_batch(log, 1, model::term_id(8));
+        check_dirty_and_closed_segment_bytes(log);
         // compact log
         log->housekeeping(c_cfg).get();
+        check_dirty_and_closed_segment_bytes(log);
     }
 
     // force recovery
@@ -1513,6 +1520,7 @@ FIXTURE_TEST(
       ss::default_priority_class(),
       as);
     log->flush().get();
+    check_dirty_and_closed_segment_bytes(log);
     model::offset truncate_at(7);
     info("Truncating at offset:{}", truncate_at);
     BOOST_REQUIRE_EQUAL(log->segment_count(), 1);
@@ -1522,10 +1530,12 @@ FIXTURE_TEST(
       .get();
     append_single_record_batch(log, 10, model::term_id(1));
     log->flush().get();
+    check_dirty_and_closed_segment_bytes(log);
 
     // segment should be rolled after truncation
     BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
     log->housekeeping(c_cfg).get();
+    check_dirty_and_closed_segment_bytes(log);
 
     auto read = read_and_validate_all_batches(log);
     BOOST_REQUIRE_EQUAL(read.begin()->base_offset(), model::offset(6));

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5388,3 +5388,136 @@ FIXTURE_TEST(dirty_ratio, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(disk_log->closed_segment_bytes(), 0);
     BOOST_REQUIRE_CLOSE(disk_log->dirty_ratio(), 0.0, tolerance);
 }
+
+FIXTURE_TEST(dirty_and_closed_bytes_bookkeeping, storage_test_fixture) {
+    auto log_cfg = default_log_config(test_dir);
+    using namespace storage;
+
+    ss::abort_source abs;
+    auto ntp = model::ntp("test_ns", "test_tpc", 0);
+
+    ntp_config::default_overrides overrides;
+    overrides.retention_bytes = tristate<size_t>{1};
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction
+        | model::cleanup_policy_bitflags::deletion;
+
+    std::unique_ptr<log_manager> mgr = std::make_unique<log_manager>(
+      log_cfg, kvstore, resources, feature_table);
+    auto deferred = ss::defer([&mgr]() mutable { mgr->stop().get(); });
+    auto log = mgr
+                 ->manage(ntp_config(
+                   ntp,
+                   mgr->config().base_dir,
+                   std::make_unique<ntp_config::default_overrides>(overrides)))
+                 .get();
+
+    auto* disk_log = static_cast<disk_log_impl*>(log.get());
+
+    housekeeping_config cfg{
+      model::timestamp::max(),
+      1,
+      model::offset::max(),
+      std::nullopt,
+      ss::default_priority_class(),
+      abs};
+
+    // add a segment with random keys until a certain size
+    auto add_segment = [&](size_t size, model::term_id term) {
+        do {
+            static const auto to_add = 1_KiB;
+            append_single_record_batch(log, 1, term, to_add, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    using func_t = std::function<void()>;
+
+    // Adds a new (random sized) segment to the log.
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(1));
+    };
+
+    // Force rolls the log.
+    auto force_roll_func = [&]() {
+        disk_log->force_roll(ss::default_priority_class()).get();
+    };
+
+    // Restarts the log manager- this has the added benefit of forcing recovery
+    // from the existing segment set.
+    auto restart_log_manager_func = [&]() {
+        mgr->stop().get();
+        mgr = std::make_unique<log_manager>(
+          log_cfg, kvstore, resources, feature_table);
+        log = mgr
+                ->manage(ntp_config(
+                  ntp,
+                  mgr->config().base_dir,
+                  std::make_unique<ntp_config::default_overrides>(overrides)))
+                .get();
+        disk_log = static_cast<disk_log_impl*>(log.get());
+    };
+
+    auto adjacent_merge_func = [&]() {
+        disk_log->adjacent_merge_compact(cfg.compact).get();
+    };
+
+    auto sliding_window_func = [&]() {
+        disk_log->sliding_window_compact(cfg.compact).get();
+    };
+
+    // Prefix truncate at a random point in the log.
+    auto prefix_truncate_func = [&]() {
+        auto dirty_offset = disk_log->offsets().dirty_offset;
+        auto offset = random_generators::get_int(1L, dirty_offset());
+        disk_log
+          ->truncate_prefix(truncate_prefix_config(
+            model::offset(offset), ss::default_priority_class()))
+          .get();
+    };
+
+    // Truncate to a random point in the log.
+    auto truncate_func = [&]() {
+        auto dirty_offset = disk_log->offsets().dirty_offset;
+        auto offset = random_generators::get_int(1L, dirty_offset());
+        disk_log
+          ->truncate(storage::truncate_config(
+            model::offset{offset}, ss::default_priority_class()))
+          .get();
+    };
+
+    std::vector<func_t> funcs = {
+      add_segment_func,
+      force_roll_func,
+      restart_log_manager_func,
+      adjacent_merge_func,
+      sliding_window_func,
+      prefix_truncate_func,
+      truncate_func};
+
+#ifdef NDEBUG
+    static constexpr int num_operations = 50;
+#else
+    static constexpr int num_operations = 25;
+#endif
+
+    for (int i = 0; i < num_operations; ++i) {
+        // Invoke one of the functions that influences the dirty and closed
+        // bytes of the log.
+        random_generators::random_choice(funcs)();
+        check_dirty_and_closed_segment_bytes(log);
+        // We should drive segment production to ensure there is always
+        // something for the functions to do.
+        add_segment_func();
+
+        // Recheck post segment addition.
+        check_dirty_and_closed_segment_bytes(log);
+    }
+
+    // Sliding window compact down the rest of the log
+    bool did_compact = true;
+    while (did_compact) {
+        did_compact = disk_log->sliding_window_compact(cfg.compact).get();
+        check_dirty_and_closed_segment_bytes(log);
+    }
+}

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -417,4 +417,32 @@ public:
           .consume(batch_validating_consumer(), model::no_timeout)
           .get();
     }
+
+    std::pair<ssize_t, ssize_t> expected_dirty_and_closed_segment_bytes(
+      ss::shared_ptr<storage::log> log) const {
+        ssize_t dirty{0};
+        ssize_t closed{0};
+        for (const auto& segment : log->segments()) {
+            if (!segment->has_appender()) {
+                if (!segment->has_clean_compact_timestamp()) {
+                    dirty += segment->file_size();
+                }
+                closed += segment->file_size();
+            }
+        }
+        return {dirty, closed};
+    }
+
+    // Assert that the book-kept dirty and closed bytes reflect the contents of
+    // the log.
+    void check_dirty_and_closed_segment_bytes(
+      ss::shared_ptr<storage::log> log) const {
+        auto expected = expected_dirty_and_closed_segment_bytes(log);
+        tlog.trace(
+          "Expect dirty bytes: {}, expect closed bytes: {}",
+          expected.first,
+          expected.second);
+        RPTEST_EXPECT_EQ(log->dirty_segment_bytes(), expected.first);
+        RPTEST_EXPECT_EQ(log->closed_segment_bytes(), expected.second);
+    }
 };

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -172,6 +172,12 @@ ss::future<bool>
 disk_log_builder::update_start_offset(model::offset start_offset) {
     return get_disk_log_impl().update_start_offset(start_offset);
 }
+void disk_log_builder::add_dirty_segment_bytes(ssize_t bytes) {
+    get_disk_log_impl().add_dirty_segment_bytes(bytes);
+}
+void disk_log_builder::add_closed_segment_bytes(ssize_t bytes) {
+    get_disk_log_impl().add_closed_segment_bytes(bytes);
+}
 
 ss::future<> disk_log_builder::stop() {
     return _storage.stop().then([this]() { return _feature_table.stop(); });

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -318,6 +318,8 @@ public:
       compaction_config cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
     ss::future<bool> update_start_offset(model::offset start_offset);
+    void add_dirty_segment_bytes(ssize_t bytes);
+    void add_closed_segment_bytes(ssize_t bytes);
     ss::future<> add_batch(
       model::record_batch batch,
       log_append_config config = append_config(),


### PR DESCRIPTION
There were a number of bugs in the `disk_log_impl` `dirty` and `closed` bytes book-keeping added in PR https://github.com/redpanda-data/redpanda/pull/24649 that are fixed by this PR:

1. Some calls to `subtract_dirty_segment_bytes` which did not check if the segment in question was already cleanly compacted. This would leave to over-deduction of dirty bytes.
2. In `do_compact_adjacent_segments()`, it is possible to merge a cleanly compacted segment with a non-cleanly compacted segment. Later on, when this replacement segment is finally marked cleanly compacted, the sum of bytes (including those that have already been removed when the cleanly compacted segment was marked) will once again be deducted. We must add these back and consider them as "dirty" to avoid this over-deduction.
3. Also in `do_compact_adjacent_segments()`, a call to `remove_segment_permanently()` for one of the segments being merged would remove its dirty and closed bytes. These bytes are still present in the replacement segment and should not be removed.
4. Segments removed in `remove_segment_permanently()` should only deduct bytes iff the segment was previously closed (i.e does not have an appender).
5. The reduction in bytes caused by a truncation operation was not deducted from the dirty/closed bytes counter.
6. Finally, in `rewrite_segment_with_offset_map()`, we would again over-deduct dirty bytes for a segment that was already marked as cleanly compacted.

Another major issue was the assumption that, for a compaction result, `size_after < size_before`. This is an invalid assumption, as we recompress batches during the compaction process, which could lead to a larger segment post compaction.

To fix the resulting issue of possible unsigned integer underflow in this case, this PR replaces the types of book-keeping variables with their signed integer equivalents.

Finally, a fixture test that utilizes a fixed number of random operations which can influence the dirty and closed bytes of a log and compares the expected values with the book-kept values after each operation is added to ensure correctness.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
