### PR TITLE
dl/coordinator: property to disable snapshot expiry

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3981,6 +3981,14 @@ configuration::configuration()
       "but may be useful if the Iceberg catalog does not support tags.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , iceberg_disable_automatic_snapshot_expiry(
+      *this,
+      "iceberg_disable_automatic_snapshot_expiry",
+      "Whether to disable automatic Iceberg snapshot expiry. This may be "
+      "useful if the Iceberg catalog expects to perform snapshot expiry on "
+      "its own.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -740,6 +740,7 @@ struct configuration final : public config_store {
       iceberg_invalid_record_action;
     bounded_property<std::chrono::milliseconds> iceberg_target_lag_ms;
     property<bool> iceberg_disable_snapshot_tagging;
+    property<bool> iceberg_disable_automatic_snapshot_expiry;
 
     configuration();
 

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -11,6 +11,7 @@
 
 #include "base/vlog.h"
 #include "cluster/topic_table.h"
+#include "config/configuration.h"
 #include "container/fragmented_vector.h"
 #include "datalake/catalog_schema_manager.h"
 #include "datalake/coordinator/state_update.h"
@@ -156,23 +157,25 @@ coordinator::run_until_term_change(model::term_id term) {
         for (const auto& t : topics) {
             // TODO: per topic means embarrassingly parallel.
 
-            // Before we add to the table, clean up any expired snapshots.
-            // TODO: consider decoupling this from the commit interval.
-            auto removal_res
-              = co_await snapshot_remover_.remove_expired_snapshots(
-                t, model::timestamp::now());
-            if (removal_res.has_error()) {
-                switch (removal_res.error()) {
-                case snapshot_remover::errc::shutting_down:
-                    co_return errc::shutting_down;
-                case snapshot_remover::errc::failed:
-                    vlog(
-                      datalake_log.debug,
-                      "Error removing snapshots from catalog for topic {}",
-                      t);
+            if (!disable_snapshot_expiry_()) {
+                // Before we add to the table, clean up any expired snapshots.
+                // TODO: consider decoupling this from the commit interval.
+                auto removal_res
+                  = co_await snapshot_remover_.remove_expired_snapshots(
+                    t, model::timestamp::now());
+                if (removal_res.has_error()) {
+                    switch (removal_res.error()) {
+                    case snapshot_remover::errc::shutting_down:
+                        co_return errc::shutting_down;
+                    case snapshot_remover::errc::failed:
+                        vlog(
+                          datalake_log.debug,
+                          "Error removing snapshots from catalog for topic {}",
+                          t);
+                    }
+                    // Inentional fallthrough -- snapshot removal shouldn't
+                    // block progressing appends.
                 }
-                // Inentional fallthrough -- snapshot removal shouldn't block
-                // progressing appends.
             }
 
             auto commit_res

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -47,7 +47,8 @@ public:
       file_committer& file_committer,
       snapshot_remover& snapshot_remover,
       config::binding<std::chrono::milliseconds> commit_interval,
-      config::binding<ss::sstring> default_partition_spec)
+      config::binding<ss::sstring> default_partition_spec,
+      config::binding<bool> disable_snapshot_expiry)
       : stm_(std::move(stm))
       , topic_table_(topics)
       , type_resolver_(type_resolver)
@@ -56,7 +57,8 @@ public:
       , file_committer_(file_committer)
       , snapshot_remover_(snapshot_remover)
       , commit_interval_(std::move(commit_interval))
-      , default_partition_spec_(std::move(default_partition_spec)) {}
+      , default_partition_spec_(std::move(default_partition_spec))
+      , disable_snapshot_expiry_(std::move(disable_snapshot_expiry)) {}
 
     void start();
     ss::future<> stop_and_wait();
@@ -121,6 +123,7 @@ private:
     snapshot_remover& snapshot_remover_;
     config::binding<std::chrono::milliseconds> commit_interval_;
     config::binding<ss::sstring> default_partition_spec_;
+    config::binding<bool> disable_snapshot_expiry_;
 
     ss::gate gate_;
     ss::abort_source as_;

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -132,7 +132,9 @@ void coordinator_manager::start_managing(cluster::partition& p) {
       *file_committer_,
       *snapshot_remover_,
       config::shard_local_cfg().iceberg_catalog_commit_interval_ms.bind(),
-      config::shard_local_cfg().iceberg_default_partition_spec.bind());
+      config::shard_local_cfg().iceberg_default_partition_spec.bind(),
+      config::shard_local_cfg()
+        .iceberg_disable_automatic_snapshot_expiry.bind());
     if (p.is_leader()) {
         crd->notify_leadership(self_);
     }

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -78,7 +78,8 @@ struct coordinator_node {
           *file_committer,
           *snapshot_remover,
           commit_interval_ms.bind(),
-          default_partition_spec.bind()) {}
+          default_partition_spec.bind(),
+          disable_snapshot_expiry.bind()) {}
 
     ss::future<checked<std::nullopt_t, coordinator::errc>>
     remove_tombstone(const model::topic&, model::revision_id) {
@@ -97,6 +98,7 @@ struct coordinator_node {
     config::mock_property<std::chrono::milliseconds> commit_interval_ms;
     config::mock_property<ss::sstring> default_partition_spec{
       "(hour(redpanda.timestamp))"};
+    config::mock_property<bool> disable_snapshot_expiry{false};
     cluster::data_migrations::migrated_resources mr;
     cluster::topic_table topic_table;
     datalake::binary_type_resolver type_resolver;

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -41,6 +41,10 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
         return config::mock_binding<ss::sstring>("(hour(redpanda.timestamp))");
     }
 
+    config::binding<bool> disable_snapshot_expiry() const {
+        return config::mock_binding<bool>(false);
+    }
+
     stm_shptrs_t create_stms(
       state_machine_manager_builder& builder,
       raft_node_instance& node) override {
@@ -64,7 +68,8 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
                 file_committer,
                 snapshot_remover,
                 commit_interval(),
-                default_partition_spec());
+                default_partition_spec(),
+                disable_snapshot_expiry());
             coordinators[node.get_vnode()]->start();
             return ss::now();
         });


### PR DESCRIPTION
Adds a cluster config property to disable Iceberg snapshot expiry. This is primarily and escape hatch in case the Iceberg catalog expects to perform maintenance on its own.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
