### PR TITLE
k/server/tests: reset leaders table on restart

### DIFF
--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -176,6 +176,7 @@ FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
     wait_for_controller_leadership().get();
     info("Creating {} with {} partitions", test_tp, 3);
     create_topic(test_tp(), 3, 1);
+    wait_until_topic_status(test_tp, kafka::error_code::none).get();
     info("Deleting {}", test_tp);
     delete_topics({test_tp});
     wait_until_topic_status(

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -122,18 +122,6 @@ public:
               });
         });
     }
-
-    void restart() {
-        shutdown();
-        app_signal = std::make_unique<::stop_signal>();
-        ss::smp::invoke_on_all([] {
-            auto& config = config::shard_local_cfg();
-            config.get("disable_metrics").set_value(false);
-        }).get();
-        app.initialize(proxy_config(), proxy_client_config());
-        app.check_environment();
-        app.wire_up_and_start(*app_signal, true);
-    }
 };
 
 FIXTURE_TEST(test_topic_recreation, recreate_test_fixture) {
@@ -184,7 +172,7 @@ FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
       test_tp, kafka::error_code::unknown_topic_or_partition)
       .get();
     info("Restarting redpanda, first time");
-    restart();
+    restart(should_wipe::no);
     wait_for_controller_leadership().get();
     info("Creating {} with {} partitions", test_tp, 3);
     create_topic(test_tp(), 3, 1);
@@ -197,7 +185,7 @@ FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {
     create_topic(test_tp(), 3, 1);
     wait_until_topic_status(test_tp, kafka::error_code::none).get();
     info("Restarting redpanda, second time");
-    restart();
+    restart(should_wipe::no);
     info("Waiting for recovery");
     wait_for_controller_leadership().get();
     wait_until_topic_status(test_tp, kafka::error_code::none).get();
@@ -272,7 +260,7 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
             })
           .get();
     info("Restarting redpanda");
-    restart();
+    restart(should_wipe::no);
 
     // make sure we can read the same amount of data
     {

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -280,6 +280,9 @@ public:
         app.initialize(proxy_config(), proxy_client_config());
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);
+        app.controller->get_partition_leaders()
+          .invoke_on_all([](cluster::partition_leaders_table& t) { t.reset(); })
+          .get();
     }
 
     config::configuration& lconf() { return config::shard_local_cfg(); }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
