### PR TITLE
crash_tracker: fix helper for clang-20

### DIFF
--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -25,8 +25,11 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/util/print_safe.hh>
 
+#include <fmt/core.h>
+
 #include <chrono>
 #include <filesystem>
+#include <iterator>
 #include <string_view>
 
 using namespace std::chrono_literals;
@@ -155,32 +158,40 @@ ss::future<> recorder::start() {
 
 namespace {
 
+template<typename OutputIt, typename... Args>
+void format_to_safe(
+  OutputIt& it,
+  size_t& remaining,
+  fmt::format_string<Args...> fmt,
+  Args&&... args) {
+    if (remaining == 0) {
+        return; // Prevent buffer overflow
+    }
+
+    auto result = fmt::format_to_n(
+      it, remaining, fmt, std::forward<Args>(args)...);
+    size_t bytes_written = std::distance(it, result.out);
+
+    it = result.out;
+    remaining -= std::min(remaining, bytes_written);
+}
+
 void record_backtrace(crash_description& cd) {
-    size_t pos = 0;
-    auto printer = [&pos, &cd](auto fmt, auto&&... args) {
-        if (pos >= cd.stacktrace.capacity()) {
-            return; // Prevent buffer overflow
-        }
+    auto it = cd.stacktrace.begin();
+    auto remaining = cd.stacktrace.capacity();
+    auto first = true;
 
-        auto result = fmt::format_to_n(
-          cd.stacktrace.begin() + pos,
-          cd.stacktrace.capacity() - pos,
-          fmt,
-          std::forward<decltype(args)...>(args)...);
-        pos = std::min(pos + result.size, cd.stacktrace.capacity());
-    };
-
-    ss::backtrace([&pos, &printer](ss::frame f) {
-        const bool first = pos == 0;
+    ss::backtrace([&it, &remaining, &first](ss::frame f) {
         if (!first) {
-            printer(FMT_STRING(" "), " ");
+            format_to_safe(it, remaining, " ");
         }
+        first = false;
 
         if (!f.so->name.empty()) {
-            printer(FMT_STRING("{}+"), f.so->name.c_str());
+            format_to_safe(it, remaining, "{}+", f.so->name.c_str());
         }
 
-        printer(FMT_STRING("{:#x}"), f.addr);
+        format_to_safe(it, remaining, "{:#x}", f.addr);
     });
 }
 

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -10,6 +10,7 @@
 
 #include "config/node_config.h"
 #include "crash_tracker/recorder.h"
+#include "crash_tracker/types.h"
 #include "test_utils/tmp_dir.h"
 
 #include <seastar/core/memory.hh>
@@ -62,6 +63,23 @@ TEST_F(RecorderTest, TestFileCleanup) {
 
     crashes = rec.get_recorded_crashes().get();
     ASSERT_EQ(crashes.size(), recorder::crash_files_to_keep);
+}
+
+TEST_F(RecorderTest, TestLargeException) {
+    auto large_exception_msg = ss::sstring(5000, 'E');
+    const auto test_eptr = std::make_exception_ptr(
+      std::runtime_error{large_exception_msg});
+
+    auto rec = get_test_recorder();
+    rec.start().get();
+    rec.record_crash_exception(test_eptr);
+
+    auto crashes = get_test_recorder().get_recorded_crashes().get();
+    ASSERT_EQ(crashes.size(), 1);
+    ASSERT_TRUE(crashes[0].crash.has_value());
+    ASSERT_EQ(
+      crashes[0].crash->crash_message.length(),
+      crash_description::string_buffer_reserve);
 }
 
 TEST_F(RecorderTest, TestUploadMarkers) {


### PR DESCRIPTION
This makes the printer helper a templated function instead of a lambda
with auto parameters. This fixes compilation errors when compiling with
clang-20.

I couldn't figure out exactly why clang was complaining, but I suspect it got confused trying to deduce the constexpr-ness of the parameters of the lambda function. This lambda was too much magic anyway, so I think it makes sense to pull it out into a templated function that is both easier to reason about and compiles with clang-20.

Relates to: https://github.com/redpanda-data/redpanda/pull/25246#issuecomment-2699605374

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
