### PR TITLE
pandaproxy/sr: Improve schema lookup

### DIFF
--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -294,17 +294,15 @@ ss::future<subject_schema> sharded_store::has_schema(
     for (auto ver : versions) {
         try {
             auto res = co_await get_subject_schema(schema.sub(), ver, inc_del);
-            if (norm) {
-                res.schema = co_await make_canonical_schema(
-                  unparsed_schema{
-                    res.schema.sub(),
-                    unparsed_schema_definition{
-                      unparsed_schema_definition::raw_string{
-                        res.schema.def().raw()().copy()},
-                      res.schema.def().type(),
-                      res.schema.def().refs()}},
-                  norm);
-            }
+            res.schema = co_await make_canonical_schema(
+              unparsed_schema{
+                res.schema.sub(),
+                unparsed_schema_definition{
+                  unparsed_schema_definition::raw_string{
+                    res.schema.def().raw()().copy()},
+                  res.schema.def().type(),
+                  res.schema.def().refs()}},
+              norm);
             if (schema.def() == res.schema.def()) {
                 sub_schema.emplace(std::move(res));
                 break;


### PR DESCRIPTION
Change lookup strategy to always apply active transformation to existing schemas, instead of only applying it when normalisation is turned on.

Motivation:

This allows a specific workflow performed by SR clients following this pattern to lookup schema IDs:

* POST /subject/sub/versions?normalize=true -d {schema}
* GET /subject/sub/versions/latest -> this returns the schema and latest version but NOT IDs
* POST /subject/sub -d {schema-from-get} -> this returns ID

In our SR, a call to POST /subject/sub without normalize=true will result in this schema being sanitized which may change the content of the schema. With this change, both input schema and lookup schema go through the same operation and still be deemed equal.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
