### PR TITLE
CORE-9221 base: avoid atomics inside the vassert macro

### DIFF
--- a/src/v/base/vassert.h
+++ b/src/v/base/vassert.h
@@ -16,9 +16,6 @@
 
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
-#include <seastar/util/noncopyable_function.hh>
-
-#include <atomic>
 
 namespace detail {
 struct dummyassert {
@@ -58,19 +55,19 @@ public:
         g_assert_log.l.error("{}", buffer);
         g_assert_log.l.error("Backtrace:\n{}", bt);
 
-        auto cb_func = _cb_func.load();
-        if (cb_func != nullptr) {
-            cb_func(buffer);
+        if (_cb_func != nullptr) {
+            _cb_func(buffer);
         }
     }
 
     void register_cb(assert_cb_func cb) {
-        assert_cb_func before = nullptr;
-        _cb_func.compare_exchange_strong(before, cb);
+        if (_cb_func == nullptr) {
+            _cb_func = cb;
+        }
     }
 
 private:
-    std::atomic<assert_cb_func> _cb_func{nullptr};
+    assert_cb_func _cb_func{nullptr};
 };
 inline assert_log_holder g_assert_log_holder;
 } // namespace detail

--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -51,6 +51,8 @@ public:
     /// Must be called after a fill() that returned a non-null value
     void write();
 
+    bool uninitialized() { return _state.load() == state::uninitialized; }
+
 private:
     enum class state { uninitialized, initialized, filled, written, released };
     friend std::ostream& operator<<(std::ostream&, state);

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -149,8 +149,6 @@ ss::future<> recorder::start() {
     co_await remove_old_crashfiles();
     co_await remove_dangling_upload_markers();
     co_await _writer.initialize(co_await generate_crashfile_name());
-    ::detail::g_assert_log_holder.register_cb(
-      [](std::string_view msg) { get_recorder().record_crash_vassert(msg); });
 }
 
 namespace {
@@ -265,6 +263,15 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
 }
 
 void recorder::record_crash_vassert(std::string_view msg) {
+    if (_writer.uninitialized()) {
+        // The vassert callback may be called before the recorder is
+        // initialized. If there is a vassert crash before the recorder is
+        // initialized, we cannot record the crash and so we print and return
+        // here.
+        print_skipping();
+        return;
+    }
+
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
         // The writer has already been consumed by another crash

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -472,6 +472,13 @@ int application::run(int ac, char** av) {
     std::string cmd_line = fmt::to_string(
       fmt::join(std::span{av, size_t(ac)}, " "));
 
+    // NOTE: we register the vassert callback before the reactor is started to
+    // ensure that the callback is visible on all reactor and non-reactor
+    // threads
+    ::detail::g_assert_log_holder.register_cb([](std::string_view msg) {
+        crash_tracker::get_recorder().record_crash_vassert(msg);
+    });
+
     return app.run(ac, av, [this, &app, cmd_line = std::move(cmd_line)] {
         vlog(_log.info, "Redpanda {}", redpanda_version());
         vlog(_log.info, "Command line: {}", cmd_line);


### PR DESCRIPTION
Produce microbenchmarks have gotten slightly slower since the latest change to vassert (https://github.com/redpanda-data/redpanda/pull/25051), which we suspect is caused by the introduction of atomic operations on the (unlikely) branch taken in the case of a vassert crash.

This moves the implementation closer to the original implementation by using a non-atomic function pointer for the callback. This is safe to do because we now register the callback before any threads (reactor or non-reactor) are created, which ensures that the callback is visible on all threads. This avoids the data race that would otherwise exist if the callback was registered while other threads are already running.

https://redpandadata.atlassian.net/browse/CORE-9221

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
