### PR TITLE
`storage`: add self compaction counter tunable for use in `adjacent_merge_compact()`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1006,6 +1006,15 @@ configuration::configuration()
       "Use sliding window compaction.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       true)
+  , log_compaction_adjacent_merge_self_compaction_count(
+      *this,
+      "log_compaction_adjacent_merge_self_compaction_count",
+      "The number of self compactions that must occur before an adjacent "
+      "compaction is attempted in the log. If set to `std::nullopt`, every "
+      "segment in the log must be self-compacted before an adjacent compaction "
+      "is attempted.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -254,6 +254,8 @@ struct configuration final : public config_store {
     property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
+    property<std::optional<size_t>>
+      log_compaction_adjacent_merge_self_compaction_count;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -516,7 +516,21 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
             const ssize_t removed_bytes = ssize_t(result.size_before)
                                           - ssize_t(result.size_after);
             subtract_segment_bytes(segment, removed_bytes);
-            co_return;
+
+            auto config_adjacent_merge_count
+              = config::shard_local_cfg()
+                  .log_compaction_adjacent_merge_self_compaction_count();
+            // >= to ensure proper behavior if the config value were to be
+            // changed to be lower than the active counter.
+            if (
+              config_adjacent_merge_count.has_value()
+              && ++_adjacent_merge_counter
+                   >= config_adjacent_merge_count.value()) {
+                _adjacent_merge_counter = 0;
+                break;
+            } else {
+                co_return;
+            }
         }
     }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -505,6 +505,14 @@ private:
     void subtract_segment_bytes(ss::lw_shared_ptr<segment> s, ssize_t bytes);
 
     bool _compaction_enabled;
+
+    // The counter for the number of self compactions that have occured in
+    // adjacent_merge_compact() since the last adjacent merge operation was
+    // triggered. Used in combination with the cluster tunable
+    // `log_compaction_adjacent_merge_self_compaction_count`, which sets the
+    // number of self compactions that must occur before attempting to
+    // compaction adjacent segments.
+    size_t _adjacent_merge_counter{0};
 };
 
 } // namespace storage


### PR DESCRIPTION
In order to allow adjacent merge compaction to make forward progress in all situations, change this unconditional `co_return;` after self compaction to a conditional `break;` or `co_return;` depending on the number of segments that have been self compacted since the last adjacent merge.

Having this as a tunable allows control over the read/write amplification of adjacent merge compaction when sliding window compaction is disabled.

Tagged for backports.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Adds the tunable `log_compaction_adjacent_merge_self_compaction_count`, which allows for adjacent merge compaction to make more forward progress in all situations when `log_compaction_use_sliding_window` is disabled.