### PR TITLE
`storage`: use `absl::btree_multimap<>` for `ntp_by_gc_size`

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -57,6 +57,7 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/file.hh>
 
+#include <absl/container/btree_map.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <fmt/format.h>
 
@@ -439,7 +440,8 @@ ss::future<> log_manager::housekeeping_loop() {
              * estimated reclaimable space. since logs may be asynchronously
              * deleted doing this safely is tricky.
              */
-            absl::btree_map<size_t, model::ntp, std::greater<>> ntp_by_gc_size;
+            absl::btree_multimap<size_t, model::ntp, std::greater<>>
+              ntp_by_gc_size;
 
             /*
              * first we build a collection of ntp's as their estimated
@@ -474,8 +476,8 @@ ss::future<> log_manager::housekeeping_loop() {
              * official log registry to avoid problems with concurrent removals
              * since the log interface does not tolerate ops on closed logs.
              */
-            for (const auto& candidate : ntp_by_gc_size) {
-                auto log = get(candidate.second);
+            for (const auto& [_, candidate] : ntp_by_gc_size) {
+                auto log = get(candidate);
                 if (!log) {
                     continue;
                 }


### PR DESCRIPTION
### BLUF 

This map is used in the `log_manager` to order `ntp`s by the amount of data they have for reclamation during urgent garbage collection.

Currently, if multiple `ntp`s were to have the same amount of data available for reclaim, the entry in this map for that `size_t` key would only maintain the first `ntp` added, and therefore only one `ntp` of the set would end up being considered for urgent garbage collection.

This is particularly bad since we are only considering the local retention, and not the total available bytes that could be reclaimed due to data being uploaded to tiered storage (i.e a common case here is `usage.reclaim.retention == 0` for multiple `ntp`s, despite the fact that resource management has identified data is available for reclaim from tiered storage enabled topics).

### Demonstrative CI Failure 

[CORE-8500](https://redpandadata.atlassian.net/browse/CORE-8500)

This was manifesting as a CI failure in `full_disk_test.py::LogStorageMaxSizeSI.test_stay_below_target_size` after merging `min.cleanable.dirty.ratio` changes in PR https://github.com/redpanda-data/redpanda/pull/24991.

What this means is that this test was actually depending on regularly scheduled `gc()` every `log_compaction_interval_ms` in addition to urgent `gc()`, and it was because of this bug.

For example, log lines from a failed test:

```
INFO  2025-03-06 04:34:51,766 [shard 0:main] resource_mgmt - storage.cc:656 - Scheduling 12.215MiB for reclaim
TRACE 2025-03-06 04:34:51,766 [shard 1:main] resource_mgmt - storage.cc:356 - Marking offset 223 in cloud partition 1 group {kafka/target-size-topic/1} for estimated 12.215MiB reclaim
INFO  2025-03-06 04:34:51,766 [shard 0:main] resource_mgmt - storage.cc:327 - Requested truncation from 1 cloud partitions
DEBUG 2025-03-06 04:34:51,933 [shard 0:main] storage - log_manager.cc:966 - triggered gc
DEBUG 2025-03-06 04:34:51,933 [shard 0:main] storage - log_manager.cc:432 - Performing urgent gc
DEBUG 2025-03-06 04:35:16,729 [shard 0:main] storage - log_manager.cc:483 - emplacing back usage retention 0 for {redpanda/controller/0}
DEBUG 2025-03-06 04:35:16,730 [shard 0:main] storage - log_manager.cc:483 - emplacing back usage retention 0 for {kafka/target-size-topic/1}
DEBUG 2025-03-06 04:35:16,730 [shard 0:main] storage - log_manager.cc:483 - emplacing back usage retention 0 for {kafka/target-size-topic/3}
DEBUG 2025-03-06 04:35:16,730 [shard 0:main] storage - log_manager.cc:505 - Performing urgent gc on {redpanda/controller/0}
```

Firstly, resource management has identified `target-size-topic/1` as having available bytes for reclaim, and has requested truncation from this partition.

As can be seen, on shard `0`, we have 3 partitions (`controller/0`, `target-size-topic/1`, `target-size-topic/3`) that all have `0` bytes available for removal, according to the local retention policy. Because `controller/0` was considered first, it is the only `ntp` that ultimately has garbage collection performed on it.

In this context, it blocks urgent garbage collection from collecting what it knows to be available bytes from tiered storage topics, and the test fails to reclaim the data it wants to reclaim.

### Change

Fix this by using a `btree_multimap` for the `ntp_by_gc_size` map to prevent this collision case from occuring and blocking urgent garbage collection of certain `ntp`s.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug in which urgent garbage collection of multiple partitions may only consider one partition in the set.


[CORE-8500]: https://redpandadata.atlassian.net/browse/CORE-8500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ