### PR TITLE
rpk: use `runtime.GO*` information instead of injecting it

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -9,8 +9,6 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
@@ -28,8 +26,6 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
@@ -46,8 +42,6 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
@@ -64,8 +58,6 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0
@@ -82,8 +74,6 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
-      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - CGO_ENABLED=0

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -28,8 +28,6 @@ var (
 	version   string // Semver of rpk.
 	rev       string // Short git SHA.
 	buildTime string // Timestamp of build time, RFC3339.
-	hostOs    string // OS that was used to built rpk (go env GOHOSTOS).
-	hostArch  string // Arch that was used to built rpk (go env GOHOSTARCH).
 )
 
 type rpkVersion struct {
@@ -70,7 +68,7 @@ To get only the rpk version, use 'rpk --version'.`,
 				GitRef:    rev,
 				BuildTime: buildTime,
 				GoVersion: runtime.Version(),
-				OsArch:    fmt.Sprintf("%s/%s", hostOs, hostArch),
+				OsArch:    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 			}
 			printRpkVersion(rv)
 			var rows redpandaVersions


### PR DESCRIPTION
The comments seem to think this goreleaser data is the host information,
it's not it the build target information, so we can remove it and
replace it with the variables in the `runtime` package.

This PR is a noop functionally because if I run `rpk version` on my macbook I get:

```
Version:     v24.3.5
Git ref:     ecec5278ad
Build date:  2025-02-03T22:31:04Z
OS/Arch:     darwin/arm64
Go version:  go1.23.1
```

Which I know we don't build rpk for homebrew on `darwin/arm64` in buildkite so we can remove the ldFlags for this because it's always the same as the `runtime` variables

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
