### PR TITLE
[v24.1.x] json: fix empty string case in iobuf_writer

### DIFF
--- a/src/v/json/iobuf_writer.h
+++ b/src/v/json/iobuf_writer.h
@@ -48,14 +48,17 @@ public:
 
 private:
     bool write_chunked_string(const iobuf& buf) {
-        const auto last_frag = [this]() {
-            return std::prev(this->os_->_impl.end());
-        };
+        const auto last_frag = [this]() { return this->os_->_impl.rbegin(); };
         using Ch = Base::Ch;
         this->Prefix(rapidjson::kStringType);
         const auto beg = buf.begin();
         const auto end = buf.end();
-        const auto last = std::prev(end);
+        if (beg == end) {
+            if (!Base::WriteString("", 0)) {
+                return false;
+            }
+            return this->EndValue(true);
+        }
         Ch stashed{};
         Ch* stash_pos{};
         // Base::WriteString is used to JSON encode the string, and requires a
@@ -73,7 +76,7 @@ private:
         //   3. Drop the final character
         // For each encoded fragment that is written (except the first one):
         //   4. Restore the stashed character over the prefix-quote
-        for (auto i = beg; i != end; ++i) {
+        for (auto i = beg;;) {
             if (!Base::WriteString(i->get(), i->size())) {
                 return false;
             }
@@ -81,23 +84,25 @@ private:
                 // 4. Restore the stashed character over the prefix-quote
                 *stash_pos = stashed;
             }
-            if (i != last) {
-                // 1. Trim the suffix quote
-                this->os_->_impl.trim_back(1);
-
-                // 2. Stash the final character, ...
-                auto last = last_frag();
-                stashed = *std::prev(last->get_current());
-                // 3. Drop the final character
-                this->os_->_impl.trim_back(1);
-
-                // Ensure a stable address to restore the stashed character
-                if (last != last_frag()) {
-                    this->os_->_impl.reserve_memory(1);
-                }
-                // 2. ...and where it is to be written.
-                stash_pos = last_frag()->get_current();
+            ++i;
+            if (i == end) {
+                break;
             }
+            // 1. Trim the suffix quote
+            this->os_->_impl.trim_back(1);
+
+            // 2. Stash the final character, ...
+            auto last = last_frag();
+            stashed = *std::prev(last->get_current());
+            // 3. Drop the final character
+            this->os_->_impl.trim_back(1);
+
+            // Ensure a stable address to restore the stashed character
+            if (last != last_frag()) {
+                this->os_->_impl.reserve_memory(1);
+            }
+            // 2. ...and where it is to be written.
+            stash_pos = last_frag()->get_current();
         }
         return this->EndValue(true);
     }

--- a/src/v/json/tests/json_serialization_test.cc
+++ b/src/v/json/tests/json_serialization_test.cc
@@ -190,4 +190,15 @@ SEASTAR_THREAD_TEST_CASE(json_iobuf_writer_test) {
         BOOST_CHECK_EQUAL(out_buf, expected);
         BOOST_CHECK_EQUAL(to_string(out_buf), to_string(expected));
     }
+
+    {
+        json::chunked_buffer out;
+        json::iobuf_writer<json::chunked_buffer> os{out};
+        iobuf buf;
+        os.String(buf);
+        auto out_buf = std::move(out).as_iobuf();
+        auto expected = iobuf::from("\"\"");
+        BOOST_CHECK_EQUAL(out_buf, expected);
+        BOOST_CHECK_EQUAL(to_string(out_buf), to_string(expected));
+    }
 }


### PR DESCRIPTION
We need to correctly handle empty string, as it stands today, an empty
iobuf will end up in invalid JSON.

While we are here also make the algorithm here only need
forward_iterator from iobuf instead of bidirectional_iterator

(cherry picked from commit 4b724280a4daf678a73d31ffae780f5f0e8b31be)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
