### PR TITLE
[CORE-9072] [CORE-9137] `rptest`: deflake `log_compaction_test`

### DIFF
--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -293,24 +293,11 @@ class LogCompactionTest(LogCompactionTestBase, PreallocNodesTest,
                                          TopicSpec.PROPERTY_RETENTION_TIME,
                                          1000)
 
-        self.prev_closed_segment_bytes = self.get_closed_segment_bytes()
-        self.prev_dirty_segment_bytes = self.get_dirty_segment_bytes()
-        self.prev_dirty_ratio = self.get_dirty_ratio()
-
         def all_segments_removed():
-            new_closed_segment_bytes = self.get_closed_segment_bytes()
-            new_dirty_segment_bytes = self.get_dirty_segment_bytes()
-            new_dirty_ratio = self.get_dirty_ratio()
+            closed_segment_bytes = self.get_closed_segment_bytes()
+            dirty_segment_bytes = self.get_dirty_segment_bytes()
 
-            assert new_closed_segment_bytes <= self.prev_closed_segment_bytes
-            assert new_dirty_segment_bytes <= self.prev_dirty_segment_bytes
-            assert new_dirty_ratio <= self.prev_dirty_ratio
-
-            self.prev_closed_segment_bytes = new_closed_segment_bytes
-            self.prev_dirty_segment_bytes = new_dirty_segment_bytes
-            self.prev_dirty_ratio = new_dirty_ratio
-
-            return new_dirty_segment_bytes == 0 and new_closed_segment_bytes == 0
+            return dirty_segment_bytes == 0 and closed_segment_bytes == 0
 
         wait_until(all_segments_removed,
                    timeout_sec=120,


### PR DESCRIPTION
These asserts were race-y due to the fact a segment roll could easily add to the dirty/closed bytes of a log.

Furthermore, these asserts don't really prove anything, as we are waiting for the number of dirty/closed bytes to eventually go to zero due to retention enforcement anyways.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
