### PR TITLE
kafka: validator for Iceberg topics and read replicas

### DIFF
--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -307,13 +307,30 @@ struct iceberg_config_validator {
                 return false;
             }
         }
+        bool is_iceberg_topic = parsed_mode != model::iceberg_mode::disabled;
+        if (!is_iceberg_topic) {
+            // Not an Iceberg topic, nothing more to validate.
+            return true;
+        }
+
+        bool is_read_replica = std::find_if(
+                                 c.configs.begin(),
+                                 c.configs.end(),
+                                 [](const createable_topic_config& cfg) {
+                                     return cfg.name
+                                            == topic_property_read_replica;
+                                 })
+                               != c.configs.end();
+        if (is_read_replica) {
+            // Not yet supported: read replicas must not be Iceberg topics.
+            return false;
+        }
 
         // If iceberg is enabled at the cluster level, the topic can
         // be created with any override. If it is disabled
         // at the cluster level, it cannot be enabled with a topic
         // override.
-        return config::shard_local_cfg().iceberg_enabled()
-               || parsed_mode == model::iceberg_mode::disabled;
+        return config::shard_local_cfg().iceberg_enabled();
     }
 };
 

--- a/tests/rptest/tests/datalake/topic_properties_test.py
+++ b/tests/rptest/tests/datalake/topic_properties_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.si_utils import quiesce_uploads
+
+
+class TopicPropertiesTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(TopicPropertiesTest,
+              self).__init__(extra_rp_conf=dict({"iceberg_enabled": True}),
+                             si_settings=SISettings(test_context=test_context,
+                                                    fast_uploads=True),
+                             test_context=test_context,
+                             num_brokers=1)
+
+    @cluster(num_nodes=1)
+    def test_iceberg_topic_as_read_replica_is_rejected(self):
+        topic = "read_replica_tp"
+        rpk = RpkTool(self.redpanda)
+
+        # Create a topic that can be pointed at with a read replica.
+        # NOTE: it's unusual to do this on the cluster hosting the RRR, but
+        # that's unimportant for validating topic properties.
+        rpk.create_topic(topic,
+                         replicas=1,
+                         config={'redpanda.remote.delete': False})
+        rpk.produce(topic, key="foo", msg="bar")
+        quiesce_uploads(self.redpanda, [topic], timeout_sec=30)
+        rpk.delete_topic(topic)
+
+        # Iceberg topic shouldn't be creatable as a read replica.
+        try:
+            rpk.create_topic(topic,
+                             replicas=1,
+                             config={
+                                 'redpanda.iceberg.mode':
+                                 'key_value',
+                                 'redpanda.remote.readreplica':
+                                 self.si_settings.cloud_storage_bucket,
+                             })
+        except Exception as e:
+            self.logger.info(
+                f"Creation failed as expected: expected exception {e}")
+        else:
+            raise RuntimeError("Topic creation should have failed to create")
+
+        # Shouldn't be able to set a read replica to be an Icberg topic.
+        rpk.create_topic(topic,
+                         replicas=1,
+                         config={
+                             'redpanda.remote.readreplica':
+                             self.si_settings.cloud_storage_bucket,
+                         })
+        try:
+            rpk.alter_topic_config(self.topic, "redpanda.iceberg.mode",
+                                   "key_value")
+        except Exception as e:
+            self.logger.info(
+                f"Alter failed as expected: expected exception {e}")
+        else:
+            raise RuntimeError("Topic should have failed to alter")


### PR DESCRIPTION
The story for Iceberg topics that are read replicas is not complete (e.g. what catalog to write to, how to use the correct schemas, what it means if/when we stream Kafka from parquet), so for now we explicitly disallow this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
