### PR TITLE
[CORE-9250] `storage`: rewrite raft data batches with `compression.type` during compaction

### DIFF
--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -139,7 +139,7 @@ bool topic_properties::has_overrides() const {
         || iceberg_invalid_record_action.has_value()
         || iceberg_target_lag_ms.has_value()
         || min_cleanable_dirty_ratio.is_engaged()
-        || remote_topic_allow_gaps.has_value();
+        || remote_topic_allow_gaps.has_value() || compression.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -184,6 +184,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.tombstone_retention_ms = delete_retention_ms;
     ret.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio;
     ret.remote_allow_gaps = remote_topic_allow_gaps;
+    ret.compression = compression;
     return ret;
 }
 

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -11,6 +11,7 @@
 
 #include "base/vlog.h"
 #include "compression/compression.h"
+#include "model/compression.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
 #include "model/record_utils.h"
@@ -308,7 +309,28 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
                 r.offset_delta());
           });
     }
-    auto batch = co_await compress_batch(original, std::move(to_copy.value()));
+
+    auto compression_type = [original, &batch = to_copy.value(), this]() {
+        // Recompress with the original compression type if the topic is
+        // configured with `compaction.type=producer`. Otherwise, compress with
+        // `compaction.type`.
+        if (_compression_type == model::compression::producer) {
+            return original;
+        } else {
+            // We are going to apply the topic `compression.type` to this batch.
+            // We'd better be sure it's data MEANT to be compressed, i.e raft
+            // data.
+            if (batch.header().type == model::record_batch_type::raft_data) {
+                return _compression_type;
+            }
+        }
+
+        // Fall back to returning original compression type.
+        return original;
+    }();
+
+    auto batch = co_await compress_batch(
+      compression_type, std::move(to_copy.value()));
     const auto start_pos = _appender->file_byte_offset();
     const auto header_size = batch.header().size_bytes;
     _acc += header_size;

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -15,6 +15,7 @@
 #include "bytes/bytes.h"
 #include "container/fragmented_vector.h"
 #include "hashing/xx.h"
+#include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "storage/compacted_index.h"
@@ -163,12 +164,14 @@ public:
       bool internal_topic,
       offset_delta_time apply_offset,
       model::offset segment_last_offset,
+      model::compression compression_type,
       compacted_index_writer* cidx = nullptr,
       bool inject_failure = false,
       ss::abort_source* as = nullptr)
       : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
       , _appender(a)
+      , _compression_type(compression_type)
       , _compacted_idx(cidx)
       , _idx(index_state::make_empty_index(apply_offset))
       , _internal_topic(internal_topic)
@@ -198,6 +201,8 @@ private:
     // Offset to keep in case the index is empty as of getting to this offset.
     model::offset _segment_last_offset;
     segment_appender* _appender;
+
+    model::compression _compression_type;
 
     // Compacted index writer for the newly written segment. May not be
     // supplied if the compacted index isn't expected to change, e.g. when

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -431,6 +431,18 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
     co_return _start_offset;
 }
 
+ss::future<compaction_result> disk_log_impl::segment_self_compact(
+  ss::lw_shared_ptr<segment> s, const compaction_config& cfg) {
+    return storage::internal::self_compact_segment(
+      s,
+      _stm_manager,
+      cfg,
+      *_probe,
+      *_readers_cache,
+      _manager.resources(),
+      _feature_table);
+}
+
 ss::future<> disk_log_impl::adjacent_merge_compact(
   compaction_config cfg, std::optional<model::offset> new_start_offset) {
     vlog(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -225,6 +225,9 @@ public:
 
     storage_resources& resources();
 
+    ss::future<compaction_result> segment_self_compact(
+      ss::lw_shared_ptr<segment> s, const compaction_config& cfg);
+
     // Performs self-compaction on the earliest segment possible, and then
     // attempts to perform compaction on adjacent segments.
     ss::future<> adjacent_merge_compact(

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -351,7 +351,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           _config.compaction_priority,
           _abort_source,
           std::move(ntp_sanitizer_cfg),
-          _compaction_hash_key_map.get()));
+          _compaction_hash_key_map.get(),
+          current_log.handle->config().compression_type()));
         _probe->housekeeping_log_processed();
 
         // bail out of compaction early in order to get back to gc

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "config/configuration.h"
+#include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -89,6 +90,8 @@ public:
         tristate<double> min_cleanable_dirty_ratio;
         // Controls behavior during pause
         std::optional<bool> remote_allow_gaps;
+
+        std::optional<model::compression> compression;
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
@@ -388,6 +391,13 @@ public:
             }
         }
         return config::shard_local_cfg().min_cleanable_dirty_ratio();
+    }
+
+    model::compression compression_type() const {
+        if (_overrides && _overrides->compression.has_value()) {
+            return _overrides->compression.value();
+        }
+        return config::shard_local_cfg().log_compression_type();
     }
 
     ntp_config copy() const {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -234,6 +234,7 @@ ss::future<index_state> deduplicate_segment(
       seg->path().is_internal_topic(),
       should_offset_delta_times,
       seg->offsets().get_committed_offset(),
+      cfg.compression_type,
       &cmp_idx_writer,
       inject_reader_failure,
       cfg.asrc);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -422,6 +422,7 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->path().is_internal_topic(),
       apply_offset,
       segment_last_offset,
+      cfg.compression_type,
       /*cidx=*/nullptr,
       /*inject_failure=*/false,
       cfg.asrc);

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -835,9 +835,11 @@ redpanda_cc_gtest(
     ],
     cpu = 1,
     deps = [
+        ":disk_log_builder",
         "//src/v/base",
         "//src/v/kafka/server/tests:kafka_test_utils",
         "//src/v/model",
+        "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/redpanda/tests:fixture",
         "//src/v/storage",

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -163,7 +163,7 @@ rp_test(
   GTEST
   BINARY_NAME gtest_storage_e2e
   SOURCES compaction_e2e_test.cc
-  LIBRARIES  v::application v::features v::gtest_main v::kafka_test_utils
+  LIBRARIES  v::application v::features v::gtest_main v::kafka_test_utils v::storage_test_utils v::model_test_utils
   LABELS storage
   ARGS "-- -c 1"
 )

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -10,11 +10,14 @@
 #include "base/vlog.h"
 #include "gtest/gtest.h"
 #include "kafka/server/tests/produce_consume_utils.h"
+#include "model/compression.h"
 #include "model/namespace.h"
 #include "model/record_batch_types.h"
+#include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/tests/manual_mixin.h"
+#include "storage/tests/utils/disk_log_builder.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
@@ -1336,3 +1339,100 @@ INSTANTIATE_TEST_SUITE_P(
   RandomDistributionMultiPass,
   CompactionFixtureTombstonesMultiPassRandomParamTest,
   ::testing::Combine(::testing::Bool(), ::testing::Values(10, 25, 100)));
+
+class CompactionFixtureTopicCompressionTest
+  : public ::testing::Test
+  , public ::testing::WithParamInterface<model::compression> {
+public:
+    struct compression_type_validating_consumer {
+        ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+            RPTEST_EXPECT_EQ(
+              b.header().attrs.compression(),
+              _expected_compression_types[index++]);
+            return ss::make_ready_future<ss::stop_iteration>(
+              ss::stop_iteration::no);
+        }
+
+        void end_of_stream() {}
+
+        std::vector<model::compression> _expected_compression_types;
+        size_t index{0};
+    };
+};
+
+TEST_P(CompactionFixtureTopicCompressionTest, TopicCompressionTypeTest) {
+    using namespace storage;
+    disk_log_builder b;
+    b | start();
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    auto num_batches = 100;
+    // Make random batches.
+    auto batches = model::test::make_random_batches(
+                     /*offset=*/model::offset{0},
+                     /*count=*/num_batches,
+                     /*allow_compression=*/true)
+                     .get();
+
+    std::vector<model::compression> original_compression_types{};
+    for (auto& batch : batches) {
+        original_compression_types.push_back(
+          batch.header().attrs.compression());
+    }
+
+    // Add the batches and force roll the log.
+    b | add_segment(0);
+    for (auto& batch : batches) {
+        b | add_batch(std::move(batch));
+    }
+    disk_log.force_roll(ss::default_priority_class()).get();
+
+    auto topic_compression_type = GetParam();
+    ss::abort_source as;
+    compaction_config compact_cfg(
+      model::offset::max(),
+      std::nullopt,
+      ss::default_priority_class(),
+      as,
+      /*san_cfg=*/std::nullopt,
+      /*max_keys=*/std::nullopt,
+      /*key_map=*/nullptr,
+      /*to_clean=*/nullptr,
+      topic_compression_type);
+
+    EXPECT_EQ(disk_log.segment_count(), 2);
+    // Self compact the rolled segment with all the compressed batches in it.
+    disk_log.segment_self_compact(disk_log.segments()[0], compact_cfg).get();
+
+    // Make a reader and check each of the compression types in the
+    // re-compressed batches.
+    log_reader_config cfg(
+      model::offset{0}, model::offset::max(), ss::default_priority_class());
+
+    auto reader = disk_log.make_reader(std::move(cfg)).get();
+
+    std::vector<model::compression> expected_compression_types;
+    if (topic_compression_type == model::compression::producer) {
+        expected_compression_types = std::move(original_compression_types);
+    } else {
+        expected_compression_types = std::vector<model::compression>(
+          num_batches, topic_compression_type);
+    }
+    reader
+      .consume(
+        compression_type_validating_consumer{
+          ._expected_compression_types = std::move(expected_compression_types)},
+        model::no_timeout)
+      .get();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  TopicCompressionTest,
+  CompactionFixtureTopicCompressionTest,
+  ::testing::Values(
+    model::compression::none,
+    model::compression::gzip,
+    model::compression::snappy,
+    model::compression::lz4,
+    model::compression::zstd,
+    model::compression::producer));

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -208,10 +208,12 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
       o,
       "{{max_collectible_offset:{}, "
       "should_sanitize:{}, "
-      "tombstone_retention_ms:{}}}",
+      "tombstone_retention_ms:{}, "
+      "compression_type:{}}}",
       c.max_collectible_offset,
       c.sanitizer_config,
-      c.tombstone_retention_ms);
+      c.tombstone_retention_ms,
+      c.compression_type);
     return o;
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "container/fragmented_vector.h"
+#include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
 #include "model/record.h"
@@ -476,7 +477,8 @@ struct compaction_config {
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
       hash_key_offset_map* key_map = nullptr,
-      scoped_file_tracker::set_t* to_clean = nullptr)
+      scoped_file_tracker::set_t* to_clean = nullptr,
+      model::compression comp_type = model::compression::producer)
       : max_collectible_offset(max_collect_offset)
       , tombstone_retention_ms(tombstone_ret_ms)
       , iopc(p)
@@ -484,7 +486,8 @@ struct compaction_config {
       , key_offset_map_max_keys(max_keys)
       , hash_key_map(key_map)
       , files_to_cleanup(to_clean)
-      , asrc(&as) {}
+      , asrc(&as)
+      , compression_type(comp_type) {}
 
     // Cannot delete or compact past this offset (i.e. for unresolved txn
     // records): that is, only offsets <= this may be compacted.
@@ -520,6 +523,10 @@ struct compaction_config {
     // abort source for compaction task
     ss::abort_source* asrc;
 
+    // The topic compression type used to recompress batches during compaction
+    // (from ntp config).
+    model::compression compression_type;
+
     friend std::ostream& operator<<(std::ostream&, const compaction_config&);
 };
 
@@ -538,7 +545,8 @@ struct housekeeping_config {
       ss::io_priority_class p,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
-      hash_key_offset_map* key_map = nullptr)
+      hash_key_offset_map* key_map = nullptr,
+      model::compression comp_type = model::compression::producer)
       : compact(
           max_collect_offset,
           tombstone_retention_ms,
@@ -546,7 +554,9 @@ struct housekeeping_config {
           as,
           std::move(san_cfg),
           std::nullopt,
-          key_map)
+          key_map,
+          nullptr,
+          comp_type)
       , gc(upper, max_bytes_in_log) {}
 
     compaction_config compact;


### PR DESCRIPTION
The broker/topic properties `log_compaction_type`/`compression.type` are not currently used for broker side compression in `redpanda`. The only compression `redpanda` supports in the present is producer side compression, and we make no attempts to respect the broker/topic properties.

This PR is half the battle. Now, when re-writing raft data batches in segments during compaction, we will respect `compression.type` and actively re-compress segments according to this property. If the `compression.type=producer`, we respect the original compression type in the record batch's header, and re-compress using that. If the `compression.type=none`, we will not re-compress the batch, even if it was compressed on the producer side originally. If `compression.type` is any other specific compression algorithm, the batch is re-compressed using the provided algorithm.

This is applied only to raft data batches presently to avoid any radical changes in `redpanda` behavior w/r/t other batch types. There are a number of code paths which don't expect compressed batches (`batch_applicator` in `state_machine_manager`, `kafka::group_recovery_consumer`, etc), and will trigger `vassert()`s when attempting to iterate over compressed batches via a log reader.  While these crashes have trivial fixes, the choice of which batch types it is worth applying compression to is an open question.

The other half of the battle is broker compression on the produce path- this is left as future work.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Features

* Support broker-side compression using `compression.type` during the re-writing of kafka data batches during compaction. 
