### PR TITLE
Include partition key in the Iceberg data file location

### DIFF
--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -41,6 +41,7 @@ redpanda_cc_library(
         "//src/v/container:intrusive",
         "//src/v/hashing:secure",
         "//src/v/http",
+        "//src/v/http:utils",
         "//src/v/json",
         "//src/v/metrics",
         "//src/v/model",

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -19,6 +19,7 @@
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
 #include "config/configuration.h"
+#include "http/utils.h"
 #include "json/document.h"
 #include "json/istreamwrapper.h"
 
@@ -186,7 +187,10 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
     // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
-    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const auto target = fmt::format(
+      "/{}/{}",
+      name(),
+      http::uri_encode(key().string(), http::uri_encode_slash::no));
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
     http::client::request_header header{};
@@ -218,7 +222,10 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
     // Authorization:{signature}           # added by 'add_auth'
     // Content-Length:{payload-size}
     // Content-Type: text/plain
-    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const auto target = fmt::format(
+      "/{}/{}",
+      name(),
+      http::uri_encode(key().string(), http::uri_encode_slash::no));
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
     http::client::request_header header{};
@@ -248,7 +255,9 @@ abs_request_creator::make_get_blob_metadata_request(
     // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format(
-      "/{}/{}?comp=metadata", name(), key().string());
+      "/{}/{}?comp=metadata",
+      name(),
+      http::uri_encode(key().string(), http::uri_encode_slash::no));
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
     http::client::request_header header{};
@@ -272,7 +281,10 @@ abs_request_creator::make_delete_blob_request(
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
     // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
-    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const auto target = fmt::format(
+      "/{}/{}",
+      name(),
+      http::uri_encode(key().string(), http::uri_encode_slash::no));
 
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
@@ -374,7 +386,10 @@ abs_request_creator::make_set_expiry_to_blob_request(
     auto header = http::client::request_header{};
 
     header.method(boost::beast::http::verb::put);
-    header.target(fmt::format("/{}/{}?comp=expiry", name(), key().string()));
+    header.target(fmt::format(
+      "/{}/{}?comp=expiry",
+      name(),
+      http::uri_encode(key().string(), http::uri_encode_slash::no)));
     header.set(boost::beast::http::field::host, {_ap().data(), _ap().size()});
     header.set(expiry_option_name, expiry_option_value);
     header.set(
@@ -401,7 +416,10 @@ abs_request_creator::make_delete_file_request(
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
     // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
-    const auto target = fmt::format("/{}/{}", name(), path().string());
+    const auto target = fmt::format(
+      "/{}/{}",
+      name(),
+      http::uri_encode(path().string(), http::uri_encode_slash::no));
 
     const boost::beast::string_view host{adls_ap().data(), adls_ap().length()};
 

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -22,6 +22,7 @@
 #include "config/types.h"
 #include "hashing/secure.h"
 #include "http/client.h"
+#include "http/utils.h"
 #include "net/types.h"
 #include "ssx/sformat.h"
 #include "utils/base64.h"
@@ -115,7 +116,27 @@ result<http::client::request_header> request_creator::make_get_object_request(
     if (ec) {
         return ec;
     }
+    url_encode_target(header);
     return header;
+}
+
+void request_creator::url_encode_target(
+  http::client::request_header& header) const {
+    auto query_pos = header.target().find_first_of("?");
+    // encode full target as there are no query parameters
+    if (query_pos == std::string::npos) {
+        header.target(std::string(
+          http::uri_encode(header.target(), http::uri_encode_slash::no)));
+    } else {
+        // encode only the path part of the target
+        // TODO: add individual query parameters encoding here as well.
+        header.target(fmt::format(
+          "{}{}",
+          http::uri_encode(
+            std::string_view(header.target().begin(), query_pos),
+            http::uri_encode_slash::no),
+          header.target().substr(query_pos)));
+    }
 }
 
 result<http::client::request_header> request_creator::make_head_object_request(
@@ -143,6 +164,7 @@ result<http::client::request_header> request_creator::make_head_object_request(
     if (ec) {
         return ec;
     }
+    url_encode_target(header);
     return header;
 }
 
@@ -181,6 +203,7 @@ request_creator::make_unsigned_put_object_request(
     if (ec) {
         return ec;
     }
+    url_encode_target(header);
     return header;
 }
 
@@ -232,6 +255,7 @@ request_creator::make_list_objects_v2_request(
     if (ec) {
         return ec;
     }
+    url_encode_target(header);
     return header;
 }
 
@@ -263,6 +287,7 @@ request_creator::make_delete_object_request(
     if (ec) {
         return ec;
     }
+    url_encode_target(header);
     return header;
 }
 
@@ -362,7 +387,7 @@ request_creator::make_delete_objects_request(
     if (ec) {
         return ec;
     }
-
+    url_encode_target(header);
     return {
       std::move(header),
       ss::input_stream<char>{ss::data_source{

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -113,6 +113,8 @@ private:
     std::string
     make_target(const bucket_name& name, const object_key& key) const;
 
+    void url_encode_target(http::client::request_header& header) const;
+
     access_point_uri _ap;
 
     s3_url_style _ap_style;

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -119,6 +119,7 @@ redpanda_cc_library(
     include_prefix = "datalake",
     visibility = [":__subpackages__"],
     deps = [
+        ":partition_key_path",
         ":writer",
         "//src/v/container:chunked_hash_map",
         "//src/v/iceberg:datatypes",
@@ -645,6 +646,7 @@ redpanda_cc_library(
         ":logger",
         "//src/v/base",
         "//src/v/bytes:iobuf_parser",
+        "//src/v/http:utils",
         "//src/v/iceberg:partition_key",
         "//src/v/ssx:sformat",
         "//src/v/utils:base64",

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -58,6 +58,7 @@ v_cc_library(
     values_parquet.cc
     local_parquet_file_writer.cc
     serde_parquet_writer.cc
+    partition_key_path.cc
   DEPS
     v::cloud_io
     v::datalake_common

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -323,9 +323,7 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
     auto record_translator = make_record_translator(mode);
     auto table_creator = translation::make_default_table_creator(
       _coordinator_frontend->local());
-    auto term = partition->term();
-    auto path = remote_path{
-      fmt::format("{}/{}/{}", iceberg_data_path_prefix, ntp.path(), term)};
+
     auto& reservations = _scheduler.reservations();
     //  make a new translator
     auto coordinator
@@ -344,7 +342,7 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
         std::move(record_translator),
         std::move(table_creator),
         _location_provider,
-        std::move(path),
+        remote_path{iceberg_data_path_prefix},
         *reservations,
         _topic_table,
         _features,

--- a/src/v/datalake/partition_key_path.cc
+++ b/src/v/datalake/partition_key_path.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "bytes/iobuf_parser.h"
 #include "datalake/logger.h"
+#include "http/utils.h"
 #include "ssx/sformat.h"
 #include "utils/base64.h"
 
@@ -243,17 +244,8 @@ checked<ss::sstring, partition_key_error> escape(std::string_view s) {
     if (!is_valid_utf8(s)) {
         return partition_key_error("Invalid UTF-8 string, unable to escape");
     }
-    static constexpr std::
-      array<std::pair<absl::string_view, absl::string_view>, 24>
-        encode_lut = {
-          {{"&", "%26"}, {"$", "%24"},  {"@", "%40"}, {"=", "%3D"},
-           {";", "%3B"}, {"/", "%2F"},  {":", "%3A"}, {"+", "%2B"},
-           {" ", "%20"}, {",", "%2C"},  {"?", "%3F"}, {"\"", "%22"},
-           {"#", "%23"}, {"%", "%25"},  {"<", "%3C"}, {">", "%3E"},
-           {"[", "%5B"}, {"\\", "%5C"}, {"]", "%5D"}, {"^", "%5E"},
-           {"`", "%60"}, {"{", "%7B"},  {"|", "%7C"}, {"}", "%7D"}}};
 
-    return absl::StrReplaceAll(s, encode_lut);
+    return http::uri_encode(s, http::uri_encode_slash::no);
 }
 
 checked<ss::sstring, partition_key_error> format_field_value(

--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -12,6 +12,7 @@
 #include "base/vlog.h"
 #include "datalake/data_writer_interface.h"
 #include "datalake/logger.h"
+#include "datalake/partition_key_path.h"
 
 #include <exception>
 
@@ -113,6 +114,14 @@ partitioning_writer::finish() && {
             // Even on error, move on so that we can close all the writers.
             continue;
         }
+        auto partition_key_path_res = partition_key_to_path(spec_, pk);
+        if (partition_key_path_res.has_error()) {
+            vlog(
+              datalake_log.error,
+              "Failed to convert partition key to remote path - {}",
+              partition_key_path_res.error().what());
+            continue;
+        }
 
         files.push_back(partitioned_file{
           .local_file = std::move(file_res.value()),
@@ -120,7 +129,7 @@ partitioning_writer::finish() && {
           .schema_id = schema_id_,
           .partition_spec_id = spec_.spec_id,
           .partition_key = std::move(pk),
-        });
+          .partition_key_path = std::move(partition_key_path_res.value())});
     }
     if (first_error != writer_error::ok) {
         co_return first_error;

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -62,6 +62,7 @@ public:
         iceberg::schema::id_t schema_id;
         iceberg::partition_spec::id_t partition_spec_id;
         iceberg::partition_key partition_key;
+        remote_path partition_key_path;
 
         friend std::ostream& operator<<(std::ostream&, const partitioned_file&);
     };

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -36,7 +36,7 @@ ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
   retry_chain_node& parent_rcn,
   lazy_abort_source& lazy_as) {
     auto file_remote_path = remote_path{
-      file.table_location / remote_path_prefix
+      file.table_location / remote_path_prefix / file.partition_key_path
       / file.local_file.path().filename()};
 
     auto result = co_await _cloud_io.upload_data_file(

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -6,6 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import datetime
+import re
 import time
 from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
@@ -331,6 +333,78 @@ class DatalakeE2ETests(RedpandaTest):
             manifests = spark.run_query_fetch_all(
                 f"select path from {table_name}.manifests")
             assert_location_prefix(manifests, table.location())
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types(),
+            custom_partition_spec=[None, "(timestamp_us)", "(number)"])
+    def test_iceberg_partition_key_file_location(self, cloud_storage_type,
+                                                 catalog_type,
+                                                 custom_partition_spec: str):
+        """
+        Test that the data file location includes the partition key
+        """
+        count = 100
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              catalog_type=catalog_type,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+            config = {}
+            if custom_partition_spec:
+                config[
+                    "redpanda.iceberg.partition.spec"] = custom_partition_spec
+
+            dl.create_iceberg_enabled_topic(
+                self.topic_name,
+                partitions=2,
+                iceberg_mode="value_schema_id_prefix",
+                config=config)
+
+            schema = avro.loads(avro_schema_str)
+            producer = AvroProducer(
+                {
+                    'bootstrap.servers': self.redpanda.brokers(),
+                    'schema.registry.url':
+                    self.redpanda.schema_reg().split(",")[0]
+                },
+                default_value_schema=schema)
+            current_date = datetime.datetime.now()
+            for _ in range(count):
+                t = time.time()
+                record = {"number": int(t), "timestamp_us": int(t * 1000000)}
+                producer.produce(topic=self.topic_name, value=record)
+
+            producer.flush()
+            dl.wait_for_translation(self.topic_name, msg_count=count)
+
+            spark = dl.spark()
+            table_name = f"redpanda.{self.topic_name}"
+            uri_pattern = re.compile(
+                r"(?P<scheme>.*?)://(?P<bucket>.*?)/(?P<key>.*)")
+
+            def validate_data_file_path(file_url):
+                m = uri_pattern.match(file_url)
+                assert m, f"Expected file url to match URI pattern: {file_url}"
+                assert m[
+                    'bucket'] == self.si_settings.cloud_storage_bucket, f"Expected bucket {m['bucket']} to be {self.si_settings.cloud_storage_bucket}"
+
+                path_parts = m['key'].split("/")
+                partition_key = path_parts[4]
+
+                if custom_partition_spec is None:
+                    assert f"redpanda.timestamp_hour={current_date.year}" in partition_key, f"Expected default partition key in data file location {partition_key}"
+                elif custom_partition_spec == "(timestamp_us)":
+                    assert f"timestamp_us={current_date.year}" in partition_key, f"Expected timestamp_us partition key in data file location {partition_key}"
+                elif custom_partition_spec == "(number)":
+                    assert "number=" in partition_key, f"Expected number partition key in data file location {partition_key}"
+
+            files = spark.run_query_fetch_all(
+                f"select file_path from {table_name}.files")
+            assert len(files) > 0, "Expected at least one file"
+            for f_tuple in files:
+                f_name = f_tuple[0]
+                validate_data_file_path(f_name)
 
 
 class DatalakeMetricsTest(RedpandaTest):


### PR DESCRIPTION
Including a partition key derived path component in the Iceberg data files remote location. The partition key being part of the path allow users to better navigate the Iceberg data files in the object store. Additionally it will allow per partition access control. 

Fixes: https://redpandadata.atlassian.net/browse/CORE-8716

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none