### PR TITLE
`storage`: add `disk_log_impl::reset_dirty_and_closed_bytes()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4116,7 +4116,21 @@ ss::future<> disk_log_impl::remove_kvstore_state(
       .discard_result();
 }
 
-double disk_log_impl::dirty_ratio() const {
+double disk_log_impl::dirty_ratio() {
+    // Sanity check/safety hatch against negative values
+    if (_dirty_segment_bytes < 0 || _closed_segment_bytes < 0) {
+        vlog(
+          stlog.info,
+          "{}: _dirty_segment_bytes ({}) and/or _closed_segment_bytes ({}) "
+          "have become negative - clearing counters and resumming over {} "
+          "segments in the log.",
+          config().ntp(),
+          _dirty_segment_bytes,
+          _closed_segment_bytes,
+          _segs.size());
+
+        reset_dirty_and_closed_bytes();
+    }
     // Avoid division by 0.
     return (_closed_segment_bytes == 0)
              ? 0.0
@@ -4163,6 +4177,21 @@ void disk_log_impl::subtract_segment_bytes(
         subtract_dirty_segment_bytes(bytes);
     }
     subtract_closed_segment_bytes(bytes);
+}
+
+void disk_log_impl::reset_dirty_and_closed_bytes() {
+    ssize_t dirty{0};
+    ssize_t closed{0};
+    for (const auto& seg : _segs) {
+        if (!seg->has_appender()) {
+            if (!seg->has_clean_compact_timestamp()) {
+                dirty += seg->size_bytes();
+            }
+            closed += seg->size_bytes();
+        }
+    }
+    _dirty_segment_bytes = dirty;
+    _closed_segment_bytes = closed;
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -267,7 +267,7 @@ public:
     // Returns the dirty ratio of the log.
     // The dirty ratio is the ratio of bytes in closed, dirty segments to the
     // total number of bytes in all closed segments in the log.
-    double dirty_ratio() const;
+    double dirty_ratio();
 
 private:
     friend class disk_log_appender; // for multi-term appends
@@ -503,6 +503,12 @@ private:
     // compaction or truncation. The argument `bytes` is removed from
     // closed_segment_bytes, and conditionally removed from dirty_segment_bytes.
     void subtract_segment_bytes(ss::lw_shared_ptr<segment> s, ssize_t bytes);
+
+    // Performs a manual O(n) reset of the dirty and closed bytes in the log by
+    // iterating over segment in the log. Used as a safety hatch in
+    // dirty_ratio() to prevent returning a bogus value due to improper
+    // book-keeping.
+    void reset_dirty_and_closed_bytes();
 
     bool _compaction_enabled;
 };

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5521,3 +5521,59 @@ FIXTURE_TEST(dirty_and_closed_bytes_bookkeeping, storage_test_fixture) {
         check_dirty_and_closed_segment_bytes(log);
     }
 }
+
+FIXTURE_TEST(
+  negative_dirty_and_closed_bytes_triggers_reset, storage_test_fixture) {
+    using namespace storage;
+    disk_log_builder b;
+    b | start();
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    const auto num_segs = 5;
+    const auto start_offset = 0;
+    const auto records_per_seg = 150;
+    for (int i = 0; i < num_segs; ++i) {
+        auto offset = start_offset + i * records_per_seg;
+        b | add_segment(offset)
+          | add_random_batch(
+            offset, records_per_seg, maybe_compress_batches::yes);
+        disk_log.force_roll(ss::default_priority_class()).get();
+    }
+
+    auto saved_dirty_segment_bytes = disk_log.dirty_segment_bytes();
+    auto saved_closed_segment_bytes = disk_log.closed_segment_bytes();
+    BOOST_REQUIRE_EQUAL(disk_log.size_bytes(), saved_dirty_segment_bytes);
+    BOOST_REQUIRE_EQUAL(saved_dirty_segment_bytes, saved_closed_segment_bytes);
+
+    // Add a large negative number to dirty segment bytes.
+    ssize_t large_negative_number
+      = -5 * static_cast<ssize_t>(disk_log.size_bytes());
+    b.add_dirty_segment_bytes(large_negative_number);
+
+    BOOST_REQUIRE_LT(disk_log.dirty_segment_bytes(), 0);
+    // Calling disk_log.dirty_ratio() will trigger
+    // disk_log_impl::reset_dirty_and_closed_bytes(), a safety hatch that should
+    // reset the dirty segment bytes to the proper value.
+    auto dirty_ratio = disk_log.dirty_ratio();
+
+    static const double epsilon = 1.0e-6;
+    BOOST_REQUIRE_CLOSE(dirty_ratio, 1.0, epsilon);
+
+    // Dirty segment bytes should be equal to its value before the bogus
+    // negative amount was added.
+    BOOST_REQUIRE_EQUAL(
+      saved_dirty_segment_bytes, disk_log.dirty_segment_bytes());
+
+    // We can repeat the same process with the closed segment bytes.
+    b.add_closed_segment_bytes(large_negative_number);
+
+    BOOST_REQUIRE_LT(disk_log.closed_segment_bytes(), 0);
+
+    // Trigger the safety hatch again.
+    dirty_ratio = disk_log.dirty_ratio();
+
+    BOOST_REQUIRE_CLOSE(dirty_ratio, 1.0, epsilon);
+
+    BOOST_REQUIRE_EQUAL(
+      saved_closed_segment_bytes, disk_log.closed_segment_bytes());
+}


### PR DESCRIPTION
By request: https://github.com/redpanda-data/redpanda/pull/25076#discussion_r1966830488

Acts as a safety hatch during calls to `disk_log_impl::dirty_ratio()` against negative, bogus values in `_dirty_segment_bytes` and `_closed_segment_bytes` by performing an `O(n)` summation of the proper dirty and closed bytes values over each segment in the log.

It is expected that `disk_log_impl::dirty_ratio()` is the public function used to probe these values by external services, and that is why the safety hatch is triggered there and not in one of the `add/subtract` functions. This approach also has the added benefit of allowing the `dassert()`s in those functions to still trigger on negative values, and help identify any potential remaining bugs in the bytes bookkeeping.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
