### PR TITLE
`rptest`: correct authentication property name in `nessie`

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -116,6 +116,7 @@ class NessieCatalog(CatalogService):
         """
         These options don't work nicely with conversion to env variable format.
         Specify them as Java -D properties instead.
+        https://projectnessie.org/nessie-latest/configuration/#s3-default-bucket-settings
         """
         d_flags = ""
         if isinstance(self.credentials, cloud_storage.S3Credentials):
@@ -125,7 +126,7 @@ class NessieCatalog(CatalogService):
             d_flags += "-Dnessie.catalog.validate-secrets=true"
         elif isinstance(self.credentials,
                         cloud_storage.AWSInstanceMetadataCredentials):
-            d_flags += "-Dnessie.catalog.service.s3.default-options.default-options.server-auth-mode=APPLICATION_GLOBAL"
+            d_flags += "-Dnessie.catalog.service.s3.default-options.auth-type=APPLICATION_GLOBAL"
         return d_flags
 
     def _java_cmd(self, node):


### PR DESCRIPTION
PR https://github.com/redpanda-data/redpanda/pull/25143 had the right idea, but at some point in `nessie`'s history, `nessie.catalog.service.s3.default-options.default-options.server-auth-mode` was changed to `nessie.catalog.service.s3.default-options.auth-type` (the PR mistakenly linked to old documentation. [The latest documentation shows this new property name here](https://projectnessie.org/nessie-latest/configuration/#s3-default-bucket-settings))

Correct it here.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
