### PR TITLE
dt: disable core dumps in crash tracker tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -395,7 +395,8 @@ class ResourceSettings:
                  memory_mb: Optional[int] = None,
                  bypass_fsync: Optional[bool] = None,
                  nfiles: Optional[int] = None,
-                 reactor_stall_threshold: Optional[int] = None):
+                 reactor_stall_threshold: Optional[int] = None,
+                 core_dump_limit: Optional[str] = "unlimited"):
         self._num_cpus = num_cpus
         self._memory_mb = memory_mb
 
@@ -406,6 +407,7 @@ class ResourceSettings:
 
         self._nfiles = nfiles
         self._reactor_stall_threshold = reactor_stall_threshold
+        self._core_dump_limit = core_dump_limit
 
     @property
     def memory_mb(self):
@@ -423,7 +425,7 @@ class ResourceSettings:
 
         :return: 2 tuple of strings, first goes before the binary, second goes after it
         """
-        preamble = "ulimit -Sc unlimited"
+        preamble = f"ulimit -Sc {self._core_dump_limit}"
         preamble += f" -Sn {self._nfiles}; " if self._nfiles else "; "
 
         if self._num_cpus is None and not dedicated_node:

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -11,7 +11,7 @@ import signal
 from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, ResourceSettings
 from rptest.util import expect_exception
 from rptest.services.redpanda import LoggingConfig
 from ducktape.errors import TimeoutError
@@ -60,6 +60,9 @@ class CrashLoopChecksTest(RedpandaTest):
                                          'main': 'debug',
                                          'crash_tracker': 'trace'
                                      }),
+            # Disable core dumps as they take a long time (>1min). Core dumps are uninteresting for
+            # this test, since this test intentionally triggers crashes.
+            resource_settings=ResourceSettings(core_dump_limit="0"),
         )
         self.broker = self.redpanda.nodes[0]
 


### PR DESCRIPTION
Currently, the `CrashLoopChecksTest.test_crash_report_with_signal` ducktape tests consistently fail in CDT. This is because when a crash signal is sent to the redpanda process during the test, in CDT a core dump gets generated, which takes a long time (>1min) and causes the test to time out waiting for redpanda to stop (in 10s).

To fix this, this PR disables core dumps for `CrashLoopChecksTest` ducktape tests.

See the commit message for implementation details.

Fixes https://redpandadata.atlassian.net/browse/CORE-9044
Tested this on PR https://github.com/redpanda-data/redpanda/pull/25100

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
