### PR TITLE
base/vassert: type-erase assert handling

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -2,6 +2,9 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
     name = "base",
+    srcs = [
+        "vassert.cc",
+    ],
     hdrs = [
         "likely.h",
         "oncore.h",
@@ -13,6 +16,7 @@ redpanda_cc_library(
         "units.h",
         "unreachable.h",
         "vassert.h",
+        "vassert-register.h",
         "vformat.h",
         "vlog.h",
     ],

--- a/src/v/base/CMakeLists.txt
+++ b/src/v/base/CMakeLists.txt
@@ -1,5 +1,7 @@
 v_cc_library(
     NAME base
+    SRCS
+      vassert.cc
     DEPS
       Seastar::seastar
 )

--- a/src/v/base/oncore.h
+++ b/src/v/base/oncore.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "base/seastarx.h"
 #include "base/vassert.h"
 #include "source_location.h"
 

--- a/src/v/base/tests/assert_log_holder_test.cc
+++ b/src/v/base/tests/assert_log_holder_test.cc
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-#include "base/vassert.h"
+#include "base/vassert-register.h"
 
 #include <seastar/util/backtrace.hh>
 
@@ -26,21 +26,18 @@ TEST_F(AssertLogHolderTest, ValidateAssertLogHolder) {
     };
 
     auto bt = ss::current_backtrace();
-    detail::g_assert_log_holder.register_event(
-      bt, "This is a test event: {}", "test");
+    base::register_event(bt, "This is a test event: test");
     EXPECT_TRUE(message.empty());
-    detail::g_assert_log_holder.register_cb(cb);
-    detail::g_assert_log_holder.register_event(
-      bt, "This is a test event: {}", "test");
+    base::register_cb(cb);
+    base::register_event(bt, "This is a test event: test");
 
     EXPECT_EQ(message, fmt::format("This is a test event: test"));
     EXPECT_TRUE(unused_message.empty());
 
     // Verify that a second call to `register_cb` does not replace the current
     // callback
-    detail::g_assert_log_holder.register_cb(unused_cb);
-    detail::g_assert_log_holder.register_event(
-      bt, "This is a second test event: {}", "test");
+    base::register_cb(unused_cb);
+    base::register_event(bt, "This is a second test event: test");
 
     EXPECT_EQ(message, fmt::format("This is a second test event: test"));
     EXPECT_TRUE(unused_message.empty());

--- a/src/v/base/unreachable.h
+++ b/src/v/base/unreachable.h
@@ -16,13 +16,4 @@
 #include <seastar/util/backtrace.hh>
 
 // NOLINTNEXTLINE
-#define unreachable()                                                          \
-    /* NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while) */                     \
-    do {                                                                       \
-        ::detail::g_assert_log_holder.register_event(                          \
-          ss::current_backtrace(),                                             \
-          "This code should not be reached ({}:{})",                           \
-          __FILE__,                                                            \
-          __LINE__);                                                           \
-        __builtin_trap();                                                      \
-    } while (0)
+#define unreachable() vassert(false, "This code should not be reached")

--- a/src/v/base/vassert-register.h
+++ b/src/v/base/vassert-register.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/backtrace.hh>
+
+#include <string_view>
+
+namespace base {
+// We want to enforce using a non-capturing function for callbacks to ensure
+// a static lifetime for the callback as we will not permit unregistering
+// a callback to prevent a race condition between unregistering the callback
+// on one thread and having the callback called by a different thread.
+
+// A callback function which can be registered.
+using assert_cb_func = void (*)(std::string_view);
+
+// Register a callback which will be called after an assert files, but before
+// the abort. It receives as its argument the full message of any assert or
+// register_event calls.
+// Only the first registration has any effect, calls to this function do
+// nothing.
+void register_cb(assert_cb_func cb);
+
+/**
+ * @brief Registers a vassert event
+ *
+ * @param bt The backtrace from the assert
+ * @param message The message to register.
+ */
+void register_event(const ss::saved_backtrace& bt, std::string_view message);
+
+} // namespace base

--- a/src/v/base/vassert.cc
+++ b/src/v/base/vassert.cc
@@ -15,59 +15,29 @@
 
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
-#include <seastar/util/noncopyable_function.hh>
 
 #include <atomic>
 #include <string_view>
 
-namespace detail {
 using namespace base;
-struct dummyassert {
-    static inline ss::logger l{"assert"};
-};
-inline dummyassert g_assert_log;
-/**
- * @brief Class used to format assert messages
- *
- * This class will format the provided assert message and produce a backtrace
- * caused by an assert.  It also provides a means of registering a callback
- * function that will be called when an assert is triggered.
- */
-class assert_log_holder {
-public:
-    void do_assert(
-      ss::saved_backtrace bt,
-      const char* prefix, // NOLINT(bugprone-easily-swappable-parameters)
-      const char* format,
-      fmt::format_args args) noexcept {
-        std::string buffer = fmt::format(
-          "Assert failure: {} {}", prefix, fmt::vformat(format, args));
-        assert_handler(bt, buffer);
+
+namespace detail {
+namespace {
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
+ss::logger assert_logger{"assert"};
+std::atomic<assert_cb_func> _cb_func{nullptr};
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
+
+void assert_handler(const ss::saved_backtrace& bt, std::string_view text) {
+    assert_logger.error("{}", text);
+    assert_logger.error("Backtrace:\n{}", bt);
+
+    auto cb_func = _cb_func.load();
+    if (cb_func != nullptr) {
+        cb_func(text);
     }
-
-    void register_cb(assert_cb_func cb) {
-        assert_cb_func before = nullptr;
-        _cb_func.compare_exchange_strong(before, cb);
-    }
-
-private:
-    friend void ::base::register_event(
-      const ss::saved_backtrace&, std::string_view);
-
-    void assert_handler(ss::saved_backtrace bt, std::string_view text) {
-        g_assert_log.l.error("{}", text);
-        g_assert_log.l.error("Backtrace:\n{}", bt);
-
-        auto cb_func = _cb_func.load();
-        if (cb_func != nullptr) {
-            cb_func(text);
-        }
-    }
-
-    std::atomic<assert_cb_func> _cb_func{nullptr};
-};
-
-assert_log_holder g_assert_log_holder;
+}
 
 // Implementation notes:
 // Asserts rarely trigger: after all, they can occur at most once
@@ -121,25 +91,29 @@ assert_log_holder g_assert_log_holder;
 // This goldbolt link may be useful when considering changes to this
 // strategy: https://godbolt.org/z/naYddPff5
 
+} // namespace
+
 // This thunk is fully type erased. See implementation details above.
 [[gnu::cold]] [[noreturn]]
 void assert_failed_thunk2(
-  const char* prefix, const char* msg, fmt::format_args args) noexcept {
-    ::detail::g_assert_log_holder.do_assert(
-      ss::current_backtrace(), prefix, msg, args);
+  const char* prefix, const char* format, fmt::format_args args) noexcept {
+    std::string buffer = fmt::format(
+      "Assert failure: {} {}", prefix, fmt::vformat(format, args));
+    assert_handler(ss::current_backtrace(), buffer);
     __builtin_trap();
 }
 
 } // namespace detail
 
-using namespace detail;
-
 namespace base {
 
 void register_event(const ss::saved_backtrace& bt, std::string_view message) {
-    g_assert_log_holder.assert_handler(bt, message);
+    detail::assert_handler(bt, message);
 }
 
-void register_cb(assert_cb_func cb) { g_assert_log_holder.register_cb(cb); }
+void register_cb(assert_cb_func cb) {
+    assert_cb_func before = nullptr;
+    detail::_cb_func.compare_exchange_strong(before, cb);
+}
 
 } // namespace base

--- a/src/v/base/vassert.cc
+++ b/src/v/base/vassert.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/vassert.h"
+
+#include "base/seastarx.h"
+#include "base/vassert-register.h"
+
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <atomic>
+#include <string_view>
+
+namespace detail {
+using namespace base;
+struct dummyassert {
+    static inline ss::logger l{"assert"};
+};
+inline dummyassert g_assert_log;
+/**
+ * @brief Class used to format assert messages
+ *
+ * This class will format the provided assert message and produce a backtrace
+ * caused by an assert.  It also provides a means of registering a callback
+ * function that will be called when an assert is triggered.
+ */
+class assert_log_holder {
+public:
+    void do_assert(
+      ss::saved_backtrace bt,
+      const char* prefix, // NOLINT(bugprone-easily-swappable-parameters)
+      const char* format,
+      fmt::format_args args) noexcept {
+        std::string buffer = fmt::format(
+          "Assert failure: {} {}", prefix, fmt::vformat(format, args));
+        assert_handler(bt, buffer);
+    }
+
+    void register_cb(assert_cb_func cb) {
+        assert_cb_func before = nullptr;
+        _cb_func.compare_exchange_strong(before, cb);
+    }
+
+private:
+    friend void ::base::register_event(
+      const ss::saved_backtrace&, std::string_view);
+
+    void assert_handler(ss::saved_backtrace bt, std::string_view text) {
+        g_assert_log.l.error("{}", text);
+        g_assert_log.l.error("Backtrace:\n{}", bt);
+
+        auto cb_func = _cb_func.load();
+        if (cb_func != nullptr) {
+            cb_func(text);
+        }
+    }
+
+    std::atomic<assert_cb_func> _cb_func{nullptr};
+};
+
+assert_log_holder g_assert_log_holder;
+
+// Implementation notes:
+// Asserts rarely trigger: after all, they can occur at most once
+// during the lifetime of the program! So the priorities are,
+// in no specific order, something like:
+// 1) Avoid slowing down the fast path (no assert) in terms of
+//    instructions, i.e. "micro" execution
+// 2) Avoid polluting the hot path icache lines with cold code that
+//    is rarely going to be executed, i.e., the assertion
+//    handling code
+// 3) Avoid duplicating assertion handling code in every TU, which
+//    slows down compile time and wastes disk space (and in the shared
+//    library build space in the final binaries)
+//
+// To do (1) we note that both clang and gcc are pretty bad at keeping
+// the hot path clean, even when the cold path is clearly hidden behind an
+// [[unlikely]] annotation. In particular, in the hot path it will spill locals
+// that are passed by reference to an opaque function in the cold part, and also
+// insert stack canary checks (we use -fstack-protector-strong) in the hot path
+// even though none of that is needed in the hot path.
+//
+// See the following bugs for examples directly derived from this case:
+//
+// https://github.com/llvm/llvm-project/issues/129750
+// https://github.com/llvm/llvm-project/issues/129748
+//
+// In order to minimize junk on the hot path we should try to avoid the address
+// of local variables escaping out of the inlined function where the original
+// vassert call occur. Calls to fmt::format pass locals will generally escape
+// them because: (a) it holds most arguments by void *, and (b) even for
+// primitives, which it does hold by value, the size of the format_args
+// structure quickly exceeds 16 bytes which means it will be passed on the stack
+// anyway, which escapes the address of that object causing similar problems.
+//
+// So the approach is to use several things in the cold path: the thunk0 takes
+// all fmt arguments by reference and will be inlined (so doesn't cause
+// escaping) and decides on a per-argument basis whether to pass by value or
+// reference (passing trivially constructible values by value) and calls thunk1
+// with all arguments passed in the selected way. Thunk0 ends up in the calling
+// function but "out of line" (as it is called on an [[unlikely]] branch. Then
+// thunk1 is a template function depending on all the argument types but cold
+// and so not inlined and compiled into the text.unlikely section (helping with
+// goal 2). This thunk uses make::format_args which erases the arguments and
+// calls thunk2 which is not a template and can be implemented entirely in the
+// .cc.
+//
+// For many simple calls this results in a good hot path with no junk from the
+// cold path. The hot path will still get junk if format arguments need to be
+// passed by reference.
+//
+// This goldbolt link may be useful when considering changes to this
+// strategy: https://godbolt.org/z/naYddPff5
+
+// This thunk is fully type erased. See implementation details above.
+[[gnu::cold]] [[noreturn]]
+void assert_failed_thunk2(
+  const char* prefix, const char* msg, fmt::format_args args) noexcept {
+    ::detail::g_assert_log_holder.do_assert(
+      ss::current_backtrace(), prefix, msg, args);
+    __builtin_trap();
+}
+
+} // namespace detail
+
+using namespace detail;
+
+namespace base {
+
+void register_event(const ss::saved_backtrace& bt, std::string_view message) {
+    g_assert_log_holder.assert_handler(bt, message);
+}
+
+void register_cb(assert_cb_func cb) { g_assert_log_holder.register_cb(cb); }
+
+} // namespace base

--- a/src/v/base/vassert.h
+++ b/src/v/base/vassert.h
@@ -12,138 +12,12 @@
 #pragma once
 
 #include "base/likely.h"
-#include "base/seastarx.h"
 
-#include <seastar/util/backtrace.hh>
-#include <seastar/util/log.hh>
-#include <seastar/util/noncopyable_function.hh>
+#include <fmt/core.h>
 
-#include <atomic>
-#include <string_view>
+#include <type_traits>
 
 namespace detail {
-struct dummyassert {
-    static inline ss::logger l{"assert"};
-};
-inline dummyassert g_assert_log;
-/**
- * @brief Class used to format assert messages
- *
- * This class will format the provided assert message and produce a backtrace
- * caused by an assert.  It also provides a means of registering a callback
- * function that will be called when an assert is triggered.
- */
-class assert_log_holder {
-public:
-    // We want to enforce using a non-capturing function for callbacks to ensure
-    // a static lifetime for the callback as we will not permit unregistering
-    // a callback to prevent a race condition between unregistering the callback
-    // on one thread and having the callback called by a different thread.
-    using assert_cb_func = void (*)(std::string_view);
-
-    /**
-     * @brief Registers a vassert event
-     *
-     * @tparam Args The argument template
-     * @param bt The backtrace from the assert
-     * @param fmt The format string for the log
-     * @param args The arguments to @p fmt
-     */
-    template<typename... Args>
-    void register_event(
-      const ss::saved_backtrace& bt,
-      ss::logger::format_info_t<Args...> fmt,
-      Args&&... args) {
-        auto text = fmt::format(
-          fmt::runtime(fmt.format), std::forward<Args>(args)...);
-        assert_handler(bt, text);
-    }
-
-    /**
-     * @brief Registers a vassert event
-     *
-     * @tparam Args The argument template
-     * @param bt The backtrace from the assert
-     * @param fmt The format string for the log
-     * @param args The arguments to @p fmt
-     */
-    void do_assert(
-      ss::saved_backtrace bt,
-      const char* prefix, // NOLINT(bugprone-easily-swappable-parameters)
-      const char* format,
-      fmt::format_args args) noexcept {
-        std::string buffer = fmt::format(
-          "Assert failure: {} {}", prefix, fmt::vformat(format, args));
-        assert_handler(bt, buffer);
-    }
-
-    void register_cb(assert_cb_func cb) {
-        assert_cb_func before = nullptr;
-        _cb_func.compare_exchange_strong(before, cb);
-    }
-
-private:
-    void assert_handler(ss::saved_backtrace bt, std::string_view text) {
-        g_assert_log.l.error("{}", text);
-        g_assert_log.l.error("Backtrace:\n{}", bt);
-
-        auto cb_func = _cb_func.load();
-        if (cb_func != nullptr) {
-            cb_func(text);
-        }
-    }
-
-    std::atomic<assert_cb_func> _cb_func{nullptr};
-};
-inline assert_log_holder g_assert_log_holder;
-
-// Implementation notes:
-// Asserts rarely trigger: after all, they can occur at most once
-// during the lifetime of the program! So the priorities are,
-// in no specific order something like:
-// 1) Avoid slowing down the fast path (no assert) in terms of
-//    instructions, "micro" execution
-// 2) Avoid polluting the hot icache lines with cold code that
-//    is rarely going to be executed, i.e., the assertion
-//    handling code
-// 3) Avoid duplicating assertion handling code in every TU, which
-//    slows down compile time and wastes space.
-//
-// To do (1) we node that both clang and gcc is pretty bad at keeping
-// the hot path clean, even when the cold path is clearly hidden behind an
-// [[unlikely]] annotation. In particular, it will spill locals that are passed
-// by reference in the cold part, and also insert stack canary checks (we use
-// -fstack-protector-strong) in the hot path even though none of that is needed
-// here. See the following bugs for examples directly derived from this case:
-// https://github.com/llvm/llvm-project/issues/129750
-// https://github.com/llvm/llvm-project/issues/129748
-//
-// In order to minimize junk on the hot path we should try to avoid the address
-// of local variables escaping out of the inlined function where the original
-// vassert call occur. Calls to fmt::format pass locals will generally escape
-// them because: (a) it holds most arguments by void *, and (b) even for
-// primitives, which it does hold by value, the size of the format_args
-// structure quickly exceeds 16 bytes which means it will be passed on the stack
-// anyway, which escapes the address of that object causing similar problems.
-//
-// So the approach is to use several things in the cold path: the thunk0 takes
-// all fmt arguments by reference and will be inlined (so doesn't cause
-// escaping) and decides on a per-argument basis whether to pass by value or
-// reference (passing trivially constructible values by value) and calls thunk1
-// with all arguments passed in the selected way. Thunk0 ends up in the calling
-// function but "out of line" (as it is called on an [[unlikely]] branch. Then
-// thunk1 is a template function depending on all the argument types but cold
-// and so not inlined and compiled into the text.unlikely section (helping with
-// goal 2). This thunk uses make::format_args which erases the arguments and
-// calls thunk2 which is not a template and can be implemented entirely in the
-// .cc.
-//
-// For many simple calls this results in a good hot path with no junk from the
-// cold path. The hot path will still get junk if format arguments need to be
-// passed by reference.
-//
-// This godbolt link may be useful when considering changes to this
-// strategy: https://godbolt.org/z/naYddPff5
 
 // Pass by value for 16-byte values which are trivially copyable.
 // This captures most/all of the values which can be passed in registers,
@@ -159,12 +33,8 @@ using fwd_type = std::conditional_t<pass_by_value<T_>, T_, const T&>;
 
 // This thunk is fully type erased. See implementation details in vassert.cc.
 [[gnu::cold]] [[noreturn]]
-inline void assert_failed_thunk2(
-  const char* prefix, const char* msg, fmt::format_args args) {
-    ::detail::g_assert_log_holder.do_assert(
-      ss::current_backtrace(), prefix, msg, args);
-    __builtin_trap();
-}
+void assert_failed_thunk2(
+  const char* prefix, const char* msg, fmt::format_args args) noexcept;
 
 // This thunk accepts all the format arguments using the selected passing method
 // and erases them. It is cold so appears in the cold section of the binary.

--- a/src/v/base/vassert.h
+++ b/src/v/base/vassert.h
@@ -19,6 +19,7 @@
 #include <seastar/util/noncopyable_function.hh>
 
 #include <atomic>
+#include <string_view>
 
 namespace detail {
 struct dummyassert {
@@ -39,6 +40,7 @@ public:
     // a callback to prevent a race condition between unregistering the callback
     // on one thread and having the callback called by a different thread.
     using assert_cb_func = void (*)(std::string_view);
+
     /**
      * @brief Registers a vassert event
      *
@@ -49,19 +51,30 @@ public:
      */
     template<typename... Args>
     void register_event(
-      ss::saved_backtrace bt,
+      const ss::saved_backtrace& bt,
       ss::logger::format_info_t<Args...> fmt,
-      Args&&... args) noexcept {
-        auto buffer = fmt::format(
+      Args&&... args) {
+        auto text = fmt::format(
           fmt::runtime(fmt.format), std::forward<Args>(args)...);
+        assert_handler(bt, text);
+    }
 
-        g_assert_log.l.error("{}", buffer);
-        g_assert_log.l.error("Backtrace:\n{}", bt);
-
-        auto cb_func = _cb_func.load();
-        if (cb_func != nullptr) {
-            cb_func(buffer);
-        }
+    /**
+     * @brief Registers a vassert event
+     *
+     * @tparam Args The argument template
+     * @param bt The backtrace from the assert
+     * @param fmt The format string for the log
+     * @param args The arguments to @p fmt
+     */
+    void do_assert(
+      ss::saved_backtrace bt,
+      const char* prefix, // NOLINT(bugprone-easily-swappable-parameters)
+      const char* format,
+      fmt::format_args args) noexcept {
+        std::string buffer = fmt::format(
+          "Assert failure: {} {}", prefix, fmt::vformat(format, args));
+        assert_handler(bt, buffer);
     }
 
     void register_cb(assert_cb_func cb) {
@@ -70,10 +83,113 @@ public:
     }
 
 private:
+    void assert_handler(ss::saved_backtrace bt, std::string_view text) {
+        g_assert_log.l.error("{}", text);
+        g_assert_log.l.error("Backtrace:\n{}", bt);
+
+        auto cb_func = _cb_func.load();
+        if (cb_func != nullptr) {
+            cb_func(text);
+        }
+    }
+
     std::atomic<assert_cb_func> _cb_func{nullptr};
 };
 inline assert_log_holder g_assert_log_holder;
+
+// Implementation notes:
+// Asserts rarely trigger: after all, they can occur at most once
+// during the lifetime of the program! So the priorities are,
+// in no specific order something like:
+// 1) Avoid slowing down the fast path (no assert) in terms of
+//    instructions, "micro" execution
+// 2) Avoid polluting the hot icache lines with cold code that
+//    is rarely going to be executed, i.e., the assertion
+//    handling code
+// 3) Avoid duplicating assertion handling code in every TU, which
+//    slows down compile time and wastes space.
+//
+// To do (1) we node that both clang and gcc is pretty bad at keeping
+// the hot path clean, even when the cold path is clearly hidden behind an
+// [[unlikely]] annotation. In particular, it will spill locals that are passed
+// by reference in the cold part, and also insert stack canary checks (we use
+// -fstack-protector-strong) in the hot path even though none of that is needed
+// here. See the following bugs for examples directly derived from this case:
+// https://github.com/llvm/llvm-project/issues/129750
+// https://github.com/llvm/llvm-project/issues/129748
+//
+// In order to minimize junk on the hot path we should try to avoid the address
+// of local variables escaping out of the inlined function where the original
+// vassert call occur. Calls to fmt::format pass locals will generally escape
+// them because: (a) it holds most arguments by void *, and (b) even for
+// primitives, which it does hold by value, the size of the format_args
+// structure quickly exceeds 16 bytes which means it will be passed on the stack
+// anyway, which escapes the address of that object causing similar problems.
+//
+// So the approach is to use several things in the cold path: the thunk0 takes
+// all fmt arguments by reference and will be inlined (so doesn't cause
+// escaping) and decides on a per-argument basis whether to pass by value or
+// reference (passing trivially constructible values by value) and calls thunk1
+// with all arguments passed in the selected way. Thunk0 ends up in the calling
+// function but "out of line" (as it is called on an [[unlikely]] branch. Then
+// thunk1 is a template function depending on all the argument types but cold
+// and so not inlined and compiled into the text.unlikely section (helping with
+// goal 2). This thunk uses make::format_args which erases the arguments and
+// calls thunk2 which is not a template and can be implemented entirely in the
+// .cc.
+//
+// For many simple calls this results in a good hot path with no junk from the
+// cold path. The hot path will still get junk if format arguments need to be
+// passed by reference.
+//
+// This godbolt link may be useful when considering changes to this
+// strategy: https://godbolt.org/z/naYddPff5
+
+// Pass by value for 16-byte values which are trivially copyable.
+// This captures most/all of the values which can be passed in registers,
+// and avoids large copies. The condition here only affects binary size
+// and performance, not correctness: it could be hardcoded to false or
+// true and still be correct.
+template<typename T>
+constexpr bool pass_by_value = std::is_trivially_copy_constructible_v<T>
+                               && sizeof(T) <= 16;
+
+template<typename T, typename T_ = std::remove_cvref_t<T>>
+using fwd_type = std::conditional_t<pass_by_value<T_>, T_, const T&>;
+
+// This thunk is fully type erased. See implementation details in vassert.cc.
+[[gnu::cold]] [[noreturn]]
+inline void assert_failed_thunk2(
+  const char* prefix, const char* msg, fmt::format_args args) {
+    ::detail::g_assert_log_holder.do_assert(
+      ss::current_backtrace(), prefix, msg, args);
+    __builtin_trap();
+}
+
+// This thunk accepts all the format arguments using the selected passing method
+// and erases them. It is cold so appears in the cold section of the binary.
+template<typename... Args>
+[[gnu::cold]] [[noreturn]] [[gnu::noinline]]
+void assert_failed_thunk1(
+  const char* prefix, const char* msg, Args... args) noexcept {
+    assert_failed_thunk2(prefix, msg, fmt::make_format_args(args...));
+}
+
+// This thunk will be inlined into the calling function and is responsible for
+// dispatching. We need the always_inline since otherwise the noreturn attribute
+// causes clang to outline it.
+template<typename... Args>
+[[noreturn]] [[gnu::always_inline]]
+inline void assert_failed_thunk0(
+  const char* prefix, const char* msg, const Args&... args) noexcept {
+    ::detail::assert_failed_thunk1<fwd_type<Args>...>(prefix, msg, args...);
+}
+
 } // namespace detail
+
+// helpers to turn __LINE__ into a string literal
+#define STR_VASSERT2(x) #x
+#define STR_VASSERT(x) STR_VASSERT2(x)
 
 /** Meant to be used in the same way as assert(condition, msg);
  * which means we use the negative conditional.
@@ -90,14 +206,10 @@ inline assert_log_holder g_assert_log_holder;
     do {                                                                       \
         /*The !(x) is not an error. see description above*/                    \
         if (unlikely(!(x))) {                                                  \
-            ::detail::g_assert_log_holder.register_event(                      \
-              ss::current_backtrace(),                                         \
-              "Assert failure: ({}:{}) '{}' " msg,                             \
-              __FILE__,                                                        \
-              __LINE__,                                                        \
-              #x,                                                              \
+            ::detail::assert_failed_thunk0(                                    \
+              "(" __FILE__ ":" STR_VASSERT(__LINE__) ") '" #x "'",             \
+              msg,                                                             \
               ##args);                                                         \
-            __builtin_trap();                                                  \
         }                                                                      \
     } while (0)
 

--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>

--- a/src/v/compression/compression.cc
+++ b/src/v/compression/compression.cc
@@ -9,7 +9,6 @@
 
 #include "compression/compression.h"
 
-#include "base/units.h"
 #include "base/vassert.h"
 #include "base/vlog.h"
 #include "compression/async_stream_zstd.h"
@@ -17,6 +16,8 @@
 #include "compression/internal/lz4_frame_compressor.h"
 #include "compression/internal/snappy_java_compressor.h"
 #include "compression/internal/zstd_compressor.h"
+
+#include <seastar/util/log.hh>
 
 namespace compression {
 

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -11,7 +11,7 @@
 
 #include "crash_tracker/recorder.h"
 
-#include "base/vassert.h"
+#include "base/vassert-register.h"
 #include "config/node_config.h"
 #include "crash_tracker/logger.h"
 #include "crash_tracker/types.h"
@@ -149,7 +149,7 @@ ss::future<> recorder::start() {
     co_await remove_old_crashfiles();
     co_await remove_dangling_upload_markers();
     co_await _writer.initialize(co_await generate_crashfile_name());
-    ::detail::g_assert_log_holder.register_cb(
+    base::register_cb(
       [](std::string_view msg) { get_recorder().record_crash_vassert(msg); });
 }
 

--- a/src/v/datalake/schema_avro.cc
+++ b/src/v/datalake/schema_avro.cc
@@ -10,8 +10,10 @@
 #include "datalake/schema_avro.h"
 
 #include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
 
 #include <avro/Schema.hh>
+
 namespace datalake {
 
 namespace {

--- a/src/v/datalake/values_avro.cc
+++ b/src/v/datalake/values_avro.cc
@@ -14,6 +14,8 @@
 #include "iceberg/avro_decimal.h"
 #include "serde/avro/parser.h"
 
+#include <seastar/util/log.hh>
+
 namespace datalake {
 
 namespace {

--- a/src/v/datalake/values_protobuf.cc
+++ b/src/v/datalake/values_protobuf.cc
@@ -16,6 +16,7 @@
 #include "iceberg/values.h"
 #include "ssx/future-util.h"
 
+#include <seastar/util/log.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <fmt/core.h>

--- a/src/v/debug_bundle/tests/BUILD
+++ b/src/v/debug_bundle/tests/BUILD
@@ -21,6 +21,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/utils:uuid",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@boost//:lexical_cast",
         "@fmt",
         "@googletest//:gtest",
         "@rapidjson",

--- a/src/v/debug_bundle/tests/types_test.cc
+++ b/src/v/debug_bundle/tests/types_test.cc
@@ -14,6 +14,7 @@
 #include "model/namespace.h"
 
 #include <absl/container/flat_hash_map.h>
+#include <boost/lexical_cast.hpp>
 #include <gtest/gtest.h>
 
 #include <iomanip>

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -1061,6 +1061,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":transform",
+        "//src/v/base",
         "//src/v/container:fragmented_vector",
         "@seastar",
     ],

--- a/src/v/iceberg/compatibility_types.cc
+++ b/src/v/iceberg/compatibility_types.cc
@@ -10,6 +10,8 @@
 
 #include "iceberg/compatibility_types.h"
 
+#include <fmt/format.h>
+
 namespace iceberg {
 
 std::string_view to_string_view(type_promoted tp) {

--- a/src/v/iceberg/unresolved_partition_spec.h
+++ b/src/v/iceberg/unresolved_partition_spec.h
@@ -8,8 +8,11 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "base/seastarx.h"
 #include "container/fragmented_vector.h"
 #include "iceberg/transform.h"
+
+#include <seastar/core/sstring.hh>
 
 namespace iceberg {
 

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -217,6 +217,7 @@ redpanda_cc_gtest(
     tags = ["exclusive"],
     deps = [
         ":simple_record_fixture",
+        "//src/v/base",
         "//src/v/config",
         "//src/v/model",
         "//src/v/raft",

--- a/src/v/raft/tests/group_configuration_tests.cc
+++ b/src/v/raft/tests/group_configuration_tests.cc
@@ -7,9 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/seastarx.h"
 #include "gmock/gmock.h"
 #include "raft/group_configuration.h"
 #include "test_utils/randoms.h"
+
+#include <seastar/util/log.hh>
 
 #include <fmt/ostream.h>
 

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -8,6 +8,7 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#include "base/vassert-register.h"
 #include "base/vassert.h"
 #include "cloud_storage/cache_service.h"
 #include "cluster/cloud_storage_size_reducer.h"
@@ -1075,8 +1076,7 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::put_ctracker_va(
     auto msg = ss::sstring{doc["message"].GetString()};
 
     co_await ss::smp::submit_to(shard, [msg = std::move(msg)] {
-        ::detail::g_assert_log_holder.register_event(
-          ss::current_backtrace(), "{}", msg);
+        base::register_event(ss::current_backtrace(), msg);
     });
 
     res->set_status(ss::http::reply::status_type::ok);

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "base/seastarx.h"
 #include "base/vassert.h"
 #include "utils/functional.h"
 

--- a/src/v/test_utils/tmpbuf_file.h
+++ b/src/v/test_utils/tmpbuf_file.h
@@ -9,6 +9,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/later.hh>
+#include <seastar/util/log.hh>
 
 #include <absl/container/btree_map.h>
 #include <sys/stat.h>

--- a/src/v/utils/chunked_kv_cache.h
+++ b/src/v/utils/chunked_kv_cache.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/seastarx.h"
 #include "container/chunked_hash_map.h"
 #include "utils/s3_fifo.h"
 

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -110,6 +110,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/utils:xid",
         "@abseil-cpp//absl/container:node_hash_map",
+        "@boost//:lexical_cast",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/utils/tests/xid_test.cc
+++ b/src/v/utils/tests/xid_test.cc
@@ -13,6 +13,7 @@
 #include "utils/xid.h"
 
 #include <absl/container/node_hash_map.h>
+#include <boost/lexical_cast.hpp>
 #include <gtest/gtest.h>
 
 xid random_xid() {


### PR DESCRIPTION
Type erase the assert handling so that we can move the bulk of the handling out of the header file entirely. Only the basic macro and a small amount of code to type-erase the format arguments really need to be the in the header. This helps the hot path.

Further on the specific in the implementation can be found in the first commit.

This change is best review commit-by-commit as there is movement of code from the .h to the .cc file.

One change implements the type erasure but leaves the implementation in the .h file, in order to more easily understand the change. A later change moves everything that can move (everything except the thunks which depend on the format argument types) to the .cc file with a few fixups. Then we clean up the .cc file to remove extraneous stuff which was needed only when the implementation was in the header.

Before this change, a simple function with a `vassert` with two format arguments like so:

```
int test_two_int_args(int x, int y) {
    vassert(x < y, "{} >= {}", x, y);
    return x + y;
}
```
compiles like so in `--config=release`:

```
0000000000000000 <test_two_int_args(int, int)>:
   0:	55                   	push   rbp
   1:	48 89 e5             	mov    rbp,rsp
   4:	53                   	push   rbx
   5:	48 81 ec 88 05 00 00 	sub    rsp,0x588
   c:	64 48 8b 04 25 28 00 00 00 	mov    rax,QWORD PTR fs:0x28
  15:	48 89 45 f0          	mov    QWORD PTR [rbp-0x10],rax   // save stack cookie
  19:	89 bd bc fa ff ff    	mov    DWORD PTR [rbp-0x544],edi  // spill x
  1f:	89 b5 b8 fa ff ff    	mov    DWORD PTR [rbp-0x548],esi  // spill y
  25:	39 f7                	cmp    edi,esi
  27:	7d 21                	jge    4a <test_two_int_args(int, int)+0x4a>
  29:	64 48 8b 04 25 28 00 00 00 	mov    rax,QWORD PTR fs:0x28
  32:	48 3b 45 f0          	cmp    rax,QWORD PTR [rbp-0x10]
  36:	0f 85 a8 00 00 00    	jne    e4 <test_two_int_args(int, int)+0xe4>
  3c:	01 fe                	add    esi,edi
  3e:	89 f0                	mov    eax,esi
  40:	48 81 c4 88 05 00 00 	add    rsp,0x588
  47:	5b                   	pop    rbx
  48:	5d                   	pop    rbp
  49:	c3                   	ret    

  # hot path above
  # cold (assert) path below

  4a:	48 8d 9d c0 fa ff ff 	lea    rbx,[rbp-0x540]
  51:	48 89 df             	mov    rdi,rbx
  54:	ff 15 00 00 00 00    	call   QWORD PTR [rip+0x0]        # 5a <test_two_int_args(int, int)+0x5a>	56: R_X86_64_GOTPCRELX	seastar::current_backtrace()-0x4
  5a:	48 8d 05 00 00 00 00 	lea    rax,[rip+0x0]        # 61 <test_two_int_args(int, int)+0x61>	5d: R_X86_64_PC32	.L.str.1-0x4
  61:	48 89 85 a0 fa ff ff 	mov    QWORD PTR [rbp-0x560],rax
  68:	48 c7 85 a8 fa ff ff 25 00 00 00 	mov    QWORD PTR [rbp-0x558],0x25
  73:	48 8d 05 00 00 00 00 	lea    rax,[rip+0x0]        # 7a <test_two_int_args(int, int)+0x7a>	76: R_X86_64_PC32	.data.rel.ro..L.constant.6-0x4
  7a:	48 89 85 b0 fa ff ff 	mov    QWORD PTR [rbp-0x550],rax
  81:	c7 85 9c fa ff ff 13 00 00 00 	mov    DWORD PTR [rbp-0x564],0x13
  8b:	48 8b 85 b0 fa ff ff 	mov    rax,QWORD PTR [rbp-0x550]
  92:	48 89 44 24 10       	mov    QWORD PTR [rsp+0x10],rax
  97:	0f 10 85 a0 fa ff ff 	movups xmm0,XMMWORD PTR [rbp-0x560]
  9e:	0f 11 04 24          	movups XMMWORD PTR [rsp],xmm0
  a2:	48 8d 85 b8 fa ff ff 	lea    rax,[rbp-0x548]
  a9:	48 89 44 24 18       	mov    QWORD PTR [rsp+0x18],rax
  ae:	48 8d 3d 00 00 00 00 	lea    rdi,[rip+0x0]        # b5 <test_two_int_args(int, int)+0xb5>	b1: R_X86_64_PC32	detail::g_assert_log_holder-0x4
  b5:	48 8d 15 00 00 00 00 	lea    rdx,[rip+0x0]        # bc <test_two_int_args(int, int)+0xbc>	b8: R_X86_64_PC32	.L.str.2-0x4
  bc:	4c 8d 05 00 00 00 00 	lea    r8,[rip+0x0]        # c3 <test_two_int_args(int, int)+0xc3>	bf: R_X86_64_PC32	.L.str.4-0x4
  c3:	48 8d 8d 9c fa ff ff 	lea    rcx,[rbp-0x564]
  ca:	4c 8d 8d bc fa ff ff 	lea    r9,[rbp-0x544]
  d1:	48 89 de             	mov    rsi,rbx
  d4:	e8 00 00 00 00       	call   d9 <test_two_int_args(int, int)+0xd9>	d5: R_X86_64_PLT32	void detail::assert_log_holder::register_event<char const (&) [34], int, char const (&) [6], int&, int&>(seastar::tasktrace, seastar::logger::format_info, char const (&) [34], int&&, char const (&) [6], int&, int&)-0x4
  d9:	48 89 df             	mov    rdi,rbx
  dc:	ff 15 00 00 00 00    	call   QWORD PTR [rip+0x0]        # e2 <test_two_int_args(int, int)+0xe2>	de: R_X86_64_GOTPCRELX	seastar::tasktrace::~tasktrace()-0x4
  e2:	0f 0b                	ud2    
  e4:	e8 00 00 00 00       	call   e9 <.L__const._ZN3fmt2v96detail18make_write_int_argIoEENS1_13write_int_argINSt3__211conditionalIXaalecl8num_bitsIT_EELi32EntLi0EEjNS5_IXlecl8num_bitsIS6_EELi64EEmoE4typeEE4typeEEES6_NS0_4sign4typeE.prefixes+0x19>	e5: R_X86_64_PLT32	__stack_chk_fail-0x4
```

Note that the hot path is some ~19 instructions and there is also a large cold path which is compiled into the same function. The hot path is so large because it is affected by the cold path: it spills variables to the stack which only need to be spilled on the cold path and it does stack cookie (from `-fstack-protector-strong`) checking even though the conditions for stack cookie insertion are only met on the cold path.

After the changes in this PR, the same function looks like:

```
0000000000000000 <test_two_int_args(int, int)>:
   0:	89 f0                	mov    eax,esi
   2:	89 fa                	mov    edx,edi
   4:	39 f7                	cmp    edi,esi
   6:	7d 03                	jge    b <test_two_int_args(int, int)+0xb>
   8:	01 d0                	add    eax,edx
   a:	c3                   	ret    

  // hot above
  // cold below

   b:	55                   	push   rbp
   c:	48 89 e5             	mov    rbp,rsp
   f:	48 8d 3d 00 00 00 00 	lea    rdi,[rip+0x0]        # 16 <test_two_int_args(int, int)+0x16>	12: R_X86_64_PC32	.L.str.2-0x4
  16:	48 8d 35 00 00 00 00 	lea    rsi,[rip+0x0]        # 1d <test_two_int_args(int, int)+0x1d>	19: R_X86_64_PC32	.L.str.1-0x4
  1d:	89 c1                	mov    ecx,eax
  1f:	e8 00 00 00 00       	call   24 <.LCPI15_2+0x4>	20: R_X86_64_PLT32	void detail::assert_failed_thunk1<int, int>(char const*, char const*, int, int)-0x4
```
The hot path is much faster, almost as fast as possible and involves no spills or stack cookie checking (it's not perfect, the first two `mov` are putting x and y into the registers needed for the cold path, this could be referred to the cold path). The cold path inside the function is also much shorter, and ends with a call to `void detail::assert_failed_thunk1<int, int>`. This function is also in the .o, and look like:

```
Disassembly of section .text.unlikely._ZN6detail20assert_failed_thunk1IJiiEEEvPKcS2_DpT_:

0000000000000000 <void detail::assert_failed_thunk1<int, int>(char const*, char const*, int, int)>:
   0:	55                   	push   rbp
   1:	48 89 e5             	mov    rbp,rsp
   4:	48 83 ec 20          	sub    rsp,0x20
   8:	89 d0                	mov    eax,edx
   a:	89 ca                	mov    edx,ecx
   c:	48 8d 4d e0          	lea    rcx,[rbp-0x20]
  10:	48 89 01             	mov    QWORD PTR [rcx],rax
  13:	48 89 51 10          	mov    QWORD PTR [rcx+0x10],rdx
  17:	ba 11 00 00 00       	mov    edx,0x11
  1c:	ff 15 00 00 00 00    	call   QWORD PTR [rip+0x0]        # 22 <.LCPI15_2+0x2>	1e: R_X86_64_GOTPCRELX	detail::assert_failed_thunk2(char const*, char const*, fmt::v9::basic_format_args<fmt::v9::basic_format_context<fmt::v9::appender, char> >)-0x4
```
This is in the ".text.unlikely" section which means that it is compiled into a different part of the binary which probably won't even be loaded unless an assert occurs, so it is much less costly than the cold path which appears attached to the function and shares cache lines with hot code etc. This `thunk1` ends with a call to `thunk2` which is the type-erased assert impl which lives in the cc file.

Beyond that the "before" file has ~25,000 additional lines of asm implementing the rest of the assert stuff, mostly in fmt and logger code, and lazy creation of the global and thread local objects. These lines are gone in after (there are about 2500 lines needed if you format an object which has an `ostream operator<<` which is handled by fmt). 

[Full asm dump for before and after](https://gist.github.com/travisdowns/ba9166b37953b49381118026bdbf5574) covering these three cases:

```
#include "base/vassert.h"

#include <fmt/ostream.h>

#include <ostream>

struct nontrivial {
    int x;
};

int test_no_args(int x, int y) {
    vassert(x < y, "{} >= {}");
    return x + y;
}

int test_two_int_args(int x, int y) {
    vassert(x < y, "{} >= {}", x, y);
    return x + y;
}

int test_nontrivial(int x, int y, nontrivial hi) {
    vassert(x < y, "{} >= {}", hi);
    return x + y;
}

std::ostream& operator<<(std::ostream& os, nontrivial hi) {
    os << hi.x;
    return os;
}
```

After this change, the redpanda binary sizes reduces by ~ 2 MB (189 -> 187) so not a huge change, but the intermediate .o files reduce by a lot in many cases (the savings in the binary is less since most of the redundant code is de-duplicated by the linker).

For example, taking `//src/v/utils` as a random example, the .o files that changed in size:

```
95544 bazel-bin/src/v/utils/_objs/vint/vint.o                 | 90872 bazel-bin/src/v/utils/_objs/vint/vint.o
130656 bazel-bin/src/v/utils/_objs/log_hist/log_hist.o        | 125216 bazel-bin/src/v/utils/_objs/log_hist/log_hist.o
517392 bazel-bin/src/v/utils/_objs/base64/base64.o            | 63376 bazel-bin/src/v/utils/_objs/base64/base64.o
530464 bazel-bin/src/v/utils/_objs/xid/xid.o                  | 526832 bazel-bin/src/v/utils/_objs/xid/xid.o
647320 bazel-bin/src/v/utils/_objs/file_io/file_io.o          | 643232 bazel-bin/src/v/utils/_objs/file_io/file_io.o
676616 bazel-bin/src/v/utils/_objs/tracking_allocator/trackin | 571800 bazel-bin/src/v/utils/_objs/tracking_allocator/trackin
684960 bazel-bin/src/v/utils/_objs/external_process/external_ | 236768 bazel-bin/src/v/utils/_objs/external_process/external_
888544 bazel-bin/src/v/utils/_objs/retry_chain_node/retry_cha | 788048 bazel-bin/src/v/utils/_objs/retry_chain_node/retry_cha
```

So base64.o went from 517K to 64K, external process from 684K to 236K etc. So this should have a compile-time benefit as well.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


