### PR TITLE
`storage`: alter sliding window log line level

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -584,7 +584,7 @@ segment_set disk_log_impl::find_sliding_range(
 
 ss::future<bool> disk_log_impl::sliding_window_compact(
   const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
-    vlog(gclog.debug, "[{}] running sliding window compaction", config().ntp());
+    vlog(gclog.info, "[{}] running sliding window compaction", config().ntp());
     auto segs = find_sliding_range(cfg, new_start_offset);
     if (segs.empty()) {
         vlog(
@@ -661,7 +661,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         co_return has_self_compacted;
     }
     vlog(
-      gclog.debug,
+      gclog.info,
       "[{}] window compacting {} segments in interval [{}, {}]",
       config().ntp(),
       segs.size(),


### PR DESCRIPTION
To provide better observability into compaction scheduling, up these log line levels to `INFO` from `DEBUG`. The rate at which these are printed will, in the general case, be equal to `log_compaction_interval_ms`.

## Backports Required


- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
