### PR TITLE
dl/translation: add jitter to partition_translator

### DIFF
--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -12,19 +12,28 @@
 
 #include <fmt/core.h>
 namespace datalake {
-std::string data_writer_error_category::message(int ev) const {
-    switch (static_cast<writer_error>(ev)) {
+std::ostream& operator<<(std::ostream& os, const writer_error& ev) {
+    switch (ev) {
     case writer_error::ok:
-        return "Ok";
+        os << "Ok";
+        break;
     case writer_error::parquet_conversion_error:
-        return "Parquet Conversion Error";
+        os << "Parquet Conversion Error";
+        break;
     case writer_error::file_io_error:
-        return "File IO Error";
+        os << "File IO Error";
+        break;
     case writer_error::no_data:
-        return "No data";
+        os << "No data";
+        break;
     case writer_error::flush_error:
-        return "Flush failed";
+        os << "Flush failed";
+        break;
     }
+    return os;
+}
+std::string data_writer_error_category::message(int ev) const {
+    return fmt::to_string(static_cast<writer_error>(ev));
 }
 
 } // namespace datalake

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -27,6 +27,7 @@ enum class writer_error {
     no_data,
     flush_error,
 };
+std::ostream& operator<<(std::ostream&, const writer_error&);
 
 struct data_writer_error_category : std::error_category {
     const char* name() const noexcept final { return "Data Writer Error"; }

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -139,6 +139,7 @@ redpanda_cc_library(
         "//src/v/datalake:logger",
         "//src/v/features",
         "//src/v/model",
+        "//src/v/random:time_jitter",
         "//src/v/resource_mgmt:io_priority",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -14,6 +14,7 @@
 #include "resource_mgmt/io_priority.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/util/defer.hh>
 
 namespace datalake::translation {
 
@@ -62,6 +63,9 @@ ss::futurize_t<FuncRet> retry_with_backoff(
         co_await ss::sleep_abortable(retry.delay, *retry.abort_source);
     }
 }
+constexpr std::chrono::milliseconds translation_jitter{500};
+constexpr std::chrono::milliseconds translation_jitter_base{5000};
+
 } // namespace
 
 partition_translator::partition_translator(
@@ -73,6 +77,7 @@ partition_translator::partition_translator(
   , _coordinator(std::move(coordinator))
   , _data_source(std::move(data_source))
   , _translation_ctx(std::move(translation_ctx))
+  , _jitter{translation_jitter_base, translation_jitter}
   , _term(_data_source->term())
   , _logger(
       datalake_log, fmt::format("{}-term-{}", _data_source->ntp(), _term)) {}
@@ -152,7 +157,16 @@ ss::future<> partition_translator::translate_until_stopped() {
       "[{}] Translation started before the translator is properly initialized",
       id);
 
+    bool needs_jitter = false;
     while (!_as.abort_requested()) {
+        if (needs_jitter) {
+            co_await ss::sleep_abortable(_jitter.next_duration(), _as);
+        }
+        // We'll keep track of if we exit early out of this iteration, in which
+        // case the next iteration should see some jitter.
+        auto scoped_set_jitter = ss::defer(
+          [&needs_jitter] { needs_jitter = true; });
+
         retry_chain_node rcn{
           _as, max_translation_task_timeout, initial_backoff};
 
@@ -269,6 +283,7 @@ ss::future<> partition_translator::translate_until_stopped() {
               _logger.warn,
               "Failed to checkpoint translated files: {}",
               checkpoint_result);
+            continue;
         }
 
         reset_error = co_await _data_source->update_highest_translated_offset(
@@ -278,7 +293,10 @@ ss::future<> partition_translator::translate_until_stopped() {
               _logger.warn,
               "error updating highest translated offset: {}",
               reset_error);
+            continue;
         }
+        scoped_set_jitter.cancel();
+        needs_jitter = false;
     }
 }
 

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -12,6 +12,7 @@
 
 #include "datalake/translation/deps.h"
 #include "datalake/translation/scheduling.h"
+#include "random/simple_time_jitter.h"
 #include "utils/prefix_logger.h"
 #include "utils/retry_chain_node.h"
 
@@ -143,6 +144,10 @@ private:
     std::unique_ptr<coordinator_api> _coordinator;
     std::unique_ptr<data_source> _data_source;
     std::unique_ptr<translation_context> _translation_ctx;
+    // TODO: consider baking backoff into the scheduler on translation failure.
+    using jitter_t
+      = simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>;
+    jitter_t _jitter;
     model::term_id _term;
     prefix_logger _logger;
     bool _initialized = false;

--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -40,6 +40,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
             # Frequent Iceberg uploads.
             "iceberg_enabled": "true",
             "iceberg_catalog_commit_interval_ms": 1000,
+            "iceberg_target_lag_ms": 1000,
         }
         si_settings = SISettings(
             test_context,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
    The previous implementation of the partition_translator had a jitter
    between retries of translation. This went away once we moved to
    scheduler-based translation, but led to situations where failures in
    translation would get retried immediately, which could overwhelm the
    catalog if the failure were caused by a catalog issue.

    This adds a temporary fix to add jitter to the partition translator's
    loop. A more complete solution may be to build backoffs into the
    scheduler upon translation failure.

This was initially thought to be the fix for deflaking datalake/cluster_restore_test.py, but that actually turned out to be fixed by https://github.com/redpanda-data/redpanda/pull/25258. This still seems worthwhile to have around.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
