### PR TITLE
iceberg/rest_client: don't throw shutdown exceptions

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -1224,6 +1224,7 @@ redpanda_cc_library(
         ":table_requests",
         ":table_requirement_json",
         "//src/v/iceberg/rest_client:client",
+        "//src/v/iceberg/rest_client:error",
         "//src/v/json",
         "//src/v/utils:mutex",
     ],

--- a/src/v/iceberg/rest_catalog.cc
+++ b/src/v/iceberg/rest_catalog.cc
@@ -11,6 +11,7 @@
 #include "iceberg/rest_catalog.h"
 
 #include "iceberg/rest_client/catalog_client.h"
+#include "iceberg/rest_client/error.h"
 #include "iceberg/table_requests.h"
 namespace iceberg {
 
@@ -49,6 +50,10 @@ struct http_error_mapping_visitor {
 
     errc operator()(const http::url_build_error&) const {
         return unexpected_state;
+    }
+
+    errc operator()(const rest_client::aborted_error&) const {
+        return shutting_down;
     }
 };
 // Translates domain error to more general catalog::errc.

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -18,6 +18,7 @@
 #include "iceberg/json_writer.h"
 #include "iceberg/logger.h"
 #include "iceberg/rest_client/entities.h"
+#include "iceberg/rest_client/error.h"
 #include "iceberg/rest_client/json.h"
 #include "iceberg/table_requests_json.h"
 #include "json/istreamwrapper.h"
@@ -220,6 +221,10 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         }
 
         auto& error = call_res.error();
+        if (error.aborted) {
+            co_return tl::unexpected(
+              aborted_error{"Shutting down while evaluating retry"});
+        }
         if (!error.can_be_retried) {
             co_return tl::unexpected(std::move(error.err));
         }
@@ -229,9 +234,9 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
           ss::sleep_abortable(permit.delay, rtc.root_abort_source()));
         if (sleep_fut.failed()) {
             auto ex = sleep_fut.get_exception();
-            vlog(log.debug, "Exception during sleep: {}", ex);
-            co_return tl::unexpected(
-              retries_exhausted{.errors = std::move(retriable_errors)});
+            auto msg = fmt::format("Exception during retry sleep: {}", ex);
+            vlog(log.debug, "{}", msg);
+            co_return tl::unexpected(aborted_error{msg});
         }
     }
 }

--- a/src/v/iceberg/rest_client/error.h
+++ b/src/v/iceberg/rest_client/error.h
@@ -40,13 +40,17 @@ struct retries_exhausted {
     std::vector<http_call_error> errors;
 };
 
+// Error returned when the underlying subsystems are being shut down.
+using aborted_error = named_type<ss::sstring, struct aborted_tag>;
+
 // Represents the sum of all error types which can be encountered during
 // rest-client operations.
 using domain_error = std::variant<
   http::url_build_error,
   json_parse_error,
   http_call_error,
-  retries_exhausted>;
+  retries_exhausted,
+  aborted_error>;
 
 // The core result type used by all operations in the iceberg/rest-client which
 // can fail. Allows chaining of operations together and short-circuiting when an

--- a/src/v/iceberg/rest_client/retry_policy.cc
+++ b/src/v/iceberg/rest_client/retry_policy.cc
@@ -12,16 +12,25 @@
 
 #include "net/connection.h"
 
+#include <exception>
+
 namespace {
 
 using iceberg::rest_client::failure;
 
+failure aborted(std::string_view msg) {
+    return failure{
+      .can_be_retried = false, .aborted = true, .err = ss::sstring{msg}};
+}
+
 failure unretriable(std::string_view msg) {
-    return failure{.can_be_retried = false, .err = ss::sstring{msg}};
+    return failure{
+      .can_be_retried = false, .aborted = false, .err = ss::sstring{msg}};
 }
 
 failure retriable(std::string_view msg) {
-    return failure{.can_be_retried = true, .err = ss::sstring{msg}};
+    return failure{
+      .can_be_retried = true, .aborted = false, .err = ss::sstring{msg}};
 }
 
 using enum boost::beast::http::status;
@@ -95,14 +104,14 @@ failure default_retry_policy::should_retry(std::exception_ptr ex) const {
         }
         return retriable(err.what());
     } catch (const ss::gate_closed_exception&) {
-        throw;
+        return aborted(fmt::format("{}", std::current_exception()));
     } catch (const ss::abort_requested_exception&) {
-        throw;
+        return aborted(fmt::format("{}", std::current_exception()));
     } catch (const ss::nested_exception& nested) {
         if (
           is_abort_or_gate_close_exception(nested.inner)
           || is_abort_or_gate_close_exception(nested.outer)) {
-            throw;
+            return aborted(fmt::format("{}", std::current_exception()));
         };
         return unretriable(fmt::format(
           "{} [outer: {}, inner: {}]",

--- a/src/v/iceberg/rest_client/retry_policy.h
+++ b/src/v/iceberg/rest_client/retry_policy.h
@@ -18,7 +18,10 @@ namespace iceberg::rest_client {
 // Represents an http call which failed, encodes information about possible
 // retriability and cause
 struct failure {
-    bool can_be_retried;
+    bool can_be_retried{false};
+
+    // NOTE: takes precedence over can_be_retried.
+    bool aborted{false};
     http_call_error err;
     bool is_transport_error() const;
 };
@@ -40,8 +43,8 @@ struct retry_policy {
     virtual result_t should_retry(http::downloaded_response response) const = 0;
 
     // Handles the case where the future failed with an exception. Shutdown
-    // related errors are rethrown, all other errors are classified into
-    // retriable or unretriable.
+    // related errors are returned indicating so, all other errors are
+    // classified into retriable or unretriable.
     virtual failure should_retry(std::exception_ptr ex) const = 0;
     virtual ~retry_policy() = default;
 };

--- a/src/v/iceberg/rest_client/tests/retry_policy_tests.cc
+++ b/src/v/iceberg/rest_client/tests/retry_policy_tests.cc
@@ -47,6 +47,7 @@ TEST(default_retry_policy, status_retriable) {
           .status = status, .body = iobuf::from("retry")});
         ASSERT_FALSE(result.has_value());
         ASSERT_TRUE(result.error().can_be_retried);
+        ASSERT_FALSE(result.error().aborted);
     }
 }
 
@@ -58,6 +59,7 @@ TEST(default_retry_policy, status_not_retriable) {
           .status = status, .body = iobuf::from("retry")});
         ASSERT_FALSE(result.has_value());
         ASSERT_FALSE(result.error().can_be_retried);
+        ASSERT_FALSE(result.error().aborted);
     }
 }
 
@@ -65,39 +67,44 @@ TEST(default_retry_policy, boost_system_errors) {
     auto retriable = throw_and_catch(
       boost::system::system_error{boost::beast::http::error::end_of_stream});
     ASSERT_TRUE(retriable.can_be_retried);
+    ASSERT_FALSE(retriable.aborted);
     auto unretriable = throw_and_catch(
       boost::system::system_error{boost::beast::http::error::bad_alloc});
     ASSERT_FALSE(unretriable.can_be_retried);
+    ASSERT_FALSE(unretriable.aborted);
 }
 
 TEST(default_retry_policy, system_errors) {
     auto retriable = throw_and_catch(
       std::system_error{ETIMEDOUT, std::generic_category()});
     ASSERT_TRUE(retriable.can_be_retried);
+    ASSERT_FALSE(retriable.aborted);
     auto unretriable = throw_and_catch(
       std::system_error{ETIMEDOUT, ss::tls::error_category()});
     ASSERT_FALSE(unretriable.can_be_retried);
+    ASSERT_FALSE(unretriable.aborted);
 }
 
-TEST(default_retry_policy, rethrown_exceptions) {
-    EXPECT_THROW(
-      throw_and_catch(ss::gate_closed_exception{}), ss::gate_closed_exception);
-    EXPECT_THROW(
-      throw_and_catch(ss::abort_requested_exception{}),
-      ss::abort_requested_exception);
+TEST(default_retry_policy, abort_exception) {
+    auto gate_failure = throw_and_catch(ss::gate_closed_exception{});
+    ASSERT_TRUE(gate_failure.aborted);
+    ASSERT_FALSE(gate_failure.can_be_retried);
+    auto abort_failure = throw_and_catch(ss::abort_requested_exception{});
+    ASSERT_TRUE(abort_failure.aborted);
+    ASSERT_FALSE(abort_failure.can_be_retried);
 }
 
 TEST(default_retry_policy, nested_exception) {
-    EXPECT_THROW(
-      throw_and_catch(ss::nested_exception{
-        std::make_exception_ptr(ss::gate_closed_exception{}),
-        std::make_exception_ptr(std::runtime_error{"out"})}),
-      ss::nested_exception);
-    EXPECT_THROW(
-      throw_and_catch(ss::nested_exception{
-        std::make_exception_ptr(std::invalid_argument{""}),
-        std::make_exception_ptr(ss::abort_requested_exception{})}),
-      ss::nested_exception);
+    auto gate_failure = throw_and_catch(ss::nested_exception{
+      std::make_exception_ptr(ss::gate_closed_exception{}),
+      std::make_exception_ptr(std::runtime_error{"out"})});
+    ASSERT_TRUE(gate_failure.aborted);
+    ASSERT_FALSE(gate_failure.can_be_retried);
+    auto abort_failure = throw_and_catch(ss::nested_exception{
+      std::make_exception_ptr(std::invalid_argument{""}),
+      std::make_exception_ptr(ss::abort_requested_exception{})});
+    ASSERT_TRUE(abort_failure.aborted);
+    ASSERT_FALSE(abort_failure.can_be_retried);
 
     auto result = throw_and_catch(ss::nested_exception{
       std::make_exception_ptr(std::invalid_argument{"i"}),


### PR DESCRIPTION
We previously relied on callers to catch shutdown exceptions. This didn't jive well with the rest of the codebase that operates on explicit error types, and we would see error messages like below, resulting in flaky tests:

```
...
ERROR 2025-02-28 08:33:42,849 [shard 1:main] datalake - coordinator.cc:124 - Coordinator hit exception while running in term 1: seastar::gate_closed_exception (gate closed)
DEBUG 2025-02-28 08:33:42,851 [shard 1:main] datalake - coordinator.cc:147 - Running coordinator loop in term 1
DEBUG 2025-02-28 08:33:42,851 [shard 1:main] datalake - coordinator.cc:73 - Coordinator stopping...
DEBUG 2025-02-28 08:33:42,851 [shard 1:main] cluster - partition.cc:560 - Stopping partition: {kafka_internal/datalake_coordinator/1}
DEBUG 2025-02-28 08:33:42,852 [shard 1:main] cluster - partition.cc:608 - Stopped partition {kafka_internal/datalake_coordinator/1}
DEBUG 2025-02-28 08:33:42,889 [shard 1:main] datalake - coordinator.cc:189 - Error while committing files to catalog for topic unstructured_tp_0
ERROR 2025-02-28 08:33:42,889 [shard 1:main] datalake - coordinator.cc:124 - Coordinator hit exception while running in term 1: seastar::abort_requested_exception (abort requested)
DEBUG 2025-02-28 08:33:42,889 [shard 1:main] datalake - coordinator.cc:80 - Coordinator stopped...
```

This commit updates the relevant codepath to return an explicit type that indicates a shutdown is in progress, and maps it to an appropriate catalog error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
