### PR TITLE
gha/rpk-build: test and build multi os and arch

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -26,6 +26,11 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [amd64, arm64]
+        exclude:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +41,10 @@ jobs:
       - run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o rpk cmd/rpk/main.go
         working-directory: src/go/rpk/
   test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runner: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -21,21 +21,27 @@ on:
       - 'src/v/pandaproxy/schema_registry/protobuf/**'
       - '.github/workflows/rpk-build.yml'
 jobs:
-  test:
-    name: Test rpk
+  build:
     strategy:
       matrix:
-        os: [linux, darwin, windows]
-        arch: [amd64, arm64]
-    runs-on: ubuntu-latest
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    runs-on: ubuntu-24.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: stable
           cache-dependency-path: 'src/go/rpk/go.sum'
-      - name: Run tests
+      - run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o rpk cmd/rpk/main.go
         working-directory: src/go/rpk/
-        run: go run gotest.tools/gotestsum@v1.11.0 -- -cover ./...
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache-dependency-path: 'src/go/rpk/go.sum'
+      - run: go run gotest.tools/gotestsum@v1.12.0 -- -cover ./...
+        working-directory: src/go/rpk/


### PR DESCRIPTION
jira: [DEVPROD-2669]

The variables in the `matrix` of `rpk-build.yml` were not used, so all matrix tests were compiled and run on linux amd64.

This PR changes the workflow to run `gotestsum` on:
1. linux amd64
2. darwin arm64

And build (cross-compile) for:
1. linux arm64
2. darwin amd64
3. windows amd64
4. windows arm64

Ref:
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none

[DEVPROD-2669]: https://redpandadata.atlassian.net/browse/DEVPROD-2669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ