### PR TITLE
[rptest] Add rpk_cloud_logout to CloudClusterUtils

### DIFF
--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -110,9 +110,19 @@ class CloudClusterUtils:
         self.logger.debug(f"Running '{cmd}'")
         return self.rpk._execute(cmd, env=self.env, timeout=timeout)
 
+    # rpk_cloud_logout clears credentials
+    def rpk_cloud_logout(self):
+        self.logger.debug(f"Clearing rpk login")
+        cmd = self._get_rpk_cloud_cmd()
+        cmd += ["logout", "--clear-credentials"]
+        return self._exec(cmd)
+
     def rpk_cloud_login(self, client_id, client_secret):
+        # first, log out and clear client credentials
+        self.rpk_cloud_logout()
+
         # perform cloud login
-        self.logger.debug(f"...[{client_id}] Loggin in to cloud cluster")
+        self.logger.debug(f"...[{client_id}] Logging in to cloud cluster")
         cmd = self._get_rpk_cloud_cmd()
         cmd += [
             "login", "--save", f"--client-id={client_id}",


### PR DESCRIPTION
Force `rpk cloud logout --clear-credentials` before attempting to `rpk cloud login` in CloudClusterUtils.

jira: [DEVPROD-2658]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

[DEVPROD-2658]: https://redpandadata.atlassian.net/browse/DEVPROD-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ