### PR TITLE
bazel: remove seastar fortify patch

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -200,7 +200,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "7yHEvqkGjICm+74vrxJH44/bjB/C66ZXUPSLBwrvXZQ=",
+        "bzlTransitiveDigest": "BTwSxx/LbTaYB8+WCrZwj0CyvhMbjQhm43vjRM15rng=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -381,7 +381,6 @@
               "strip_prefix": "seastar-534c1a88bccacd2bcd8a35a062e929001ecda279",
               "url": "https://github.com/redpanda-data/seastar/archive/534c1a88bccacd2bcd8a35a062e929001ecda279.tar.gz",
               "patches": [
-                "@@//bazel/thirdparty:seastar-fortify-source.patch",
                 "@@//bazel/thirdparty:seastar-remove-libnuma.patch"
               ],
               "patch_args": [

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,7 +162,7 @@ def data_dependency():
         sha256 = "d12be25cebdd06ad91a70b950f9ab61a4fd43d27b119a943e95911f5b25bdf97",
         strip_prefix = "seastar-534c1a88bccacd2bcd8a35a062e929001ecda279",
         url = "https://github.com/redpanda-data/seastar/archive/534c1a88bccacd2bcd8a35a062e929001ecda279.tar.gz",
-        patches = ["//bazel/thirdparty:seastar-fortify-source.patch", "//bazel/thirdparty:seastar-remove-libnuma.patch"],
+        patches = ["//bazel/thirdparty:seastar-remove-libnuma.patch"],
         patch_args = ["-p1"],
     )
 

--- a/bazel/thirdparty/seastar-fortify-source.patch
+++ b/bazel/thirdparty/seastar-fortify-source.patch
@@ -1,9 +1,0 @@
-diff --git a/src/core/thread.cc b/src/core/thread.cc
-index eb9b6d6c..6addbc25 100644
---- a/src/core/thread.cc
-+++ b/src/core/thread.cc
-@@ -1,3 +1,4 @@
-+#undef _FORTIFY_SOURCE
- /*
-  * This file is open source software, licensed to you under the terms
-  * of the Apache License, Version 2.0 (the "License").  See the NOTICE file


### PR DESCRIPTION
This fix has been integrated in our 25.1.x fork in

adf1c04c379216e1dc243ef3dad146d322a51b96

so we no longer need the the patch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
