### PR TITLE
rpk cluster health improvements

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/BUILD
@@ -30,5 +30,6 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@com_github_twmb_types//:types",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -25,6 +25,20 @@ import (
 	"go.uber.org/zap"
 )
 
+type healthResponse struct {
+	ClusterUUID               *string  `json:"cluster_uuid,omitempty" yaml:"cluster_uuid,omitempty"`
+	IsHealthy                 bool     `json:"is_healthy" yaml:"is_healthy"`
+	UnhealthyReasons          []string `json:"unhealthy_reasons" yaml:"unhealthy_reasons"`
+	ControllerID              int      `json:"controller_id" yaml:"controller_id"`
+	AllNodes                  []int    `json:"all_nodes" yaml:"all_nodes"`
+	NodesDown                 []int    `json:"nodes_down" yaml:"nodes_down"`
+	NodesInRecoveryMode       []int    `json:"nodes_in_recovery_mode" yaml:"nodes_in_recovery_mode"`
+	LeaderlessPartitions      []string `json:"leaderless_partitions" yaml:"leaderless_partitions"`
+	LeaderlessCount           *int     `json:"leaderless_count,omitempty" yaml:"leaderless_count,omitempty"`
+	UnderReplicatedCount      *int     `json:"under_replicated_count,omitempty" yaml:"under_replicated_count,omitempty"`
+	UnderReplicatedPartitions []string `json:"under_replicated_partitions" yaml:"under_replicated_partitions"`
+}
+
 func newHealthOverviewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var watch, exit bool
 	cmd := &cobra.Command{
@@ -54,6 +68,13 @@ Get cluster health information and exit when the cluster is healthy:
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if f.Kind != "text" && f.Kind != "help" && (watch || exit) {
+				out.Die("format type %q cannot be used along with --watch or --exit-when-healthy", f.Kind)
+			}
+			if h, ok := f.Help(healthResponse{}); ok {
+				out.Exit(h)
+			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)
@@ -78,7 +99,13 @@ Get cluster health information and exit when the cluster is healthy:
 				out.MaybeDie(err, "unable to request cluster health: %v", err)
 				exit10 = !ret.IsHealthy
 				if !reflect.DeepEqual(ret, lastOverview) {
-					printHealthOverview(&ret, clusterUUID)
+					hr := buildHealthResponses(&ret, clusterUUID)
+					if isText, _, s, err := f.Format(hr); !isText {
+						out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
+						fmt.Println(s)
+					} else {
+						printHealthOverview(hr)
+					}
 				}
 				lastOverview = ret
 				if !watch || exit && lastOverview.IsHealthy {
@@ -95,46 +122,69 @@ Get cluster health information and exit when the cluster is healthy:
 	}
 	p.InstallAdminFlags(cmd)
 	p.InstallSASLFlags(cmd)
+	p.InstallFormatFlag(cmd)
 
-	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Blocks and writes out all cluster health changes")
-	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "Exits when the cluster is back in a healthy state")
+	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Blocks and writes out all cluster health changes. Only available for --format=text")
+	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "Exits when the cluster is back in a healthy state. Only available for --format=text")
 	return cmd
 }
 
-func printHealthOverview(hov *rpadmin.ClusterHealthOverview, clusterUUID *string) {
-	types.Sort(hov)
+func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, clusterUUID *string) healthResponse {
+	// This is needed as NodesInRecoveryMode can be nil, and the json formatter
+	// will print "null" instead of an empty array.
+	nodesInRecoveryMode := hov.NodesInRecoveryMode
+	if len(nodesInRecoveryMode) == 0 {
+		nodesInRecoveryMode = []int{}
+	}
+	return healthResponse{
+		ClusterUUID:               clusterUUID,
+		IsHealthy:                 hov.IsHealthy,
+		UnhealthyReasons:          hov.UnhealthyReasons,
+		ControllerID:              hov.ControllerID,
+		AllNodes:                  hov.AllNodes,
+		NodesDown:                 hov.NodesDown,
+		NodesInRecoveryMode:       nodesInRecoveryMode,
+		LeaderlessPartitions:      hov.LeaderlessPartitions,
+		LeaderlessCount:           hov.LeaderlessCount,
+		UnderReplicatedCount:      hov.UnderReplicatedCount,
+		UnderReplicatedPartitions: hov.UnderReplicatedPartitions,
+	}
+}
+
+func printHealthOverview(hr healthResponse) {
+	types.Sort(hr)
 	out.Section("CLUSTER HEALTH OVERVIEW")
 
 	// leaderless partitions and under-replicated counts are available starting
 	// v23.3.
 	lp := "Leaderless partitions:"
 	urp := "Under-replicated partitions:"
-	if hov.LeaderlessCount != nil {
-		lp = fmt.Sprintf("Leaderless partitions (%v):", *hov.LeaderlessCount)
-		if *hov.LeaderlessCount > len(hov.LeaderlessPartitions) {
-			hov.LeaderlessPartitions = append(hov.LeaderlessPartitions, "...truncated")
+	if hr.LeaderlessCount != nil {
+		lp = fmt.Sprintf("Leaderless partitions (%v):", *hr.LeaderlessCount)
+		if *hr.LeaderlessCount > len(hr.LeaderlessPartitions) {
+			hr.LeaderlessPartitions = append(hr.LeaderlessPartitions, "...truncated")
 		}
 	}
-	if hov.UnderReplicatedCount != nil {
-		urp = fmt.Sprintf("Under-replicated partitions (%v):", *hov.UnderReplicatedCount)
-		if *hov.UnderReplicatedCount > len(hov.UnderReplicatedPartitions) {
-			hov.UnderReplicatedPartitions = append(hov.UnderReplicatedPartitions, "...truncated")
+	if hr.UnderReplicatedCount != nil {
+		urp = fmt.Sprintf("Under-replicated partitions (%v):", *hr.UnderReplicatedCount)
+		if *hr.UnderReplicatedCount > len(hr.UnderReplicatedPartitions) {
+			hr.UnderReplicatedPartitions = append(hr.UnderReplicatedPartitions, "...truncated")
 		}
 	}
 
 	tw := out.NewTable()
 	defer tw.Flush()
-	tw.Print("Healthy:", hov.IsHealthy)
-	tw.Print("Unhealthy reasons:", hov.UnhealthyReasons)
-	tw.Print("Controller ID:", hov.ControllerID)
-	tw.Print("All nodes:", hov.AllNodes)
-	tw.Print("Nodes down:", hov.NodesDown)
-	if hov.NodesInRecoveryMode != nil {
-		tw.Print("Nodes in recovery mode:", hov.NodesInRecoveryMode)
+	tw.Print("Healthy:", hr.IsHealthy)
+	tw.Print("Unhealthy reasons:", hr.UnhealthyReasons)
+	tw.Print("Controller ID:", hr.ControllerID)
+	tw.Print("All nodes:", hr.AllNodes)
+	tw.Print("Nodes down:", hr.NodesDown)
+	if hr.NodesInRecoveryMode != nil {
+		tw.Print("Nodes in recovery mode:", hr.NodesInRecoveryMode)
 	}
-	tw.Print(lp, hov.LeaderlessPartitions)
-	tw.Print(urp, hov.UnderReplicatedPartitions)
-	if clusterUUID != nil {
-		tw.Print("Cluster UUID:", *clusterUUID)
+	tw.Print(lp, hr.LeaderlessPartitions)
+	tw.Print(urp, hr.UnderReplicatedPartitions)
+	if hr.ClusterUUID != nil {
+		tw.Print("Cluster UUID:", *hr.ClusterUUID)
 	}
 }

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/types"
+	"go.uber.org/zap"
 )
 
 func newHealthOverviewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -28,15 +29,25 @@ func newHealthOverviewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Queries cluster for health overview",
-		Long: `Queries health overview.
+		Long: `Queries cluster for health overview.
 
 Health overview is created based on the health reports collected periodically
 from all nodes in the cluster. A cluster is considered healthy when the
 following conditions are met:
 
-* all cluster nodes are responding
-* all partitions have leaders
-* the cluster controller is present
+  * All cluster nodes are responding
+  * All partitions have leaders
+  * The cluster controller is present
+`,
+		Example: `
+Basic usage, get cluster health information:
+  rpk cluster health
+
+Get cluster health information and watch for changes:
+  rpk cluster health --watch
+
+Get cluster health information and exit when the cluster is healthy:
+  rpk cluster health --exit-when-healthy
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -47,6 +58,13 @@ following conditions are met:
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
+			resp, err := cl.ClusterUUID(cmd.Context())
+			var clusterUUID *string
+			if err != nil {
+				zap.L().Sugar().Warnf("unable to get cluster UUID for the cluster health report: %v; skipping collection and checking cluster health", err)
+			} else {
+				clusterUUID = &resp.UUID
+			}
 			// --exit-when-healthy only makes sense with --watch, so we enable
 			// watch if --exit-when-healthy is provided.
 			watch = exit || watch
@@ -55,7 +73,7 @@ following conditions are met:
 				ret, err := cl.GetHealthOverview(cmd.Context())
 				out.MaybeDie(err, "unable to request cluster health: %v", err)
 				if !reflect.DeepEqual(ret, lastOverview) {
-					printHealthOverview(&ret)
+					printHealthOverview(&ret, clusterUUID)
 				}
 				lastOverview = ret
 				if !watch || exit && lastOverview.IsHealthy {
@@ -73,7 +91,7 @@ following conditions are met:
 	return cmd
 }
 
-func printHealthOverview(hov *rpadmin.ClusterHealthOverview) {
+func printHealthOverview(hov *rpadmin.ClusterHealthOverview, clusterUUID *string) {
 	types.Sort(hov)
 	out.Section("CLUSTER HEALTH OVERVIEW")
 
@@ -106,4 +124,7 @@ func printHealthOverview(hov *rpadmin.ClusterHealthOverview) {
 	}
 	tw.Print(lp, hov.LeaderlessPartitions)
 	tw.Print(urp, hov.UnderReplicatedPartitions)
+	if clusterUUID != nil {
+		tw.Print("Cluster UUID:", *clusterUUID)
+	}
 }

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -11,6 +11,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 
@@ -38,6 +39,8 @@ following conditions are met:
   * All cluster nodes are responding
   * All partitions have leaders
   * The cluster controller is present
+
+If the cluster is reported as unhealthy, rpk will exit with code 10.
 `,
 		Example: `
 Basic usage, get cluster health information:
@@ -69,9 +72,11 @@ Get cluster health information and exit when the cluster is healthy:
 			// watch if --exit-when-healthy is provided.
 			watch = exit || watch
 			var lastOverview rpadmin.ClusterHealthOverview
+			var exit10 bool
 			for {
 				ret, err := cl.GetHealthOverview(cmd.Context())
 				out.MaybeDie(err, "unable to request cluster health: %v", err)
+				exit10 = !ret.IsHealthy
 				if !reflect.DeepEqual(ret, lastOverview) {
 					printHealthOverview(&ret, clusterUUID)
 				}
@@ -80,6 +85,11 @@ Get cluster health information and exit when the cluster is healthy:
 					break
 				}
 				time.Sleep(2 * time.Second)
+			}
+			if exit10 {
+				// We choose 10 to differentiate from any other error (1), or
+				// unhandled panics (2).
+				os.Exit(10)
 			}
 		},
 	}


### PR DESCRIPTION
This PR adds a few improvements to `rpk cluster health`:

- 9933f60ad96a12d5bdeda054c133cb0e15e8958d adds the cluster UUID to the `rpk cluster health` output. Please note that if the request for the UUID fails we still print the health output without it, we don't want to block the health report for a missing UUID.
- 374ef0b6835529466898e0802dee0caed26248dc changes the exit status code (to 10) when the cluster is reported as unhealthy so a script can differentiate when the command failed to run vs the cluster is unhealthy Fixes #16128 
- eb9b4533db71f65e7d6411b10e79a7c18d0b3e02 adds `--format json/yaml` support to the command. Examples below.

### Examples

**Exit code changes**
```bash
# Normal behavior
$ rpk cluster health
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          true
Unhealthy reasons:                []
Controller ID:                    2
All nodes:                        [0 1 2]
Nodes down:                       []
Nodes in recovery mode:           []
Leaderless partitions (0):        []
Under-replicated partitions (0):  []
Cluster UUID:                     537a36a4-deb1-4738-a02e-cab08a57469f
$ echo $?
0

# Exit 1 due to a connection refused
$ rpk cluster health
unable to get cluster UUID for the cluster health report: Get "http://127.0.0.1:9644/v1/partitions/redpanda/controller/0": dial tcp 127.0.0.1:9644: connect: connection refused
$ echo $?            
1

# Exit 10 if the cluster is unhealthy
$ rpk cluster health
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          false
Unhealthy reasons:                [leaderless_partitions nodes_down]
...
$ echo $?
10
```

**Format Examples**

```
$ rpk cluster health --format yaml
cluster_uuid: 537a36a4-deb1-4738-a02e-cab08a57469f
is_healthy: false
unhealthy_reasons:
    - nodes_down
    - under_replicated_partitions
controller_id: 0
all_nodes:
    - 0
    - 1
    - 2
nodes_down:
    - 1
nodes_in_recovery_mode: []
leaderless_partitions: []
leaderless_count: 0
under_replicated_count: 3
under_replicated_partitions:
    - kafka/_schemas/0
    - kafka_internal/id_allocator/0
    - redpanda/controller/0

$ rpk cluster health --format json | jq .
{
  "cluster_uuid": "537a36a4-deb1-4738-a02e-cab08a57469f",
  "is_healthy": false,
  "unhealthy_reasons": [
    "nodes_down",
    "under_replicated_partitions"
  ],
  "controller_id": 0,
  "all_nodes": [
    0,
    1,
    2
  ],
  "nodes_down": [
    1
  ],
  "nodes_in_recovery_mode": [],
  "leaderless_partitions": [],
  "leaderless_count": 0,
  "under_replicated_count": 3,
  "under_replicated_partitions": [
    "redpanda/controller/0",
    "kafka/_schemas/0",
    "kafka_internal/id_allocator/0"
  ]
}
```
**Failure to get the UUID**
```
...
18:40:27.720  WARN  unable to get cluster UUID for the cluster health report: no Admin API leader found; skipping collection and checking cluster health
...
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          false
Unhealthy reasons:                [leaderless_partitions no_elected_controller nodes_down]
Controller ID:                    -1
All nodes:                        [0 1 2]
Nodes down:                       [1 2]
Nodes in recovery mode:           []
Leaderless partitions (3):        [kafka/_schemas/0 kafka_internal/id_allocator/0 redpanda/controller/0]
Under-replicated partitions (0):  []
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* rpk improvements in `rpk cluster health`: rpk now exits with code 10 if the cluster is unhealthy; added support of `--format` to the command and added the cluster UUID to the commands' output.
