### PR TITLE
pandaproxy/sr: Fix normalization not being applied on stored schemas

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -485,7 +485,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       is_deleted::no};
 
     auto ids = co_await rq.service().schema_store().get_schema_version(
-      schema.share());
+      schema.share(), norm);
 
     schema_id schema_id{ids.id.value_or(invalid_schema_id)};
     if (!ids.version.has_value()) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -13,6 +13,7 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "container/fragmented_vector.h"
 #include "hashing/jump_consistent_hash.h"
 #include "hashing/xx.h"
 #include "pandaproxy/logger.h"
@@ -27,13 +28,16 @@
 #include "pandaproxy/schema_registry/util.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/exception.hh>
 
 #include <absl/algorithm/container.h>
 #include <fmt/core.h>
 
+#include <exception>
 #include <functional>
 #include <iterator>
 
@@ -133,13 +137,64 @@ sharded_store::make_valid_schema(canonical_schema schema) {
 }
 
 ss::future<sharded_store::has_schema_result>
-sharded_store::get_schema_version(subject_schema schema) {
+sharded_store::get_schema_version(subject_schema schema, normalize norm) {
     // Validate the schema (may throw)
     co_await validate_schema(schema.schema.share());
 
     // Determine if the definition already exists
-    auto map = [&schema](store& s) {
-        return s.get_schema_id(schema.schema.def());
+    auto map = [this, norm, &schema](
+                 const store& s) -> ss::future<std::optional<schema_id>> {
+        chunked_vector<schema_id> stored_ids{
+          s.get_schemas() | std::views::keys};
+
+        return ss::do_with(
+          std::optional<schema_id>{},
+          std::move(stored_ids),
+          [this, norm, &s, &schema](
+            std::optional<schema_id>& ret_id, chunked_vector<schema_id>& ids) {
+              auto loop_condition = [&ret_id, &ids]() {
+                  return ret_id.has_value() || ids.empty();
+              };
+
+              auto loop_body =
+                [this, norm, &s, &ids, &ret_id, &schema]() -> ss::future<> {
+                  auto id = ids.back();
+                  ids.pop_back();
+
+                  auto s_res = s.get_schema_definition(id);
+                  if (s_res.has_error()) {
+                      return ss::make_ready_future();
+                  }
+
+                  auto [raw, type, refs]
+                    = std::move(s_res.value()).destructure();
+                  return this
+                    ->make_canonical_schema(
+                      unparsed_schema{
+                        subject{},
+                        unparsed_schema_definition{
+                          std::move(raw), type, std::move(refs)}},
+                      norm)
+                    .then([id, &ret_id, &schema](canonical_schema processed) {
+                        if (processed.def() == schema.schema.def()) {
+                            ret_id = id;
+                        }
+                        return ss::make_ready_future();
+                    })
+                    .handle_exception([id](std::exception_ptr e) {
+                        vlog(
+                          plog.warn,
+                          "Failed to parse stored schema with "
+                          "id {}. Error: {}",
+                          id,
+                          e);
+                    });
+              };
+
+              return ss::do_until(
+                       std::move(loop_condition), std::move(loop_body))
+                .then([&ret_id] { return ret_id; });
+          });
     };
     auto reduce = [](
                     std::optional<schema_id> acc,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -46,7 +46,8 @@ public:
         std::optional<schema_id> id;
         std::optional<schema_version> version;
     };
-    ss::future<has_schema_result> get_schema_version(subject_schema schema);
+    ss::future<has_schema_result>
+    get_schema_version(subject_schema schema, normalize norm = normalize::no);
 
     struct insert_result {
         schema_version version;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -104,18 +104,6 @@ public:
         return {it->second.definition.share()};
     }
 
-    ///\brief Return the id of the schema, if it already exists.
-    std::optional<schema_id>
-    get_schema_id(const canonical_schema_definition& def) const {
-        const auto s_it = std::find_if(
-          _schemas.begin(), _schemas.end(), [&](const auto& s) {
-              const auto& entry = s.second;
-              return def == entry.definition;
-          });
-        return s_it == _schemas.end() ? std::optional<schema_id>{}
-                                      : s_it->first;
-    }
-
     ///\brief Return a list of subject-versions for the shema id.
     chunked_vector<subject_version> get_schema_subject_versions(schema_id id) {
         chunked_vector<subject_version> svs;
@@ -782,6 +770,9 @@ public:
               });
         }
     };
+
+    ///\brief _schemas const getter
+    const auto& get_schemas() const { return _schemas; }
 
 private:
     struct schema_entry {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -205,6 +205,37 @@ message myrecord {
     json_incompat=r'{"type": "number", "multipleOf": 20}',
 )
 
+imported_schema_proto_def = """
+syntax = "proto3";
+message AType {
+  double d =   2;
+  float f =   1;
+}"""
+
+imported_schema_sanitized_proto_def = """
+syntax = "proto3";
+
+message AType {
+  double d = 2;
+  float f = 1;
+}"""
+
+imported_schema_normalized_proto_def = """
+syntax = "proto3";
+
+message AType {
+  float f = 1;
+  double d = 2;
+}"""
+
+imported_schema = {
+    "subject": "imported",
+    "version": 1,
+    "schema": imported_schema_proto_def,
+    "sanitized": imported_schema_sanitized_proto_def,
+    "normalized": imported_schema_normalized_proto_def,
+}
+
 log_config = LoggingConfig('info',
                            logger_levels={
                                'security': 'trace',
@@ -801,6 +832,36 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
     """
     def __init__(self, context, **kwargs):
         super(SchemaRegistryTestMethods, self).__init__(context, **kwargs)
+
+    def _push_to_schemas_topic(self, schemas):
+
+        schema_topic = TopicSpec(name="_schemas",
+                                 partition_count=1,
+                                 replication_factor=1)
+        self.client().create_topic(schema_topic)
+
+        rpk = self._get_rpk_tools()
+
+        for i_schema, schema in enumerate(schemas):
+            key = {
+                "keytype": "SCHEMA",
+                "subject": schema["subject"],
+                "version": schema["version"],
+                "magic": 1,
+            }
+            value = {
+                "subject": schema["subject"],
+                "version": schema["version"],
+                "id": i_schema + 1,
+                "schemaType": "PROTOBUF",
+                "schema": schema["schema"],
+                "deleted": False,
+            }
+            if "references" in schema:
+                value["references"] = schema["references"]
+            rpk.produce(topic="_schemas",
+                        key=json.dumps(key),
+                        msg=json.dumps(value))
 
     @cluster(num_nodes=3)
     def test_schemas_types(self):
@@ -2053,6 +2114,88 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         result = result_raw.json()
         assert result["schemaType"] == "JSON"
         assert result["schema"].strip() == json_number_schema_def.strip()
+
+    @cluster(num_nodes=3)
+    def test_unsanitized_import(self):
+        """
+        Verify that all endpoints sanitize the retrieved schema
+        """
+        #Test setup: Simulate import of a schema by writting directly into the _schemas topic.
+        #This schema is neither sanitized nor normalized
+        self._push_to_schemas_topic([imported_schema])
+
+        self.redpanda.set_cluster_config(
+            {'schema_registry_protobuf_renderer_v2': True},
+            expect_restart=True)
+
+        schema_def = imported_schema["schema"]
+        #Normalization:off - /subjects/{subject}
+        result_raw = self._post_subjects_subject(subject="imported",
+                                                 data=json.dumps({
+                                                     "schema":
+                                                     schema_def,
+                                                     "schemaType":
+                                                     "PROTOBUF"
+                                                 }))
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+            f"for request 'POST subjects/imported'"
+        result = result_raw.json()["schema"].strip()
+        expected_result = imported_schema["sanitized"].strip()
+        assert result == expected_result, \
+            f"Expected:\n{expected_result}\nGot:\n{result}\n"\
+            "for request 'POST subjects/imported'"
+
+        #Normalization:on - /subjects/{subject}
+        result_raw = self._post_subjects_subject(subject="imported",
+                                                 data=json.dumps({
+                                                     "schema":
+                                                     schema_def,
+                                                     "schemaType":
+                                                     "PROTOBUF"
+                                                 }),
+                                                 normalize=True)
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+            f"for request 'POST subjects/imported?normalize=true'"
+        result = result_raw.json()["schema"].strip()
+        expected_result = imported_schema["normalized"].strip()
+        assert result == expected_result, \
+            f"Expected:\n{expected_result}\nGot:\n{result}\n"\
+            "for request 'POST subjects/imported?normalize=true'"
+
+        #Normalization:off - /subjects/{subject}/versions
+        result_raw = self._post_subjects_subject_versions(subject="imported",
+                                                          data=json.dumps({
+                                                              "schema":
+                                                              schema_def,
+                                                              "schemaType":
+                                                              "PROTOBUF"
+                                                          }))
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+            f"for request 'POST subjects/imported/versions'"
+        result_id = result_raw.json()["id"]
+        assert result_id == 1, \
+            f"Expected id 1 but got {result_id}, "\
+            "for request 'POST subjects/imported/versions'"
+
+        #Normalization:on - /subjects/{subject}/versions
+        result_raw = self._post_subjects_subject_versions(subject="imported",
+                                                          data=json.dumps({
+                                                              "schema":
+                                                              schema_def,
+                                                              "schemaType":
+                                                              "PROTOBUF"
+                                                          }),
+                                                          normalize=True)
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+            "for request 'POST subjects/imported/versions?normalize=true'"
+        result_id = result_raw.json()["id"]
+        assert result_id == 1, \
+            f"Expected id 1 but got {result_id}, "\
+            "for request 'POST subjects/imported/versions?normalize=true'"
 
     @cluster(num_nodes=4)
     @parametrize(protocol=SchemaType.AVRO, client_type=SerdeClientType.Python)


### PR DESCRIPTION
Fixes: [CORE-9288](https://redpandadata.atlassian.net/browse/CORE-9288)

Update /subjects/subject/versions endpoint, for schemas being read from store to be processed based on the normalization argument.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none



[CORE-9288]: https://redpandadata.atlassian.net/browse/CORE-9288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ