### PR TITLE
http/utils: changed url encoding to use upper case hex representation

### DIFF
--- a/src/v/http/tests/request_builder_test.cc
+++ b/src/v/http/tests/request_builder_test.cc
@@ -94,7 +94,7 @@ TEST(request_builder, test_url_percent_encoding) {
     ASSERT_TRUE(req.has_value());
     EXPECT_EQ(
       req->target(),
-      "/?afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
-      "40%5b%5dafgz0119=afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%"
-      "3f%40%5b%5dafgz0119");
+      "/?afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%"
+      "40%5B%5Dafgz0119=afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%"
+      "3F%40%5B%5Dafgz0119");
 }

--- a/src/v/http/tests/uri_encoding_test.cc
+++ b/src/v/http/tests/uri_encoding_test.cc
@@ -21,13 +21,13 @@ TEST(uri_encoding, encode_special_chars) {
     constexpr auto input = "afgz0119!#$&'()*+,/:;=?@[]afgz0119";
     ASSERT_EQ(
       http::uri_encode(input, http::uri_encode_slash::yes),
-      "afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
-      "40%5b%5dafgz0119");
+      "afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%"
+      "40%5B%5Dafgz0119");
 
     ASSERT_EQ(
       http::uri_encode(input, http::uri_encode_slash::no),
-      "afgz0119%21%23%24%26%27%28%29%2a%2b%2c/"
-      "%3a%3b%3d%3f%40%5b%5dafgz0119");
+      "afgz0119%21%23%24%26%27%28%29%2A%2B%2C/"
+      "%3A%3B%3D%3F%40%5B%5Dafgz0119");
 }
 
 TEST(uri_encoding, form_encoded_data) {
@@ -38,15 +38,15 @@ TEST(uri_encoding, form_encoded_data) {
     iobuf_parser p{http::form_encode_data(input)};
 
     // Order of kv pairs is not guaranteed due to map iteration order
+    auto s = p.read_string(p.bytes_left());
+    fmt::print(">>> {}\n", s);
     ASSERT_THAT(
-      p.read_string(p.bytes_left()),
+      s,
       AnyOf(
-        "foo=bar&afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%40%"
-        "5b%"
-        "5dafgz0119=afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
-        "40%"
-        "5b%5dafgz0119",
-        "afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%3b%3d%3f%"
-        "40%5b%5dafgz0119=afgz0119%21%23%24%26%27%28%29%2a%2b%2c%2F%3a%"
-        "3b%3d%3f%40%5b%5dafgz0119&foo=bar"));
+        "foo=bar&afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%"
+        "5Dafgz0119=afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%"
+        "5B%5Dafgz0119",
+        "afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%"
+        "40%5B%5Dafgz0119=afgz0119%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%"
+        "3B%3D%3F%40%5B%5Dafgz0119&foo=bar"));
 }

--- a/src/v/http/utils.cc
+++ b/src/v/http/utils.cc
@@ -11,16 +11,16 @@
 
 #include "http/utils.h"
 
-#include "bytes/bytes.h"
-
 #include <boost/algorithm/string/join.hpp>
-
 namespace {
-
+/**
+ * Each URI encoded byte is formed by a '%' and the two-digit hexadecimal
+ * value of the byte.
+ * from:
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+ */
 inline void append_hex_utf8(ss::sstring& result, char ch) {
-    bytes b = {static_cast<uint8_t>(ch)};
-    result.append("%", 1);
-    auto h = to_hex(b);
+    auto h = fmt::format("%{:02X}", static_cast<uint8_t>(ch));
     result.append(h.data(), h.size());
 }
 

--- a/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
+++ b/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
@@ -117,7 +117,7 @@ ss::future<http::downloaded_response> validate_token_request(
     std::ranges::sort(received);
 
     ss::sstring expected{
-      "grant_type=client_credentials&scope=PRINCIPAL_ROLE%3aALL&client_secret="
+      "grant_type=client_credentials&scope=PRINCIPAL_ROLE%3AALL&client_secret="
       "secret&client_id=id"};
     std::ranges::sort(expected);
 

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -127,7 +127,7 @@ ss::future<http::downloaded_response> handle_token_request(
     EXPECT_TRUE(query_params_equal(
       absl::flat_hash_map<ss::sstring, ss::sstring>{
         {"grant_type", "client_credentials"},
-        {"scope", "PRINCIPAL_ROLE%3aALL"},
+        {"scope", "PRINCIPAL_ROLE%3AALL"},
         {"client_secret", get_credentials().client_secret},
         {"client_id", get_credentials().client_id}},
       received));


### PR DESCRIPTION
According to the S3 documentation related with signature calculation the canonical URI format must be encoded and use the upper case characters in hexadecimal characters representation.

Document:
https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

This PR changes the canonical URI encode to use the upper case hexadecimal representation.

from @mmaslankaprv 
> This started to happen after we started including partition key in parquet file path. Previously our topic didn't have any special characters so the encoding wasn't required. I could make it part of the other PR but wanted this fix to be separate one as it is really independent from the other work.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none