### PR TITLE
Added directory mode package for ducktape

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -20,6 +20,15 @@ redpanda_package(
     rpath_override = "$ORIGIN/../lib",
 )
 
+redpanda_package(
+    name = "ducktape",
+    out = "redpanda_ducktape",
+    include_sysroot_libs = True,
+    redpanda_binary = "//:redpanda",
+    rpath_override = "$ORIGIN/../lib",
+    rpk_binary = "//:rpk",
+)
+
 # This is the ID for the nonroot user in the distroless containers.
 NONROOT_USER = 65532
 

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -91,6 +91,8 @@ def _prepare_package_content(ctx, dynamic_loader_path = "/opt/redpanda/lib"):
     )
 
 def _impl(ctx):
+    use_dir = not ctx.attr.out.endswith(".tar.gz")
+    out = ctx.actions.declare_directory(ctx.attr.out) if use_dir else ctx.actions.declare_file(ctx.attr.out)
     package_content = _prepare_package_content(ctx)
 
     # Create the configuration file for the packaging tool
@@ -101,6 +103,7 @@ def _impl(ctx):
         "shared_libraries": [solib.path for solib in package_content.shared_libraries],
         "default_yaml_config": ctx.file.default_yaml_config.path if ctx.file.default_yaml_config else None,
         "owner": ctx.attr.owner,
+        "directory_mode": use_dir,
     }
     ctx.actions.write(cfg_file, content = json.encode_indent(cfg))
 
@@ -113,7 +116,7 @@ def _impl(ctx):
 
     # run the packaging tool
     ctx.actions.run(
-        outputs = [ctx.outputs.out],
+        outputs = [out],
         inputs = inputs,
         tools = [ctx.executable._tool],
         executable = ctx.executable._tool,
@@ -121,12 +124,12 @@ def _impl(ctx):
             "-config",
             cfg_file.path,
             "-output",
-            ctx.outputs.out.path,
+            out.path,
         ],
         mnemonic = "BuildingRedpandaPackage",
         use_default_shell_env = False,
     )
-    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+    return [DefaultInfo(files = depset([out]))]
 
 redpanda_package = rule(
     implementation = _impl,
@@ -142,7 +145,7 @@ redpanda_package = rule(
             allow_single_file = True,
         ),
         "owner": attr.int(),
-        "out": attr.output(
+        "out": attr.string(
             mandatory = True,
         ),
         "include_sysroot_libs": attr.bool(),

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -33,6 +33,7 @@ type pkgConfig struct {
 	SharedLibraries   []string `json:"shared_libraries"`
 	DefaultYAMLConfig *string  `json:"default_yaml_config"`
 	Owner             int      `json:"owner"`
+	DirectoryMode     bool     `json:"directory_mode"`
 }
 
 func createTarball(cfg pkgConfig, w io.Writer) error {
@@ -113,6 +114,75 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 	}
 	return nil
 }
+func copyFile(src string, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+	dstFile.ReadFrom(srcFile)
+
+	return nil
+}
+
+func createPackageDir(cfg pkgConfig, output string) error {
+	if err := os.MkdirAll(output, 0755); err != nil {
+		return err
+	}
+
+	dir := func(path string) error {
+		if err := os.Mkdir(filepath.Join(output, path), 0755); err != nil {
+			return fmt.Errorf("Error creating directory %s: %v", path, err)
+		}
+		return nil
+	}
+
+	file := func(src string, dir string, name string) error {
+		if err := copyFile(src, filepath.Join(output, dir, name)); err != nil {
+			return fmt.Errorf("Error copying file %s: %v", src, err)
+		}
+		return nil
+	}
+
+	if cfg.DefaultYAMLConfig != nil {
+		if err := dir("config"); err != nil {
+			return err
+		}
+	}
+	if err := dir("bin"); err != nil {
+		return err
+	}
+	if err := dir("lib"); err != nil {
+		return err
+	}
+
+	if err := dir("libexec"); err != nil {
+		return err
+	}
+
+	for _, so := range cfg.SharedLibraries {
+		if err := file(so, "lib", filepath.Base(so)); err != nil {
+			return err
+		}
+	}
+
+	if err := file(cfg.RedpandaBinary, "libexec", "redpanda"); err != nil {
+		return err
+	}
+
+	if cfg.RPKBinary != nil {
+		if err := file(*cfg.RPKBinary, "bin", "rpk"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func runTool() error {
 	configPath := flag.String("config", "", "path to a configuration file to create the tarball")
@@ -124,17 +194,24 @@ func runTool() error {
 	} else if err := json.Unmarshal(b, &cfg); err != nil {
 		return fmt.Errorf("unable to parse config: %w", err)
 	}
-	file, err := os.OpenFile(*output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("unable to open output file: %w", err)
-	}
-	defer file.Close()
-	bw := bufio.NewWriter(file)
-	defer bw.Flush()
-	gw := gzip.NewWriter(bw)
-	defer gw.Close()
-	if err := createTarball(cfg, gw); err != nil {
-		return fmt.Errorf("unable to create tarball: %w", err)
+
+	if cfg.DirectoryMode {
+		if err := createPackageDir(cfg, *output); err != nil {
+			return fmt.Errorf("unable to create package directory: %w", err)
+		}
+	} else {
+		file, err := os.OpenFile(*output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("unable to open output file: %w", err)
+		}
+		defer file.Close()
+		bw := bufio.NewWriter(file)
+		defer bw.Flush()
+		gw := gzip.NewWriter(bw)
+		defer gw.Close()
+		if err := createTarball(cfg, gw); err != nil {
+			return fmt.Errorf("unable to create tarball: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Added a mode where Bazel creates a directory containing the Redpanda package content. The directory is intended to be used by ducktape tests running in container mode.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 