### PR TITLE
CORE-8694 Implement rate limiting crash report telemetry

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -720,7 +720,10 @@ ss::future<> controller::start(
     co_await _metrics_reporter.invoke_on(0, &metrics_reporter::start);
 
     co_await _crash_reporter.start_single(
-      std::ref(_stm), std::ref(_as), std::ref(_metrics_reporter));
+      std::ref(_storage.local().kvs()),
+      std::ref(_stm),
+      std::ref(_as),
+      std::ref(_metrics_reporter));
     co_await _crash_reporter.invoke_on(
       crash_reporter::shard, &crash_reporter::start);
 

--- a/src/v/cluster/crash_reporter.cc
+++ b/src/v/cluster/crash_reporter.cc
@@ -23,6 +23,10 @@
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 #include "model/fundamental.h"
+#include "model/timestamp.h"
+#include "serde/rw/rw.h"
+#include "serde/serde_exception.h"
+#include "storage/kvstore.h"
 #include "utils/prefix_logger.h"
 
 #include <seastar/core/coroutine.hh>
@@ -36,6 +40,10 @@
 namespace cluster {
 
 static ss::logger logger("crash-reporter");
+
+/// Key used to rate limiting metadata in the kvstore
+static constexpr std::string_view rate_limiter_kvs_key
+  = "rate_limiting_metadata";
 
 /// We can upload multiple crash reports per-request in batch, but want to limit
 /// the total request size to avoid large allocations or too large requests.
@@ -70,6 +78,49 @@ ss::future<> crash_reporter::start() {
 ss::future<> crash_reporter::stop() {
     vlog(logger.info, "Stopping Crash Reporter...");
     co_await _gate.close();
+}
+
+/// Called before an upload
+ss::future<> crash_reporter::rate_limiter::record() {
+    auto md = crash_reporter_rate_limiting_metadata{
+      .last_upload_time = model::to_timestamp(clock::now())};
+
+    iobuf buf;
+    serde::write(buf, md);
+
+    vlog(
+      logger.trace,
+      "Recording rate limiter last upload time as: {}",
+      md.last_upload_time);
+    co_await _kvstore.put(
+      storage::kvstore::key_space::crash_tracker,
+      bytes::from_string(rate_limiter_kvs_key),
+      std::move(buf));
+}
+
+/// Called before an upload to get how long to wait before uploading
+crash_reporter::rate_limiter::clock::duration
+crash_reporter::rate_limiter::wait_time() {
+    auto buf = _kvstore.get(
+      storage::kvstore::key_space::crash_tracker,
+      bytes::from_string(rate_limiter_kvs_key));
+    if (!buf) {
+        return 0s;
+    }
+    try {
+        auto md = serde::from_iobuf<crash_reporter_rate_limiting_metadata>(
+          std::move(*buf));
+        auto rate_limit_time = model::to_time_point(md.last_upload_time)
+                               + upload_rate;
+        auto remaining = rate_limit_time - clock::now();
+        return std::clamp<clock::duration>(remaining, 0s, upload_rate);
+    } catch (const serde::serde_exception& e) {
+        vlog(
+          logger.info,
+          "Error while reading crash reporter rate limiting metadata: {}",
+          e);
+        return upload_rate;
+    }
 }
 
 ss::future<crash_reporter::crash_report_payload>

--- a/src/v/cluster/crash_reporter.cc
+++ b/src/v/cluster/crash_reporter.cc
@@ -53,10 +53,12 @@ static constexpr auto max_reports_per_request = std::max<size_t>(
   upload_req_bound / crash_tracker::crash_description::serde_size_overestimate);
 
 crash_reporter::crash_reporter(
+  storage::kvstore& kvs,
   ss::sharded<controller_stm>& stm,
   ss::sharded<ss::abort_source>& as,
   ss::sharded<metrics_reporter>& mr)
-  : _controller_stm(stm)
+  : _rate_limiter(kvs)
+  , _controller_stm(stm)
   , _metrics_reporter(mr)
   , _as(as)
   , _client_logger{logger, "crash-reporter"} {}
@@ -196,11 +198,20 @@ ss::future<> crash_reporter::report_crashes() {
         for (size_t i = 0; i < max_upload_attempts && !success
                            && !_as.local().abort_requested();
              ++i) {
-            success = co_await try_report_crashes(current_batch);
+            // Record the upload to the rate limiter before sending the report
+            // to ensure that if there is a crash while sending telemetry data,
+            // the rate limiter will still limit subsequent uploads
+            auto rl_wait = _rate_limiter.wait_time();
+            if (rl_wait > 0s) {
+                vlog(
+                  logger.trace,
+                  "Sleeping for {}ms for rate limit to pass",
+                  rl_wait / 1ms);
+                co_await ss::sleep_abortable(rl_wait, _as.local());
+            }
+            co_await _rate_limiter.record();
 
-            // TODO: improve rate limiting to be robust against crashes
-            constexpr auto upload_interval = 30s;
-            co_await ss::sleep_abortable(upload_interval, _as.local());
+            success = co_await try_report_crashes(current_batch);
         }
 
         if (!success) {

--- a/src/v/cluster/crash_reporter.h
+++ b/src/v/cluster/crash_reporter.h
@@ -14,6 +14,8 @@
 #include "cluster/fwd.h"
 #include "cluster/metrics_reporter.h"
 #include "crash_tracker/recorder.h"
+#include "model/timestamp.h"
+#include "storage/fwd.h"
 #include "utils/prefix_logger.h"
 
 #include <seastar/core/abort_source.hh>
@@ -51,6 +53,25 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+
+    class rate_limiter {
+    public:
+        using clock = model::timestamp_clock;
+
+        static constexpr auto upload_rate = std::chrono::seconds{30};
+
+        explicit rate_limiter(storage::kvstore& kvstore)
+          : _kvstore(kvstore) {}
+
+        /// Called before an upload to rate limit subsequent uploads
+        ss::future<> record();
+
+        /// Called before an upload to get how long to wait before uploading
+        clock::duration wait_time();
+
+    private:
+        storage::kvstore& _kvstore;
+    };
 
 private:
     using report_batch = std::vector<crash_tracker::recorder::recorded_crash>;

--- a/src/v/cluster/crash_reporter.h
+++ b/src/v/cluster/crash_reporter.h
@@ -47,6 +47,7 @@ public:
     static constexpr ss::shard_id shard = 0;
 
     crash_reporter(
+      storage::kvstore&,
       ss::sharded<controller_stm>&,
       ss::sharded<ss::abort_source>&,
       ss::sharded<metrics_reporter>&);
@@ -81,6 +82,7 @@ private:
     build_crash_report_payload(const report_batch&);
     iobuf serialize_payload(const crash_report_payload&);
 
+    rate_limiter _rate_limiter;
     ss::sharded<controller_stm>& _controller_stm;
     ss::sharded<metrics_reporter>& _metrics_reporter;
     ss::sharded<ss::abort_source>& _as;

--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -573,6 +573,23 @@ redpanda_cc_btest(
     ],
 )
 
+redpanda_cc_btest(
+    name = "crash_reporter_test",
+    timeout = "short",
+    srcs = [
+        "crash_reporter_test.cc",
+    ],
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/storage/tests:kvstore_fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
 redpanda_cc_gtest(
     name = "manual_log_deletion_test",
     timeout = "short",

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -87,7 +87,8 @@ set(srcs
         health_monitor_test.cc
         metadata_dissemination_test.cc
         replicas_rebalancing_tests.cc
-        security_frontend_test.cc)
+        security_frontend_test.cc
+        crash_reporter_test.cc)
 
 foreach(cluster_test_src ${srcs})
     get_filename_component(test_name ${cluster_test_src} NAME_WE)

--- a/src/v/cluster/tests/crash_reporter_test.cc
+++ b/src/v/cluster/tests/crash_reporter_test.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/crash_reporter.h"
+#include "storage/tests/kvstore_fixture.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+FIXTURE_TEST(rate_limiter_test, kvstore_test_fixture) {
+    auto kvstore = make_kvstore();
+    kvstore->start().get();
+    auto defer = ss::defer([&] { kvstore->stop().get(); });
+
+    cluster::crash_reporter::rate_limiter rl{*kvstore};
+
+    // Initially there is no rate limit
+    auto wt = rl.wait_time();
+    BOOST_CHECK_EQUAL(wt, 0s);
+
+    rl.record().get();
+
+    // After calling record, there is a rate limit
+    wt = rl.wait_time();
+    BOOST_CHECK_GT(wt, 0s);
+    BOOST_CHECK_LE(wt, cluster::crash_reporter::rate_limiter::upload_rate);
+}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3276,6 +3276,16 @@ struct metrics_reporter_cluster_info
     auto serde_fields() { return std::tie(uuid, creation_timestamp); }
 };
 
+struct crash_reporter_rate_limiting_metadata
+  : serde::envelope<
+      crash_reporter_rate_limiting_metadata,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    model::timestamp last_upload_time;
+
+    auto serde_fields() { return std::tie(last_upload_time); }
+};
+
 struct controller_committed_offset_request
   : serde::envelope<
       controller_committed_offset_request,

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -104,6 +104,7 @@ public:
         stms = 6,
         shard_placement = 7,
         debug_bundle = 8,
+        crash_tracker = 9,
         /* your sub-system here */
     };
 


### PR DESCRIPTION
Introduce a new kvstore key space crash_tracker, a key in that key space called rate_limiting_metadata with a serde value crash_reporter_rate_limiting_metadata containing a timestamp of the last time an attempt was made to upload crash telemetry data.

This is to provide a way of rate limiting crash telemetry uploads in a way that is robust to crashes that may happen while uploading data.

This is integrated in the next commit to implement an upload rate of 1 request every 30s.

Fixes https://redpandadata.atlassian.net/browse/CORE-8694

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
