### PR TITLE
[DRAFT/DNM] vassert: Change memory load to relaxed

### DIFF
--- a/src/v/base/vassert.h
+++ b/src/v/base/vassert.h
@@ -58,7 +58,7 @@ public:
         g_assert_log.l.error("{}", buffer);
         g_assert_log.l.error("Backtrace:\n{}", bt);
 
-        auto cb_func = _cb_func.load();
+        auto cb_func = _cb_func.load(std::memory_order_relaxed);
         if (cb_func != nullptr) {
             cb_func(buffer);
         }
@@ -66,7 +66,7 @@ public:
 
     void register_cb(assert_cb_func cb) {
         assert_cb_func before = nullptr;
-        _cb_func.compare_exchange_strong(before, cb);
+        _cb_func.compare_exchange_strong(before, cb, std::memory_order_relaxed);
     }
 
 private:


### PR DESCRIPTION
Using the default memory_order_seq_cst may have caused a performance regression due to the compiler being unable to optimize around atomic loads even on the success path.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
