### PR TITLE
[CORE-8933] Setup for translation scheduling port

### DIFF
--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -22,6 +22,8 @@ std::string data_writer_error_category::message(int ev) const {
         return "File IO Error";
     case writer_error::no_data:
         return "No data";
+    case writer_error::flush_error:
+        return "Flush failed";
     }
 }
 

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -94,7 +94,7 @@ public:
     virtual ~parquet_ostream() = default;
 
     virtual ss::future<writer_error>
-      add_data_struct(iceberg::struct_value, size_t) = 0;
+    add_data_struct(iceberg::struct_value, size_t, ss::abort_source&) = 0;
 
     /**
      * Returns the total bytes buffered in the writer pending flush.
@@ -124,8 +124,9 @@ public:
 
     virtual ~parquet_ostream_factory() = default;
 
-    virtual ss::future<std::unique_ptr<parquet_ostream>>
-    create_writer(const iceberg::struct_type&, ss::output_stream<char>) = 0;
+    virtual ss::future<std::unique_ptr<parquet_ostream>> create_writer(
+      const iceberg::struct_type&, ss::output_stream<char>, writer_mem_tracker&)
+      = 0;
 };
 
 /**
@@ -145,7 +146,9 @@ public:
     virtual ~parquet_file_writer() = default;
 
     virtual ss::future<writer_error> add_data_struct(
-      iceberg::struct_value /* data */, int64_t /* approx_size */)
+      iceberg::struct_value /* data */,
+      int64_t /* approx_size */,
+      ss::abort_source&)
       = 0;
 
     /**

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -25,6 +25,7 @@ enum class writer_error {
     parquet_conversion_error,
     file_io_error,
     no_data,
+    flush_error,
 };
 
 struct data_writer_error_category : std::error_category {
@@ -95,6 +96,20 @@ public:
     virtual ss::future<writer_error>
       add_data_struct(iceberg::struct_value, size_t) = 0;
 
+    /**
+     * Returns the total bytes buffered in the writer pending flush.
+     */
+    virtual size_t buffered_bytes() const = 0;
+    /**
+     * Returns the total bytes flushed to the ostream.
+     */
+    virtual size_t flushed_bytes() const = 0;
+    /**
+     * Forces a flush of bytes to ostream. Guarantees that all the buffered
+     * memory is released.
+     */
+    virtual ss::future<> flush() = 0;
+
     virtual ss::future<writer_error> finish() = 0;
 };
 
@@ -132,6 +147,17 @@ public:
     virtual ss::future<writer_error> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */)
       = 0;
+
+    /**
+     * Returns the total bytes buffered in the writer pending flush.
+     */
+    virtual size_t buffered_bytes() const = 0;
+    /**
+     * Returns the total bytes flushed to the ostream.
+     */
+    virtual size_t flushed_bytes() const = 0;
+
+    virtual ss::future<writer_error> flush() = 0;
 
     virtual ss::future<result<local_file_metadata, writer_error>> finish() = 0;
 };

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -43,6 +43,43 @@ inline std::error_code make_error_code(writer_error e) noexcept {
 }
 
 /**
+ * Interface to track memory used by the parquet writer. The reservations are
+ * held until the tracker object is alive or release is explicitly called.
+ */
+class writer_mem_tracker {
+public:
+    writer_mem_tracker() = default;
+    writer_mem_tracker(const writer_mem_tracker&) = delete;
+    writer_mem_tracker(writer_mem_tracker&&) = default;
+    writer_mem_tracker& operator=(const writer_mem_tracker&) = delete;
+    writer_mem_tracker& operator=(writer_mem_tracker&&) = delete;
+
+    virtual ~writer_mem_tracker() = default;
+
+    /**
+     * Reserves `bytes` worth of memory. If the memory is already available
+     * (due to unused bytes from prior reservations), does nothing. May not be
+     * called concurrently with other methods.
+     */
+    virtual ss::future<>
+    maybe_reserve_memory(size_t bytes, ss::abort_source&) = 0;
+
+    /**
+     * Notify the mem tracker of current memory usage. The writer may
+     * choose to compress/shrink memory upon which the tracker must be
+     * notified of the current usage. May not be called concurrently with
+     * other methods.
+     */
+    virtual void update_current_memory_usage(size_t current_bytes_usage) = 0;
+
+    /**
+     * Releases all the reservations. After this caller, the reserved bytes
+     * tracked is 0. May not be called concurrently with other methods.
+     */
+    virtual void release() = 0;
+};
+
+/**
  * Parquet writer interface. The writer should write parquet serialized data to
  * the output stream provided during its creation.
  */

--- a/src/v/datalake/local_parquet_file_writer.cc
+++ b/src/v/datalake/local_parquet_file_writer.cc
@@ -21,9 +21,11 @@ namespace datalake {
 
 local_parquet_file_writer::local_parquet_file_writer(
   local_path output_file_path,
-  ss::shared_ptr<parquet_ostream_factory> writer_factory)
+  ss::shared_ptr<parquet_ostream_factory> writer_factory,
+  writer_mem_tracker& mem_tracker)
   : _output_file_path(std::move(output_file_path))
-  , _writer_factory(std::move(writer_factory)) {}
+  , _writer_factory(std::move(writer_factory))
+  , _mem_tracker(mem_tracker) {}
 
 ss::future<checked<std::nullopt_t, writer_error>>
 local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
@@ -56,17 +58,18 @@ local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
     }
 
     _writer = co_await _writer_factory->create_writer(
-      schema, std::move(fut.get()));
+      schema, std::move(fut.get()), _mem_tracker);
     _initialized = true;
     co_return std::nullopt;
 }
 
 ss::future<writer_error> local_parquet_file_writer::add_data_struct(
-  iceberg::struct_value data, int64_t sz) {
+  iceberg::struct_value data, int64_t sz, ss::abort_source& as) {
     if (!_initialized) {
         co_return writer_error::file_io_error;
     }
-    auto write_result = co_await _writer->add_data_struct(std::move(data), sz);
+    auto write_result = co_await _writer->add_data_struct(
+      std::move(data), sz, as);
     if (write_result != writer_error::ok) {
         vlog(
           datalake_log.warn,
@@ -154,16 +157,18 @@ local_path local_parquet_file_writer_factory::create_filename() const {
 local_parquet_file_writer_factory::local_parquet_file_writer_factory(
   local_path base_directory,
   ss::sstring file_name_prefix,
-  ss::shared_ptr<parquet_ostream_factory> writer_factory)
+  ss::shared_ptr<parquet_ostream_factory> writer_factory,
+  std::unique_ptr<writer_mem_tracker> mem_tracker)
   : _base_directory(std::move(base_directory))
   , _file_name_prefix(std::move(file_name_prefix))
-  , _writer_factory(std::move(writer_factory)) {}
+  , _writer_factory(std::move(writer_factory))
+  , _mem_tracker(std::move(mem_tracker)) {}
 
 ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
 local_parquet_file_writer_factory::create_writer(
   const iceberg::struct_type& schema) {
     auto writer = std::make_unique<local_parquet_file_writer>(
-      create_filename(), _writer_factory);
+      create_filename(), _writer_factory, *_mem_tracker);
 
     auto res = co_await writer->initialize(schema);
     if (res.has_error()) {

--- a/src/v/datalake/local_parquet_file_writer.cc
+++ b/src/v/datalake/local_parquet_file_writer.cc
@@ -83,6 +83,27 @@ ss::future<writer_error> local_parquet_file_writer::add_data_struct(
     co_return writer_error::ok;
 }
 
+size_t local_parquet_file_writer::buffered_bytes() const {
+    return _writer->buffered_bytes();
+}
+
+size_t local_parquet_file_writer::flushed_bytes() const {
+    return _writer->flushed_bytes();
+}
+
+ss::future<writer_error> local_parquet_file_writer::flush() {
+    if (!_initialized) {
+        co_return writer_error::flush_error;
+    }
+    auto result = co_await ss::coroutine::as_future(_writer->flush());
+    if (result.failed()) {
+        auto ex = result.get_exception();
+        vlog(datalake_log.warn, "Error flushing {}: {}", _output_file_path, ex);
+        co_return writer_error::flush_error;
+    }
+    co_return writer_error::ok;
+}
+
 ss::future<result<local_file_metadata, writer_error>>
 local_parquet_file_writer::finish() {
     if (!_initialized) {

--- a/src/v/datalake/local_parquet_file_writer.h
+++ b/src/v/datalake/local_parquet_file_writer.h
@@ -24,13 +24,15 @@ namespace datalake {
 class local_parquet_file_writer : public parquet_file_writer {
 public:
     local_parquet_file_writer(
-      local_path, ss::shared_ptr<parquet_ostream_factory>);
+      local_path, ss::shared_ptr<parquet_ostream_factory>, writer_mem_tracker&);
 
     ss::future<checked<std::nullopt_t, writer_error>>
     initialize(const iceberg::struct_type&);
 
     ss::future<writer_error> add_data_struct(
-      iceberg::struct_value /* data */, int64_t /* approx_size */) final;
+      iceberg::struct_value /* data */,
+      int64_t /* approx_size */,
+      ss::abort_source&) final;
 
     size_t buffered_bytes() const final;
 
@@ -50,6 +52,7 @@ private:
 
     std::unique_ptr<parquet_ostream> _writer;
     ss::shared_ptr<parquet_ostream_factory> _writer_factory;
+    writer_mem_tracker& _mem_tracker;
     bool _initialized{false};
 };
 
@@ -58,7 +61,8 @@ public:
     local_parquet_file_writer_factory(
       local_path base_directory,
       ss::sstring file_name_prefix,
-      ss::shared_ptr<parquet_ostream_factory>);
+      ss::shared_ptr<parquet_ostream_factory>,
+      std::unique_ptr<writer_mem_tracker>);
 
     ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
     create_writer(const iceberg::struct_type& schema) final;
@@ -69,6 +73,7 @@ private:
     local_path _base_directory;
     ss::sstring _file_name_prefix;
     ss::shared_ptr<parquet_ostream_factory> _writer_factory;
+    std::unique_ptr<writer_mem_tracker> _mem_tracker;
 };
 
 } // namespace datalake

--- a/src/v/datalake/local_parquet_file_writer.h
+++ b/src/v/datalake/local_parquet_file_writer.h
@@ -32,6 +32,12 @@ public:
     ss::future<writer_error> add_data_struct(
       iceberg::struct_value /* data */, int64_t /* approx_size */) final;
 
+    size_t buffered_bytes() const final;
+
+    size_t flushed_bytes() const final;
+
+    ss::future<writer_error> flush() final;
+
     ss::future<result<local_file_metadata, writer_error>> finish() final;
 
 private:

--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -41,8 +41,8 @@ ss::future<> partitioning_writer::flush() {
     });
 }
 
-ss::future<writer_error>
-partitioning_writer::add_data(iceberg::struct_value val, int64_t approx_size) {
+ss::future<writer_error> partitioning_writer::add_data(
+  iceberg::struct_value val, int64_t approx_size, ss::abort_source& as) {
     iceberg::partition_key pk;
     try {
         pk = iceberg::partition_key::create(val, accessors_, spec_);
@@ -70,7 +70,7 @@ partitioning_writer::add_data(iceberg::struct_value val, int64_t approx_size) {
     }
     auto& writer = writer_iter->second;
     auto write_res = co_await writer->add_data_struct(
-      std::move(val), approx_size);
+      std::move(val), approx_size, as);
     if (write_res != writer_error::ok) {
         vlog(datalake_log.error, "Failed to add data: {}", write_res);
         co_return write_res;

--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -30,6 +30,17 @@ operator<<(std::ostream& o, const partitioning_writer::partitioned_file& f) {
     return o;
 }
 
+ss::future<> partitioning_writer::flush() {
+    return ss::max_concurrent_for_each(writers_, 10, [](auto& entry) {
+        return entry.second->flush().then([](writer_error err) {
+            if (err == writer_error::ok) {
+                return ss::make_ready_future();
+            }
+            return ss::make_exception_future<>(err);
+        });
+    });
+}
+
 ss::future<writer_error>
 partitioning_writer::add_data(iceberg::struct_value val, int64_t approx_size) {
     iceberg::partition_key pk;
@@ -65,6 +76,22 @@ partitioning_writer::add_data(iceberg::struct_value val, int64_t approx_size) {
         co_return write_res;
     }
     co_return write_res;
+}
+
+size_t partitioning_writer::buffered_bytes() const {
+    size_t result = 0;
+    for (const auto& [_, writer] : writers_) {
+        result += writer->buffered_bytes();
+    }
+    return result;
+}
+
+size_t partitioning_writer::flushed_bytes() const {
+    size_t result = 0;
+    for (const auto& [_, writer] : writers_) {
+        result += writer->flushed_bytes();
+    }
+    return result;
 }
 
 ss::future<

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -48,7 +48,7 @@ public:
     //
     // Expects that the input value abides by the schema denoted by `type_`.
     ss::future<writer_error>
-    add_data(iceberg::struct_value, int64_t approx_size);
+    add_data(iceberg::struct_value, int64_t approx_size, ss::abort_source&);
 
     size_t buffered_bytes() const;
     size_t flushed_bytes() const;

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -50,6 +50,12 @@ public:
     ss::future<writer_error>
     add_data(iceberg::struct_value, int64_t approx_size);
 
+    size_t buffered_bytes() const;
+    size_t flushed_bytes() const;
+
+    // Flushes all the inflight writers.
+    ss::future<> flush();
+
     struct partitioned_file {
         local_file_metadata local_file;
         remote_path table_location;

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -251,7 +251,7 @@ record_multiplexer::operator()(model::record_batch batch) {
 
         auto& writer = writer_iter->second;
         auto write_result = co_await writer->add_data(
-          std::move(record_data_res.value()), estimated_size);
+          std::move(record_data_res.value()), estimated_size, _noop_as);
 
         if (write_result != writer_error::ok) {
             vlog(
@@ -438,7 +438,7 @@ record_multiplexer::handle_invalid_record(
         _result.value().last_offset = offset;
 
         auto add_data_err = co_await _invalid_record_writer->add_data(
-          std::move(record_data_res.value()), estimated_size);
+          std::move(record_data_res.value()), estimated_size, _noop_as);
 
         if (add_data_err != writer_error::ok) {
             vlog(

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -27,6 +27,26 @@
 
 namespace datalake {
 
+namespace {
+template<typename Func>
+requires requires(Func f, model::record_batch batch) {
+    { f(std::move(batch)) } -> std::same_as<ss::future<ss::stop_iteration>>;
+}
+class relaying_consumer {
+public:
+    explicit relaying_consumer(Func f)
+      : _func(std::move(f)) {}
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+        return _func(std::move(b));
+    }
+    void end_of_stream() {}
+
+private:
+    Func _func;
+};
+} // namespace
+
 record_multiplexer::record_multiplexer(
   const model::ntp& ntp,
   model::revision_id topic_revision,
@@ -37,8 +57,7 @@ record_multiplexer::record_multiplexer(
   table_creator& table_creator,
   model::iceberg_invalid_record_action invalid_record_action,
   location_provider location_provider,
-  translation_probe& translation_probe,
-  lazy_abort_source& as)
+  translation_probe& translation_probe)
   : _log(datalake_log, fmt::format("{}", ntp))
   , _ntp(ntp)
   , _topic_revision(topic_revision)
@@ -49,31 +68,29 @@ record_multiplexer::record_multiplexer(
   , _table_creator(table_creator)
   , _invalid_record_action(invalid_record_action)
   , _location_provider(std::move(location_provider))
-  , _translation_probe(translation_probe)
-  , _as(as) {}
+  , _translation_probe(translation_probe) {}
 
-ss::future<ss::stop_iteration>
-record_multiplexer::operator()(model::record_batch batch) {
-    if (_as.abort_requested()) {
-        vlog(
-          _log.debug,
-          "Abort requested, stopping translation, reason: {}",
-          _as.abort_reason());
-        co_return ss::stop_iteration::yes;
-    }
+ss::future<> record_multiplexer::multiplex(
+  model::record_batch_reader reader,
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as) {
+    co_await std::move(reader).consume(
+      relaying_consumer{[this, &as](model::record_batch b) mutable {
+          return do_multiplex(std::move(b), as);
+      }},
+      deadline);
+}
+
+ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
+  model::record_batch batch, ss::abort_source& as) {
     if (batch.compressed()) {
         batch = co_await storage::internal::decompress_batch(std::move(batch));
     }
     auto first_timestamp = batch.header().first_timestamp.value();
-
     auto it = model::record_batch_iterator::create(batch);
-
     while (it.has_next()) {
-        if (_as.abort_requested()) {
-            vlog(
-              _log.debug,
-              "Abort requested, stopping translation, reason: {}",
-              _as.abort_reason());
+        if (as.abort_requested()) {
+            vlog(_log.debug, "Abort requested, stopping translation");
             co_return ss::stop_iteration::yes;
         }
         auto record = it.next();
@@ -106,7 +123,8 @@ record_multiplexer::operator()(model::record_batch batch) {
                   record.share_key(),
                   record.share_value(),
                   timestamp,
-                  std::move(header_kvs));
+                  std::move(header_kvs),
+                  as);
                 if (invalid_res.has_error()) {
                     _error = invalid_res.error();
                     co_return ss::stop_iteration::yes;
@@ -139,7 +157,8 @@ record_multiplexer::operator()(model::record_batch batch) {
                   record.share_key(),
                   record.share_value(),
                   timestamp,
-                  std::move(header_kvs));
+                  std::move(header_kvs),
+                  as);
                 if (invalid_res.has_error()) {
                     _error = invalid_res.error();
                     co_return ss::stop_iteration::yes;
@@ -164,7 +183,8 @@ record_multiplexer::operator()(model::record_batch batch) {
                       record.share_key(),
                       record.share_value(),
                       timestamp,
-                      std::move(header_kvs));
+                      std::move(header_kvs),
+                      as);
                     if (invalid_res.has_error()) {
                         _error = invalid_res.error();
                         co_return ss::stop_iteration::yes;
@@ -251,7 +271,7 @@ record_multiplexer::operator()(model::record_batch batch) {
 
         auto& writer = writer_iter->second;
         auto write_result = co_await writer->add_data(
-          std::move(record_data_res.value()), estimated_size, _noop_as);
+          std::move(record_data_res.value()), estimated_size, as);
 
         if (write_result != writer_error::ok) {
             vlog(
@@ -268,8 +288,22 @@ record_multiplexer::operator()(model::record_batch batch) {
     co_return ss::stop_iteration::no;
 }
 
+ss::future<writer_error> record_multiplexer::flush_writers() {
+    if (_error) {
+        co_return *_error;
+    }
+    auto result = co_await ss::coroutine::as_future(ss::max_concurrent_for_each(
+      _writers, 10, [](auto& entry) { return entry.second->flush(); }));
+    if (result.failed()) {
+        vlog(_log.warn, "Error flushing writers: {}", result.get_exception());
+        _error = writer_error::flush_error;
+        co_return _error.value();
+    }
+    co_return writer_error::ok;
+}
+
 ss::future<result<record_multiplexer::write_result, writer_error>>
-record_multiplexer::end_of_stream() {
+record_multiplexer::finish() && {
     if (_error) {
         co_return *_error;
     }
@@ -314,10 +348,9 @@ record_multiplexer::handle_invalid_record(
   std::optional<iobuf> key,
   std::optional<iobuf> val,
   model::timestamp ts,
-  chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>
-    headers) {
+  chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>> headers,
+  ss::abort_source& as) {
     _translation_probe.increment_invalid_record(cause);
-
     switch (_invalid_record_action) {
     case model::iceberg_invalid_record_action::drop:
         vlog(_log.debug, "Dropping invalid record at offset {}", offset);
@@ -438,7 +471,7 @@ record_multiplexer::handle_invalid_record(
         _result.value().last_offset = offset;
 
         auto add_data_err = co_await _invalid_record_writer->add_data(
-          std::move(record_data_res.value()), estimated_size, _noop_as);
+          std::move(record_data_res.value()), estimated_size, as);
 
         if (add_data_err != writer_error::ok) {
             vlog(

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -92,6 +92,10 @@ private:
 
     std::optional<writer_error> _error;
     std::optional<write_result> _result;
+
+    // a temporary unused abort_source, will be removed in the subsequent
+    // commits.
+    ss::abort_source _noop_as;
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -17,7 +17,7 @@
 #include "datalake/schema_identifier.h"
 #include "datalake/translation/translation_probe.h"
 #include "model/record.h"
-#include "utils/lazy_abort_source.h"
+#include "model/record_batch_reader.h"
 #include "utils/prefix_logger.h"
 
 #include <seastar/core/future.hh>
@@ -29,9 +29,25 @@ class record_translator;
 class schema_manager;
 class type_resolver;
 
-// Consumes logs and sends records to the appropriate translator
-// based on the schema ID. This is meant to be called with a
-// read_committed_reader created from a kafka::partition_proxy.
+/**
+ * record_multiplexer
+ *
+ * Consumes logs and sends records to the appropriate translator
+ * based on the schema ID. This is meant to be called with a
+ * read_committed_reader created from a kafka::partition_proxy.
+ * We want the multiplexer to work  across scheduling iterations
+ * and release resouces inbetween. The pattern would look something like:
+ *
+ * mux = create_mux();
+ * mux.multiplex(reader1...)
+ * mux.flush_writers(); // optional
+ * mux.multiplex(reader2..)
+ * mux.flush_writers(); // optional
+ * ...
+ * ...
+ *
+ * result = co_await std::move(mux).finish();
+ */
 class record_multiplexer {
 public:
     struct write_result {
@@ -55,11 +71,36 @@ public:
       table_creator&,
       model::iceberg_invalid_record_action,
       location_provider,
-      translation_probe&,
-      lazy_abort_source& as);
+      translation_probe&);
 
-    ss::future<ss::stop_iteration> operator()(model::record_batch batch);
-    ss::future<result<write_result, writer_error>> end_of_stream();
+    /**
+     * Multiplex the data from a reader into writers per schema and partition.
+     * Can be called multiple times in succession before calling finish().
+     */
+    ss::future<> multiplex(
+      model::record_batch_reader reader,
+      model::timeout_clock::time_point deadline,
+      ss::abort_source& as);
+
+    /**
+     * Abortable multiplexing on a single batch. Visible for testing.
+     */
+    ss::future<ss::stop_iteration>
+    do_multiplex(model::record_batch batch, ss::abort_source&);
+
+    /**
+     * Forces a flush on all the underlying file writers resulting in freeing
+     * up buffered in flight writes. May not be called in parallel with other
+     * methods.
+     */
+    ss::future<writer_error> flush_writers();
+
+    /**
+     * Cleanup and return the result. Should be the last operation to
+     * be called. May not be called in parallel while multiplexing is in
+     * progress.
+     */
+    ss::future<result<write_result, writer_error>> finish() &&;
 
 private:
     // Handles the given record components of a record that is invalid for the
@@ -70,7 +111,8 @@ private:
       std::optional<iobuf>,
       std::optional<iobuf>,
       model::timestamp,
-      chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>);
+      chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>,
+      ss::abort_source&);
 
     prefix_logger _log;
     const model::ntp& _ntp;
@@ -83,7 +125,6 @@ private:
     model::iceberg_invalid_record_action _invalid_record_action;
     location_provider _location_provider;
     translation_probe& _translation_probe;
-    lazy_abort_source& _as;
     chunked_hash_map<
       record_schema_components,
       std::unique_ptr<partitioning_writer>>
@@ -92,10 +133,6 @@ private:
 
     std::optional<writer_error> _error;
     std::optional<write_result> _result;
-
-    // a temporary unused abort_source, will be removed in the subsequent
-    // commits.
-    ss::abort_source _noop_as;
 };
 
 } // namespace datalake

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -8,8 +8,8 @@
 
 namespace datalake {
 
-ss::future<writer_error>
-serde_parquet_writer::add_data_struct(iceberg::struct_value value, size_t) {
+ss::future<writer_error> serde_parquet_writer::add_data_struct(
+  iceberg::struct_value value, size_t approx_size, ss::abort_source& as) {
     auto conversion_result = co_await to_parquet_value(
       std::make_unique<iceberg::struct_value>(std::move(value)));
     if (conversion_result.has_error()) {
@@ -19,9 +19,11 @@ serde_parquet_writer::add_data_struct(iceberg::struct_value value, size_t) {
     auto group = std::get<serde::parquet::group_value>(
       std::move(conversion_result.value()));
     try {
+        co_await _mem_tracker.maybe_reserve_memory(approx_size, as);
         auto stats = co_await _writer.write_row(std::move(group));
         _buffered_bytes = stats.buffered_size;
         _flushed_bytes = stats.flushed_size;
+        _mem_tracker.update_current_memory_usage(_buffered_bytes);
     } catch (...) {
         vlog(
           datalake_log.warn,
@@ -44,17 +46,21 @@ ss::future<> serde_parquet_writer::flush() {
       _buffered_bytes == 0,
       "Memory buffered in the writer after flush: {}",
       _buffered_bytes);
+    _mem_tracker.release();
 }
 
 ss::future<writer_error> serde_parquet_writer::finish() {
     co_await _writer.close();
+    _mem_tracker.release();
     _buffered_bytes = _flushed_bytes = 0;
     co_return writer_error::ok;
 }
 
 ss::future<std::unique_ptr<parquet_ostream>>
 serde_parquet_writer_factory::create_writer(
-  const iceberg::struct_type& schema, ss::output_stream<char> out) {
+  const iceberg::struct_type& schema,
+  ss::output_stream<char> out,
+  writer_mem_tracker& mem_tracker) {
     serde::parquet::writer::options opts{
       .schema = schema_to_parquet(schema),
       .version = ss::sstring(redpanda_git_version()),
@@ -63,7 +69,8 @@ serde_parquet_writer_factory::create_writer(
     };
     serde::parquet::writer writer(std::move(opts), std::move(out));
     co_await writer.init();
-    co_return std::make_unique<serde_parquet_writer>(std::move(writer));
+    co_return std::make_unique<serde_parquet_writer>(
+      std::move(writer), mem_tracker);
 }
 
 } // namespace datalake

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -19,7 +19,9 @@ serde_parquet_writer::add_data_struct(iceberg::struct_value value, size_t) {
     auto group = std::get<serde::parquet::group_value>(
       std::move(conversion_result.value()));
     try {
-        co_await _writer.write_row(std::move(group));
+        auto stats = co_await _writer.write_row(std::move(group));
+        _buffered_bytes = stats.buffered_size;
+        _flushed_bytes = stats.flushed_size;
     } catch (...) {
         vlog(
           datalake_log.warn,
@@ -30,8 +32,23 @@ serde_parquet_writer::add_data_struct(iceberg::struct_value value, size_t) {
     co_return writer_error::ok;
 }
 
+size_t serde_parquet_writer::buffered_bytes() const { return _buffered_bytes; }
+size_t serde_parquet_writer::flushed_bytes() const { return _flushed_bytes; }
+
+ss::future<> serde_parquet_writer::flush() {
+    co_await _writer.flush_row_group();
+    auto stats = _writer.stats();
+    _buffered_bytes = stats.buffered_size;
+    _flushed_bytes = stats.flushed_size;
+    vassert(
+      _buffered_bytes == 0,
+      "Memory buffered in the writer after flush: {}",
+      _buffered_bytes);
+}
+
 ss::future<writer_error> serde_parquet_writer::finish() {
     co_await _writer.close();
+    _buffered_bytes = _flushed_bytes = 0;
     co_return writer_error::ok;
 }
 

--- a/src/v/datalake/serde_parquet_writer.h
+++ b/src/v/datalake/serde_parquet_writer.h
@@ -7,10 +7,12 @@
 namespace datalake {
 class serde_parquet_writer : public parquet_ostream {
 public:
-    explicit serde_parquet_writer(serde::parquet::writer writer)
-      : _writer(std::move(writer)) {}
+    explicit serde_parquet_writer(
+      serde::parquet::writer writer, writer_mem_tracker& mem_tracker)
+      : _writer(std::move(writer))
+      , _mem_tracker(mem_tracker) {}
     ss::future<writer_error>
-      add_data_struct(iceberg::struct_value, size_t) final;
+    add_data_struct(iceberg::struct_value, size_t, ss::abort_source&) final;
 
     size_t buffered_bytes() const final;
 
@@ -22,14 +24,17 @@ public:
 
 private:
     serde::parquet::writer _writer;
+    writer_mem_tracker& _mem_tracker;
     size_t _buffered_bytes{0};
     size_t _flushed_bytes{0};
 };
 
 class serde_parquet_writer_factory : public parquet_ostream_factory {
 public:
-    ss::future<std::unique_ptr<parquet_ostream>>
-    create_writer(const iceberg::struct_type&, ss::output_stream<char>) final;
+    ss::future<std::unique_ptr<parquet_ostream>> create_writer(
+      const iceberg::struct_type&,
+      ss::output_stream<char>,
+      writer_mem_tracker&) final;
 };
 
 } // namespace datalake

--- a/src/v/datalake/serde_parquet_writer.h
+++ b/src/v/datalake/serde_parquet_writer.h
@@ -12,10 +12,18 @@ public:
     ss::future<writer_error>
       add_data_struct(iceberg::struct_value, size_t) final;
 
+    size_t buffered_bytes() const final;
+
+    size_t flushed_bytes() const final;
+
+    ss::future<> flush() final;
+
     ss::future<writer_error> finish() final;
 
 private:
     serde::parquet::writer _writer;
+    size_t _buffered_bytes{0};
+    size_t _flushed_bytes{0};
 };
 
 class serde_parquet_writer_factory : public parquet_ostream_factory {

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -362,6 +362,7 @@ redpanda_cc_gtest(
         "local_parquet_file_writer_test.cc",
     ],
     deps = [
+        ":test_data_writer",
         "//src/v/datalake:local_parquet_file_writer",
         "//src/v/datalake/tests:test_data",
         "//src/v/iceberg:datatypes",
@@ -381,6 +382,7 @@ redpanda_cc_gtest(
         "serde_parquet_writer_test.cc",
     ],
     deps = [
+        ":test_data_writer",
         "//src/v/bytes:iostream",
         "//src/v/datalake:serde_parquet_writer",
         "//src/v/datalake/tests:test_data",

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -268,6 +268,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:filesystem_catalog",
         "//src/v/model",
         "//src/v/pandaproxy",
+        "//src/v/random:generators",
         "//src/v/schema:registry",
         "//src/v/storage:record_batch_builder",
         "//src/v/test_utils:gtest",

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -144,7 +144,9 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     auto writer_factory = std::make_unique<local_parquet_file_writer_factory>(
       datalake::local_path(tmp_dir.get_path()),
       "data",
-      ss::make_shared<datalake::serde_parquet_writer_factory>());
+      ss::make_shared<datalake::serde_parquet_writer_factory>(),
+      std::make_unique<noop_mem_tracker>());
+
     translation_probe probe(ntp);
     datalake::record_multiplexer multiplexer(
       ntp,
@@ -269,7 +271,8 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
     auto writer_factory = std::make_unique<local_parquet_file_writer_factory>(
       datalake::local_path(tmp_dir.get_path()),
       "data",
-      ss::make_shared<datalake::serde_parquet_writer_factory>());
+      ss::make_shared<datalake::serde_parquet_writer_factory>(),
+      std::make_unique<noop_mem_tracker>());
     translation_probe probe(ntp);
     record_multiplexer mux(
       ntp,

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -41,7 +41,7 @@ const model::ntp
   ntp(model::ns{"rp"}, model::topic{"t"}, model::partition_id{0});
 const model::revision_id rev{123};
 default_translator translator;
-lazy_abort_source as([] { return std::nullopt; });
+ss::abort_source as;
 } // namespace
 
 TEST(DatalakeMultiplexerTest, TestMultiplexer) {
@@ -63,8 +63,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
       location_provider(
         cloud_io::s3_compat_provider{"s3"},
         cloud_storage_clients::bucket_name{"bucket"}),
-      probe,
-      as);
+      probe);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -79,8 +78,8 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
             std::move(batches));
       });
 
-    auto result
-      = reader.consume(std::move(multiplexer), model::no_timeout).get();
+    multiplexer.multiplex(std::move(reader), model::no_timeout, as).get();
+    auto result = std::move(multiplexer).finish().get();
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().data_files.size(), 1);
@@ -111,8 +110,7 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
       location_provider(
         cloud_io::s3_compat_provider{"s3"},
         cloud_storage_clients::bucket_name{"bucket"}),
-      probe,
-      as);
+      probe);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -125,7 +123,8 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
           return ss::make_ready_future<model::record_batch_reader::data_t>(
             std::move(batches));
       });
-    auto res = reader.consume(std::move(multiplexer), model::no_timeout).get();
+    multiplexer.multiplex(std::move(reader), model::no_timeout, as).get();
+    auto res = std::move(multiplexer).finish().get();
     ASSERT_TRUE(res.has_error());
     EXPECT_EQ(res.error(), datalake::writer_error::parquet_conversion_error);
 }
@@ -160,8 +159,7 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
       location_provider(
         cloud_io::s3_compat_provider{"s3"},
         cloud_storage_clients::bucket_name{"bucket"}),
-      probe,
-      as);
+      probe);
 
     model::test::record_batch_spec batch_spec;
     batch_spec.records = record_count;
@@ -176,8 +174,8 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
             std::move(batches));
       });
 
-    auto result
-      = reader.consume(std::move(multiplexer), model::no_timeout).get();
+    multiplexer.multiplex(std::move(reader), model::no_timeout, as).get();
+    auto result = std::move(multiplexer).finish().get();
 
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().data_files.size(), 1);
@@ -284,9 +282,9 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
       t_creator,
       model::iceberg_invalid_record_action::dlq_table,
       location_provider(scoped_remote->remote.local().provider(), bucket_name),
-      probe,
-      as);
-    auto res = reader.consume(std::move(mux), model::no_timeout).get();
+      probe);
+    mux.multiplex(std::move(reader), model::no_timeout, as).get();
+    auto res = std::move(mux).finish().get();
     ASSERT_FALSE(res.has_error()) << res.error();
     EXPECT_EQ(res.value().start_offset(), start_offset());
 

--- a/src/v/datalake/tests/local_parquet_file_writer_test.cc
+++ b/src/v/datalake/tests/local_parquet_file_writer_test.cc
@@ -10,8 +10,8 @@
 
 #include "datalake/local_parquet_file_writer.h"
 #include "datalake/tests/test_data.h"
+#include "datalake/tests/test_data_writer.h"
 #include "iceberg/tests/value_generator.h"
-#include "test_utils/test.h"
 #include "test_utils/tmp_dir.h"
 
 #include <seastar/core/seastar.hh>
@@ -28,7 +28,7 @@ struct test_writer : datalake::parquet_ostream {
       , error_on_finish_(error_on_finish)
       , os_(std::move(os)) {}
     ss::future<datalake::writer_error>
-    add_data_struct(iceberg::struct_value, size_t) final {
+    add_data_struct(iceberg::struct_value, size_t, ss::abort_source&) final {
         if (rows_ >= error_after_rows_) {
             co_return datalake::writer_error::file_io_error;
         }
@@ -63,7 +63,9 @@ struct test_writer_factory : datalake::parquet_ostream_factory {
       , error_on_finish_(error_on_finish) {}
 
     ss::future<std::unique_ptr<datalake::parquet_ostream>> create_writer(
-      const iceberg::struct_type&, ss::output_stream<char> os) final {
+      const iceberg::struct_type&,
+      ss::output_stream<char> os,
+      datalake::writer_mem_tracker&) final {
         co_return std::make_unique<test_writer>(
           error_after_rows_, error_on_finish_, std::move(os));
     };
@@ -84,11 +86,15 @@ struct LocalFileWriterTest : public testing::Test {
     temporary_dir tmp_dir = temporary_dir("batching_parquet_writer");
     std::filesystem::path file_path = "test_file.parquet";
     std::filesystem::path full_path = tmp_dir.get_path() / file_path;
+    datalake::noop_mem_tracker mem_tracker;
+    ss::abort_source as;
 };
 
 TEST_F(LocalFileWriterTest, TestHappyPath) {
     datalake::local_parquet_file_writer file_writer(
-      datalake::local_path(full_path), ss::make_shared<test_writer_factory>());
+      datalake::local_path(full_path),
+      ss::make_shared<test_writer_factory>(),
+      mem_tracker);
 
     auto schema = test_schema(iceberg::field_required::no);
     file_writer.initialize(schema).get();
@@ -99,7 +105,7 @@ TEST_F(LocalFileWriterTest, TestHappyPath) {
           iceberg::tests::value_spec{},
           test_schema(iceberg::field_required::no));
 
-        auto res = file_writer.add_data_struct(std::move(data), 1000).get();
+        auto res = file_writer.add_data_struct(std::move(data), 1000, as).get();
         ASSERT_EQ(datalake::writer_error::ok, res);
     }
 
@@ -116,7 +122,8 @@ TEST_F(LocalFileWriterTest, TestHappyPath) {
 TEST_F(LocalFileWriterTest, TestErrorOnWrite) {
     datalake::local_parquet_file_writer file_writer(
       datalake::local_path(full_path),
-      ss::make_shared<test_writer_factory>(100));
+      ss::make_shared<test_writer_factory>(100),
+      mem_tracker);
     auto schema = test_schema(iceberg::field_required::no);
     file_writer.initialize(schema).get();
 
@@ -126,7 +133,7 @@ TEST_F(LocalFileWriterTest, TestErrorOnWrite) {
           iceberg::tests::value_spec{},
           test_schema(iceberg::field_required::no));
 
-        file_writer.add_data_struct(std::move(data), 1000).get();
+        file_writer.add_data_struct(std::move(data), 1000, as).get();
     }
 
     auto result = file_writer.finish().get();
@@ -140,7 +147,8 @@ TEST_F(LocalFileWriterTest, TestErrorOnWrite) {
 TEST_F(LocalFileWriterTest, TestErrorOnFinish) {
     datalake::local_parquet_file_writer file_writer(
       datalake::local_path(full_path),
-      ss::make_shared<test_writer_factory>(5000, true));
+      ss::make_shared<test_writer_factory>(5000, true),
+      mem_tracker);
     auto schema = test_schema(iceberg::field_required::no);
     file_writer.initialize(schema).get();
 
@@ -150,7 +158,7 @@ TEST_F(LocalFileWriterTest, TestErrorOnFinish) {
           iceberg::tests::value_spec{},
           test_schema(iceberg::field_required::no));
 
-        file_writer.add_data_struct(std::move(data), 1000).get();
+        file_writer.add_data_struct(std::move(data), 1000, as).get();
     }
 
     auto result = file_writer.finish().get();

--- a/src/v/datalake/tests/local_parquet_file_writer_test.cc
+++ b/src/v/datalake/tests/local_parquet_file_writer_test.cc
@@ -37,6 +37,10 @@ struct test_writer : datalake::parquet_ostream {
         co_return datalake::writer_error::ok;
     };
 
+    size_t buffered_bytes() const final { return 0; };
+    size_t flushed_bytes() const final { return 0; }
+    ss::future<> flush() final { return ss::make_ready_future<>(); }
+
     ss::future<datalake::writer_error> finish() final {
         if (error_on_finish_) {
             co_return datalake::writer_error::file_io_error;

--- a/src/v/datalake/tests/partitioning_writer_test.cc
+++ b/src/v/datalake/tests/partitioning_writer_test.cc
@@ -62,6 +62,8 @@ chunked_vector<struct_value> generate_values(
     return vals;
 }
 
+ss::abort_source as;
+
 } // namespace
 
 class PartitioningWriterExtraColumnsTest
@@ -88,7 +90,7 @@ TEST_P(PartitioningWriterExtraColumnsTest, TestSchemaHappyPath) {
 
     // Give the data to the partitioning writer.
     for (auto& v : source_vals) {
-        auto err = writer.add_data(std::move(v), /*approx_size=*/0).get();
+        auto err = writer.add_data(std::move(v), /*approx_size=*/0, as).get();
         EXPECT_EQ(err, writer_error::ok);
     }
 
@@ -131,7 +133,8 @@ TEST(PartitioningWriterTest, TestWriterError) {
     auto err = writer
                  .add_data(
                    val_with_timestamp(field, model::timestamp::now()),
-                   /*approx_size=*/0)
+                   /*approx_size=*/0,
+                   as)
                  .get();
     EXPECT_EQ(err, writer_error::parquet_conversion_error);
 }
@@ -149,7 +152,8 @@ TEST(PartitioningWriterTest, TestUnexpectedSchema) {
                  .add_data(
                    val_with_timestamp(
                      unexpected_field_type, model::timestamp::now()),
-                   /*approx_size=*/0)
+                   /*approx_size=*/0,
+                   as)
                  .get();
     EXPECT_EQ(err, writer_error::parquet_conversion_error);
 }
@@ -170,7 +174,7 @@ TEST(PartitioningWriterTest, TestEmptyKey) {
 
     // Give the data to the partitioning writer.
     for (auto& v : source_vals) {
-        auto err = writer.add_data(std::move(v), /*approx_size=*/0).get();
+        auto err = writer.add_data(std::move(v), /*approx_size=*/0, as).get();
         EXPECT_EQ(err, writer_error::ok);
     }
 
@@ -233,7 +237,7 @@ TEST(PartitioningWriterTest, TestCompositeKey) {
 
     // Give the data to the partitioning writer.
     for (auto& v : source_vals) {
-        auto err = writer.add_data(std::move(v), /*approx_size=*/0).get();
+        auto err = writer.add_data(std::move(v), /*approx_size=*/0, as).get();
         EXPECT_EQ(err, writer_error::ok);
     }
 

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -249,12 +249,13 @@ share_batches(chunked_vector<model::record_batch>& batches) {
 struct counting_consumer {
     size_t total_bytes = 0;
     datalake::record_multiplexer mux;
+    ss::abort_source& as;
     ss::future<ss::stop_iteration> operator()(model::record_batch&& batch) {
         total_bytes += batch.size_bytes();
-        return mux(std::move(batch));
+        return mux.do_multiplex(std::move(batch), as);
     }
     ss::future<counting_consumer> end_of_stream() {
-        auto res = co_await mux.end_of_stream();
+        auto res = co_await std::move(mux).finish();
         if (res.has_error()) [[unlikely]] {
             throw std::runtime_error(
               fmt::format("failed to end stream: {}", res.error()));
@@ -273,8 +274,7 @@ public:
       , _schema_mgr(catalog)
       , _type_resolver(registry, _schema_cache)
       , _record_gen(&registry)
-      , _table_creator(_type_resolver, _schema_mgr)
-      , _as([] { return std::nullopt; }) {}
+      , _table_creator(_type_resolver, _schema_mgr) {}
 
     template<typename T>
     requires std::same_as<T, ::testing::protobuf_generator_config>
@@ -301,7 +301,7 @@ public:
     ss::future<size_t> run_bench() {
         auto reader = model::make_fragmented_memory_record_batch_reader(
           share_batches(_batch_data));
-        auto consumer = counting_consumer{.mux = create_mux()};
+        auto consumer = counting_consumer{.mux = create_mux(), .as = _as};
 
         perf_tests::start_measuring_time();
         auto res = co_await reader.consume(
@@ -325,7 +325,7 @@ private:
     datalake::direct_table_creator _table_creator;
     datalake::translation_probe _translation_probe{ntp};
     chunked_vector<model::record_batch> _batch_data;
-    lazy_abort_source _as;
+    ss::abort_source _as;
 
     datalake::record_multiplexer create_mux() {
         return datalake::record_multiplexer(
@@ -339,8 +339,7 @@ private:
           model::iceberg_invalid_record_action::dlq_table,
           datalake::location_provider(
             scoped_remote->remote.local().provider(), bucket_name),
-          _translation_probe,
-          _as);
+          _translation_probe);
     }
 
     ss::future<>

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -101,8 +101,7 @@ public:
     RecordMultiplexerTestBase()
       : schema_mgr(catalog)
       , type_resolver(registry)
-      , t_creator(type_resolver, schema_mgr)
-      , as([] { return std::nullopt; }) {}
+      , t_creator(type_resolver, schema_mgr) {}
 
     // Runs the multiplexer on records generated with cb() based on the test
     // parameters.
@@ -145,9 +144,9 @@ public:
           model::iceberg_invalid_record_action::dlq_table,
           location_provider(
             scoped_remote->remote.local().provider(), bucket_name),
-          *get_or_create_probe(ntp),
-          as);
-        auto res = reader.consume(std::move(mux), model::no_timeout).get();
+          *get_or_create_probe(ntp));
+        mux.multiplex(std::move(reader), model::no_timeout, as).get();
+        auto res = std::move(mux).finish().get();
         if (expect_error) {
             EXPECT_TRUE(res.has_error());
         } else {
@@ -206,7 +205,7 @@ public:
     record_schema_resolver type_resolver;
     direct_table_creator t_creator;
     std::map<model::ntp, ss::lw_shared_ptr<translation_probe>> probes;
-    lazy_abort_source as;
+    ss::abort_source as;
 
     static constexpr records_param default_param = {
       .records_per_batch = 1,

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -22,6 +22,7 @@
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "random/generators.h"
 #include "storage/record_batch_builder.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -131,8 +132,6 @@ public:
                 batches.emplace_back(std::move(batch_builder).build());
             }
         }
-        auto reader = model::make_memory_record_batch_reader(
-          std::move(batches));
         record_multiplexer mux(
           ntp,
           topic_rev,
@@ -145,7 +144,24 @@ public:
           location_provider(
             scoped_remote->remote.local().provider(), bucket_name),
           *get_or_create_probe(ntp));
-        mux.multiplex(std::move(reader), model::no_timeout, as).get();
+        // randomly split batches into multiple readers
+        size_t total_batches = batches.size();
+        size_t total_split_batches = 0;
+        while (!batches.empty()) {
+            auto subset_size = random_generators::get_int<size_t>(
+              1, batches.size());
+            ss::circular_buffer<model::record_batch> subset;
+            while (subset.size() != subset_size) {
+                subset.push_back(batches.front().share());
+                batches.pop_front();
+            }
+            total_split_batches += subset.size();
+            auto reader = model::make_memory_record_batch_reader(
+              std::move(subset));
+            mux.multiplex(std::move(reader), model::no_timeout, as).get();
+            mux.flush_writers().get();
+        }
+        EXPECT_EQ(total_batches, total_split_batches);
         auto res = std::move(mux).finish().get();
         if (expect_error) {
             EXPECT_TRUE(res.has_error());

--- a/src/v/datalake/tests/serde_parquet_writer_test.cc
+++ b/src/v/datalake/tests/serde_parquet_writer_test.cc
@@ -1,6 +1,7 @@
 #include "bytes/iostream.h"
 #include "datalake/serde_parquet_writer.h"
 #include "datalake/tests/test_data.h"
+#include "datalake/tests/test_data_writer.h"
 #include "iceberg/tests/value_generator.h"
 
 #include <seastar/core/seastar.hh>
@@ -11,8 +12,10 @@ TEST(SerdeParquetWriterTest, CheckIfTheWriterWritesData) {
     auto schema = test_schema(iceberg::field_required::no);
     iobuf target;
 
+    datalake::noop_mem_tracker mem_tracker;
     auto writer = datalake::serde_parquet_writer_factory{}
-                    .create_writer(schema, make_iobuf_ref_output_stream(target))
+                    .create_writer(
+                      schema, make_iobuf_ref_output_stream(target), mem_tracker)
                     .get();
 
     auto v = iceberg::tests::make_value(
@@ -21,7 +24,8 @@ TEST(SerdeParquetWriterTest, CheckIfTheWriterWritesData) {
 
     auto s_v = std::get<std::unique_ptr<iceberg::struct_value>>(std::move(v));
 
-    auto result = writer->add_data_struct(std::move(*s_v), 0).get();
+    ss::abort_source as;
+    auto result = writer->add_data_struct(std::move(*s_v), 0, as).get();
     ASSERT_EQ(result, datalake::writer_error::ok);
     auto finish_result = writer->finish().get();
 

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -21,6 +21,14 @@
 #include <cstdint>
 #include <memory>
 namespace datalake {
+class noop_mem_tracker : public writer_mem_tracker {
+public:
+    ss::future<> maybe_reserve_memory(size_t, ss::abort_source&) override {
+        return ss::make_ready_future<>();
+    }
+    void update_current_memory_usage(size_t) override {}
+    void release() override {}
+};
 
 class test_data_writer : public parquet_file_writer {
 public:
@@ -31,7 +39,9 @@ public:
       , _return_error{return_error} {}
 
     ss::future<writer_error> add_data_struct(
-      iceberg::struct_value /* data */, int64_t /* approx_size */) override {
+      iceberg::struct_value /* data */,
+      int64_t /* approx_size */,
+      ss::abort_source&) override {
         _result.row_count++;
         writer_error status = _return_error
                                 ? writer_error::parquet_conversion_error
@@ -80,10 +90,10 @@ public:
       : _writer(std::move(writer))
       , _result{} {}
 
-    ss::future<writer_error>
-    add_data_struct(iceberg::struct_value data, int64_t sz) override {
+    ss::future<writer_error> add_data_struct(
+      iceberg::struct_value data, int64_t sz, ss::abort_source& as) override {
         auto write_result = co_await _writer->add_data_struct(
-          std::move(data), sz);
+          std::move(data), sz, as);
         _result.row_count++;
         co_return write_result;
     }
@@ -114,7 +124,7 @@ public:
     ss::future<result<std::unique_ptr<parquet_file_writer>, writer_error>>
     create_writer(const iceberg::struct_type& schema) override {
         auto ostream_writer = co_await _serde_parquet_factory.create_writer(
-          schema, utils::make_null_output_stream());
+          schema, utils::make_null_output_stream(), _mem_tracker);
 
         co_return std::make_unique<test_serde_parquet_data_writer>(
           std::move(ostream_writer));
@@ -122,6 +132,7 @@ public:
 
 private:
     serde_parquet_writer_factory _serde_parquet_factory;
+    noop_mem_tracker _mem_tracker;
 };
 
 } // namespace datalake

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -39,6 +39,14 @@ public:
         return ss::make_ready_future<writer_error>(status);
     }
 
+    size_t buffered_bytes() const override { return 0; }
+
+    size_t flushed_bytes() const override { return 0; }
+
+    ss::future<writer_error> flush() override {
+        return ss::make_ready_future<writer_error>(writer_error::ok);
+    }
+
     ss::future<result<local_file_metadata, writer_error>> finish() override {
         return ss::make_ready_future<result<local_file_metadata, writer_error>>(
           _result);
@@ -78,6 +86,14 @@ public:
           std::move(data), sz);
         _result.row_count++;
         co_return write_result;
+    }
+
+    size_t buffered_bytes() const override { return _writer->buffered_bytes(); }
+
+    size_t flushed_bytes() const override { return _writer->flushed_bytes(); }
+
+    ss::future<writer_error> flush() override {
+        return ss::make_ready_future<writer_error>(writer_error::ok);
     }
 
     ss::future<result<local_file_metadata, writer_error>> finish() override {

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -16,8 +16,8 @@
 #include "datalake/location.h"
 #include "datalake/record_schema_resolver.h"
 #include "datalake/record_translator.h"
-#include "datalake/serde_parquet_writer.h"
 #include "datalake/table_creator.h"
+#include "datalake/tests/test_data_writer.h"
 #include "datalake/tests/test_utils.h"
 #include "datalake/translation/translation_probe.h"
 #include "datalake/translation_task.h"
@@ -92,7 +92,8 @@ public:
         return std::make_unique<datalake::local_parquet_file_writer_factory>(
           datalake::local_path(tmp_dir.get_path()),
           "test-prefix",
-          ss::make_shared<datalake::serde_parquet_writer_factory>());
+          ss::make_shared<datalake::serde_parquet_writer_factory>(),
+          std::make_unique<datalake::noop_mem_tracker>());
     }
 
     lazy_abort_source& never_abort() {

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -132,6 +132,9 @@ public:
 
     translation_task create_task() {
         return translation_task(
+          ntp,
+          rev,
+          get_writer_factory(),
           cloud_io,
           *schema_mgr,
           *schema_resolver,
@@ -181,13 +184,14 @@ private:
 };
 
 TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
-    auto result = create_task()
-                    .translate(
-                      ntp,
-                      rev,
-                      get_writer_factory(),
+    datalake::translation_task task = create_task();
+    task.translate_once(make_batches(10, 16), as).get();
+    auto flush_result = task.flush().get();
+    ASSERT_FALSE(flush_result.has_error());
+    task.translate_once(make_batches(10, 16, model::offset{160}), as).get();
+    auto result = std::move(task)
+                    .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)
@@ -198,7 +202,9 @@ TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
     auto transformed_range = std::move(result.value());
     // check offset range
     ASSERT_EQ(transformed_range.start_offset, kafka::offset(0));
-    ASSERT_EQ(transformed_range.last_offset, kafka::offset(159));
+    // 2 translations of 10 batches with 16 records each
+    // = 2 * 10 * 16 = 320 records
+    ASSERT_EQ(transformed_range.last_offset, kafka::offset(319));
     ASSERT_EQ(transformed_range.files.size(), 1);
 
     // check that the resulting files were actually uploaded to the cloud
@@ -208,17 +214,15 @@ TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
 }
 
 TEST_F(TranslateTaskTest, TestDataFileMissing) {
+    datalake::translation_task task = create_task();
     // create deleting task to cause local io error
     deleter del(tmp_dir.get_path().string());
     del.start();
     auto stop_deleter = ss::defer([&del] { del.stop().get(); });
-    auto result = create_task()
-                    .translate(
-                      ntp,
-                      rev,
-                      get_writer_factory(),
+    task.translate_once(make_batches(10, 16), as).get();
+    auto result = std::move(task)
+                    .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)
@@ -229,6 +233,18 @@ TEST_F(TranslateTaskTest, TestDataFileMissing) {
 }
 
 TEST_F(TranslateTaskTest, TestUploadError) {
+    datalake::translation_task task(
+      ntp,
+      model::revision_id{123},
+      get_writer_factory(),
+      cloud_io,
+      *schema_mgr,
+      *schema_resolver,
+      *translator,
+      *t_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider,
+      probe);
     // fail all PUT requests
     fail_request_if(
       [](const http_test_utils::request_info& req) -> bool {
@@ -238,13 +254,10 @@ TEST_F(TranslateTaskTest, TestUploadError) {
         .body = "failed!",
         .status = ss::http::reply::status_type::internal_server_error});
 
-    auto result = create_task()
-                    .translate(
-                      ntp,
-                      model::revision_id{123},
-                      get_writer_factory(),
+    task.translate_once(make_batches(10, 16), as).get();
+    auto result = std::move(task)
+                    .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -96,12 +96,6 @@ public:
           std::make_unique<datalake::noop_mem_tracker>());
     }
 
-    lazy_abort_source& never_abort() {
-        static thread_local lazy_abort_source noop = {
-          []() { return std::nullopt; }};
-        return noop;
-    }
-
     template<typename R>
     AssertionResult check_object_store_content(R range) {
         auto objects = remote().list_objects(bucket_name, test_rcn).get();
@@ -196,7 +190,7 @@ TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
                       make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
-                      never_abort())
+                      as)
                     .get();
 
     ASSERT_FALSE(result.has_error());
@@ -227,7 +221,7 @@ TEST_F(TranslateTaskTest, TestDataFileMissing) {
                       make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
-                      never_abort())
+                      as)
                     .get();
 
     ASSERT_TRUE(result.has_error());
@@ -253,7 +247,7 @@ TEST_F(TranslateTaskTest, TestUploadError) {
                       make_batches(10, 16),
                       datalake::remote_path("test/location/1"),
                       test_rcn,
-                      never_abort())
+                      as)
                     .get();
 
     ASSERT_TRUE(result.has_error());

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -111,6 +111,7 @@ redpanda_cc_library(
         ":model",
         ":stm",
         ":translation_probe",
+        ":translator_deps",
         ":utils",
         "//src/v/base",
         "//src/v/cluster",

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -82,6 +82,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "translator_deps",
+    srcs = [
+        "deps.cc",
+    ],
+    hdrs = [
+        "deps.h",
+    ],
+    include_prefix = "datalake/translation",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":scheduler",
+        "//src/v/datalake:writer",
+    ],
+)
+
+redpanda_cc_library(
     name = "partition_translator",
     srcs = [
         "partition_translator.cc",

--- a/src/v/datalake/translation/CMakeLists.txt
+++ b/src/v/datalake/translation/CMakeLists.txt
@@ -1,11 +1,12 @@
 v_cc_library(
     NAME datalake_translation
     SRCS
+        deps.cc
         partition_translator.cc
         state_machine.cc
         scheduling_policies.cc
         scheduling.cc
-	utils.cc
+        utils.cc
     DEPS
         v::cluster
         v::datalake_writer

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/translation/deps.h"
+
+namespace datalake::translation {
+
+ss::future<> noop_mem_tracker::maybe_reserve_memory(size_t, ss::abort_source&) {
+    return ss::make_ready_future<>();
+}
+void noop_mem_tracker::update_current_memory_usage(size_t) {}
+void noop_mem_tracker::release() {}
+
+} // namespace datalake::translation

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "datalake/data_writer_interface.h"
+
+namespace datalake::translation {
+
+class noop_mem_tracker : public writer_mem_tracker {
+public:
+    ss::future<> maybe_reserve_memory(size_t bytes, ss::abort_source&) override;
+    void update_current_memory_usage(size_t) override;
+    void release() override;
+};
+
+} // namespace datalake::translation

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -22,6 +22,7 @@
 #include "datalake/record_translator.h"
 #include "datalake/serde_parquet_writer.h"
 #include "datalake/table_creator.h"
+#include "datalake/translation/deps.h"
 #include "datalake/translation/state_machine.h"
 #include "datalake/translation/translation_probe.h"
 #include "datalake/translation_task.h"
@@ -286,7 +287,8 @@ partition_translator::do_translation_for_range(
     auto writer_factory = std::make_unique<local_parquet_file_writer_factory>(
       local_path{_writer_scratch_space},    // storage temp files are written to
       fmt::format("{}", read_begin_offset), // file prefix
-      ss::make_shared<serde_parquet_writer_factory>());
+      ss::make_shared<serde_parquet_writer_factory>(),
+      std::make_unique<noop_mem_tracker>());
 
     auto task = translation_task{
       **_cloud_io,

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -289,8 +289,11 @@ partition_translator::do_translation_for_range(
       fmt::format("{}", read_begin_offset), // file prefix
       ss::make_shared<serde_parquet_writer_factory>(),
       std::make_unique<noop_mem_tracker>());
-
+    const auto& ntp = _partition->ntp();
     auto task = translation_task{
+      ntp,
+      _partition->get_topic_revision_id(),
+      std::move(writer_factory),
       **_cloud_io,
       *_schema_mgr,
       *_type_resolver,
@@ -300,7 +303,6 @@ partition_translator::do_translation_for_range(
       _location_provider,
       *_probe,
     };
-    const auto& ntp = _partition->ntp();
     auto remote_path_prefix = remote_path{
       fmt::format("{}/{}/{}", iceberg_data_path_prefix, ntp.path(), _term)};
     vlog(
@@ -329,15 +331,9 @@ partition_translator::do_translation_for_range(
     // of kafka_reader. The reader is cleaned up along with consumption,
     // so we need to ensure that the reader is dispatched to translation
     // in all cases.
-    auto result = co_await task.translate(
-      ntp,
-      _partition->get_topic_revision_id(),
-      std::move(writer_factory),
-      is_cp_enabled,
-      std::move(kafka_reader),
-      remote_path_prefix,
-      parent,
-      _as);
+    co_await task.translate_once(std::move(kafka_reader), _as);
+    auto result = co_await std::move(task).finish(
+      is_cp_enabled, remote_path_prefix, parent, _as);
     if (result.has_error()) {
         vlog(_logger.warn, "Error translating range {}", result.error());
         co_return std::nullopt;

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -303,11 +303,6 @@ partition_translator::do_translation_for_range(
     const auto& ntp = _partition->ntp();
     auto remote_path_prefix = remote_path{
       fmt::format("{}/{}/{}", iceberg_data_path_prefix, ntp.path(), _term)};
-    lazy_abort_source las{[this] {
-        return can_continue() ? std::nullopt
-                              : std::make_optional("translator stopping");
-    }};
-
     vlog(
       _logger.debug,
       "translating data in kafka range: [{}, {}]",
@@ -342,7 +337,7 @@ partition_translator::do_translation_for_range(
       std::move(kafka_reader),
       remote_path_prefix,
       parent,
-      las);
+      _as);
     if (result.has_error()) {
         vlog(_logger.warn, "Error translating range {}", result.error());
         co_return std::nullopt;

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -172,6 +172,9 @@ upload_files(
 
 } // namespace
 translation_task::translation_task(
+  const model::ntp& ntp,
+  model::revision_id topic_revision,
+  std::unique_ptr<parquet_file_writer_factory> writer_factory,
   cloud_data_io& cloud_io,
   schema_manager& schema_mgr,
   type_resolver& type_resolver,
@@ -187,20 +190,8 @@ translation_task::translation_task(
   , _table_creator(&table_creator)
   , _invalid_record_action(invalid_record_action)
   , _location_provider(std::move(location_provider))
-  , _translation_probe(&probe) {}
-
-ss::future<
-  checked<coordinator::translated_offset_range, translation_task::errc>>
-translation_task::translate(
-  const model::ntp& ntp,
-  model::revision_id topic_revision,
-  std::unique_ptr<parquet_file_writer_factory> writer_factory,
-  custom_partitioning_enabled is_custom_partitioning_enabled,
-  model::record_batch_reader reader,
-  const remote_path& remote_path_prefix,
-  retry_chain_node& rcn,
-  ss::abort_source& as) {
-    record_multiplexer mux(
+  , _translation_probe(&probe)
+  , _multiplexer(
       ntp,
       topic_revision,
       std::move(writer_factory),
@@ -210,13 +201,31 @@ translation_task::translate(
       *_table_creator,
       _invalid_record_action,
       _location_provider,
-      *_translation_probe);
-    // Write local files
+      *_translation_probe) {}
 
-    co_await mux.multiplex(
+ss::future<> translation_task::translate_once(
+  model::record_batch_reader reader, ss::abort_source& as) {
+    return _multiplexer.multiplex(
       std::move(reader), _read_timeout + model::timeout_clock::now(), as);
+}
 
-    auto mux_result = co_await std::move(mux).finish();
+ss::future<checked<void, translation_task::errc>> translation_task::flush() {
+    auto result = co_await _multiplexer.flush_writers();
+    if (result != writer_error::ok) {
+        vlog(datalake_log.debug, "error flushing writers: {}", result);
+        co_return translation_task::errc::flush_error;
+    }
+    co_return outcome::success();
+}
+
+ss::future<
+  checked<coordinator::translated_offset_range, translation_task::errc>>
+translation_task::finish(
+  custom_partitioning_enabled is_custom_partitioning_enabled,
+  const remote_path& remote_path_prefix,
+  retry_chain_node& rcn,
+  ss::abort_source& as) && {
+    auto mux_result = co_await std::move(_multiplexer).finish();
     if (mux_result.has_error()) {
         vlog(
           datalake_log.warn,
@@ -284,6 +293,8 @@ std::ostream& operator<<(std::ostream& o, translation_task::errc ec) {
         return o << "local file IO error";
     case translation_task::errc::cloud_io_error:
         return o << "cloud IO error";
+    case translation_task::errc::flush_error:
+        return o << "writer flush error";
     }
 }
 } // namespace datalake

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -199,7 +199,12 @@ translation_task::translate(
   model::record_batch_reader reader,
   const remote_path& remote_path_prefix,
   retry_chain_node& rcn,
-  lazy_abort_source& lazy_as) {
+  ss::abort_source& as) {
+    lazy_abort_source lazy_as{[&as]() {
+        return as.abort_requested()
+                 ? std::make_optional("translation task stop requested")
+                 : std::nullopt;
+    }};
     record_multiplexer mux(
       ntp,
       topic_revision,

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -200,11 +200,6 @@ translation_task::translate(
   const remote_path& remote_path_prefix,
   retry_chain_node& rcn,
   ss::abort_source& as) {
-    lazy_abort_source lazy_as{[&as]() {
-        return as.abort_requested()
-                 ? std::make_optional("translation task stop requested")
-                 : std::nullopt;
-    }};
     record_multiplexer mux(
       ntp,
       topic_revision,
@@ -215,12 +210,13 @@ translation_task::translate(
       *_table_creator,
       _invalid_record_action,
       _location_provider,
-      *_translation_probe,
-      lazy_as);
+      *_translation_probe);
     // Write local files
-    auto mux_result = co_await std::move(reader).consume(
-      std::move(mux), _read_timeout + model::timeout_clock::now());
 
+    co_await mux.multiplex(
+      std::move(reader), _read_timeout + model::timeout_clock::now(), as);
+
+    auto mux_result = co_await std::move(mux).finish();
     if (mux_result.has_error()) {
         vlog(
           datalake_log.warn,
@@ -242,6 +238,12 @@ translation_task::translate(
       .start_offset = write_result.start_offset,
       .last_offset = write_result.last_offset,
     };
+
+    lazy_abort_source lazy_as{[&as]() {
+        return as.abort_requested()
+                 ? std::make_optional("translation task stop requested")
+                 : std::nullopt;
+    }};
 
     // Data files.
     {

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -15,10 +15,10 @@
 #include "datalake/data_writer_interface.h"
 #include "datalake/fwd.h"
 #include "datalake/location.h"
+#include "datalake/record_multiplexer.h"
 #include "datalake/translation/translation_probe.h"
 #include "model/metadata.h"
 #include "model/record_batch_reader.h"
-#include "utils/lazy_abort_source.h"
 #include "utils/retry_chain_node.h"
 
 namespace datalake {
@@ -29,6 +29,9 @@ namespace datalake {
 class translation_task {
 public:
     explicit translation_task(
+      const model::ntp& ntp,
+      model::revision_id topic_revision,
+      std::unique_ptr<parquet_file_writer_factory> writer_factory,
       cloud_data_io& uploader,
       schema_manager& schema_mgr,
       type_resolver& type_resolver,
@@ -40,25 +43,36 @@ public:
     enum class errc {
         file_io_error,
         cloud_io_error,
+        flush_error,
     };
 
     using custom_partitioning_enabled
       = ss::bool_class<struct custom_partitioning_enabled_t>;
 
     /**
-     * Executes the translation and uploads files to the object store. The tasks
-     * accepts an abort source indicating when the upload retires should be
-     * stopped and a root retry chain node.
+     * Executes translation using the data from the reader until aborted.
+     * Can be called multiple times if needed. The results of translation can be
+     * uploading using finish().
      */
-    ss::future<checked<coordinator::translated_offset_range, errc>> translate(
-      const model::ntp& ntp,
-      model::revision_id topic_revision,
-      std::unique_ptr<parquet_file_writer_factory> writer_factory,
+    ss::future<>
+    translate_once(model::record_batch_reader reader, ss::abort_source&);
+
+    /**
+     * Flushes all the inflight translated bytes and releases memory
+     * reservations. May not be called while translation is in progress.
+     */
+    ss::future<checked<void, errc>> flush();
+
+    /**
+     * Uploads the resulting translated files to the object store. The tasks
+     * accepts an abort source indicating when the upload retires should be
+     * stopped and a root retry chain node
+     */
+    ss::future<checked<coordinator::translated_offset_range, errc>> finish(
       custom_partitioning_enabled is_custom_partitioning_enabled,
-      model::record_batch_reader reader,
       const remote_path& remote_path_prefix,
       retry_chain_node& parent_rcn,
-      ss::abort_source& as);
+      ss::abort_source&) &&;
 
 private:
     friend std::ostream& operator<<(std::ostream&, errc);
@@ -75,5 +89,6 @@ private:
     model::iceberg_invalid_record_action _invalid_record_action;
     location_provider _location_provider;
     translation_probe* _translation_probe;
+    record_multiplexer _multiplexer;
 };
 } // namespace datalake

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -58,7 +58,7 @@ public:
       model::record_batch_reader reader,
       const remote_path& remote_path_prefix,
       retry_chain_node& parent_rcn,
-      lazy_abort_source& lazy_as);
+      ss::abort_source& as);
 
 private:
     friend std::ostream& operator<<(std::ostream&, errc);

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -66,17 +66,22 @@ public:
         co_await write_iobuf(iobuf::from("PAR1"));
     }
 
-    ss::future<> write_row(group_value row) {
+    ss::future<file_stats> write_row(group_value row) {
         co_await shred_record(
           _opts.schema, std::move(row), [this](shredded_value sv) {
               return write_value(std::move(sv));
           });
+        file_stats stats;
+        stats.buffered_size = 0;
         for (auto& [_, col] : _columns) {
             int64_t usage = col.writer.current_page_memory_usage();
             if (usage > _opts.page_buffer_size) {
                 co_await col.writer.next_page();
             }
+            stats.buffered_size += col.writer.current_page_memory_usage();
         }
+        stats.flushed_size = _flushed_bytes;
+        co_return stats;
     }
 
     file_stats stats() const {
@@ -218,7 +223,7 @@ writer::~writer() noexcept = default;
 
 ss::future<> writer::init() { return _impl->init(); }
 
-ss::future<> writer::write_row(group_value row) {
+ss::future<file_stats> writer::write_row(group_value row) {
     return _impl->write_row(std::move(row));
 }
 

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -74,7 +74,7 @@ public:
     //
     // This method may not be called concurrently with other methods on this
     // class.
-    ss::future<> write_row(group_value);
+    ss::future<file_stats> write_row(group_value);
 
     // The current stats on the file being written.
     //

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -680,6 +680,9 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "null_output_stream",
+    srcs = [
+        "null_output_stream.cc",
+    ],
     hdrs = [
         "null_output_stream.h",
     ],

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     log_hist.cc
     xid.cc
     external_process.cc
+    null_output_stream.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/null_output_stream.cc
+++ b/src/v/utils/null_output_stream.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/null_output_stream.h"
+
+#include "base/units.h"
+
+namespace utils {
+
+ss::future<> null_data_sink::put(ss::net::packet data) {
+    return put(data.release());
+}
+
+ss::future<> null_data_sink::put(std::vector<ss::temporary_buffer<char>> all) {
+    return ss::do_with(
+      std::move(all), [this](std::vector<ss::temporary_buffer<char>>& all) {
+          return ss::do_for_each(all, [this](ss::temporary_buffer<char>& buf) {
+              return put(std::move(buf));
+          });
+      });
+}
+
+ss::future<> null_data_sink::put(ss::temporary_buffer<char>) {
+    return ss::now();
+}
+
+ss::future<> null_data_sink::flush() { return ss::now(); }
+ss::future<> null_data_sink::close() { return ss::now(); }
+
+ss::output_stream<char> make_null_output_stream() {
+    auto ds = ss::data_sink(std::make_unique<null_data_sink>());
+    ss::output_stream<char> ostr(std::move(ds), 4_KiB);
+    return ostr;
+}
+} // namespace utils

--- a/src/v/utils/null_output_stream.h
+++ b/src/v/utils/null_output_stream.h
@@ -9,8 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
+#pragma once
+
 #include "base/seastarx.h"
-#include "base/units.h"
 
 #include <seastar/core/iostream.hh>
 #include <seastar/util/later.hh>
@@ -19,25 +20,13 @@ namespace utils {
 // Data sink for noop output_stream instance
 // needed to implement scanning
 struct null_data_sink final : ss::data_sink_impl {
-    ss::future<> put(ss::net::packet data) final { return put(data.release()); }
-    ss::future<> put(std::vector<ss::temporary_buffer<char>> all) final {
-        return ss::do_with(
-          std::move(all), [this](std::vector<ss::temporary_buffer<char>>& all) {
-              return ss::do_for_each(
-                all, [this](ss::temporary_buffer<char>& buf) {
-                    return put(std::move(buf));
-                });
-          });
-    }
-    ss::future<> put(ss::temporary_buffer<char>) final { return ss::now(); }
-    ss::future<> flush() final { return ss::now(); }
-    ss::future<> close() final { return ss::now(); }
+    ss::future<> put(ss::net::packet data) final;
+    ss::future<> put(std::vector<ss::temporary_buffer<char>> all) final;
+    ss::future<> put(ss::temporary_buffer<char>) final;
+    ss::future<> flush() final;
+    ss::future<> close() final;
 };
 
-ss::output_stream<char> make_null_output_stream() {
-    auto ds = ss::data_sink(std::make_unique<null_data_sink>());
-    ss::output_stream<char> ostr(std::move(ds), 4_KiB);
-    return ostr;
-}
+ss::output_stream<char> make_null_output_stream();
 
 } // namespace utils


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Datalake API changes setting us up for porting the translation path to the new scheduler infrastructure. As written, should be functionally equivalent to current world, but some APIs have changes shape significantly.

Pulled form #25077 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
