### PR TITLE
`storage`: perform `gc()` every `log_compaction_interval_ms`

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -306,11 +306,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         }
     }
 
-    // If there are no partitions to compact, return early
-    if (compaction_heuristic_to_log_metas.empty()) {
-        co_return;
-    }
-
     for (const auto& [weight, log_metas] : compaction_heuristic_to_log_metas) {
         for (auto* meta_ptr : log_metas) {
             meta_ptr->link.unlink();
@@ -332,6 +327,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         current_log.flags |= bflags::compaction_checked;
 
         if (is_not_set(current_log.flags, bflags::should_compact)) {
+            // Still perform gc() here on a regular `log_compaction_interval_ms`
+            // basis.
+            co_await current_log.handle->gc(
+              gc_config(collection_threshold, _config.retention_bytes()));
             continue;
         }
 


### PR DESCRIPTION
Recent changes to `log_manager` housekeeping scheduling using the dirty ratio had the side effect that we would no longer perform regular garbage collection of logs every `log_compaction_interval_ms`.

This regression in behavior was unintended, and likely undesirable.

Revert to the previous behavior by calling `current_log.handle->gc()` before continuing in `housekeeping_scan()` in the case that `bflags::should_compact` is not set for a log.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
