### PR TITLE
CORE-7598 serde/test: bazel for serde_fuzz_test

### DIFF
--- a/src/v/serde/test/BUILD
+++ b/src/v/serde/test/BUILD
@@ -1,4 +1,6 @@
-load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:build.bzl", "redpanda_cc_binary")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_fuzz_test", "redpanda_test_cc_library")
 
 redpanda_cc_bench(
     name = "serde_rpbench",
@@ -54,5 +56,63 @@ redpanda_cc_btest(
         "@boost//:test",
         "@seastar",
         "@seastar//:testing",
+    ],
+)
+
+py_binary(
+    name = "struct_gen",
+    srcs = ["struct_gen.py"],
+    main = "struct_gen.py",
+    visibility = ["//visibility:public"],
+    deps = ["@python_deps//jinja2"],
+)
+
+genrule(
+    name = "generated_structs_genrule",
+    outs = ["generated_structs.h"],
+    cmd = "$(PYTHON3) $(execpath :struct_gen) $@",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = [":struct_gen"],
+)
+
+redpanda_test_cc_library(
+    name = "generated_structs",
+    hdrs = [":generated_structs.h"],
+    include_prefix = "serde/test",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/serde",
+        "//src/v/serde:iobuf",
+        "//src/v/serde:optional",
+        "//src/v/serde:sstring",
+        "//src/v/serde:vector",
+    ],
+)
+
+redpanda_cc_fuzz_test(
+    name = "serde_fuzz_test",
+    timeout = "moderate",
+    srcs = ["fuzz.cc"],
+    args = [
+        "-max_total_time=60",
+        "-rss_limit_mb=8192",
+    ],
+    deps = [
+        ":generated_structs",
+        "//src/v/reflection:type_traits",
+        "//src/v/serde",
+        "//src/v/serde:vector",
+    ],
+)
+
+redpanda_cc_binary(
+    name = "serde_fuzz_main",
+    testonly = True,
+    srcs = ["fuzz.cc"],
+    defines = ["MAIN=1"],
+    deps = [
+        ":generated_structs",
+        "//src/v/reflection:type_traits",
+        "//src/v/serde",
     ],
 )

--- a/src/v/serde/test/fuzz.cc
+++ b/src/v/serde/test/fuzz.cc
@@ -1,5 +1,5 @@
-#include "generated_structs.h"
 #include "reflection/type_traits.h"
+#include "serde/test/generated_structs.h"
 
 #if defined(MAIN)
 #include <fstream>
@@ -164,8 +164,7 @@ bool test_failure(
 }
 
 template<typename T, std::size_t... Generations>
-bool eq_generations(
-  T&& a, T&& b, std::index_sequence<Generations...> generations) {
+bool eq_generations(T&& a, T&& b, std::index_sequence<Generations...>) {
     return (
       (a.template get_generation<Generations>()
        == b.template get_generation<Generations>())


### PR DESCRIPTION
Add a bazel build for the serde fuzz test and a test binary to run the fuzzer directly.

The test source is changed to fix compile errors when compiled with the codebase's standard compile options.

Fixes https://redpandadata.atlassian.net/browse/CORE-7598

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
