### PR TITLE
CORE-8695 crash_tracker: implement crash report upload markers

### DIFF
--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_library(
         "//src/v/serde:iobuf",
         "//src/v/serde:sstring",
         "//src/v/serde:vector",
+        "//src/v/utils:directory_walker",
         "//src/v/utils:file_io",
         "@fmt",
     ],

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -42,6 +42,13 @@ to_upload_marker_path(const std::filesystem::path& crash_report_path) {
     return crash_report_path.string() + recorder::upload_marker_suffix;
 }
 
+std::filesystem::path
+to_crash_report_path(const std::filesystem::path& upload_marker_path) {
+    auto full_path = upload_marker_path.string();
+    return full_path.substr(
+      0, full_path.size() - recorder::upload_marker_suffix.size());
+}
+
 } // namespace
 
 recorder& get_recorder() {
@@ -106,9 +113,41 @@ ss::future<> recorder::remove_old_crashfiles() const {
     co_return;
 }
 
+namespace {
+ss::future<> upload_marker_walker_fn(
+  std::filesystem::path basedir, ss::directory_entry entry) {
+    const auto path = (basedir / std::string_view{entry.name}).string();
+    if (!path.ends_with(recorder::upload_marker_suffix)) {
+        // Not an upload marker
+        co_return;
+    }
+
+    auto dangling = !co_await ss::file_exists(
+      to_crash_report_path(std::filesystem::path{path}).string());
+    if (dangling) {
+        vlog(
+          ctlog.trace, "Removing dangling crash report upload marker {}", path);
+        co_await ss::remove_file(path);
+    }
+}
+} // namespace
+
+ss::future<> recorder::remove_dangling_upload_markers() const {
+    auto basedir = config::node().crash_report_dir_path();
+    if (!co_await ss::file_exists(basedir.string())) {
+        co_return;
+    }
+
+    co_await directory_walker::walk(
+      basedir.string(), [basedir](ss::directory_entry entry) -> ss::future<> {
+          return upload_marker_walker_fn(basedir, std::move(entry));
+      });
+}
+
 ss::future<> recorder::start() {
     co_await ensure_crashdir_exists();
     co_await remove_old_crashfiles();
+    co_await remove_dangling_upload_markers();
     co_await _writer.initialize(co_await generate_crashfile_name());
     ::detail::g_assert_log_holder.register_cb(
       [](std::string_view msg) { get_recorder().record_crash_vassert(msg); });

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -35,6 +35,15 @@ namespace crash_tracker {
 
 static constexpr std::string_view crash_report_suffix = ".crash";
 
+namespace {
+
+std::filesystem::path
+to_upload_marker_path(const std::filesystem::path& crash_report_path) {
+    return crash_report_path.string() + recorder::upload_marker_suffix;
+}
+
+} // namespace
+
 recorder& get_recorder() {
     static recorder inst;
     return inst;
@@ -231,6 +240,19 @@ void recorder::record_crash_vassert(std::string_view msg) {
 
     _writer.write();
 }
+
+ss::future<bool> recorder::recorded_crash::is_uploaded() const {
+    co_return co_await ss::file_exists(
+      to_upload_marker_path(file_path).string());
+}
+
+ss::future<> recorder::recorded_crash::mark_uploaded() const {
+    // Create an empty upload marker
+    const auto marker_path = to_upload_marker_path(file_path).string();
+    auto f = co_await ss::open_file_dma(marker_path, ss::open_flags::create);
+    co_await f.close();
+    co_return;
+};
 
 std::chrono::system_clock::time_point
 recorder::recorded_crash::timestamp() const {

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -17,6 +17,7 @@
 #include "crash_tracker/types.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
+#include "utils/directory_walker.h"
 #include "utils/file_io.h"
 
 #include <seastar/core/file.hh>
@@ -233,17 +234,43 @@ void recorder::record_crash_vassert(std::string_view msg) {
 
 std::chrono::system_clock::time_point
 recorder::recorded_crash::timestamp() const {
-    auto recorded_timestamp_opt = crash
-                                    ? std::make_optional(
-                                        model::to_time_point(crash->crash_time))
-                                    : std::nullopt;
-    auto lwt_sys_timepoint = std::chrono::system_clock::time_point{
-      std::chrono::duration_cast<std::chrono::system_clock::duration>(
-        last_write_time.time_since_epoch())};
-
     // Prefer the recorded timestamp, fall back to the last write time
-    return recorded_timestamp_opt.value_or(lwt_sys_timepoint);
+    return crash ? model::to_time_point(crash->crash_time) : last_write_time;
 }
+
+namespace {
+ss::future<> recorded_crashes_walker_fn(
+  std::filesystem::path basedir,
+  ss::directory_entry entry,
+  std::vector<recorder::recorded_crash>& result,
+  recorder::include_malformed_files incl_malformed) {
+    const auto path = (basedir / std::string_view{entry.name}).string();
+    if (!path.ends_with(crash_report_suffix)) {
+        // Filter only for crash files
+        co_return;
+    }
+
+    auto file_stats = co_await ss::file_stat(path);
+
+    auto buf = co_await read_fully(path);
+    try {
+        auto crash_desc = serde::from_iobuf<crash_description>(std::move(buf));
+        result.emplace_back(
+          path, std::move(crash_desc), file_stats.time_changed);
+    } catch (const serde::serde_exception& e) {
+        vlog(
+          ctlog.debug,
+          "Exception while deserializing a crash report file {}: {}",
+          path,
+          e);
+        if (incl_malformed) {
+            result.emplace_back(path, std::nullopt, file_stats.time_changed);
+        } else {
+            vlog(ctlog.warn, "Ignoring malformed crash report file {}", path);
+        }
+    }
+}
+} // namespace
 
 ss::future<std::vector<recorder::recorded_crash>>
 recorder::get_recorded_crashes(
@@ -254,36 +281,12 @@ recorder::get_recorded_crashes(
         co_return result;
     }
 
-    for (const auto& entry :
-         std::filesystem::directory_iterator(crash_report_dir)) {
-        if (!entry.path().string().ends_with(crash_report_suffix)) {
-            // Filter only for crash files
-            continue;
-        }
-
-        auto buf = co_await read_fully(entry.path());
-        try {
-            auto crash_desc = serde::from_iobuf<crash_description>(
-              std::move(buf));
-            result.emplace_back(
-              entry.path(), std::move(crash_desc), entry.last_write_time());
-        } catch (const serde::serde_exception& e) {
-            vlog(
-              ctlog.debug,
-              "Exception while deserializing a crash report file {}: {}",
-              entry.path(),
-              e);
-            if (incl_malformed) {
-                result.emplace_back(
-                  entry.path(), std::nullopt, entry.last_write_time());
-            } else {
-                vlog(
-                  ctlog.warn,
-                  "Ignoring malformed crash report file {}",
-                  entry.path());
-            }
-        }
-    }
+    co_await directory_walker::walk(
+      crash_report_dir.string(),
+      [crash_report_dir, &result, incl_malformed](ss::directory_entry entry) {
+          return recorded_crashes_walker_fn(
+            crash_report_dir, std::move(entry), result, incl_malformed);
+      });
 
     std::sort(
       result.begin(),

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -68,6 +68,7 @@ private:
     ss::future<> ensure_crashdir_exists() const;
     ss::future<std::filesystem::path> generate_crashfile_name() const;
     ss::future<> remove_old_crashfiles() const;
+    ss::future<> remove_dangling_upload_markers() const;
 
     prepared_writer _writer;
 

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -27,6 +27,7 @@ namespace crash_tracker {
 class recorder {
 public:
     static constexpr auto crash_files_to_keep = 50;
+    static constexpr std::string upload_marker_suffix = ".uploaded";
 
     struct recorded_crash {
         std::filesystem::path file_path;

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -31,7 +31,7 @@ public:
     struct recorded_crash {
         std::filesystem::path file_path;
         std::optional<crash_description> crash;
-        std::filesystem::file_time_type last_write_time;
+        std::chrono::system_clock::time_point last_write_time;
 
         ss::future<bool> is_uploaded() const;
         ss::future<> mark_uploaded() const;

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -39,8 +39,7 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
             res.addition_info = crash_description::reserved_string_t{
               "false != true at example.cc:123"};
         }
-        return recorder::recorded_crash{
-          "", std::move(res), std::chrono::file_clock::time_point{}};
+        return recorder::recorded_crash{"", std::move(res), {}};
     };
 
     crashes.emplace_back(make_crash(with_additional_info::no));

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -87,6 +87,57 @@ TEST_F(RecorderTest, TestUploadMarkers) {
     }
 }
 
+namespace {
+
+size_t count_upload_markers() {
+    size_t result = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(
+           config::node().crash_report_dir_path())) {
+        if (entry.path().string().ends_with(recorder::upload_marker_suffix)) {
+            result++;
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+TEST_F(RecorderTest, TestUploadMarkerCleanup) {
+    const auto test_eptr = std::make_exception_ptr(std::runtime_error{""});
+
+    // Simulate lots of crashed restarts to generate crash reports on disk
+    for (size_t i = 0; i < recorder::crash_files_to_keep + 5; i++) {
+        auto rec = get_test_recorder();
+        rec.start().get();
+
+        // Mark all earlier crash reports as uploaded before each crash
+        auto crashes = rec.get_recorded_crashes().get();
+        for (auto& report : crashes) {
+            report.mark_uploaded().get();
+        }
+
+        rec.record_crash_exception(test_eptr);
+    }
+    // Note: the crash report generated in the last iteration was not been
+    // marked uploaded
+
+    // Run one more restart and observe that old crash files and crash markers
+    // are cleaned up
+    auto rec = get_test_recorder();
+    rec.start().get();
+
+    // Verify that all but the latest report has been marked uploaded
+    auto crashes = rec.get_recorded_crashes().get();
+    ASSERT_EQ(crashes.size(), recorder::crash_files_to_keep);
+    for (size_t i = 0; i < crashes.size(); ++i) {
+        const auto expect_uploaded = (i != (crashes.size() - 1));
+        ASSERT_EQ(crashes[i].is_uploaded().get(), expect_uploaded);
+    }
+
+    // Verify that there are no dangling upload markers
+    ASSERT_EQ(count_upload_markers(), recorder::crash_files_to_keep - 1);
+}
+
 class ParametrizedRecorderTest
   : public testing::TestWithParam<recorder::recorded_signo> {
 public:

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -64,6 +64,29 @@ TEST_F(RecorderTest, TestFileCleanup) {
     ASSERT_EQ(crashes.size(), recorder::crash_files_to_keep);
 }
 
+TEST_F(RecorderTest, TestUploadMarkers) {
+    constexpr auto n_reports = 5;
+
+    // Generate some crash reports
+    const auto test_eptr = std::make_exception_ptr(std::runtime_error{""});
+    for (size_t i = 0; i < n_reports; i++) {
+        auto rec = get_test_recorder();
+        rec.start().get();
+        rec.record_crash_exception(test_eptr);
+    }
+
+    auto rec = get_test_recorder();
+    rec.start().get();
+
+    // Verify upload markers work as expected
+    auto crashes = rec.get_recorded_crashes().get();
+    for (auto& report : crashes) {
+        ASSERT_EQ(report.is_uploaded().get(), false);
+        report.mark_uploaded().get();
+        ASSERT_EQ(report.is_uploaded().get(), true);
+    }
+}
+
 class ParametrizedRecorderTest
   : public testing::TestWithParam<recorder::recorded_signo> {
 public:


### PR DESCRIPTION
We will use empty files to track if a certain crash file has been uploaded through our metrics reporter telemetry mechanism.

To mark a crash file as uploaded, we touch a new file with the same name + the ".uploaded" suffix. To check if a crash file has been uploaded, we check if a file with the same name + the ".uploaded" suffix exists. We also implement the clean up of any upload markers on disk that do not have an associated crash report.

Fixes https://redpandadata.atlassian.net/browse/CORE-8695

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
