### PR TITLE
datalake: invalid record action metrics followup

### DIFF
--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -39,7 +39,7 @@ public:
         counter_ref(cause)++;
     }
 
-    constexpr size_t& counter_ref(invalid_record_cause cause) {
+    size_t& counter_ref(invalid_record_cause cause) {
         switch (cause) {
         case invalid_record_cause::failed_kafka_schema_resolution:
             return _num_failed_kafka_schema_resolution;

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -20,11 +20,12 @@ public:
     // register_invalid_record_metric.
     enum class invalid_record_cause {
         /// Failed to resolve the Kafka schema for the record. This covers the
-        /// cases where magic byte is missing from the record or it references a
-        /// non-existent schema in the registry.
+        /// cases where the magic byte is missing from the record or schema id
+        /// refers to a non-existent schema.
         failed_kafka_schema_resolution,
-        /// Failed to translate the record data according to the schema fetches
-        /// from schema registry to an equivalent Iceberg schema.
+        /// Failed to translate the record data according to the schema fetched
+        /// from the schema registry to an equivalent Iceberg schema/Parquet
+        /// format.
         failed_data_translation,
         /// Failed to ensure the table schema matches the inferred Iceberg
         /// schema.


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
