### PR TITLE
rptest: unique cloud diagnostics archive per run with deflake

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3827,10 +3827,16 @@ class RedpandaService(RedpandaServiceBase):
             if manifest_dump_limit == 0 and key_dump_limit == 0:
                 break
 
-        archive_basename = "cloud_diagnostics.zip"
-        archive_path = os.path.join(
+        service_dir = os.path.join(
             TestContext.results_dir(self._context, self._context.test_index),
-            archive_basename)
+            self.service_id)
+
+        if not os.path.isdir(service_dir):
+            mkdir_p(service_dir)
+
+        archive_basename = "cloud_diagnostics.zip"
+        archive_path = os.path.join(service_dir, archive_basename)
+
         with zipfile.ZipFile(archive_path, mode='w') as archive:
             for m in manifests_to_dump:
                 self.logger.info(f"Fetching manifest {m}")


### PR DESCRIPTION
When ducktape is run with deflake mode enabled it will re-use the same "test runner" for multiple runs. We need to account for that when generating cloud diagnostics archive. Ducktape exposes service_id property which should be unique per run.

There is one caveat in which the service_id doesn't exactly match the one ducktape uses for collecting logs. I.e. it doesn't have the run suffix. That seems like a bug in ducktape. It sets the MultiRunServiceIdFactory only after the test have run/before collecting logs so we don't have access to it when we need it. This has to be fixed separately.

Until then the results look like this:

```
$ tree
.
├── 1-NessieCatalog-0-140675237208144
│   └── docker-rp-9
│       └── nessie.log
├── 1-RedpandaService-0-140675237206608
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 1-TrinoService-0-140675340627840
│   └── docker-rp-10
│       └── trino_server.log
├── 2-NessieCatalog-0-140675083583696
│   └── docker-rp-9
│       └── nessie.log
├── 2-RedpandaService-0-140675083589456
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 2-TrinoService-0-140675127129760
│   └── docker-rp-10
│       └── trino_server.log
├── 3-NessieCatalog-0-140675127331856
│   └── docker-rp-9
│       └── nessie.log
├── 3-RedpandaService-0-140675125598656
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 3-TrinoService-0-140675083557120
│   └── docker-rp-10
│       └── trino_server.log
├── 4-NessieCatalog-0-140675126862576
│   └── docker-rp-9
│       └── nessie.log
├── 4-RedpandaService-0-140675126860176
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 4-TrinoService-0-140675083585232
│   └── docker-rp-10
│       └── trino_server.log
├── 5-NessieCatalog-0-140675124447552
│   └── docker-rp-9
│       └── nessie.log
├── 5-RedpandaService-0-140675126868912
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 5-TrinoService-0-140675127207600
│   └── docker-rp-10
│       └── trino_server.log
├── 6-NessieCatalog-0-140675125240608
│   └── docker-rp-9
│       └── nessie.log
├── 6-RedpandaService-0-140675125236384
│   ├── cluster_config.yaml
│   ├── docker-rp-6
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 6-TrinoService-0-140675083551264
│   └── docker-rp-10
│       └── trino_server.log
├── 7-NessieCatalog-0-140675123564880
│   └── docker-rp-9
│       └── nessie.log
├── 7-RedpandaService-0-140675124353760
│   ├── docker-rp-6
│   ├── docker-rp-7
│   └── docker-rp-8
├── 8-NessieCatalog-0-140675123563680
│   └── docker-rp-6
│       └── nessie.log
├── 8-RedpandaService-0-140675123566128
│   ├── cluster_config.yaml
│   ├── docker-rp-10
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── 8-TrinoService-0-140675124355056
│   └── docker-rp-9
│       └── trino_server.log
├── 9-NessieCatalog-0-140675123941088
│   └── docker-rp-6
│       └── nessie.log
├── 9-RedpandaService-0-140675123938496
│   ├── docker-rp-10
│   │   └── redpanda.log
│   ├── docker-rp-7
│   │   └── redpanda.log
│   └── docker-rp-8
│       └── redpanda.log
├── RedpandaService-0-140675083589456
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675123566128
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675125236384
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675125598656
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675126860176
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675126868912
│   └── cloud_diagnostics.zip
├── RedpandaService-0-140675237206608
│   └── cloud_diagnostics.zip
├── test_log.debug
└── test_log.info
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
