### PR TITLE
`rptest`: add `nessie` end to end `datalake` testing

### DIFF
--- a/src/v/iceberg/table_requests.h
+++ b/src/v/iceberg/table_requests.h
@@ -31,7 +31,7 @@ struct create_table_request {
 
     // If set to true, the table is not created, but table metadata is
     // initialized and returned by the catalog.
-    std::optional<bool> stage_create;
+    std::optional<bool> stage_create = false;
 
     std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
 };

--- a/tests/rptest/tests/datalake/catalog_service_factory.py
+++ b/tests/rptest/tests/datalake/catalog_service_factory.py
@@ -13,9 +13,9 @@ from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
 
 from typing import List
 
-# TODO: Nessie is not supported here yet. Add it back once
-# required datalake authentication changes have been made.
-SUPPORTED_CATALOG_TYPES = [CatalogType.REST_JDBC, CatalogType.REST_HADOOP]
+SUPPORTED_CATALOG_TYPES = [
+    CatalogType.REST_JDBC, CatalogType.REST_HADOOP, CatalogType.NESSIE
+]
 
 
 def filesystem_catalog_type() -> CatalogType:
@@ -38,5 +38,9 @@ def make_catalog_service_for_type(catalog_type: CatalogType, test_ctx,
                                   cloud_storage_bucket=cloud_storage_bucket,
                                   warehouse_name=warehouse_name,
                                   filesystem_wrapper_mode=True)
+    elif catalog_type == CatalogType.NESSIE:
+        return NessieCatalog(test_ctx,
+                             cloud_storage_bucket=cloud_storage_bucket,
+                             warehouse_name=warehouse_name)
     else:
         raise NotImplementedError(f"No catalog of type {catalog_type}")

--- a/tests/rptest/tests/datalake/catalog_service_factory.py
+++ b/tests/rptest/tests/datalake/catalog_service_factory.py
@@ -29,8 +29,6 @@ def supported_catalog_types() -> List[CatalogType]:
 def make_catalog_service_for_type(catalog_type: CatalogType, test_ctx,
                                   cloud_storage_bucket: str,
                                   warehouse_name: str) -> CatalogService:
-    if catalog_type not in SUPPORTED_CATALOG_TYPES:
-        raise NotImplementedError(f"No catalog of type {catalog_type}")
     if catalog_type == CatalogType.REST_JDBC:
         return IcebergRESTCatalog(test_ctx,
                                   cloud_storage_bucket=cloud_storage_bucket,
@@ -40,3 +38,5 @@ def make_catalog_service_for_type(catalog_type: CatalogType, test_ctx,
                                   cloud_storage_bucket=cloud_storage_bucket,
                                   warehouse_name=warehouse_name,
                                   filesystem_wrapper_mode=True)
+    else:
+        raise NotImplementedError(f"No catalog of type {catalog_type}")

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -20,7 +20,7 @@ from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.tests.datalake.catalog_service_factory import supported_catalog_types, filesystem_catalog_type
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from ducktape.utils.util import wait_until
 from rptest.services.metrics_check import MetricCheck
 from rptest.services.catalog_service import CatalogType
@@ -159,9 +159,16 @@ class DatalakeE2ETests(RedpandaTest):
             assert count_after_produce == count, f"{count_after_produce} rows, expected {count}"
 
     @cluster(num_nodes=4)
+    @ignore(catalog_type=CatalogType.NESSIE,
+            cloud_storage_type=CloudStorageType.S3)
+    @ignore(catalog_type=CatalogType.NESSIE,
+            cloud_storage_type=CloudStorageType.ABS)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
     def test_remove_expired_snapshots(self, cloud_storage_type, catalog_type):
+        """
+        Nessie doesn't support tags, so it is ignored for this test.
+        """
         table_name = f"redpanda.{self.topic_name}"
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -83,12 +83,13 @@ class DatalakeServices():
 
         for engine in self.included_query_engines:
             svc_cls = get_query_engine_by_type(engine)
-            svc = svc_cls(
-                self.test_ctx,
-                iceberg_catalog_uri=self.catalog_service.iceberg_rest_url,
-                default_warehouse_dir=self.catalog_service.
-                cloud_storage_warehouse,
-                catalog_type=self.catalog_service.catalog_type())
+            catalog_uri = self.catalog_service.vendor_api_url if self.catalog_service.catalog_type(
+            ) == CatalogType.NESSIE else self.catalog_service.iceberg_rest_url
+            svc = svc_cls(self.test_ctx,
+                          iceberg_catalog_uri=catalog_uri,
+                          default_warehouse_dir=self.catalog_service.
+                          cloud_storage_warehouse,
+                          catalog_type=self.catalog_service.catalog_type())
             svc.start()
             self.query_engines.append(svc)
 

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -75,7 +75,9 @@ class DatalakeServices():
         if self.catalog_service.catalog_type() == CatalogType.NESSIE:
             self.redpanda.add_extra_rp_conf({
                 "iceberg_rest_catalog_prefix":
-                NessieCatalog.NESSIE_DEFAULT_WAREHOUSE
+                NessieCatalog.NESSIE_DEFAULT_WAREHOUSE,
+                "iceberg_disable_snapshot_tagging":
+                "true"
             })
         self.redpanda.start(start_si=False)
 


### PR DESCRIPTION
Now that https://github.com/redpanda-data/redpanda/pull/25230 is merged, we can support end to end `nessie` testing in our `datalake` testing.

Makes a minor change to `iceberg` in the core and a minor change to `datalake_services.py`, and then adds `nessie` as a supported catalog type in order to parameterize all of our end to end `datalake` testing with it.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
