### PR TITLE
[CORE-9244] `rptest`: deflake `datalake/compaction_test.py`

### DIFF
--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -35,7 +35,7 @@ class CompactionGapsTest(RedpandaTest):
                 "iceberg_enabled": "true",
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "datalake_coordinator_snapshot_max_delay_secs": 10,
-                "log_compaction_interval_ms": 5000,
+                "log_compaction_interval_ms": 10000,
                 "min_cleanable_dirty_ratio": 0.0
             },
             *args,
@@ -63,11 +63,11 @@ class CompactionGapsTest(RedpandaTest):
         wait_until(
             lambda: self.partition_segments() == count,
             timeout_sec=120,
-            backoff_sec=3,
+            backoff_sec=2,
             err_msg=f"Timed out waiting for segment count to reach {count}")
 
     def produce_until_segment_count(self, count):
-        timeout_sec = 60
+        timeout_sec = 180
         deadline = time() + timeout_sec
         while True:
             current_segment_count = self.partition_segments()

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -131,9 +131,10 @@ class CompactionTest(RedpandaTest):
             "iceberg_enabled": "true",
             "iceberg_catalog_commit_interval_ms": 5000,
             "datalake_coordinator_snapshot_max_delay_secs": 10,
-            "log_compaction_interval_ms": 2000,
+            "log_compaction_interval_ms": 4000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
-            "compacted_log_segment_size": 1024**2  # 1 MiB
+            "compacted_log_segment_size": 1024**2,  # 1 MiB
+            "min_cleanable_dirty_ratio": 0.0
         }
 
         super(CompactionTest,
@@ -190,9 +191,9 @@ class CompactionTest(RedpandaTest):
 
         wait_until(
             compaction_has_completed,
-            timeout_sec=120,
+            timeout_sec=180,
             backoff_sec=self.extra_rp_conf['log_compaction_interval_ms'] /
-            1000 * 10,
+            1000 * 4,
             err_msg="Compaction did not stabilize.")
 
     def verify_log_and_table(self, dl: DatalakeServices):


### PR DESCRIPTION
This test should have had it's `min.cleanable.dirty.ratio` set to 0.0 in commit https://github.com/redpanda-data/redpanda/pull/24991/commits/cba07b87f82bce719b33745391b0c02efd1c9e80 for unconditional compacting of the log per expectations of the test.

Also, alter some backoff and timeout parameters for additional leniency.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
