### PR TITLE
gha/promote: fix trigger promote action

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,7 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: buildkite/trigger-pipeline-action@v2.0.0
+      - uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,4 +25,4 @@ jobs:
           pipeline: "redpanda/redpanda"
           branch: dev
           message: ":github: Promote redpanda ${{ github.ref_name }} packages"
-          build_env_vars: '{"PROMOTE_REDPANDA_FROM_STAGING": "1", "TARGET_VERSION": "${{ github.ref_name }}"}'
+          build_env_vars: '{"PIPELINE_ACTION": "promote-from-staging", "TARGET_VERSION": "${{ github.ref_name }}"}'

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   trigger-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
jira: [DEVPROD-2679]

The triggered buildkite pipeline actions are [failing](https://buildkite.com/redpanda/redpanda/builds/62371#019544b9-5bbd-44da-958e-a5272d4aa631/401-459) because `PIPELINE_ACTION` is not set. This PR ensures the env var is set.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none

[DEVPROD-2679]: https://redpandadata.atlassian.net/browse/DEVPROD-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ