### PR TITLE
`rptest`: fix race in `compaction_recovery_test.py`

### DIFF
--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -59,10 +59,17 @@ class CompactionRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_index_recovery(self):
-        partitions = self.produce_until_segments(3)
+        partition_node_list = [p.node for p in self.produce_until_segments(3)]
 
-        for p in partitions:
-            self.redpanda.stop_node(p.node)
+        for node in partition_node_list:
+            self.redpanda.stop_node(node)
+
+        # The segment information returned from produce_until_segments()
+        # could be outdated by the time we stop the redpanda nodes,
+        # e.g due to adjacent segment compaction. Query it here
+        # after stopping the cluster.
+        storage = self.redpanda.storage(all_nodes=True)
+        partitions = storage.partitions("kafka", self.topic)
 
         for p in partitions:
             p.delete_indices(allow_fail=False)
@@ -73,8 +80,8 @@ class CompactionRecoveryTest(RedpandaTest):
                              compaction_ctrl_min_shares=1000,
                              compaction_ctrl_max_shares=1000)
 
-        for p in partitions:
-            self.redpanda.start_node(p.node)
+        for node in partition_node_list:
+            self.redpanda.start_node(node)
 
         self.redpanda.set_cluster_config(extra_rp_conf, True)
 


### PR DESCRIPTION
Attempting to delete segment indices for the list of segments returned by `produce_until_segments()` is race-y, due to the fact adjacent merge compaction could have kicked in while we were waiting for the `redpanda` nodes to be stopped.

This can be easily proven/reproduced by adding a `time.sleep()` call to the test:

```diff
--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -61,6 +61,7 @@ class CompactionRecoveryTest(RedpandaTest):
     def test_index_recovery(self):
         partitions = self.produce_until_segments(3)
 
+        time.sleep(10) # This will now fail reliably.
         for p in partitions:
             self.redpanda.stop_node(p.node)

```

Requery the partition information after the nodes have been restarted to ensure the segment data is up-to-date.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
