### PR TITLE
Adding try and log message with pod details to better handle missing nodeName in the spec

### DIFF
--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -34,8 +34,14 @@ class CloudBroker():
 
         # Backward compatibility
         # Various classes will use this to hash and compare nodes
-        self.account = DummyAccount(node_name=pod['spec']['nodeName'],
-                                    pod_name=pod['metadata']['name'])
+        try:
+            self.account = DummyAccount(node_name=pod['spec']['nodeName'],
+                                        pod_name=pod['metadata']['name'])
+        except KeyError as e:
+            self.logger.error(
+                f"Failed to create DummyAccount: missing key {e} in pod spec. Pod details: {pod}"
+            )
+            raise
 
         # It appears that the node-id label will only be added if the cluster
         # is still being managed by the operator - if managed=false then this


### PR DESCRIPTION
Adding try and raise error with a log message to print out pod details. This should better handle the case if nodeName is not available in the spec

Error:
```
self.account = DummyAccount(node_name=pod['spec']['nodeName'],
KeyError: 'nodeName'
```

#DEVPROD-2560

## Backports Required

- [ X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

### Improvements

Adding try and raise error with a log message to print out pod details. This should better handle the case if nodeName is not available in the spec 