### PR TITLE
schema: make get API used by Iceberg more robust

### DIFF
--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -309,6 +309,10 @@ public:
     getter() const override {
         co_return &_store;
     }
+    ss::future<pandaproxy::schema_registry::schema_getter*>
+    synced_getter() const override {
+        co_return &_store;
+    }
     ss::future<pandaproxy::schema_registry::canonical_schema_definition>
     get_schema_definition(
       pandaproxy::schema_registry::schema_id id) const override {

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -43,6 +43,12 @@ public:
         co_return reader;
     }
 
+    ss::future<ppsr::schema_getter*> synced_getter() const override {
+        auto [reader, writer] = co_await service();
+        co_await writer->read_sync();
+        co_return reader;
+    }
+
     ss::future<ppsr::canonical_schema_definition>
     get_schema_definition(ppsr::schema_id id) const override {
         auto [reader, _] = co_await service();
@@ -83,6 +89,10 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
+    ss::future<ppsr::schema_getter*> synced_getter() const override {
+        throw std::logic_error(
+          "invalid attempted usage of a disabled schema registry");
+    }
     ss::future<ppsr::canonical_schema_definition>
     get_schema_definition(ppsr::schema_id) const override {
         throw std::logic_error(
@@ -106,7 +116,15 @@ registry::get_valid_schema(ppsr::schema_id schema_id) const {
     auto schema_def_opt = co_await reader->maybe_get_schema_definition(
       schema_id);
     if (!schema_def_opt.has_value()) {
-        co_return std::nullopt;
+        // Assume that we expect to have the schema. If it's not there, one
+        // possibility is that the reader needs to catch up, so do that and try
+        // again.
+        reader = co_await synced_getter();
+        schema_def_opt = co_await reader->maybe_get_schema_definition(
+          schema_id);
+        if (!schema_def_opt.has_value()) {
+            co_return std::nullopt;
+        }
     }
     auto& schema_def = *schema_def_opt;
     auto schema_type = schema_def.type();

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -43,6 +43,10 @@ public:
     virtual ss::future<pandaproxy::schema_registry::schema_getter*>
     getter() const = 0;
 
+    // Returns a getter after syncing with the underlying store.
+    virtual ss::future<pandaproxy::schema_registry::schema_getter*>
+    synced_getter() const = 0;
+
     ss::future<std::optional<pandaproxy::schema_registry::valid_schema>>
     get_valid_schema(pandaproxy::schema_registry::schema_id schema_id) const;
 

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -41,6 +41,10 @@ public:
 
     ss::future<pandaproxy::schema_registry::schema_getter*>
     getter() const override;
+    ss::future<pandaproxy::schema_registry::schema_getter*>
+    synced_getter() const override {
+        return getter();
+    }
     ss::future<pandaproxy::schema_registry::canonical_schema_definition>
     get_schema_definition(
       pandaproxy::schema_registry::schema_id id) const override;


### PR DESCRIPTION
We were previously getting schemas without explicitly syncing (listing offsets and consuming _schemas until the current HWM) with the underlying schema store. This meant that Iceberg translation could see a stale result that misled it into thinking it was missing a schema.

This commit updates the API that Iceberg uses to sync if it detects that the requested schema is missing. I opted to do this conditionally because the sync seems somewhat expensive.

Without this change, datalake/cluster_restore_test.py was very flaky, even when run locally (creating DLQ tables, not creating main tables). With this change, it at least passes locally.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
