### PR TITLE
kafka/server: fix case of use after move

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -626,18 +626,19 @@ public:
     ss::future<offset_fetch_response>
     handle_offset_fetch(offset_fetch_request&& r);
 
-    void insert_offset(model::topic_partition tp, offset_metadata md) {
+    void insert_offset(const model::topic_partition& tp, offset_metadata md) {
         if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
             o_it->second->metadata = std::move(md);
         } else {
             _offsets.emplace(
-              std::move(tp),
+              tp,
               std::make_unique<offset_metadata_with_probe>(
                 std::move(md), _id, tp, _enable_group_metrics));
         }
     }
 
-    bool try_upsert_offset(model::topic_partition tp, offset_metadata md) {
+    bool
+    try_upsert_offset(const model::topic_partition& tp, offset_metadata md) {
         if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
             if (o_it->second->metadata.log_offset < md.log_offset) {
                 o_it->second->metadata = std::move(md);
@@ -646,7 +647,7 @@ public:
             return false;
         } else {
             _offsets.emplace(
-              std::move(tp),
+              tp,
               std::make_unique<offset_metadata_with_probe>(
                 std::move(md), _id, tp, _enable_group_metrics));
             return true;


### PR DESCRIPTION
Fix a minor issue of a move-after-use.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none
