### PR TITLE
`rptest`: set `APPLICATION_DEFAULT` provider for `GCP` in `nessie_catalog`

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -127,6 +127,9 @@ class NessieCatalog(CatalogService):
         elif isinstance(self.credentials,
                         cloud_storage.AWSInstanceMetadataCredentials):
             d_flags += "-Dnessie.catalog.service.s3.default-options.auth-type=APPLICATION_GLOBAL"
+        elif isinstance(self.credentials,
+                        cloud_storage.GCPInstanceMetadataCredentials):
+            d_flags += "-Dnessie.catalog.service.gcs.default-options.auth-type=APPLICATION_DEFAULT"
         return d_flags
 
     def _java_cmd(self, node):


### PR DESCRIPTION
Similar to the `S3` credentials authorization setting, but a slightly different value name.

Prevents `nessie` from failing with `NotAuthorizedExceptions` in GCP runs.

https://projectnessie.org/nessie-latest/configuration/#gcs-default-bucket-settings

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
