### PR TITLE
[v24.2.x] gha/promote: fix trigger promote action

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,8 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - name: trigger redpanda promote pipeline
-        uses: "buildkite/trigger-pipeline-action@v2.0.0"
+      - uses: buildkite/trigger-pipeline-action@v2
         with:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,7 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: buildkite/trigger-pipeline-action@v2
+      - uses: buildkite/trigger-pipeline-action@v2.0.0
         with:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,7 +19,7 @@ jobs:
           secret-ids: |
             ,sdlc/prod/github/buildkite_token
           parse-json-secrets: true
-      - uses: buildkite/trigger-pipeline-action@v2.0.0
+      - uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ env.BUILDKITE_TOKEN }}
           pipeline: "redpanda/redpanda"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,4 +25,4 @@ jobs:
           pipeline: "redpanda/redpanda"
           branch: dev
           message: ":github: Promote redpanda ${{ github.ref_name }} packages"
-          build_env_vars: '{"PROMOTE_REDPANDA_FROM_STAGING": "1", "TARGET_VERSION": "${{ github.ref_name }}"}'
+          build_env_vars: '{"PIPELINE_ACTION": "promote-from-staging", "TARGET_VERSION": "${{ github.ref_name }}"}'

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   trigger-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Fixes #25209
Backport of PR #25207
jira: [DEVPROD-2679] [CORE-9233]

resolved conflict by backporting 2 extra commits edeb97d 0abd1f6, and then cherry-picks were clean:
```console
bash$ git cherry-pick -x edeb97d 0abd1f6 81471c9 47fe54b ad02623
Auto-merging .github/workflows/promote.yml
[DEVPROD-2679-fix-promote-v24.2.x d8e7bf88c8] gha: update actions in promote.yml
 Date: Sat Sep 21 19:32:37 2024 -0500
 1 file changed, 1 insertion(+), 2 deletions(-)
Auto-merging .github/workflows/promote.yml
[DEVPROD-2679-fix-promote-v24.2.x 4ef0f9c6fb] gha: use full major.minor.patch version ID
 Author: Ivo Jimenez <ivo@redpanda.com>
 Date: Tue Dec 3 08:17:08 2024 -0700
 1 file changed, 1 insertion(+), 1 deletion(-)
[DEVPROD-2679-fix-promote-v24.2.x 74461642ff] gha/promote: pin run on ubuntu 24.04
 Date: Thu Feb 27 11:11:10 2025 -0800
 1 file changed, 1 insertion(+), 1 deletion(-)
[DEVPROD-2679-fix-promote-v24.2.x 4948451c83] gha/promote: update to latest buildkite/trigger-pipeline-action
 Date: Thu Feb 27 11:13:07 2025 -0800
 1 file changed, 1 insertion(+), 1 deletion(-)
[DEVPROD-2679-fix-promote-v24.2.x 2ab03a8c9f] gha/promote: use PIPELINE_ACTION=promote-from-staging
 Date: Thu Feb 27 11:16:34 2025 -0800
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

[DEVPROD-2679]: https://redpandadata.atlassian.net/browse/DEVPROD-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-9233]: https://redpandadata.atlassian.net/browse/CORE-9233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ