### PR TITLE
datalake/translator: followups to #5152

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -72,6 +72,7 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_18_toolchain/
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 build:clang-tidy --copt -Wno-pragma-once-outside-header
 build:clang-tidy --output_groups=report
+build:clang-tidy --jobs=36
 
 # =================================
 # Security

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -29,6 +29,10 @@
 
 #include <memory>
 
+constexpr std::chrono::milliseconds translation_jitter{500};
+constexpr std::chrono::milliseconds translation_jitter_base{5000};
+static constexpr std::chrono::milliseconds retry_initial_backoff{300};
+static constexpr std::chrono::milliseconds retry_max_timeout{3min};
 static constexpr std::string_view iceberg_data_path_prefix = "data";
 
 namespace datalake {
@@ -354,7 +358,11 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
       _sg,
       std::move(coordinator),
       std::move(data_src),
-      std::move(translation_ctx));
+      std::move(translation_ctx),
+      simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>{
+        translation_jitter_base, translation_jitter},
+      retry_max_timeout,
+      retry_initial_backoff);
 
     auto add_f = co_await ss::coroutine::as_future(
       _scheduler.add_translator(std::move(translator)));

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -473,6 +473,14 @@ public:
         co_return std::make_optional(std::move(result.value()));
     }
 
+    ss::future<> discard() final {
+        if (!_in_progress_translation) {
+            co_return;
+        }
+        auto task = std::exchange(_in_progress_translation, std::nullopt);
+        co_await std::move(task.value()).discard().discard_result();
+    }
+
 private:
     scheduling::clock::duration compute_target_lag() const {
         // todo: In addition to integrating with config subsystem, an additional

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -192,6 +192,11 @@ public:
     virtual ss::future<std::optional<coordinator::translated_offset_range>>
     finish(retry_chain_node&, ss::abort_source&) = 0;
 
+    /**
+     * Cleans up state and discards an translated result.
+     */
+    virtual ss::future<> discard() = 0;
+
     static std::unique_ptr<translation_context>
     make_default_translation_context(
       local_path,

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -239,9 +239,7 @@ ss::future<> partition_translator::translate_until_stopped() {
               "Translation attempt failed: {}, discarding state to reset "
               "translation",
               translate_f.get_exception());
-            // todo(tests): add more tests to exercise this branch logic
-            // todo: enhance the API to skip uploading to cloud storage.
-            co_await _translation_ctx->finish(rcn, _as).discard_result();
+            co_await _translation_ctx->discard();
             continue;
         }
 

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -21,8 +21,6 @@ namespace datalake::translation {
 namespace {
 using namespace std::chrono_literals;
 // A simple utility to conditionally retry with backoff on failures.
-static constexpr std::chrono::milliseconds initial_backoff{300};
-static constexpr std::chrono::milliseconds max_translation_task_timeout{3min};
 constexpr model::timeout_clock::duration wait_timeout = 5s;
 
 template<
@@ -63,8 +61,6 @@ ss::futurize_t<FuncRet> retry_with_backoff(
         co_await ss::sleep_abortable(retry.delay, *retry.abort_source);
     }
 }
-constexpr std::chrono::milliseconds translation_jitter{500};
-constexpr std::chrono::milliseconds translation_jitter_base{5000};
 
 } // namespace
 
@@ -72,12 +68,17 @@ partition_translator::partition_translator(
   ss::scheduling_group sg,
   std::unique_ptr<coordinator_api> coordinator,
   std::unique_ptr<data_source> data_source,
-  std::unique_ptr<translation_context> translation_ctx)
+  std::unique_ptr<translation_context> translation_ctx,
+  jitter_t jitter,
+  std::chrono::milliseconds retry_max_timeout,
+  std::chrono::milliseconds retry_initial_backoff)
   : _sg(sg)
   , _coordinator(std::move(coordinator))
   , _data_source(std::move(data_source))
   , _translation_ctx(std::move(translation_ctx))
-  , _jitter{translation_jitter_base, translation_jitter}
+  , _jitter{std::move(jitter)}
+  , _retry_max_timeout(retry_max_timeout)
+  , _retry_initial_backoff(retry_initial_backoff)
   , _term(_data_source->term())
   , _logger(
       datalake_log, fmt::format("{}-term-{}", _data_source->ntp(), _term)) {}
@@ -167,8 +168,7 @@ ss::future<> partition_translator::translate_until_stopped() {
         auto scoped_set_jitter = ss::defer(
           [&needs_jitter] { needs_jitter = true; });
 
-        retry_chain_node rcn{
-          _as, max_translation_task_timeout, initial_backoff};
+        retry_chain_node rcn{_as, _retry_max_timeout, _retry_initial_backoff};
 
         // Reconcile with the coordinator
         auto result = co_await fetch_latest_translated_offset(rcn);

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -63,12 +63,19 @@ namespace datalake::translation {
  * See scheduler.h for more details on scheduling translators in general.
  */
 class partition_translator : public scheduling::translator {
+private:
+    using jitter_t
+      = simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>;
+
 public:
     explicit partition_translator(
       ss::scheduling_group,
       std::unique_ptr<coordinator_api>,
       std::unique_ptr<data_source>,
-      std::unique_ptr<translation_context>);
+      std::unique_ptr<translation_context>,
+      jitter_t jitter,
+      std::chrono::milliseconds retry_max_timeout,
+      std::chrono::milliseconds retry_initial_backoff);
 
     const scheduling::translator_id& id() const final;
 
@@ -145,9 +152,9 @@ private:
     std::unique_ptr<data_source> _data_source;
     std::unique_ptr<translation_context> _translation_ctx;
     // TODO: consider baking backoff into the scheduler on translation failure.
-    using jitter_t
-      = simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>;
     jitter_t _jitter;
+    std::chrono::milliseconds _retry_max_timeout;
+    std::chrono::milliseconds _retry_initial_backoff;
     model::term_id _term;
     prefix_logger _logger;
     bool _initialized = false;

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -282,7 +282,7 @@ scheduler::scheduler(
       });
 }
 
-void scheduler::notify_ready(const translator_id& id) {
+void scheduler::notify_ready(const translator_id& id) noexcept {
     if (_executor.gate.is_closed()) {
         return;
     }
@@ -307,8 +307,10 @@ void scheduler::notify_ready(const translator_id& id) {
     _state_changed_cvar.signal();
 }
 
-void scheduler::notify_done(const translator_id& id) {
-    auto holder = _executor.gate.hold();
+void scheduler::notify_done(const translator_id& id) noexcept {
+    if (_executor.gate.is_closed()) {
+        return;
+    }
     vlog(datalake_log.trace, "done notification from translator: {}", id);
     auto it = _executor.translators.find(id);
     if (it == _executor.translators.end()) {

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -41,13 +41,13 @@ public:
      * Notifies that the translator with the given id is ready to translate
      * data.
      */
-    virtual void notify_ready(const translator_id&) = 0;
+    virtual void notify_ready(const translator_id&) noexcept = 0;
 
     /**
      * Notifies that the translator with the given id has finished the currently
      * in progress translation and has released all the resources.
      */
-    virtual void notify_done(const translator_id&) = 0;
+    virtual void notify_done(const translator_id&) noexcept = 0;
 
     /**
      * Notifies that the translators cannot make progress due to memory
@@ -333,8 +333,8 @@ public:
     scheduler& operator=(scheduler&&) = delete;
     ~scheduler() override = default;
 
-    void notify_ready(const translator_id&) override;
-    void notify_done(const translator_id&) override;
+    void notify_ready(const translator_id&) noexcept override;
+    void notify_done(const translator_id&) noexcept override;
     void notify_memory_exhausted() override;
 
     ss::future<> stop();

--- a/src/v/datalake/translation/tests/BUILD
+++ b/src/v/datalake/translation/tests/BUILD
@@ -72,3 +72,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "partition_translator_test",
+    timeout = "short",
+    srcs = [
+        "partition_translator_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":scheduler_fixture",
+        "//src/v/datalake/translation:partition_translator",
+        "//src/v/datalake/translation:translator_deps",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "@seastar",
+    ],
+)

--- a/src/v/datalake/translation/tests/CMakeLists.txt
+++ b/src/v/datalake/translation/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set (srcs
     scheduler_fixture.cc
     scheduler_tests.cc
     fair_scheduling_policy_tests.cc
+    partition_translator_tests.cc
 )
 
 rp_test(
@@ -11,7 +12,7 @@ rp_test(
   TIMEOUT 2000
   BINARY_NAME datalake_translation_tests
   SOURCES ${srcs}
-  LIBRARIES  v::datalake_translation v::features v::raft_fixture v::gtest_main
+  LIBRARIES  v::datalake_translation v::features v::raft_fixture v::gtest_main v::model_test_utils
   LABELS datalake
   ARGS "-- -c 1 -m 2G"
 )

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/translation/partition_translator.h"
+#include "datalake/translation/tests/scheduler_fixture.h"
+#include "model/namespace.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/async.h"
+
+using namespace datalake::translation;
+using namespace datalake::coordinator;
+
+static ss::logger test_logger{"translator_test"};
+
+static const ss::scheduling_group test_sg = ss::default_scheduling_group();
+static thread_local model::partition_id::type partition_counter = 0;
+static constexpr std::chrono::milliseconds retry_initial_backoff{1ms};
+static constexpr std::chrono::milliseconds retry_max_timeout{10ms};
+
+static model::ntp next_ntp() {
+    return {
+      model::kafka_namespace,
+      model::topic{"test"},
+      model::partition_id{partition_counter++}};
+}
+
+// Encapsulates test context and also acts as a medium of communication between
+// test driver and the translator interfaces that hold a reference to this
+// context.
+class fake_test_ctx {
+public:
+    explicit fake_test_ctx(
+      model::ntp ntp, model::revision_id rev, model::term_id term)
+      : _ntp(std::move(ntp))
+      , _rev(rev)
+      , _term(term)
+      , _max_translatable_offset(kafka::offset{100}) {}
+
+    const model::ntp& ntp() const { return _ntp; }
+    model::revision_id rev() const { return _rev; }
+    model::term_id term() const { return _term; }
+
+    void set_max_translatable_offset(kafka::offset offset) {
+        _max_translatable_offset = offset;
+    }
+
+    kafka::offset max_translatable_offset() const {
+        return _max_translatable_offset;
+    }
+
+    kafka::offset max_translated_offset() const {
+        return _highest_translated_offset;
+    }
+
+    // coordinator API error propagation
+    void set_error_on_add_translated_files(bool error) {
+        _error_on_add_translated_files = error;
+    }
+
+    bool error_on_add_translated_files() const {
+        return _error_on_add_translated_files;
+    }
+
+    // translation error propagation
+    void set_error_on_translation(bool error) { _error_on_translation = error; }
+
+    bool error_on_translation() const { return _error_on_translation; }
+
+    void set_error_on_flush(bool error) { _error_on_flush = error; }
+
+    bool error_on_flush() const { return _error_on_flush; }
+
+    void translation_attempt() { _num_translation_attempts++; }
+
+    ss::future<> wait_for_translation_attempts(
+      size_t attempts, std::chrono::seconds timeout = 10s) {
+        auto target = _num_translation_attempts + attempts;
+        RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, [target, this] {
+            return _num_translation_attempts >= target;
+        });
+    }
+
+    void update_highest_translated_offset(kafka::offset offset) {
+        _highest_translated_offset = std::max(
+          _highest_translated_offset, offset);
+        _max_translatable_offset = std::max(
+          _max_translatable_offset,
+          _highest_translated_offset + kafka::offset_delta(100));
+    }
+
+private:
+    model::ntp _ntp;
+    model::revision_id _rev;
+    model::term_id _term;
+
+    kafka::offset _highest_translated_offset{};
+    kafka::offset _max_translatable_offset{};
+
+    bool _error_on_add_translated_files{false};
+    bool _error_on_translation{false};
+    bool _error_on_flush{false};
+    size_t _num_translation_attempts{0};
+};
+
+class fake_data_src : public data_source {
+public:
+    explicit fake_data_src(fake_test_ctx& partition)
+      : _test_ctx(partition) {}
+
+    void close() noexcept final {}
+
+    const model::ntp& ntp() const final { return _test_ctx.ntp(); }
+
+    model::revision_id topic_revision() const final { return _test_ctx.rev(); }
+
+    model::term_id term() const final { return _test_ctx.term(); }
+
+    ss::future<std::optional<kafka::offset>> wait_for_data_to_translate(
+      std::optional<kafka::offset> last_translated_offset,
+      ss::abort_source& as) final {
+        while (!as.abort_requested()) {
+            auto offset = max_offset_for_translation();
+            if (offset && offset.value() >= kafka::offset{0} && (!last_translated_offset || offset.value() > last_translated_offset.value())) {
+                co_return last_translated_offset
+                  ? kafka::next_offset(last_translated_offset.value())
+                  : min_offset_for_translation();
+            }
+            co_await ss::sleep_abortable(1ms, as);
+        }
+        co_return std::nullopt;
+    }
+
+    ss::future<std::optional<model::record_batch_reader>> make_log_reader(
+      kafka::offset o, ss::io_priority_class, ss::abort_source&) final {
+        auto batches = co_await model::test::make_random_batches(
+          kafka::offset_cast(o), 5, true);
+        auto reader = model::make_generating_record_batch_reader(
+          [batches = std::move(batches)]() mutable {
+              return ss::make_ready_future<model::record_batch_reader::data_t>(
+                std::move(batches));
+          });
+        co_return co_await ss::make_ready_future<
+          std::optional<model::record_batch_reader>>(std::move(reader));
+    }
+
+    kafka::offset min_offset_for_translation() const final {
+        return kafka::offset{0};
+    }
+
+    std::optional<kafka::offset> max_offset_for_translation() const final {
+        return _test_ctx.max_translatable_offset();
+    }
+
+    ss::future<std::error_code> replicate_highest_translated_offset(
+      kafka::offset offset,
+      model::term_id,
+      model::timeout_clock::duration,
+      ss::abort_source&) final {
+        _test_ctx.update_highest_translated_offset(offset);
+        co_return std::make_error_code(std::errc());
+    }
+
+    ss::future<std::optional<std::chrono::milliseconds>>
+    current_lag_ms(model::timeout_clock::duration) final {
+        co_return std::nullopt;
+    }
+
+    void update_commit_lag(std::optional<kafka::offset>) const final {}
+    void update_translation_lag(kafka::offset) const final {}
+
+private:
+    fake_test_ctx& _test_ctx;
+};
+
+class fake_coordinator_api : public coordinator_api {
+public:
+    explicit fake_coordinator_api(fake_test_ctx& test_ctx)
+      : _test_ctx(test_ctx) {}
+
+    ss::future<add_translated_data_files_reply>
+    add_translated_data_files(add_translated_data_files_request request) final {
+        add_translated_data_files_reply reply{};
+        if (_test_ctx.error_on_add_translated_files()) {
+            reply.errc = errc::not_leader;
+            co_return reply;
+        }
+        reply.errc = errc::ok;
+        if (request.ranges.empty()) {
+            co_return reply;
+        }
+        auto& last = request.ranges.back();
+        auto it = _last_added_offsets.find(request.tp);
+        if (it == _last_added_offsets.end() || it->second < last.last_offset) {
+            _last_added_offsets[request.tp] = last.last_offset;
+        } else {
+            reply.errc = errc::failed;
+        }
+        co_return reply;
+    }
+
+    ss::future<fetch_latest_translated_offset_reply>
+    fetch_latest_translated_offset(
+      fetch_latest_translated_offset_request request) final {
+        fetch_latest_translated_offset_reply reply;
+        reply.errc = errc::ok;
+        auto it = _last_added_offsets.find(request.tp);
+        if (it != _last_added_offsets.end()) {
+            reply.last_added_offset = it->second;
+        }
+        co_return reply;
+    }
+
+private:
+    absl::flat_hash_map<model::topic_partition, kafka::offset>
+      _last_added_offsets;
+    fake_test_ctx& _test_ctx;
+};
+
+class fake_translation_ctx : public translation_context {
+public:
+    explicit fake_translation_ctx(fake_test_ctx& test_ctx)
+      : _test_ctx(test_ctx) {}
+
+    ~fake_translation_ctx() {
+        vassert(
+          !_inflight_translation,
+          "finish() must be called in all cases for cleanup");
+    }
+
+    ss::future<>
+    translate_now(model::record_batch_reader rdr, ss::abort_source&) final {
+        _test_ctx.translation_attempt();
+        _inflight_translation = true;
+        auto batches = co_await model::consume_reader_to_fragmented_memory(
+          std::move(rdr), model::timeout_clock::now() + 10s);
+        if (_test_ctx.error_on_translation()) {
+            throw std::runtime_error("translation error simulation");
+        }
+        if (batches.empty()) {
+            co_return;
+        }
+        auto min = model::offset_cast(batches.begin()->base_offset());
+        auto max = model::offset_cast(batches.back().last_offset());
+
+        // keep track of translation boundaries for result propagation
+        _min_offset_translated = std::min(
+          min, _min_offset_translated.value_or(kafka::offset::max()));
+        _max_offset_translated = std::max(
+          max, _max_offset_translated.value_or(kafka::offset::min()));
+    }
+
+    ss::future<> flush() final {
+        if (_test_ctx.error_on_flush()) {
+            return ss::make_exception_future("flush error simulation");
+        }
+        return ss::make_ready_future();
+    }
+
+    void reconcile_properties() final {}
+
+    ss::future<std::optional<translated_offset_range>>
+    finish(retry_chain_node&, ss::abort_source&) final {
+        _inflight_translation = false;
+        translated_offset_range result;
+        if (_min_offset_translated && _max_offset_translated) {
+            result.start_offset = _min_offset_translated.value();
+            result.last_offset = _max_offset_translated.value();
+        }
+        return ss::make_ready_future<std::optional<translated_offset_range>>(
+          std::move(result));
+    }
+
+    ss::future<> discard() final {
+        _inflight_translation = false;
+        return ss::make_ready_future();
+    }
+
+private:
+    std::optional<kafka::offset> _min_offset_translated;
+    std::optional<kafka::offset> _max_offset_translated;
+    fake_test_ctx& _test_ctx;
+    bool _inflight_translation{false};
+};
+
+class partition_translator_fixture : public scheduling::scheduler_fixture {
+public:
+    ss::future<> SetUpAsync() override {
+        co_await scheduling::scheduler_fixture::SetUpAsync();
+    }
+
+    std::unique_ptr<scheduling::scheduling_policy>
+    make_scheduling_policy() override {
+        return scheduling::scheduling_policy::make_default(
+          max_concurrent_translators, task_quota);
+    }
+
+protected:
+    ss::future<bool> add_translator(fake_test_ctx& ctx) {
+        return _scheduler->add_translator(
+          std::make_unique<partition_translator>(
+            test_sg,
+            std::make_unique<fake_coordinator_api>(ctx),
+            std::make_unique<fake_data_src>(ctx),
+            std::make_unique<fake_translation_ctx>(ctx),
+            simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>{
+              retry_max_timeout, retry_initial_backoff},
+            retry_max_timeout,
+            retry_initial_backoff));
+    }
+
+    fake_test_ctx& make_test_context() {
+        _test_ctxs.emplace_back(
+          next_ntp(), model::revision_id{0}, model::term_id{0});
+        return _test_ctxs.back();
+    }
+
+private:
+    static constexpr auto task_quota
+      = std::chrono::duration_cast<scheduling::clock::duration>(2ms);
+
+    chunked_vector<fake_test_ctx> _test_ctxs;
+};
+
+TEST_F_CORO(partition_translator_fixture, test_cleanup_on_translation_error) {
+    auto& test_ctx = make_test_context();
+    test_ctx.set_error_on_translation(true);
+    co_await add_translator(test_ctx);
+    co_await test_ctx.wait_for_translation_attempts(30);
+    // Ensure translation does not make any progress
+    ASSERT_LT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+    // undo
+    test_ctx.set_error_on_translation(false);
+    co_await test_ctx.wait_for_translation_attempts(30);
+    ASSERT_GT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+}
+
+TEST_F_CORO(partition_translator_fixture, test_cleanup_on_flush_error) {
+    auto& test_ctx = make_test_context();
+    test_ctx.set_error_on_flush(true);
+    co_await add_translator(test_ctx);
+    co_await test_ctx.wait_for_translation_attempts(30);
+    // Ensure translation does not make any progress
+    ASSERT_LT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+    // undo
+    test_ctx.set_error_on_flush(false);
+    co_await test_ctx.wait_for_translation_attempts(30);
+    ASSERT_GT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+}
+
+TEST_F_CORO(partition_translator_fixture, test_coordinator_retries) {
+    auto& test_ctx = make_test_context();
+    // simulate no leader conditions
+    test_ctx.set_error_on_add_translated_files(true);
+    co_await add_translator(test_ctx);
+    co_await test_ctx.wait_for_translation_attempts(10);
+    // Ensure translation does not make any progress
+    ASSERT_LT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+    test_ctx.set_error_on_add_translated_files(false);
+    co_await test_ctx.wait_for_translation_attempts(10);
+    ASSERT_GT_CORO(test_ctx.max_translated_offset(), kafka::offset{0});
+}
+
+// todo: add a test for batching once the functionality is checked in

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -287,6 +287,38 @@ translation_task::finish(
     co_return ret;
 }
 
+ss::future<checked<std::nullopt_t, translation_task::errc>>
+translation_task::discard() && {
+    auto mux_result = co_await std::move(_multiplexer).finish();
+    if (mux_result.has_error()) {
+        vlog(
+          datalake_log.warn,
+          "Error writing data files - {}",
+          mux_result.error());
+        co_return errc::file_io_error;
+    }
+    auto write_result = std::move(mux_result).value();
+    auto [data_result, dlq_result] = co_await ss::when_all_succeed(
+      delete_local_data_files(write_result.data_files),
+      delete_local_data_files(write_result.dlq_files));
+
+    if (data_result.has_error()) {
+        vlog(
+          datalake_log.warn,
+          "error deleting local data files - {}",
+          data_result.error());
+        co_return data_result.error();
+    }
+    if (dlq_result.has_error()) {
+        vlog(
+          datalake_log.warn,
+          "error deleting local dlq files - {}",
+          data_result.error());
+        co_return dlq_result.error();
+    }
+    co_return std::nullopt;
+}
+
 std::ostream& operator<<(std::ostream& o, translation_task::errc ec) {
     switch (ec) {
     case translation_task::errc::file_io_error:

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -74,6 +74,13 @@ public:
       retry_chain_node& parent_rcn,
       ss::abort_source&) &&;
 
+    /**
+     * Cleans up any translated files locally and discards the translation
+     * result. This task does not accept an abort source as it is intended
+     * to be short running.
+     */
+    ss::future<checked<std::nullopt_t, translation_task::errc>> discard() &&;
+
 private:
     friend std::ostream& operator<<(std::ostream&, errc);
 


### PR DESCRIPTION
Fixes a few TODOs from the original work.

* Added unit tests for error paths in translator lifecycle, which found a couple of bugs
* Added translation_task::discard() to short circuit expensive uploads during translation failures.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
