### PR TITLE
rptest: fix rpk error Bearer token is invalid

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -101,7 +101,8 @@ class CloudCleanup():
         self.utils = CloudClusterUtils(fake_context, self.log, keyId, secret,
                                        self.config.provider,
                                        self.config.api_url, oauth_url_origin,
-                                       self.config.oauth_audience)
+                                       self.config.oauth_audience,
+                                       self.config.public_api_url)
 
         self.log.info(f"# Using CloudV2 API at '{self.config.api_url}'")
 

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -1,6 +1,7 @@
 import json
 from rptest.clients.rpk import RpkTool
 from rptest.services.redpanda_types import KafkaClientSecurity
+from typing import Any
 
 
 class FakePanda:
@@ -16,20 +17,20 @@ class FakePanda:
 
 
 class CloudClusterUtils:
-    def __init__(self, context, logger, infra_id, infra_secret, provider,
-                 cloud_url_origin, oauth_url_origin, oauth_audience):
-        """
-        Initialize CloudClusterUtils.
+    def __init__(self, context: Any, logger: Any, infra_id: str,
+                 infra_secret: str, provider: str, cloud_url_origin: str,
+                 oauth_url_origin: str, oauth_audience: str) -> None:
+        """Initialize CloudClusterUtils.
 
-        :param logger: logging object
-        :param cluster_config: dict object loaded from
-               context.globals["cloud_cluster"]
-        :param infra_id: access key id
-        :param infra_secret: access key secret
-        :param provider: cloud provider, e.g. AWS
-        :param cloud_url_origin: just scheme and hostname
-        :param oauth_url_origin: just scheme and hostname
-        :param oauth_audience: audience for issued token
+        Args:
+            context (Any): context object
+            logger (Any): logger object
+            infra_id (str): aws access key id
+            infra_secret (str): aws access key secret
+            provider (str): cloud provider, e.g. 'aws', 'gcp', 'azure'
+            cloud_url_origin (str): rpk cloud url
+            oauth_url_origin (str): rpk cloud auth url
+            oauth_audience (str): rpk cloud auth audience for issued token
         """
         self.fake_panda = FakePanda(context, logger)
         # Create rpk to use several functions that is isolated

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -19,7 +19,8 @@ class FakePanda:
 class CloudClusterUtils:
     def __init__(self, context: Any, logger: Any, infra_id: str,
                  infra_secret: str, provider: str, cloud_url_origin: str,
-                 oauth_url_origin: str, oauth_audience: str) -> None:
+                 oauth_url_origin: str, oauth_audience: str,
+                 rpk_public_api_url: str) -> None:
         """Initialize CloudClusterUtils.
 
         Args:
@@ -31,6 +32,7 @@ class CloudClusterUtils:
             cloud_url_origin (str): rpk cloud url
             oauth_url_origin (str): rpk cloud auth url
             oauth_audience (str): rpk cloud auth audience for issued token
+            rpk_public_api_url (str): rpk cloud public api url
         """
         self.fake_panda = FakePanda(context, logger)
         # Create rpk to use several functions that is isolated
@@ -43,6 +45,7 @@ class CloudClusterUtils:
             'RPK_CLOUD_URL': cloud_url_origin,
             'RPK_CLOUD_AUTH_URL': oauth_url_origin,
             'RPK_CLOUD_AUTH_AUDIENCE': oauth_audience,
+            'RPK_PUBLIC_API_URL': rpk_public_api_url,
             'CLOUD_URL': f'{cloud_url_origin}/api/v1'
         }
         if self.provider == 'aws':

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -316,7 +316,8 @@ class CloudCluster():
                                        self.provider_key, self.provider_secret,
                                        self.config.provider,
                                        self.config.api_url, oauth_url_origin,
-                                       self.config.oauth_audience)
+                                       self.config.oauth_audience,
+                                       self.config.public_api_url)
         if self.config.type == CLOUD_TYPE_BYOC:
             # remove current plugin if any
             self.utils.rpk_plugin_uninstall('byoc', sudo=True)


### PR DESCRIPTION
jira: [DEVPROD-2658]

Fixes error when connecting to redpanda cloud:
```
Unable to login to Redpanda Cloud (unable to retrieve the organization for this token: unauthenticated: Bearer token is invalid).
```

Following on PR #24877, the `rpk` env var `RPK_PUBLIC_API_URL` is now required to connect to non-prod redpanda cloud clusters.

This PR changes the tests to use that env var when tests are run.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

* none

[DEVPROD-2658]: https://redpandadata.atlassian.net/browse/DEVPROD-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ