### PR TITLE
debug bundle: use common file io utility

### DIFF
--- a/src/v/debug_bundle/BUILD
+++ b/src/v/debug_bundle/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_library(
         "//src/v/container:fragmented_vector",
         "//src/v/ssx:future_util",
         "//src/v/utils:external_process",
+        "//src/v/utils:file_io",
         "@boost//:algorithm",
     ],
     include_prefix = "debug_bundle",

--- a/src/v/debug_bundle/debug_bundle_service.cc
+++ b/src/v/debug_bundle/debug_bundle_service.cc
@@ -23,6 +23,7 @@
 #include "ssx/future-util.h"
 #include "storage/kvstore.h"
 #include "utils/external_process.h"
+#include "utils/file_io.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -105,16 +106,6 @@ std::filesystem::path form_debug_bundle_storage_directory() {
     return debug_bundle_dir.value_or(
       config::node().data_directory.value().path
       / service::debug_bundle_dir_name);
-}
-
-ss::future<iobuf> read_file(std::string_view path) {
-    iobuf buf;
-    auto file = co_await ss::open_file_dma(path, ss::open_flags::ro);
-    auto h = ss::defer([file]() mutable { ssx::background = file.close(); });
-    auto istrm = ss::make_file_input_stream(file);
-    auto ostrm = make_iobuf_ref_output_stream(buf);
-    co_await ss::copy(istrm, ostrm);
-    co_return buf;
 }
 
 ss::future<> write_file(std::string_view path, iobuf buf) {
@@ -900,7 +891,8 @@ ss::future<> service::maybe_reload_previous_run() {
       process_output_file_path);
     if (process_output_file_exists) {
         try {
-            auto buf = co_await read_file(process_output_file_path);
+            auto buf = co_await read_fully(
+              std::filesystem::path(process_output_file_path));
             iobuf_parser p(std::move(buf));
             po.emplace(serde::read<process_output>(p));
         } catch (const std::exception& e) {

--- a/src/v/debug_bundle/tests/BUILD
+++ b/src/v/debug_bundle/tests/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_gtest(
         "//src/v/storage",
         "//src/v/storage:resources",
         "//src/v/test_utils:gtest",
+        "//src/v/utils:file_io",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/debug_bundle/tests/debug_bundle_service_test.cc
+++ b/src/v/debug_bundle/tests/debug_bundle_service_test.cc
@@ -25,6 +25,7 @@
 #include "storage/kvstore.h"
 #include "storage/storage_resources.h"
 #include "test_utils/test.h"
+#include "utils/file_io.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
@@ -722,17 +723,6 @@ ss::future<> wait_for_kvstore_to_populate(
     throw std::runtime_error("Timed out waiting for metadata to be written");
 }
 
-ss::future<iobuf> read_file_contents(std::string_view file_path) {
-    auto file = co_await ss::open_file_dma(
-      file_path.data(), ss::open_flags::ro);
-    auto h = ss::defer([file]() mutable { ssx::background = file.close(); });
-    auto istrm = ss::make_file_input_stream(file);
-    iobuf buf;
-    auto ostrm = make_iobuf_ref_output_stream(buf);
-    co_await ss::copy(istrm, ostrm);
-    co_return buf;
-}
-
 TEST_F_CORO(debug_bundle_service_started_fixture, validate_metadata) {
     debug_bundle::job_id_t job_id(uuid_t::create());
 
@@ -772,8 +762,7 @@ TEST_F_CORO(debug_bundle_service_started_fixture, validate_metadata) {
       co_await debug_bundle::calculate_sha256_sum(job_file.native()));
 
     ASSERT_TRUE_CORO(co_await ss::file_exists(process_output_file.native()));
-    auto process_output_buf = co_await read_file_contents(
-      process_output_file.native());
+    auto process_output_buf = co_await read_fully(process_output_file);
 
     iobuf_parser process_output_parser(std::move(process_output_buf));
     auto po = serde::read<debug_bundle::process_output>(process_output_parser);

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -19,8 +19,6 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/temporary_buffer.hh>
 
-#include <exception>
-
 ss::future<ss::temporary_buffer<char>>
 read_fully_tmpbuf(const std::filesystem::path& name) {
     return ss::with_file(

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -32,11 +32,23 @@ read_fully_tmpbuf(const std::filesystem::path& name) {
 }
 
 ss::future<iobuf> read_fully(const std::filesystem::path& name) {
-    return read_fully_tmpbuf(name).then([](ss::temporary_buffer<char> buf) {
-        iobuf iob;
-        iob.append(std::move(buf));
-        return iob;
-    });
+    return ss::with_file(
+      ss::open_file_dma(name.string(), ss::open_flags::ro), [](ss::file file) {
+          auto buf = std::make_unique<iobuf>();
+          auto* buf_ptr = buf.get();
+          return ss::do_with(
+            std::move(buf),
+            ss::make_file_input_stream(std::move(file)),
+            make_iobuf_ref_output_stream(*buf_ptr),
+            [](
+              std::unique_ptr<iobuf>& buf,
+              ss::input_stream<char>& input,
+              ss::output_stream<char>& output) {
+                return ss::copy(input, output).then([&buf] {
+                    return std::move(*buf);
+                });
+            });
+      });
 }
 
 /**

--- a/src/v/utils/file_io.h
+++ b/src/v/utils/file_io.h
@@ -20,6 +20,9 @@
 #include <filesystem>
 
 /// \brief Read an entire file into a ss::temporary_buffer
+///
+/// Use this interface only when you are certain that the resulting allocation
+/// will be under the recommended maximum size (128 KB).
 ss::future<ss::temporary_buffer<char>>
 read_fully_tmpbuf(const std::filesystem::path&);
 

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -530,3 +530,16 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "file_io_test",
+    timeout = "short",
+    srcs = ["file_io_test.cc"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:random",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:file_io",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/utils/tests/file_io_test.cc
+++ b/src/v/utils/tests/file_io_test.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/units.h"
+#include "bytes/random.h"
+#include "utils/file_io.h"
+
+#include <gtest/gtest.h>
+
+class ReadFully : public ::testing::TestWithParam<size_t> {};
+
+TEST_P(ReadFully, RoundTrip) {
+    const auto input = random_generators::make_iobuf(GetParam());
+    write_fully("out.dat", input.copy()).get();
+    const auto output = read_fully("out.dat").get();
+    EXPECT_EQ(input, output);
+}
+
+namespace {
+std::vector<uint64_t> test_case_sizes() {
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+    auto sizes = std::vector<size_t>{
+      0,
+      1,
+      2,
+      3,
+      4_KiB - 2,
+      4_KiB - 1,
+      4_KiB,
+      4_KiB + 1,
+      4_KiB + 2,
+      512_KiB - 2,
+      512_KiB - 1,
+      512_KiB,
+      512_KiB + 1,
+      512_KiB + 2,
+    };
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+    for (auto size : details::io_allocation_size::alloc_table) {
+        sizes.push_back(size);
+    }
+    return sizes;
+}
+} // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+  SizeRange, ReadFully, ::testing::ValuesIn(test_case_sizes()));


### PR DESCRIPTION
Updates the common file io utility for reading an entire file into an iobuf so that it can work with larger files, then update debug bundle to take advantage of this.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
