### PR TITLE
datalake: introduced function converting partition key to path

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -627,3 +627,27 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "partition_key_path",
+    srcs = [
+        "partition_key_path.cc",
+    ],
+    hdrs = [
+        "partition_key_path.h",
+    ],
+    include_prefix = "datalake",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":base_types",
+        ":logger",
+        "//src/v/base",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/iceberg:partition_key",
+        "//src/v/ssx:sformat",
+        "//src/v/utils:base64",
+        "@abseil-cpp//absl/strings",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/partition_key_path.cc
+++ b/src/v/datalake/partition_key_path.cc
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/partition_key_path.h"
+
+#include "base/vlog.h"
+#include "bytes/iobuf_parser.h"
+#include "datalake/logger.h"
+#include "ssx/sformat.h"
+#include "utils/base64.h"
+
+#include <absl/strings/str_replace.h>
+#include <fmt/chrono.h>
+namespace datalake {
+namespace {
+// AWS S3 path size limit is 1024 bytes, we allow a single key to be up to 64
+// bytes of size.
+static constexpr size_t max_key_value_length = 64;
+static constexpr size_t max_path_length = 512;
+
+size_t limited_size(const iobuf& original) {
+    return std::min(original.size_bytes(), max_key_value_length);
+}
+
+std::chrono::microseconds
+get_sub_seconds(const std::chrono::system_clock::time_point& tp) {
+    return std::chrono::microseconds(tp.time_since_epoch().count())
+           - std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::duration_cast<std::chrono::seconds>(
+               tp.time_since_epoch()));
+}
+/**
+ * Return true if the given time point can not be represented as full
+ * milliseconds and it requires microsecond precision
+ */
+bool has_millisecond_fraction(std::chrono::microseconds sub_seconds_us) {
+    // round to full milliseconds
+    const auto sub_seconds_ms
+      = std::chrono::duration_cast<std::chrono::milliseconds>(sub_seconds_us);
+
+    return sub_seconds_us
+             - std::chrono::duration_cast<std::chrono::microseconds>(
+               sub_seconds_ms)
+           != std::chrono::microseconds(0);
+}
+
+ss::sstring format_timestamp(size_t value, bool include_zone) {
+    std::chrono::system_clock::time_point tp{std::chrono::microseconds(value)};
+    const auto sub_seconds_us = get_sub_seconds(tp);
+
+    if (sub_seconds_us == std::chrono::microseconds(0)) {
+        if (include_zone) {
+            return ssx::sformat("{:%Y-%m-%dT%H:%M:%S}{:%z}", tp, tp);
+        }
+        return ssx::sformat("{:%Y-%m-%dT%H:%M:%S}Z", tp);
+    }
+
+    if (has_millisecond_fraction(sub_seconds_us)) {
+        if (include_zone) {
+            return ssx::sformat(
+              "{:%Y-%m-%dT%H:%M:%S}.{:06}{:%z}",
+              tp,
+              get_sub_seconds(tp).count(),
+              tp);
+        }
+        return ssx::sformat(
+          "{:%Y-%m-%dT%H:%M:%S}.{:06}Z", tp, get_sub_seconds(tp).count());
+    }
+
+    // no millisecond fraction
+    const auto sub_seconds_ms
+      = std::chrono::duration_cast<std::chrono::milliseconds>(sub_seconds_us);
+
+    if (include_zone) {
+        return ssx::sformat(
+          "{:%Y-%m-%dT%H:%M:%S}.{:03}{:%z}", tp, sub_seconds_ms.count(), tp);
+    }
+    return ssx::sformat(
+      "{:%Y-%m-%dT%H:%M:%S}.{:03}Z", tp, sub_seconds_ms.count());
+}
+/**
+ * Default formatting rules used for identity type
+ */
+struct primitive_formatting_visitor {
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::boolean_value& v) {
+        return fmt::to_string(v.val);
+    }
+    checked<ss::sstring, partition_key_error> operator()(const auto& v) {
+        return fmt::to_string(v.val);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::date_value& v) {
+        const std::chrono::system_clock::time_point tp{
+          std::chrono::days(v.val)};
+
+        return ssx::sformat("{:%Y-%m-%d}", tp);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::time_value& v) {
+        std::chrono::hh_mm_ss tp(std::chrono::microseconds(v.val));
+        const auto sub_seconds_us = std::chrono::microseconds(
+          tp.subseconds().count());
+        if (sub_seconds_us == std::chrono::microseconds(0)) {
+            return ssx::sformat(
+              "{:02}:{:02}:{:02}",
+              tp.hours().count(),
+              tp.minutes().count(),
+              tp.seconds().count());
+        }
+
+        if (has_millisecond_fraction(sub_seconds_us)) {
+            return ssx::sformat(
+              "{:02}:{:02}:{:02}.{:06}",
+              tp.hours().count(),
+              tp.minutes().count(),
+              tp.seconds().count(),
+              sub_seconds_us.count());
+        }
+        const auto sub_seconds_ms
+          = std::chrono::duration_cast<std::chrono::milliseconds>(
+            sub_seconds_us);
+
+        return ssx::sformat(
+          "{:02}:{:02}:{:02}.{:03}",
+          tp.hours().count(),
+          tp.minutes().count(),
+          tp.seconds().count(),
+          sub_seconds_ms.count());
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::timestamp_value& v) {
+        return format_timestamp(v.val, false);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::timestamptz_value& v) {
+        return format_timestamp(v.val, true);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::string_value& v) {
+        iobuf_const_parser p(v.val);
+        auto ret = p.read_string(limited_size(v.val));
+        return ret;
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::uuid_value& v) {
+        return fmt::to_string(v.val);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::fixed_value& v) {
+        return iobuf_to_base64(v.val, limited_size(v.val));
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::binary_value& v) {
+        return iobuf_to_base64(v.val, limited_size(v.val));
+    }
+};
+
+template<typename DurationT>
+checked<ss::sstring, partition_key_error>
+format_time_transform_key(const iceberg::primitive_value& value) {
+    if (!std::holds_alternative<iceberg::int_value>(value)) {
+        return partition_key_error("time transform expects an integer value");
+    }
+    auto v = std::get<iceberg::int_value>(value);
+
+    std::chrono::system_clock::time_point tp{std::chrono::milliseconds(0)};
+    // offset epoch by the given duration
+    tp += DurationT(v.val);
+
+    if constexpr (std::is_same_v<std::chrono::years, DurationT>) {
+        return ssx::sformat("{:%Y}", tp);
+    }
+
+    if constexpr (std::is_same_v<std::chrono::months, DurationT>) {
+        return ssx::sformat("{:%Y-%m}", tp);
+    }
+
+    if constexpr (std::is_same_v<std::chrono::days, DurationT>) {
+        return ssx::sformat("{:%Y-%m-%d}", tp);
+    }
+
+    if constexpr (std::is_same_v<std::chrono::hours, DurationT>) {
+        return ssx::sformat("{:%Y-%m-%d-%H}", tp);
+    }
+}
+
+struct transform_value_formatting_visitor {
+    explicit transform_value_formatting_visitor(
+      const iceberg::primitive_value& v)
+      : value(v) {}
+    // This case handles:
+    // - Identity transform
+    // - Truncation transform
+    checked<ss::sstring, partition_key_error> operator()(const auto&) {
+        return std::visit(primitive_formatting_visitor{}, value);
+    }
+
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::year_transform&) {
+        return format_time_transform_key<std::chrono::years>(value);
+    }
+
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::month_transform&) {
+        return format_time_transform_key<std::chrono::months>(value);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::day_transform&) {
+        return format_time_transform_key<std::chrono::days>(value);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::hour_transform&) {
+        return format_time_transform_key<std::chrono::hours>(value);
+    }
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::void_transform&) {
+        return "null";
+    }
+
+    const iceberg::primitive_value& value;
+};
+
+struct value_formatting_visitor {
+    checked<ss::sstring, partition_key_error>
+    operator()(const iceberg::primitive_value& v) {
+        return std::visit(primitive_formatting_visitor{}, v);
+    }
+    checked<ss::sstring, partition_key_error> operator()(const auto&) {
+        return partition_key_error(
+          "non primitive iceberg partition values are not supported");
+    }
+};
+
+checked<ss::sstring, partition_key_error> escape(std::string_view s) {
+    if (!is_valid_utf8(s)) {
+        return partition_key_error("Invalid UTF-8 string, unable to escape");
+    }
+    static constexpr std::
+      array<std::pair<absl::string_view, absl::string_view>, 24>
+        encode_lut = {
+          {{"&", "%26"}, {"$", "%24"},  {"@", "%40"}, {"=", "%3D"},
+           {";", "%3B"}, {"/", "%2F"},  {":", "%3A"}, {"+", "%2B"},
+           {" ", "%20"}, {",", "%2C"},  {"?", "%3F"}, {"\"", "%22"},
+           {"#", "%23"}, {"%", "%25"},  {"<", "%3C"}, {">", "%3E"},
+           {"[", "%5B"}, {"\\", "%5C"}, {"]", "%5D"}, {"^", "%5E"},
+           {"`", "%60"}, {"{", "%7B"},  {"|", "%7C"}, {"}", "%7D"}}};
+
+    return absl::StrReplaceAll(s, encode_lut);
+}
+
+checked<ss::sstring, partition_key_error> format_field_value(
+  const iceberg::transform& transform,
+  const std::optional<iceberg::value>& value) {
+    if (!value) {
+        return "null";
+    }
+    if (!std::holds_alternative<iceberg::primitive_value>(*value)) {
+        return partition_key_error(
+          "non primitive iceberg partition values are not supported");
+    }
+    auto res = std::visit(
+      transform_value_formatting_visitor{
+        std::get<iceberg::primitive_value>(*value)},
+      transform);
+    if (res.has_error()) {
+        return res.error();
+    }
+    return escape(res.value());
+}
+} // namespace
+
+checked<remote_path, partition_key_error> partition_key_to_path(
+  const iceberg::partition_spec& spec, const iceberg::partition_key& key) {
+    std::filesystem::path ret;
+
+    if (!key.val) {
+        return partition_key_error{"Partition key value is missing"};
+    }
+
+    if (spec.fields.size() != key.val->fields.size()) {
+        return partition_key_error{ssx::sformat(
+          "Partition key/spec mismatch.The key has {} fields, but the spec has "
+          "{} fields",
+          key.val->fields.size(),
+          spec.fields.size())};
+    }
+    size_t total_length = 0;
+    for (size_t i = 0; i < spec.fields.size(); i++) {
+        auto& field = spec.fields[i];
+        const auto& value = key.val->fields[i];
+        auto formatting_res = format_field_value(field.transform, value);
+        if (formatting_res.has_error()) {
+            return formatting_res.error();
+        }
+        auto element_key = escape(field.name);
+        if (element_key.has_error()) {
+            return element_key.error();
+        }
+        auto element = ssx::sformat(
+          "{}={}", element_key.value(), formatting_res.value());
+        total_length += element.size() + 1;
+        if (total_length > max_path_length) {
+            static constexpr auto rate_limit = std::chrono::seconds(5);
+            static thread_local ss::logger::rate_limit rate(rate_limit);
+            vloglr(
+              datalake_log,
+              ss::log_level::warn,
+              rate,
+              "Partition key path {}, exceeds the maximum length of {} bytes, "
+              "truncating",
+              ret,
+              max_path_length);
+            break;
+        }
+
+        ret /= std::filesystem::path(std::move(element));
+    }
+
+    return remote_path(std::move(ret));
+}
+
+} // namespace datalake

--- a/src/v/datalake/partition_key_path.h
+++ b/src/v/datalake/partition_key_path.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/outcome.h"
+#include "datalake/base_types.h"
+#include "iceberg/partition_key.h"
+namespace datalake {
+/**
+ * Error in partition key to path conversion
+ */
+class partition_key_error : std::exception {
+public:
+    explicit partition_key_error(std::string msg) noexcept
+      : msg_(std::move(msg)) {}
+
+    const char* what() const noexcept final { return msg_.c_str(); }
+
+private:
+    std::string msg_;
+};
+
+/**
+ * Converts a partition key value described by the partition spec to an object
+ * store path.
+ *
+ * The value is converted to the string representation based on the transform
+ * type and the key value. The path is constructed by concatenating the key
+ * fields in the form of: <field_name>=<field_value> subsequent fields are
+ * separated with '/'.
+ *
+ * The value to string conversion is not described explicitly in the Iceberg
+ * spec. The conversion is based on the reference implementation:
+ *
+ * https://github.com/apache/iceberg/blob/fad0c1e6c68fbc7e48b5b17c02ed9c26a2693afb/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L206
+ *
+ * The conversion is done based on the following rules:
+ * - Identity and truncate transform result values are rendered based on the
+ *   source field type
+ * - Bucket transform value is rendered as an integer
+ * - Time transform values are rendered as a string representing date/time
+ *
+ * Returned path elements are url encoded.
+ */
+checked<remote_path, partition_key_error> partition_key_to_path(
+  const iceberg::partition_spec& spec, const iceberg::partition_key& key);
+} // namespace datalake

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -420,3 +420,19 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "partition_key_path_test",
+    timeout = "short",
+    srcs = [
+        "partition_key_path_test.cc",
+    ],
+    deps = [
+        ":test_data",
+        "//src/v/datalake:partition_key_path",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/tests/partition_key_path_test.cc
+++ b/src/v/datalake/tests/partition_key_path_test.cc
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/partition_key_path.h"
+#include "datalake/tests/test_data.h"
+
+#include <gmock/gmock.h>
+
+using namespace datalake;
+using namespace std::chrono_literals;
+struct test_context {
+    iceberg::partition_spec spec;
+    iceberg::partition_key key;
+};
+
+test_context make_identity_partitions_spec() {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_bool"},
+      .transform = iceberg::identity_transform{},
+      .name = "bool_partition",
+    });
+
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_int"},
+      .transform = iceberg::identity_transform{},
+      .name = "int_partition",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_long"},
+      .transform = iceberg::identity_transform{},
+      .name = "long_test_partition",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_float"},
+      .transform = iceberg::identity_transform{},
+      .name = "fl_partition",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_double"},
+      .transform = iceberg::identity_transform{},
+      .name = "d_partition",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_decimal"},
+      .transform = iceberg::identity_transform{},
+      .name = "decimal_partition",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_date"},
+      .transform = iceberg::identity_transform{},
+      .name = "date_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_time"},
+      .transform = iceberg::identity_transform{},
+      .name = "time_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamptz"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamptz_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_string"},
+      .transform = iceberg::identity_transform{},
+      .name = "string_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_uuid"},
+      .transform = iceberg::identity_transform{},
+      .name = "uuid_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_fixed"},
+      .transform = iceberg::identity_transform{},
+      .name = "fixed_identity",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_binary"},
+      .transform = iceberg::identity_transform{},
+      .name = "binary_identity",
+    });
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+
+    key.val->fields.push_back(iceberg::boolean_value{.val = true});
+    key.val->fields.push_back(iceberg::int_value{.val = 128});
+    key.val->fields.push_back(iceberg::long_value{.val = 4096});
+    key.val->fields.push_back(iceberg::float_value{.val = 3.1415});
+    key.val->fields.push_back(iceberg::double_value{.val = 2.7182});
+    key.val->fields.push_back(
+      iceberg::decimal_value{.val = absl::int128{1231123}});
+    key.val->fields.push_back(iceberg::date_value{.val = 20140});
+    key.val->fields.push_back(iceberg::time_value{
+      .val = (std::chrono::hours(14) + 43min + 15s + 167ms) / 1us});
+    key.val->fields.push_back(
+      iceberg::timestamp_value{.val = 1740143929000000});
+    key.val->fields.push_back(
+      iceberg::timestamptz_value{.val = 1740143929000000});
+    key.val->fields.push_back(
+      iceberg::string_value{.val = iobuf::from("test_string_value")});
+    key.val->fields.push_back(iceberg::uuid_value{
+      .val = uuid_t::from_string("f47ac10b-58cc-4372-a567-0e02b2c3d479")});
+    key.val->fields.push_back(
+      iceberg::fixed_value{.val = iobuf::from("Hello world")});
+    key.val->fields.push_back(
+      iceberg::binary_value{.val = iobuf::from("PandasAreCuties")});
+
+    return test_context{.spec = std::move(*spec), .key = std::move(key)};
+}
+/**
+ * Test validating conversion of PartitionSpec containing only identity
+ * transforms, this is special case as the identity transform is the only one
+ * preserving the type of the field that it is calculated from.
+ */
+TEST(PartitionKeyPathConversionTest, TestIdentityTransform) {
+    auto [spec, key] = make_identity_partitions_spec();
+
+    auto res = partition_key_to_path(spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(
+      res.value()().string(),
+      "bool_partition=true/"
+      "int_partition=128/"
+      "long_test_partition=4096/"
+      "fl_partition=3.1415/"
+      "d_partition=2.7182/"
+      "decimal_partition=1231123/"
+      "date_identity=2025-02-21/"
+      "time_identity=14%3A43%3A15.167/"
+      "timestamp_identity=2025-02-21T13%3A18%3A49Z/"
+      "timestamptz_identity=2025-02-21T13%3A18%3A49%2B0000/"
+      "string_identity=test_string_value/"
+      "uuid_identity=f47ac10b-58cc-4372-a567-0e02b2c3d479/"
+      "fixed_identity=SGVsbG8gd29ybGQ%3D/"
+      "binary_identity=UGFuZGFzQXJlQ3V0aWVz");
+}
+
+TEST(PartitionKeyPathConversionTest, TestTimestampTransform) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_no_ms",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_ms",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_us",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamptz"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_tz_no_ms",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamptz"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_tz_ms",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamptz"},
+      .transform = iceberg::identity_transform{},
+      .name = "timestamp_tz_us",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_time"},
+      .transform = iceberg::identity_transform{},
+      .name = "time_s",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_time"},
+      .transform = iceberg::identity_transform{},
+      .name = "time_ms",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_time"},
+      .transform = iceberg::identity_transform{},
+      .name = "time_us",
+    });
+
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    // 10-02-2025 10:37:13
+    key.val->fields.push_back(
+      iceberg::timestamp_value{.val = 1739183833000000});
+    // 10-02-2025 10:37:13.321
+    key.val->fields.push_back(
+      iceberg::timestamp_value{.val = 1739183833321000});
+    // 10-02-2025 10:37:13.321123
+    key.val->fields.push_back(
+      iceberg::timestamp_value{.val = 1739183833321123});
+
+    // 10-02-2025 10:37:13
+    key.val->fields.push_back(
+      iceberg::timestamptz_value{.val = 1739183833000000});
+    // 10-02-2025 10:37:13.321
+    key.val->fields.push_back(
+      iceberg::timestamptz_value{.val = 1739183833321000});
+    // 10-02-2025 10:37:13.321123
+    key.val->fields.push_back(
+      iceberg::timestamptz_value{.val = 1739183833321123});
+
+    key.val->fields.push_back(
+      iceberg::time_value{.val = (std::chrono::hours(11) + 11min + 11s) / 1us});
+    key.val->fields.push_back(iceberg::time_value{
+      .val = (std::chrono::hours(11) + 11min + 11s + 456ms) / 1us});
+    key.val->fields.push_back(iceberg::time_value{
+      .val = (std::chrono::hours(11) + 11min + 11s + 789us) / 1us});
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(
+      res.value()().string(),
+      "timestamp_no_ms=2025-02-10T10%3A37%3A13Z/"
+      "timestamp_ms=2025-02-10T10%3A37%3A13.321Z/"
+      "timestamp_us=2025-02-10T10%3A37%3A13.321123Z/"
+      "timestamp_tz_no_ms=2025-02-10T10%3A37%3A13%2B0000/"
+      "timestamp_tz_ms=2025-02-10T10%3A37%3A13.321%2B0000/"
+      "timestamp_tz_us=2025-02-10T10%3A37%3A13.321123%2B0000/"
+      "time_s=11%3A11%3A11/"
+      "time_ms=11%3A11%3A11.456/"
+      "time_us=11%3A11%3A11.000789"
+
+    );
+}
+
+TEST(PartitionKeyPathConversionTest, TimeTransformsTest) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::year_transform{},
+      .name = "year_transform",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::month_transform{},
+      .name = "month_transform",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::day_transform{},
+      .name = "day_transform",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_timestamp"},
+      .transform = iceberg::hour_transform{},
+      .name = "hour_transform",
+    });
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    key.val->fields.push_back(iceberg::int_value{.val = 2025 - 1969});
+    key.val->fields.push_back(
+      iceberg::int_value{.val = (2025 - 1970) * 12 + 5});
+
+    key.val->fields.push_back(iceberg::int_value{
+      .val = std::chrono::floor<std::chrono::days>(
+               std::chrono::system_clock::time_point(
+                 std::chrono::seconds(1740396135))
+                 .time_since_epoch())
+               .count()});
+    key.val->fields.push_back(iceberg::int_value{
+      .val = std::chrono::floor<std::chrono::hours>(
+               std::chrono::system_clock::time_point(
+                 std::chrono::seconds(1740396135))
+                 .time_since_epoch())
+               .count()});
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(
+      res.value()().string(),
+      "year_transform=2025/"
+      "month_transform=2025-06/"
+      "day_transform=2025-02-24/"
+      "hour_transform=2025-02-24-11");
+}
+
+TEST(PartitionKeyPathConversionTest, VoidTransformTest) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_int"},
+      .transform = iceberg::void_transform{},
+      .name = "void_transform",
+    });
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    key.val->fields.push_back(iceberg::value{});
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(res.value()().string(), "void_transform=null");
+}
+
+TEST(PartitionKeyPathConversionTest, BucketTransformTest) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_int"},
+      .transform = iceberg::bucket_transform{},
+      .name = "bucket_transform",
+    });
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    key.val->fields.push_back(iceberg::int_value{.val = 32});
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(res.value()().string(), "bucket_transform=32");
+}
+
+TEST(PartitionKeyPathConversionTest, TestElementSizeLimiting) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_string"},
+      .transform = iceberg::identity_transform{},
+      .name = "identity_string",
+    });
+    u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+      .source_name = {"test_binary"},
+      .transform = iceberg::identity_transform{},
+      .name = "identity_binary",
+    });
+
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    key.val->fields.push_back(iceberg::string_value{
+      .val = iobuf::from(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque "
+        "ipsum magna, pellentesque quis nisl eu, congue aliquam id.")});
+    key.val->fields.push_back(iceberg::binary_value{
+      .val = iobuf::from(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque "
+        "ipsum magna, pellentesque quis nisl eu, congue aliquam id.")});
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+
+    ASSERT_EQ(
+      res.value()().string(),
+      "identity_string=Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%"
+      "20adipiscing%20elit.%20Pellent/"
+      "identity_binary="
+      "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxp"
+      "dC4gUGVsbGVudA%3D%3D");
+}
+
+TEST(PartitionKeyPathConversionTest, TestPathSizeLimitting) {
+    auto schema = test_schema(iceberg::field_required::yes);
+
+    iceberg::unresolved_partition_spec u_spec;
+    // create lots of partition keys
+    for (size_t i = 0; i < 64; ++i) {
+        u_spec.fields.push_back(iceberg::unresolved_partition_spec::field{
+          .source_name = {"test_int"},
+          .transform = iceberg::identity_transform{},
+          .name = fmt::format("identity_int_{}", i),
+        });
+    }
+
+    auto spec = iceberg::partition_spec::resolve(u_spec, schema);
+    iceberg::partition_key key;
+    key.val = std::make_unique<iceberg::struct_value>();
+    for (int i = 0; i < 64; ++i) {
+        key.val->fields.push_back(iceberg::int_value{.val = i});
+    }
+
+    auto res = partition_key_to_path(*spec, key);
+
+    ASSERT_FALSE(res.has_error());
+    // make sure the path is truncated
+    const auto path = res.value()().string();
+    ASSERT_LE(path.size(), 512);
+    // check the path ends wih the full segment
+    ASSERT_THAT(path, ::testing::EndsWith("identity_int_27=27"));
+}

--- a/src/v/utils/base64.cc
+++ b/src/v/utils/base64.cc
@@ -72,8 +72,9 @@ ss::sstring bytes_to_base64(bytes_view input) {
     return output;
 }
 
-ss::sstring iobuf_to_base64(const iobuf& input) {
-    const size_t output_capacity = encode_capacity(input.size_bytes());
+ss::sstring iobuf_to_base64(const iobuf& input, std::optional<size_t> limit) {
+    auto sz_bytes = limit.value_or(input.size_bytes());
+    const size_t output_capacity = encode_capacity(sz_bytes);
     ss::sstring output(ss::sstring::initialized_later{}, output_capacity);
     size_t written = 0;
 
@@ -83,7 +84,7 @@ ss::sstring iobuf_to_base64(const iobuf& input) {
     // encode each iobuf fragment
     iobuf::iterator_consumer input_it(input.cbegin(), input.cend());
     input_it.consume(
-      input.size_bytes(),
+      sz_bytes,
       [&state, &written, &output, output_capacity](const char* src, size_t sz) {
           size_t output_len;                          // NOLINT
           char* output_ptr = output.data() + written; // NOLINT

--- a/src/v/utils/base64.h
+++ b/src/v/utils/base64.h
@@ -40,7 +40,7 @@ ss::sstring base64_to_string(std::string_view);
 iobuf base64_to_iobuf(const iobuf&);
 
 // base64 <-> iobuf
-ss::sstring iobuf_to_base64(const iobuf&);
+ss::sstring iobuf_to_base64(const iobuf&, std::optional<size_t> = std::nullopt);
 
 /// \brief Used to decode URL encoded base64 values
 ///

--- a/src/v/utils/tests/base64_test.cc
+++ b/src/v/utils/tests/base64_test.cc
@@ -49,6 +49,16 @@ BOOST_AUTO_TEST_CASE(iobuf_type) {
     auto encoded = iobuf_to_base64(buf);
     auto decoded = base64_to_bytes(encoded);
     BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(buf));
+
+    auto encdec_limit = [](iobuf input, const auto expected, size_t sz_bytes) {
+        auto encoded = iobuf_to_base64(input, sz_bytes);
+        BOOST_REQUIRE_EQUAL(encoded, expected);
+        auto decoded = base64_to_bytes(encoded);
+        BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(input.share(0, sz_bytes)));
+    };
+
+    encdec_limit(iobuf::from("this is a string"), "dGhpcyBpcyA=", 8);
+    encdec_limit(iobuf::from("this"), "dGhpcw==", 8);
 }
 
 BOOST_AUTO_TEST_CASE(test_base64_to_iobuf) {


### PR DESCRIPTION
The value is converted to the string representation based on the transform type and the key value. The path is constructed by concatenating the key fields in the form of: <field_name>=<field_value> subsequent fields are separated with '/'.

The value to string conversion is not described explicitly in the Iceberg spec. The conversion is based on the reference implementation:

https://github.com/apache/iceberg/blob/fad0c1e6c68fbc7e48b5b17c02ed9c26a2693afb/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L206

The conversion is done based on the following rules:
- Identity and truncate transform result values are rendered based on the source field type
- Bucket transform value is rendered as an integer
- Time transform values are rendered as a string representing date/time

Returned path elements are url encoded.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
