### PR TITLE
`ssx`: move `watchdog` into `ssx` namespace

### DIFF
--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -141,10 +141,10 @@ ss::future<walk_result> recursive_directory_walker::walk(
 
     auto guard = _gate.hold();
 
-    watchdog wd1m(std::chrono::seconds(60), [] {
+    ssx::watchdog wd1m(std::chrono::seconds(60), [] {
         vlog(cst_log.info, "Directory walk is taking more than 1 min");
     });
-    watchdog wd10m(std::chrono::seconds(600), [] {
+    ssx::watchdog wd10m(std::chrono::seconds(600), [] {
         vlog(cst_log.warn, "Directory walk is taking more than 10 min");
     });
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -966,7 +966,7 @@ ss::future<> remote_partition::run_eviction_loop() {
         // got stuck. The deadline is set to 5 minutes to avoid false positives.
         // The callback is self sufficient and can outlive the remote_partition
         // instance.
-        watchdog wd(300s, [ntp = _ntp] {
+        ssx::watchdog wd(300s, [ntp = _ntp] {
             vlog(cst_log.error, "Eviction loop for partition {} stuck", ntp);
         });
         auto eviction_in_flight = std::exchange(_eviction_pending, {});
@@ -1150,7 +1150,7 @@ remote_partition::aborted_transactions(offset_range offsets) {
 
 ss::future<> remote_partition::stop() {
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
-    watchdog wd(300s, [ntp = get_ntp()] {
+    ssx::watchdog wd(300s, [ntp = get_ntp()] {
         vlog(cst_log.error, "remote_partition {} stop operation stuck", ntp);
     });
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -210,7 +210,7 @@ ss::future<> remote_segment::stop() {
         co_return;
     }
 
-    watchdog wd(300s, [path = _path] {
+    ssx::watchdog wd(300s, [path = _path] {
         vlog(cst_log.error, "remote_segment {} stop operation stuck", path);
     });
 
@@ -1549,7 +1549,7 @@ ss::future<> remote_segment_batch_reader::stop() {
         co_return;
     }
 
-    watchdog wd(300s, [path = _seg->get_segment_path()] {
+    ssx::watchdog wd(300s, [path = _seg->get_segment_path()] {
         vlog(
           cst_log.error,
           "remote_segment_batch_reader {} stop operation stuck",

--- a/src/v/ssx/tests/watchdog_test.cc
+++ b/src/v/ssx/tests/watchdog_test.cc
@@ -20,7 +20,7 @@ using namespace std::chrono_literals;
 SEASTAR_THREAD_TEST_CASE(watchdog_test_defuse) {
     bool watchdog_triggered = false;
     {
-        watchdog wd(100ms, [&] { watchdog_triggered = true; });
+        ssx::watchdog wd(100ms, [&] { watchdog_triggered = true; });
         // to allow some async code to run
         ss::sleep(1ms).get();
     }
@@ -34,7 +34,7 @@ SEASTAR_THREAD_TEST_CASE(watchdog_test_defuse) {
 SEASTAR_THREAD_TEST_CASE(watchdog_test_trigger) {
     bool watchdog_triggered = false;
     {
-        watchdog wd(100ms, [&] { watchdog_triggered = true; });
+        ssx::watchdog wd(100ms, [&] { watchdog_triggered = true; });
         ss::sleep(200ms).get();
     }
     BOOST_REQUIRE(watchdog_triggered == true);

--- a/src/v/ssx/watchdog.h
+++ b/src/v/ssx/watchdog.h
@@ -19,6 +19,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+namespace ssx {
 /// This tool can be used to detect anomalously long
 /// running operations or stuck async loops.
 /// You can create an instance of 'watchdog' and pass
@@ -92,3 +93,5 @@ private:
     void cancel() { _as.request_abort(); }
     seastar::abort_source _as;
 };
+
+} // namespace ssx


### PR DESCRIPTION
This utility class was defined in the global namespace.

Move it into `ssx::`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
