### PR TITLE
[CORE-9329] `storage`: concurrent housekeeping

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -409,6 +409,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
+        "//src/v/ssx:watchdog",
         "//src/v/strings:static_str",
         "//src/v/strings:string_switch",
         "//src/v/utils:adjustable_semaphore",

--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -13,6 +13,7 @@
 
 #include "container/intrusive_list_helpers.h"
 #include "storage/log.h"
+#include "utils/mutex.h"
 
 namespace storage {
 struct log_housekeeping_meta {
@@ -29,6 +30,8 @@ struct log_housekeeping_meta {
     ss::shared_ptr<log> handle;
     bitflags flags{bitflags::none};
     ss::lowres_clock::time_point last_compaction;
+    // Mutex used for handling concurrency between housekeeping and gc fibres
+    mutex housekeeping_lock{"housekeeping_lock"};
 
     intrusive_list_hook link;
 };

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -143,12 +143,12 @@ log_manager::log_manager(
   , _kvstore(kvstore)
   , _resources(resources)
   , _feature_table(feature_table)
-  , _jitter(_config.compaction_interval())
+  , _housekeeping_jitter(_config.compaction_interval())
   , _trigger_gc_jitter(0s, 5s)
   , _batch_cache(_config.reclaim_opts)
   , _probe(std::make_unique<log_manager_probe>()) {
     _config.compaction_interval.watch([this]() {
-        _jitter = simple_time_jitter<ss::lowres_clock>{
+        _housekeeping_jitter = simple_time_jitter<ss::lowres_clock>{
           _config.compaction_interval()};
         _housekeeping_sem.signal();
     });
@@ -399,9 +399,9 @@ ss::future<> log_manager::housekeeping_loop() {
      */
     while (true) {
         try {
-            const auto prev_jitter_base = _jitter.base_duration();
+            const auto prev_jitter_base = _housekeeping_jitter.base_duration();
             co_await _housekeeping_sem.wait(
-              _jitter.next_duration(),
+              _housekeeping_jitter.next_duration(),
               std::max(_housekeeping_sem.current(), size_t(1)));
 
             /*
@@ -410,7 +410,7 @@ ss::future<> log_manager::housekeeping_loop() {
              * this attempts to avoid thundering herd since config changes are
              * delivered immediately to all shards.
              */
-            if (_jitter.base_duration() != prev_jitter_base) {
+            if (_housekeeping_jitter.base_duration() != prev_jitter_base) {
                 continue;
             }
         } catch (const ss::semaphore_timed_out&) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -188,6 +188,7 @@ ss::future<> log_manager::start() {
 ss::future<> log_manager::stop() {
     _abort_source.request_abort();
     _housekeeping_sem.broken();
+    _gc_sem.broken();
 
     co_await _gate.close();
     co_await ss::coroutine::parallel_for_each(

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -38,12 +38,14 @@
 #include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "utils/directory_walker.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/seastar.hh>
@@ -56,6 +58,7 @@
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/file.hh>
+#include <seastar/util/later.hh>
 
 #include <absl/container/btree_map.h>
 #include <boost/algorithm/string/predicate.hpp>
@@ -64,6 +67,7 @@
 #include <chrono>
 #include <exception>
 #include <filesystem>
+#include <functional>
 #include <optional>
 
 using namespace std::chrono_literals;
@@ -181,9 +185,17 @@ ss::future<> log_manager::start() {
                    .log_disable_housekeeping_for_tests.value())) {
         co_return;
     }
+
+    // The main housekeeping job loop (triggered by log_compaction_interval_ms).
     ssx::spawn_with_gate(_gate, [this] {
-        return run_housekeeping_job(
-          [this]() { return housekeeping_loop(); }, "housekeeping");
+        return ss::with_scheduling_group(_config.compaction_sg, [this]() {
+            return run_housekeeping_job(
+              [this]() { return housekeeping_loop(); }, "housekeeping");
+        });
+    });
+    // The urgent garbage collection loop (triggered by disk pressure).
+    ssx::spawn_with_gate(_gate, [this] {
+        return run_housekeeping_job([this]() { return gc_loop(); }, "gc");
     });
     co_return;
 }
@@ -251,6 +263,16 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _logs_list.shift_forward();
 
         current_log.flags |= bflags::lifetime_checked;
+
+        // Obtain housekeeping lock to prevent concurrency of
+        // log->apply_segment_ms() with gc fibre.
+        auto housekeeping_lock_holder
+          = co_await current_log.housekeeping_lock.get_units();
+
+        if (!current_log.link.is_linked()) {
+            continue;
+        }
+
         // NOTE: apply_segment_ms holds _compaction_housekeeping_gate, that
         // prevents the removal of the parent object. this makes awaiting
         // apply_segment_ms safe against removal of segments from _logs_list
@@ -333,9 +355,14 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         if (is_not_set(current_log.flags, bflags::should_compact)) {
             // Still perform gc() here on a regular `log_compaction_interval_ms`
-            // basis.
-            co_await current_log.handle->gc(
-              gc_config(collection_threshold, _config.retention_bytes()));
+            // basis. Use `try_get_units()` to avoid concurrent garbage
+            // collection with `gc_loop()`.
+            auto units = current_log.housekeeping_lock.try_get_units();
+            if (units.has_value()) {
+                co_await current_log.handle->gc(
+                  gc_config(collection_threshold, _config.retention_bytes()));
+            }
+
             continue;
         }
 
@@ -344,6 +371,16 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         auto ntp_sanitizer_cfg = _config.maybe_get_ntp_sanitizer_config(
           current_log.handle->config().ntp());
+
+        // Obtain housekeeping lock to prevent concurrency of
+        // log->housekeeping() with gc fibre.
+        auto housekeeping_lock_holder
+          = co_await current_log.housekeeping_lock.get_units();
+
+        if (!current_log.link.is_linked()) {
+            continue;
+        }
+
         // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
         // the removal of the parent object. this makes awaiting housekeeping
         // safe against removal of segments from _logs_list
@@ -357,11 +394,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           std::move(ntp_sanitizer_cfg),
           _compaction_hash_key_map.get()));
         _probe->housekeeping_log_processed();
-
-        // bail out of compaction early in order to get back to gc
-        if (_gc_triggered) {
-            co_return;
-        }
     }
 }
 
@@ -408,21 +440,61 @@ ss::future<> log_manager::housekeeping_loop() {
      * data older than this threshold may be garbage collected
      */
     while (true) {
+        const auto prev_jitter_base = _housekeeping_jitter.base_duration();
         try {
-            const auto prev_jitter_base = _housekeeping_jitter.base_duration();
             co_await _housekeeping_sem.wait(
               _housekeeping_jitter.next_duration(),
               std::max(_housekeeping_sem.current(), size_t(1)));
+        } catch (const ss::semaphore_timed_out&) {
+            // time for some chores
+        }
 
-            /*
-             * if it appears that the compaction interval config changed while
-             * we were sleeping then reschedule rather than run immediately.
-             * this attempts to avoid thundering herd since config changes are
-             * delivered immediately to all shards.
-             */
-            if (_housekeeping_jitter.base_duration() != prev_jitter_base) {
-                continue;
+        /*
+         * if it appears that the compaction interval config changed while
+         * we were sleeping then reschedule rather than run immediately.
+         * this attempts to avoid thundering herd since config changes are
+         * delivered immediately to all shards.
+         */
+        if (_housekeeping_jitter.base_duration() != prev_jitter_base) {
+            continue;
+        }
+
+        /*
+         * Perform compaction. Additional scheduling heuristics will be added
+         * here, including:
+         *
+         * - Logs can be compacted in order of most space savings first, but the
+         *   estimation will be harder, most likely based on recent compaction
+         *   ratio acehived.
+         *
+         * - It may be wise to skip compaction completely in extreme low-disk
+         *   situations because the compaction process itself requires
+         *   additional disk space to stage new segments and indices.
+         *
+         * - Enhance the `disk_usage` interface to estimate when new data will
+         *   become reclaimable and cancel non-impactful housekeeping work.
+         *
+         * - Early out compaction process if a new disk space alert arrives
+         */
+        try {
+            co_await housekeeping_scan(lowest_ts_to_retain());
+        } catch (...) {
+            auto eptr = std::current_exception();
+            if (ssx::is_shutdown_exception(eptr)) {
+                std::rethrow_exception(eptr);
             }
+            vlog(stlog.warn, "Error processing housekeeping(): {}", eptr);
+        }
+    }
+}
+
+ss::future<> log_manager::gc_loop() {
+    /*
+     * data older than this threshold may be garbage collected
+     */
+    while (true) {
+        try {
+            co_await _gc_sem.wait(std::max(_gc_sem.current(), size_t(1)));
         } catch (const ss::semaphore_timed_out&) {
             // time for some chores
         }
@@ -485,49 +557,35 @@ ss::future<> log_manager::housekeeping_loop() {
              * official log registry to avoid problems with concurrent removals
              * since the log interface does not tolerate ops on closed logs.
              */
-            for (const auto& [_, candidate] : ntp_by_gc_size) {
-                auto log = get(candidate);
-                if (!log) {
-                    continue;
-                }
-                co_await log->gc(
-                  gc_config(lowest_ts_to_retain(), _config.retention_bytes()));
-            }
+            static constexpr size_t max_concurrent_gc = 20;
+            co_await ss::max_concurrent_for_each(
+              ntp_by_gc_size.begin(),
+              ntp_by_gc_size.end(),
+              max_concurrent_gc,
+              [this](const auto& candidate) {
+                  auto* log_meta = get_log_meta(candidate.second);
+                  if (!log_meta) {
+                      return ss::now();
+                  }
+
+                  auto log = log_meta->handle;
+
+                  if (!log) {
+                      return ss::now();
+                  }
+
+                  auto& housekeeping_lock = log_meta->housekeeping_lock;
+                  auto units = housekeeping_lock.try_get_units();
+                  if (!units.has_value()) {
+                      return ss::now();
+                  }
+
+                  return log
+                    ->gc(gc_config(
+                      lowest_ts_to_retain(), _config.retention_bytes()))
+                    .finally([units = std::move(units)] {});
+              });
         }
-
-        /*
-         * Fall through for an iteration of the original housekeeping loop which
-         * will perform compaction. Additional scheduling heuristics will be
-         * added here, including:
-         *
-         * - Logs can be compacted in order of most space savings first, but the
-         *   estimation will be harder, most likely based on recent compaction
-         *   ratio acehived.
-         *
-         * - It may be wise to skip compaction completely in extreme low-disk
-         *   situations because the compaction process itself requires
-         *   additional disk space to stage new segments and indices.
-         *
-         * - Enhance the `disk_usage` interface to estimate when new data will
-         *   become reclaimable and cancel non-impactful housekeeping work.
-         *
-         * - Early out compaction process if a new disk space alert arives so
-         *   that we return this main scheduling loop.
-         */
-
-        auto prev_sg = co_await ss::coroutine::switch_to(_config.compaction_sg);
-
-        try {
-            co_await housekeeping_scan(lowest_ts_to_retain());
-        } catch (...) {
-            auto eptr = std::current_exception();
-            if (ssx::is_shutdown_exception(eptr)) {
-                std::rethrow_exception(eptr);
-            }
-            vlog(stlog.warn, "Error processing housekeeping(): {}", eptr);
-        }
-
-        co_await ss::coroutine::switch_to(prev_sg);
     }
 }
 
@@ -673,6 +731,7 @@ ss::future<> log_manager::shutdown(model::ntp ntp) {
     if (!handle) {
         co_return;
     }
+
     co_await clean_close(handle.value().second->handle);
     vlog(stlog.debug, "Shutdown: {}", ntp);
 }
@@ -685,6 +744,7 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     if (!handle) {
         co_return;
     }
+
     // 'ss::shared_ptr<>' make a copy
     auto lg = handle.value().second->handle;
     vlog(stlog.info, "Removing: {}", lg);
@@ -937,7 +997,7 @@ void log_manager::handle_disk_notification(storage::disk_space_alert alert) {
     if (_disk_space_alert != alert) {
         _disk_space_alert = alert;
         if (alert != disk_space_alert::ok) {
-            _housekeeping_sem.signal();
+            _gc_sem.signal();
         }
     }
 }
@@ -948,7 +1008,7 @@ void log_manager::trigger_gc() {
                  _trigger_gc_jitter.next_duration(), _abort_source)
           .then([this] {
               _gc_triggered = true;
-              _housekeeping_sem.signal();
+              _gc_sem.signal();
           });
     });
 }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -181,7 +181,10 @@ ss::future<> log_manager::start() {
                    .log_disable_housekeeping_for_tests.value())) {
         co_return;
     }
-    ssx::spawn_with_gate(_gate, [this] { return housekeeping(); });
+    ssx::spawn_with_gate(_gate, [this] {
+        return run_housekeeping_job(
+          [this]() { return housekeeping_loop(); }, "housekeeping");
+    });
     co_return;
 }
 
@@ -362,10 +365,11 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     }
 }
 
-ss::future<> log_manager::housekeeping() {
+ss::future<> log_manager::run_housekeeping_job(
+  std::function<ss::future<>()> loop_func, std::string_view ctx) {
     while (!_gate.is_closed()) {
         try {
-            co_await housekeeping_loop();
+            co_await loop_func();
         } catch (...) {
             /*
              * continue on shutdown exception because it may be bubbling up from
@@ -376,11 +380,16 @@ ss::future<> log_manager::housekeeping() {
             if (ssx::is_shutdown_exception(e)) {
                 vlog(
                   stlog.debug,
-                  "Shutdown error caught in housekeeping(): {}",
+                  "Shutdown error caught in run_housekeeping_job({}): {}",
+                  ctx,
                   e);
                 continue;
             }
-            vlog(stlog.info, "Error processing housekeeping(): {}", e);
+            vlog(
+              stlog.info,
+              "Error processing run_housekeeping_job({}): {}",
+              ctx,
+              e);
         }
     }
 }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -379,14 +379,14 @@ ss::future<> log_manager::run_housekeeping_job(
             auto e = std::current_exception();
             if (ssx::is_shutdown_exception(e)) {
                 vlog(
-                  stlog.debug,
+                  gclog.debug,
                   "Shutdown error caught in run_housekeeping_job({}): {}",
                   ctx,
                   e);
                 continue;
             }
             vlog(
-              stlog.info,
+              gclog.info,
               "Error processing run_housekeeping_job({}): {}",
               ctx,
               e);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -19,6 +19,7 @@
 #include "resource_mgmt/memory_groups.h"
 #include "ssx/async-clear.h"
 #include "ssx/future-util.h"
+#include "ssx/watchdog.h"
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/disk_log_impl.h"
@@ -380,6 +381,13 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         if (!current_log.link.is_linked()) {
             continue;
         }
+
+        // Until we better implement bailing out of compaction, the best thing
+        // we can do for observability is add a watchdog here.
+        ssx::watchdog wd5m(5min, [ntp = current_log.handle->config().ntp()] {
+            vlog(
+              gclog.warn, "{}: Housekeeping process exceeding 5 minutes", ntp);
+        });
 
         // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
         // the removal of the parent object. this makes awaiting housekeeping

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -229,6 +229,14 @@ public:
         return nullptr;
     }
 
+    /// Returns the log meta for the specified ntp.
+    log_housekeeping_meta* get_log_meta(const model::ntp& ntp) {
+        if (auto it = _logs.find(ntp); it != _logs.end()) {
+            return it->second.get();
+        }
+        return nullptr;
+    }
+
     /// Returns all ntp's managed by this instance
     absl::flat_hash_set<model::ntp> get_all_ntps() const;
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -276,6 +276,8 @@ private:
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
 
     bool _gc_triggered{false};
+    ssx::semaphore _gc_sem{0, "log_manager::gc"};
+
     disk_space_alert _disk_space_alert{disk_space_alert::ok};
 
     std::optional<batch_cache_index> create_cache(with_cache);

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -272,9 +272,11 @@ private:
      */
     ss::future<> housekeeping();
     ss::future<> housekeeping_loop();
+    ss::future<> housekeeping_scan(model::timestamp);
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
-    disk_space_alert _disk_space_alert{disk_space_alert::ok};
+
     bool _gc_triggered{false};
+    disk_space_alert _disk_space_alert{disk_space_alert::ok};
 
     std::optional<batch_cache_index> create_cache(with_cache);
 
@@ -282,15 +284,13 @@ private:
     ss::future<> maybe_clear_kvstore(const ntp_config&);
     ss::future<> async_clear_logs();
 
-    ss::future<> housekeeping_scan(model::timestamp);
-
     void update_log_count();
 
     log_config _config;
     kvstore& _kvstore;
     storage_resources& _resources;
     ss::sharded<features::feature_table>& _feature_table;
-    simple_time_jitter<ss::lowres_clock> _jitter;
+    simple_time_jitter<ss::lowres_clock> _housekeeping_jitter;
     simple_time_jitter<ss::lowres_clock> _trigger_gc_jitter;
     logs_type _logs;
     compaction_list_type _logs_list;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -279,10 +279,21 @@ private:
     ss::future<> run_housekeeping_job(
       std::function<ss::future<>()> loop_func, std::string_view ctx);
 
+    // The housekeeping loop, which runs according to
+    // `log_compaction_interval_ms`. Calls into log->housekeeping() serially,
+    // which invokes garbage collection and then compaction.
     ss::future<> housekeeping_loop();
     ss::future<> housekeeping_scan(model::timestamp);
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};
 
+    // The garbage collection loop, which waits for urgent garbage collection to
+    // be triggered by space management via trigger_gc(), or by an update to
+    // disk alerts via handle_disk_notification(). In order of estimated
+    // reclaimable space, per-partition garbage collection futures are kicked
+    // off and waited on. This loop runs in a detached fibre
+    // concurrently with housekeeping_loop(), and therefore considerations about
+    // scheduling/early bailing out of compaction must be taken.
+    ss::future<> gc_loop();
     bool _gc_triggered{false};
     ssx::semaphore _gc_sem{0, "log_manager::gc"};
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -266,11 +266,11 @@ private:
       std::vector<model::record_batch_type> translator_batch_types);
     ss::future<> clean_close(ss::shared_ptr<storage::log>);
 
-    /**
-     * \brief delete old segments and trigger compacted segments
-     *        runs inside a seastar thread
-     */
-    ss::future<> housekeeping();
+    // Kicks off a housekeeping job loop behind the local `_gate`, catching any
+    // exceptions that may occur.
+    ss::future<> run_housekeeping_job(
+      std::function<ss::future<>()> loop_func, std::string_view ctx);
+
     ss::future<> housekeeping_loop();
     ss::future<> housekeeping_scan(model::timestamp);
     ssx::semaphore _housekeeping_sem{0, "log_manager::housekeeping"};

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -19,6 +19,7 @@
 #include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
 #include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "random/generators.h"
@@ -5692,4 +5693,92 @@ FIXTURE_TEST(compaction_scheduling, storage_test_fixture) {
     for (auto& log : logs) {
         auto batches = read_and_validate_all_batches(log);
     }
+}
+
+// Ensures that the log_housekeeping_meta level locking/concurrency in
+// the log_manager is race free during ntp removal, addition, and housekeeping.
+// By allowing regular housekeeping to run on a quick interval and also
+// triggering urgent garbage collection, we create contention over a log_meta's
+// housekeeping lock, all while ntps are being concurrently removed.
+FIXTURE_TEST(
+  log_manager_concurrent_housekeeping_and_removal, storage_test_fixture) {
+#ifdef NDEBUG
+    int num_rounds = 100;
+#else
+    int num_rounds = 50;
+#endif
+
+    ss::abort_source as;
+    static constexpr auto abort_func_sleep = 100ms;
+    static constexpr auto manage_func_sleep = 25ms;
+    static constexpr auto remove_func_sleep = 50ms;
+    static constexpr auto trigger_gc_func_sleep = 50ms;
+    static constexpr auto log_compaction_interval_ms = 50ms;
+
+    auto log_cfg = default_log_config(test_dir);
+    log_cfg.compaction_interval
+      = config::mock_binding<std::chrono::milliseconds>(
+        log_compaction_interval_ms);
+    storage::log_manager mgr = make_log_manager(log_cfg);
+    mgr.start().get();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction
+                                 | model::cleanup_policy_bitflags::deletion;
+
+    ov.min_cleanable_dirty_ratio = tristate<double>{};
+
+    auto abort_fut = ss::do_until(
+                       [&] { return num_rounds == 0; },
+                       [&]() {
+                           --num_rounds;
+                           return ss::sleep(abort_func_sleep);
+                       })
+                       .then([&]() {
+                           as.request_abort();
+                           return ss::now();
+                       });
+
+    auto manage_ntp_fut = ss::do_until(
+      [&] { return as.abort_requested(); },
+      [&]() {
+          auto ntp = model::random_ntp();
+          ntp.ns = model::kafka_namespace;
+          return mgr
+            .manage(storage::ntp_config(
+              ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+            .then([]([[maybe_unused]] auto log) {
+                return ss::sleep(manage_func_sleep);
+            });
+      });
+
+    auto remove_ntp_fut = ss::do_until(
+      [&] { return as.abort_requested(); },
+      [&]() {
+          auto managed_ntps = mgr.get_all_ntps();
+          if (managed_ntps.empty()) {
+              return ss::now();
+          }
+
+          auto ntp_to_remove = random_generators::random_choice(
+            std::vector<model::ntp>(managed_ntps.begin(), managed_ntps.end()));
+          return mgr.remove(ntp_to_remove).then([]() {
+              return ss::sleep(remove_func_sleep);
+          });
+      });
+
+    auto trigger_gc_fut = ss::do_until(
+      [&] { return as.abort_requested(); },
+      [&]() {
+          mgr.trigger_gc();
+          return ss::sleep(trigger_gc_func_sleep);
+      });
+
+    ss::when_all(
+      std::move(abort_fut),
+      std::move(manage_ntp_fut),
+      std::move(trigger_gc_fut),
+      std::move(remove_ntp_fut))
+      .get();
 }

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -319,7 +319,7 @@ class FullDiskReclaimTest(RedpandaTest):
             metric_name=
             "vectorized_storage_manager_housekeeping_log_processed_total",
             metrics_endpoint=MetricsEndpoint.METRICS
-        ) == 0, "Housekeeping should not have run yet"
+        ) == 0, "Housekeeping should not have run"
 
         assert self.redpanda.metric_sum(
             metric_name="vectorized_storage_manager_urgent_gc_runs_total",
@@ -342,11 +342,12 @@ class FullDiskReclaimTest(RedpandaTest):
             timeout_sec=10,
             backoff_sec=2)
 
+        # Disk space alerts only triggers urgent gc, not housekeeping.
         assert self.redpanda.metric_sum(
             metric_name=
             "vectorized_storage_manager_housekeeping_log_processed_total",
             metrics_endpoint=MetricsEndpoint.METRICS
-        ) > 0, "Housekeeping should have run"
+        ) == 0, "Housekeeping should not have run"
 
         assert self.redpanda.metric_sum(
             metric_name="vectorized_storage_manager_urgent_gc_runs_total",


### PR DESCRIPTION
This PR splits the housekeeping work done in `log_manager::housekeeping_loop()` into two separate background fibers.

The two background fibers are `log_manager::gc_loop()`, and `log_manager::housekeeping_loop()`.

`log_manager::gc_loop()` handles the urgent garbage collection triggered by resource management and disk space alerts- like before, a semaphore being waited upon is triggered by one of these events, and we attempt to reclaim space from the logs via the `log_eviction_stm` in `log->gc()`.

There is another important change in behavior here though- garbage collection of many logs in the `log_manager` are scheduled at once and waited upon. The fast path to acquire units from a housekeeping lock in `log_housekeeping_meta` is attempted, and if the units aren't acquired, it is because a compaction operation is currently taking place for that log. To prevent blocking `gc_loop()`, garbage collection for that log is aborted early.

`log_manager::housekeeping_loop()` is responsible for invoking garbage collection and then the compaction of a log through `log->housekeeping()`. This still has to be performed serially, as we only allocate one block of memory per shard for sliding window compaction.

All of this has the effect that, concurrently, we can be performing garbage collection of `N-1` logs WHILE compacting 1 log, instead of performing everything serially in one background fiber.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Makes urgent garbage collection and compaction of logs separate, concurrent processes.
