### PR TITLE
[CORE-9153] [CORE-9154] [CORE-9155] `rptest`: deflake `java_compression_test.py`

### DIFF
--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -124,7 +124,8 @@ class JavaCompressionTest(EndToEndTest):
         """
         self.start_redpanda(num_nodes=1)
         self.topic_spec = TopicSpec(replication_factor=1,
-                                    cleanup_policy=TopicSpec.CLEANUP_COMPACT)
+                                    cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+                                    min_cleanable_dirty_ratio=0.0)
         self.client().create_topic(self.topic_spec)
 
         expected_num_segments = 4
@@ -189,6 +190,17 @@ class JavaCompressionTest(EndToEndTest):
         self.produce_until_segment_count(
             expected_num_segments, compression_type=compression_type.value)
         self.wait_for_compacted_segments(expected_num_segments)
+
+        # The min_cleanable_dirty_ratio cluster config was not in the original
+        # version of redpanda installed above, it was added in v25.1.0.
+        # Patch its value here to ensure that every snappy batch will be
+        # re-written by compaction. Also push compaction to happen quite rapidly.
+        self.redpanda._admin.patch_cluster_config(
+            upsert={
+                "min_cleanable_dirty_ratio": 0.0,
+                "log_compaction_interval_ms": 500
+            })
+
 
         # In the case of `snappy`, every single batch should have been decompressed
         # and recompressed using the new big-endian fix. Expect to see consuming

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -64,7 +64,6 @@ class JavaCompressionTest(EndToEndTest):
                 err_msg=
                 f"Timed out waiting for {count} segments to be produced.")
         finally:
-            producer.stop()
             producer.clean()
             producer.free()
 
@@ -72,7 +71,6 @@ class JavaCompressionTest(EndToEndTest):
         deadline = time() + timeout_sec
         consumer = KafkaConsumer(self.topic_spec.name,
                                  bootstrap_servers=self.redpanda.brokers(),
-                                 group_id="0",
                                  consumer_timeout_ms=1000,
                                  auto_offset_reset='earliest',
                                  enable_auto_commit=False)
@@ -95,7 +93,7 @@ class JavaCompressionTest(EndToEndTest):
             f"Saw {num_compacted_segments} compacted segments")
         return num_compacted_segments
 
-    def wait_for_compacted_segments(self, num_segments, timeout_sec=120):
+    def wait_for_compacted_segments(self, num_segments, timeout_sec=360):
         self.redpanda.logger.debug(
             f"Waiting for {num_segments} compacted segments")
         wait_until(
@@ -183,13 +181,20 @@ class JavaCompressionTest(EndToEndTest):
         # Install the latest version of `redpanda` and restart nodes
         self.redpanda._installer.install(self.redpanda.nodes,
                                          RedpandaInstaller.HEAD)
-        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.stop_node(self.redpanda.nodes[0])
+
+        # Delete all the compaction indices to force self compaction of segments.
+        storage = self.redpanda.storage(all_nodes=True)
+        partitions = storage.partitions("kafka", self.topic_spec.name)
+        for p in partitions:
+            p.delete_indices(allow_fail=True)
+
+        self.redpanda.start_node(self.redpanda.nodes[0])
 
         # Repeat the process
         expected_num_segments = 8
         self.produce_until_segment_count(
             expected_num_segments, compression_type=compression_type.value)
-        self.wait_for_compacted_segments(expected_num_segments)
 
         # The min_cleanable_dirty_ratio cluster config was not in the original
         # version of redpanda installed above, it was added in v25.1.0.
@@ -201,8 +206,19 @@ class JavaCompressionTest(EndToEndTest):
                 "log_compaction_interval_ms": 500
             })
 
+        def consumer_succeeds():
+            """
+            In the case of `snappy`, every single batch should eventually be decompressed
+            and recompressed using the new big-endian fix during compaction.
+            Expect to see consuming with `kafka-python` eventually succeed.
+            """
+            try:
+                self.consume()
+                return True
+            except:
+                return False
 
-        # In the case of `snappy`, every single batch should have been decompressed
-        # and recompressed using the new big-endian fix. Expect to see consuming
-        # with `kafka-python` succeed.
-        self.consume()
+        wait_until(consumer_succeeds,
+                   timeout_sec=360,
+                   backoff_sec=5,
+                   err_msg=f"Timed out waiting for consuming to succeed.")

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -47,16 +47,20 @@ class JavaCompressionTest(EndToEndTest):
                                     count,
                                     compression_type,
                                     timeout_sec=120):
+        # Arbitrarily high key set cardinality
+        key_set_cardinality = 100000
         producer = VerifiableProducer(self.test_context,
                                       num_nodes=1,
                                       redpanda=self.redpanda,
                                       topic=self.topic_spec.name,
-                                      compression_types=[compression_type])
+                                      compression_types=[compression_type],
+                                      repeating_keys=key_set_cardinality)
         producer.start()
         try:
             wait_until(
                 lambda: self.partition_segments() >= count,
                 timeout_sec=timeout_sec,
+                backoff_sec=1,
                 err_msg=
                 f"Timed out waiting for {count} segments to be produced.")
         finally:
@@ -64,7 +68,7 @@ class JavaCompressionTest(EndToEndTest):
             producer.clean()
             producer.free()
 
-    def consume(self, num_messages=100, timeout_sec=120):
+    def consume(self, num_messages=10, timeout_sec=120):
         deadline = time() + timeout_sec
         consumer = KafkaConsumer(self.topic_spec.name,
                                  bootstrap_servers=self.redpanda.brokers(),

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -87,15 +87,23 @@ class JavaCompressionTest(EndToEndTest):
                 assert False, f"Failed to consume messages"
 
     def get_compacted_segments(self):
-        return self.redpanda.metric_sum(
+        num_compacted_segments = self.redpanda.metric_sum(
             metric_name="vectorized_storage_log_compacted_segment_total",
             metrics_endpoint=MetricsEndpoint.METRICS,
             topic=self.topic_spec.name)
+        self.redpanda.logger.debug(
+            f"Saw {num_compacted_segments} compacted segments")
+        return num_compacted_segments
 
     def wait_for_compacted_segments(self, num_segments, timeout_sec=120):
-        wait_until(lambda: self.get_compacted_segments() >= num_segments,
-                   timeout_sec=timeout_sec,
-                   err_msg=f"Timed out waiting for compacted segments.")
+        self.redpanda.logger.debug(
+            f"Waiting for {num_segments} compacted segments")
+        wait_until(
+            lambda: self.get_compacted_segments() >= num_segments,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=f"Timed out waiting for {num_segments} compacted segments."
+        )
 
     @cluster(num_nodes=2)
     @matrix(compression_type=[

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -131,7 +131,7 @@ class JavaCompressionTest(EndToEndTest):
         expected_num_segments = 4
         self.produce_until_segment_count(
             expected_num_segments, compression_type=compression_type.value)
-        self.wait_for_compacted_segments(expected_num_segments)
+        self.wait_for_compacted_segments(expected_num_segments - 1)
 
         self.consume()
 
@@ -166,7 +166,7 @@ class JavaCompressionTest(EndToEndTest):
         expected_num_segments = 4
         self.produce_until_segment_count(
             expected_num_segments, compression_type=compression_type.value)
-        self.wait_for_compacted_segments(expected_num_segments)
+        self.wait_for_compacted_segments(expected_num_segments - 1)
 
         if compression_type == TopicSpec.CompressionTypes.SNAPPY:
             # Refer to the Github issue in the function comment above re: the issue with


### PR DESCRIPTION
Another source of flakes in this test was the `VerifiableProducer`, [which will produce records without a key](https://github.com/a0x8o/kafka/blob/54eff6af115ee647f60129f2ce6a044cb17215d0/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java#L300-L309) (i.e key is `null` for all records produced). This caused two failures:

1. The test was having trouble producing to the desired number of segments, as adjacent segment compaction seems to be able to keep up with the producer after sliding window compaction essentially reduces all of the segments to close to 0 bytes.
2. Because all records have the same `null` key, the consumer would not be able to consume the desired number of messages after all the records were compacted down to `1` visible record.

To fix this, specify `repeating_keys`, which will produce records with the key set cardinality specified. 

Also, the `min.cleanable.dirty.ratio` should have been set in commit https://github.com/redpanda-data/redpanda/commit/cba07b87f82bce719b33745391b0c02efd1c9e80 for unconditional compacting of the log per expectations of the test.

[Backporting to fix tests in previous versions.](https://github.com/redpanda-data/redpanda/pull/25157#issuecomment-2679744406) (the backports won't need the `min.cleanable.dirty.ratio` change, but they do need the other changes for deflaking.)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

* none
