### PR TITLE
bazel: add consumer_groups_test, segment_meta_cstore_fuzz_rpfixture, security_test

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:test.bzl",
     "redpanda_cc_bench",
     "redpanda_cc_btest",
+    "redpanda_cc_fuzz_test",
     "redpanda_cc_gtest",
     "redpanda_test_cc_library",
 )
@@ -606,5 +607,24 @@ redpanda_cc_bench(
         "@abseil-cpp//absl/container:btree",
         "@seastar",
         "@seastar//:benchmark",
+    ],
+)
+
+redpanda_cc_fuzz_test(
+    name = "segment_meta_cstore_fuzz_rpfixture",
+    timeout = "short",
+    srcs = ["segment_meta_cstore_fuzz.cc"],
+    args = [
+        "-max_total_time=30",
+        "-rss_limit_mb=8192",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_storage",
+        "//src/v/model",
+        "//src/v/reflection:to_tuple",
+        "//src/v/serde",
+        "@abseil-cpp//absl/container:btree",
+        "@fmt",
     ],
 )

--- a/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_fuzz.cc
@@ -270,7 +270,8 @@ public:
     template<typename T>
     T read() {
         std::array<char, sizeof(T)> buf;
-        if (std::distance(pc_, program_.cend()) < buf.size()) {
+        if (
+          std::distance(pc_, program_.cend()) < static_cast<long>(buf.size())) {
             throw end_of_program();
         }
         std::copy_n(pc_, buf.size(), buf.begin());
@@ -328,7 +329,7 @@ public:
 };
 
 struct noop {
-    auto operator()(cstore_ops& ops) const {}
+    auto operator()(cstore_ops&) const {}
 };
 struct self_move_op {
     auto operator()(cstore_ops& ops) const { ops.self_moves(); }

--- a/src/v/kafka/protocol/tests/BUILD
+++ b/src/v/kafka/protocol/tests/BUILD
@@ -2,6 +2,31 @@ load("//bazel:test.bzl", "redpanda_cc_btest")
 load("//src/v/kafka/protocol:protocol.bzl", "MESSAGE_TYPES")
 
 redpanda_cc_btest(
+    name = "security_test",
+    timeout = "short",
+    srcs = [
+        "security_test.cc",
+    ],
+    data = [
+        "//src/v/test_utils/go/kreq-gen:kafka_request_generator",
+    ],
+    # could also use runfiles here, which would be easier once cmake is gone
+    # because then we could use bazel_tools runfiles library
+    env = {"GENERATOR_BIN": "$(rootpath //src/v/test_utils/go/kreq-gen:kafka_request_generator)"},
+    deps = [
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol/schemata:sasl_authenticate_request",
+        "//src/v/kafka/protocol/schemata:sasl_authenticate_response",
+        "//src/v/kafka/server",
+        "//src/v/security",
+        "@boost//:algorithm",
+        "@boost//:test",
+        "@fmt",
+        "@seastar//:testing",
+    ] + MESSAGE_TYPES,
+)
+
+redpanda_cc_btest(
     name = "protocol_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/protocol/tests/security_test.cc
+++ b/src/v/kafka/protocol/tests/security_test.cc
@@ -10,14 +10,10 @@
 #include "kafka/protocol/schemata/sasl_authenticate_request.h"
 #include "kafka/protocol/schemata/sasl_authenticate_response.h"
 #include "kafka/server/handlers/details/security.h"
-#include "random/generators.h"
 #include "security/acl.h"
-#include "security/authorizer.h"
-#include "utils/base64.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
-#include <absl/container/flat_hash_set.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ostream.h>

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -265,6 +265,38 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "consumer_groups_test",
+    timeout = "short",
+    srcs = [
+        "consumer_groups_test.cc",
+    ],
+    cpu = 1,
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/kafka/client",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:describe_groups",
+        "//src/v/kafka/protocol:find_coordinator",
+        "//src/v/kafka/protocol:join_group",
+        "//src/v/kafka/protocol:offset_commit",
+        "//src/v/kafka/protocol/schemata:join_group_request",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/model:timeout_clock",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:base64",
+        "//src/v/utils:to_string",
+        "@boost//:test",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "group_test",
     timeout = "short",
     srcs = [

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/controller_api.h"
-#include "features/feature_table.h"
 #include "kafka/client/client.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"


### PR DESCRIPTION
Add bazel builds for 3 tests:
* [k/server/tests: bazel for consumer_groups_test](https://github.com/redpanda-data/redpanda/commit/36598628b1039fc3af8f05e68dd406468a7f441b) 
* [cloud_storage/tests: bazel for segment_meta_cstore_fuzz_rpfixture](https://github.com/redpanda-data/redpanda/commit/eddaedd561b3f086283ffa9fd237cc9832c141ef) 
* [k/protocol/tests: bazel for security_test](https://github.com/redpanda-data/redpanda/commit/be5598ce9117dc9e531d74f81e26ce46c9ce3404)

Minor modifications are made to the tests as appropriate. See the commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-7498
Fixes https://redpandadata.atlassian.net/browse/CORE-7379
Fixes https://redpandadata.atlassian.net/browse/CORE-7491

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
