### PR TITLE
`rptest`: set `APPLICATION_GLOBAL` provider for `AWS` in `nessie_catalog`

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -123,6 +123,9 @@ class NessieCatalog(CatalogService):
             d_flags += f"-Dmy-secrets-default.name={self.credentials.access_key} "
             d_flags += f"-Dmy-secrets-default.secret={self.credentials.secret_key} "
             d_flags += "-Dnessie.catalog.validate-secrets=true"
+        elif isinstance(self.credentials,
+                        cloud_storage.AWSInstanceMetadataCredentials):
+            d_flags += "-Dnessie.catalog.service.s3.default-options.default-options.server-auth-mode=APPLICATION_GLOBAL"
         return d_flags
 
     def _java_cmd(self, node):


### PR DESCRIPTION
 set APPLICATION_GLOBAL provider for AWS in nessie_catalog In order to allow `nessie` to fetch credentials [through the default provider](https://projectnessie.org/nessie-0-93-1/configuration/#s3-default-bucket-settings) in AWS CDT testing.

Currently, `nessie_catalog_smoke_test.py` fails with the error 

```
pyiceberg.exceptions.BadRequestError: IllegalArgumentException: Location for ICEBERG_TABLE 'test_ns.bids' cannot be associated with any configured object storage location: Missing access key and secret for STATIC authentication mode
```

in [AWS CDT](https://buildkite.com/redpanda/vtools/builds/20722#01952786-7c79-4873-99f9-298104f8d5f1).

This change should fix the authentication mode for AWS runs.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
