### PR TITLE
`rptest`: add ABS endpoint to `nessie` credentials

### DIFF
--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -99,6 +99,7 @@ class NessieCatalog(CatalogService):
         elif isinstance(self.credentials,
                         cloud_storage.ABSSharedKeyCredentials):
             env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_AUTH_TYPE"] = "STORAGE_SHARED_KEY"
+            env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_ENDPOINT"] = self.credentials.endpoint
             env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_ACCOUNT_NAME"] = self.credentials.account_name
             env["NESSIE_CATALOG_SERVICE_ADLS_DEFAULT_OPTIONS_ACCOUNT_SECRET"] = self.credentials.account_key
         return env


### PR DESCRIPTION
This is also a required field that wasn't being set, see: https://projectnessie.org/nessie-latest/configuration/#adls-default-file-system-settings

Without this, we see errors in Azure runs such as:

```
pyiceberg.exceptions.BadRequestError: IllegalArgumentException: Location for ICEBERG_TABLE 'test_ns.bids' cannot be associated with any configured object storage location: Mandatory ADLS endpoint is not configured for storage account panda-container-c1cb6aa4-f937-11ef-9d42-ff87a9b0dda9@cdtstrg960563508212.dfs.core.windows.net.
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none