### PR TITLE
`rptest`: use `RedpandaVersionTriple` in `java_compression_test.py`

### DIFF
--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -17,7 +17,7 @@ from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import MetricsEndpoint
-from rptest.services.redpanda_installer import RedpandaVersionLine, InstallOptions, RedpandaInstaller
+from rptest.services.redpanda_installer import RedpandaVersionTriple, InstallOptions, RedpandaInstaller
 from rptest.util import expect_exception
 
 
@@ -141,7 +141,7 @@ class JavaCompressionTest(EndToEndTest):
         https://github.com/redpanda-data/redpanda/issues/25091), but this test is parameterized
         with all compression types for completion's sake.
         """
-        pre_big_endian_snappy_fix_version = RedpandaVersionLine((24, 3))
+        pre_big_endian_snappy_fix_version = RedpandaVersionTriple((24, 3, 5))
         self.start_redpanda(num_nodes=1,
                             install_opts=InstallOptions(
                                 version=pre_big_endian_snappy_fix_version))


### PR DESCRIPTION
The PR https://github.com/redpanda-data/redpanda/pull/25092 is being backported to `v24.3` (see https://github.com/redpanda-data/redpanda/pull/25110).

Using a `RedpandaVersionLine` of `((24, 3))` will result in the latest available version being used in the ducktape test in the future, and the upgrade test expectation is that we should be using a version without the fix, which will fail with snappy compression, before upgrading and succeeding.

Change the `pre_big_endian_snappy_fix_version` variable to use the value `RedpandaVersionTriple((24, 3, 5))` to ensure we are using the correct version pre `snappy` fix in the future.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
