### PR TITLE
[CORE-8990] `storage`: use `segment_closed_exception` in compaction utils

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -980,8 +980,7 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
             co_return ret;
         }
         if (unlikely(segment->is_closed())) {
-            throw std::runtime_error(fmt::format(
-              "Aborting compaction of closed segment: {}", *segment));
+            throw segment_closed_exception();
         }
         ++gen_it;
     }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -824,8 +824,7 @@ make_concatenated_segment(
     // happened to be racing with an operation like truncation or shutdown.
     for (const auto& segment : segments) {
         if (unlikely(segment->is_closed())) {
-            throw std::runtime_error(fmt::format(
-              "Aborting compaction of closed segment: {}", *segment));
+            throw segment_closed_exception();
         }
     }
 


### PR DESCRIPTION
In PR https://github.com/redpanda-data/redpanda/pull/24874, we introduced [a race condition in the test `log_truncate_test`](https://redpandadata.atlassian.net/issues/CORE-8990?jql=textfields%20~%20%22log_truncate_test%22) (due to expectations of the test itself). This PR fixes the flakey test. 

In compaction utility functions, we throw a `segment_closed_exception` when encountering a segment that has been closed concurrently during the process.

However, there is [one location in `do_compact_adjacent_segments()`](https://github.com/redpanda-data/redpanda/blob/59ee571fe90251804f1e53afd1857b9466f5df10/src/v/storage/disk_log_impl.cc#L982-L985), and [another in `make_concatenated_segment()`](https://github.com/redpanda-data/redpanda/blob/59ee571fe90251804f1e53afd1857b9466f5df10/src/v/storage/segment_utils.cc#L825-L830) in which we throw `std::runtime_error`s with a descriptive message of the segment closed instead.

Change these throw sites to use `segment_closed_exception`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
