### PR TITLE
bazel: support microsoft fips compiler

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,9 @@ build --linkopt -stdlib=libc++
 # By default build without CGO
 build --@rules_go//go/config:pure
 
+build:gofips --@rules_go//go/toolchain:sdk_name=go_sdk_with_systemcrypto
+build:gofips --@rules_go//go/config:pure=false
+
 # Improve caching and readability of filepaths that the compiler uses by not using
 # absolute paths, and instead use paths that are relative to the redpanda repo.
 # https://github.com/bazel-contrib/toolchains_llvm/pull/445#issuecomment-2605443516

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,7 @@ single_version_override(
 
 bazel_dep(name = "re2", version = "2024-07-02")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
-bazel_dep(name = "rules_go", version = "0.50.1")
+bazel_dep(name = "rules_go", version = "0.53.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_rust", version = "0.57.1")
 bazel_dep(name = "snappy", version = "1.2.1")
@@ -168,6 +168,20 @@ register_toolchains("@llvm_18_toolchain//:all")
 # ====================================
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")
+
+# The microsoft compiler versions can be listed at their github release under the `asset.json` file
+go_sdk.download(
+    name = "go_sdk_with_systemcrypto",
+    experiments = ["systemcrypto"],
+    sdks = {
+        "linux_amd64": ("22c15eae18e90a5a995dee497c3486b9/go1.24.1-20250304.4.linux-amd64.tar.gz", "b0ca85ecc435a93e2ddb626dd9ef7fb6689700a0847b0392eb3e146345a8dea0"),
+        "linux_arm64": ("e256ca0c885e677ad7b8fc233798b579/go1.24.1-20250304.4.linux-arm64.tar.gz", "73b1befea457d5967632b2b0b93f8d2c0d899d5b6fbd1396c55d0a015292608b"),
+        "darwin_amd64": ("f139d53d3fce534c6deb63e58e5b7be1/go1.24.1-20250304.4.darwin-amd64.tar.gz", "fa5a2d74488d99d75cd8cbd4fa8f2d892932078e92728b0b580468c95488a7c0"),
+        "darwin_arm64": ("5798ae818c617e0f8bb8b4b221555997/go1.24.1-20250304.4.darwin-arm64.tar.gz", "fe669bea5d0b4a45b135f00ff83e57fb3dc61bc9f96e9d9f001f918d938fbc54"),
+    },
+    urls = ["https://download.visualstudio.microsoft.com/download/pr/f3428561-0ec5-4554-8c3e-f77ccc696490/{}"],
+    version = "1.24.1",
+)
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//bazel/thirdparty:go.work")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -167,7 +167,7 @@ register_toolchains("@llvm_18_toolchain//:all")
 # Go Toolchain
 # ====================================
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.0")
+go_sdk.download(version = "1.24.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_work = "//bazel/thirdparty:go.work")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -123,7 +123,8 @@
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
     "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
-    "https://bcr.bazel.build/modules/rules_go/0.50.1/source.json": "205765fd30216c70321f84c9a967267684bdc74350af3f3c46c857d9f80a4fa2",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/source.json": "c6dc34fb5bb8838652221a167d8f35ca3c8fdcbff8568f13cc75719802f95cff",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
@@ -5476,7 +5477,7 @@
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//bazel/thirdparty/Cargo.lock": "931fa1bc55d0e5d2e5b6d96da399569a4c2254a4bb1d99c98f71bb4b98eead73",
           "@@//bazel/thirdparty/Cargo.toml": "cb23768a6e7edc8f97215921e956f5be06521ad93cc0ecf64a932e3a8caada54",
-          "@@//MODULE.bazel": "12a46b2c8deb9f667e461d551a99be188edec80636f92b4a067b8b9ca9ffb77f",
+          "@@//MODULE.bazel": "d82a79ad451ef0b4e3680882f9a93e7d088d271e2524cfb53a76f9aa2fe74502",
           "@@//bazel/thirdparty/wasmtime.BUILD": "4b55deaf51f5b8be25fc3592f9bcf3d732f99632cd793c685436ddca9a177534",
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5476,7 +5476,7 @@
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//bazel/thirdparty/Cargo.lock": "931fa1bc55d0e5d2e5b6d96da399569a4c2254a4bb1d99c98f71bb4b98eead73",
           "@@//bazel/thirdparty/Cargo.toml": "cb23768a6e7edc8f97215921e956f5be06521ad93cc0ecf64a932e3a8caada54",
-          "@@//MODULE.bazel": "cf4d49ac4dede421671500f888514d4aaac7d6f7e4c5517f262d8766e20039d2",
+          "@@//MODULE.bazel": "12a46b2c8deb9f667e461d551a99be188edec80636f92b4a067b8b9ca9ffb77f",
           "@@//bazel/thirdparty/wasmtime.BUILD": "4b55deaf51f5b8be25fc3592f9bcf3d732f99632cd793c685436ddca9a177534",
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },

--- a/src/go/rpk/cmd/rpk/BUILD
+++ b/src/go/rpk/cmd/rpk/BUILD
@@ -12,4 +12,10 @@ go_binary(
     name = "rpk",
     embed = [":rpk_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version": "{STABLE_GIT_LATEST_TAG}",
+        "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev": "{STABLE_GIT_COMMIT}",
+        "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime": "{FORMATTED_DATE}",
+        "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag": "{STABLE_GIT_LATEST_TAG}",
+    },
 )


### PR DESCRIPTION
- **bazel: upgrade golang compiler version**
- **bazel: set x_defs for RPK**
- **bazel: support building rpk with microsoft's fips enabled compiler**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
