### PR TITLE
kafka: set max_timestamp if missing and using timestamp_type::create_time

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -18,6 +18,7 @@
 #include "kafka/protocol/wire.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/timestamp.h"
 #include "storage/parser_utils.h"
 
 #include <seastar/core/smp.hh>
@@ -191,13 +192,33 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
      * Perform some type of validation on the uncompressed input. In this case
      * we make sure that the records can be materialized but we avoid
      * re-encoding them using the lazy-record optimization.
+     *
+     * TODO(kafka): we should also be validating compressed batches - the
+     * reference implementation does this, and this also means they are able to
+     * set the max_timestamp when using timestamp_type::create_time.
      */
     if (!new_batch.compressed()) {
+        int64_t max_timestamp_delta = 0;
         try {
-            new_batch.for_each_record([](model::record r) { (void)r; });
+            new_batch.for_each_record([&max_timestamp_delta](model::record r) {
+                max_timestamp_delta = std::max(
+                  r.timestamp_delta(), max_timestamp_delta);
+            });
         } catch (const std::exception& e) {
             vlog(klog.error, "Parsing uncompressed records: {}", e.what());
             return remainder;
+        }
+        // If using append_time, we'll override the timestamp in the produce
+        // handler. Otherwise if the client does not set the max_timestamp we
+        // need to so that timequeries work correctly.
+        if (
+          header.max_timestamp == model::timestamp::missing()
+          && header.attrs.timestamp_type()
+               == model::timestamp_type::create_time) {
+            model::timestamp max_timestamp(
+              header.first_timestamp() + max_timestamp_delta);
+            new_batch.set_max_timestamp(
+              model::timestamp_type::create_time, max_timestamp);
         }
     }
 


### PR DESCRIPTION
Some clients (looking at you Sarama!) don't set a max_timestamp for
batches when being produced. In Apache Kafka, all incoming batches have
the max_timestamp batch header field set BY THE BROKER. Code references:

Here for uncompressed batches:
https://github.com/apache/kafka/blob/e124d3975bdb3a9ec85eee2fba7a1b0a6967d3a6/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L275

Here for compressed batches:
https://github.com/apache/kafka/blob/e124d3975bdb3a9ec85eee2fba7a1b0a6967d3a6/storage/src/main/java/org/apache/kafka/storage/internals/log/LogValidator.java#L404

When the timestamp_type is log_append then we do set the max_timestamp
in the broker:
https://github.com/redpanda-data/redpanda/blob/be699729fbbb0b48cc684d4417383ad1320103b7/src/v/kafka/server/handlers/produce.cc#L309

But don't do anything in the create_time case. This has the effect of
breaking timequeries, which only look at the max_timestamp in many
places of the storage layer (which is similar to the Kafka behavior, but
they have the max_timestamp set correctly).

However historically we've not decompressed batches on the produce path
(which is technically a validation bug). Since that has many perf
impliciations and doing that decompressing would presumably need at
least a cluster config flag, we only partially fix this bug when the
batch is uncompressed. For compressed batches we should really just
do the right thing and validate the batch (but maybe behind a flag?).

Note that we only set the max_timestamp if the client doesn't set it,
which deviates from Apache Kafka behavior. I could be convinced to always
set it, but then we'd do extra crc computations if there was a client bug.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

### Bug Fixes

* Fixes timequeries in some cases when `message.timestamp.type=CreateTime` and the producer leaves the `max_timestamp` batch header as the missing timestamp (`-1`).
