### PR TITLE
[CORE-9218] `storage`: reduce `dirty_and_closed_bytes_bookkeeping::num_operations`

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5500,7 +5500,7 @@ FIXTURE_TEST(dirty_and_closed_bytes_bookkeeping, storage_test_fixture) {
 #ifdef NDEBUG
     static constexpr int num_operations = 50;
 #else
-    static constexpr int num_operations = 25;
+    static constexpr int num_operations = 10;
 #endif
 
     for (int i = 0; i < num_operations; ++i) {


### PR DESCRIPTION
This test was occasionally timing out in debug mode.

Reduce the number of operations performed on the log in `debug` mode to prevent the timeouts from occurring.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
