### PR TITLE
[CORE-8669] `storage`: early abort compaction

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1208,6 +1208,10 @@ ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
     compact_cfg.disk_log = this;
+
+    // Check for an early exit from compaction
+    compact_cfg.maybe_abort_compaction();
+
     if (!config::shard_local_cfg().log_compaction_use_sliding_window()) {
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -593,9 +593,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     }
     bool has_self_compacted = false;
     for (auto& seg : segs) {
-        if (cfg.asrc) {
-            cfg.asrc->check();
-        }
+        cfg.maybe_abort_compaction();
 
         auto result = co_await storage::internal::self_compact_segment(
           seg,
@@ -688,6 +686,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         // We failed to index even one segment (the last entry of the segs set).
         // Perform chunked compaction on it.
         needs_chunked_sliding_window_compact = true;
+    } catch (const gc_required_exception&) {
+        throw;
     } catch (...) {
         auto eptr = std::current_exception();
         if (ssx::is_shutdown_exception(eptr)) {
@@ -739,10 +739,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
 
     auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
     for (auto& seg : segs) {
-        if (cfg.asrc) {
-            cfg.asrc->check();
-        }
-
+        cfg.maybe_abort_compaction();
         // A segment is considered "clean" if it has been fully indexed (all
         // keys are de-duplicated)
         const bool is_finished_window_compaction = true;
@@ -1173,7 +1170,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
     auto new_start_offset = co_await do_gc(cfg.gc);
 
     /*
-     * comapction. could factor out into a public interface like gc/retention if
+     * compaction. could factor out into a public interface like gc/retention if
      * there is a need to run it separately.
      */
     if (config().is_compacted() && !_segs.empty()) {
@@ -1210,6 +1207,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
+    compact_cfg.disk_log = this;
     if (!config::shard_local_cfg().log_compaction_use_sliding_window()) {
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -267,6 +267,8 @@ public:
     // total number of bytes in all closed segments in the log.
     double dirty_ratio() const;
 
+    bool has_cloud_gc_offset() const { return _cloud_gc_offset.has_value(); }
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -39,3 +39,14 @@ public:
 private:
     ss::sstring _msg;
 };
+
+class gc_required_exception : public std::exception {
+public:
+    explicit gc_required_exception(ss::sstring s)
+      : _msg(std::move(s)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -290,7 +290,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _probe->housekeeping_log_processed();
 
         // bail out of compaction early in order to get back to gc
-        if (_gc_triggered) {
+        if (gc_required()) {
             co_return;
         }
     }
@@ -361,9 +361,7 @@ ss::future<> log_manager::housekeeping_loop() {
          * This amount can be estimated using the log::disk_usage(gc_config)
          * interface.
          */
-        if (
-          _gc_triggered || _disk_space_alert == disk_space_alert::degraded
-          || _disk_space_alert == disk_space_alert::low_space) {
+        if (gc_required()) {
             // it is expected that callers set the flag whenever they want the
             // next round of housekeeping to priortize gc.
             _gc_triggered = false;
@@ -893,6 +891,11 @@ void log_manager::update_log_count() {
 
     _resources.update_partition_count(count);
     _probe->set_log_count(count);
+}
+
+bool log_manager::gc_required() const {
+    return _gc_triggered || _disk_space_alert == disk_space_alert::degraded
+           || _disk_space_alert == disk_space_alert::low_space;
 }
 
 } // namespace storage

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -278,16 +278,26 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
         // the removal of the parent object. this makes awaiting housekeeping
         // safe against removal of segments from _logs_list
-        co_await current_log.handle->housekeeping(housekeeping_config(
-          collection_threshold,
-          _config.retention_bytes(),
-          current_log.handle->stm_manager()->max_collectible_offset(),
-          current_log.handle->config().tombstone_retention_ms(),
-          _config.compaction_priority,
-          _abort_source,
-          std::move(ntp_sanitizer_cfg),
-          _compaction_hash_key_map.get()));
-        _probe->housekeeping_log_processed();
+        try {
+            co_await current_log.handle->housekeeping(housekeeping_config(
+              collection_threshold,
+              _config.retention_bytes(),
+              current_log.handle->stm_manager()->max_collectible_offset(),
+              current_log.handle->config().tombstone_retention_ms(),
+              _config.compaction_priority,
+              _abort_source,
+              std::move(ntp_sanitizer_cfg),
+              _compaction_hash_key_map.get(),
+              &_disk_space_alert));
+            _probe->housekeeping_log_processed();
+        } catch (const gc_required_exception& e) {
+            vlog(
+              gclog.debug,
+              "Compaction of {} stopped: {}",
+              current_log.handle->config().ntp(),
+              e.what());
+            co_return;
+        }
 
         // bail out of compaction early in order to get back to gc
         if (gc_required()) {

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -286,6 +286,13 @@ private:
 
     void update_log_count();
 
+    /*
+      Returns true if garbage collection is required due to a low or degraded
+      disk space alert, or if it has been periodicially triggered.
+      Returns false if neither condition is met.
+      */
+    bool gc_required() const;
+
     log_config _config;
     kvstore& _kvstore;
     storage_resources& _resources;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -109,9 +109,7 @@ ss::future<model::offset> build_offset_map(
     // Build the key offset map by iterating on older and older data.
     auto iter = std::prev(segs.end());
     while (true) {
-        if (cfg.asrc) {
-            cfg.asrc->check();
-        }
+        cfg.maybe_abort_compaction();
         auto seg = *iter;
         if (seg->index().has_clean_compact_timestamp()) {
             // This segment has already been fully deduplicated, so building the

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -549,9 +549,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
   offset_delta_time apply_offset,
   ss::rwlock::holder read_holder,
   ss::sharded<features::feature_table>& feature_table) {
-    if (cfg.asrc) {
-        cfg.asrc->check();
-    }
+    cfg.maybe_abort_compaction();
 
     vlog(gclog.trace, "self compacting segment {}", s->reader().path());
     auto segment_generation = s->get_generation_id();
@@ -568,10 +566,8 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     auto staging_file = s->reader().path().to_staging();
     auto staging_to_clean = scoped_file_tracker{
       cfg.files_to_cleanup, {staging_file}};
-    // check the abort source after compacting segment index
-    if (cfg.asrc) {
-        cfg.asrc->check();
-    }
+    // check if compaction should be aborted after compacting segment index
+    cfg.maybe_abort_compaction();
     auto idx = co_await do_copy_segment_data(
       s,
       cfg,

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -14,6 +14,7 @@
 #include "model/record_batch_types.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
+#include "storage/exceptions.h"
 #include "storage/tests/manual_mixin.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
@@ -225,7 +226,8 @@ public:
     ss::future<bool> do_sliding_window_compact(
       model::offset max_collect_offset,
       std::optional<std::chrono::milliseconds> tombstone_ret_ms,
-      std::optional<size_t> max_keys = std::nullopt) {
+      std::optional<size_t> max_keys = std::nullopt,
+      storage::disk_space_alert* space_alerter = nullptr) {
         // Compact, allowing the map to grow as large as we need.
         ss::abort_source never_abort;
         storage::compaction_config cfg(
@@ -236,10 +238,12 @@ public:
           std::nullopt,
           max_keys,
           nullptr,
-          nullptr);
+          nullptr,
+          space_alerter);
         auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
         // sliding_window_compact takes cfg by const&, so return will be a
         // use-after-free
+        cfg.disk_log = &disk_log;
         co_return co_await disk_log.sliding_window_compact(cfg);
     }
 
@@ -1336,3 +1340,78 @@ INSTANTIATE_TEST_SUITE_P(
   RandomDistributionMultiPass,
   CompactionFixtureTombstonesMultiPassRandomParamTest,
   ::testing::Combine(::testing::Bool(), ::testing::Values(10, 25, 100)));
+
+class CompactionFixtureSpaceAlertTest
+  : public CompactionFixtureTest
+  , public ::testing::WithParamInterface<storage::disk_space_alert> {};
+
+TEST_P(CompactionFixtureSpaceAlertTest, SpaceAlertEarlyAbortsCompaction) {
+    auto num_segments = 10;
+    auto total_records = 100;
+    auto cardinality = total_records;
+    size_t records_per_segment = total_records / num_segments;
+    generate_data(num_segments, cardinality, records_per_segment).get();
+
+    ss::abort_source never_abort;
+    storage::disk_space_alert disk_alert = GetParam();
+
+    if (
+      disk_alert == storage::disk_space_alert::low_space
+      || disk_alert == storage::disk_space_alert::degraded) {
+        ASSERT_THROW(
+          do_sliding_window_compact(
+            log->segments().back()->offsets().get_base_offset(),
+            std::nullopt,
+            std::nullopt,
+            &disk_alert)
+            .get(),
+          gc_required_exception);
+    } else {
+        bool did_compact
+          = do_sliding_window_compact(
+              log->segments().back()->offsets().get_base_offset(),
+              std::nullopt,
+              std::nullopt,
+              &disk_alert)
+              .get();
+        ASSERT_TRUE(did_compact);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  CompactionSpaceAlert,
+  CompactionFixtureSpaceAlertTest,
+  ::testing::Values(
+    storage::disk_space_alert::low_space,
+    storage::disk_space_alert::degraded,
+    storage::disk_space_alert::ok));
+
+class CompactionFixtureEvictionTest : public CompactionFixtureTest {
+public:
+    CompactionFixtureEvictionTest() {
+        // These need to be enabled in order to set the eviction offset
+        test_local_cfg.get("cloud_storage_enabled").set_value(true);
+        test_local_cfg.get("cloud_storage_enable_remote_write").set_value(true);
+    }
+};
+
+TEST_F(CompactionFixtureEvictionTest, EvictionEarlyAbortsCompaction) {
+    auto num_segments = 10;
+    auto total_records = 100;
+    auto cardinality = total_records;
+    size_t records_per_segment = total_records / num_segments;
+    generate_data(num_segments, cardinality, records_per_segment).get();
+
+    ss::abort_source never_abort;
+
+    // Set the eviction offset
+    log->set_cloud_gc_offset(model::offset{123456});
+
+    ASSERT_THROW(
+      do_sliding_window_compact(
+        log->segments().back()->offsets().get_base_offset(),
+        std::nullopt,
+        std::nullopt)
+        .get(),
+      gc_required_exception);
+}

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -11,6 +11,8 @@
 
 #include "base/vlog.h"
 #include "storage/compacted_index.h"
+#include "storage/disk_log_impl.h"
+#include "storage/exceptions.h"
 #include "storage/logger.h"
 #include "storage/ntp_config.h"
 #include "utils/human.h"
@@ -242,6 +244,37 @@ operator<<(std::ostream& o, compacted_index::recovery_state state) {
         return o << "index_recovered";
     }
     __builtin_unreachable();
+}
+
+void compaction_config::maybe_abort_compaction() const {
+    // Check the abort_source, this will throw if abort has been requested
+    if (asrc) {
+        asrc->check();
+    }
+
+    if (disk_log) {
+        const auto& log = *disk_log;
+        if (disk_alert) {
+            auto alert = *disk_alert;
+
+            // In a low or degraded disk space situation, bail out of
+            // compaction early to allow gc to quickly reclaim data.
+            if (
+              alert == disk_space_alert::degraded
+              || alert == disk_space_alert::low_space) {
+                throw gc_required_exception(fmt::format(
+                  "Bailing out of compaction due to {} disk state", alert));
+            }
+        }
+
+        // If resource management has set a cloud_gc_offset, bail out of
+        // compaction early to allow prefix truncation to quickly reclaim data.
+        if (log.has_cloud_gc_offset()) {
+            throw gc_required_exception(
+              fmt::format("Bailing out of compaction due to resource "
+                          "management setting cloud_gc_offset"));
+        }
+    }
 }
 
 } // namespace storage

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -467,6 +467,11 @@ struct gc_config {
     friend std::ostream& operator<<(std::ostream&, const gc_config&);
 };
 
+// Forward declaration for disk log impl (used in compaction_config)
+// TODO: remove this and put all variables that make up the
+// maybe_abort_compaction() heuristic into a struct.
+class disk_log_impl;
+
 struct compaction_config {
     compaction_config(
       model::offset max_collect_offset,
@@ -476,7 +481,8 @@ struct compaction_config {
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       hash_key_offset_map* key_map = nullptr,
-      scoped_file_tracker::set_t* to_clean = nullptr)
+      scoped_file_tracker::set_t* to_clean = nullptr,
+      disk_space_alert* alert = nullptr)
       : max_collectible_offset(max_collect_offset)
       , tombstone_retention_ms(tombstone_ret_ms)
       , iopc(p)
@@ -484,7 +490,8 @@ struct compaction_config {
       , key_offset_map_max_keys(max_keys)
       , hash_key_map(key_map)
       , files_to_cleanup(to_clean)
-      , asrc(&as) {}
+      , asrc(&as)
+      , disk_alert(alert) {}
 
     // Cannot delete or compact past this offset (i.e. for unresolved txn
     // records): that is, only offsets <= this may be compacted.
@@ -520,6 +527,24 @@ struct compaction_config {
     // abort source for compaction task
     ss::abort_source* asrc;
 
+    // Disk space indicator to help decide whether compaction should be aborted
+    // in a degraded or low disk space state to allow for emergency garbage
+    // collection
+    disk_space_alert* disk_alert;
+
+    // Used along with disk_space_alert to provide heuristics about whether
+    // compaction should be aborted early in a disk pressure situation or not.
+    // TODO: remove this and put all variables that make up the heuristic into a
+    // struct.
+    disk_log_impl* disk_log{nullptr};
+
+    // Checks if compaction should be aborted early, due to abort source being
+    // triggered or by a disk space alert.
+    //
+    // Will throw a ss::abort_requested_exception or a
+    // gc_required_exception in the case that compaction should be aborted.
+    void maybe_abort_compaction() const;
+
     friend std::ostream& operator<<(std::ostream&, const compaction_config&);
 };
 
@@ -538,7 +563,8 @@ struct housekeeping_config {
       ss::io_priority_class p,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
-      hash_key_offset_map* key_map = nullptr)
+      hash_key_offset_map* key_map = nullptr,
+      disk_space_alert* alert = nullptr)
       : compact(
           max_collect_offset,
           tombstone_retention_ms,
@@ -546,7 +572,9 @@ struct housekeeping_config {
           as,
           std::move(san_cfg),
           std::nullopt,
-          key_map)
+          key_map,
+          nullptr,
+          alert)
       , gc(upper, max_bytes_in_log) {}
 
     compaction_config compact;


### PR DESCRIPTION
### Converting to draft, no need to review. We will work on separating garbage collection and compaction in separate loops first, and then worry about the ideas here.


Compaction can be a long running process, during which prefix truncation and regularly scheduled garbage collection is blocked.

This PR, most notably, adds `compaction_config::maybe_abort_compaction()` which checks the abort source (as was done before) but also now considers two signals for terminating the compaction process early:

1. Degraded or low disk space alerts
2. Resource management triggered garbage collection

In either of these cases, compaction is aborted early.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Allow the early abortion of compaction in the cases of disk pressure or resource management triggered garbage collection in order to prevent long running compactions from blocking emergency retention measures 
