### PR TITLE
CORE-9231 Add `redpanda_version()` into crash reports and telemetry

### DIFF
--- a/src/v/cluster/crash_reporter.cc
+++ b/src/v/cluster/crash_reporter.cc
@@ -88,6 +88,7 @@ crash_reporter::build_crash_report_payload(
         if (report.crash) {
             r.stacktrace = ss::sstring{report.crash->stacktrace.c_str()};
             r.reason = fmt::format("{}", report.crash->type);
+            r.app_version = report.crash->app_version;
 
             if (
               report.crash->type
@@ -229,16 +230,16 @@ void rjson_serialize(
     w.StartObject();
     w.Key("timestamp");
     w.Uint64(report.timestamp);
-
     w.Key("node_id");
     w.Int(report.node_id);
-
     w.Key("stacktrace");
     w.String(report.stacktrace);
     w.Key("reason");
     w.String(report.reason);
     w.Key("description");
     w.String(report.description);
+    w.Key("app_version");
+    w.String(report.app_version);
     w.EndObject();
 }
 

--- a/src/v/cluster/crash_reporter.h
+++ b/src/v/cluster/crash_reporter.h
@@ -35,6 +35,7 @@ public:
             ss::sstring stacktrace;
             ss::sstring reason;
             ss::sstring description;
+            ss::sstring app_version;
         };
 
         ss::sstring cluster_uuid;

--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -35,6 +35,7 @@ redpanda_cc_library(
         "//src/v/serde:vector",
         "//src/v/utils:directory_walker",
         "//src/v/utils:file_io",
+        "//src/v/version",
         "@fmt",
     ],
     include_prefix = "crash_tracker",

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     v::serde
     v::hashing
     v::random
+    v::version
 )
 
 add_subdirectory(tests)

--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -15,6 +15,7 @@
 #include "crash_tracker/types.h"
 #include "hashing/xx.h"
 #include "model/timestamp.h"
+#include "version/version.h"
 
 #include <seastar/core/file-types.hh>
 #include <seastar/core/file.hh>
@@ -76,6 +77,8 @@ prepared_writer::initialize(std::filesystem::path crash_file_path) {
             "Failed to open {} to record crash reason",
             _crash_report_file_name));
     }
+
+    _prepared_cd.app_version = ss::sstring{redpanda_version()};
 
     // Update _state as the last step in initialize() to make earlier changes
     // visible across threads.

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -11,6 +11,8 @@ redpanda_cc_gtest(
         "//src/v/crash_tracker",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "//src/v/version",
+        "@fmt",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ rp_test(
   BINARY_NAME limiter_test
   SOURCES
     limiter_test.cc
-  LIBRARIES v::gtest_main v::crash_tracker Seastar::seastar
+  LIBRARIES v::gtest_main v::crash_tracker v::version Seastar::seastar
   ARGS "-- -c 1"
 )
 

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -12,9 +12,12 @@
 #include "crash_tracker/recorder.h"
 #include "crash_tracker/types.h"
 #include "model/timestamp.h"
+#include "version/version.h"
 
+#include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 namespace crash_tracker {
@@ -39,6 +42,7 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
             res.addition_info = crash_description::reserved_string_t{
               "false != true at example.cc:123"};
         }
+        res.app_version = ss::sstring{redpanda_version()};
         return recorder::recorded_crash{"", std::move(res), {}};
     };
 
@@ -46,33 +50,33 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
 
     EXPECT_EQ(
       crash_tracker::impl::describe_crashes(crashes),
-      // clang-format off
-      "The following crashes have been recorded:"
-      "\nCrash #1 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb."
-      // clang-format on
-    );
+      fmt::format(
+        // clang-format off
+        "The following crashes have been recorded:"
+        "\nCrash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.",
+        // clang-format on
+        redpanda_version()));
 
     for (int i = 0; i < 10; i++) {
         crashes.emplace_back(make_crash(with_additional_info::yes));
     }
 
-    EXPECT_EQ(
-      crash_tracker::impl::describe_crashes(crashes),
-      // clang-format off
-      "The following crashes have been recorded:"
-      "\nCrash #1 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb."
-      "\nCrash #2 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #3 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #4 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #5 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\n    ..."
-      "\nCrash #7 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #8 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #9 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #10 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      "\nCrash #11 at 1970-01-01 00:00:00 UTC - Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123"
-      // clang-format on
-    );
+    auto expected = fmt::format(
+      R"(The following crashes have been recorded:
+Crash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #2 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #3 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #4 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #5 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+    ...
+Crash #7 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #8 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #9 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #10 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #11 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123)",
+      fmt::arg("version", redpanda_version()));
+
+    EXPECT_EQ(crash_tracker::impl::describe_crashes(crashes), expected);
 }
 
 } // namespace crash_tracker

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -11,6 +11,8 @@
 
 #include "crash_tracker/types.h"
 
+#include "version/version.h"
+
 namespace crash_tracker {
 
 std::ostream& operator<<(std::ostream& os, crash_type ct) {
@@ -31,6 +33,7 @@ std::ostream& operator<<(std::ostream& os, crash_type ct) {
 }
 
 std::ostream& operator<<(std::ostream& os, const crash_description& cd) {
+    fmt::print(os, "Redpanda version: {}. ", cd.app_version);
     fmt::print(os, "{}", cd.crash_message.c_str());
 
     const auto opt_stacktrace = cd.stacktrace.c_str();

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -125,12 +125,18 @@ struct crash_description
     /// verbose for telemetry.
     /// Eg. top-N allocations
     reserved_string_t addition_info;
+    ss::sstring app_version;
 
     crash_description() = default;
 
     auto serde_fields() {
         return std::tie(
-          type, crash_time, crash_message, stacktrace, addition_info);
+          type,
+          crash_time,
+          crash_message,
+          stacktrace,
+          addition_info,
+          app_version);
     }
 
     friend std::ostream& operator<<(std::ostream&, const crash_description&);

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -214,7 +214,7 @@ class CrashLoopChecksTest(RedpandaTest):
                                              "Too many consecutive crashes")
         assert self.redpanda.search_log_node(
             broker,
-            "Crash #4 at 20.* UTC - Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: .*"
+            "Crash #4 at 20.* UTC - Redpanda version: .*. Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found) Backtrace: .*"
         )
         self.expect_crash_count(1 + CrashLoopChecksTest.CRASH_LOOP_LIMIT + 1)
 
@@ -289,7 +289,7 @@ class CrashLoopChecksTest(RedpandaTest):
 
         assert self.redpanda.search_log_node(
             broker,
-            f"Crash #4 at 20.* - {signo_prefix()} on shard {signal_shard}. Backtrace: "
+            f"Crash #4 at 20.* - Redpanda version: .*. {signo_prefix()} on shard {signal_shard}. Backtrace: "
         )
 
         report = self.read_first_crash_report()

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -234,6 +234,8 @@ class CrashLoopChecksTest(RedpandaTest):
             'crash_message'], f'Unexpected crash message: {report["crash_message"]}'
         assert len(report['stacktrace']) > 0, \
             f'Unexpected empty stacktrace for report: {report}'
+        assert len(report['app_version']) > 0, \
+            f'Unexpected empty app_version for report: {report}'
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + SIGNAL_CRASH_LOG)
     @matrix(signo=[signal.SIGSEGV, signal.SIGABRT, signal.SIGILL],

--- a/tests/rptest/tests/crash_reporter_test.py
+++ b/tests/rptest/tests/crash_reporter_test.py
@@ -90,3 +90,5 @@ class CrashReporterTest(RedpandaTest):
             f"Unexpected: {crash['reason']=}"
         assert crash['description'] == "", \
             f"Unexpected: {crash['description']}"
+        assert len(crash['app_version']) > 0, \
+            f"Unexpected: {crash['app_version']}"

--- a/tools/offline_log_viewer/crash_report.py
+++ b/tools/offline_log_viewer/crash_report.py
@@ -9,5 +9,6 @@ def decode_crash_report(path: str) -> dict[str, Any]:
             'timestamp': rdr.read_int64(),
             'crash_message': rdr.read_string(),
             'stacktrace': rdr.read_string(),
-            'additional_info': rdr.read_string()
+            'additional_info': rdr.read_string(),
+            'app_version': rdr.read_string()
         })


### PR DESCRIPTION
This adds a new field to crash reports which is populated with the redpanda build version. This gets printed in the logs when the crash loop limit is reached, can be decoded with offline log viewer and is included in the crash telemetry data.

Currently we can use the heartbeat dataset to join the cluster uuid of a telemetry-reported crash to figure out which version of redpanda crashes and therefore which redpanda binary we need to use to decode the crash stacktrace. However, for crashes that happen around the time when a cluster is upgraded, it is more reliable to record the redpanda build version directly into the crash report. This will also be included in the telemetry data.

Fixes https://redpandadata.atlassian.net/browse/CORE-9231

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
