### PR TITLE
Iceberg: adapt `merge_append_action` to schema evolution and multiple partition specs

### DIFF
--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -279,16 +279,28 @@ public:
                     return pk.error();
                 }
 
-                // TODO: pass schema_id and pspec_id to merge_append_action
-                // (currently it assumes that the files were serialized with the
-                // current schema and a single partition spec).
-                icb_files_.push_back({
+                iceberg::data_file file{
                   .content_type = iceberg::data_file_content_type::data,
                   .file_path = io.to_uri(std::filesystem::path(f.remote_path)),
                   .file_format = iceberg::data_file_format::parquet,
                   .partition = std::move(pk.value()),
                   .record_count = f.row_count,
                   .file_size_bytes = f.file_size_bytes,
+                };
+                // For files created by a legacy Redpanda version that only
+                // supported hourly partitioning, choose current schema and
+                // spec ids.
+                auto schema_id = f.table_schema_id >= 0
+                                   ? iceberg::schema::id_t{f.table_schema_id}
+                                   : table_.current_schema_id;
+                auto pspec_id
+                  = f.partition_spec_id >= 0
+                      ? iceberg::partition_spec::id_t{f.partition_spec_id}
+                      : table_.default_spec_id;
+                icb_files_.push_back(iceberg::file_to_append{
+                  .file = std::move(file),
+                  .schema_id = schema_id,
+                  .partition_spec_id = pspec_id,
                 });
             }
         }
@@ -392,7 +404,7 @@ private:
     bool with_snapshot_tag_;
 
     // State accumulated.
-    chunked_vector<iceberg::data_file> icb_files_;
+    chunked_vector<iceberg::file_to_append> icb_files_;
     std::optional<model::offset> new_committed_offset_;
 };
 

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -495,14 +495,19 @@ TEST_F(FileCommitterTest, TestDeduplicateFromAncestor) {
     // Add a new snapshot to the table by appending some data. Explicitly
     // _don't_ add the commit metadata property.
     iceberg::transaction tx(std::move(load_res.value()));
-    chunked_vector<iceberg::data_file> new_files;
+    chunked_vector<iceberg::file_to_append> new_files;
     iceberg::partition_key pk;
     pk.val = std::make_unique<iceberg::struct_value>();
     pk.val->fields.emplace_back(iceberg::int_value{0});
-    new_files.emplace_back(iceberg::data_file{
+    iceberg::data_file icb_file{
       .file_path = iceberg::uri("foobar"),
       .partition = std::move(pk),
       .file_size_bytes = 1024,
+    };
+    new_files.emplace_back(iceberg::file_to_append{
+      .file = std::move(icb_file),
+      .schema_id = tx.table().current_schema_id,
+      .partition_spec_id = tx.table().default_spec_id,
     });
     auto append_res = tx.merge_append(manifest_io, std::move(new_files)).get();
     ASSERT_FALSE(append_res.has_error());

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -148,17 +148,9 @@ public:
         ASSERT_TRUE(mlist_res.has_value());
         const auto& mlist = mlist_res.value();
 
-        auto schema = datalake::default_schema();
-        auto pspec = iceberg::partition_spec::resolve(
-          datalake::hour_partition_spec(), schema.schema_struct);
-        ASSERT_TRUE(pspec.has_value());
-        auto pk_type = iceberg::partition_key_type::create(
-          pspec.value(), schema);
-
         // Collect all the data files for this snapshot.
         for (const auto& m : mlist.files) {
-            auto m_res
-              = manifest_io.download_manifest(m.manifest_path, pk_type).get();
+            auto m_res = manifest_io.download_manifest(m.manifest_path).get();
             ASSERT_TRUE(m_res.has_value());
             for (const auto& e : m_res.value().entries) {
                 uris->emplace_back(e.data_file.file_path());

--- a/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_snapshot_remover_test.cc
@@ -65,25 +65,29 @@ public:
     }
 
     ss::future<> add_snapshot(const iceberg::table_identifier& table_id) {
-        chunked_vector<iceberg::data_file> files;
+        chunked_vector<iceberg::file_to_append> files;
         auto filename = make_filename(file_counter_++);
         auto file_uri = manifest_io.to_uri({filename});
-
-        iceberg::partition_key pk;
-        pk.val = std::make_unique<iceberg::struct_value>();
-        pk.val->fields.emplace_back(iceberg::int_value{0});
-        files.emplace_back(iceberg::data_file{
-          .file_path = file_uri,
-          .partition = std::move(pk),
-          .file_size_bytes = 0,
-        });
 
         auto load_res = co_await catalog.load_table(table_id);
         ASSERT_FALSE_CORO(load_res.has_error())
           << "Error loading: " << load_res.error();
+        iceberg::transaction txn(std::move(load_res.value()));
 
-        auto& table = load_res.value();
-        iceberg::transaction txn(std::move(table));
+        iceberg::partition_key pk;
+        pk.val = std::make_unique<iceberg::struct_value>();
+        pk.val->fields.emplace_back(iceberg::int_value{0});
+        iceberg::data_file file{
+          .file_path = file_uri,
+          .partition = std::move(pk),
+          .file_size_bytes = 0,
+        };
+        files.emplace_back(iceberg::file_to_append{
+          .file = std::move(file),
+          .schema_id = txn.table().current_schema_id,
+          .partition_spec_id = txn.table().default_spec_id,
+        });
+
         auto merge_res = co_await txn.merge_append(
           manifest_io, std::move(files));
         ASSERT_FALSE_CORO(merge_res.has_error())

--- a/src/v/datalake/coordinator/tests/state_test_utils.cc
+++ b/src/v/datalake/coordinator/tests/state_test_utils.cc
@@ -22,6 +22,10 @@ chunked_vector<translated_offset_range> make_pending_files(
             fs.emplace_back(data_file{
               .remote_path = fmt::format("{}-{}", begin, end),
               .file_size_bytes = 1024,
+              .table_schema_id = 0,
+              .partition_spec_id = 0,
+              .partition_key = chunked_vector<std::optional<bytes>>::single(
+                std::nullopt),
             });
         }
         files.emplace_back(translated_offset_range{

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -175,6 +175,7 @@ redpanda_cc_library(
         ":compatibility_utils",
         ":datatypes",
         ":partition",
+        ":values",
         "//src/v/base",
     ],
 )

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -1099,6 +1099,7 @@ redpanda_cc_library(
     include_prefix = "iceberg",
     visibility = ["//visibility:public"],
     deps = [
+        ":datatypes",
         "//src/v/bytes:iobuf",
         "//src/v/container:fragmented_vector",
         "//src/v/utils:uuid",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -464,6 +464,7 @@ redpanda_cc_library(
         "merge_append_action.h",
     ],
     implementation_deps = [
+        ":compatibility",
         ":logger",
         ":manifest",
         ":manifest_file_packer",

--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -401,6 +401,26 @@ private:
     const partition_spec* spec_;
 };
 
+struct primitive_value_type_promoting_visitor {
+    template<typename TVal, typename TType>
+    primitive_value operator()(TVal v, const TType& t) const {
+        if constexpr (std::is_same_v<TType, primitive_value_type_t<TVal>>) {
+            return v;
+        }
+        if constexpr (
+          std::is_same_v<TVal, int_value> && std::is_same_v<TType, long_type>) {
+            return long_value{v.val};
+        }
+        if constexpr (
+          std::is_same_v<TVal, float_value>
+          && std::is_same_v<TType, double_type>) {
+            return double_value{v.val};
+        }
+        throw std::invalid_argument(
+          fmt::format("Cannot promote primitive value {} to type {}", v, t));
+    }
+};
+
 } // namespace
 
 type_check_result
@@ -409,6 +429,12 @@ check_types(const iceberg::field_type& src, const iceberg::field_type& dest) {
       field_type_check_visitor{primitive_type_promotion_policy_visitor{}},
       src,
       dest);
+}
+
+primitive_value promote_primitive_value_type(
+  primitive_value value, const primitive_type& dest_type) {
+    return std::visit(
+      primitive_value_type_promoting_visitor{}, std::move(value), dest_type);
 }
 
 schema_transform_result annotate_schema_transform(

--- a/src/v/iceberg/compatibility.h
+++ b/src/v/iceberg/compatibility.h
@@ -13,6 +13,7 @@
 #include "iceberg/compatibility_types.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/partition.h"
+#include "iceberg/values.h"
 
 namespace iceberg {
 
@@ -41,6 +42,15 @@ namespace iceberg {
  */
 type_check_result
 check_types(const iceberg::field_type& src, const iceberg::field_type& dest);
+
+// Promote primitive value variant c++ type to the c++ variant type determined
+// by `dest`. Trivial promotion to the same type is allowed (e.g. int_value ->
+// int_value if `dest` is int_type), as well as promotions allowed by the v2
+// spec Primitive Type Promotion policy (int -> long, float -> double, decimal
+// -> decimal). Note: underlying c++ type for decimal values with any precision
+// is the same, so the promotion is trivial in this case as well.
+primitive_value
+promote_primitive_value_type(primitive_value value, const primitive_type& dest);
 
 /**
  * annotate_schema_transform - Answers whether a one schema can "evolve" into

--- a/src/v/iceberg/manifest_avro.cc
+++ b/src/v/iceberg/manifest_avro.cc
@@ -105,8 +105,7 @@ metadata_to_map(const manifest_metadata& meta) {
       {"format-version", std::string{format_to_str(meta.format_version)}}};
 }
 // TODO: make DataFileReader::getMetadata const!
-manifest_metadata
-metadata_from_reader(avro::DataFileReader<avro::GenericDatum>& rdr) {
+manifest_metadata metadata_from_reader(avro::DataFileReaderBase& rdr) {
     const auto find_required_str = [&rdr](const std::string& key) {
         auto val = rdr.getMetadata(key);
         if (!val) {
@@ -168,14 +167,20 @@ iobuf serialize_avro(const manifest& m) {
     return buf;
 }
 
-manifest parse_manifest(const partition_key_type& pk_type, iobuf buf) {
-    auto entry_type = field_type{manifest_entry_type(pk_type.copy())};
+manifest parse_manifest(iobuf buf) {
+    auto in = std::make_unique<avro_iobuf_istream>(std::move(buf));
+    auto reader_base = std::make_unique<avro::DataFileReaderBase>(
+      std::move(in));
+
+    auto meta = metadata_from_reader(*reader_base);
+    auto entry_type = field_type{manifest_entry_type(
+      partition_key_type::create(meta.partition_spec, meta.schema))};
     auto entry_schema = avro::ValidSchema(
       struct_type_to_avro(std::get<struct_type>(entry_type), "manifest_entry"));
-    auto in = std::make_unique<avro_iobuf_istream>(std::move(buf));
+
     avro::DataFileReader<avro::GenericDatum> reader(
-      std::move(in), entry_schema);
-    auto meta = metadata_from_reader(reader);
+      std::move(reader_base), entry_schema);
+
     chunked_vector<manifest_entry> entries;
     while (true) {
         avro::GenericDatum d(entry_schema);

--- a/src/v/iceberg/manifest_avro.h
+++ b/src/v/iceberg/manifest_avro.h
@@ -16,6 +16,6 @@
 namespace iceberg {
 
 iobuf serialize_avro(const manifest&);
-manifest parse_manifest(const partition_key_type&, iobuf);
+manifest parse_manifest(iobuf);
 
 } // namespace iceberg

--- a/src/v/iceberg/manifest_io.cc
+++ b/src/v/iceberg/manifest_io.cc
@@ -24,15 +24,14 @@
 using namespace std::chrono_literals;
 
 namespace iceberg {
-ss::future<checked<manifest, metadata_io::errc>> manifest_io::download_manifest(
-  const uri& uri, const partition_key_type& pk_type) {
+ss::future<checked<manifest, metadata_io::errc>>
+manifest_io::download_manifest(const uri& uri) {
     auto path_res = from_uri(uri);
     if (path_res.has_error()) {
         co_return path_res.error();
     }
 
-    co_return co_await download_manifest(
-      manifest_path(path_res.value()), pk_type);
+    co_return co_await download_manifest(manifest_path(path_res.value()));
 }
 
 ss::future<checked<manifest_list, metadata_io::errc>>
@@ -46,12 +45,10 @@ manifest_io::download_manifest_list(const uri& uri) {
       manifest_list_path{path_res.value()});
 }
 
-ss::future<checked<manifest, metadata_io::errc>> manifest_io::download_manifest(
-  const manifest_path& path, const partition_key_type& pk_type) {
+ss::future<checked<manifest, metadata_io::errc>>
+manifest_io::download_manifest(const manifest_path& path) {
     co_return co_await download_object<manifest>(
-      path(), "iceberg::manifest", [&pk_type](iobuf b) {
-          return parse_manifest(pk_type, std::move(b));
-      });
+      path(), "iceberg::manifest", parse_manifest);
 }
 
 ss::future<checked<manifest_list, metadata_io::errc>>

--- a/src/v/iceberg/manifest_io.h
+++ b/src/v/iceberg/manifest_io.h
@@ -35,10 +35,10 @@ public:
       : metadata_io(io, std::move(b)) {}
     ~manifest_io() = default;
 
-    ss::future<checked<manifest, metadata_io::errc>> download_manifest(
-      const manifest_path& path, const partition_key_type& pk_type);
     ss::future<checked<manifest, metadata_io::errc>>
-    download_manifest(const uri& uri, const partition_key_type& pk_type);
+    download_manifest(const manifest_path& path);
+    ss::future<checked<manifest, metadata_io::errc>>
+    download_manifest(const uri& uri);
 
     ss::future<checked<manifest_list, metadata_io::errc>>
     download_manifest_list(const manifest_list_path& path);

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -161,29 +161,7 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
     }
     const auto& schema = *schema_it;
 
-    // Look for the current partition spec.
-    const auto& pspecs = table_.partition_specs;
-    auto pspec_it = std::ranges::find(
-      pspecs, table_.default_spec_id, &partition_spec::spec_id);
-    if (pspec_it == pspecs.end()) {
-        vlog(
-          log.error,
-          "Partition spec {} is missing from metadata",
-          table_.default_spec_id);
-        co_return action::errc::unexpected_state;
-    }
-    if (pspecs.size() != 1) {
-        // TODO: when we support multiple partition specs, we'll need to group
-        // them by spec id and write manifest files per spec.
-        vlog(
-          log.error,
-          "Currently exactly one partition spec is supported: {} found",
-          pspecs.size());
-        co_return action::errc::unexpected_state;
-    }
-
     // Validate our input files that their partition keys look sane.
-    const auto& pspec = *pspec_it;
     for (const auto& f : new_data_files_) {
         if (f.file.partition.val == nullptr) {
             vlog(
@@ -192,14 +170,23 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
               f.file.file_path);
             co_return action::errc::unexpected_state;
         }
+        const auto* pspec = table_.get_partition_spec(f.partition_spec_id);
+        if (!pspec) {
+            vlog(
+              log.error,
+              "partition spec {} for file {} not found in metadata",
+              f.partition_spec_id,
+              f.file.file_path);
+            co_return action::errc::unexpected_state;
+        }
         auto f_num_fields = f.file.partition.val->fields.size();
-        if (f_num_fields != pspec.fields.size()) {
+        if (f_num_fields != pspec->fields.size()) {
             vlog(
               log.error,
               "Partition key for data file {} has {} fields, expected {}",
               f.file.file_path,
               f_num_fields,
-              pspec.fields.size());
+              pspec->fields.size());
             co_return action::errc::unexpected_state;
         }
     }
@@ -252,12 +239,9 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
     const auto new_seq_num = sequence_number{table_.last_sequence_number() + 1};
     const auto new_snap_id = generate_unused_snap_id(table_);
 
-    // TODO: support more than one partition spec by grouping the merged
-    // manifests by spec id.
     const table_snapshot_ctx ctx{
       .commit_uuid = commit_uuid_,
       .schema = schema,
-      .pspec = pspec,
       .snap_id = new_snap_id,
       .seq_num = new_seq_num,
     };
@@ -386,6 +370,7 @@ ss::future<checked<chunked_vector<manifest_file>, action::errc>>
 merge_append_action::maybe_merge_mfiles_and_new_data(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<file_to_append> new_data_files,
+  const partition_spec& pspec,
   const table_snapshot_ctx& ctx) {
     vlog(
       log.info,
@@ -410,7 +395,7 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     if (to_merge.size() < default_min_to_merge_new_files) {
         // Upload and return. This bin is too small to merge.
         auto new_mfile_res = co_await merge_mfiles(
-          {}, std::move(new_data_entries), ctx);
+          {}, std::move(new_data_entries), pspec, ctx);
         if (new_mfile_res.has_error()) {
             co_return new_mfile_res.error();
         }
@@ -419,7 +404,7 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
         co_return ret;
     }
     auto merged_mfile_res = co_await merge_mfiles(
-      std::move(to_merge), std::move(new_data_entries), ctx);
+      std::move(to_merge), std::move(new_data_entries), pspec, ctx);
     if (merged_mfile_res.has_error()) {
         co_return merged_mfile_res.error();
     }
@@ -431,6 +416,7 @@ ss::future<checked<manifest_file, action::errc>>
 merge_append_action::merge_mfiles(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<manifest_entry> added_entries,
+  const partition_spec& pspec,
   const table_snapshot_ctx& ctx) {
     vlogl(
       log,
@@ -460,13 +446,13 @@ merge_append_action::merge_mfiles(
         existing_files += m.entries.size();
         for (auto& e : m.entries) {
             auto f_num_fields = e.data_file.partition.val->fields.size();
-            if (f_num_fields != ctx.pspec.fields.size()) {
+            if (f_num_fields != pspec.fields.size()) {
                 vlog(
                   log.error,
                   "Partition key for data file {} has {} fields, expected {}",
                   e.data_file.file_path,
                   f_num_fields,
-                  ctx.pspec.fields.size());
+                  pspec.fields.size());
                 co_return action::errc::unexpected_state;
             }
 
@@ -490,9 +476,9 @@ merge_append_action::merge_mfiles(
           std::back_inserter(merged_entries));
     }
 
-    auto pk_type = partition_key_type::create(ctx.pspec, ctx.schema);
+    auto pk_type = partition_key_type::create(pspec, ctx.schema);
     auto partition_summaries = field_summary_val::empty_summaries(
-      ctx.pspec.fields.size());
+      pspec.fields.size());
     for (auto& e : merged_entries) {
         try {
             promote_partition_key_type(e.data_file.partition, pk_type);
@@ -510,14 +496,14 @@ merge_append_action::merge_mfiles(
     const auto merged_manifest_path = get_manifest_path(
       table_.location, ctx.commit_uuid, generate_manifest_num());
     const auto mfile_up_res = co_await upload_as_manifest(
-      merged_manifest_path, ctx.schema, ctx.pspec, std::move(merged_entries));
+      merged_manifest_path, ctx.schema, pspec, std::move(merged_entries));
     if (mfile_up_res.has_error()) {
         co_return to_action_errc(mfile_up_res.error());
     }
     manifest_file merged_file{
       .manifest_path = merged_manifest_path,
       .manifest_length = mfile_up_res.value(),
-      .partition_spec_id = ctx.pspec.spec_id,
+      .partition_spec_id = pspec.spec_id,
       .content = manifest_file_content::data,
       .seq_number = ctx.seq_num,
       .min_seq_number = min_seq_num,
@@ -538,46 +524,76 @@ merge_append_action::pack_mlist_and_new_data(
   const table_snapshot_ctx& ctx,
   manifest_list old_mlist,
   chunked_vector<file_to_append> new_data_files) {
-    auto num_old_files = old_mlist.files.size();
-    auto binned_mfiles = manifest_packer::pack(
-      default_target_size_bytes, std::move(old_mlist.files));
-    vlog(
-      log.info,
-      "Packed {} manifests into {} bins",
-      num_old_files,
-      binned_mfiles.size());
-    if (binned_mfiles.empty()) {
-        // If we had no manifests at all, at least create an empty bin to add
-        // new manifests to below.
-        binned_mfiles.emplace_back(chunked_vector<manifest_file>{});
-    }
-    chunked_vector<manifest_file> new_mfiles;
-    // Always add files to the first bin, which by convention will be the
-    // latest data. We may not merge existing manifests if the bin is
-    // small, but we'll at least add metadata for the new data files.
-    auto merged_bins_res = co_await maybe_merge_mfiles_and_new_data(
-      std::move(binned_mfiles[0]), std::move(new_data_files), ctx);
-    if (merged_bins_res.has_error()) {
-        co_return merged_bins_res.error();
-    }
-    auto merged_bins = std::move(merged_bins_res.value());
-    std::move(
-      merged_bins.begin(), merged_bins.end(), std::back_inserter(new_mfiles));
+    struct per_spec_data {
+        chunked_vector<manifest_file> existing_manifests;
+        chunked_vector<file_to_append> new_data_files;
+    };
 
-    // Merge the rest of the bins.
-    for (size_t i = 1; i < binned_mfiles.size(); i++) {
-        auto& bin = binned_mfiles[i];
-        if (bin.size() == 1) {
-            // The bin has only a single manifest so there's nothing to do,
-            // just add it as is.
-            new_mfiles.emplace_back(std::move(bin[0]));
-            continue;
+    chunked_hash_map<partition_spec::id_t, per_spec_data> spec2data;
+    for (auto& m : old_mlist.files) {
+        auto spec_id = m.partition_spec_id;
+        spec2data[spec_id].existing_manifests.push_back(std::move(m));
+    }
+    for (auto& f : new_data_files) {
+        auto spec_id = f.partition_spec_id;
+        spec2data[spec_id].new_data_files.push_back(std::move(f));
+    }
+
+    chunked_vector<manifest_file> new_mfiles;
+    for (auto& [spec_id, data] : spec2data) {
+        const auto* pspec = table_.get_partition_spec(spec_id);
+        if (!pspec) {
+            vlog(log.error, "partition spec {} not found in metadata", spec_id);
+            co_return errc::unexpected_state;
         }
-        auto merged_bin_res = co_await merge_mfiles(std::move(bin), {}, ctx);
-        if (merged_bin_res.has_error()) {
-            co_return merged_bin_res.error();
+
+        auto num_old_manifests = data.existing_manifests.size();
+        auto binned_mfiles = manifest_packer::pack(
+          default_target_size_bytes, std::move(data.existing_manifests));
+        vlog(
+          log.info,
+          "Packed {} manifests into {} bins for partition spec id {}",
+          num_old_manifests,
+          binned_mfiles.size(),
+          spec_id);
+        if (binned_mfiles.empty()) {
+            // If we had no manifests at all, at least create an empty bin to
+            // add new manifests to below.
+            binned_mfiles.emplace_back(chunked_vector<manifest_file>{});
         }
-        new_mfiles.emplace_back(std::move(merged_bin_res.value()));
+        // Always add files to the first bin, which by convention will be the
+        // latest data. We may not merge existing manifests if the bin is
+        // small, but we'll at least add metadata for the new data files.
+        auto merged_bins_res = co_await maybe_merge_mfiles_and_new_data(
+          std::move(binned_mfiles[0]),
+          std::move(data.new_data_files),
+          *pspec,
+          ctx);
+        if (merged_bins_res.has_error()) {
+            co_return merged_bins_res.error();
+        }
+        auto merged_bins = std::move(merged_bins_res.value());
+        std::move(
+          merged_bins.begin(),
+          merged_bins.end(),
+          std::back_inserter(new_mfiles));
+
+        // Merge the rest of the bins.
+        for (size_t i = 1; i < binned_mfiles.size(); i++) {
+            auto& bin = binned_mfiles[i];
+            if (bin.size() == 1) {
+                // The bin has only a single manifest so there's nothing to do,
+                // just add it as is.
+                new_mfiles.emplace_back(std::move(bin[0]));
+                continue;
+            }
+            auto merged_bin_res = co_await merge_mfiles(
+              std::move(bin), {}, *pspec, ctx);
+            if (merged_bin_res.has_error()) {
+                co_return merged_bin_res.error();
+            }
+            new_mfiles.emplace_back(std::move(merged_bin_res.value()));
+        }
     }
     co_return new_mfiles;
 }

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -119,9 +119,8 @@ chunked_vector<field_summary> release_with_bytes(field_summary_val::list_t l) {
 } // namespace
 
 field_summary_val::list_t
-field_summary_val::empty_summaries(const partition_key_type& pk_type) {
+field_summary_val::empty_summaries(size_t num_fields) {
     field_summary_val::list_t ret;
-    const auto num_fields = pk_type.type.fields.size();
     ret.reserve(num_fields);
     for (size_t i = 0; i < num_fields; ++i) {
         ret.emplace_back(field_summary_val{});
@@ -254,12 +253,10 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
 
     // TODO: support more than one partition spec by grouping the merged
     // manifests by spec id.
-    auto pk_type = partition_key_type::create(pspec, schema);
     const table_snapshot_ctx ctx{
       .commit_uuid = commit_uuid_,
       .schema = schema,
       .pspec = pspec,
-      .pk_type = pk_type,
       .snap_id = new_snap_id,
       .seq_num = new_seq_num,
     };
@@ -359,8 +356,6 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<file_to_append> new_data_files,
   const table_snapshot_ctx& ctx) {
-    size_t added_rows{0};
-    size_t added_files{0};
     vlog(
       log.info,
       "Considering {} existing manifest files and {} data files to merge",
@@ -370,10 +365,7 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     // of if we upload a brand new manifest or merge with an existing manifest,
     // the new data files will need new entries.
     chunked_vector<manifest_entry> new_data_entries;
-    auto partition_summaries = field_summary_val::empty_summaries(ctx.pk_type);
     for (auto& f : new_data_files) {
-        update_partition_summaries(f.file, partition_summaries);
-        added_rows += f.file.record_count;
         manifest_entry e{
           .status = manifest_entry_status::added,
           .snapshot_id = ctx.snap_id,
@@ -386,44 +378,17 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     chunked_vector<manifest_file> ret;
     if (to_merge.size() < default_min_to_merge_new_files) {
         // Upload and return. This bin is too small to merge.
-        const auto new_manifest_path = get_manifest_path(
-          table_.location, ctx.commit_uuid, generate_manifest_num());
-        added_files = new_data_entries.size();
-        const auto mfile_up_res = co_await upload_as_manifest(
-          new_manifest_path,
-          ctx.schema,
-          ctx.pspec,
-          std::move(new_data_entries));
-        if (mfile_up_res.has_error()) {
-            co_return mfile_up_res.error();
+        auto new_mfile_res = co_await merge_mfiles(
+          {}, std::move(new_data_entries), ctx);
+        if (new_mfile_res.has_error()) {
+            co_return new_mfile_res.error();
         }
-        // Since this bin was too small to merge, we won't do anything else to
-        // its manifests, just add them back to the returned container.
-        ret.emplace_back(manifest_file{
-          .manifest_path = new_manifest_path,
-          .manifest_length = mfile_up_res.value(),
-          .partition_spec_id = ctx.pspec.spec_id,
-          .content = manifest_file_content::data,
-          .seq_number = ctx.seq_num,
-          .min_seq_number = ctx.seq_num,
-          .added_snapshot_id = ctx.snap_id,
-          .added_files_count = added_files,
-          .existing_files_count = 0,
-          .deleted_files_count = 0,
-          .added_rows_count = added_rows,
-          .existing_rows_count = 0,
-          .deleted_rows_count = 0,
-          .partitions = release_with_bytes(std::move(partition_summaries)),
-        });
+        ret.emplace_back(std::move(new_mfile_res.value()));
         std::move(to_merge.begin(), to_merge.end(), std::back_inserter(ret));
         co_return ret;
     }
     auto merged_mfile_res = co_await merge_mfiles(
-      std::move(to_merge),
-      ctx,
-      std::move(partition_summaries),
-      std::move(new_data_entries),
-      added_rows);
+      std::move(to_merge), std::move(new_data_entries), ctx);
     if (merged_mfile_res.has_error()) {
         co_return merged_mfile_res.error();
     }
@@ -434,24 +399,25 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
 ss::future<checked<manifest_file, metadata_io::errc>>
 merge_append_action::merge_mfiles(
   chunked_vector<manifest_file> to_merge,
-  const table_snapshot_ctx& ctx,
-  field_summary_val::list_t added_summaries,
   chunked_vector<manifest_entry> added_entries,
-  size_t added_rows) {
-    vlog(
-      log.info,
+  const table_snapshot_ctx& ctx) {
+    vlogl(
+      log,
+      to_merge.empty() ? ss::log_level::debug : ss::log_level::info,
       "Merging {} manifest files and {} added manifest entries",
       to_merge.size(),
       added_entries.size());
-    auto added_files = added_entries.size();
+
+    const size_t added_files = added_entries.size();
+    size_t added_rows = 0;
+    for (const auto& e : added_entries) {
+        added_rows += e.data_file.record_count;
+    }
+
     auto merged_entries = std::move(added_entries);
     size_t existing_rows = 0;
     size_t existing_files = 0;
     auto min_seq_num = ctx.seq_num;
-    auto partition_summaries = added_summaries.empty()
-                                 ? field_summary_val::empty_summaries(
-                                     ctx.pk_type)
-                                 : std::move(added_summaries);
     for (const auto& mfile : to_merge) {
         // Download the manifest file and collect the entries into the merged
         // container.
@@ -462,7 +428,6 @@ merge_append_action::merge_mfiles(
         auto m = std::move(mfile_res).value();
         existing_files += m.entries.size();
         for (auto& e : m.entries) {
-            update_partition_summaries(e.data_file, partition_summaries);
             existing_rows += e.data_file.record_count;
             // Rewrite sequence numbers for previously added entries.
             // These entries refer to files committed prior to this action.
@@ -482,6 +447,13 @@ merge_append_action::merge_mfiles(
           m.entries.end(),
           std::back_inserter(merged_entries));
     }
+
+    auto partition_summaries = field_summary_val::empty_summaries(
+      ctx.pspec.fields.size());
+    for (const auto& e : merged_entries) {
+        update_partition_summaries(e.data_file, partition_summaries);
+    }
+
     const auto merged_manifest_path = get_manifest_path(
       table_.location, ctx.commit_uuid, generate_manifest_num());
     const auto mfile_up_res = co_await upload_as_manifest(
@@ -548,7 +520,7 @@ merge_append_action::pack_mlist_and_new_data(
             new_mfiles.emplace_back(std::move(bin[0]));
             continue;
         }
-        auto merged_bin_res = co_await merge_mfiles(std::move(bin), ctx);
+        auto merged_bin_res = co_await merge_mfiles(std::move(bin), {}, ctx);
         if (merged_bin_res.has_error()) {
             co_return merged_bin_res.error();
         }

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -185,19 +185,19 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
     // Validate our input files that their partition keys look sane.
     const auto& pspec = *pspec_it;
     for (const auto& f : new_data_files_) {
-        if (f.partition.val == nullptr) {
+        if (f.file.partition.val == nullptr) {
             vlog(
               log.error,
               "Metadata for data file {} is missing partition key",
-              f.file_path);
+              f.file.file_path);
             co_return action::errc::unexpected_state;
         }
-        auto f_num_fields = f.partition.val->fields.size();
+        auto f_num_fields = f.file.partition.val->fields.size();
         if (f_num_fields != pspec.fields.size()) {
             vlog(
               log.error,
               "Partition key for data file {} has {} fields, expected {}",
-              f.file_path,
+              f.file.file_path,
               f_num_fields,
               pspec.fields.size());
             co_return action::errc::unexpected_state;
@@ -357,7 +357,7 @@ merge_append_action::upload_as_manifest(
 ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
 merge_append_action::maybe_merge_mfiles_and_new_data(
   chunked_vector<manifest_file> to_merge,
-  chunked_vector<data_file> new_data_files,
+  chunked_vector<file_to_append> new_data_files,
   const table_snapshot_ctx& ctx) {
     size_t added_rows{0};
     size_t added_files{0};
@@ -372,14 +372,14 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     chunked_vector<manifest_entry> new_data_entries;
     auto partition_summaries = field_summary_val::empty_summaries(ctx.pk_type);
     for (auto& f : new_data_files) {
-        update_partition_summaries(f, partition_summaries);
-        added_rows += f.record_count;
+        update_partition_summaries(f.file, partition_summaries);
+        added_rows += f.file.record_count;
         manifest_entry e{
           .status = manifest_entry_status::added,
           .snapshot_id = ctx.snap_id,
           .sequence_number = std::nullopt,
           .file_sequence_number = std::nullopt,
-          .data_file = std::move(f),
+          .data_file = std::move(f.file),
         };
         new_data_entries.emplace_back(std::move(e));
     }
@@ -513,7 +513,7 @@ ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
 merge_append_action::pack_mlist_and_new_data(
   const table_snapshot_ctx& ctx,
   manifest_list old_mlist,
-  chunked_vector<data_file> new_data_files) {
+  chunked_vector<file_to_append> new_data_files) {
     auto num_old_files = old_mlist.files.size();
     auto binned_mfiles = manifest_packer::pack(
       default_target_size_bytes, std::move(old_mlist.files));

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -11,6 +11,7 @@
 
 #include "base/units.h"
 #include "base/vlog.h"
+#include "iceberg/compatibility.h"
 #include "iceberg/logger.h"
 #include "iceberg/manifest.h"
 #include "iceberg/manifest_file_packer.h"
@@ -264,7 +265,7 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
     auto mfiles_res = co_await pack_mlist_and_new_data(
       ctx, std::move(mlist), std::move(new_data_files_));
     if (mfiles_res.has_error()) {
-        co_return to_action_errc(mfiles_res.error());
+        co_return mfiles_res.error();
     }
     manifest_list new_mlist{std::move(mfiles_res.value())};
 
@@ -351,7 +352,37 @@ merge_append_action::upload_as_manifest(
     co_return co_await io_.upload_manifest(path, m);
 }
 
-ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
+namespace {
+
+// Depending on how schema evolves, type of partition key fields can change
+// (e.g. a field type can be promoted from int to long). This means that
+// partition values of all data files in the new manifest need to be
+// promoted to the common type before creating the manifest.
+//
+// Preconditions: pk and pk_type have the same size, and the promotion for each
+// field is possible.
+void promote_partition_key_type(
+  partition_key& pk, const partition_key_type& pk_type) {
+    // ensured by the callers
+    vassert(
+      pk.val->fields.size() == pk_type.type.fields.size(),
+      "unexpected partition key size: {} (expected: {})",
+      pk.val->fields.size(),
+      pk_type.type.fields.size());
+    for (size_t i = 0; i < pk.val->fields.size(); ++i) {
+        auto& field = pk.val->fields[i];
+        if (field) {
+            const auto& type = std::get<primitive_type>(
+              pk_type.type.fields[i]->type);
+            field = promote_primitive_value_type(
+              std::move(std::get<primitive_value>(*field)), type);
+        }
+    }
+}
+
+} // namespace
+
+ss::future<checked<chunked_vector<manifest_file>, action::errc>>
 merge_append_action::maybe_merge_mfiles_and_new_data(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<file_to_append> new_data_files,
@@ -396,7 +427,7 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     co_return ret;
 }
 
-ss::future<checked<manifest_file, metadata_io::errc>>
+ss::future<checked<manifest_file, action::errc>>
 merge_append_action::merge_mfiles(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<manifest_entry> added_entries,
@@ -423,11 +454,22 @@ merge_append_action::merge_mfiles(
         // container.
         auto mfile_res = co_await io_.download_manifest(mfile.manifest_path);
         if (mfile_res.has_error()) {
-            co_return mfile_res.error();
+            co_return to_action_errc(mfile_res.error());
         }
         auto m = std::move(mfile_res).value();
         existing_files += m.entries.size();
         for (auto& e : m.entries) {
+            auto f_num_fields = e.data_file.partition.val->fields.size();
+            if (f_num_fields != ctx.pspec.fields.size()) {
+                vlog(
+                  log.error,
+                  "Partition key for data file {} has {} fields, expected {}",
+                  e.data_file.file_path,
+                  f_num_fields,
+                  ctx.pspec.fields.size());
+                co_return action::errc::unexpected_state;
+            }
+
             existing_rows += e.data_file.record_count;
             // Rewrite sequence numbers for previously added entries.
             // These entries refer to files committed prior to this action.
@@ -448,10 +490,21 @@ merge_append_action::merge_mfiles(
           std::back_inserter(merged_entries));
     }
 
+    auto pk_type = partition_key_type::create(ctx.pspec, ctx.schema);
     auto partition_summaries = field_summary_val::empty_summaries(
       ctx.pspec.fields.size());
-    for (const auto& e : merged_entries) {
-        update_partition_summaries(e.data_file, partition_summaries);
+    for (auto& e : merged_entries) {
+        try {
+            promote_partition_key_type(e.data_file.partition, pk_type);
+            update_partition_summaries(e.data_file, partition_summaries);
+        } catch (const std::exception& ex) {
+            vlog(
+              log.error,
+              "bad partition key for file {}: {}",
+              e.data_file.file_path,
+              ex);
+            co_return errc::unexpected_state;
+        }
     }
 
     const auto merged_manifest_path = get_manifest_path(
@@ -459,7 +512,7 @@ merge_append_action::merge_mfiles(
     const auto mfile_up_res = co_await upload_as_manifest(
       merged_manifest_path, ctx.schema, ctx.pspec, std::move(merged_entries));
     if (mfile_up_res.has_error()) {
-        co_return mfile_up_res.error();
+        co_return to_action_errc(mfile_up_res.error());
     }
     manifest_file merged_file{
       .manifest_path = merged_manifest_path,
@@ -480,7 +533,7 @@ merge_append_action::merge_mfiles(
     co_return merged_file;
 }
 
-ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
+ss::future<checked<chunked_vector<manifest_file>, action::errc>>
 merge_append_action::pack_mlist_and_new_data(
   const table_snapshot_ctx& ctx,
   manifest_list old_mlist,

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -455,8 +455,7 @@ merge_append_action::merge_mfiles(
     for (const auto& mfile : to_merge) {
         // Download the manifest file and collect the entries into the merged
         // container.
-        auto mfile_res = co_await io_.download_manifest(
-          mfile.manifest_path, ctx.pk_type);
+        auto mfile_res = co_await io_.download_manifest(mfile.manifest_path);
         if (mfile_res.has_error()) {
             co_return mfile_res.error();
         }

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -151,15 +151,6 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
       log.info,
       "Building append update for {} data files",
       new_data_files_.size());
-    // Look for the current schema.
-    const auto schema_id = table_.current_schema_id;
-    auto schema_it = std::ranges::find(
-      table_.schemas, schema_id, &schema::schema_id);
-    if (schema_it == table_.schemas.end()) {
-        vlog(log.error, "Table schema {} is missing from metadata", schema_id);
-        co_return action::errc::unexpected_state;
-    }
-    const auto& schema = *schema_it;
 
     // Validate our input files that their partition keys look sane.
     for (const auto& f : new_data_files_) {
@@ -241,7 +232,6 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
 
     const table_snapshot_ctx ctx{
       .commit_uuid = commit_uuid_,
-      .schema = schema,
       .snap_id = new_snap_id,
       .seq_num = new_seq_num,
     };
@@ -282,7 +272,7 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
           .other = {},
       },
       .manifest_list_path = new_mlist_path,
-      .schema_id = schema.schema_id,
+      .schema_id = table_.current_schema_id,
     };
     for (auto& [k, v] : snapshot_props_) {
         s.summary.other.emplace(k, v);
@@ -381,7 +371,9 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     // of if we upload a brand new manifest or merge with an existing manifest,
     // the new data files will need new entries.
     chunked_vector<manifest_entry> new_data_entries;
+    auto max_schema_id_in_added = schema::id_t::min();
     for (auto& f : new_data_files) {
+        max_schema_id_in_added = std::max(max_schema_id_in_added, f.schema_id);
         manifest_entry e{
           .status = manifest_entry_status::added,
           .snapshot_id = ctx.snap_id,
@@ -395,7 +387,7 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     if (to_merge.size() < default_min_to_merge_new_files) {
         // Upload and return. This bin is too small to merge.
         auto new_mfile_res = co_await merge_mfiles(
-          {}, std::move(new_data_entries), pspec, ctx);
+          {}, std::move(new_data_entries), max_schema_id_in_added, pspec, ctx);
         if (new_mfile_res.has_error()) {
             co_return new_mfile_res.error();
         }
@@ -404,7 +396,11 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
         co_return ret;
     }
     auto merged_mfile_res = co_await merge_mfiles(
-      std::move(to_merge), std::move(new_data_entries), pspec, ctx);
+      std::move(to_merge),
+      std::move(new_data_entries),
+      max_schema_id_in_added,
+      pspec,
+      ctx);
     if (merged_mfile_res.has_error()) {
         co_return merged_mfile_res.error();
     }
@@ -416,6 +412,7 @@ ss::future<checked<manifest_file, action::errc>>
 merge_append_action::merge_mfiles(
   chunked_vector<manifest_file> to_merge,
   chunked_vector<manifest_entry> added_entries,
+  std::optional<schema::id_t> max_schema_id_in_added,
   const partition_spec& pspec,
   const table_snapshot_ctx& ctx) {
     vlogl(
@@ -432,6 +429,7 @@ merge_append_action::merge_mfiles(
     }
 
     auto merged_entries = std::move(added_entries);
+    auto max_schema_id = max_schema_id_in_added.value_or(schema::id_t::min());
     size_t existing_rows = 0;
     size_t existing_files = 0;
     auto min_seq_num = ctx.seq_num;
@@ -443,6 +441,7 @@ merge_append_action::merge_mfiles(
             co_return to_action_errc(mfile_res.error());
         }
         auto m = std::move(mfile_res).value();
+        max_schema_id = std::max(max_schema_id, m.metadata.schema.schema_id);
         existing_files += m.entries.size();
         for (auto& e : m.entries) {
             auto f_num_fields = e.data_file.partition.val->fields.size();
@@ -476,7 +475,24 @@ merge_append_action::merge_mfiles(
           std::back_inserter(merged_entries));
     }
 
-    auto pk_type = partition_key_type::create(pspec, ctx.schema);
+    // If the partition spec is not the default one, there is a risk that the
+    // partition key type can't be resolved with the current schema (e.g. if the
+    // spec uses a source column that was subsequently deleted). To prevent
+    // that, we choose the schema with the highest id among all manifests and
+    // new files with this spec. Presumably, any of these schemas can be used to
+    // resolve the key type, but we choose the one with the highest id because
+    // it should contain the "most promoted" types, and therefore partition keys
+    // for all files can be promoted to the key type resolved with this schema.
+    auto schema_id = pspec.spec_id == table_.default_spec_id
+                       ? table_.current_schema_id
+                       : max_schema_id;
+    const auto* schema = table_.get_schema(schema_id);
+    if (!schema) {
+        vlog(log.error, "Table schema {} is missing from metadata", schema_id);
+        co_return errc::unexpected_state;
+    }
+
+    auto pk_type = partition_key_type::create(pspec, *schema);
     auto partition_summaries = field_summary_val::empty_summaries(
       pspec.fields.size());
     for (auto& e : merged_entries) {
@@ -496,7 +512,7 @@ merge_append_action::merge_mfiles(
     const auto merged_manifest_path = get_manifest_path(
       table_.location, ctx.commit_uuid, generate_manifest_num());
     const auto mfile_up_res = co_await upload_as_manifest(
-      merged_manifest_path, ctx.schema, pspec, std::move(merged_entries));
+      merged_manifest_path, *schema, pspec, std::move(merged_entries));
     if (mfile_up_res.has_error()) {
         co_return to_action_errc(mfile_up_res.error());
     }
@@ -588,7 +604,7 @@ merge_append_action::pack_mlist_and_new_data(
                 continue;
             }
             auto merged_bin_res = co_await merge_mfiles(
-              std::move(bin), {}, *pspec, ctx);
+              std::move(bin), {}, std::nullopt, *pspec, ctx);
             if (merged_bin_res.has_error()) {
                 co_return merged_bin_res.error();
             }

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -62,7 +62,6 @@ struct field_summary_val {
 // Does not deduplicate new data files against files referenced by existing
 // manifests. This is left to the caller, if desired.
 //
-// TODO: currently throws for tables with multiple partition specs.
 // TODO: doesn't clean up any wasted (e.g. on error) manifest files.
 // TODO: shouldn't be too difficult to parallelize IO.
 class merge_append_action : public action {
@@ -97,7 +96,6 @@ private:
     struct table_snapshot_ctx {
         const uuid_t& commit_uuid;
         const schema& schema;
-        const partition_spec& pspec;
         const snapshot_id snap_id;
         const sequence_number seq_num;
     };
@@ -124,6 +122,7 @@ private:
     maybe_merge_mfiles_and_new_data(
       chunked_vector<manifest_file> to_merge,
       chunked_vector<file_to_append> new_data_files,
+      const partition_spec& pspec,
       const table_snapshot_ctx& ctx);
 
     // Takes the given list of manifest files and merges them with the optional
@@ -131,6 +130,7 @@ private:
     ss::future<checked<manifest_file, action::errc>> merge_mfiles(
       chunked_vector<manifest_file> to_merge,
       chunked_vector<manifest_entry> added_entries,
+      const partition_spec& pspec,
       const table_snapshot_ctx& ctx);
 
     // Takes the given manifest list and bin-packs them to reduce the number of

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -32,12 +32,13 @@ struct file_to_append {
 //
 // Unlike the field_summary in manifest_file, which stores bytes per bound,
 // this is value-comparable by maintaining the bounds as values instead of
-// serialized bytes.
+// serialized bytes. Note that only values that are the same primitive_value
+// variant are directly comparable.
 struct field_summary_val {
     using list_t = chunked_vector<field_summary_val>;
-    // Creates a list of field summaries meant to summarize the fields of the
-    // given partition key type.
-    static list_t empty_summaries(const partition_key_type&);
+    // Creates a list of field summaries meant to summarize partition key values
+    // with the given number of fields.
+    static list_t empty_summaries(size_t num_fields);
     // Returns this summary with the bounds converted to bytes.
     field_summary release_with_bytes() &&;
 
@@ -97,7 +98,6 @@ private:
         const uuid_t& commit_uuid;
         const schema& schema;
         const partition_spec& pspec;
-        const partition_key_type& pk_type;
         const snapshot_id snap_id;
         const sequence_number seq_num;
     };
@@ -130,10 +130,8 @@ private:
     // new manifest entries (i.e. data file metadata).
     ss::future<checked<manifest_file, metadata_io::errc>> merge_mfiles(
       chunked_vector<manifest_file> to_merge,
-      const table_snapshot_ctx& ctx,
-      field_summary_val::list_t added_summaries = {},
-      chunked_vector<manifest_entry> added_entries = {},
-      size_t added_rows = 0);
+      chunked_vector<manifest_entry> added_entries,
+      const table_snapshot_ctx& ctx);
 
     // Takes the given manifest list and bin-packs them to reduce the number of
     // manifests, adding new data files either to a new manifest or the latest

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -120,7 +120,7 @@ private:
     //
     // Returns the resulting list of manifest files, which will be size 1 in
     // the merging case, or the input size + 1 otherwise.
-    ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
+    ss::future<checked<chunked_vector<manifest_file>, action::errc>>
     maybe_merge_mfiles_and_new_data(
       chunked_vector<manifest_file> to_merge,
       chunked_vector<file_to_append> new_data_files,
@@ -128,7 +128,7 @@ private:
 
     // Takes the given list of manifest files and merges them with the optional
     // new manifest entries (i.e. data file metadata).
-    ss::future<checked<manifest_file, metadata_io::errc>> merge_mfiles(
+    ss::future<checked<manifest_file, action::errc>> merge_mfiles(
       chunked_vector<manifest_file> to_merge,
       chunked_vector<manifest_entry> added_entries,
       const table_snapshot_ctx& ctx);
@@ -140,7 +140,7 @@ private:
     // Returns the resulting list of manifest files, which should encompass all
     // data from the latest snapshot + new data files, and can be written as a
     // new manifest list and committed as a new snapshot.
-    ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
+    ss::future<checked<chunked_vector<manifest_file>, action::errc>>
     pack_mlist_and_new_data(
       const table_snapshot_ctx& ctx,
       manifest_list old_mlist,

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -19,6 +19,14 @@
 
 namespace iceberg {
 
+// File with schema and partition spec information, used as input to
+// merge_append_action.
+struct file_to_append {
+    data_file file;
+    schema::id_t schema_id;
+    partition_spec::id_t partition_spec_id;
+};
+
 // Container for a metadata required to build manifest_file::partitions (the
 // field summaries for each partition key field).
 //
@@ -63,7 +71,7 @@ public:
     merge_append_action(
       manifest_io& io,
       const table_metadata& table,
-      chunked_vector<data_file> files,
+      chunked_vector<file_to_append> files,
       chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props = {},
       std::optional<ss::sstring> tag_name = std::nullopt,
       std::optional<int64_t> tag_expiration_ms = std::nullopt,
@@ -115,7 +123,7 @@ private:
     ss::future<checked<chunked_vector<manifest_file>, metadata_io::errc>>
     maybe_merge_mfiles_and_new_data(
       chunked_vector<manifest_file> to_merge,
-      chunked_vector<data_file> new_data_files,
+      chunked_vector<file_to_append> new_data_files,
       const table_snapshot_ctx& ctx);
 
     // Takes the given list of manifest files and merges them with the optional
@@ -138,7 +146,7 @@ private:
     pack_mlist_and_new_data(
       const table_snapshot_ctx& ctx,
       manifest_list old_mlist,
-      chunked_vector<data_file> new_data_files);
+      chunked_vector<file_to_append> new_data_files);
 
 private:
     manifest_io& io_;
@@ -153,7 +161,7 @@ private:
     const size_t mfile_target_size_bytes_;
 
     size_t next_manifest_num_{0};
-    chunked_vector<data_file> new_data_files_;
+    chunked_vector<file_to_append> new_data_files_;
     chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props_;
     std::optional<ss::sstring> tag_name_;
     std::optional<int64_t> tag_expiration_ms_;

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -95,7 +95,6 @@ private:
     // fields here all pertain to the new snapshot created by this action.
     struct table_snapshot_ctx {
         const uuid_t& commit_uuid;
-        const schema& schema;
         const snapshot_id snap_id;
         const sequence_number seq_num;
     };
@@ -130,6 +129,7 @@ private:
     ss::future<checked<manifest_file, action::errc>> merge_mfiles(
       chunked_vector<manifest_file> to_merge,
       chunked_vector<manifest_entry> added_entries,
+      std::optional<schema::id_t> max_added_schema_id,
       const partition_spec& pspec,
       const table_snapshot_ctx& ctx);
 

--- a/src/v/iceberg/metadata_query.cc
+++ b/src/v/iceberg/metadata_query.cc
@@ -127,37 +127,6 @@ bool matches(const metadata_query<ResultT>& query, const manifest& s) {
     return !query.manifest_matcher.has_value() || (*query.manifest_matcher)(s);
 }
 
-checked<
-  std::reference_wrapper<const schema>,
-  iceberg::metadata_query_executor::errc>
-get_snapshot_schema(const table_metadata& table, const snapshot& snap) {
-    auto s_it = std::ranges::find(
-      table.schemas, snap.schema_id, &schema::schema_id);
-    if (s_it == table.schemas.end()) {
-        return iceberg::metadata_query_executor::errc::
-          table_metadata_inconsistency;
-    }
-    return std::ref(*s_it);
-}
-
-checked<partition_key_type, iceberg::metadata_query_executor::errc>
-make_partition_key_type(
-  const table_metadata& table,
-  const schema& schema,
-  const manifest_file& m_file) {
-    auto p_spec_it = std::ranges::find(
-      table.partition_specs,
-      m_file.partition_spec_id,
-      &partition_spec::spec_id);
-
-    if (p_spec_it == table.partition_specs.end()) {
-        return iceberg::metadata_query_executor::errc::
-          table_metadata_inconsistency;
-    }
-
-    return partition_key_type::create(*p_spec_it, schema);
-}
-
 } // namespace
 
 template<result_type ResultT>
@@ -198,11 +167,6 @@ do_execute_query(
               fmt::underlying_t<metadata_io::errc>(m_list_result.error()));
             co_return metadata_query_executor::errc::metadata_io_error;
         }
-        auto schema_result = get_snapshot_schema(table, s);
-        if (schema_result.has_error()) {
-            co_return schema_result.error();
-        }
-        const auto& schema = schema_result.value().get();
         for (auto& manifest_file : m_list_result.value().files) {
             if (!matches(query, manifest_file)) {
                 continue;
@@ -213,14 +177,9 @@ do_execute_query(
                 }
                 continue;
             }
-            auto pk_result = make_partition_key_type(
-              table, schema, manifest_file);
-            if (pk_result.has_error()) {
-                co_return pk_result.error();
-            }
-            auto m_result = co_await io.download_manifest(
-              manifest_file.manifest_path, std::move(pk_result.value()));
 
+            auto m_result = co_await io.download_manifest(
+              manifest_file.manifest_path);
             if (m_result.has_error()) {
                 vlog(
                   log.warn,

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -223,6 +223,7 @@ redpanda_cc_gtest(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/iceberg:compatibility",
         "//src/v/iceberg:manifest",
         "//src/v/iceberg:manifest_entry",
         "//src/v/iceberg:manifest_io",

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -1223,3 +1223,72 @@ TEST_P(StructEvoCompatibilityTest, CanCheckEquivalence) {
     EXPECT_FALSE(schemas_equivalent(original, next));
     EXPECT_FALSE(schemas_equivalent(next, original));
 }
+
+TEST(ValuePromotionTest, PrimitiveValuePromotion) {
+    // trivial promotions should leave the value intact
+    std::vector<std::pair<primitive_value, primitive_type>> trivial;
+    trivial.emplace_back(boolean_value{true}, boolean_type{});
+    trivial.emplace_back(int_value{42}, int_type{});
+    trivial.emplace_back(long_value{42}, long_type{});
+    trivial.emplace_back(float_value{1.5}, float_type{});
+    trivial.emplace_back(double_value{1.5}, double_type{});
+    trivial.emplace_back(
+      decimal_value{42}, decimal_type{.precision = 10, .scale = 2});
+    trivial.emplace_back(date_value{123}, date_type{});
+    trivial.emplace_back(time_value{1234}, time_type{});
+    trivial.emplace_back(timestamp_value{31536000000023ul}, timestamp_type{});
+    trivial.emplace_back(
+      timestamptz_value{31536000000023ul}, timestamptz_type{});
+    trivial.emplace_back(
+      string_value{bytes_to_iobuf(bytes::from_string("foobar"))},
+      string_type{});
+    trivial.emplace_back(uuid_value{uuid_t::create()}, uuid_type{});
+    trivial.emplace_back(
+      fixed_value{bytes_to_iobuf(bytes{1, 2, 3, 4, 5, 6, 7, 8, 255})},
+      fixed_type{.length = 9});
+    trivial.emplace_back(
+      binary_value{bytes_to_iobuf(bytes{1, 2, 3, 4, 5, 6, 7, 8, 255})},
+      binary_type{});
+
+    for (const auto& [val, type] : trivial) {
+        ASSERT_EQ(promote_primitive_value_type(make_copy(val), type), val);
+    }
+
+    // non-trivial promotions
+    ASSERT_EQ(
+      promote_primitive_value_type(int_value{42}, long_type{}), long_value{42});
+    ASSERT_EQ(
+      promote_primitive_value_type(float_value{1.5}, double_type{}),
+      double_value{1.5});
+
+    // test some forbidden promotions
+    std::vector<std::pair<primitive_value, primitive_type>> forbidden;
+    forbidden.emplace_back(boolean_value{true}, int_type{});
+    forbidden.emplace_back(int_value{42}, double_type{});
+    forbidden.emplace_back(long_value{42}, int_type{});
+    forbidden.emplace_back(float_value{1.5}, int_type{});
+    forbidden.emplace_back(double_value{1.5}, float_type{});
+    forbidden.emplace_back(date_value{123}, timestamptz_type{});
+    forbidden.emplace_back(time_value{1234}, timestamptz_type{});
+    forbidden.emplace_back(decimal_value{42}, int_type{});
+    forbidden.emplace_back(
+      timestamp_value{31536000000023ul}, timestamptz_type{});
+    forbidden.emplace_back(
+      timestamptz_value{31536000000023ul}, timestamp_type{});
+    forbidden.emplace_back(
+      string_value{bytes_to_iobuf(bytes::from_string("foobar"))},
+      binary_type{});
+    forbidden.emplace_back(uuid_value{uuid_t::create()}, binary_type{});
+    forbidden.emplace_back(
+      fixed_value{bytes_to_iobuf(bytes{1, 2, 3, 4, 5, 6, 7, 8, 255})},
+      binary_type{});
+    forbidden.emplace_back(
+      binary_value{bytes_to_iobuf(bytes::from_string("foobar"))},
+      string_type{});
+
+    for (const auto& [val, type] : forbidden) {
+        ASSERT_THROW(
+          promote_primitive_value_type(make_copy(val), type), std::logic_error)
+          << "value: " << val << ", type: " << type;
+    }
+}

--- a/src/v/iceberg/tests/manifest_io_test.cc
+++ b/src/v/iceberg/tests/manifest_io_test.cc
@@ -22,8 +22,6 @@
 using namespace iceberg;
 using namespace std::chrono_literals;
 
-partition_key_type empty_pk_type() { return partition_key_type{struct_type{}}; }
-
 class ManifestIOTest
   : public s3_imposter_fixture
   , public ::testing::Test {
@@ -91,7 +89,7 @@ TEST_F(ManifestIOTest, TestManifestRoundtrip) {
     // Missing manifest.
     auto io = manifest_io(remote(), bucket_name);
     auto test_path = manifest_path{"foo/bar/baz"};
-    auto dl_res = io.download_manifest(test_path, empty_pk_type()).get();
+    auto dl_res = io.download_manifest(test_path).get();
     ASSERT_TRUE(dl_res.has_error());
     ASSERT_EQ(dl_res.error(), metadata_io::errc::failed);
 
@@ -100,7 +98,7 @@ TEST_F(ManifestIOTest, TestManifestRoundtrip) {
     ASSERT_TRUE(ul_res.has_value());
     ASSERT_LT(0, ul_res.value());
 
-    dl_res = io.download_manifest(test_path, empty_pk_type()).get();
+    dl_res = io.download_manifest(test_path).get();
     ASSERT_FALSE(dl_res.has_error());
     const auto& m_roundtrip = dl_res.value();
     ASSERT_EQ(m, m_roundtrip);
@@ -137,12 +135,12 @@ TEST_F(ManifestIOTest, TestManifestRoundtripURIs) {
     ASSERT_FALSE(up_res.has_error());
 
     // Use the URI string.
-    auto dl_res = io.download_manifest(test_uri, empty_pk_type()).get();
+    auto dl_res = io.download_manifest(test_uri).get();
     ASSERT_FALSE(dl_res.has_error());
     ASSERT_EQ(m, dl_res.value());
 
     // As a safety measure, we'll still parse the raw path if given.
-    dl_res = io.download_manifest(path, empty_pk_type()).get();
+    dl_res = io.download_manifest(path).get();
     ASSERT_FALSE(dl_res.has_error());
     ASSERT_EQ(m, dl_res.value());
 }
@@ -173,7 +171,7 @@ TEST_F(ManifestIOTest, TestShutdown) {
     sr->request_stop();
     auto io = manifest_io(remote(), bucket_name);
     {
-        auto dl_res = io.download_manifest(test_path, empty_pk_type()).get();
+        auto dl_res = io.download_manifest(test_path).get();
         ASSERT_TRUE(dl_res.has_error());
         ASSERT_EQ(dl_res.error(), metadata_io::errc::shutting_down);
 
@@ -208,7 +206,7 @@ TEST_F(ManifestIOTest, TestCorruptedDownload) {
     ASSERT_EQ(ul_res, cloud_io::upload_result::success);
     auto io = manifest_io(remote(), bucket_name);
     {
-        auto dl_res = io.download_manifest(test_path, empty_pk_type()).get();
+        auto dl_res = io.download_manifest(test_path).get();
         ASSERT_TRUE(dl_res.has_error());
         ASSERT_EQ(dl_res.error(), metadata_io::errc::failed);
     }

--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -297,11 +297,9 @@ TEST(ManifestSerializationTest, TestMetadataWithPartitionSpec) {
       .metadata = std::move(meta),
       .entries = {},
     };
-    auto pk_type = partition_key_type::create(
-      m.metadata.partition_spec, m.metadata.schema);
     auto serialized_buf = serialize_avro(m);
     for (int i = 0; i < 10; i++) {
-        auto m_roundtrip = parse_manifest(pk_type, std::move(serialized_buf));
+        auto m_roundtrip = parse_manifest(std::move(serialized_buf));
         ASSERT_EQ(m.metadata, m_roundtrip.metadata);
         ASSERT_EQ(0, m_roundtrip.entries.size());
 
@@ -319,7 +317,7 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
     }
     auto orig_buf = iobuf{
       ss::util::read_entire_file(manifest_path.value()).get()};
-    auto m = parse_manifest({struct_type{}}, orig_buf.copy());
+    auto m = parse_manifest(orig_buf.copy());
     ASSERT_EQ(100, m.entries.size());
     ASSERT_EQ(m.metadata.manifest_content_type, manifest_content_type::data);
     ASSERT_EQ(m.metadata.format_version, format_version::v2);
@@ -331,8 +329,7 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
 
     auto serialized_buf = serialize_avro(m);
     for (int i = 0; i < 10; i++) {
-        auto m_roundtrip = parse_manifest(
-          {struct_type{}}, std::move(serialized_buf));
+        auto m_roundtrip = parse_manifest(std::move(serialized_buf));
         ASSERT_EQ(m.metadata, m_roundtrip.metadata);
         ASSERT_EQ(100, m_roundtrip.entries.size());
         ASSERT_EQ(

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -502,12 +502,6 @@ TEST_F(MergeAppendActionTest, TestBadMetadata) {
         ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
     }
     {
-        // More than one partition spec.
-        auto t = create_table();
-        t.partition_specs.emplace_back(partition_spec{});
-        ASSERT_NO_FATAL_FAILURE(check_bad(std::move(t)));
-    }
-    {
         // Current schema is bogus.
         auto t = create_table();
         t.current_schema_id = schema::id_t{1234};

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -83,7 +83,9 @@ public:
       const ss::sstring& path_base,
       size_t num_files,
       size_t record_count,
-      primitive_value pk_value = int_value{42}) {
+      primitive_value pk_value = int_value{42},
+      std::optional<schema::id_t> schema_id = std::nullopt,
+      std::optional<partition_spec::id_t> partition_spec_id = std::nullopt) {
         chunked_vector<file_to_append> ret;
         ret.reserve(num_files);
         const auto records_per_file = record_count / num_files;
@@ -99,8 +101,9 @@ public:
             };
             ret.emplace_back(file_to_append{
               .file = std::move(file),
-              .schema_id = md.current_schema_id,
-              .partition_spec_id = md.default_spec_id,
+              .schema_id = (schema_id ? *schema_id : md.current_schema_id),
+              .partition_spec_id
+              = (partition_spec_id ? *partition_spec_id : md.default_spec_id),
             });
         }
         ret[0].file.record_count += leftover_records;
@@ -643,4 +646,120 @@ TEST_F(MergeAppendActionTest, TestTagWithExpiration) {
     ASSERT_FALSE(tag_snap.min_snapshots_to_keep.has_value());
     ASSERT_TRUE(tag_snap.max_ref_age_ms.has_value());
     ASSERT_EQ(long_max, tag_snap.max_ref_age_ms.value());
+}
+
+TEST_F(MergeAppendActionTest, TestMultiplePartitionSpecs) {
+    const size_t num_to_merge_at
+      = merge_append_action::default_min_to_merge_new_files;
+    const size_t files_per_man = 2;
+    const size_t rows_per_man = 25;
+    transaction tx(create_table());
+
+    auto files_with_first_spec = [&]() {
+        return create_data_files(
+          tx.table(),
+          "foo",
+          files_per_man,
+          rows_per_man,
+          int_value{42},
+          tx.table().schemas.at(0).schema_id,
+          tx.table().partition_specs.at(0).spec_id);
+    };
+
+    // Repeatedly add 50 manifests with old partition spec.
+    for (size_t i = 0; i < num_to_merge_at / 2; i++) {
+        const auto expected_snapshots = i + 1;
+        const auto expected_manifests = expected_snapshots;
+        merge_append_and_check(
+          tx, files_with_first_spec(), expected_snapshots, expected_manifests);
+    }
+
+    // Add new partition spec and make it default.
+    {
+        auto table = std::move(tx).release_metadata();
+        auto new_spec = partition_spec{.spec_id = partition_spec::id_t{1}};
+        new_spec.fields.push_back(partition_field{
+          .source_id = nested_field::id_t{3}, // baz
+          .field_id = partition_field::id_t{1001},
+          .name = "baz",
+          .transform = identity_transform{},
+        });
+        table.partition_specs.push_back(std::move(new_spec));
+        table.default_spec_id = table.partition_specs.back().spec_id;
+        tx = transaction(std::move(table));
+    }
+
+    auto files_with_second_spec = [&]() {
+        return create_data_files(
+          tx.table(),
+          "foo",
+          files_per_man,
+          rows_per_man,
+          boolean_value{true},
+          tx.table().schemas.at(0).schema_id,
+          tx.table().partition_specs.at(1).spec_id);
+    };
+
+    auto files_with_both_specs = [&]() {
+        auto ret = files_with_first_spec();
+        auto more_files = files_with_second_spec();
+        std::move(
+          more_files.begin(), more_files.end(), std::back_inserter(ret));
+        return ret;
+    };
+
+    // Add more files with both specs. Number of manifests with the old spec
+    // will reach the merge threshold.
+    for (size_t i = 0; i < num_to_merge_at / 2; i++) {
+        // each merge_append here adds 1 snapshot and 2 manifests
+        const auto expected_snapshots = num_to_merge_at / 2 + i + 1;
+        const auto expected_manifests = num_to_merge_at / 2 + 1 + 2 * i + 1;
+        merge_append_and_check(
+          tx, files_with_both_specs(), expected_snapshots, expected_manifests);
+    }
+
+    // At the merge threshold, we expect the latest snapshot contains a merged
+    // manifest for the old spec and the initial set of unmerged manifests for
+    // the new spec.
+    auto res = tx.merge_append(io, files_with_both_specs()).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    const auto& table = tx.table();
+    ASSERT_TRUE(table.snapshots.has_value());
+    ASSERT_EQ(table.snapshots.value().size(), num_to_merge_at + 1);
+
+    // Validate that the latest snapshot indeed contains a single manifest for
+    // the old spec.
+    auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
+    auto latest_mlist = io.download_manifest_list(latest_mlist_path).get();
+    ASSERT_TRUE(latest_mlist.has_value());
+    ASSERT_EQ(latest_mlist.value().files.size(), num_to_merge_at / 2 + 2);
+
+    const manifest_file* merged_mfile = nullptr;
+    for (const auto& m : latest_mlist.value().files) {
+        if (m.partition_spec_id() == 0) {
+            ASSERT_FALSE(merged_mfile);
+            merged_mfile = &m;
+        } else {
+            // still unmerged files with new partition spec
+            ASSERT_EQ(m.partition_spec_id(), 1);
+            ASSERT_EQ(m.added_files_count, files_per_man);
+            ASSERT_EQ(m.added_rows_count, rows_per_man);
+            ASSERT_EQ(m.existing_files_count, 0);
+            ASSERT_EQ(m.existing_rows_count, 0);
+            ASSERT_EQ(m.deleted_files_count, 0);
+            ASSERT_EQ(m.deleted_rows_count, 0);
+        }
+    }
+    ASSERT_TRUE(merged_mfile);
+
+    // Check that the manifest file's metadata seem sane.
+    ASSERT_EQ(merged_mfile->partition_spec_id(), 0);
+    ASSERT_EQ(merged_mfile->added_files_count, files_per_man);
+    ASSERT_EQ(merged_mfile->added_rows_count, rows_per_man);
+    ASSERT_EQ(
+      merged_mfile->existing_files_count, num_to_merge_at * files_per_man);
+    ASSERT_EQ(
+      merged_mfile->existing_rows_count, num_to_merge_at * rows_per_man);
+    ASSERT_EQ(merged_mfile->deleted_files_count, 0);
+    ASSERT_EQ(merged_mfile->deleted_rows_count, 0);
 }

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -10,6 +10,7 @@
 #include "cloud_io/remote.h"
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_io/tests/scoped_remote.h"
+#include "iceberg/compatibility.h"
 #include "iceberg/manifest_entry.h"
 #include "iceberg/manifest_io.h"
 #include "iceberg/merge_append_action.h"
@@ -71,9 +72,9 @@ public:
         };
     }
 
-    partition_key make_int_pk(int32_t v) {
+    partition_key make_single_field_pk(primitive_value v) {
         auto pk_struct = std::make_unique<struct_value>();
-        pk_struct->fields.emplace_back(int_value{v});
+        pk_struct->fields.emplace_back(std::move(v));
         return {std::move(pk_struct)};
     }
 
@@ -82,7 +83,7 @@ public:
       const ss::sstring& path_base,
       size_t num_files,
       size_t record_count,
-      int32_t pk_value = 42) {
+      primitive_value pk_value = int_value{42}) {
         chunked_vector<file_to_append> ret;
         ret.reserve(num_files);
         const auto records_per_file = record_count / num_files;
@@ -92,7 +93,7 @@ public:
             data_file file{
               .content_type = data_file_content_type::data,
               .file_path = uri(path),
-              .partition = partition_key{make_int_pk(pk_value)},
+              .partition = make_single_field_pk(make_copy(pk_value)),
               .record_count = records_per_file,
               .file_size_bytes = 1_KiB,
             };
@@ -104,6 +105,25 @@ public:
         }
         ret[0].file.record_count += leftover_records;
         return ret;
+    }
+
+    void merge_append_and_check(
+      transaction& tx,
+      chunked_vector<file_to_append> files,
+      size_t expected_snapshots,
+      size_t expected_manifests) {
+        auto res = tx.merge_append(io, std::move(files)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        const auto& table = tx.table();
+        ASSERT_TRUE(table.snapshots.has_value());
+        ASSERT_TRUE(table.current_snapshot_id.has_value());
+        ASSERT_EQ(table.snapshots.value().size(), expected_snapshots);
+
+        auto latest_mlist_path
+          = table.snapshots.value().back().manifest_list_path;
+        auto latest_mlist = io.download_manifest_list(latest_mlist_path).get();
+        ASSERT_TRUE(latest_mlist.has_value());
+        ASSERT_EQ(latest_mlist.value().files.size(), expected_manifests);
     }
 
     std::unique_ptr<cloud_io::scoped_remote> sr;
@@ -260,6 +280,101 @@ TEST_F(MergeAppendActionTest, TestMergeByBytes) {
     ASSERT_EQ(merged_mfile.deleted_rows_count, 0);
 }
 
+TEST_F(MergeAppendActionTest, TestMergeAfterTypePromotion) {
+    const size_t num_to_merge_at
+      = merge_append_action::default_min_to_merge_new_files;
+    const size_t files_per_man = 2;
+    const size_t rows_per_man = 25;
+    transaction tx(create_table());
+    // Repeatedly add new data files up to the merge count threshold. First half
+    // of the files will be with the old schema.
+    for (size_t i = 0; i < num_to_merge_at / 2; i++) {
+        const auto expected_snapshots = i + 1;
+        const auto expected_manifests = expected_snapshots;
+        merge_append_and_check(
+          tx,
+          create_data_files(tx.table(), "foo", files_per_man, rows_per_man),
+          expected_snapshots,
+          expected_manifests);
+    }
+
+    // Promote int partition column to long.
+    {
+        auto orig_type = tx.table().schemas.at(0).schema_struct.copy();
+        auto new_type = orig_type.copy();
+        bool found = false;
+        for (auto& field : new_type.fields) {
+            if (field->name == "bar") {
+                field->type = long_type{};
+                found = true;
+            }
+        }
+        ASSERT_TRUE(found);
+
+        auto compat_res = evolve_schema(
+          orig_type, new_type, tx.table().partition_specs.back());
+        ASSERT_FALSE(compat_res.has_error());
+
+        auto res = tx.set_schema(iceberg::schema{
+                                   .schema_struct = std::move(new_type),
+                                   .schema_id = iceberg::schema::unassigned_id,
+                                   .identifier_field_ids = {},
+                                 })
+                     .get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+    }
+
+    // Add the remaining files, now partition column value is long.
+    for (size_t i = num_to_merge_at / 2; i < num_to_merge_at; i++) {
+        const auto expected_snapshots = i + 1;
+        const auto expected_manifests = expected_snapshots;
+        merge_append_and_check(
+          tx,
+          create_data_files(
+            tx.table(), "foo", files_per_man, rows_per_man, long_value{42}),
+          expected_snapshots,
+          expected_manifests);
+    }
+
+    // At the merge threshold, we expect the latest snapshot contains a merged
+    // manifest. All manifests should be successfully merged, even though the
+    // type of the partition column is not the same.
+    auto res = tx.merge_append(
+                   io,
+                   create_data_files(
+                     tx.table(), "foo", files_per_man, rows_per_man))
+                 .get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+    const auto& table = tx.table();
+    ASSERT_TRUE(table.snapshots.has_value());
+    ASSERT_EQ(table.snapshots.value().size(), num_to_merge_at + 1);
+
+    // Validate that the latest snapshot indeed contains a single manifest.
+    auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
+    auto latest_mlist = io.download_manifest_list(latest_mlist_path).get();
+    ASSERT_TRUE(latest_mlist.has_value());
+    ASSERT_EQ(latest_mlist.value().files.size(), 1);
+    const auto& merged_mfile = latest_mlist.value().files[0];
+
+    // Check that the manifest file's metadata seem sane.
+    ASSERT_EQ(merged_mfile.partition_spec_id(), 0);
+
+    ASSERT_EQ(merged_mfile.partitions.size(), 1);
+    ASSERT_FALSE(merged_mfile.partitions[0].contains_nan);
+    ASSERT_FALSE(merged_mfile.partitions[0].contains_null);
+    auto partition_bytes = value_to_bytes(long_value{42});
+    ASSERT_EQ(merged_mfile.partitions[0].lower_bound, partition_bytes);
+    ASSERT_EQ(merged_mfile.partitions[0].upper_bound, partition_bytes);
+
+    ASSERT_EQ(merged_mfile.added_files_count, files_per_man);
+    ASSERT_EQ(merged_mfile.added_rows_count, rows_per_man);
+    ASSERT_EQ(
+      merged_mfile.existing_files_count, num_to_merge_at * files_per_man);
+    ASSERT_EQ(merged_mfile.existing_rows_count, num_to_merge_at * rows_per_man);
+    ASSERT_EQ(merged_mfile.deleted_files_count, 0);
+    ASSERT_EQ(merged_mfile.deleted_rows_count, 0);
+}
+
 TEST_F(MergeAppendActionTest, TestUniqueSnapshotIds) {
     transaction tx(create_table());
     const auto& table = tx.table();
@@ -300,9 +415,10 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
     for (size_t i = 0; i < num_to_merge_at; i++) {
         int32_t pk = base_pk + i;
         const auto expected_manifests = i + 1;
-        auto res = tx.merge_append(
-                       io, create_data_files(tx.table(), "foo", 1, 1, pk))
-                     .get();
+        auto res
+          = tx.merge_append(
+                io, create_data_files(tx.table(), "foo", 1, 1, int_value{pk}))
+              .get();
         ASSERT_FALSE(res.has_error()) << res.error();
 
         // Download the resulting manifest list and make sure we only added a
@@ -333,9 +449,10 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
     }
     // Write one more manifest, triggering a merge.
     const int32_t last_pk = base_pk + num_to_merge_at + 123;
-    auto res = tx.merge_append(
-                   io, create_data_files(tx.table(), "foo", 1, 1, last_pk))
-                 .get();
+    auto res
+      = tx.merge_append(
+            io, create_data_files(tx.table(), "foo", 1, 1, int_value{last_pk}))
+          .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
     auto latest_mlist_res = io.download_manifest_list(latest_mlist_path).get();

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -77,26 +77,32 @@ public:
         return {std::move(pk_struct)};
     }
 
-    chunked_vector<data_file> create_data_files(
+    chunked_vector<file_to_append> create_data_files(
+      const table_metadata& md,
       const ss::sstring& path_base,
       size_t num_files,
       size_t record_count,
       int32_t pk_value = 42) {
-        chunked_vector<data_file> ret;
+        chunked_vector<file_to_append> ret;
         ret.reserve(num_files);
         const auto records_per_file = record_count / num_files;
         const auto leftover_records = record_count % num_files;
         for (size_t i = 0; i < num_files; i++) {
             const auto path = fmt::format("{}-{}", path_base, i);
-            ret.emplace_back(data_file{
+            data_file file{
               .content_type = data_file_content_type::data,
               .file_path = uri(path),
               .partition = partition_key{make_int_pk(pk_value)},
               .record_count = records_per_file,
               .file_size_bytes = 1_KiB,
+            };
+            ret.emplace_back(file_to_append{
+              .file = std::move(file),
+              .schema_id = md.current_schema_id,
+              .partition_spec_id = md.default_spec_id,
             });
         }
-        ret[0].record_count += leftover_records;
+        ret[0].file.record_count += leftover_records;
         return ret;
     }
 
@@ -117,7 +123,8 @@ TEST_F(MergeAppendActionTest, TestMergeByCount) {
         const auto expected_manifests = expected_snapshots;
         auto res = tx.merge_append(
                        io,
-                       create_data_files("foo", files_per_man, rows_per_man))
+                       create_data_files(
+                         tx.table(), "foo", files_per_man, rows_per_man))
                      .get();
         ASSERT_FALSE(res.has_error()) << res.error();
         const auto& table = tx.table();
@@ -135,7 +142,9 @@ TEST_F(MergeAppendActionTest, TestMergeByCount) {
     // At the merge threshold, we expect the latest snapshot contains a merged
     // manifest.
     auto res = tx.merge_append(
-                   io, create_data_files("foo", files_per_man, rows_per_man))
+                   io,
+                   create_data_files(
+                     tx.table(), "foo", files_per_man, rows_per_man))
                  .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     const auto& table = tx.table();
@@ -174,10 +183,11 @@ TEST_F(MergeAppendActionTest, TestMergeByBytes) {
     for (size_t i = 0; i < num_to_merge_at; i++) {
         const auto expected_snapshots = i + 1;
         const auto expected_manifests = expected_snapshots;
-        auto res
-          = tx.merge_append(
-                io, create_data_files(path_base, files_per_man, rows_per_man))
-              .get();
+        auto res = tx.merge_append(
+                       io,
+                       create_data_files(
+                         tx.table(), path_base, files_per_man, rows_per_man))
+                     .get();
         ASSERT_FALSE(res.has_error()) << res.error();
         const auto& table = tx.table();
         ASSERT_TRUE(table.snapshots.has_value());
@@ -195,7 +205,8 @@ TEST_F(MergeAppendActionTest, TestMergeByBytes) {
     // manifest.
     auto res = tx.merge_append(
                    io,
-                   create_data_files(path_base, files_per_man, rows_per_man))
+                   create_data_files(
+                     tx.table(), path_base, files_per_man, rows_per_man))
                  .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     const auto& table = tx.table();
@@ -256,7 +267,9 @@ TEST_F(MergeAppendActionTest, TestUniqueSnapshotIds) {
     const size_t num_snapshots = 1000;
     for (auto i = 0; i < 1000; i++) {
         const auto expected_snapshots = i + 1;
-        auto res = tx.merge_append(io, create_data_files("foo", 1, 1)).get();
+        auto res = tx.merge_append(
+                       io, create_data_files(tx.table(), "foo", 1, 1))
+                     .get();
         ASSERT_FALSE(res.has_error()) << res.error();
         ASSERT_TRUE(table.snapshots.has_value());
         ASSERT_TRUE(table.current_snapshot_id.has_value());
@@ -287,8 +300,9 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
     for (size_t i = 0; i < num_to_merge_at; i++) {
         int32_t pk = base_pk + i;
         const auto expected_manifests = i + 1;
-        auto res
-          = tx.merge_append(io, create_data_files("foo", 1, 1, pk)).get();
+        auto res = tx.merge_append(
+                       io, create_data_files(tx.table(), "foo", 1, 1, pk))
+                     .get();
         ASSERT_FALSE(res.has_error()) << res.error();
 
         // Download the resulting manifest list and make sure we only added a
@@ -319,8 +333,9 @@ TEST_F(MergeAppendActionTest, TestPartitionSummaries) {
     }
     // Write one more manifest, triggering a merge.
     const int32_t last_pk = base_pk + num_to_merge_at + 123;
-    auto res
-      = tx.merge_append(io, create_data_files("foo", 1, 1, last_pk)).get();
+    auto res = tx.merge_append(
+                   io, create_data_files(tx.table(), "foo", 1, 1, last_pk))
+                 .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     auto latest_mlist_path = table.snapshots.value().back().manifest_list_path;
     auto latest_mlist_res = io.download_manifest_list(latest_mlist_path).get();
@@ -345,7 +360,9 @@ TEST_F(MergeAppendActionTest, TestBadMetadata) {
     chunked_vector<table_metadata> bad_tables;
     auto check_bad = [this](table_metadata t) {
         transaction tx(std::move(t));
-        auto res = tx.merge_append(io, create_data_files("foo", 1, 1)).get();
+        auto res = tx.merge_append(
+                       io, create_data_files(tx.table(), "foo", 1, 1))
+                     .get();
         ASSERT_TRUE(res.has_error());
         ASSERT_EQ(res.error(), action::errc::unexpected_state);
     };
@@ -389,9 +406,9 @@ TEST_F(MergeAppendActionTest, TestBadMetadata) {
 
 TEST_F(MergeAppendActionTest, TestBadFile) {
     transaction tx(create_table());
-    auto bad_files = create_data_files("foo", 1, 1);
+    auto bad_files = create_data_files(tx.table(), "foo", 1, 1);
     for (auto& f : bad_files) {
-        f.partition = partition_key{};
+        f.file.partition = partition_key{};
     }
     auto res = tx.merge_append(io, std::move(bad_files)).get();
     ASSERT_TRUE(res.has_error());
@@ -401,10 +418,12 @@ TEST_F(MergeAppendActionTest, TestBadFile) {
 TEST_F(MergeAppendActionTest, TestTagSnapshot) {
     transaction tx(create_table());
     const auto& table = tx.table();
-    auto res
-      = tx.merge_append(
-            io, create_data_files("foo", 1, 1), /*snapshot_props=*/{}, "tag")
-          .get();
+    auto res = tx.merge_append(
+                   io,
+                   create_data_files(tx.table(), "foo", 1, 1),
+                   /*snapshot_props=*/{},
+                   "tag")
+                 .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     ASSERT_TRUE(table.current_snapshot_id.has_value());
 
@@ -425,7 +444,10 @@ TEST_F(MergeAppendActionTest, TestTagSnapshot) {
 
     // Merge again with a tag.
     res = tx.merge_append(
-              io, create_data_files("foo", 1, 1), /*snapshot_props=*/{}, "tag")
+              io,
+              create_data_files(tx.table(), "foo", 1, 1),
+              /*snapshot_props=*/{},
+              "tag")
             .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     ASSERT_TRUE(table.current_snapshot_id.has_value());
@@ -439,7 +461,7 @@ TEST_F(MergeAppendActionTest, TestTagSnapshot) {
     // Now merge with a different tag. The old tag shouldn't be affected.
     res = tx.merge_append(
               io,
-              create_data_files("foo", 1, 1),
+              create_data_files(tx.table(), "foo", 1, 1),
               /*snapshot_props=*/{},
               /*tag_name=*/"other")
             .get();
@@ -465,10 +487,12 @@ TEST_F(MergeAppendActionTest, TestTagWithExpiration) {
     const auto& table = tx.table();
     chunked_hash_set<snapshot_id> snap_ids;
     // Add a snapshot without an explicit tag expiration.
-    auto res
-      = tx.merge_append(
-            io, create_data_files("foo", 1, 1), /*snapshot_props=*/{}, "tag")
-          .get();
+    auto res = tx.merge_append(
+                   io,
+                   create_data_files(tx.table(), "foo", 1, 1),
+                   /*snapshot_props=*/{},
+                   "tag")
+                 .get();
     ASSERT_FALSE(res.has_error()) << res.error();
     ASSERT_TRUE(table.current_snapshot_id.has_value());
 
@@ -488,7 +512,7 @@ TEST_F(MergeAppendActionTest, TestTagWithExpiration) {
     auto long_max = std::numeric_limits<long>::max();
     res = tx.merge_append(
               io,
-              create_data_files("foo", 1, 1),
+              create_data_files(tx.table(), "foo", 1, 1),
               /*snapshot_props=*/{},
               "tag",
               /*tag_expiration_ms=*/long_max)

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -674,8 +674,8 @@ TEST_F(MergeAppendActionTest, TestMultiplePartitionSpecs) {
           tx, files_with_first_spec(), expected_snapshots, expected_manifests);
     }
 
-    // Add new partition spec and make it default.
     {
+        // Add new partition spec and make it default.
         auto table = std::move(tx).release_metadata();
         auto new_spec = partition_spec{.spec_id = partition_spec::id_t{1}};
         new_spec.fields.push_back(partition_field{
@@ -687,6 +687,27 @@ TEST_F(MergeAppendActionTest, TestMultiplePartitionSpecs) {
         table.partition_specs.push_back(std::move(new_spec));
         table.default_spec_id = table.partition_specs.back().spec_id;
         tx = transaction(std::move(table));
+
+        // delete the field used by the old spec
+        const auto& orig_type = tx.table().schemas.at(0).schema_struct.copy();
+        chunked_vector<nested_field_ptr> fields_copy;
+        for (const auto& f : orig_type.fields) {
+            if (f->name != "bar") {
+                fields_copy.emplace_back(f->copy());
+            }
+        }
+        struct_type new_type{.fields = std::move(fields_copy)};
+        auto compat_res = evolve_schema(
+          orig_type, new_type, tx.table().partition_specs.back());
+        ASSERT_FALSE(compat_res.has_error());
+
+        auto res = tx.set_schema(iceberg::schema{
+                                   .schema_struct = std::move(new_type),
+                                   .schema_id = iceberg::schema::unassigned_id,
+                                   .identifier_field_ids = {},
+                                 })
+                     .get();
+        ASSERT_FALSE(res.has_error()) << res.error();
     }
 
     auto files_with_second_spec = [&]() {
@@ -696,7 +717,7 @@ TEST_F(MergeAppendActionTest, TestMultiplePartitionSpecs) {
           files_per_man,
           rows_per_man,
           boolean_value{true},
-          tx.table().schemas.at(0).schema_id,
+          tx.table().schemas.at(1).schema_id,
           tx.table().partition_specs.at(1).spec_id);
     };
 

--- a/src/v/iceberg/tests/metadata_query_test.cc
+++ b/src/v/iceberg/tests/metadata_query_test.cc
@@ -74,26 +74,32 @@ public:
         return {std::move(pk_struct)};
     }
 
-    chunked_vector<data_file> create_data_files(
+    chunked_vector<file_to_append> create_data_files(
+      const table_metadata& md,
       const ss::sstring& path_base,
       size_t num_files,
       size_t record_count,
       int32_t pk_value = 42) {
-        chunked_vector<data_file> ret;
+        chunked_vector<file_to_append> ret;
         ret.reserve(num_files);
         const auto records_per_file = record_count / num_files;
         const auto leftover_records = record_count % num_files;
         for (size_t i = 0; i < num_files; i++) {
             const auto path = uri(fmt::format("{}-{}", path_base, i));
-            ret.emplace_back(data_file{
+            data_file file{
               .content_type = data_file_content_type::data,
               .file_path = path,
               .partition = partition_key{make_int_pk(pk_value)},
               .record_count = records_per_file,
               .file_size_bytes = 1_KiB,
+            };
+            ret.emplace_back(file_to_append{
+              .file = std::move(file),
+              .schema_id = md.current_schema_id,
+              .partition_spec_id = md.default_spec_id,
             });
         }
-        ret[0].record_count += leftover_records;
+        ret[0].file.record_count += leftover_records;
         return ret;
     }
     /**
@@ -102,15 +108,15 @@ public:
     ss::future<transaction> generate_metadata() {
         transaction tx(create_table());
         (void)co_await tx.merge_append(
-          io, create_data_files("test_1", 1, 10, 1));
+          io, create_data_files(tx.table(), "test_1", 1, 10, 1));
         (void)co_await tx.merge_append(
-          io, create_data_files("test_2", 2, 20, 2));
+          io, create_data_files(tx.table(), "test_2", 2, 20, 2));
         (void)co_await tx.merge_append(
-          io, create_data_files("test_3", 3, 30, 3));
+          io, create_data_files(tx.table(), "test_3", 3, 30, 3));
         (void)co_await tx.merge_append(
-          io, create_data_files("test_4", 2, 40, 4));
+          io, create_data_files(tx.table(), "test_4", 2, 40, 4));
         (void)co_await tx.merge_append(
-          io, create_data_files("test_5", 1, 50, 5));
+          io, create_data_files(tx.table(), "test_5", 1, 50, 5));
         co_return tx;
     }
 

--- a/src/v/iceberg/tests/metadata_query_test.cc
+++ b/src/v/iceberg/tests/metadata_query_test.cc
@@ -148,8 +148,7 @@ public:
         chunked_vector<iceberg::manifest> manifests;
         auto files = co_await collect_all_manifest_files(table);
         for (auto& f : files) {
-            auto m = co_await io.download_manifest(
-              f.manifest_path, make_partition_key_type(table));
+            auto m = co_await io.download_manifest(f.manifest_path);
             manifests.push_back(std::move(m.assume_value()));
         }
         co_return manifests;

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -440,18 +440,22 @@ TEST_F(RestCatalogTest, CommitTxnHappyPath) {
     iceberg::rest_catalog catalog(
       std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
     auto table_md = create_empty_table_metadata(bucket_name);
-    chunked_vector<iceberg::data_file> files;
+    iceberg::transaction txn(std::move(table_md));
+
+    chunked_vector<iceberg::file_to_append> files;
     std::unique_ptr<iceberg::struct_value> partition_key_val
       = std::make_unique<iceberg::struct_value>();
     partition_key_val->fields.push_back(iceberg::int_value{0});
-
-    files.push_back(iceberg::data_file{
+    iceberg::data_file file{
       .content_type = iceberg::data_file_content_type::data,
       .file_format = iceberg::data_file_format::parquet,
       .partition = iceberg::partition_key{.val = std::move(partition_key_val)},
+    };
+    files.push_back(iceberg::file_to_append{
+      .file = std::move(file),
+      .schema_id = txn.table().current_schema_id,
+      .partition_spec_id = txn.table().default_spec_id,
     });
-
-    iceberg::transaction txn(std::move(table_md));
 
     auto outcome = txn.merge_append(io, std::move(files)).get();
     ASSERT_FALSE(outcome.has_error());

--- a/src/v/iceberg/transaction.cc
+++ b/src/v/iceberg/transaction.cc
@@ -71,7 +71,7 @@ ss::future<transaction::txn_outcome> transaction::set_schema(schema s) {
 
 ss::future<transaction::txn_outcome> transaction::merge_append(
   manifest_io& io,
-  chunked_vector<data_file> files,
+  chunked_vector<file_to_append> files,
   chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props,
   std::optional<ss::sstring> tag_name,
   std::optional<int64_t> tag_expiration_ms) {

--- a/src/v/iceberg/transaction.h
+++ b/src/v/iceberg/transaction.h
@@ -77,6 +77,9 @@ public:
         return tx;
     }
 
+    // Release the resulting metadata object. Used for testing.
+    table_metadata release_metadata() && { return std::move(table_); }
+
 private:
     // Applies the given action to `table_`.
     ss::future<txn_outcome> apply(std::unique_ptr<action>);

--- a/src/v/iceberg/transaction.h
+++ b/src/v/iceberg/transaction.h
@@ -13,6 +13,7 @@
 #include "container/fragmented_vector.h"
 #include "iceberg/action.h"
 #include "iceberg/manifest_io.h"
+#include "iceberg/merge_append_action.h"
 #include "iceberg/schema.h"
 #include "iceberg/table_metadata.h"
 
@@ -51,7 +52,7 @@ public:
     // back on table-wide properties.
     ss::future<txn_outcome> merge_append(
       manifest_io&,
-      chunked_vector<data_file>,
+      chunked_vector<file_to_append>,
       chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props = {},
       std::optional<ss::sstring> tag_name = std::nullopt,
       std::optional<int64_t> tag_expiration_ms = std::nullopt);

--- a/src/v/iceberg/values.h
+++ b/src/v/iceberg/values.h
@@ -11,6 +11,7 @@
 
 #include "bytes/iobuf.h"
 #include "container/fragmented_vector.h"
+#include "iceberg/datatypes.h"
 #include "utils/uuid.h"
 
 #include <absl/numeric/int128.h>
@@ -168,6 +169,70 @@ std::ostream& operator<<(std::ostream&, const value&);
 
 size_t value_hash(const struct_value&);
 size_t value_hash(const value&);
+
+// Provides the mapping between the c++ type of a primitive iceberg value
+// variant and the c++ type of the corresponding primitive iceberg type variant.
+template<typename TVal>
+struct primitive_value_type {};
+template<>
+struct primitive_value_type<boolean_value> {
+    using type = boolean_type;
+};
+template<>
+struct primitive_value_type<int_value> {
+    using type = int_type;
+};
+template<>
+struct primitive_value_type<long_value> {
+    using type = long_type;
+};
+template<>
+struct primitive_value_type<float_value> {
+    using type = float_type;
+};
+template<>
+struct primitive_value_type<double_value> {
+    using type = double_type;
+};
+template<>
+struct primitive_value_type<decimal_value> {
+    using type = decimal_type;
+};
+template<>
+struct primitive_value_type<date_value> {
+    using type = date_type;
+};
+template<>
+struct primitive_value_type<time_value> {
+    using type = time_type;
+};
+template<>
+struct primitive_value_type<timestamp_value> {
+    using type = timestamp_type;
+};
+template<>
+struct primitive_value_type<timestamptz_value> {
+    using type = timestamptz_type;
+};
+template<>
+struct primitive_value_type<string_value> {
+    using type = string_type;
+};
+template<>
+struct primitive_value_type<uuid_value> {
+    using type = uuid_type;
+};
+template<>
+struct primitive_value_type<fixed_value> {
+    using type = fixed_type;
+};
+template<>
+struct primitive_value_type<binary_value> {
+    using type = binary_type;
+};
+
+template<typename TVal>
+using primitive_value_type_t = typename primitive_value_type<TVal>::type;
 
 } // namespace iceberg
 


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-8718

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none