### PR TITLE
`storage`: check if `seg->is_closed()` in self compaction locations before removing bytes

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -504,6 +504,12 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
           _manager.resources(),
           _feature_table);
 
+        if (segment->is_closed()) {
+            // We can race here with a truncation operation that removes the
+            // full segment, since we are not under a rewrite lock.
+            continue;
+        }
+
         vlog(
           gclog.debug,
           "[{}] segment {} compaction result: {}",
@@ -614,6 +620,12 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           _feature_table);
 
         if (result.did_compact() == false) {
+            continue;
+        }
+
+        if (seg->is_closed()) {
+            // We can race here with a truncation operation that removes the
+            // full segment, since we are not under a rewrite lock.
             continue;
         }
 


### PR DESCRIPTION
Reported in: https://redpandadata.atlassian.net/browse/CORE-8091, but this does not close that issue, since this JIRA ticket deals with all failures in `storage_e2e_single_thread_rpunit`.

There are two locations in `disk_log_impl` where we self compact segments without obtaining rewrite locks. These are in `sliding_window_compact()` and `adjacent_merge_compact()`.

While these aren't necessarily dangerous for correctness, they can trigger the `dassert()` in updating the dirty/closed segment bytes in the log if we happen to race with a truncation operation that removes the segment.

For an example of this happening, see the following log lines:

```
TRACE 2025-03-04 08:32:24,779 [shard 0:main] storage-gc - segment_utils.cc:543 - self compacting segment test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log
TRACE 2025-03-04 08:32:24,809 [shard 0:main] storage-gc - segment_utils.cc:390 - copying compacted segment data from test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log to test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log.staging
INFO  2025-03-04 08:32:24,812 [shard 0:main] storage-gc - segment_utils.cc:448 - Self compaction filtering removing data from test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log: { batches_processed: 16, batches_discarded: 2, records_discarded: 2, non_compactible_batches: 0 }
TRACE 2025-03-04 08:32:24,812 [shard 0:main] storage-gc - segment_utils.cc:571 - finished copying segment data for test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log
TRACE 2025-03-04 08:32:24,812 [shard 0:main] storage-gc - segment_utils.cc:508 - swapping compacted segment temp file test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log.staging with the segment test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log
INFO  2025-03-04 08:32:24,813 [shard 0:main] storage - disk_log_impl.cc:2838 - Removing "test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log" (remove_full_segments, {offset_tracker:{term:0, base_offset:44, committed_offset:59, dirty_offset:59}, compacted_segment=1, finished_self_compaction=0, finished_windowed_compaction=0, generation=23, reader={test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log, (1263 bytes)}, writer=nullptr, cache=nullptr, compaction_index:nullopt, closed=0, tombstone=0, index={file:test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.base_index, offsets:44, index:{header_bitflags:0, base_offset:44, max_offset:0, base_timestamp:{timestamp: 0}, max_timestamp:{timestamp: 0}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{nullopt}, num_compactible_records_appended:{0}, clean_compact_timestamp:{nullopt}, may_have_tombstone_records:1, index(0, 0, 0)}, step:32768, needs_persistence:0}})
INFO  2025-03-04 08:32:24,813 [shard 0:main] storage - disk_log_impl.cc:4208 - {default/test/0}: remove segment permanently: remove_full_segments: subtracting 1263 dirty bytes, leaving 0
INFO  2025-03-04 08:32:24,813 [shard 0:main] storage - disk_log_impl.cc:4223 - {default/test/0}: remove segment permanently: remove_full_segments: subtracting 1263 closed bytes, leaving 1735
INFO  2025-03-04 08:32:24,813 [shard 0:main] storage - disk_log_impl.cc:2854 - Segment has outstanding locks. Might take a while to close:test.data.IQp5JVeBRx/default/test/0_0/44-0-v1.log
INFO  2025-03-04 08:32:24,814 [shard 0:main] storage - disk_log_impl.cc:4208 - {default/test/0}: self compact in sliding window compact: subtracting 158 dirty bytes, leaving -158
ERROR 2025-03-04 08:32:24,814 [shard 0:main] assert - Assert failure: (/home/willem/redpanda/src/v/storage/disk_log_impl.cc:4210) '_dirty_segment_bytes >= 0' _dirty_segment_bytes must not be negative.
```

Fix the race by checking if `segment->is_closed()` before removing bytes in these self compaction locations.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
