### PR TITLE
dl/coordinator: only load tables with pending state

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -589,7 +589,7 @@ redpanda_cc_library(
         "table_id_provider.h",
     ],
     include_prefix = "datalake",
-    visibility = [":__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//src/v/iceberg:table_identifier",
         "//src/v/model",

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -436,12 +436,16 @@ iceberg_file_committer::commit_topic_files_to_catalog(
         vlog(datalake_log.debug, "Topic {} has no pending entries", topic);
         co_return chunked_vector<mark_files_committed_update>{};
     }
-    auto topic_revision = tp_it->second.revision;
+    // Make a copy up here so we don't have to worry about the state changing
+    // underneath us. The STM should be robust enough to detect and reject
+    // concurrent changes that result in invalid state updates.
+    auto tp_state = tp_it->second.copy();
+    auto topic_revision = tp_state.revision;
 
     // Main table (may not exist if all records so far were invalid and the
     // schema couldn't be determined):
     std::optional<table_commit_builder> main_table_commit_builder;
-    {
+    if (tp_state.has_pending_main_entries()) {
         auto main_table_id = table_id_provider::table_id(topic);
         auto main_table_res = co_await catalog_.load_table(main_table_id);
         if (main_table_res.has_error()) {
@@ -477,10 +481,7 @@ iceberg_file_committer::commit_topic_files_to_catalog(
 
     // DLQ table (optional):
     std::optional<table_commit_builder> dlq_table_commit_builder;
-    {
-        // TODO(iceberg-dlq): Load it on demand.
-        //  For now, we load it unconditionally because once we start processing
-        //  pending entries we are not allowed to suspend/co_await.
+    if (tp_state.has_pending_dlq_entries()) {
         auto dlq_table_id = table_id_provider::dlq_table_id(topic);
         auto dlq_table_res = co_await catalog_.load_table(dlq_table_id);
         if (dlq_table_res.has_error()) {
@@ -519,38 +520,15 @@ iceberg_file_committer::commit_topic_files_to_catalog(
         }
     }
 
-    // update the iterator after a scheduling point
-    tp_it = state.topic_to_state.find(topic);
-    if (
-      tp_it == state.topic_to_state.end()
-      || tp_it->second.revision != topic_revision) {
-        vlog(
-          datalake_log.debug,
-          "Commit returning early, topic {} state is missing or revision has "
-          "changed: current {} vs expected {}",
-          topic,
-          tp_it->second.revision,
-          topic_revision);
-        co_return chunked_vector<mark_files_committed_update>{};
-    }
-
     chunked_hash_map<model::partition_id, kafka::offset> pending_commits;
-    const auto& tp_state = tp_it->second;
     for (const auto& [pid, p_state] : tp_state.pid_to_pending_files) {
         for (const auto& e : p_state.pending_entries) {
             pending_commits[pid] = e.data.last_offset;
 
             if (!e.data.files.empty()) {
-                if (!main_table_commit_builder) {
-                    vlog(
-                      datalake_log.error,
-                      "Pending files for topic {} revision {} but no main "
-                      "table",
-                      topic,
-                      topic_revision);
-                    co_return file_committer::errc::failed;
-                }
-
+                vassert(
+                  main_table_commit_builder.has_value(),
+                  "Should have main table builder");
                 auto res = main_table_commit_builder->process_pending_entry(
                   topic, topic_revision, io_, e.added_pending_at, e.data.files);
                 if (res.has_error()) {
@@ -559,16 +537,9 @@ iceberg_file_committer::commit_topic_files_to_catalog(
             }
 
             if (!e.data.dlq_files.empty()) {
-                if (!dlq_table_commit_builder) {
-                    vlog(
-                      datalake_log.error,
-                      "Pending DLQ files for topic {} revision {} but no DLQ "
-                      "table",
-                      topic,
-                      topic_revision);
-                    co_return file_committer::errc::failed;
-                }
-
+                vassert(
+                  dlq_table_commit_builder.has_value(),
+                  "Should have DLQ table builder");
                 auto dlq_res = dlq_table_commit_builder->process_pending_entry(
                   topic,
                   topic_revision,

--- a/src/v/datalake/coordinator/state.cc
+++ b/src/v/datalake/coordinator/state.cc
@@ -78,4 +78,26 @@ bool topic_state::has_pending_entries() const {
     return false;
 }
 
+bool topic_state::has_pending_main_entries() const {
+    for (const auto& [_, partition_state] : pid_to_pending_files) {
+        for (const auto& e : partition_state.pending_entries) {
+            if (!e.data.files.empty()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool topic_state::has_pending_dlq_entries() const {
+    for (const auto& [_, partition_state] : pid_to_pending_files) {
+        for (const auto& e : partition_state.pending_entries) {
+            if (!e.data.dlq_files.empty()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/state.h
+++ b/src/v/datalake/coordinator/state.h
@@ -100,6 +100,8 @@ struct topic_state
     operator<<(std::ostream&, topic_state::lifecycle_state_t);
 
     bool has_pending_entries() const;
+    bool has_pending_main_entries() const;
+    bool has_pending_dlq_entries() const;
 
     // Topic revision
     model::revision_id revision;

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -67,6 +67,7 @@ redpanda_cc_gtest(
         "//src/v/datalake:catalog_schema_manager",
         "//src/v/datalake:logger",
         "//src/v/datalake:table_definition",
+        "//src/v/datalake:table_id_provider",
         "//src/v/datalake/coordinator:commit_offset_metadata",
         "//src/v/datalake/coordinator:iceberg_file_committer",
         "//src/v/datalake/tests:test_utils",

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -16,6 +16,7 @@
 #include "datalake/coordinator/iceberg_file_committer.h"
 #include "datalake/coordinator/tests/state_test_utils.h"
 #include "datalake/table_definition.h"
+#include "datalake/table_id_provider.h"
 #include "datalake/tests/test_utils.h"
 #include "features/feature_table.h"
 #include "iceberg/filesystem_catalog.h"
@@ -43,12 +44,13 @@ void add_partition_state(
   std::vector<pairs_t> offset_bounds_by_pid,
   topic_state& state,
   model::offset added_at,
-  bool with_files) {
+  bool with_files,
+  bool dlq = false) {
     for (size_t i = 0; i < offset_bounds_by_pid.size(); i++) {
         auto pid = static_cast<model::partition_id>(i);
         partition_state p_state;
         for (auto& f :
-             make_pending_files(offset_bounds_by_pid[i], with_files)) {
+             make_pending_files(offset_bounds_by_pid[i], with_files, dlq)) {
             p_state.pending_entries.emplace_back(pending_entry{
               .data = std::move(f), .added_pending_at = added_at});
         }
@@ -58,10 +60,11 @@ void add_partition_state(
 topic_state make_topic_state(
   std::vector<pairs_t> offset_bounds_by_pid,
   model::offset added_at = model::offset{1000},
-  bool with_files = false) {
+  bool with_files = false,
+  bool dlq = false) {
     topic_state state;
     add_partition_state(
-      std::move(offset_bounds_by_pid), state, added_at, with_files);
+      std::move(offset_bounds_by_pid), state, added_at, with_files, dlq);
     return state;
 }
 
@@ -670,4 +673,56 @@ TEST_F(FileCommitterTest, TestDeduplicateConcurrently) {
     }
     // The total number of data files should match the number of chunks.
     ASSERT_EQ(max_num_files, num_chunks);
+}
+
+TEST_F(FileCommitterTest, TestDontLoadDLQTable) {
+    create_table();
+    topics_state state;
+    state.topic_to_state[topic] = make_topic_state(
+      {
+        {{0, 99}, {100, 199}},
+      },
+      /*added_at=*/model::offset{1000},
+      /*with_files=*/true,
+      /*dlq=*/false);
+    auto res = committer.commit_topic_files_to_catalog(topic, state).get();
+    ASSERT_FALSE(res.has_error());
+
+    // In committing data to the main table, we should send no requests asking
+    // about the DLQ table.
+    auto is_dlq_request = [](const http_test_utils::request_info& req) {
+        return req.url.contains("/test-topic~dlq/");
+    };
+    auto dlq_reqs = get_requests(is_dlq_request);
+    ASSERT_EQ(0, dlq_reqs.size());
+}
+
+TEST_F(FileCommitterTest, TestDontLoadMainTable) {
+    // Create a DLQ table.
+    auto create_res = schema_mgr
+                        .ensure_table_schema(
+                          datalake::table_id_provider::dlq_table_id(topic),
+                          datalake::schemaless_struct_type(),
+                          datalake::hour_partition_spec())
+                        .get();
+    ASSERT_FALSE(create_res.has_error());
+    topics_state state;
+
+    // Commit data to the DLQ.
+    state.topic_to_state[topic] = make_topic_state(
+      {
+        {{0, 99}, {100, 199}},
+      },
+      /*added_at=*/model::offset{1000},
+      /*with_files=*/true,
+      /*dlq=*/true);
+    auto res = committer.commit_topic_files_to_catalog(topic, state).get();
+    ASSERT_FALSE(res.has_error());
+
+    // We should send no requests asking about the main table.
+    auto is_main_request = [](const http_test_utils::request_info& req) {
+        return req.url.contains("/test-topic/");
+    };
+    auto main_reqs = get_requests(is_main_request);
+    ASSERT_EQ(0, main_reqs.size());
 }

--- a/src/v/datalake/coordinator/tests/state_test_utils.cc
+++ b/src/v/datalake/coordinator/tests/state_test_utils.cc
@@ -13,7 +13,8 @@ namespace datalake::coordinator {
 
 chunked_vector<translated_offset_range> make_pending_files(
   const std::vector<std::pair<int64_t, int64_t>>& offset_bounds,
-  bool with_file) {
+  bool with_file,
+  bool dlq) {
     chunked_vector<translated_offset_range> files;
     files.reserve(offset_bounds.size());
     for (const auto& [begin, end] : offset_bounds) {
@@ -24,12 +25,21 @@ chunked_vector<translated_offset_range> make_pending_files(
               .file_size_bytes = 1024,
             });
         }
-        files.emplace_back(translated_offset_range{
-          .start_offset = kafka::offset{begin},
-          .last_offset = kafka::offset{end},
-          .files = std::move(fs),
-          // Other args irrelevant.
-        });
+        if (dlq) {
+            files.emplace_back(translated_offset_range{
+              .start_offset = kafka::offset{begin},
+              .last_offset = kafka::offset{end},
+              .dlq_files = std::move(fs),
+              // Other args irrelevant.
+            });
+        } else {
+            files.emplace_back(translated_offset_range{
+              .start_offset = kafka::offset{begin},
+              .last_offset = kafka::offset{end},
+              .files = std::move(fs),
+              // Other args irrelevant.
+            });
+        }
     }
     return files;
 }

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -69,9 +69,12 @@ public:
 // If with_file is true, the range will contain a data file, which may be
 // useful when callers need more than just offset bounds (e.g. to test file
 // deduplication).
+//
+// If dlq is true, all files will be marked as DLQ files.
 chunked_vector<translated_offset_range> make_pending_files(
   const std::vector<std::pair<int64_t, int64_t>>& offset_bounds,
-  bool with_file = false);
+  bool with_file = false,
+  bool dlq = false);
 
 // Asserts that the given state has the expected partition state.
 void check_partition(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
    Addresses a TODO in the iceberg_file_committer that highlighted that we
    previously made some extraneous calls to the catalog.

    The previous code structure relied on checking the STM state between
    scheduling points to handle concurrent updates, and bailing out. This
    meant that it was tricky to guarantee the presence or absence of DLQ
    files during this method, and so we previously always attempted to load
    both the main and DLQ tables.

    Instead, this commit updates the concurrency strategy of this function
    to make a copy of the STM state for the topic in question, and rely on
    STM validation to ensure updates are rejected appropriately if there was
    indeed a concurrent STM update that invalidated the new state change.

    This change has the added benefit of avoiding potential iterator
    invalidations that we've seen in this function in the past.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
