### PR TITLE
iceberg: make snapshot expiration an explicit 64-bit

### DIFF
--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -317,7 +317,7 @@ public:
           std::move(icb_files_),
           {{commit_meta_prop, to_json_str(commit_meta)}},
           commit_tag_name,
-          /*tag_expiration_ms=*/std::numeric_limits<long>::max());
+          /*tag_expiration_ms=*/std::numeric_limits<int64_t>::max());
         if (icb_append_res.has_error()) {
             co_return log_and_convert_action_errc(
               icb_append_res.error(),

--- a/src/v/iceberg/merge_append_action.h
+++ b/src/v/iceberg/merge_append_action.h
@@ -66,7 +66,7 @@ public:
       chunked_vector<data_file> files,
       chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props = {},
       std::optional<ss::sstring> tag_name = std::nullopt,
-      std::optional<long> tag_expiration_ms = std::nullopt,
+      std::optional<int64_t> tag_expiration_ms = std::nullopt,
       size_t min_to_merge_new_files = default_min_to_merge_new_files,
       size_t mfile_target_size_bytes = default_target_size_bytes)
       : io_(io)
@@ -156,7 +156,7 @@ private:
     chunked_vector<data_file> new_data_files_;
     chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props_;
     std::optional<ss::sstring> tag_name_;
-    std::optional<long> tag_expiration_ms_;
+    std::optional<int64_t> tag_expiration_ms_;
 };
 
 } // namespace iceberg

--- a/src/v/iceberg/transaction.cc
+++ b/src/v/iceberg/transaction.cc
@@ -74,7 +74,7 @@ ss::future<transaction::txn_outcome> transaction::merge_append(
   chunked_vector<data_file> files,
   chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props,
   std::optional<ss::sstring> tag_name,
-  std::optional<long> tag_expiration_ms) {
+  std::optional<int64_t> tag_expiration_ms) {
     auto a = std::make_unique<merge_append_action>(
       io,
       table_,

--- a/src/v/iceberg/transaction.h
+++ b/src/v/iceberg/transaction.h
@@ -54,7 +54,7 @@ public:
       chunked_vector<data_file>,
       chunked_vector<std::pair<ss::sstring, ss::sstring>> snapshot_props = {},
       std::optional<ss::sstring> tag_name = std::nullopt,
-      std::optional<long> tag_expiration_ms = std::nullopt);
+      std::optional<int64_t> tag_expiration_ms = std::nullopt);
 
     // Removes expired snapshots from the table, computing expiration based on
     // the given timestamp. Note, this does not perform IO to delete any


### PR DESCRIPTION
Longs in Iceberg are 64-bit, so we should be explicit about that.

Review follow-up from
https://github.com/redpanda-data/redpanda/pull/25038

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
