### PR TITLE
CORE-7595 security/tests: bazel build for ocsf_schemas_test.cc

### DIFF
--- a/src/v/security/audit/schemas/tests/BUILD
+++ b/src/v/security/audit/schemas/tests/BUILD
@@ -1,0 +1,20 @@
+load("//bazel:test.bzl", "redpanda_cc_btest")
+
+redpanda_cc_btest(
+    name = "ocsf_schemas_test",
+    timeout = "short",
+    srcs = [
+        "ocsf_schemas_test.cc",
+    ],
+    deps = [
+        "//src/v/json",
+        "//src/v/security",
+        "//src/v/security:request_auth",
+        "//src/v/security/audit",
+        "//src/v/security/audit:types",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@rapidjson",
+        "@seastar",
+    ],
+)

--- a/src/v/security/audit/schemas/tests/CMakeLists.txt
+++ b/src/v/security/audit/schemas/tests/CMakeLists.txt
@@ -4,6 +4,6 @@ rp_test(
     SOURCES
       ocsf_schemas_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES Boost::unit_test_framework v::json v::version v::security_audit
+    LIBRARIES Boost::unit_test_framework v::json v::version v::security_audit RapidJSON::rapidjson
     LABELS audit
 )

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -16,6 +16,8 @@
 
 #include <seastar/net/socket_defs.hh>
 
+#include <rapidjson/document.h>
+
 #include <optional>
 #define BOOST_TEST_MODULE security_audit
 
@@ -258,6 +260,39 @@ static const ss::sstring test_service_ser{
   "name": "test"
 }
   )"};
+
+void sort_http_headers(rapidjson::Document& doc) {
+    // Sort http_request.http_headers by name
+    if (
+      doc.HasMember("http_request") && doc["http_request"].IsObject()
+      && doc["http_request"].HasMember("http_headers")
+      && doc["http_request"]["http_headers"].IsArray()) {
+        auto& headers = doc["http_request"]["http_headers"];
+        std::sort(
+          headers.Begin(),
+          headers.End(),
+          [](const rapidjson::Value& a, const rapidjson::Value& b) {
+              return std::strcmp(a["name"].GetString(), b["name"].GetString())
+                     < 0;
+          });
+    }
+}
+
+/// Normalize an API activity json object where some fields are expected to be
+/// unordered but we want them in a consistent order for test comparisons (eg.
+/// http_headers)
+std::string normalize_json(const std::string& json_str) {
+    rapidjson::Document doc;
+    doc.Parse(json_str.c_str());
+
+    BOOST_REQUIRE_MESSAGE(!doc.HasParseError(), "JSON parse error");
+    sort_http_headers(doc);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    doc.Accept(writer);
+    return buffer.GetString();
+}
 
 BOOST_AUTO_TEST_CASE(validate_api_activity) {
     auto dst_endpoint = rp_kafka_endpoint;
@@ -618,7 +653,7 @@ BOOST_AUTO_TEST_CASE(make_api_activity_event_authorized) {
 
     auto ser = sa::rjson_serialize(api_activity);
 
-    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
+    BOOST_REQUIRE_EQUAL(normalize_json(ser), normalize_json(expected));
 }
 
 BOOST_AUTO_TEST_CASE(make_authentication_event_success) {
@@ -817,7 +852,7 @@ BOOST_AUTO_TEST_CASE(make_api_activity_event_authorized_authn_disabled) {
 
     auto ser = sa::rjson_serialize(api_activity);
 
-    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
+    BOOST_REQUIRE_EQUAL(normalize_json(ser), normalize_json(expected));
 }
 
 BOOST_AUTO_TEST_CASE(make_authn_event_failure) {


### PR DESCRIPTION
This PR adds a Bazel build for the test above. Running it with bazel highlighted that the tests were non-deterministic, causing failures when built with Bazel. To address this, I modified the tests to ensure they are deterministic by normalizing the json output.

Fixes https://redpandadata.atlassian.net/browse/CORE-7595

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
