### PR TITLE
cloud_storage: Add manifest operations fuzzer

### DIFF
--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2682,3 +2682,256 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE(restored == m);
     BOOST_REQUIRE(m.get_applied_offset() == model::offset{100});
 }
+
+struct manifest_mutator {
+    manifest_mutator()
+      : m(manifest_ntp, model::initial_revision_id(0))
+      , current_offset() {}
+
+    void add_new_segment(std::pair<int, int> params) {
+        auto [num_offsets, num_configs] = params;
+        BOOST_REQUIRE(num_offsets > 0);
+        BOOST_REQUIRE(num_configs >= 0);
+        BOOST_REQUIRE(num_offsets >= num_configs);
+        auto base = model::next_offset(current_offset);
+        auto last = base + model::offset(num_offsets - 1);
+        auto delta_end = current_delta + model::offset_delta(num_configs);
+        segment_meta meta{
+          .is_compacted = false,
+          .size_bytes = (size_t)num_offsets,
+          .base_offset = base,
+          .committed_offset = last,
+          .delta_offset = current_delta,
+          .ntp_revision = model::initial_revision_id{0},
+          .delta_offset_end = current_delta + model::offset_delta(num_configs),
+          .sname_format = segment_name_format::v3,
+        };
+        current_offset = last;
+        current_delta = delta_end;
+        m.add(meta);
+    }
+
+    void spill(model::offset so) {
+        if (so == model::offset{}) {
+            return;
+        }
+        cloud_storage::spillover_manifest tail(
+          manifest_ntp, model::initial_revision_id(0));
+        for (const auto& meta : m) {
+            if (meta.base_offset >= so) {
+                break;
+            }
+            tail.add(meta);
+        }
+        if (tail.empty() || tail.size() == m.size()) {
+            // Spillover manifest can not be empty but
+            // also we're not allowed to spill all segments
+            // from the manifest.
+            return;
+        }
+        const auto first = *tail.begin();
+        const auto sm = tail.make_manifest_metadata();
+        m.spillover(sm);
+        if (m.get_archive_start_offset() == model::offset{}) {
+            m.set_archive_start_offset(first.base_offset, first.delta_offset);
+            m.set_archive_clean_offset(first.base_offset, 0);
+        }
+    }
+
+    void retention(model::offset so) {
+        if (so == model::offset{}) {
+            return;
+        }
+        auto has_archive = m.get_archive_start_offset() != model::offset{};
+        if (has_archive) {
+            vlog(test_log.info, "Triggering archive retention");
+            size_t bytes_removed = 0;
+            model::offset aligned_so;
+            model::offset_delta aligned_delta;
+            for (auto i = m.get_spillover_map().begin();
+                 i != m.get_spillover_map().end();
+                 ++i) {
+                if (i->committed_offset < so) {
+                    bytes_removed += i->size_bytes;
+                    aligned_so = model::next_offset(i->committed_offset);
+                    aligned_delta = i->delta_offset_end;
+                } else {
+                    break;
+                }
+            }
+            if (aligned_so != model::offset{}) {
+                m.set_archive_start_offset(aligned_so, aligned_delta);
+                // GC archive area
+                m.set_archive_clean_offset(aligned_so, bytes_removed);
+            }
+        } else {
+            vlog(test_log.info, "Triggering manifest retention");
+            // apply manifest retention
+            model::offset aligned_so;
+            for (const auto& meta : m) {
+                if (meta.committed_offset < so) {
+                    aligned_so = model::next_offset(meta.committed_offset);
+                } else {
+                    break;
+                }
+            }
+            if (aligned_so != model::offset{}) {
+                m.advance_start_offset(aligned_so);
+            }
+        }
+        // garbage collect manifest
+        // in case of spillover we still need to do GC to
+        // get rid of replaced segments.
+        vlog(test_log.info, "GC");
+        m.delete_replaced_segments();
+        m.truncate();
+    }
+
+    void housekeeping(std::pair<model::offset, model::offset> so) {
+        auto [retention_so, archive_so] = so;
+        retention(retention_so);
+        spill(archive_so);
+    }
+
+    // Check manifest consistency
+    void validate() {
+        // Check that spillover start offset makes sense
+        BOOST_REQUIRE(
+          m.get_archive_start_offset()
+          <= m.get_start_offset().value_or(model::offset{}));
+
+        // Check that offsets are consistent between
+        // spillover and segment storage
+        model::offset expected_next;
+        model::offset_delta expected_delta;
+        for (const auto& spill : m.get_spillover_map()) {
+            if (expected_next != model::offset{}) {
+                BOOST_REQUIRE(spill.base_offset == expected_next);
+                BOOST_REQUIRE(spill.delta_offset == expected_delta);
+            }
+            expected_next = model::next_offset(spill.committed_offset);
+            expected_delta = spill.delta_offset_end;
+        }
+
+        for (const auto& meta : m) {
+            if (expected_next != model::offset{}) {
+                BOOST_REQUIRE(meta.base_offset == expected_next);
+                BOOST_REQUIRE(meta.delta_offset == expected_delta);
+            }
+            expected_next = model::next_offset(meta.committed_offset);
+            expected_delta = meta.delta_offset_end;
+        }
+    }
+
+    partition_manifest m;
+    model::offset current_offset;
+    model::offset_delta current_delta;
+};
+
+enum class fuzzer_commands {
+    add_new_segment,
+    housekeeping,
+};
+
+struct fuzzer {
+    static constexpr int max_segment_offsets = 100;
+    std::vector<fuzzer_commands> commands;
+
+    explicit fuzzer(size_t segments_per_housekeeping) {
+        for (size_t i = 0; i < segments_per_housekeeping; i++) {
+            commands.push_back(fuzzer_commands::add_new_segment);
+        }
+        commands.push_back(fuzzer_commands::housekeeping);
+    }
+
+    fuzzer_commands get_next() const {
+        return random_generators::random_choice(commands);
+    }
+
+    std::pair<int, int> add_new_segment(const manifest_mutator&) const {
+        int num_offsets = random_generators::get_int(1, max_segment_offsets);
+        int num_configs = random_generators::get_int(0, num_offsets);
+        return std::make_pair(num_offsets, num_configs);
+    }
+
+    std::pair<model::offset, model::offset>
+    housekeeping(const manifest_mutator& mr) const {
+        if (mr.m.empty()) {
+            // Special case, no need to run housekeeping
+            return std::make_pair(model::offset{}, model::offset{});
+        }
+        // The retention so should be smaller than archive so
+        auto so = mr.m.full_log_start_offset().value();
+        auto lo = mr.m.get_last_offset();
+        auto retention = random_generators::get_int(so(), lo());
+        auto spillover = random_generators::get_int(retention, lo());
+        return std::make_pair(
+          model::offset(retention), model::offset(spillover));
+    }
+};
+
+void manifest_operations_fuzz(
+  size_t num_segments_per_housekeeping, size_t num_iterations) {
+    manifest_mutator runner;
+
+    fuzzer f(num_segments_per_housekeeping);
+
+    runner.validate();
+    for (int i = 0; i < num_iterations; i++) {
+        switch (f.get_next()) {
+        case fuzzer_commands::add_new_segment:
+            runner.add_new_segment(f.add_new_segment(runner));
+            break;
+        case fuzzer_commands::housekeeping:
+            runner.housekeeping(f.housekeeping(runner));
+            break;
+        }
+        runner.validate();
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_fuzz) {
+    manifest_operations_fuzz(100, 10000);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_recycle) {
+    // 1. Add segments to the manifest.
+    // 2. Apply spillover.
+    // 3. Let retention remove everything.
+    // 4. Fill with data again,
+    // 5. Apply spillover.
+    manifest_mutator mr;
+    // 1.
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    BOOST_REQUIRE_EQUAL(mr.m.get_last_offset(), model::offset(499));
+    // 2.
+    mr.spill(model::offset(300));
+    BOOST_REQUIRE_EQUAL(mr.m.get_archive_start_offset(), model::offset(0));
+    BOOST_REQUIRE_EQUAL(mr.m.get_start_offset(), model::offset(300));
+    // 3.1.
+    // This should only remove
+    mr.retention(model::offset(500));
+    // This indicates that the archive is removed completely
+    BOOST_REQUIRE_EQUAL(mr.m.get_archive_start_offset(), model::offset());
+    // 3.2.
+    // This should get rid of the data in the manifest
+    mr.retention(model::offset(500));
+    BOOST_REQUIRE_EQUAL(mr.m.get_archive_start_offset(), model::offset());
+    BOOST_REQUIRE_EQUAL(mr.m.get_last_offset(), model::offset(499));
+    BOOST_REQUIRE(mr.m.get_start_offset() == std::nullopt);
+    // 4.
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    mr.add_new_segment(std::make_pair(100, 10));
+    BOOST_REQUIRE_EQUAL(mr.m.get_last_offset(), model::offset(999));
+    // 5.
+    mr.spill(model::offset(800));
+    BOOST_REQUIRE_EQUAL(mr.m.get_archive_start_offset(), model::offset(500));
+    BOOST_REQUIRE_EQUAL(mr.m.get_start_offset(), model::offset(800));
+}

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -20,6 +20,7 @@
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/offset_interval.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
 #include "utils/tracking_allocator.h"
@@ -2711,6 +2712,36 @@ struct manifest_mutator {
         m.add(meta);
     }
 
+    void replace_offset_range(
+      const std::optional<model::bounded_offset_interval>& maybe_range) {
+        if (!maybe_range.has_value()) {
+            return;
+        }
+        auto range = maybe_range.value();
+        segment_meta replacement{
+          .is_compacted = true,
+          .size_bytes = 0,
+          .ntp_revision = model::initial_revision_id{0},
+          .sname_format = segment_name_format::v3,
+        };
+        for (const auto& meta : m) {
+            auto current = model::bounded_offset_interval::checked(
+              meta.base_offset, meta.committed_offset);
+            if (range.overlaps(current)) {
+                replacement.base_offset = std::min(
+                  replacement.base_offset, meta.base_offset);
+                replacement.committed_offset = std::max(
+                  replacement.committed_offset, meta.committed_offset);
+                replacement.delta_offset = std::min(
+                  replacement.delta_offset, meta.delta_offset);
+                replacement.delta_offset_end = std::max(
+                  replacement.delta_offset_end, meta.delta_offset_end);
+                replacement.size_bytes += meta.size_bytes;
+            }
+        }
+        m.add(replacement);
+    }
+
     void spill(model::offset so) {
         if (so == model::offset{}) {
             return;
@@ -2830,6 +2861,7 @@ struct manifest_mutator {
 
 enum class fuzzer_commands {
     add_new_segment,
+    replace_segments,
     housekeeping,
 };
 
@@ -2837,9 +2869,13 @@ struct fuzzer {
     static constexpr int max_segment_offsets = 100;
     std::vector<fuzzer_commands> commands;
 
-    explicit fuzzer(size_t segments_per_housekeeping) {
+    explicit fuzzer(
+      size_t segments_per_housekeeping, size_t replacements_per_housekeeping) {
         for (size_t i = 0; i < segments_per_housekeeping; i++) {
             commands.push_back(fuzzer_commands::add_new_segment);
+        }
+        for (size_t i = 0; i < replacements_per_housekeeping; i++) {
+            commands.push_back(fuzzer_commands::replace_segments);
         }
         commands.push_back(fuzzer_commands::housekeeping);
     }
@@ -2852,6 +2888,19 @@ struct fuzzer {
         int num_offsets = random_generators::get_int(1, max_segment_offsets);
         int num_configs = random_generators::get_int(0, num_offsets);
         return std::make_pair(num_offsets, num_configs);
+    }
+
+    std::optional<model::bounded_offset_interval>
+    replace_segments(const manifest_mutator& mm) {
+        auto base = mm.m.get_start_offset();
+        auto last = mm.m.get_last_offset();
+        if (!base.has_value()) {
+            return std::nullopt;
+        }
+        auto rb = random_generators::get_int((*base)(), last());
+        auto re = random_generators::get_int(rb, last());
+        return model::bounded_offset_interval::checked(
+          model::offset(rb), model::offset(re));
     }
 
     std::pair<model::offset, model::offset>
@@ -2871,16 +2920,21 @@ struct fuzzer {
 };
 
 void manifest_operations_fuzz(
-  size_t num_segments_per_housekeeping, size_t num_iterations) {
+  size_t num_segments_per_housekeeping,
+  size_t num_replacements_per_housekeeping,
+  size_t num_iterations) {
     manifest_mutator runner;
 
-    fuzzer f(num_segments_per_housekeeping);
+    fuzzer f(num_segments_per_housekeeping, num_replacements_per_housekeeping);
 
     runner.validate();
     for (int i = 0; i < num_iterations; i++) {
         switch (f.get_next()) {
         case fuzzer_commands::add_new_segment:
             runner.add_new_segment(f.add_new_segment(runner));
+            break;
+        case fuzzer_commands::replace_segments:
+            runner.replace_offset_range(f.replace_segments(runner));
             break;
         case fuzzer_commands::housekeeping:
             runner.housekeeping(f.housekeeping(runner));
@@ -2891,7 +2945,11 @@ void manifest_operations_fuzz(
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_fuzz) {
-    manifest_operations_fuzz(100, 10000);
+    manifest_operations_fuzz(100, 0, 10000);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_fuzz_with_replacement) {
+    manifest_operations_fuzz(100, 10, 10000);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_recycle) {


### PR DESCRIPTION
The PR adds a new component called `manifest_mutator` which contains a `partition_manifest` instances and applies different operations to it. The examples of operations are 'add segment' or 'spill' or 'replace segment'. All operations are implemented similarly to how they are done in the `ntp_archiver`.  So basically, if the archiver replicates STM commands in certain order then the mutator is doing the same thing. 

The mutator is used to add two new fuzz tests which trigger different operations randomly. It can also be used to implement normal tests because it removes a lot of boilerplate. It's also used to add a new unit test that generates the data then triggers spillover then lets retention to remove all spillover manifests and all segments and then adds data again.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none