### PR TITLE
bazel: add utility binaries to packaging

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -15,9 +15,14 @@ redpanda_package(
 redpanda_package(
     name = "vtools_input",
     out = "bazel_out.tar.gz",
+    hwloc_calc = "@hwloc//:hwloc_calc",
+    hwloc_distrib = "@hwloc//:hwloc_distrib",
     include_sysroot_libs = True,
+    iotune = "@seastar//:iotune",
+    openssl = "@openssl//:openssl_binary",
     redpanda_binary = "//:redpanda",
     rpath_override = "$ORIGIN/../lib",
+    rpk_binary = "//:rpk",
 )
 
 redpanda_package(

--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -15,6 +15,8 @@ redpanda_package(
 redpanda_package(
     name = "vtools_input",
     out = "bazel_out.tar.gz",
+    fips_config = "@openssl-fips//:fipsmodule_cnf",
+    fips_module = "@openssl-fips//:fipsmodule_so",
     hwloc_calc = "@hwloc//:hwloc_calc",
     hwloc_distrib = "@hwloc//:hwloc_distrib",
     include_sysroot_libs = True,

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -2,6 +2,7 @@
 A rule to create a redpanda tarball given inputs from the build system.
 """
 
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _is_versioned(file, starts_with):
@@ -67,27 +68,67 @@ def _prepare_package_content(ctx, dynamic_loader_path = "/opt/redpanda/lib"):
     if ctx.attr.include_sysroot_libs and dynamic_loader == None:
         fail("Dynamic loader not found in sysroot")
 
-    # Collect all the shared libraries that we built as part of Redpanda.
-    rp_runfiles = ctx.attr.redpanda_binary[DefaultInfo].default_runfiles.files.to_list()
-    for solib in rp_runfiles:
-        # Why the redpanda binary is marked as a runfile of itself? No idea...
-        if solib == ctx.file.redpanda_binary:
+    # Collect all the shared libraries that we built as part of each binary.
+    # NOTE: We don't need to do this for `rpk` because it's a static binary,
+    # this is only needed for binaries with shared libraries.
+    binaries = [
+        ctx.attr.redpanda_binary,
+        ctx.attr.rp_util,
+        ctx.attr.iotune,
+        ctx.attr.hwloc_calc,
+        ctx.attr.hwloc_distrib,
+        ctx.attr.openssl,
+    ]
+    binary_files = [
+        ctx.file.redpanda_binary,
+        ctx.file.rp_util,
+        ctx.file.iotune,
+        ctx.file.hwloc_calc,
+        ctx.file.hwloc_distrib,
+        ctx.file.openssl,
+    ]
+    for b in binaries:
+        if b == None:
             continue
-        shared_libraries.append(solib)
-    rp_binary = ctx.file.redpanda_binary
+        runfiles = b[DefaultInfo].default_runfiles.files.to_list()
+        for solib in runfiles:
+            # Why the binary is marked as a runfile of itself? No idea...
+            if solib in binary_files:
+                continue
+            shared_libraries.append(solib)
 
     if ctx.attr.rpath_override != "":
-        #TODO: add overriding iotune and rp_util rpaths after we add them to the package
-        rp_binary = _override_binary_rpath(ctx, ctx.attr.rpath_override, rp_binary)
+        for i in range(0, len(binary_files)):
+            if binary_files[i] == None:
+                continue
+            binary_files[i] = _override_binary_rpath(
+                ctx,
+                ctx.attr.rpath_override,
+                binary_files[i],
+            )
 
-    # TODO: set dynamic loader for other native binaries in the package
     if ctx.attr.include_sysroot_libs:
-        rp_binary = _set_dynamic_loader(ctx, rp_binary, dynamic_loader, dynamic_loader_path)
+        for i in range(0, len(binary_files)):
+            if binary_files[i] == None:
+                continue
+            binary_files[i] = _set_dynamic_loader(
+                ctx,
+                binary_files[i],
+                dynamic_loader,
+                dynamic_loader_path,
+            )
+
+    [rp_binary, rp_util, iotune, hwloc_calc, hwloc_distrib, openssl] = binary_files
 
     return struct(
         redpanda_binary = rp_binary,
+        rp_util = rp_util,
+        iotune = iotune,
+        hwloc_calc = hwloc_calc,
+        hwloc_distrib = hwloc_distrib,
+        openssl = openssl,
         rpk_binary = ctx.file.rpk_binary,
-        shared_libraries = shared_libraries,
+        shared_libraries = collections.uniq(shared_libraries),
     )
 
 def _impl(ctx):
@@ -99,6 +140,11 @@ def _impl(ctx):
     cfg_file = ctx.actions.declare_file("%s.config.json" % ctx.attr.name)
     cfg = {
         "redpanda_binary": package_content.redpanda_binary.path,
+        "rp_util": package_content.rp_util.path if package_content.rp_util else None,
+        "iotune": package_content.iotune.path if package_content.iotune else None,
+        "hwloc_calc": package_content.hwloc_calc.path if package_content.hwloc_calc else None,
+        "hwloc_distrib": package_content.hwloc_distrib.path if package_content.hwloc_distrib else None,
+        "openssl": package_content.openssl.path if package_content.openssl else None,
         "rpk": package_content.rpk_binary.path if package_content.rpk_binary else None,
         "shared_libraries": [solib.path for solib in package_content.shared_libraries],
         "default_yaml_config": ctx.file.default_yaml_config.path if ctx.file.default_yaml_config else None,
@@ -109,10 +155,19 @@ def _impl(ctx):
 
     inputs = [cfg_file, package_content.redpanda_binary] + package_content.shared_libraries
 
-    if package_content.rpk_binary:
-        inputs.append(package_content.rpk_binary)
-    if ctx.file.default_yaml_config:
-        inputs.append(ctx.file.default_yaml_config)
+    optional_inputs = [
+        package_content.rp_util,
+        package_content.iotune,
+        package_content.hwloc_calc,
+        package_content.hwloc_distrib,
+        package_content.openssl,
+        package_content.rpk_binary,
+        ctx.file.default_yaml_config,
+    ]
+
+    for input in optional_inputs:
+        if input != None:
+            inputs.append(input)
 
     # run the packaging tool
     ctx.actions.run(
@@ -137,6 +192,21 @@ redpanda_package = rule(
         "redpanda_binary": attr.label(
             allow_single_file = True,
             mandatory = True,
+        ),
+        "rp_util": attr.label(
+            allow_single_file = True,
+        ),
+        "iotune": attr.label(
+            allow_single_file = True,
+        ),
+        "hwloc_calc": attr.label(
+            allow_single_file = True,
+        ),
+        "hwloc_distrib": attr.label(
+            allow_single_file = True,
+        ),
+        "openssl": attr.label(
+            allow_single_file = True,
         ),
         "default_yaml_config": attr.label(
             allow_single_file = True,

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -136,6 +136,10 @@ def _impl(ctx):
     out = ctx.actions.declare_directory(ctx.attr.out) if use_dir else ctx.actions.declare_file(ctx.attr.out)
     package_content = _prepare_package_content(ctx)
 
+    fips_enabled = ctx.file.fips_module != None
+    if fips_enabled != (ctx.file.fips_config != None):
+        fail("`fips_module` and `fips_config` must both be specified in", ctx.attr.name)
+
     # Create the configuration file for the packaging tool
     cfg_file = ctx.actions.declare_file("%s.config.json" % ctx.attr.name)
     cfg = {
@@ -148,6 +152,7 @@ def _impl(ctx):
         "rpk": package_content.rpk_binary.path if package_content.rpk_binary else None,
         "shared_libraries": [solib.path for solib in package_content.shared_libraries],
         "default_yaml_config": ctx.file.default_yaml_config.path if ctx.file.default_yaml_config else None,
+        "fips": {"module": ctx.file.fips_module.path, "config": ctx.file.fips_config.path} if fips_enabled else None,
         "owner": ctx.attr.owner,
         "directory_mode": use_dir,
     }
@@ -168,6 +173,10 @@ def _impl(ctx):
     for input in optional_inputs:
         if input != None:
             inputs.append(input)
+
+    if fips_enabled:
+        inputs.append(ctx.file.fips_module)
+        inputs.append(ctx.file.fips_config)
 
     # run the packaging tool
     ctx.actions.run(
@@ -209,6 +218,12 @@ redpanda_package = rule(
             allow_single_file = True,
         ),
         "default_yaml_config": attr.label(
+            allow_single_file = True,
+        ),
+        "fips_module": attr.label(
+            allow_single_file = True,
+        ),
+        "fips_config": attr.label(
             allow_single_file = True,
         ),
         "rpk_binary": attr.label(

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -29,6 +29,11 @@ import (
 
 type pkgConfig struct {
 	RedpandaBinary    string   `json:"redpanda_binary"`
+	RPUtil            *string  `json:"rp_util"`
+	IOTune            *string  `json:"iotune"`
+	HWLocCalc         *string  `json:"hwloc_calc"`
+	HWLocDistrib      *string  `json:"hwloc_distrib"`
+	OpenSSL           *string  `json:"openssl"`
 	RPKBinary         *string  `json:"rpk"`
 	SharedLibraries   []string `json:"shared_libraries"`
 	DefaultYAMLConfig *string  `json:"default_yaml_config"`
@@ -98,8 +103,17 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 
 	dir("opt/redpanda/bin/")
 	file("opt/redpanda/bin/redpanda", cfg.RedpandaBinary)
-	if cfg.RPKBinary != nil {
-		file("opt/redpanda/bin/rpk", *cfg.RPKBinary)
+	for name, binary := range map[string]*string{
+		"rp_util":       cfg.RPUtil,
+		"rpk":           cfg.RPKBinary,
+		"iotune":        cfg.IOTune,
+		"hwloc_calc":    cfg.HWLocCalc,
+		"hwloc_distrib": cfg.HWLocDistrib,
+		"openssl":       cfg.OpenSSL,
+	} {
+		if binary != nil {
+			file(filepath.Join("opt/redpanda/bin/", name), *binary)
+		}
 	}
 	dir("var/")
 	dir("var/lib/")
@@ -175,8 +189,18 @@ func createPackageDir(cfg pkgConfig, output string) error {
 		return err
 	}
 
-	if cfg.RPKBinary != nil {
-		if err := file(*cfg.RPKBinary, "bin", "rpk"); err != nil {
+	for name, binary := range map[string]*string{
+		"rp_util":       cfg.RPUtil,
+		"rpk":           cfg.RPKBinary,
+		"iotune":        cfg.IOTune,
+		"hwloc_calc":    cfg.HWLocCalc,
+		"hwloc_distrib": cfg.HWLocDistrib,
+		"openssl":       cfg.OpenSSL,
+	} {
+		if binary == nil {
+			continue
+		}
+		if err := file(*binary, "bin", name); err != nil {
 			return err
 		}
 	}

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -27,18 +27,24 @@ import (
 	"time"
 )
 
+type fipsPkgConfig struct {
+	Module string `json:"module"`
+	Config string `json:"config"`
+}
+
 type pkgConfig struct {
-	RedpandaBinary    string   `json:"redpanda_binary"`
-	RPUtil            *string  `json:"rp_util"`
-	IOTune            *string  `json:"iotune"`
-	HWLocCalc         *string  `json:"hwloc_calc"`
-	HWLocDistrib      *string  `json:"hwloc_distrib"`
-	OpenSSL           *string  `json:"openssl"`
-	RPKBinary         *string  `json:"rpk"`
-	SharedLibraries   []string `json:"shared_libraries"`
-	DefaultYAMLConfig *string  `json:"default_yaml_config"`
-	Owner             int      `json:"owner"`
-	DirectoryMode     bool     `json:"directory_mode"`
+	RedpandaBinary    string         `json:"redpanda_binary"`
+	RPUtil            *string        `json:"rp_util"`
+	IOTune            *string        `json:"iotune"`
+	HWLocCalc         *string        `json:"hwloc_calc"`
+	HWLocDistrib      *string        `json:"hwloc_distrib"`
+	OpenSSL           *string        `json:"openssl"`
+	RPKBinary         *string        `json:"rpk"`
+	SharedLibraries   []string       `json:"shared_libraries"`
+	DefaultYAMLConfig *string        `json:"default_yaml_config"`
+	Owner             int            `json:"owner"`
+	DirectoryMode     bool           `json:"directory_mode"`
+	Fips              *fipsPkgConfig `json:"fips"`
 }
 
 func createTarball(cfg pkgConfig, w io.Writer) error {
@@ -114,6 +120,11 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 		if binary != nil {
 			file(filepath.Join("opt/redpanda/bin/", name), *binary)
 		}
+	}
+	if cfg.Fips != nil {
+		dir("opt/redpanda/fips/")
+		file("opt/redpanda/fips/fips.so", cfg.Fips.Module)
+		file("opt/redpanda/fips/fipsmodule.cnf", cfg.Fips.Config)
 	}
 	dir("var/")
 	dir("var/lib/")
@@ -203,6 +214,11 @@ func createPackageDir(cfg pkgConfig, output string) error {
 		if err := file(*binary, "bin", name); err != nil {
 			return err
 		}
+	}
+
+	if cfg.Fips != nil {
+		file(cfg.Fips.Module, "fips", "fips.so")
+		file(cfg.Fips.Config, "fips", "fipsmodule.cnf")
 	}
 
 	return nil

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -1,4 +1,13 @@
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+# Make this build faster by setting `build --@hwloc//:build_jobs=16` in user.bazelrc
+# if you have the cores to spare.
+int_flag(
+    name = "build_jobs",
+    build_setting_default = 8,
+    make_variable = "BUILD_JOBS",
+)
 
 filegroup(
     name = "srcs",
@@ -7,6 +16,7 @@ filegroup(
 
 configure_make(
     name = "hwloc",
+    args = ["-j$HWLOC_BUILD_JOBS"],
     autoreconf = True,
     autoreconf_options = ["-ivf"],
     configure_in_place = True,
@@ -24,12 +34,34 @@ configure_make(
         "--disable-shared",
         "--enable-static",
     ],
+    env = {
+        "HWLOC_BUILD_JOBS": "$(BUILD_JOBS)",
+    },
     lib_source = ":srcs",
+    out_binaries = [
+        "hwloc-calc",
+        "hwloc-distrib",
+    ],
     out_static_libs = ["libhwloc.a"],
+    toolchains = [":build_jobs"],
     visibility = [
         "//visibility:public",
     ],
     deps = [
         "@libpciaccess",
     ],
+)
+
+filegroup(
+    name = "hwloc_calc",
+    srcs = [":hwloc"],
+    output_group = "hwloc-calc",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "hwloc_distrib",
+    srcs = [":hwloc"],
+    output_group = "hwloc-distrib",
+    visibility = ["//visibility:public"],
 )

--- a/bazel/thirdparty/openssl-fips.BUILD
+++ b/bazel/thirdparty/openssl-fips.BUILD
@@ -12,6 +12,7 @@ configure_make(
     configure_options = [
         "enable-fips",
         "--libdir=lib",
+        "no-tests",
     ] + select({
         "@openssl//:debug_mode": ["--debug"],
         "@openssl//:release_mode": ["--release"],
@@ -34,15 +35,25 @@ filegroup(
     name = "gen_dir",
     srcs = [":openssl-fips"],
     output_group = "gen_dir",
-    visibility = [
-        "//visibility:public",
-    ],
 )
 
 select_file(
     name = "fipsmodule_so",
     srcs = ":openssl-fips",
     subpath = "lib/ossl-modules/fips.so",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+# We must use a genrule here because the output of `gen_dir`
+# is a directory artifact, which you cannot pluck things out of
+# using select_file.
+genrule(
+    name = "fipsmodule_cnf",
+    srcs = [":gen_dir"],
+    outs = ["fipsmodule.cnf"],
+    cmd = "cp -L $(SRCS)/ssl/fipsmodule.cnf $@",
     visibility = [
         "//visibility:public",
     ],

--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -72,10 +72,16 @@ configure_make(
     ],
 )
 
+# This is only the plain binary and does not have LD_LIBRARY_PATH
+# properly setup, so don't expect to be able to easily run this
+# binary and it pickup the proper shared libraries.
 filegroup(
-    name = "gen_dir",
+    name = "openssl_binary",
     srcs = [":openssl"],
-    output_group = "gen_dir",
+    output_group = "openssl",
+    visibility = [
+        "//visibility:public",
+    ],
 )
 
 select_file(
@@ -87,6 +93,7 @@ select_file(
     ],
 )
 
+# If you need to bazel_run or use a genrule with openssl, this is the target you want
 runnable_binary(
     name = "openssl_exe",
     binary = "openssl",

--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -706,6 +706,7 @@ cc_binary(
     srcs = [
         "apps/iotune/iotune.cc",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":seastar",
         "@boost//:program_options",

--- a/src/v/crypto/tests/BUILD
+++ b/src/v/crypto/tests/BUILD
@@ -97,9 +97,9 @@ expand_template(
 
 genrule(
     name = "fipsmodule_cnf",
-    srcs = ["@openssl-fips//:gen_dir"],
+    srcs = ["@openssl-fips//:fipsmodule_cnf"],
     outs = ["etc/ssl/fipsmodule.cnf"],
-    cmd = "cp -L $(SRCS)/ssl/fipsmodule.cnf $@",
+    cmd = "cp -L $(SRCS) $@",
 )
 
 common_data_deps = [


### PR DESCRIPTION
- **bazel/thirdparty: make iotune public**
- **bazel: expose the openssl binary for packaging**
- **bazel/hwloc: expose utility binaries for packaging**
- **bazel/packaging: add optional utilities to packaging**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
