### PR TITLE
[CORE-8532] Disallow certain schema evolution actions if a field appears in the partition spec

### DIFF
--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -76,10 +76,12 @@ fill_field_ids(iceberg::struct_type& dest, const iceberg::struct_type& source) {
 // pulled from.
 // NOTE: Post processing is required to assign IDs to any destination fields not
 // found in source (i.e. new fields).
-checked<std::nullopt_t, fill_errc>
-check_schema_compat(iceberg::struct_type& dest, iceberg::struct_type source) {
+checked<std::nullopt_t, fill_errc> check_schema_compat(
+  iceberg::struct_type& dest,
+  iceberg::struct_type source,
+  const iceberg::partition_spec& spec) {
     using namespace iceberg;
-    if (auto evo_res = evolve_schema(source, dest); evo_res.has_error()) {
+    if (auto evo_res = evolve_schema(source, dest, spec); evo_res.has_error()) {
         vlog(
           datalake_log.warn,
           "Schema compatibility error: '{}'\n",
@@ -290,8 +292,18 @@ catalog_schema_manager::get_ids_from_table_meta(
         return errc::failed;
     }
 
+    const auto* cur_spec = table_meta.get_partition_spec(
+      table_meta.default_spec_id);
+    if (cur_spec == nullptr) {
+        vlog(
+          datalake_log.error,
+          "Cannot find default partition spec {} in table {}",
+          table_meta.default_spec_id,
+          table_id);
+        return errc::failed;
+    }
     auto compat_res = check_schema_compat(
-      dest_type, schema->schema_struct.copy());
+      dest_type, schema->schema_struct.copy(), *cur_spec);
     if (compat_res.has_error()) {
         switch (compat_res.error()) {
         case fill_errc::invalid_schema:

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -174,6 +174,7 @@ redpanda_cc_library(
         ":compatibility_types",
         ":compatibility_utils",
         ":datatypes",
+        ":partition",
         "//src/v/base",
     ],
 )

--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -10,6 +10,7 @@
 
 #include "iceberg/compatibility.h"
 
+#include "iceberg/compatibility_types.h"
 #include "iceberg/compatibility_utils.h"
 #include "iceberg/datatypes.h"
 
@@ -141,8 +142,12 @@ schema_transform_state add_field(const nested_field& f) {
  * remove_field - This field (from the source schema) does not appear in the
  * destination schema. Mark it as such.
  */
-schema_transform_state remove_field(const nested_field& f) {
+schema_transform_state
+remove_field(const nested_field& f, const partition_spec& pspec) {
     f.set_evolution_metadata(nested_field::removed::yes);
+    if (pspec.get_field(f.id) != nullptr) {
+        return {.n_removed = 1, .n_removed_partition_fields = 1};
+    }
     return {.n_removed = 1};
 }
 
@@ -156,6 +161,8 @@ schema_transform_state remove_field(const nested_field& f) {
  */
 class annotate_schema_visitor {
 public:
+    explicit annotate_schema_visitor(const partition_spec& pspec)
+      : pspec_(&pspec) {}
     schema_transform_result
     visit(const struct_type& source_t, const struct_type& dest_t) && {
         return std::invoke(*this, source_t, dest_t);
@@ -183,7 +190,9 @@ public:
         // downstream.
         if (auto res = for_each_field(
               source_struct,
-              [&state](const nested_field* f) { state += remove_field(*f); },
+              [this, &state](const nested_field* f) {
+                  state += remove_field(*f, *pspec_);
+              },
               [](const nested_field* f) {
                   // visit only those fields that were not already marked (i.e.
                   // mapped correctly into the destination struct). assume that
@@ -319,6 +328,9 @@ public:
     schema_transform_result operator()(const S&, const D&) const {
         return schema_evolution_errc::incompatible;
     }
+
+private:
+    const partition_spec* pspec_;
 };
 
 /**
@@ -399,14 +411,24 @@ check_types(const iceberg::field_type& src, const iceberg::field_type& dest) {
       dest);
 }
 
-schema_transform_result
-annotate_schema_transform(const struct_type& source, const struct_type& dest) {
-    return annotate_schema_visitor{}.visit(source, dest);
+schema_transform_result annotate_schema_transform(
+  const struct_type& source,
+  const struct_type& dest,
+  const partition_spec& spec) {
+    return annotate_schema_visitor{spec}.visit(source, dest);
 }
 
-schema_transform_result
-validate_schema_transform(struct_type& dest, const partition_spec& spec) {
-    schema_transform_state state{};
+schema_transform_result validate_schema_transform(
+  const schema_transform_result& annotate_res,
+  struct_type& dest,
+  const partition_spec& spec) {
+    if (annotate_res.has_error()) {
+        return annotate_res.error();
+    }
+    if (annotate_res.value().n_removed_partition_fields > 0) {
+        return schema_evolution_errc::partition_spec_conflict;
+    }
+    auto state = annotate_res.value();
     if (auto res = for_each_field(
           dest,
           [&state, &spec](nested_field* f) {
@@ -425,21 +447,8 @@ validate_schema_transform(struct_type& dest, const partition_spec& spec) {
 namespace {
 schema_transform_result do_visit_schemas(
   const struct_type& source, struct_type& dest, const partition_spec& spec) {
-    schema_transform_state result;
-    if (auto annotate_res = annotate_schema_transform(source, dest);
-        annotate_res.has_error()) {
-        return annotate_res.error();
-    } else {
-        result += annotate_res.value();
-    }
-
-    if (auto validate_res = validate_schema_transform(dest, spec);
-        validate_res.has_error()) {
-        return validate_res.error();
-    } else {
-        result += validate_res.value();
-    }
-    return result;
+    auto annotate_res = annotate_schema_transform(source, dest, spec);
+    return validate_schema_transform(annotate_res, dest, spec);
 }
 } // namespace
 

--- a/src/v/iceberg/compatibility.cc
+++ b/src/v/iceberg/compatibility.cc
@@ -38,7 +38,7 @@ struct primitive_type_promotion_policy_visitor {
 
     type_check_result operator()(
       const iceberg::date_type&, const iceberg::timestamp_type&) const {
-        return type_promoted::yes;
+        return type_promoted::changes_partition;
     }
 
     type_check_result
@@ -338,17 +338,24 @@ public:
  */
 struct validate_transform_visitor {
     explicit validate_transform_visitor(
-      nested_field* f, schema_transform_state& state)
+      nested_field* f,
+      schema_transform_state& state,
+      const partition_spec& spec)
       : f_(f)
-      , state_(&state) {}
+      , state_(&state)
+      , spec_(&spec) {}
     schema_errc_result operator()(const nested_field::src_info& src) {
         bool promoted = false;
         if (src.type.has_value()) {
             if (auto ct_res = check_types(src.type.value(), f_->type);
                 ct_res.has_error()) {
                 return schema_evolution_errc::type_mismatch;
-            } else if (ct_res.value() == type_promoted::yes) {
-                promoted = true;
+            } else if (
+              ct_res.value() == type_promoted::changes_partition
+              && spec_->get_field(src.id) != nullptr) {
+                return schema_evolution_errc::partition_spec_conflict;
+            } else {
+                promoted = ct_res.value() != type_promoted::no;
             }
         }
         if (
@@ -379,6 +386,7 @@ struct validate_transform_visitor {
 private:
     nested_field* f_;
     schema_transform_state* state_;
+    const partition_spec* spec_;
 };
 
 } // namespace
@@ -396,15 +404,17 @@ annotate_schema_transform(const struct_type& source, const struct_type& dest) {
     return annotate_schema_visitor{}.visit(source, dest);
 }
 
-schema_transform_result validate_schema_transform(struct_type& dest) {
+schema_transform_result
+validate_schema_transform(struct_type& dest, const partition_spec& spec) {
     schema_transform_state state{};
     if (auto res = for_each_field(
           dest,
-          [&state](nested_field* f) {
+          [&state, &spec](nested_field* f) {
               vassert(
                 f->has_evolution_metadata(),
                 "Should have visited every destination field");
-              return std::visit(validate_transform_visitor{f, state}, f->meta);
+              return std::visit(
+                validate_transform_visitor{f, state, spec}, f->meta);
           });
         res.has_error()) {
         return res.error();
@@ -413,8 +423,8 @@ schema_transform_result validate_schema_transform(struct_type& dest) {
 }
 
 namespace {
-schema_transform_result
-do_visit_schemas(const struct_type& source, struct_type& dest) {
+schema_transform_result do_visit_schemas(
+  const struct_type& source, struct_type& dest, const partition_spec& spec) {
     schema_transform_state result;
     if (auto annotate_res = annotate_schema_transform(source, dest);
         annotate_res.has_error()) {
@@ -423,7 +433,7 @@ do_visit_schemas(const struct_type& source, struct_type& dest) {
         result += annotate_res.value();
     }
 
-    if (auto validate_res = validate_schema_transform(dest);
+    if (auto validate_res = validate_schema_transform(dest, spec);
         validate_res.has_error()) {
         return validate_res.error();
     } else {
@@ -433,9 +443,9 @@ do_visit_schemas(const struct_type& source, struct_type& dest) {
 }
 } // namespace
 
-schema_evolution_result
-evolve_schema(const struct_type& source, struct_type& dest) {
-    if (auto res = do_visit_schemas(source, dest); res.has_error()) {
+schema_evolution_result evolve_schema(
+  const struct_type& source, struct_type& dest, const partition_spec& spec) {
+    if (auto res = do_visit_schemas(source, dest, spec); res.has_error()) {
         return res.error();
     } else {
         return schema_changed{res.value().total() > 0};
@@ -444,7 +454,8 @@ evolve_schema(const struct_type& source, struct_type& dest) {
 
 fill_ids_result
 try_fill_field_ids(const struct_type& source, struct_type& dest) {
-    if (auto res = do_visit_schemas(source, dest); res.has_error()) {
+    if (auto res = do_visit_schemas(source, dest, partition_spec{});
+        res.has_error()) {
         return res.error();
     } else {
         // All we care about here is that every field got an ID

--- a/src/v/iceberg/compatibility.h
+++ b/src/v/iceberg/compatibility.h
@@ -65,11 +65,15 @@ check_types(const iceberg::field_type& src, const iceberg::field_type& dest);
  *                 schema for some table)
  * @param dest   - the proposed schema (probably extracted from some incoming
  *                 record)
+ * @param spec  - a partition spec, resolved to the source schema. for
+ *                 evaluating allowability of field removals.
  *
  * @return schema_transform_state (indicating success), or an error code
  */
-schema_transform_result
-annotate_schema_transform(const struct_type& source, const struct_type& dest);
+schema_transform_result annotate_schema_transform(
+  const struct_type& source,
+  const struct_type& dest,
+  const partition_spec& spec);
 
 /**
  * validate_schema_transform - Finish evaluating backwards compatibility of
@@ -84,6 +88,7 @@ annotate_schema_transform(const struct_type& source, const struct_type& dest);
  *   - 'dest' has been fed though 'annotate_schema_transform' already, along
  *     with a source schema.
  *
+ * @param annotate_res - the result of the annotation we're validating
  * @param dest - the proposed schema (probably extracted from some incoming
  *               record)
  * @param spec - a partition specification against which the fields
@@ -92,8 +97,10 @@ annotate_schema_transform(const struct_type& source, const struct_type& dest);
  *
  * @return schema_transform_state (indicating success), or an error code
  */
-schema_transform_result
-validate_schema_transform(struct_type& dest, const partition_spec& spec);
+schema_transform_result validate_schema_transform(
+  const schema_transform_result& annotate_res,
+  struct_type& dest,
+  const partition_spec& spec);
 
 /**
  * evolve_schema - Prepares dest for insertion into table metadata.

--- a/src/v/iceberg/compatibility.h
+++ b/src/v/iceberg/compatibility.h
@@ -122,9 +122,7 @@ validate_schema_transform(struct_type& dest, const partition_spec& spec);
  * @return Whether the schema changed from source->dest, or an error
  */
 schema_evolution_result evolve_schema(
-  const struct_type& source,
-  struct_type& dest,
-  const partition_spec& spec = partition_spec{});
+  const struct_type& source, struct_type& dest, const partition_spec& spec);
 
 /**
  * try_fill_field_ids - Try to fill all dest fields with IDs from source.

--- a/src/v/iceberg/compatibility.h
+++ b/src/v/iceberg/compatibility.h
@@ -12,6 +12,7 @@
 
 #include "iceberg/compatibility_types.h"
 #include "iceberg/datatypes.h"
+#include "iceberg/partition.h"
 
 namespace iceberg {
 
@@ -31,6 +32,9 @@ namespace iceberg {
    @return The result of the type check:
              - type_promoted::yes - if src -> dest is a valid type promotion
                e.g. int -> long
+             - type_promoted::unless_partition - if src -> dest is a valid type
+               promotion but would change the value of a partition transform
+               involving src
              - type_promoted::no  - if src == dest
              - compat_errc::mismatch - if src != dest but src -> dest is not
                permitted e.g. int -> string or struct -> list
@@ -82,10 +86,14 @@ annotate_schema_transform(const struct_type& source, const struct_type& dest);
  *
  * @param dest - the proposed schema (probably extracted from some incoming
  *               record)
+ * @param spec - a partition specification against which the fields
+ *               of dest are compared to enforce that type promotions don't
+ *               interfere with existing partition fields.
  *
  * @return schema_transform_state (indicating success), or an error code
  */
-schema_transform_result validate_schema_transform(struct_type& dest);
+schema_transform_result
+validate_schema_transform(struct_type& dest, const partition_spec& spec);
 
 /**
  * evolve_schema - Prepares dest for insertion into table metadata.
@@ -107,11 +115,16 @@ schema_transform_result validate_schema_transform(struct_type& dest);
  * @param source - The source (i.e original) schema
  * @param dest   - the proposed schema (probably extracted from some incoming
  *                 record)
+ * @param spec   - The current partition spec for the target table.
+ *                 Used to enforce that type promotions don't interfere with
+ *                 partition fields.
  *
  * @return Whether the schema changed from source->dest, or an error
  */
-schema_evolution_result
-evolve_schema(const struct_type& source, struct_type& dest);
+schema_evolution_result evolve_schema(
+  const struct_type& source,
+  struct_type& dest,
+  const partition_spec& spec = partition_spec{});
 
 /**
  * try_fill_field_ids - Try to fill all dest fields with IDs from source.

--- a/src/v/iceberg/compatibility_types.cc
+++ b/src/v/iceberg/compatibility_types.cc
@@ -49,6 +49,7 @@ operator+=(schema_transform_state& lhs, const schema_transform_state& rhs) {
     lhs.n_removed += rhs.n_removed;
     lhs.n_added += rhs.n_added;
     lhs.n_promoted += rhs.n_promoted;
+    lhs.n_removed_partition_fields += rhs.n_removed_partition_fields;
     return lhs;
 }
 

--- a/src/v/iceberg/compatibility_types.cc
+++ b/src/v/iceberg/compatibility_types.cc
@@ -12,6 +12,17 @@
 
 namespace iceberg {
 
+std::string_view to_string_view(type_promoted tp) {
+    switch (tp) {
+    case type_promoted::no:
+        return "type_promoted::no";
+    case type_promoted::yes:
+        return "type_promoted::yes";
+    case type_promoted::changes_partition:
+        return "type_promoted::changes_partition";
+    }
+}
+
 std::string_view to_string_view(schema_evolution_errc ec) {
     switch (ec) {
     case schema_evolution_errc::type_mismatch:
@@ -43,6 +54,12 @@ operator+=(schema_transform_state& lhs, const schema_transform_state& rhs) {
 
 auto fmt::formatter<iceberg::schema_evolution_errc>::format(
   iceberg::schema_evolution_errc ec,
+  format_context& ctx) const -> format_context::iterator {
+    return formatter<string_view>::format(iceberg::to_string_view(ec), ctx);
+}
+
+auto fmt::formatter<iceberg::type_promoted>::format(
+  iceberg::type_promoted ec,
   format_context& ctx) const -> format_context::iterator {
     return formatter<string_view>::format(iceberg::to_string_view(ec), ctx);
 }

--- a/src/v/iceberg/compatibility_types.cc
+++ b/src/v/iceberg/compatibility_types.cc
@@ -39,6 +39,8 @@ std::string_view to_string_view(schema_evolution_errc ec) {
         return "schema_evolution_errc::null_nested_field";
     case schema_evolution_errc::invalid_state:
         return "schema_evolution_errc::invalid_state";
+    case schema_evolution_errc::partition_spec_conflict:
+        return "schema_evolution_errc::partition_spec_conflict";
     }
 }
 

--- a/src/v/iceberg/compatibility_types.h
+++ b/src/v/iceberg/compatibility_types.h
@@ -68,6 +68,12 @@ struct schema_transform_state {
     size_t n_removed{0};
     size_t n_added{0};
     size_t n_promoted{0};
+    size_t n_removed_partition_fields{0};
+
+    // when we remove a field, it's always counted in n_removed, and _also_
+    // counted in n_removed_partition_fields iff it was a partition field.
+    // therefore, to avoid double counting, don't include
+    // n_removed_partition_fields in the total.
     size_t total() { return n_removed + n_added + n_promoted; }
 };
 

--- a/src/v/iceberg/compatibility_types.h
+++ b/src/v/iceberg/compatibility_types.h
@@ -23,7 +23,25 @@ enum class compat_errc {
     mismatch,
 };
 
-using type_promoted = ss::bool_class<struct type_promoted_tag>;
+/**
+ * type_promoted - returned from check_types(field_type src, field_type dest)
+ * to indicate
+ *   a) that src & dest are compatible types
+ *   b) whether a field of type src requires type promotion to type dest, as
+ *      follows:
+ *      - ::no - types are identical if primitive, of same structural type
+ *         otherwise
+ *      - ::yes - src is promoted to dest and it is always safe to do so
+ *      - ::changes_partition - src is promoted to dest but doing so would
+ *        change the value of a partition transform function involving that
+ *        field.
+ */
+enum class type_promoted {
+    no,
+    yes,
+    changes_partition,
+};
+
 using type_check_result = checked<type_promoted, compat_errc>;
 
 // TODO(oren): possibly a whole error_code?
@@ -71,5 +89,11 @@ template<>
 struct fmt::formatter<iceberg::schema_evolution_errc>
   : formatter<std::string_view> {
     auto format(iceberg::schema_evolution_errc d, format_context& ctx) const
+      -> format_context::iterator;
+};
+
+template<>
+struct fmt::formatter<iceberg::type_promoted> : formatter<std::string_view> {
+    auto format(iceberg::type_promoted d, format_context& ctx) const
       -> format_context::iterator;
 };

--- a/src/v/iceberg/compatibility_types.h
+++ b/src/v/iceberg/compatibility_types.h
@@ -53,6 +53,7 @@ enum class schema_evolution_errc {
     new_required_field,
     null_nested_field,
     invalid_state,
+    partition_spec_conflict,
 };
 
 /**

--- a/src/v/iceberg/partition.cc
+++ b/src/v/iceberg/partition.cc
@@ -54,4 +54,13 @@ std::optional<partition_spec> partition_spec::resolve(
     };
 }
 
+const partition_field*
+partition_spec::get_field(nested_field::id_t source_id) const {
+    auto it = std::ranges::find(fields, source_id, &partition_field::source_id);
+    if (it == fields.end()) {
+        return nullptr;
+    }
+    return &(*it);
+}
+
 } // namespace iceberg

--- a/src/v/iceberg/partition.h
+++ b/src/v/iceberg/partition.h
@@ -43,6 +43,8 @@ struct partition_spec {
     static std::optional<partition_spec>
     resolve(const unresolved_partition_spec&, const struct_type& schema_type);
 
+    const partition_field* get_field(nested_field::id_t source_id) const;
+
     friend bool operator==(const partition_spec&, const partition_spec&)
       = default;
 

--- a/src/v/iceberg/schema_avro.cc
+++ b/src/v/iceberg/schema_avro.cc
@@ -79,7 +79,7 @@ struct avro_primitive_type_visitor {
         return ret;
     }
     avro::Schema operator()(const date_type&) {
-        auto ret = avro::LongSchema();
+        auto ret = avro::IntSchema();
         ret.root()->setLogicalType(avro::LogicalType(avro::LogicalType::DATE));
         return ret;
     }

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -665,11 +665,13 @@ redpanda_cc_gtest(
     cpu = 1,
     deps = [
         ":test_schemas",
+        "//src/v/datalake:partition_spec_parser",
         "//src/v/iceberg:compatibility",
         "//src/v/iceberg:compatibility_types",
         "//src/v/iceberg:compatibility_utils",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/iceberg:partition",
         "//src/v/random:generators",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/container:btree",
@@ -703,6 +705,7 @@ redpanda_cc_bench(
         "//src/v/iceberg:compatibility",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:field_collecting_visitor",
+        "//src/v/iceberg:partition",
         "@seastar//:benchmark",
     ],
 )

--- a/src/v/iceberg/tests/compatibility_bench.cc
+++ b/src/v/iceberg/tests/compatibility_bench.cc
@@ -80,7 +80,7 @@ void run_describe_transform_bench(const struct_type& source) {
     auto dest = source.copy();
 
     perf_tests::start_measuring_time();
-    auto res = annotate_schema_transform(source, dest);
+    auto res = annotate_schema_transform(source, dest, partition_spec{});
     perf_tests::stop_measuring_time();
 
     vassert(!res.has_error(), "Expected success");
@@ -88,11 +88,11 @@ void run_describe_transform_bench(const struct_type& source) {
 
 void run_apply_transform_bench(const struct_type& source) {
     auto dest = source.copy();
-    auto xform = annotate_schema_transform(source, dest);
+    auto xform = annotate_schema_transform(source, dest, partition_spec{});
     vassert(!xform.has_error(), "Expected success");
 
     perf_tests::start_measuring_time();
-    auto res = validate_schema_transform(dest, partition_spec{});
+    auto res = validate_schema_transform(xform, dest, partition_spec{});
     perf_tests::stop_measuring_time();
 
     vassert(!res.has_error(), "Expected success");

--- a/src/v/iceberg/tests/compatibility_bench.cc
+++ b/src/v/iceberg/tests/compatibility_bench.cc
@@ -11,6 +11,7 @@
 #include "iceberg/compatibility.h"
 #include "iceberg/datatypes.h"
 #include "iceberg/field_collecting_visitor.h"
+#include "iceberg/partition.h"
 #include "iceberg/tests/test_schemas.h"
 
 #include <seastar/testing/perf_tests.hh>
@@ -91,7 +92,7 @@ void run_apply_transform_bench(const struct_type& source) {
     vassert(!xform.has_error(), "Expected success");
 
     perf_tests::start_measuring_time();
-    auto res = validate_schema_transform(dest);
+    auto res = validate_schema_transform(dest, partition_spec{});
     perf_tests::stop_measuring_time();
 
     vassert(!res.has_error(), "Expected success");

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -963,6 +963,37 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
     .validate_err = schema_evolution_errc::partition_spec_conflict,
     .pspec = "(nested.date)",
   },
+  struct_evolution_test_case{
+    .description
+    = "dropping a field which appears in the partition spec is illegal",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          s.fields.emplace_back(nested_field::create(
+            ids.get_one(), "foo", field_required::yes, int_type{}));
+          return s;
+      },
+    .update = [](struct_type& s) { s.fields.pop_back(); },
+    .validate_err = schema_evolution_errc::partition_spec_conflict,
+    .pspec = "(foo)",
+  },
+  struct_evolution_test_case{
+    .description
+    = "dropping the enclosing struct for a partition field also fails",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          struct_type nested{};
+          nested.fields.emplace_back(nested_field::create(
+            ids.get_one(), "foo", field_required::yes, int_type{}));
+          s.fields.emplace_back(nested_field::create(
+            ids.get_one(), "nested", field_required::yes, std::move(nested)));
+          return s;
+      },
+    .update = [](struct_type& s) { s.fields.pop_back(); },
+    .validate_err = schema_evolution_errc::partition_spec_conflict,
+    .pspec = "(nested.foo)",
+  },
 };
 
 static constexpr auto valid_plus_errs = [](auto&& R) {
@@ -1031,7 +1062,7 @@ TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
         // transforming self -> self returns no change
         auto c1 = type.copy();
         auto c2 = type.copy();
-        auto annotate_res = annotate_schema_transform(c1, c2);
+        auto annotate_res = annotate_schema_transform(c1, c2, partition_spec{});
         if (
           !annotate_err().has_error()
           || annotate_err().error() != schema_evolution_errc::ambiguous) {
@@ -1041,7 +1072,8 @@ TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
     }
 
     // check that annotation works or errors as expected
-    auto annotate_res = annotate_schema_transform(original_schema_struct, type);
+    auto annotate_res = annotate_schema_transform(
+      original_schema_struct, type, gen_partition_spec(original_schema_struct));
 
     ASSERT_EQ(annotate_res.has_error(), annotate_err().has_error())
       << (annotate_res.has_error()
@@ -1094,24 +1126,32 @@ TEST_P(ValidateAnnotationTest, ValidateCatchesTypeErrors) {
 
     {
         // transforming self -> self returns no change
-        auto c1 = type.copy();
-        auto c2 = type.copy();
-        auto annotate_res = annotate_schema_transform(c1, c2);
+        auto c1 = original_schema_struct.copy();
+        auto c2 = original_schema_struct.copy();
+        auto annotate_res = annotate_schema_transform(
+          c1, c2, gen_partition_spec(c1));
         ASSERT_FALSE(annotate_res.has_error());
         auto validate_res = validate_schema_transform(
-          c2, gen_partition_spec(c1));
+          annotate_res, c2, gen_partition_spec(c1));
         ASSERT_FALSE(validate_res.has_error())
           << fmt::format("Unexpected error: {}", validate_res.error());
         EXPECT_EQ(validate_res.value().total(), 0);
     }
 
     // For this subset of cases we expect annotate to pass
-    auto annotate_res = annotate_schema_transform(original_schema_struct, type);
+    auto annotate_res = annotate_schema_transform(
+      original_schema_struct, type, gen_partition_spec(original_schema_struct));
     ASSERT_FALSE(annotate_res.has_error());
+    if (annotate_res.value().n_removed_partition_fields > 0) {
+        ASSERT_TRUE(validate_err().has_error());
+        EXPECT_EQ(
+          validate_err().error(),
+          schema_evolution_errc::partition_spec_conflict);
+    }
 
     // but validate may fail
     auto validate_res = validate_schema_transform(
-      type, gen_partition_spec(original_schema_struct));
+      annotate_res, type, gen_partition_spec(original_schema_struct));
     ASSERT_EQ(validate_res.has_error(), validate_err().has_error())
       << (validate_res.has_error()
             ? fmt::format("Unexpected error: {}", validate_res.error())

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -332,7 +332,8 @@ struct struct_evolution_test_case {
     std::string_view description{};
     std::function<struct_type(unique_id_generator&)> generator;
     std::function<void(struct_type&)> update;
-    checked<std::nullopt_t, schema_evolution_errc> err{std::nullopt};
+    checked<std::nullopt_t, schema_evolution_errc> annotate_err{std::nullopt};
+    checked<std::nullopt_t, schema_evolution_errc> validate_err{std::nullopt};
     std::function<bool(const struct_type&, const struct_type&)> validator =
       [](const struct_type&, const struct_type&) { return true; };
     schema_changed any_change{true};
@@ -727,10 +728,8 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
             ids.get_one(), "foo", field_required::no, int_type{}));
           return s;
       },
-    .update = [](
-
-                struct_type& s) { s.fields[0]->type = string_type{}; },
-    .err = schema_evolution_errc::type_mismatch,
+    .update = [](struct_type& s) { s.fields[0]->type = string_type{}; },
+    .validate_err = schema_evolution_errc::type_mismatch,
   },
   struct_evolution_test_case{
     .description
@@ -750,7 +749,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
       [](struct_type& s) {
           get<list_type>(s.fields[0]).element_field->type = string_type{};
       },
-    .err = schema_evolution_errc::type_mismatch,
+    .validate_err = schema_evolution_errc::type_mismatch,
   },
   struct_evolution_test_case{
     .description
@@ -772,7 +771,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
             .fields.emplace_back(
               nested_field::create(0, "int", field_required::yes, int_type{}));
       },
-    .err = schema_evolution_errc::new_required_field,
+    .validate_err = schema_evolution_errc::new_required_field,
 
   },
   struct_evolution_test_case{
@@ -796,7 +795,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
       [](struct_type& s) {
           get<map_type>(s.fields[0]).value_field->type = string_type{};
       },
-    .err = schema_evolution_errc::type_mismatch,
+    .validate_err = schema_evolution_errc::type_mismatch,
   },
   struct_evolution_test_case{
     .description = "map keys are subject to type promotion rules (invalid)",
@@ -819,7 +818,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
       [](struct_type& s) {
           get<map_type>(s.fields[0]).key_field->type = double_type{};
       },
-    .err = schema_evolution_errc::type_mismatch,
+    .validate_err = schema_evolution_errc::type_mismatch,
   },
   struct_evolution_test_case{
     .description = "evolving a primitive field into a struct is illegal",
@@ -840,7 +839,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           s.fields.emplace_back(
             nested_field::create(0, "foo", field_required::no, std::move(foo)));
       },
-    .err = schema_evolution_errc::incompatible,
+    .annotate_err = schema_evolution_errc::incompatible,
   },
   struct_evolution_test_case{
     .description = "evolving a single field struct into a primitive is illegal",
@@ -861,7 +860,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           s.fields.clear();
           s.fields.emplace_back(std::move(bar));
       },
-    .err = schema_evolution_errc::incompatible,
+    .annotate_err = schema_evolution_errc::incompatible,
   },
   struct_evolution_test_case{
     .description
@@ -878,7 +877,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           return s;
       },
     .update = [](struct_type& s) { s.fields.back()->type = long_type{}; },
-    .err = schema_evolution_errc::ambiguous,
+    .annotate_err = schema_evolution_errc::ambiguous,
   },
   struct_evolution_test_case{
     .description = "adding fields to a map key is illegal",
@@ -890,7 +889,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           key.fields.emplace_back(
             nested_field::create(0, "qux", field_required::no, int_type{}));
       },
-    .err = schema_evolution_errc::violates_map_key_invariant,
+    .annotate_err = schema_evolution_errc::violates_map_key_invariant,
   },
   struct_evolution_test_case{
     .description = "dropping fields from a map key struct is illegal",
@@ -901,7 +900,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           auto& key = get<struct_type>(map.key_field);
           key.fields.pop_back();
       },
-    .err = schema_evolution_errc::violates_map_key_invariant,
+    .annotate_err = schema_evolution_errc::violates_map_key_invariant,
   },
   struct_evolution_test_case{
     .description
@@ -919,7 +918,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           s.fields.back()->required = field_required::yes;
           s.fields.back()->type = long_type{};
       },
-    .err = schema_evolution_errc::new_required_field,
+    .validate_err = schema_evolution_errc::new_required_field,
   },
   struct_evolution_test_case{
     .description = "adding required fields is illegal (NOTE: the spec allows "
@@ -931,7 +930,7 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
           s.fields.emplace_back(
             nested_field::create(0, "foo", field_required::yes, int_type{}));
       },
-    .err = schema_evolution_errc::new_required_field,
+    .validate_err = schema_evolution_errc::new_required_field,
   },
 };
 
@@ -956,7 +955,12 @@ public:
         reset_field_ids(cp);
         return cp;
     }
-    auto& err() { return GetParam().err; }
+    auto& err() {
+        return GetParam().annotate_err.has_error() ? GetParam().annotate_err
+                                                   : GetParam().validate_err;
+    }
+    auto& annotate_err() { return GetParam().annotate_err; }
+    auto& validate_err() { return GetParam().validate_err; }
     auto validator(const struct_type& src, const struct_type& dest) {
         return GetParam().validator(src, dest);
     }
@@ -968,12 +972,10 @@ struct AnnotateStructTest : public StructCompatibilityTestBase {};
 INSTANTIATE_TEST_SUITE_P(
   StructEvolutionTest,
   AnnotateStructTest,
-  ::testing::ValuesIn(valid_plus_errs(
-    invalid_cases | std::views::filter([](const auto& tc) {
-        return tc.err.assume_error() != schema_evolution_errc::type_mismatch
-               && tc.err.assume_error()
-                    != schema_evolution_errc::new_required_field;
-    }))));
+  ::testing::ValuesIn(
+    valid_plus_errs(invalid_cases | std::views::filter([](const auto& tc) {
+                        return tc.annotate_err.has_error();
+                    }))));
 
 TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
     // generate a schema per the test case
@@ -989,8 +991,8 @@ TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
         auto c2 = type.copy();
         auto annotate_res = annotate_schema_transform(c1, c2);
         if (
-          !err().has_error()
-          || err().error() != schema_evolution_errc::ambiguous) {
+          !annotate_err().has_error()
+          || annotate_err().error() != schema_evolution_errc::ambiguous) {
             ASSERT_FALSE(annotate_res.has_error());
             EXPECT_EQ(annotate_res.value().total(), 0);
         }
@@ -1004,7 +1006,7 @@ TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
             : fmt::format("Expected {}", err().error()));
 
     if (annotate_res.has_error()) {
-        EXPECT_EQ(annotate_res.error(), err().error());
+        EXPECT_EQ(annotate_res.error(), annotate_err().error());
         return;
     }
     // if no annotation errors, check that every field in the destination
@@ -1034,12 +1036,10 @@ struct ValidateAnnotationTest : public StructCompatibilityTestBase {};
 INSTANTIATE_TEST_SUITE_P(
   StructEvolutionTest,
   ValidateAnnotationTest,
-  ::testing::ValuesIn(valid_plus_errs(
-    invalid_cases | std::views::filter([](const auto& tc) {
-        return tc.err.assume_error() == schema_evolution_errc::type_mismatch
-               || tc.err.assume_error()
-                    == schema_evolution_errc::new_required_field;
-    }))));
+  ::testing::ValuesIn(
+    valid_plus_errs(invalid_cases | std::views::filter([](const auto& tc) {
+                        return tc.validate_err.has_error();
+                    }))));
 
 TEST_P(ValidateAnnotationTest, ValidateCatchesTypeErrors) {
     // generate a schema per the test case
@@ -1067,13 +1067,13 @@ TEST_P(ValidateAnnotationTest, ValidateCatchesTypeErrors) {
 
     // but validate may fail
     auto validate_res = validate_schema_transform(type);
-    ASSERT_EQ(validate_res.has_error(), err().has_error())
+    ASSERT_EQ(validate_res.has_error(), validate_err().has_error())
       << (validate_res.has_error()
             ? fmt::format("Unexpected error: {}", validate_res.error())
-            : fmt::format("Expected {}", err().error()));
+            : fmt::format("Expected {}", validate_err().error()));
 
     if (validate_res.has_error()) {
-        EXPECT_EQ(validate_res.error(), err().error());
+        EXPECT_EQ(validate_res.error(), validate_err().error());
         return;
     }
 

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -8,10 +8,12 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "datalake/partition_spec_parser.h"
 #include "iceberg/compatibility.h"
 #include "iceberg/compatibility_types.h"
 #include "iceberg/compatibility_utils.h"
 #include "iceberg/datatypes.h"
+#include "iceberg/partition.h"
 #include "random/generators.h"
 
 #include <absl/container/btree_map.h>
@@ -164,9 +166,8 @@ std::ostream& operator<<(std::ostream& os, const field_test_case& ftc) {
       "{}->{} [expected: {}]",
       ftc.source,
       ftc.dest,
-      ftc.expected.has_error()
-        ? std::string{"ERROR"}
-        : fmt::format("promoted={}", ftc.expected.value()));
+      ftc.expected.has_error() ? std::string{"ERROR"}
+                               : fmt::format("{}", ftc.expected.value()));
     return os;
 }
 } // namespace
@@ -177,7 +178,8 @@ std::vector<field_test_case> generate_test_cases() {
     test_data.emplace_back(int_type{}, long_type{}, type_promoted::yes);
     test_data.emplace_back(int_type{}, boolean_type{}, compat_errc::mismatch);
 
-    test_data.emplace_back(date_type{}, timestamp_type{}, type_promoted::yes);
+    test_data.emplace_back(
+      date_type{}, timestamp_type{}, type_promoted::changes_partition);
     test_data.emplace_back(date_type{}, long_type{}, compat_errc::mismatch);
 
     test_data.emplace_back(float_type{}, double_type{}, type_promoted::yes);
@@ -337,6 +339,7 @@ struct struct_evolution_test_case {
     std::function<bool(const struct_type&, const struct_type&)> validator =
       [](const struct_type&, const struct_type&) { return true; };
     schema_changed any_change{true};
+    std::optional<ss::sstring> pspec{};
 };
 
 std::ostream&
@@ -359,6 +362,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
       [](const struct_type& src, const struct_type& dst) {
           return updated(*src.fields.back(), *dst.fields.back());
       },
+    .pspec = "(foo)",
   },
   struct_evolution_test_case{
     .description = "list elements are subject to type promotion rules (valid)",
@@ -383,6 +387,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           auto& dst_list = get<list_type>(dst.fields.back());
           return updated(*src_list.element_field, *dst_list.element_field);
       },
+    .pspec = "(qux)",
   },
   struct_evolution_test_case{
     .description = "evolving a list-element struct is allowed",
@@ -441,6 +446,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           return updated(*src_map.key_field, *dst_map.key_field)
                  && updated(*src_map.value_field, *dst_map.value_field);
       },
+    .pspec = "(a_map)",
   },
   struct_evolution_test_case{
     .description = "we can 'add' nested fields",
@@ -500,6 +506,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           return orig_match && updated(*dest.fields[0])
                  && updated(*dest.fields[2]) && added(*dest.fields[1]);
       },
+    .pspec = "(foo,bar)",
   },
   struct_evolution_test_case{
     .description = "removing a required field works",
@@ -541,6 +548,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
                  && dst_nested.fields.empty()
                  && removed(*src_nested.fields.back());
       },
+    .pspec = "(nested)", // TODO(oren): seems wrong frankly, should this fail?
   },
   struct_evolution_test_case{
     .description
@@ -632,6 +640,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           auto& dst_f = dst.fields.back();
           return src_f->required != dst_f->required && updated(*src_f, *dst_f);
       },
+    .pspec = "(foo)",
   },
   struct_evolution_test_case{
     .description = "reordering fields is legal",
@@ -667,6 +676,7 @@ static const std::vector<struct_evolution_test_case> valid_cases{
     // should reordered fields in a schema correspond to some parquet layout
     // change on disk?
     .any_change = schema_changed::no,
+    .pspec = "(quux,location)",
   },
   struct_evolution_test_case{
     .description
@@ -932,6 +942,27 @@ static const std::vector<struct_evolution_test_case> invalid_cases{
       },
     .validate_err = schema_evolution_errc::new_required_field,
   },
+  struct_evolution_test_case{
+    .description = "promoting from date -> timestamp is fine as long as that "
+                   "field does not appear in the partition spec",
+    .generator =
+      [](unique_id_generator& ids) {
+          struct_type s{};
+          struct_type n{};
+          n.fields.emplace_back(nested_field::create(
+            ids.get_one(), "date", field_required::no, date_type{}));
+          s.fields.emplace_back(nested_field::create(
+            ids.get_one(), "nested", field_required::no, std::move(n)));
+          return s;
+      },
+    .update =
+      [](struct_type& s) {
+          std::get<struct_type>(s.fields.back()->type).fields.back()->type
+            = timestamp_type{};
+      },
+    .validate_err = schema_evolution_errc::partition_spec_conflict,
+    .pspec = "(nested.date)",
+  },
 };
 
 static constexpr auto valid_plus_errs = [](auto&& R) {
@@ -963,6 +994,17 @@ public:
     auto& validate_err() { return GetParam().validate_err; }
     auto validator(const struct_type& src, const struct_type& dest) {
         return GetParam().validator(src, dest);
+    }
+    partition_spec gen_partition_spec(const struct_type& s) const {
+        auto raw = GetParam().pspec;
+        if (!raw.has_value()) {
+            return partition_spec{};
+        }
+        auto parsed = datalake::parse_partition_spec(raw.value());
+        EXPECT_TRUE(parsed.has_value()) << GetParam();
+        auto resolved = partition_spec::resolve(parsed.value(), s);
+        EXPECT_TRUE(resolved.has_value()) << GetParam();
+        return std::move(resolved).value();
     }
     auto& any_change() { return GetParam().any_change; }
 };
@@ -1000,10 +1042,11 @@ TEST_P(AnnotateStructTest, AnnotationWorksAndDetectsStructuralErrors) {
 
     // check that annotation works or errors as expected
     auto annotate_res = annotate_schema_transform(original_schema_struct, type);
-    ASSERT_EQ(annotate_res.has_error(), err().has_error())
+
+    ASSERT_EQ(annotate_res.has_error(), annotate_err().has_error())
       << (annotate_res.has_error()
             ? fmt::format("Unexpected error: {}", annotate_res.error())
-            : fmt::format("Expected {}", err().error()));
+            : fmt::format("Expected {}", annotate_err().error()));
 
     if (annotate_res.has_error()) {
         EXPECT_EQ(annotate_res.error(), annotate_err().error());
@@ -1055,7 +1098,8 @@ TEST_P(ValidateAnnotationTest, ValidateCatchesTypeErrors) {
         auto c2 = type.copy();
         auto annotate_res = annotate_schema_transform(c1, c2);
         ASSERT_FALSE(annotate_res.has_error());
-        auto validate_res = validate_schema_transform(c2);
+        auto validate_res = validate_schema_transform(
+          c2, gen_partition_spec(c1));
         ASSERT_FALSE(validate_res.has_error())
           << fmt::format("Unexpected error: {}", validate_res.error());
         EXPECT_EQ(validate_res.value().total(), 0);
@@ -1066,7 +1110,8 @@ TEST_P(ValidateAnnotationTest, ValidateCatchesTypeErrors) {
     ASSERT_FALSE(annotate_res.has_error());
 
     // but validate may fail
-    auto validate_res = validate_schema_transform(type);
+    auto validate_res = validate_schema_transform(
+      type, gen_partition_spec(original_schema_struct));
     ASSERT_EQ(validate_res.has_error(), validate_err().has_error())
       << (validate_res.has_error()
             ? fmt::format("Unexpected error: {}", validate_res.error())
@@ -1106,14 +1151,17 @@ TEST_P(StructEvoCompatibilityTest, CanEvolveStructsAndDetectErrors) {
     // try to evolve the original schema into the new and update the latter
     // accordingly. check against expectations (both success and expected
     // qualities of the result)
-    auto evolve_res = evolve_schema(original_schema_struct, type);
+    auto evolve_res = evolve_schema(
+      original_schema_struct, type, gen_partition_spec(original_schema_struct));
+
     ASSERT_EQ(evolve_res.has_error(), err().has_error())
       << (evolve_res.has_error()
             ? fmt::format("Unexpected error: {}", evolve_res.error())
             : fmt::format(
                 "Expected {} got {}", err().error(), evolve_res.value()));
     if (evolve_res.has_error()) {
-        ASSERT_EQ(evolve_res.error(), err().error());
+        ASSERT_EQ(evolve_res.error(), err().error())
+          << fmt::format("{}", evolve_res.error());
         return;
     }
 

--- a/src/v/iceberg/tests/schema_avro_test.cc
+++ b/src/v/iceberg/tests/schema_avro_test.cc
@@ -402,3 +402,80 @@ TEST(SchemaAvroSerialization, TestNestedSchema) {
     const auto& parsed_struct = std::get<struct_type>(parsed_type);
     ASSERT_EQ(s.schema_struct, parsed_struct);
 }
+
+TEST(SchemaAvroSerialization, TestLogicalTypes) {
+    struct_type type;
+    type.fields.emplace_back(nested_field::create(
+      0, "decimal", field_required::yes, decimal_type{8, 0}));
+    type.fields.emplace_back(
+      nested_field::create(1, "date", field_required::yes, date_type{}));
+    type.fields.emplace_back(
+      nested_field::create(2, "time", field_required::yes, time_type{}));
+    type.fields.emplace_back(nested_field::create(
+      3, "timestamp", field_required::yes, timestamp_type{}));
+    type.fields.emplace_back(
+      nested_field::create(4, "uuid", field_required::yes, uuid_type{}));
+
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {}};
+    auto avro_root = struct_type_to_avro(s.schema_struct, "test_schema");
+    auto avro_schema = avro::ValidSchema(avro_root);
+    const auto expected_str = R"({
+    "type": "record",
+    "name": "test_schema",
+    "fields": [
+        {
+            "name": "decimal",
+            "type": {
+                "type": "fixed",
+                "name": "decimal",
+                "size": 4,
+                "logicalType": "decimal", "precision": 8, "scale": 0
+            },
+            "field-id": 0
+        },
+        {
+            "name": "date",
+            "type": {
+            "type": "int",
+            "logicalType": "date"
+},
+            "field-id": 1
+        },
+        {
+            "name": "time",
+            "type": {
+            "type": "long",
+            "logicalType": "time-micros"
+},
+            "field-id": 2
+        },
+        {
+            "name": "timestamp",
+            "type": {
+            "type": "long",
+            "logicalType": "timestamp-micros"
+},
+            "field-id": 3
+        },
+        {
+            "name": "uuid",
+            "type": {
+            "type": "string",
+            "logicalType": "uuid"
+},
+            "field-id": 4
+        }
+    ]
+}
+)";
+    ASSERT_STREQ(expected_str, avro_schema.toJson().c_str());
+
+    // Now parse it back from Avro and ensure the types are equal.
+    auto parsed_type = type_from_avro(avro_schema.root());
+    ASSERT_TRUE(std::holds_alternative<struct_type>(parsed_type));
+    const auto& parsed_struct = std::get<struct_type>(parsed_type);
+    ASSERT_EQ(s.schema_struct, parsed_struct);
+}

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -218,6 +218,7 @@ class GenericSchema:
 class EvolutionTestCase(NamedTuple):
     initial_schema: GenericSchema
     next_schema: GenericSchema
+    partition_spec: str | None = None
 
 
 LEGAL_TEST_CASES = {
@@ -264,6 +265,7 @@ LEGAL_TEST_CASES = {
                 ('ordinal', 'integer'),
             ],
         ),
+        partition_spec="(verifier_string)",
     ),
     "drop_column":
     EvolutionTestCase(
@@ -308,6 +310,7 @@ LEGAL_TEST_CASES = {
                 ('verifier_string', 'varchar'),
             ],
         ),
+        partition_spec="(verifier_string)",
     ),
     "promote_column":
     EvolutionTestCase(
@@ -345,6 +348,7 @@ LEGAL_TEST_CASES = {
                 ('ordinal', 'bigint'),
             ],
         ),
+        partition_spec="(ordinal)",
     ),
     "reorder_columns":
     EvolutionTestCase(
@@ -399,6 +403,7 @@ LEGAL_TEST_CASES = {
                 ('third', 'varchar'),
             ],
         ),
+        partition_spec="(first)",
     ),
 }
 
@@ -487,16 +492,21 @@ class SchemaEvolutionE2ETests(RedpandaTest):
     @contextmanager
     def setup_services(self,
                        query_engine: QueryEngineType,
-                       compat_level: str = "NONE"):
+                       compat_level: str = "NONE",
+                       partition_spec: str = None):
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
                               catalog_type=filesystem_catalog_type(),
                               include_query_engines=[
                                   query_engine,
                               ]) as dl:
+            config = {}
+            if partition_spec is not None:
+                config["redpanda.iceberg.partition.spec"] = partition_spec
             dl.create_iceberg_enabled_topic(
                 self.topic_name,
                 iceberg_mode="value_schema_id_prefix",
+                config=config,
             )
             SchemaRegistryClient({
                 'url':
@@ -518,11 +528,11 @@ class SchemaEvolutionE2ETests(RedpandaTest):
         Test that rows written with schema A are still readable after evolving
         the table to schema B.
         """
-        with self.setup_services(query_engine) as dl:
+        tc = LEGAL_TEST_CASES[test_case]
+        with self.setup_services(query_engine,
+                                 partition_spec=tc.partition_spec) as dl:
             count = 10
             ctx = TranslationContext()
-            tc = LEGAL_TEST_CASES[test_case]
-
             tc.initial_schema.produce(dl,
                                       self.topic_name,
                                       count,
@@ -557,11 +567,11 @@ class SchemaEvolutionE2ETests(RedpandaTest):
         check that records produced with an incompatible schema don't wind up
         in the table.
         """
-        with self.setup_services(query_engine) as dl:
+        tc = ILLEGAL_TEST_CASES[test_case]
+        with self.setup_services(query_engine,
+                                 partition_spec=tc.partition_spec) as dl:
             count = 10
             ctx = TranslationContext()
-            tc = ILLEGAL_TEST_CASES[test_case]
-
             tc.initial_schema.produce(dl,
                                       self.topic_name,
                                       count,
@@ -601,12 +611,12 @@ class SchemaEvolutionE2ETests(RedpandaTest):
         with self.setup_services(query_engine) as dl:
             count = 10
             ctx = TranslationContext()
-            initial_schema, next_schema = LEGAL_TEST_CASES["drop_column"]
+            initial_schema, next_schema, _ = LEGAL_TEST_CASES["drop_column"]
 
             dropped_field_names = list(
                 set(initial_schema.field_names) - set(next_schema.field_names))
 
-            for schema in LEGAL_TEST_CASES["drop_column"]:
+            for schema in [initial_schema, next_schema]:
                 schema.produce(dl,
                                self.topic_name,
                                count,
@@ -674,7 +684,7 @@ class SchemaEvolutionE2ETests(RedpandaTest):
         with self.setup_services(query_engine) as dl:
             count = 10
             ctx = TranslationContext()
-            initial_schema, next_schema = LEGAL_TEST_CASES['drop_column']
+            initial_schema, next_schema, _ = LEGAL_TEST_CASES['drop_column']
             dropped_field_names = list(
                 set(initial_schema.field_names) - set(next_schema.field_names))
 
@@ -713,7 +723,8 @@ class SchemaEvolutionE2ETests(RedpandaTest):
         with self.setup_services(query_engine) as dl:
             count = 10
             ctx = TranslationContext()
-            initial_schema, next_schema = LEGAL_TEST_CASES['reorder_columns']
+            initial_schema, next_schema, _ = LEGAL_TEST_CASES[
+                'reorder_columns']
             for schema in [initial_schema, next_schema]:
                 schema.produce(dl,
                                self.topic_name,
@@ -748,7 +759,7 @@ class SchemaEvolutionE2ETests(RedpandaTest):
             count = 10
             ctx = TranslationContext()
 
-            initial_schema, next_schema = LEGAL_TEST_CASES[test_case]
+            initial_schema, next_schema, _ = LEGAL_TEST_CASES[test_case]
 
             for schema in [initial_schema, next_schema]:
                 schema.produce(dl,
@@ -769,3 +780,88 @@ class SchemaEvolutionE2ETests(RedpandaTest):
 
             assert len(select_out) == count * 3, \
                 f"Expected {count*3} rows, got {len(select_out)}"
+
+    @cluster(num_nodes=3)
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        query_engine=QUERY_ENGINES,
+        use_partition_spec=[True, False],
+    )
+    def test_partition_spec_evo(self, cloud_storage_type, query_engine,
+                                use_partition_spec):
+
+        tc = EvolutionTestCase(
+            initial_schema=GenericSchema(
+                fields=[
+                    {
+                        "name": "ts",
+                        "type": {
+                            "type": "int",
+                            "logicalType": "date",
+                        }
+                    },
+                ],
+                generate_record=lambda x: {
+                    "ts": int(x),
+                },
+                spark_table=[('ts', 'date')],
+                trino_table=[
+                    ('ts', 'date'),
+                ],
+            ),
+            next_schema=GenericSchema(
+                fields=[
+                    {
+                        "name": "ts",
+                        "type": {
+                            "type": "long",
+                            "logicalType": "timestamp-millis",
+                        }
+                    },
+                ],
+                generate_record=lambda x: {
+                    "ts": int(x) * 60 * 60 * 24,
+                },
+                spark_table=[('ts', 'timestamp_ntz')],
+                trino_table=[
+                    ('ts', 'timestamp(6)'),
+                ],
+            ),
+            partition_spec="(ts)" if use_partition_spec else None,
+        )
+
+        if tc.partition_spec is not None:
+            self.logger.debug(
+                f"Schema evolution should fail if the date field is referenced in the partition spec"
+            )
+        else:
+            self.logger.debug(
+                f"Schema evolution should succeed if the date field is not referenced in the partition spec"
+            )
+
+        with self.setup_services(query_engine,
+                                 partition_spec=tc.partition_pspec) as dl:
+            count = 10
+            ctx = TranslationContext()
+            tc.initial_schema.produce(dl,
+                                      self.topic_name,
+                                      count,
+                                      ctx,
+                                      mode=ProducerType.AVRO)
+
+            tc.initial_schema.check_table_schema(dl, self.table_name,
+                                                 query_engine)
+
+            tc.next_schema.produce(dl,
+                                   self.topic_name,
+                                   count,
+                                   ctx,
+                                   should_translate=not use_partition_spec,
+                                   mode=ProducerType.AVRO)
+
+            if use_partition_spec:
+                tc.initial_schema.check_table_schema(dl, self.table_name,
+                                                     query_engine)
+            else:
+                tc.next_schema.check_table_schema(dl, self.table_name,
+                                                  query_engine)

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -19,6 +19,7 @@ from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import PandaproxyConfig, SISettings, SchemaRegistryConfig
 from rptest.services.redpanda_connect import RedpandaConnectService
@@ -38,6 +39,7 @@ from ducktape.errors import TimeoutError
 # of translation (i.e. calls to _produce)
 class TranslationContext:
     total: int = 0
+    dlq: int = 0
 
 
 class ProducerType(str, Enum):
@@ -188,12 +190,11 @@ class GenericSchema:
             dl.wait_for_translation(topic_name,
                                     msg_count=context.total + count)
             context.total = context.total + count
-            return
-
-        with expect_exception(TimeoutError, lambda _: True):
+        else:
             dl.wait_for_translation(topic_name,
-                                    msg_count=context.total + count,
-                                    timeout=10)
+                                    msg_count=context.dlq + count,
+                                    table_override=f"{topic_name}~dlq")
+            context.dlq = context.dlq + count
 
     def check_table_schema(
         self,
@@ -539,7 +540,9 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                               include_query_engines=[
                                   query_engine,
                               ]) as dl:
-            config = {}
+            config = {
+                TopicSpec.PROPERTY_ICEBERG_INVALID_RECORD_ACTION: "dlq_table"
+            }
             if partition_spec is not None:
                 config["redpanda.iceberg.partition.spec"] = partition_spec
             dl.create_iceberg_enabled_topic(
@@ -631,6 +634,8 @@ class SchemaEvolutionE2ETests(RedpandaTest):
                                      tc.next_schema.field_names)
             assert len(select_out) == count, \
                 f"Expected {count} rows, got {select_out}"
+            assert ctx.dlq == count, \
+                f"Expected {count} records were dlq'ed, got {ctx.dlq}"
 
     @cluster(num_nodes=3)
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/datalake/schema_evolution_test.py
+++ b/tests/rptest/tests/datalake/schema_evolution_test.py
@@ -439,6 +439,45 @@ ILLEGAL_TEST_CASES = {
             },
         ),
     ),
+    "drop column that appears in partition spec":
+    EvolutionTestCase(
+        initial_schema=GenericSchema(
+            fields=[
+                {
+                    "name": "verifier_string",
+                    "type": "string",
+                },
+                {
+                    "name": "ordinal",
+                    "type": "int",
+                },
+            ],
+            generate_record=lambda x: {
+                "verifier_string": f"verify-{x}",
+                "ordinal": int(x),
+            },
+            spark_table=[
+                ('verifier_string', 'string'),
+                ('ordinal', 'int'),
+            ],
+            trino_table=[
+                ('verifier_string', 'varchar'),
+                ('ordinal', 'integer'),
+            ],
+        ),
+        next_schema=GenericSchema(
+            fields=[
+                {
+                    "name": "verifier_string",
+                    "type": "string",
+                },
+            ],
+            generate_record=lambda x: {
+                "verifier_string": f"verify-{x}",
+            },
+        ),
+        partition_spec="(ordinal)",
+    ),
 }
 
 QUERY_ENGINES = [
@@ -840,7 +879,7 @@ class SchemaEvolutionE2ETests(RedpandaTest):
             )
 
         with self.setup_services(query_engine,
-                                 partition_spec=tc.partition_pspec) as dl:
+                                 partition_spec=tc.partition_spec) as dl:
             count = 10
             ctx = TranslationContext()
             tc.initial_schema.produce(dl,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.


Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

General idea is as follows (quoted from the spec):

>Type promotion is not allowed for a field that is referenced by source-id or source-ids of a partition field if the partition transform would produce a different value after promoting the type.

In general, the type promotion rules preclude this, but date -> timestamp promotions are called out specifically as potentially rule violating, if the promoted field appears in the partition spec. So this diff prevents that by wiring the current partition spec into the compat module and adding a check to the validation path.

This PR also disallows removal of any data field which also appears in the current partition spec at the time of removal. This is technically outside the spec and needs followup ecosystem investigation, but it appears that dropping a column in this way can cause downstream catalog queries to fail. The safest thing at this stage is to simply disable the capability for now.

This PR also fixes a bug in `iceberg/schema_avro` whereby we would try to serialize `date_type` to an `AVRO_LONG` with logical type "date", which itself is restricted to `AVRO_INT`. Fix includes a unit test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
