### PR TITLE
Partition field source columns should be primitive typed

### DIFF
--- a/src/v/iceberg/partition.cc
+++ b/src/v/iceberg/partition.cc
@@ -35,7 +35,9 @@ std::optional<partition_spec> partition_spec::resolve(
     for (const auto& field : spec.fields) {
         const auto* source_field = schema_type.find_field_by_name(
           field.source_name);
-        if (!source_field) {
+        if (
+          !source_field
+          || !std::holds_alternative<primitive_type>(source_field->type)) {
             return std::nullopt;
         }
 

--- a/src/v/iceberg/tests/compatibility_test.cc
+++ b/src/v/iceberg/tests/compatibility_test.cc
@@ -387,7 +387,6 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           auto& dst_list = get<list_type>(dst.fields.back());
           return updated(*src_list.element_field, *dst_list.element_field);
       },
-    .pspec = "(qux)",
   },
   struct_evolution_test_case{
     .description = "evolving a list-element struct is allowed",
@@ -446,7 +445,6 @@ static const std::vector<struct_evolution_test_case> valid_cases{
           return updated(*src_map.key_field, *dst_map.key_field)
                  && updated(*src_map.value_field, *dst_map.value_field);
       },
-    .pspec = "(a_map)",
   },
   struct_evolution_test_case{
     .description = "we can 'add' nested fields",
@@ -548,7 +546,6 @@ static const std::vector<struct_evolution_test_case> valid_cases{
                  && dst_nested.fields.empty()
                  && removed(*src_nested.fields.back());
       },
-    .pspec = "(nested)", // TODO(oren): seems wrong frankly, should this fail?
   },
   struct_evolution_test_case{
     .description
@@ -676,7 +673,6 @@ static const std::vector<struct_evolution_test_case> valid_cases{
     // should reordered fields in a schema correspond to some parquet layout
     // change on disk?
     .any_change = schema_changed::no,
-    .pspec = "(quux,location)",
   },
   struct_evolution_test_case{
     .description

--- a/src/v/iceberg/tests/partition_test.cc
+++ b/src/v/iceberg/tests/partition_test.cc
@@ -235,3 +235,47 @@ TEST(PartitionTest, TestSpecResolve) {
         ASSERT_EQ(resolved, std::nullopt);
     }
 }
+
+TEST(PartitionTest, TestInvalidSpecResolve) {
+    auto schema_field_type = test_nested_schema_type();
+    const auto& schema_type = std::get<struct_type>(schema_field_type);
+
+    {
+        // spec with struct source field
+        auto input = chunked_vector<unresolved_partition_spec::field>::single(
+          unresolved_partition_spec::field{
+            .source_name = {"person"},
+            .transform = identity_transform{},
+            .name = "field1",
+          });
+        auto resolved = partition_spec::resolve(
+          unresolved_partition_spec{.fields = std::move(input)}, schema_type);
+        ASSERT_FALSE(resolved.has_value());
+    }
+
+    {
+        // spec with list source field
+        auto input = chunked_vector<unresolved_partition_spec::field>::single(
+          unresolved_partition_spec::field{
+            .source_name = {"qux"},
+            .transform = identity_transform{},
+            .name = "field1",
+          });
+        auto resolved = partition_spec::resolve(
+          unresolved_partition_spec{.fields = std::move(input)}, schema_type);
+        ASSERT_FALSE(resolved.has_value());
+    }
+
+    {
+        // spec with map source field
+        auto input = chunked_vector<unresolved_partition_spec::field>::single(
+          unresolved_partition_spec::field{
+            .source_name = {"quux"},
+            .transform = identity_transform{},
+            .name = "field1",
+          });
+        auto resolved = partition_spec::resolve(
+          unresolved_partition_spec{.fields = std::move(input)}, schema_type);
+        ASSERT_FALSE(resolved.has_value());
+    }
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

From https://iceberg.apache.org/spec/#partitioning:

>The source columns, selected by ids, must be a primitive type and cannot be contained in a map or list, but may be nested in a struct.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
