### PR TITLE
[DEVPROD-1912] `rptest`: add retry in `get_high_watermarks()`

### DIFF
--- a/tests/rptest/remote_scripts/stream_verifier_txn.py
+++ b/tests/rptest/remote_scripts/stream_verifier_txn.py
@@ -950,7 +950,21 @@ class StreamVerifier():
             hwms = {}
             for p in partitions:
                 # Get the partitions low and high watermark offsets.
-                (lo, hi) = c.get_watermark_offsets(p, timeout=10, cached=False)
+                # This can fail with cimpl.KafkaException: KafkaError{code=NOT_LEADER_FOR_PARTITION}.
+                # Retry the command with some backoff to allow partition leadership to settle if this
+                # is encountered.
+                num_retries = 10
+                while num_retries > 0:
+                    num_retries -= 1
+                    try:
+                        (lo, hi) = c.get_watermark_offsets(p,
+                                                           timeout=10,
+                                                           cached=False)
+                        break
+                    except ck.KafkaException as e:
+                        # Backoff
+                        sleep(1)
+
                 hwms[p.partition] = hi
             return hwms
         else:


### PR DESCRIPTION
This function can often fail with a `cimpl.KafkaException: KafkaError{code=NOT_LEADER_FOR_PARTITION}` error.

Add a `while` loop with a set number of retries and some added backoff to retry the `get_watermark_offsets()` while leadership for the partition settles.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
