### PR TITLE
pandaproxy/sr: Relax schema registry startup validity requirements

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -305,7 +305,7 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     rq.req.reset();
 
     // With deferred schema validation, there might be a schema that
-    // had invalid references. These might have already been posted, soft
+    // had invalid references. These might have already been posted, so
     // we need to sync
     co_await rq.service().writer().read_sync();
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -304,6 +304,11 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     auto id = parse::request_param<schema_id>(*rq.req, "id");
     rq.req.reset();
 
+    // With deferred schema validation, there might be a schema that
+    // had invalid references. These might have already been posted, soft
+    // we need to sync
+    co_await rq.service().writer().read_sync();
+
     auto def = co_await get_or_load(rq, [&rq, id]() {
         return rq.service().schema_store().get_schema_definition(id);
     });

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -434,17 +434,17 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
         throw as_exception(has_references(sub, version));
     }
 
-    auto s_res = co_await _store.get_subject_schema(
-      sub, version, include_deleted::yes);
-    subject_schema ss = std::move(s_res);
+    schema_id s_id = co_await _store.get_id(sub, version);
+    unparsed_schema_definition schema
+      = co_await _store.get_unparsed_schema_definition(s_id);
 
     auto key = schema_key{
       .seq{write_at}, .node{_node_id}, .sub{sub}, .version{version}};
     vlog(plog.debug, "seq_writer::delete_subject_version {}", key);
-    auto value = canonical_schema_value{
-      .schema{std::move(ss.schema)},
+    unparsed_schema_value value{
+      .schema{unparsed_schema{sub, std::move(schema)}},
       .version{version},
-      .id{ss.id},
+      .id{s_id},
       .deleted{is_deleted::yes}};
 
     batch_builder rb(write_at, sub);

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -301,22 +301,6 @@ ss::future<bool> sharded_store::upsert(
   schema_id id,
   schema_version version,
   is_deleted deleted) {
-    auto norm = normalize{
-      config::shard_local_cfg().schema_registry_normalize_on_startup()};
-    co_return co_await upsert(
-      marker,
-      co_await make_canonical_schema(std::move(schema), norm),
-      id,
-      version,
-      deleted);
-}
-
-ss::future<bool> sharded_store::upsert(
-  seq_marker marker,
-  canonical_schema schema,
-  schema_id id,
-  schema_version version,
-  is_deleted deleted) {
     auto [sub, def] = std::move(schema).destructure();
     co_await upsert_schema(id, std::move(def));
     co_return co_await upsert_subject(
@@ -366,6 +350,16 @@ ss::future<subject_schema> sharded_store::has_schema(
             if (
               e.code() == error_code::subject_not_found
               || e.code() == error_code::subject_version_not_found) {
+            } else if (
+              // Stored schemas might be invalid if imported improperly
+              e.code() == error_code::schema_invalid) {
+                vlog(
+                  plog.warn,
+                  "Failed to parse stored schema, subject '{}', version {}. "
+                  "Error: {}",
+                  schema.sub(),
+                  ver,
+                  e.what());
             } else {
                 throw;
             }
@@ -379,10 +373,10 @@ ss::future<subject_schema> sharded_store::has_schema(
 
 ss::future<std::optional<canonical_schema_definition>>
 sharded_store::maybe_get_schema_definition(schema_id id) {
-    co_return co_await _store.invoke_on(
+    auto unparsed = co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
-      [id](store& s) -> std::optional<canonical_schema_definition> {
+      [id](store& s) -> std::optional<unparsed_schema_definition> {
           auto s_res = s.get_schema_definition(id);
           if (
             s_res.has_error()
@@ -391,10 +385,49 @@ sharded_store::maybe_get_schema_definition(schema_id id) {
           }
           return std::move(s_res.value());
       });
+    if (!unparsed.has_value()) {
+        co_return std::nullopt;
+    }
+
+    try {
+        auto canonical = co_await make_canonical_schema(
+          {{}, std::move(unparsed.value())});
+
+        co_return std::move(canonical).def();
+    } catch (const exception& e) {
+        vlog(
+          plog.warn,
+          "Failed to parse stored schema with id {}: Error {}",
+          id,
+          e.what());
+        throw;
+    }
 }
 
 ss::future<canonical_schema_definition>
 sharded_store::get_schema_definition(schema_id id) {
+    auto unparsed = co_await _store.invoke_on(
+      shard_for(id), _smp_opts, [id](store& s) {
+          return s.get_schema_definition(id).value();
+      });
+
+    try {
+        auto canonical = co_await make_canonical_schema(
+          {{}, std::move(unparsed)});
+
+        co_return std::move(canonical).def();
+    } catch (const exception& e) {
+        vlog(
+          plog.warn,
+          "Failed to parse stored schema with id {}: Error {}",
+          id,
+          e.what());
+        throw;
+    }
+}
+
+ss::future<unparsed_schema_definition>
+sharded_store::get_unparsed_schema_definition(schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
@@ -429,6 +462,17 @@ sharded_store::get_schema_subjects(schema_id id, include_deleted inc_del) {
     co_return subs;
 }
 
+ss::future<schema_id>
+sharded_store::get_id(subject sub, std::optional<schema_version> version) {
+    auto v_id = co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, version](store& s) {
+          return s.get_subject_version_id(sub, version, include_deleted::yes)
+            .value();
+      });
+
+    co_return v_id.id;
+}
+
 ss::future<subject_schema> sharded_store::get_subject_schema(
   subject sub, std::optional<schema_version> version, include_deleted inc_del) {
     auto sub_shard{shard_for(sub)};
@@ -442,11 +486,23 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
           return s.get_schema_definition(id).value();
       });
 
-    co_return subject_schema{
-      .schema = {sub, std::move(def)},
-      .version = v_id.version,
-      .id = v_id.id,
-      .deleted = v_id.deleted};
+    try {
+        auto canonical = co_await make_canonical_schema({sub, std::move(def)});
+
+        co_return subject_schema{
+          .schema = std::move(canonical),
+          .version = v_id.version,
+          .id = v_id.id,
+          .deleted = v_id.deleted};
+    } catch (const exception& e) {
+        vlog(
+          plog.warn,
+          "Failed to parse stored schema, subject {}, version {}: {}",
+          sub,
+          v_id.id,
+          e.what());
+        throw;
+    }
 }
 
 ss::future<chunked_vector<subject>> sharded_store::get_subjects(
@@ -704,7 +760,7 @@ sharded_store::clear_compatibility(seq_marker marker, subject sub) {
 }
 
 ss::future<bool>
-sharded_store::upsert_schema(schema_id id, canonical_schema_definition def) {
+sharded_store::upsert_schema(schema_id id, unparsed_schema_definition def) {
     co_await maybe_update_max_schema_id(id);
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id, def{std::move(def)}](store& s) mutable {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -332,16 +332,8 @@ ss::future<subject_schema> sharded_store::has_schema(
     std::optional<subject_schema> sub_schema;
     for (auto ver : versions) {
         try {
-            auto res = co_await get_subject_schema(schema.sub(), ver, inc_del);
-            res.schema = co_await make_canonical_schema(
-              unparsed_schema{
-                res.schema.sub(),
-                unparsed_schema_definition{
-                  unparsed_schema_definition::raw_string{
-                    res.schema.def().raw()().copy()},
-                  res.schema.def().type(),
-                  res.schema.def().refs()}},
-              norm);
+            auto res = co_await get_subject_schema(
+              schema.sub(), ver, inc_del, norm);
             if (schema.def() == res.schema.def()) {
                 sub_schema.emplace(std::move(res));
                 break;
@@ -475,6 +467,14 @@ sharded_store::get_id(subject sub, std::optional<schema_version> version) {
 
 ss::future<subject_schema> sharded_store::get_subject_schema(
   subject sub, std::optional<schema_version> version, include_deleted inc_del) {
+    return get_subject_schema(sub, version, inc_del, normalize::no);
+}
+
+ss::future<subject_schema> sharded_store::get_subject_schema(
+  subject sub,
+  std::optional<schema_version> version,
+  include_deleted inc_del,
+  normalize norm) {
     auto sub_shard{shard_for(sub)};
     auto v_id = co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub, version, inc_del](store& s) {
@@ -487,7 +487,8 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
       });
 
     try {
-        auto canonical = co_await make_canonical_schema({sub, std::move(def)});
+        auto canonical = co_await make_canonical_schema(
+          {sub, std::move(def)}, norm);
 
         co_return subject_schema{
           .schema = std::move(canonical),

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -92,6 +92,12 @@ public:
       std::optional<schema_version> version,
       include_deleted inc_dec) final;
 
+    ss::future<subject_schema> get_subject_schema(
+      subject sub,
+      std::optional<schema_version> version,
+      include_deleted inc_dec,
+      normalize norm);
+
     ///\brief Return the id of a schema by subject and version (or latest).
     ss::future<schema_id>
     get_id(subject sub, std::optional<schema_version> version);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -56,13 +56,6 @@ public:
 
     ss::future<bool> upsert(
       seq_marker marker,
-      canonical_schema schema,
-      schema_id id,
-      schema_version version,
-      is_deleted deleted);
-
-    ss::future<bool> upsert(
-      seq_marker marker,
       unparsed_schema schema,
       schema_id id,
       schema_version version,
@@ -77,6 +70,10 @@ public:
     ///\brief Return a schema definition by id.
     ss::future<canonical_schema_definition>
     get_schema_definition(schema_id id) override;
+
+    ///\brief Return a schema definition by id, without any processing.
+    ss::future<unparsed_schema_definition>
+    get_unparsed_schema_definition(schema_id id);
 
     ss::future<std::optional<canonical_schema_definition>>
     maybe_get_schema_definition(schema_id id) override;
@@ -94,6 +91,10 @@ public:
       subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec) final;
+
+    ///\brief Return the id of a schema by subject and version (or latest).
+    ss::future<schema_id>
+    get_id(subject sub, std::optional<schema_version> version);
 
     ///\brief Return a list of subjects.
     ss::future<chunked_vector<subject>> get_subjects(
@@ -207,7 +208,7 @@ private:
       schema_version version, canonical_schema new_schema, verbose is_verbose);
 
     ss::future<bool>
-    upsert_schema(schema_id id, canonical_schema_definition def);
+    upsert_schema(schema_id id, unparsed_schema_definition def);
     ss::future<> delete_schema(schema_id id);
 
     struct insert_subject_result {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -87,7 +87,7 @@ public:
     /// version.
     ///
     /// return the schema_version and schema_id, and whether it's new.
-    insert_result insert(canonical_schema schema) {
+    insert_result insert(unparsed_schema schema) {
         auto [sub, def] = std::move(schema).destructure();
         auto id = insert_schema(std::move(def)).id;
         auto [version, inserted] = insert_subject(std::move(sub), id);
@@ -95,7 +95,7 @@ public:
     }
 
     ///\brief Return a schema definition by id.
-    result<canonical_schema_definition>
+    result<unparsed_schema_definition>
     get_schema_definition(const schema_id& id) const {
         auto it = _schemas.find(id);
         if (it == _schemas.end()) {
@@ -157,7 +157,7 @@ public:
     }
 
     ///\brief Return a schema by subject and version.
-    result<subject_schema> get_subject_schema(
+    result<unparsed_subject_schema> get_subject_schema(
       const subject& sub,
       std::optional<schema_version> version,
       include_deleted inc_del) const {
@@ -166,7 +166,7 @@ public:
 
         auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
 
-        return subject_schema{
+        return unparsed_subject_schema{
           .schema = {sub, std::move(def)},
           .version = v_id.version,
           .id = v_id.id,
@@ -614,7 +614,7 @@ public:
         schema_id id;
         bool inserted;
     };
-    insert_schema_result insert_schema(canonical_schema_definition def) {
+    insert_schema_result insert_schema(unparsed_schema_definition def) {
         const auto s_it = std::find_if(
           _schemas.begin(), _schemas.end(), [&](const auto& s) {
               const auto& entry = s.second;
@@ -630,7 +630,7 @@ public:
         return {id, inserted};
     }
 
-    bool upsert_schema(schema_id id, canonical_schema_definition def) {
+    bool upsert_schema(schema_id id, unparsed_schema_definition def) {
         return _schemas.insert_or_assign(id, schema_entry(std::move(def)))
           .second;
     }
@@ -776,10 +776,10 @@ public:
 
 private:
     struct schema_entry {
-        explicit schema_entry(canonical_schema_definition definition)
+        explicit schema_entry(unparsed_schema_definition definition)
           : definition{std::move(definition)} {}
 
-        canonical_schema_definition definition;
+        unparsed_schema_definition definition;
     };
 
     class subject_entry {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -44,7 +44,7 @@ struct simple_sharded_store {
     simple_sharded_store& operator=(simple_sharded_store&&) = delete;
 
     pps::schema_id
-    insert(const pps::canonical_schema& schema, pps::schema_version version) {
+    insert(const pps::unparsed_schema& schema, pps::schema_version version) {
         const auto id = next_id++;
         store
           .upsert(
@@ -72,9 +72,9 @@ bool check_compatible(
     simple_sharded_store store;
     store.store.set_compatibility(lvl).get();
     store.insert(
-      pandaproxy::schema_registry::canonical_schema{
+      pandaproxy::schema_registry::unparsed_schema{
         pps::subject{"sub"},
-        pps::canonical_schema_definition{writer, pps::schema_type::protobuf}},
+        pps::unparsed_schema_definition{writer, pps::schema_type::protobuf}},
       pps::schema_version{1});
     return store.store
       .is_compatible(
@@ -106,7 +106,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
 
     auto schema1 = pps::canonical_schema{
       pps::subject{"simple"}, simple.share()};
-    store.insert(schema1, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
                           .get();
@@ -118,7 +118,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
 
     auto schema1 = pps::canonical_schema{
       pps::subject{"nested"}, nested.share()};
-    store.insert(schema1, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
     auto valid_nested = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
                           .get();
@@ -133,7 +133,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
     // imported depends on simple, which han't been inserted
     auto schema1 = pps::canonical_schema{
       pps::subject{"imported"}, imported.share()};
-    store.insert(schema1, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
     BOOST_REQUIRE_EXCEPTION(
       pps::make_protobuf_schema_definition(store.store, schema1.share()).get(),
       pps::exception,
@@ -150,7 +150,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     auto schema2 = pps::canonical_schema{
       pps::subject{"imported"}, imported_no_ref.share()};
 
-    store.insert(schema1, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -173,9 +173,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
     auto schema3 = pps::canonical_schema{
       pps::subject{"imported-again.proto"}, imported_again.share()};
 
-    store.insert(schema1, pps::schema_version{1});
-    store.insert(schema2, pps::schema_version{1});
-    store.insert(schema3, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema2.share()), pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema3.share()), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -198,9 +198,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
     auto schema3 = pps::canonical_schema{
       pps::subject{"imported-twice.proto"}, imported_twice.share()};
 
-    store.insert(schema1, pps::schema_version{1});
-    store.insert(schema2, pps::schema_version{1});
-    store.insert(schema3, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema2.share()), pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema3.share()), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -337,7 +337,7 @@ message well_known_types {
   confluent.type.Decimal c_decimal = 48;
 })",
         pps::schema_type::protobuf}};
-    store.insert(schema, pps::schema_version{1});
+    store.insert(pps::to_unparsed(schema.share()), pps::schema_version{1});
 
     auto valid_empty
       = pps::make_protobuf_schema_definition(store.store, schema.share()).get();

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -33,7 +33,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     auto sub = pps::subject{"sub"};
     s.upsert(
        dummy_marker,
-       {sub, schema1.share()},
+       pps::to_unparsed({sub, schema1.share()}),
        pps::schema_id{1},
        pps::schema_version{1},
        pps::is_deleted::no)
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
       s.is_compatible(pps::schema_version{1}, {sub, schema2.share()}).get());
     s.upsert(
        dummy_marker,
-       {sub, schema2.share()},
+       pps::to_unparsed({sub, schema2.share()}),
        pps::schema_id{2},
        pps::schema_version{2},
        pps::is_deleted::no)
@@ -56,7 +56,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     // Insert schema with non-defaulted field
     s.upsert(
        dummy_marker,
-       {sub, schema2.share()},
+       pps::to_unparsed({sub, schema2.share()}),
        pps::schema_id{2},
        pps::schema_version{2},
        pps::is_deleted::no)

--- a/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
@@ -35,8 +35,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
     // Upsert a large(ish) number of schemas to the store, all with different
     // subject names and IDs, so they should hash to different shards.
     for (int i = 1; i <= id_n; ++i) {
-        auto referenced_schema = pps::canonical_schema{
-          pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()};
+        auto referenced_schema = pps::to_unparsed(
+          {pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()});
         store
           .upsert(
             pps::seq_marker{

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -39,7 +39,7 @@ struct simple_sharded_store {
     simple_sharded_store& operator=(simple_sharded_store&&) = delete;
 
     pps::schema_id
-    insert(const pps::canonical_schema& schema, pps::schema_version version) {
+    insert(const pps::unparsed_schema& schema, pps::schema_version version) {
         const auto id = next_id++;
         store
           .upsert(

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -31,8 +31,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     const pps::schema_version ver1{1};
 
     // Insert simple
-    auto referenced_schema = pps::canonical_schema{
-      pps::subject{"simple.proto"}, simple.share()};
+    auto referenced_schema = pps::to_unparsed(
+      {pps::subject{"simple.proto"}, simple.share()});
     store
       .upsert(
         pps::seq_marker{
@@ -44,8 +44,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       .get();
 
     // Insert referenced
-    auto importing_schema = pps::canonical_schema{
-      pps::subject{"imported.proto"}, imported.share()};
+    auto importing_schema = pps::to_unparsed(
+      {pps::subject{"imported.proto"}, imported.share()});
 
     store
       .upsert(

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -11,6 +11,7 @@
 
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/test/compatibility_avro.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/schema_registry/util.h"
 
 #include <absl/algorithm/container.h>
@@ -21,13 +22,13 @@ namespace pps = pandaproxy::schema_registry;
 constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
 constexpr std::string_view sv_string_def1{R"({"type": "string"})"};
 constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
-const pps::canonical_schema_definition string_def0{
+const pps::unparsed_schema_definition string_def0{
   pps::make_schema_definition<json::UTF8<>>(sv_string_def0).value(),
   pps::schema_type::avro};
-const pps::canonical_schema_definition string_def1{
+const pps::unparsed_schema_definition string_def1{
   pps::make_schema_definition<json::UTF8<>>(sv_string_def1).value(),
   pps::schema_type::avro};
-const pps::canonical_schema_definition int_def0{
+const pps::unparsed_schema_definition int_def0{
   pps::make_schema_definition<json::UTF8<>>(sv_int_def0).value(),
   pps::schema_type::avro};
 const pps::subject subject0{"subject0"};
@@ -72,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_store_insert) {
 bool upsert(
   pps::store& store,
   pps::subject sub,
-  pps::canonical_schema_definition def,
+  pps::unparsed_schema_definition def,
   pps::schema_type,
   pps::schema_id id,
   pps::schema_version version,
@@ -207,8 +208,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     pps::seq_marker dummy_marker;
 
     // First insert, expect id{1}
-    auto ins_res = s.insert(
-      {subject0, pps::canonical_schema_definition(schema1.share())});
+    auto ins_res = s.insert(pps::to_unparsed({subject0, schema1.share()}));
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
@@ -222,8 +222,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     BOOST_REQUIRE(versions.empty());
 
     // Second insert, expect id{2}
-    ins_res = s.insert(
-      {subject0, pps::canonical_schema_definition(schema2.share())});
+    ins_res = s.insert(pps::to_unparsed({subject0, schema2.share()}));
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
@@ -259,8 +258,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     pps::seq_marker dummy_marker;
 
     // First insert, expect id{1}
-    auto ins_res = s.insert(
-      {subject0, pps::canonical_schema_definition(schema1.share())});
+    auto ins_res = s.insert(pps::to_unparsed({subject0, schema1.share()}));
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
@@ -271,15 +269,13 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject0)), 1);
 
     // Second insert, same schema, expect id{1}
-    ins_res = s.insert(
-      {subject1, pps::canonical_schema_definition(schema1.share())});
+    ins_res = s.insert(pps::to_unparsed({subject1, schema1.share()}));
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
     // Insert yet another schema associated with a different subject
-    ins_res = s.insert(
-      {subject2, pps::canonical_schema_definition(schema2.share())});
+    ins_res = s.insert(pps::to_unparsed({subject2, schema2.share()}));
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -397,7 +397,7 @@ SEASTAR_THREAD_TEST_CASE(test_json_schema_references) {
             f.store
               .upsert(
                 pps::seq_marker{},
-                canonical.share(),
+                pps::to_unparsed(canonical.share()),
                 ++id,
                 ++ver,
                 pps::is_deleted::no)

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -93,4 +93,15 @@ std::ostream& operator<<(std::ostream& os, const compatibility_result& res) {
     return os;
 }
 
+unparsed_schema_definition
+to_unparsed(canonical_schema_definition&& canonical) {
+    auto [raw, type, refs] = std::move(canonical).destructure();
+    return {std::move(raw), type, std::move(refs)};
+}
+
+unparsed_schema to_unparsed(canonical_schema&& canonical) {
+    auto [sub, def] = std::move(canonical).destructure();
+    return {std::move(sub), to_unparsed(std::move(def))};
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -203,6 +203,9 @@ using unparsed_schema_definition
 using canonical_schema_definition
   = typed_schema_definition<struct canonical_schema_definition_tag>;
 
+///\brief Util function for when a canonical schema need to be re-ingested
+unparsed_schema_definition to_unparsed(canonical_schema_definition&&);
+
 static const unparsed_schema_definition invalid_schema_definition{
   "", schema_type::avro};
 
@@ -467,16 +470,25 @@ private:
 using unparsed_schema = typed_schema<unparsed_schema_definition::tag>;
 using canonical_schema = typed_schema<canonical_schema_definition::tag>;
 
-///\brief Complete description of a subject and schema for a version.
-struct subject_schema {
-    canonical_schema schema;
+///\brief Util function for when a canonical schema need to be re-ingested
+unparsed_schema to_unparsed(canonical_schema&&);
+
+template<typename tag>
+struct typed_subject_schema {
+    typed_schema<tag> schema;
     schema_version version{invalid_schema_version};
     schema_id id{invalid_schema_id};
     is_deleted deleted{false};
-    subject_schema share() const {
+    typed_subject_schema share() const {
         return {schema.share(), version, id, deleted};
     }
 };
+///\brief Complete description of a subject and schema for a version, as stored
+/// in store
+using unparsed_subject_schema
+  = typed_subject_schema<unparsed_schema_definition::tag>;
+///\brief Complete description of a subject and schema for a version.
+using subject_schema = typed_subject_schema<canonical_schema_definition::tag>;
 
 enum class compatibility_level {
     none = 0,
@@ -592,6 +604,14 @@ template<typename Buffer>
 void rjson_serialize(
   json::iobuf_writer<Buffer>& w,
   const pandaproxy::schema_registry::canonical_schema_definition::raw_string&
+    def) {
+    w.String(def());
+}
+
+template<typename Buffer>
+void rjson_serialize(
+  json::iobuf_writer<Buffer>& w,
+  const pandaproxy::schema_registry::unparsed_schema_definition::raw_string&
     def) {
     w.String(def());
 }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -103,6 +103,163 @@ message Test2 {
   Simple id =  1;
 }"""
 
+schema_a_proto_def = """
+syntax = "proto3";
+
+message AType {
+  float f =  1;
+}"""
+
+schema_a_proto_sanitized_def = """
+syntax = "proto3";
+
+message AType {
+  float f = 1;
+}"""
+
+schema_b_proto_def = """
+syntax = "proto3";
+
+import "schema_a.proto";
+
+message BType {
+  AType at =  1;
+}"""
+
+schema_b_proto_sanitized_def = """
+syntax = "proto3";
+
+import "schema_a.proto";
+message BType {
+  .AType at = 1;
+}"""
+
+schema_c_proto_def = """
+syntax = "proto3";
+
+import "schema_b.proto";
+
+message CType {
+  BType bt =  1;
+}"""
+
+schema_c_proto_sanitized_def = """
+syntax = "proto3";
+
+import "schema_b.proto";
+message CType {
+  .BType bt = 1;
+}"""
+
+schema_d_proto_def = """
+syntax = "proto3";
+
+import "schema_e.proto";
+
+message DType {
+  EType bt =  1;
+}"""
+
+schema_d_proto_sanitized_def = """
+syntax = "proto3";
+
+import "schema_e.proto";
+message DType {
+  .EType bt = 1;
+}"""
+
+schema_e_proto_def = """
+syntax = "proto3";
+
+message EType {
+  string et =  1;
+}"""
+
+# Schemas f,g,i,j,k are already sanitized
+schema_f_v1_proto_def = """
+syntax = "proto3";
+
+message FType {
+  string ft1 = 1;
+}"""
+
+schema_f_v2_proto_def = """
+syntax = "proto3";
+
+message FType {
+  string ft1 = 1;
+  string ft2 = 2;
+}"""
+
+schema_f_v3_proto_def = """
+syntax = "proto3";
+
+message FType {
+  string ft1 = 1;
+  string ft2 = 2;
+  string ft3 = 3;
+}"""
+
+schema_f_v4_proto_def = """
+syntax = "proto3";
+
+message FType {
+  string ft1 = 1;
+  string ft2 = 2;
+  string ft3 = 3;
+  string ft4 = 4;
+}"""
+
+schema_f_v5_proto_def = """
+syntax = "proto3";
+
+message FType {
+  string ft1 = 1;
+  string ft2 = 2;
+  string ft3 = 3;
+  string ft4 = 4;
+  string ft5 = 5;
+}"""
+
+schema_g_proto_def = """
+syntax = "proto3";
+
+import "schema_f.proto";
+message GType {
+  .FType gt = 1;
+}"""
+
+schema_h_proto_def = """
+syntax = "proto3";
+
+message HType {
+  int32 ht = 1;
+}"""
+
+schema_i_proto_def = """
+syntax = "proto3";
+
+import "schema_h.proto";
+message IType {
+  .HType it = 1;
+}"""
+
+schema_j_proto_def = """
+syntax = "proto3";
+
+import "schema_i.proto";
+message JType {
+  .IType jt = 1;
+}"""
+
+schema_k_proto_def = """
+syntax = "proto3";
+
+import "schema_j.proto";
+message KType {
+  .JType kt = 1;
+}"""
+
 well_known_proto_def = """
 syntax = "proto3";
 
@@ -234,6 +391,221 @@ imported_schema = {
     "schema": imported_schema_proto_def,
     "sanitized": imported_schema_sanitized_proto_def,
     "normalized": imported_schema_normalized_proto_def,
+}
+
+import_schemas = {
+    "schema_a": {
+        "subject": "schema_a",
+        "version": 1,
+        "schema": schema_a_proto_def,
+        "sanitized": schema_a_proto_sanitized_def,
+    },
+    "schema_b": {
+        "subject":
+        "schema_b",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_a.proto",
+            "subject": "schema_a",
+            "version": 1
+        }],
+        "schema":
+        schema_b_proto_def,
+        "sanitized":
+        schema_b_proto_sanitized_def,
+    },
+    "schema_c": {
+        "subject":
+        "schema_c",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_b.proto",
+            "subject": "schema_b",
+            "version": 1
+        }],
+        "schema":
+        schema_c_proto_def,
+        "sanitized":
+        schema_c_proto_sanitized_def,
+    },
+    "schema_d": {
+        "subject":
+        "schema_d",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_e.proto",
+            "subject": "schema_e",
+            "version": 1
+        }],
+        "schema":
+        schema_d_proto_def,
+        "sanitized":
+        schema_d_proto_sanitized_def,
+    },
+    "schema_e": {
+        "subject": "schema_e",
+        "version": 1,
+        "schema": schema_e_proto_def,
+    },
+    "schema_f_v1": {
+        "subject": "schema_f",
+        "version": 1,
+        "schema": schema_f_v1_proto_def,
+        "sanitized": schema_f_v1_proto_def,
+    },
+    "schema_f_v2": {
+        "subject": "schema_f",
+        "version": 2,
+        "schema": schema_f_v2_proto_def,
+        "sanitized": schema_f_v2_proto_def,
+    },
+    "schema_f_v3": {
+        "subject": "schema_f",
+        "version": 3,
+        "schema": schema_f_v3_proto_def,
+        "sanitized": schema_f_v3_proto_def,
+    },
+    "schema_f_v4": {
+        "subject": "schema_f",
+        "version": 4,
+        "schema": schema_f_v4_proto_def,
+        "sanitized": schema_f_v4_proto_def,
+    },
+    "schema_f_v5": {
+        "subject": "schema_f",
+        "version": 5,
+        "schema": schema_f_v5_proto_def,
+        "sanitized": schema_f_v5_proto_def,
+    },
+    "schema_g_v1": {
+        "subject":
+        "schema_g",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_f.proto",
+            "subject": "schema_f",
+            "version": 1
+        }],
+        "schema":
+        schema_g_proto_def,
+        "sanitized":
+        schema_g_proto_def,
+    },
+    "schema_g_v2": {
+        "subject":
+        "schema_g",
+        "version":
+        2,
+        "references": [{
+            "name": "schema_f.proto",
+            "subject": "schema_f",
+            "version": 2
+        }],
+        "schema":
+        schema_g_proto_def,
+        "sanitized":
+        schema_g_proto_def,
+    },
+    "schema_g_v3": {
+        "subject":
+        "schema_g",
+        "version":
+        3,
+        "references": [{
+            "name": "schema_f.proto",
+            "subject": "schema_f",
+            "version": 3
+        }],
+        "schema":
+        schema_g_proto_def,
+        "sanitized":
+        schema_g_proto_def,
+    },
+    "schema_g_v4": {
+        "subject":
+        "schema_g",
+        "version":
+        4,
+        "references": [{
+            "name": "schema_f.proto",
+            "subject": "schema_f",
+            "version": 4
+        }],
+        "schema":
+        schema_g_proto_def,
+        "sanitized":
+        schema_g_proto_def,
+    },
+    "schema_g_v5": {
+        "subject":
+        "schema_g",
+        "version":
+        5,
+        "references": [{
+            "name": "schema_f.proto",
+            "subject": "schema_f",
+            "version": 5
+        }],
+        "schema":
+        schema_g_proto_def,
+        "sanitized":
+        schema_g_proto_def,
+    },
+    "schema_h": {
+        "subject": "schema_h",
+        "version": 1,
+        "schema": schema_h_proto_def,
+        "sanitized": schema_h_proto_def,
+    },
+    "schema_i": {
+        "subject":
+        "schema_i",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_h.proto",
+            "subject": "schema_h",
+            "version": 1
+        }],
+        "schema":
+        schema_i_proto_def,
+        "sanitized":
+        schema_i_proto_def,
+    },
+    "schema_j": {
+        "subject":
+        "schema_j",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_i.proto",
+            "subject": "schema_i",
+            "version": 1
+        }],
+        "schema":
+        schema_j_proto_def,
+        "sanitized":
+        schema_j_proto_def,
+    },
+    "schema_k": {
+        "subject":
+        "schema_k",
+        "version":
+        1,
+        "references": [{
+            "name": "schema_j.proto",
+            "subject": "schema_j",
+            "version": 1
+        }],
+        "schema":
+        schema_k_proto_def,
+        "sanitized":
+        schema_k_proto_def,
+    },
 }
 
 log_config = LoggingConfig('info',
@@ -2080,6 +2452,351 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.not_found
         assert result_raw.json()["error_code"] == 40402
+
+    @cluster(num_nodes=3)
+    def test_imported_schemas_with_dependencies_issues(self):
+        """
+        Verify SR behavior when importing schemas in the wrong order and missing dependencies
+        """
+        def assert_request_code(raw, expected, endpoint):
+            assert raw.status_code == expected, \
+                    f"Expected {expected} but got {raw.status_code}, "\
+                    f"for request '{endpoint}' with content: {raw.content}"
+
+        #Test setup: Simulate import of schemas by writting directly into the _schemas topic
+        #Note that trying to commit these schemas in this order, using POST subjects/{subject}/version
+        #would fail as schemas 'schema_b' and 'schema_d' have unmet dependencies
+        schemas = [
+            #schema_a has no dependencies
+            import_schemas["schema_a"],
+            #schema_c is dependent on schema_b, which is loaded later on
+            import_schemas["schema_c"],
+            #schema_b is dependent on schema_a, which is already loaded
+            import_schemas["schema_b"],
+            #schema_d is dependent on schema_e, which is not currently present
+            import_schemas["schema_d"],
+
+            #all schema_f are valid
+            import_schemas["schema_f_v1"],
+            import_schemas["schema_f_v3"],
+            import_schemas["schema_f_v5"],
+            #all schema_g depend on the equivalent schema f version
+            import_schemas["schema_g_v1"],
+            #Missing dependency - schema_f_v2
+            import_schemas["schema_g_v2"],
+            import_schemas["schema_g_v3"],
+            #Missing dependency - schema_f_v4
+            import_schemas["schema_g_v4"],
+
+            #dependency error deep in dep chain
+            #schema_i depends on schema_h which is missing
+            import_schemas["schema_i"],
+            #schema_j depends on schema_i
+            import_schemas["schema_j"],
+            #schema_k depends on schema_j
+            import_schemas["schema_k"],
+        ]
+
+        self._push_to_schemas_topic(schemas)
+
+        valid_entries = [
+            (1, "schema_a"),
+            (2, "schema_c"),
+            (3, "schema_b"),
+            (5, "schema_f_v1"),
+            (6, "schema_f_v3"),
+            (7, "schema_f_v5"),
+            (8, "schema_g_v1"),
+            (10, "schema_g_v3"),
+        ]
+        invalid_entries = [
+            (4, "schema_d"),
+            (9, "schema_g_v2"),
+            (11, "schema_g_v4"),
+            (12, "schema_i"),
+            (13, "schema_j"),
+            (14, "schema_k"),
+        ]
+
+        #Test /schemas/ids/{id}
+        def test_schemas_ids_id(id, expected_successful):
+            endpoint = f"GET schemas/ids/{id}"
+            result_raw = self._request("GET",
+                                       f"schemas/ids/{id}",
+                                       headers=HTTP_GET_HEADERS)
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+
+                result = result_raw.json()["schema"].strip()
+                expected_result = schemas[id - 1]["sanitized"].strip()
+                #Currently, schemas are not sanitized through this endpoint
+                assert result == expected_result, \
+                        f"Expected:\n{result}\nGot:\n{expected_result}\n"\
+                        f"for request 'GET schemas/ids/{id}"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        #These schemas are valid. We should be able to retrieve them.
+        for id, _ in valid_entries:
+            test_schemas_ids_id(id, expected_successful=True)
+
+        #These schemas are invalid. Tryint to retrieve them should return an error.
+        for id, _ in invalid_entries:
+            test_schemas_ids_id(id, expected_successful=False)
+
+        #Test /schemas/ids/{id}/versions
+        def test_schemas_ids_id_versions(id, expected_successful):
+            endpoint = f"GET schemas/ids/{id}/versions"
+            result_raw = self._request("GET",
+                                       f"schemas/ids/{id}/versions",
+                                       headers=HTTP_GET_HEADERS)
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        for id, _ in valid_entries:
+            test_schemas_ids_id_versions(id, expected_successful=True)
+        for id, _ in invalid_entries:
+            test_schemas_ids_id_versions(id, expected_successful=False)
+
+        #Test /schemas/ids/{id}/subjects
+        def test_schemas_ids_id_subjects(id, expected_successful):
+            endpoint = f"GET schemas/ids/{id}/subjects",
+            result_raw = self._request("GET",
+                                       f"schemas/ids/{id}/subjects",
+                                       headers=HTTP_GET_HEADERS)
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        for id, _ in valid_entries:
+            test_schemas_ids_id_subjects(id, expected_successful=True)
+        for id, _ in invalid_entries:
+            test_schemas_ids_id_subjects(id, expected_successful=False)
+
+        #Test /subjects
+        result_raw = self._request("GET",
+                                   f"subjects",
+                                   headers=HTTP_GET_HEADERS)
+        assert_request_code(result_raw, requests.codes.ok, "GET subjects")
+
+        #All subjects should be present, regardless if their schemas are valid or not
+        expected_subjects = set([
+            "schema_a", "schema_b", "schema_c", "schema_d", "schema_f",
+            "schema_g", "schema_i", "schema_j", "schema_k"
+        ])
+        subjects = set(result_raw.json())
+        assert subjects == expected_subjects, \
+            f"Expected {expected_subjects} but got {subjects}, "\
+            "for request 'GET subjects'"
+
+        def test_subjects_subject(entry, expected_successful):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            schema_def = lookup_schema["schema"]
+            version = lookup_schema["version"]
+            references = lookup_schema[
+                "references"] if "references" in lookup_schema else []
+            result_raw = self._post_subjects_subject(subject=subject,
+                                                     data=json.dumps({
+                                                         "schema":
+                                                         schema_def,
+                                                         "schemaType":
+                                                         "PROTOBUF",
+                                                         "references":
+                                                         references
+                                                     }))
+            endpoint = f"POST subjects/{subject}",
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+                result = result_raw.json()
+                assert result["version"] == version, \
+                        f"Expected version {version} but got {result['version']}, "\
+                        f"for request 'POST subjects/{subject}'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        #Test /subjects/{subject}
+        for _, s in valid_entries:
+            test_subjects_subject(s, expected_successful=True)
+
+        #These schemas should fail, as the *input* schema has an unsatisfied dependency
+        for _, s in invalid_entries:
+            test_subjects_subject(s, expected_successful=False)
+
+        #Test /subjects/{subject}/versions
+        def test_subjects_subject_versions(entry,
+                                           expected_successful,
+                                           expected_id=None):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            schema_def = lookup_schema["schema"]
+            references = lookup_schema[
+                "references"] if "references" in lookup_schema else []
+            result_raw = self._post_subjects_subject_versions(
+                subject=subject,
+                data=json.dumps({
+                    "schema": schema_def,
+                    "schemaType": "PROTOBUF",
+                    "references": references,
+                    "version": lookup_schema["version"]
+                }))
+            endpoint = f"POST subjects/{subject}/versions"
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+                result = result_raw.json()
+                assert result["id"] == expected_id, \
+                        f"Expected id {expected_id} but got {result['id']}, "\
+                        f"for request 'POST subjects/{subject}/versions'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        for id, s in valid_entries:
+            test_subjects_subject_versions(s,
+                                           expected_id=id,
+                                           expected_successful=True)
+
+        #These schemas should fail, as the *input* schema has an unsatisfied dependencies
+        for id, s in invalid_entries:
+            test_subjects_subject_versions(s,
+                                           expected_id=id,
+                                           expected_successful=False)
+
+        #Test /subjects/{subject}/versions/{version}
+        def test_subjects_subject_versions_version(entry, expected_successful):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            expected_schema = lookup_schema["sanitized"].strip()
+            #references = lookup_schema["references"] if "references" in lookup_schema else []
+            result_raw = self._get_subjects_subject_versions_version(
+                subject=subject, version=version)
+            endpoint = f"GET subjects/{subject}/versions/{version}"
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+
+                result = result_raw.json()["schema"].strip()
+                assert result == expected_schema, \
+                        f"Expected:\n{expected_schema}\nGot:\n{result}\nfor request "\
+                        f"'GET subjects/{subject}/versions/{version}'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        for _, s in valid_entries:
+            test_subjects_subject_versions_version(s, expected_successful=True)
+        for _, s in invalid_entries:
+            test_subjects_subject_versions_version(s,
+                                                   expected_successful=False)
+
+        #Test /subjects/{subject}/versions/{version}/schema
+        def test_subjects_subject_versions_version_schema(
+                entry, expected_successful):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            schema_def = lookup_schema["sanitized"].strip()
+            result_raw = self._request(
+                "GET",
+                f"subjects/{subject}/versions/{version}/schema",
+                headers=HTTP_GET_HEADERS)
+
+            endpoint = f"GET subjects/{subject}/versions/{version}/schema"
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+
+                result = result_raw.content.decode().strip()
+                assert result == schema_def, \
+                        f"Expected:\n{schema_def}\nGot:\n{result}\n"\
+                        f"for request 'GET subjects/{subject}/versions/{version}/schema'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        for _, s in valid_entries:
+            test_subjects_subject_versions_version_schema(
+                s, expected_successful=True)
+        for _, s in invalid_entries:
+            test_subjects_subject_versions_version_schema(
+                s, expected_successful=False)
+
+        #Test /subjects/{subject}/versions/{version}/referencedby
+        def test_referenced_by(entry, expected_result):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            result_raw = self._get_subjects_subject_versions_version_referenced_by(
+                subject, version)
+
+            endpoint = f"GET subjects/{subject}/versions/{version}/referencedby"
+            assert_request_code(result_raw, requests.codes.ok, endpoint)
+            result = result_raw.json()
+            assert result == expected_result, \
+                f"Expected {expected_result} but got {result}, " \
+                f"for request 'GET subjects/{subject}/versions/{version}/referencedby'"
+
+        test_referenced_by("schema_a", [3])
+        test_referenced_by("schema_b", [2])
+        test_referenced_by("schema_c", [])
+        test_referenced_by("schema_d", [])
+        test_referenced_by("schema_f_v1", [8])
+        test_referenced_by("schema_f_v3", [10])
+        test_referenced_by("schema_f_v5", [])
+        test_referenced_by("schema_g_v1", [])
+        test_referenced_by("schema_g_v2", [])
+        test_referenced_by("schema_g_v3", [])
+        test_referenced_by("schema_g_v4", [])
+
+        #Insert missing dependency, schema_e, and retry the failed schema_d requests
+        result_raw = self._post_subjects_subject_versions(
+            subject="schema_e",
+            data=json.dumps({
+                "schema": schema_e_proto_def,
+                "schemaType": "PROTOBUF"
+            }))
+        assert_request_code(result_raw, requests.codes.ok,
+                            "POST subjects/schema_e/versions")
+
+        #Validate that schema_d is recognized as a referee
+        test_referenced_by("schema_e", [4])
+
+        test_schemas_ids_id(4, expected_successful=True)
+        test_schemas_ids_id_versions(4, expected_successful=True)
+        test_schemas_ids_id_subjects(4, expected_successful=True)
+        test_subjects_subject("schema_d", expected_successful=True)
+        test_subjects_subject_versions("schema_d",
+                                       expected_id=4,
+                                       expected_successful=True)
+        test_subjects_subject_versions_version("schema_d",
+                                               expected_successful=True)
+        test_subjects_subject_versions_version_schema("schema_d",
+                                                      expected_successful=True)
+
+        #Add schema_g_v5. schema_g_v5 is valid, but schema_g_v4 and schema_g_v2 are not,
+        #so compatibility checks failed due to them.
+        test_subjects_subject_versions("schema_g_v5",
+                                       expected_successful=False)
+
+        #Fix problematic schemas by adding missing dependency for g_v2 and deleting g_v4.
+        test_subjects_subject_versions("schema_f_v2",
+                                       expected_id=16,
+                                       expected_successful=True)
+
+        result_raw = self._delete_subject_version("schema_g", version=4)
+        assert_request_code(result_raw, requests.codes.ok,
+                            "DELETE subjects/schema_g/versions/4")
+
+        test_subjects_subject_versions("schema_g_v5",
+                                       expected_id=17,
+                                       expected_successful=True)
+
+        #Fix problematic dependency chain by adding base schema.
+        test_subjects_subject_versions("schema_h",
+                                       expected_id=18,
+                                       expected_successful=True)
+        test_schemas_ids_id(12, expected_successful=True)
+        test_schemas_ids_id(13, expected_successful=True)
+        test_schemas_ids_id(14, expected_successful=True)
 
     @cluster(num_nodes=3)
     def test_json(self):


### PR DESCRIPTION
Fixes: [CORE-9166](https://redpandadata.atlassian.net/browse/CORE-9166)

The goal is to relax the schema registry requirements on schema validity on startup and allow for schemas whose dependencies have not been loaded up, yet. This would allow for these schemas to be loaded later on, even after the startup has finished.

Note that it is impossible to create such state through normal use of the API. This is motivated by potential problematic imports which might create such a situation.

Changes:
- Replace canonical schemas for unparsed schemas stored in store and
move all schema processing from `store` to `sharded_store`. This allows to have
lazy schema validation on startup and relax requirements for valid
schema.

- Add backport to sharded_store to be able to access an unparsed schema
as-is, without processing it. This is needed as now there might be an
invalid schema loaded at startup. Operations like
delete_subject_version, which needs to reference a schema before
deleting it would be problematic.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Introduce lazy evaluation in schema registry during startup.

[CORE-9166]: https://redpandadata.atlassian.net/browse/CORE-9166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ