### PR TITLE
[CORE-8760] `rptest`: fix race-y checks in `test_index_recovery_after_upgrade`

### DIFF
--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -12,6 +12,8 @@ import struct
 import collections
 import hashlib
 import subprocess
+import os
+
 from typing import Iterator
 
 
@@ -141,7 +143,7 @@ def compute_size_for_file(file: Path, calc_md5: bool):
 
 
 def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
-                 print_flat: bool):
+                 print_flat: bool, compaction_footers: bool):
     output = {}
     for ns in safe_listdir(data_dir):
         if not safe_isdir(ns):
@@ -170,11 +172,86 @@ def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
                             # It's valid to have a segment deleted
                             # at anytime
                             continue
+                    if compaction_footers:
+                        try:
+                            if segment.suffix == ".compaction_index":
+                                seg_output[
+                                    "compaction_footer"] = read_compaction_footer(
+                                        segment)
+                        except FileNotFoundError:
+                            # It's valid to have a segment deleted
+                            # at anytime
+                            continue
                     part_output[segment.name] = seg_output
                 topic_output[partition.name] = part_output
             ns_output[topic.name] = topic_output
         output[ns.name] = ns_output
     return output
+
+
+def read_compaction_footer(file_path):
+    compacted_index_file = open(file_path, "rb")
+    fsize = os.stat(file_path).st_size
+    # Keep up to date with compacted_index::footer impl
+    # Footers are encoded with little-endian.
+
+    # v1: uint32_t, uint32_t, uint32_t, uint32_t, int8_t
+    u64 = 8
+    u32 = 4
+    i8 = 1
+    FOOTER_SIZE_V1 = sum([u32 + u32 + u32 + u32 + i8])
+    FOOTER_V1 = "<IIIIb"
+
+    # v2/v3: uint64_t, uint64_t, uint32_t, uint32_t, uint32_t, uint32_t, int8_t
+    FOOTER_SIZE_V2 = sum([u64 + u64 + u32 + u32 + u32 + u32 + i8])
+    FOOTER_V2 = "<QQIIIIb"
+
+    assert fsize >= FOOTER_SIZE_V1, f"Error reading compaction footer {file_path}, file size too small ({fsize})"
+
+    footer_buf_size = min(fsize, FOOTER_SIZE_V2)
+    offset = fsize - footer_buf_size
+    compacted_index_file.seek(offset)
+    footer = compacted_index_file.read(footer_buf_size)
+    FOOTER_FLAG_TRUNCATION = 1
+    FOOTER_FLAG_SELF_COMPACTION = 1 << 1
+    FOOTER_FLAG_INCOMPLETE = 1 << 2
+    res = dict()
+    # Try to parse as V1
+    try:
+        footer_v1 = footer[footer_buf_size - FOOTER_SIZE_V1:]
+        unpacked_footer = struct.unpack(FOOTER_V1, footer_v1)
+        res["size"] = unpacked_footer[0]
+        res["keys"] = unpacked_footer[1]
+        res["truncation"] = bool(
+            (unpacked_footer[2]
+             & FOOTER_FLAG_TRUNCATION) == FOOTER_FLAG_TRUNCATION)
+        res["self_compaction"] = bool(
+            (unpacked_footer[2]
+             & FOOTER_FLAG_SELF_COMPACTION) == FOOTER_FLAG_SELF_COMPACTION)
+        res["incomplete"] = bool(
+            (unpacked_footer[2]
+             & FOOTER_FLAG_INCOMPLETE) == FOOTER_FLAG_INCOMPLETE)
+        res["crc"] = unpacked_footer[3]
+        res["version"] = unpacked_footer[4]
+    except:
+        footer_v2 = footer[:]
+        unpacked_footer = struct.unpack(FOOTER_V2, footer_v2)
+        res["size"] = unpacked_footer[0]
+        res["keys"] = unpacked_footer[1]
+        # Deprecated size [2]
+        # Deprecated keys [3]
+        res["truncation"] = bool(
+            (unpacked_footer[4]
+             & FOOTER_FLAG_TRUNCATION) == FOOTER_FLAG_TRUNCATION)
+        res["self_compaction"] = bool(
+            (unpacked_footer[4]
+             & FOOTER_FLAG_SELF_COMPACTION) == FOOTER_FLAG_SELF_COMPACTION)
+        res["incomplete"] = bool(
+            (unpacked_footer[4]
+             & FOOTER_FLAG_INCOMPLETE) == FOOTER_FLAG_INCOMPLETE)
+        res["crc"] = unpacked_footer[5]
+        res["version"] = unpacked_footer[6]
+    return res
 
 
 if __name__ == "__main__":
@@ -191,6 +268,10 @@ if __name__ == "__main__":
                         action="store_true",
                         help='Also compute md5 checksums')
     parser.add_argument(
+        '--compaction-footers',
+        action="store_true",
+        help='Also read footers for compacted indices (if they exist)')
+    parser.add_argument(
         '--print-flat',
         action="store_true",
         help='Print output for each file instead of returning as json')
@@ -198,6 +279,7 @@ if __name__ == "__main__":
 
     data_dir = Path(args.data_dir)
     assert data_dir.exists(), f"{data_dir} must exist"
-    output = compute_size(data_dir, args.sizes, args.md5, args.print_flat)
+    output = compute_size(data_dir, args.sizes, args.md5, args.print_flat,
+                          args.compaction_footers)
     if not args.print_flat:
         json.dump(output, sys.stdout)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4574,7 +4574,8 @@ class RedpandaService(RedpandaServiceBase):
     def node_storage(self,
                      node,
                      sizes: bool = False,
-                     scan_cache: bool = True) -> NodeStorage:
+                     scan_cache: bool = True,
+                     compaction_footers: bool = False) -> NodeStorage:
         """
         Retrieve a summary of storage on a node.
 
@@ -4594,6 +4595,8 @@ class RedpandaService(RedpandaServiceBase):
         ]
         if sizes:
             cmd.append("--sizes")
+        if compaction_footers:
+            cmd.append("--compaction-footers")
         output = node.account.ssh_output(shlex.join(cmd),
                                          combine_stderr=False,
                                          timeout_sec=10)
@@ -4608,10 +4611,12 @@ class RedpandaService(RedpandaServiceBase):
                     partition_path = os.path.join(topic_path, part)
                     partition = topic.add_partition(part, node, partition_path)
                     partition.add_files(list(segments.keys()))
-                    if not sizes:
-                        continue
                     for segment, data in segments.items():
-                        partition.set_segment_size(segment, data["size"])
+                        if "size" in data:
+                            partition.set_segment_size(segment, data["size"])
+                        if "compaction_footer" in data:
+                            partition.set_segment_compaction_footer(
+                                segment, data["compaction_footer"])
 
         if scan_cache and self._si_settings is not None and node.account.exists(
                 store.cache_dir):

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -21,6 +21,7 @@ class Segment:
         self.data_file = None
         self.base_index = None
         self.compaction_index = None
+        self.compaction_footer = None
 
         # Size of data_file, if caller chooses to populate it via set_size
         self.size = None
@@ -54,6 +55,9 @@ class Segment:
 
     def set_size(self, s: int):
         self.size = s
+
+    def set_compaction_footer(self, compaction_footer: dict):
+        self.compaction_footer = compaction_footer
 
     def __repr__(self):
         return "{}:{}{}{}".format(self.name, "D" if self.data_file else "d",
@@ -90,6 +94,14 @@ class Partition:
         if not (re.match(r"^\d+\-\d+\-v\d+$", seg) and ext == ".log"):
             return
         self.segments[seg].set_size(size)
+
+    def set_segment_compaction_footer(self, segment_name: str,
+                                      compaction_footer: dict):
+        seg, ext = os.path.splitext(segment_name)
+        if not (re.match(r"^\d+\-\d+\-v\d+$", seg)
+                and ext == ".compaction_index"):
+            return
+        self.segments[seg].set_compaction_footer(compaction_footer)
 
     def delete_segment(self, segment_name: str):
         try:

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -18,6 +18,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import produce_until_segments
 
 import os.path
+from collections import namedtuple
 
 
 class CompactionRecoveryTest(RedpandaTest):
@@ -147,8 +148,9 @@ class CompactionRecoveryUpgradeTest(RedpandaTest):
         # all the way to HEAD
         next_version = self.installer.latest_for_line(release_line=(23, 1))[0]
 
-        def get_storage_partition(node):
-            storage = self.redpanda.node_storage(node, sizes=True)
+        def get_storage_partition(node, compaction_footers=False):
+            storage = self.redpanda.node_storage(
+                node, sizes=True, compaction_footers=compaction_footers)
             partitions = storage.partitions('kafka', self.topic)
             assert len(partitions) == 1
             return partitions[0]
@@ -164,25 +166,30 @@ class CompactionRecoveryUpgradeTest(RedpandaTest):
                                    record_size=1024,
                                    batch_size=2048)
 
-            def no_big_closed_segments():
+            def finished_compaction():
                 partition = get_storage_partition(node)
                 return not any(
                     seg.base_index and seg.size > (self.SEGMENT_SIZE / 2)
                     for seg in partition.segments.values())
 
-            wait_until(no_big_closed_segments, timeout_sec=30, backoff_sec=2)
+            wait_until(finished_compaction, timeout_sec=30, backoff_sec=2)
 
         def get_closed_segment2mtime(node):
-            partition = get_storage_partition(node)
-
+            partition = get_storage_partition(node, compaction_footers=True)
             seg2mtime = dict()
+            mtime_and_version = namedtuple("mtime_and_version",
+                                           ["mtime", "version"])
             for sname, seg in partition.segments.items():
-                if seg.base_index:
+                if seg.compaction_footer:
                     path = os.path.join(partition.path, seg.data_file)
-                    seg2mtime[path] = partition.get_mtime(seg.data_file)
+                    seg2mtime[path] = mtime_and_version(
+                        partition.get_mtime(seg.data_file),
+                        seg.compaction_footer["version"])
 
             for k, v in sorted(seg2mtime.items()):
-                self.logger.debug(f"mtime for closed segment {k}: {v}")
+                self.logger.debug(
+                    f"mtime & compaction footer version for closed segment {k}: {v}"
+                )
 
             return seg2mtime
 
@@ -192,27 +199,38 @@ class CompactionRecoveryUpgradeTest(RedpandaTest):
         self.logger.info(f"will test node {to_restart.account.hostname}")
 
         produce_and_wait_for_compaction(to_restart, 2)
+
+        self.installer.install([to_restart], next_version)
+        self.redpanda.stop_node(to_restart)
+
         seg2mtime_1 = get_closed_segment2mtime(to_restart)
         assert len(seg2mtime_1) >= 2
 
-        self.installer.install([to_restart], next_version)
-        self.redpanda.restart_nodes([to_restart])
+        self.redpanda.start_node(to_restart)
         self.redpanda.wait_for_membership(first_start=False)
 
         # After restart we produce and wait for the new segments to be compacted.
         # Because redpanda compacts segments from the beginning, this means that
         # all earlier segments have been either recovered or rebuilt after restart.
         produce_and_wait_for_compaction(to_restart, 2)
+
+        self.installer.install([to_restart], self.OLD_VERSION)
+        self.redpanda.stop_node(to_restart)
+
         seg2mtime_2 = get_closed_segment2mtime(to_restart)
         assert len(seg2mtime_2) >= len(seg2mtime_1) + 2
 
         for index in seg2mtime_1.keys():
-            # v1 compacted segments should be left intact
             assert index in seg2mtime_2
-            assert seg2mtime_1[index] == seg2mtime_2[index]
+            # v1 compacted segments should be left intact
+            if seg2mtime_2[index].version == 1:
+                assert seg2mtime_2[index].mtime == seg2mtime_1[
+                    index].mtime, f"Expected segment index {index} mtime {seg2mtime_2[index].mtime} == {seg2mtime_1[index].mtime}"
+            else:
+                assert seg2mtime_2[index].mtime > seg2mtime_1[
+                    index].mtime, f"Expected segment index {index} mtime {seg2mtime_2[index].mtime} > {seg2mtime_1[index].mtime}"
 
-        self.installer.install([to_restart], self.OLD_VERSION)
-        self.redpanda.restart_nodes([to_restart])
+        self.redpanda.start_node(to_restart)
         self.redpanda.wait_for_membership(first_start=False)
 
         produce_and_wait_for_compaction(to_restart, 2)
@@ -220,12 +238,19 @@ class CompactionRecoveryUpgradeTest(RedpandaTest):
         assert len(seg2mtime_3) >= len(seg2mtime_2) + 2
         for index in seg2mtime_2.keys():
             assert index in seg2mtime_3
-            if index in seg2mtime_1:
+            if seg2mtime_2[index].version == 1:
                 # v1-compacted segments should not be rewritten
-                assert seg2mtime_3[index] == seg2mtime_2[index]
+                assert seg2mtime_3[index].mtime == seg2mtime_2[
+                    index].mtime, f"Expected segment index {index} mtime {seg2mtime_3[index].mtime} == {seg2mtime_2[index].mtime}"
             else:
-                # old version should rebuild v2 indices and re-compact segments
-                assert seg2mtime_3[index] > seg2mtime_2[index]
+                # old version should rebuild v2 indices and re-compact segments.
+                if seg2mtime_3[index].version == 1:
+                    assert seg2mtime_3[index].mtime > seg2mtime_2[
+                        index].mtime, f"Expected segment index {index} mtime {seg2mtime_3[index].mtime} > {seg2mtime_2[index].mtime}"
+                else:
+                    # The rebuild hasn't happened yet, check that segment index is untouched
+                    assert seg2mtime_3[index].mtime == seg2mtime_2[
+                        index].mtime, f"Expected segment index {index} mtime {seg2mtime_3[index].mtime} == {seg2mtime_2[index].mtime}"
 
         # Now that we are back at the old version, proceed to upgrade all the way to HEAD
         remaining_versions = self.load_version_range(self.OLD_VERSION)[1:]


### PR DESCRIPTION
This test can race with segment rolls and un-self-compacted segments, since self compaction may not occur before `redpanda` version changes and node restarts occur. Thus, breaking the expectations around the `mtime()` stats.

## The issues with this test (two points of failure)

To better illustrate why this test is race-y, let's look at parts of the test in chronological order:

This function, `get_closed_segment2mtime()`, is used to gather the `mtime()` statistics for the existing, **closed** segments in storage. 

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L175-L187

To begin, it is called while the nodes are still running a `redpanda` version with a compaction index footer version `V1`. Call this part of the test version epoch 1.
https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L194-L195

There is already a race condition here, as a segment could be rolled in between  `produce_and_wait_for_compaction()` and `get_closed_segment2mtime()`, thereby appearing in the `mtime` statistics gathered in `seg2mtime_1`, but not self compacted (more on the issues with `produce_and_wait_for_compaction()` later- but for now, take my word that it doesn't guarantee there won't be an open segment that eventually rolls to become a closed segment after it returns in this version epoch). Call this segment `S1` for future reference.

After this, we upgrade and restart the `to_restart` node to a `redpanda` version with a compaction index footer version `V2`. Call this version epoch 2.
https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L198-L200

Now, repeat the process of producing, "waiting" for compaction, and gathering `mtime` statistics. 
https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L202-L206

However, we now assert on some expectations around the gathered `seg2mtime_2` values:

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L209-L212

### 1. L212 is the first possible point of failure.

`S1` is present in `seg2mtime_1`, and also present in `seg2mtime_2`. It was rolled in version epoch 1, but importantly, **not self compacted**. The result of this is that in version epoch 2, when processing the compaction index footer for `S1`, `redpanda` decides to self compact `S1`, resulting in a rewritten segment `S1'` with a `mtime` that differs from `S1`, **causing the assert to fail**.

But, let's say we avoid this race. There are more issues with the test past this point.

We downgrade the `to_restart` node to the previous version of `redpanda` with a compaction index footer version `V1`, call this version epoch 3.

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L214-L216

Again, produce and "wait" for compaction.

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L218-L219

Now, even more asserts on our expected `seg2mtime_3` data:

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L221-L228

### 2. L228 is the second possible point of failure.

The assert on L225 would have a similar race condition to the one presented in the first point of failure, but L212 will fail first in this case.

L228 is dangerous because there is another race-y issue in this test, caused by the flawed logic in `produce_and_wait_for_compaction()`. More specifically, the flawed logic in `no_big_closed_segments()`, which is used to determine if compaction is "complete".

https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/tests/rptest/tests/compaction_recovery_test.py#L167-L171

This function tests if any segments are currently closed AND uncompacted. It does not guarantee that all open segments will be closed and compacted by the end of the version epoch.

What this means is that it is possible for another segment, call it `S2`, to have the following sequence of events, starting in version epoch one:
1. (Version Epoch 1) Open at time of `produce_and_wait_for_compaction()`, which returns
2. (Version Epoch 1)  Open at time of `get_closed_segment2mtime()` (therefore doesn't show up in `seg2mtime_1`), which returns
3. (Version Epoch 1) **Closed and self compacted with compaction index footer V1** after both of those function calls, but before the node is restarted
4. (Version Epoch 2) `S2` shows up in `segm2time_2`
5. (Version Epoch 3) The check `if index in seg2mtime_1` on L223 returns `False` for `S2`.
6. (Version Epoch 3) We then assert that `seg2mtime_3[index] > seg2mtime_2[index]`, which fails because in actuality, `S2`'s compaction index was written with footer version `V1`, and therefore won't be rewritten. We intended to hit the assert on L225 for this segment, but did not because of the race condition.


### Whew so what's the fix

There is no good way to guarantee there aren't races around segment rolls, and there also aren't any good ways to guarantee or even check that a segment is self compacted by the end of a version epoch/before a restart or not in this test.

The best way to ensure correctness in this test is to actually parse the version of the compacted index footer and use that to assert on the `mtime` values gathered.

Therefore, to fix the race conditions, **use a newly added compaction index footer reader from `compute_storage.py` to check the version of compacted index footers, and asserting what we can for the `mtime` values based on that version**.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
