### PR TITLE
rpk: set User Agent in public API requests.

### DIFF
--- a/src/go/rpk/pkg/cli/BUILD
+++ b/src/go/rpk/pkg/cli/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//src/go/rpk/pkg/cli/topic",
         "//src/go/rpk/pkg/cli/transform",
         "//src/go/rpk/pkg/cli/version",
+        "//src/go/rpk/pkg/cli/version/versioncmd",
         "//src/go/rpk/pkg/cobraext",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",

--- a/src/go/rpk/pkg/cli/cluster/storage/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/storage/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//src/go/rpk/pkg/cli/cluster/storage/recovery",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/publicapi",
         "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1alpha2",
         "@com_connectrpc_connect//:connect",
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",

--- a/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/cancel-mount.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,7 @@ Cancel a mount/unmount operation
 			out.MaybeDie(err, "invalid migration ID: %v", err)
 
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				req := connect.NewRequest(

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -60,7 +61,7 @@ Use filter to list only migrations in a specific state
 
 			var migrations []rpadmin.MigrationState
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.ListMountTasks(cmd.Context(), connect.NewRequest(&dataplanev1alpha2.ListMountTasksRequest{}))

--- a/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/list-mountable.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +42,7 @@ List all mountable topics:
 
 			var mountableTopics []rpadmin.MountableTopic
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.ListMountableTopics(cmd.Context(), connect.NewRequest(&dataplanev1alpha2.ListMountableTopicsRequest{}))

--- a/src/go/rpk/pkg/cli/cluster/storage/mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/mount.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +67,7 @@ with my-new-topic as the new topic name
 				if an != "" && strings.ToLower(an) != "kafka" {
 					out.Die("Failed to parse '--to' flag: namespace %q not allowed. Only kafka topics can be mounted in Redpanda Cloud clusters", an)
 				}
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				topicMount := &dataplanev1alpha2.MountTopicsRequest_TopicMount{

--- a/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/status-mount.go
@@ -24,6 +24,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +64,7 @@ Status for a mount/unmount operation
 			}
 
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.GetMountTask(

--- a/src/go/rpk/pkg/cli/cluster/storage/unmount.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/unmount.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +64,7 @@ Unmount topic 'my-topic' from the cluster in the 'my-namespace'
 				if ns != "" && strings.ToLower(ns) != "kafka" {
 					out.Die("Namespace %q not allowed. Only kafka topics can be unmounted in Redpanda Cloud clusters", ns)
 				}
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				resp, err := cl.CloudStorage.UnmountTopics(

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -536,7 +536,7 @@ func fromVirtualCluster(yAuth *config.RpkCloudAuth, rg *controlplanev1beta2.Reso
 			ClusterName:   sc.Name,
 			AuthOrgID:     yAuth.OrgID,
 			AuthKind:      yAuth.Kind,
-			ClusterType:   publicapi.ServerlessClusterType, // Virtual clusters do not include a type in the response yet.
+			ClusterType:   config.ServerlessClusterType, // Virtual clusters do not include a type in the response yet.
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/topic"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version/versioncmd"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
@@ -121,7 +122,7 @@ func Execute() {
 		security.NewCommand(fs, p),
 		topic.NewCommand(fs, p),
 		transform.NewCommand(fs, p, osExec),
-		version.NewCommand(fs, p),
+		versioncmd.NewCommand(fs, p),
 
 		newStatusCommand(), // deprecated
 	)

--- a/src/go/rpk/pkg/cli/security/user/BUILD
+++ b/src/go/rpk/pkg/cli/security/user/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/publicapi",
         "@build_buf_gen_go_redpandadata_dataplane_protocolbuffers_go//redpanda/api/dataplane/v1alpha2",
         "@com_connectrpc_connect//:connect",
         "@com_github_spf13_afero//:afero",

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -20,6 +20,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -102,7 +103,7 @@ acl help text for more info.
 			}
 
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 				req := connect.NewRequest(
 					&dataplanev1alpha2.CreateUserRequest{

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -17,6 +17,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +54,7 @@ delete any ACLs that may exist for this user.
 			}
 
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				req := connect.NewRequest(&dataplanev1alpha2.DeleteUserRequest{Name: user})

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +36,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			var users []string
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				listUsers, err := cl.User.ListUsers(cmd.Context(), connect.NewRequest(&dataplanev1alpha2.ListUsersRequest{}))

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +35,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			user := args[0]
 			if p.FromCloud {
-				cl, err := p.DataplaneClient()
+				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 
 				req := connect.NewRequest(

--- a/src/go/rpk/pkg/cli/version/BUILD
+++ b/src/go/rpk/pkg/cli/version/BUILD
@@ -5,12 +5,4 @@ go_library(
     srcs = ["version.go"],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version",
     visibility = ["//visibility:public"],
-    deps = [
-        "//src/go/rpk/pkg/adminapi",
-        "//src/go/rpk/pkg/config",
-        "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
-        "@com_github_spf13_afero//:afero",
-        "@com_github_spf13_cobra//:cobra",
-        "@org_uber_go_zap//:zap",
-    ],
 )

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -11,16 +11,6 @@ package version
 
 import (
 	"fmt"
-	"runtime"
-	"time"
-
-	"github.com/redpanda-data/common-go/rpadmin"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // Default build-time variables, passed via ldflags.
@@ -30,113 +20,12 @@ var (
 	buildTime string // Timestamp of build time, RFC3339.
 )
 
-type rpkVersion struct {
-	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
-	GitRef    string `json:"git_ref,omitempty" yaml:"git_ref,omitempty"`
-	BuildTime string `json:"build_time,omitempty" yaml:"build_time,omitempty"`
-	GoVersion string `json:"go_version,omitempty" yaml:"go_version,omitempty"`
-	OsArch    string `json:"os_arch,omitempty" yaml:"os_arch,omitempty"`
-}
-
-type redpandaVersion struct {
-	NodeID  int
-	Version string
-}
-type redpandaVersions []redpandaVersion
+var (
+	Version   = version
+	Rev       = rev
+	BuildTime = buildTime
+)
 
 func Pretty() string {
 	return fmt.Sprintf("%s (rev %s)", version, rev)
-}
-
-func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Prints the current rpk and Redpanda version",
-		Long: `Prints the current rpk and Redpanda version.
-
-This command prints the current rpk version and allows you to list the Redpanda 
-version running on each node in your cluster.
-
-To list the Redpanda version of each node in your cluster you may pass the
-Admin API hosts using flags, profile, or environment variables.
-
-To get only the rpk version, use 'rpk --version'.`,
-		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, _ []string) {
-			rv := rpkVersion{
-				Version:   version,
-				GitRef:    rev,
-				BuildTime: buildTime,
-				GoVersion: runtime.Version(),
-				OsArch:    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-			}
-			printRpkVersion(rv)
-			var rows redpandaVersions
-			printCV := true
-			defer func() {
-				if printCV {
-					printClusterVersions(&rows)
-				}
-			}()
-
-			p, err := p.LoadVirtualProfile(fs)
-			if err != nil {
-				zap.L().Sugar().Errorf("unable to load the profile: %v", err)
-				return
-			}
-			// Cloud clusters don't expose their admin API, the rest of the
-			// command will always fail. We better exit early.
-			if p.FromCloud {
-				printCV = false
-				return
-			}
-			cl, err := adminapi.NewClient(
-				cmd.Context(),
-				fs,
-				p,
-				rpadmin.ClientTimeout(3*time.Second),
-				rpadmin.MaxRetries(2),
-			)
-			if err != nil {
-				zap.L().Sugar().Errorf("unable to create the admin client: %v", err)
-				return
-			}
-			bs, err := cl.Brokers(cmd.Context())
-			if err != nil {
-				zap.L().Sugar().Errorf("unable to request broker info: %v", err)
-				return
-			}
-			for _, b := range bs {
-				if b.IsAlive != nil {
-					rows = append(rows, redpandaVersion{b.NodeID, b.Version})
-				}
-			}
-		},
-	}
-	return cmd
-}
-
-func printRpkVersion(rv rpkVersion) {
-	fmt.Printf(`Version:     %s
-Git ref:     %s
-Build date:  %s
-OS/Arch:     %s
-Go version:  %s
-`, rv.Version, rv.GitRef, rv.BuildTime, rv.OsArch, rv.GoVersion)
-}
-
-func printClusterVersions(rpv *redpandaVersions) {
-	fmt.Println()
-	fmt.Println("Redpanda Cluster")
-	if len(*rpv) == 0 {
-		fmt.Println(`  Unreachable, to debug, use the '-v' flag. To get the broker versions, pass the
-  hosts via flags, profile, or environment variables:
-    rpk version -X admin.hosts=<host address>
-
-  To get only the rpk version, use 'rpk --version'.`)
-		return
-	}
-	for _, v := range *rpv {
-		fmt.Printf("  node-%v  %s\n", v.NodeID, v.Version)
-	}
 }

--- a/src/go/rpk/pkg/cli/version/versioncmd/BUILD
+++ b/src/go/rpk/pkg/cli/version/versioncmd/BUILD
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "versioncmd",
+    srcs = ["versioncmd.go"],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version/versioncmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/go/rpk/pkg/adminapi",
+        "//src/go/rpk/pkg/cli/version",
+        "//src/go/rpk/pkg/config",
+        "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
+    ],
+)

--- a/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
+++ b/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package versioncmd
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+type rpkVersion struct {
+	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
+	GitRef    string `json:"git_ref,omitempty" yaml:"git_ref,omitempty"`
+	BuildTime string `json:"build_time,omitempty" yaml:"build_time,omitempty"`
+	GoVersion string `json:"go_version,omitempty" yaml:"go_version,omitempty"`
+	OsArch    string `json:"os_arch,omitempty" yaml:"os_arch,omitempty"`
+}
+
+type redpandaVersion struct {
+	NodeID  int
+	Version string
+}
+type redpandaVersions []redpandaVersion
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the current rpk and Redpanda version",
+		Long: `Prints the current rpk and Redpanda version.
+
+This command prints the current rpk version and allows you to list the Redpanda 
+version running on each node in your cluster.
+
+To list the Redpanda version of each node in your cluster you may pass the
+Admin API hosts using flags, profile, or environment variables.
+
+To get only the rpk version, use 'rpk --version'.`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			rv := rpkVersion{
+				Version:   version.Version,
+				GitRef:    version.Rev,
+				BuildTime: version.BuildTime,
+				GoVersion: runtime.Version(),
+				OsArch:    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+			}
+			printRpkVersion(rv)
+			var rows redpandaVersions
+			printCV := true
+			defer func() {
+				if printCV {
+					printClusterVersions(&rows)
+				}
+			}()
+
+			p, err := p.LoadVirtualProfile(fs)
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to load the profile: %v", err)
+				return
+			}
+			// Cloud clusters don't expose their admin API, the rest of the
+			// command will always fail. We better exit early.
+			if p.FromCloud {
+				printCV = false
+				return
+			}
+			cl, err := adminapi.NewClient(
+				cmd.Context(),
+				fs,
+				p,
+				rpadmin.ClientTimeout(3*time.Second),
+				rpadmin.MaxRetries(2),
+			)
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to create the admin client: %v", err)
+				return
+			}
+			bs, err := cl.Brokers(cmd.Context())
+			if err != nil {
+				zap.L().Sugar().Errorf("unable to request broker info: %v", err)
+				return
+			}
+			for _, b := range bs {
+				if b.IsAlive != nil {
+					rows = append(rows, redpandaVersion{b.NodeID, b.Version})
+				}
+			}
+		},
+	}
+	return cmd
+}
+
+func printRpkVersion(rv rpkVersion) {
+	fmt.Printf(`Version:     %s
+Git ref:     %s
+Build date:  %s
+OS/Arch:     %s
+Go version:  %s
+`, rv.Version, rv.GitRef, rv.BuildTime, rv.OsArch, rv.GoVersion)
+}
+
+func printClusterVersions(rpv *redpandaVersions) {
+	fmt.Println()
+	fmt.Println("Redpanda Cluster")
+	if len(*rpv) == 0 {
+		fmt.Println(`  Unreachable, to debug, use the '-v' flag. To get the broker versions, pass the
+  hosts via flags, profile, or environment variables:
+    rpk version -X admin.hosts=<host address>
+
+  To get only the rpk version, use 'rpk --version'.`)
+		return
+	}
+	for _, v := range *rpv {
+		fmt.Printf("  node-%v  %s\n", v.NodeID, v.Version)
+	}
+}

--- a/src/go/rpk/pkg/config/BUILD
+++ b/src/go/rpk/pkg/config/BUILD
@@ -16,8 +16,6 @@ go_library(
         "//src/go/rpk/pkg/net",
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
-        "//src/go/rpk/pkg/publicapi",
-        "@com_connectrpc_connect//:connect",
         "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -17,9 +17,7 @@ import (
 	"reflect"
 	"time"
 
-	"connectrpc.com/connect"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -298,6 +296,7 @@ const (
 	CloudAuthUninitialized     = ""
 	CloudAuthSSO               = "sso"
 	CloudAuthClientCredentials = "client-credentials"
+	ServerlessClusterType      = "TYPE_SERVERLESS" // Configuration setting to identify a serverless cluster.
 )
 
 ///////////
@@ -359,16 +358,6 @@ func (p *RpkProfile) ActualConfig() (*RpkYaml, bool) {
 		return nil, false
 	}
 	return p.c.ActualRpkYaml()
-}
-
-// DataplaneClient creates a publicapi.DataPlaneClientSet with the information
-// loaded in the profile.
-func (p *RpkProfile) DataplaneClient(opts ...connect.ClientOption) (*publicapi.DataPlaneClientSet, error) {
-	url, err := p.CloudCluster.CheckClusterURL()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster information from your profile: %v", err)
-	}
-	return publicapi.NewDataPlaneClientSet(url, p.CurrentAuth().AuthToken, opts...)
 }
 
 // HasClientCredentials returns if both ClientID and ClientSecret are non-empty.
@@ -451,7 +440,7 @@ func (c *RpkCloudCluster) HasAuth(a RpkCloudAuth) bool {
 }
 
 func (c *RpkCloudCluster) IsServerless() bool {
-	return c != nil && c.ClusterType == publicapi.ServerlessClusterType
+	return c != nil && c.ClusterType == ServerlessClusterType
 }
 
 func (c *RpkCloudCluster) CheckClusterURL() (string, error) {

--- a/src/go/rpk/pkg/publicapi/BUILD
+++ b/src/go/rpk/pkg/publicapi/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/rpk/pkg/cli/version",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/httpapi",
         "@build_buf_gen_go_redpandadata_cloud_connectrpc_go//redpanda/api/controlplane/v1beta2/controlplanev1beta2connect",

--- a/src/go/rpk/pkg/publicapi/BUILD
+++ b/src/go/rpk/pkg/publicapi/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/httpapi",
         "@build_buf_gen_go_redpandadata_cloud_connectrpc_go//redpanda/api/controlplane/v1beta2/controlplanev1beta2connect",
         "@build_buf_gen_go_redpandadata_cloud_connectrpc_go//redpanda/api/iam/v1beta2/iamv1beta2connect",

--- a/src/go/rpk/pkg/publicapi/controlplane.go
+++ b/src/go/rpk/pkg/publicapi/controlplane.go
@@ -41,8 +41,9 @@ func NewCloudClientSet(host, authToken string, opts ...connect.ClientOption) *Cl
 	}
 	opts = append([]connect.ClientOption{
 		connect.WithInterceptors(
-			newAuthInterceptor(authToken), // Add the Bearer token.
-			newLoggerInterceptor(),        // Add logs to every request.
+			newAuthInterceptor(authToken),              // Add the Bearer token.
+			newLoggerInterceptor(),                     // Add logs to every request.
+			newAgentInterceptor(defaultRpkUserAgent()), // Add the User-Agent.
 		),
 	}, opts...)
 

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -15,6 +15,7 @@ import (
 
 	"buf.build/gen/go/redpandadata/dataplane/connectrpc/go/redpanda/api/dataplane/v1alpha2/dataplanev1alpha2connect"
 	"connectrpc.com/connect"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 // DataPlaneClientSet holds the respective service clients to interact with
@@ -43,4 +44,15 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 		CloudStorage: dataplanev1alpha2connect.NewCloudStorageServiceClient(http.DefaultClient, host, opts...),
 		User:         dataplanev1alpha2connect.NewUserServiceClient(http.DefaultClient, host, opts...),
 	}, nil
+}
+
+// DataplaneClientFromRpkProfile creates a DataPlaneClientSet with the
+// information loaded in the profile. If the profile is not from cloud it will
+// return an error.
+func DataplaneClientFromRpkProfile(p *config.RpkProfile, opts ...connect.ClientOption) (*DataPlaneClientSet, error) {
+	url, err := p.CloudCluster.CheckClusterURL()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster information from your profile: %v", err)
+	}
+	return NewDataPlaneClientSet(url, p.CurrentAuth().AuthToken, opts...)
 }

--- a/src/go/rpk/pkg/publicapi/dataplane.go
+++ b/src/go/rpk/pkg/publicapi/dataplane.go
@@ -34,8 +34,9 @@ func NewDataPlaneClientSet(host, authToken string, opts ...connect.ClientOption)
 	}
 	opts = append([]connect.ClientOption{
 		connect.WithInterceptors(
-			newAuthInterceptor(authToken), // Add the Bearer token.
-			newLoggerInterceptor(),        // Add logs to every request.
+			newAuthInterceptor(authToken),              // Add the Bearer token.
+			newLoggerInterceptor(),                     // Add logs to every request.
+			newAgentInterceptor(defaultRpkUserAgent()), // Add the User-Agent.
 		),
 	}, opts...)
 

--- a/src/go/rpk/pkg/publicapi/enterprise.go
+++ b/src/go/rpk/pkg/publicapi/enterprise.go
@@ -31,7 +31,8 @@ func NewEnterpriseClientSet(host string, opts ...connect.ClientOption) *Enterpri
 	}
 	opts = append([]connect.ClientOption{
 		connect.WithInterceptors(
-			newLoggerInterceptor(), // Add logs to every request.
+			newLoggerInterceptor(),                     // Add logs to every request.
+			newAgentInterceptor(defaultRpkUserAgent()), // Add the User-Agent.
 		),
 	}, opts...)
 

--- a/src/go/rpk/pkg/publicapi/publicapi.go
+++ b/src/go/rpk/pkg/publicapi/publicapi.go
@@ -19,8 +19,7 @@ import (
 
 // ControlPlaneProdURL is the host of the Cloud Redpanda API.
 const (
-	ControlPlaneProdURL   = "https://api.redpanda.com"
-	ServerlessClusterType = "TYPE_SERVERLESS"
+	ControlPlaneProdURL = "https://api.redpanda.com"
 )
 
 func newAuthInterceptor(token string) connect.UnaryInterceptorFunc {

--- a/src/go/rpk/pkg/publicapi/publicapi.go
+++ b/src/go/rpk/pkg/publicapi/publicapi.go
@@ -12,8 +12,10 @@ package publicapi
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"connectrpc.com/connect"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
 	"go.uber.org/zap"
 )
 
@@ -38,4 +40,35 @@ func newLoggerInterceptor() connect.UnaryInterceptorFunc {
 			return next(ctx, req)
 		}
 	}
+}
+
+func defaultRpkUserAgent() string {
+	return fmt.Sprintf("rpk/%s (%s_%s)", version.Version, runtime.GOOS, runtime.GOARCH)
+}
+
+func newAgentInterceptor(agent string) connect.Interceptor {
+	return &agentInterceptor{agent: agent}
+}
+
+type agentInterceptor struct {
+	agent string
+}
+
+func (i *agentInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		req.Header().Set("User-Agent", i.agent)
+		return next(ctx, req)
+	}
+}
+
+func (i *agentInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		conn.RequestHeader().Set("User-Agent", i.agent)
+		return conn
+	}
+}
+
+func (*agentInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
 }


### PR DESCRIPTION
This PR adds the UserAgent with the form `rpk/<version> (<os>_<arch>` to our requests to the Public API.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
