### PR TITLE
bazel/packaging: rename binaries

### DIFF
--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -1,0 +1,28 @@
+---
+name: lint-bazel-pkg-tool
+on:
+  push:
+    branches: [dev]
+    paths:
+      - '.github/workflows/lint-bazel-pkg-tool.yml'
+      - 'bazel/packaging/tool.go'
+    tags-ignore:
+      - '**'
+  pull_request:
+    paths:
+      - '.github/workflows/lint-bazel-pkg-tool.yml'
+      - 'bazel/packaging/tool.go'
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout 10m --verbose tool.go
+          working-directory: bazel/packaging

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -113,8 +113,8 @@ func createTarball(cfg pkgConfig, w io.Writer) error {
 		"rp_util":       cfg.RPUtil,
 		"rpk":           cfg.RPKBinary,
 		"iotune":        cfg.IOTune,
-		"hwloc_calc":    cfg.HWLocCalc,
-		"hwloc_distrib": cfg.HWLocDistrib,
+		"hwloc-calc":    cfg.HWLocCalc,
+		"hwloc-distrib": cfg.HWLocDistrib,
 		"openssl":       cfg.OpenSSL,
 	} {
 		if binary != nil {
@@ -207,8 +207,8 @@ func createPackageDir(cfg pkgConfig, output string) error {
 		"rp_util":       cfg.RPUtil,
 		"rpk":           cfg.RPKBinary,
 		"iotune":        cfg.IOTune,
-		"hwloc_calc":    cfg.HWLocCalc,
-		"hwloc_distrib": cfg.HWLocDistrib,
+		"hwloc-calc":    cfg.HWLocCalc,
+		"hwloc-distrib": cfg.HWLocDistrib,
 		"openssl":       cfg.OpenSSL,
 	} {
 		if binary == nil {

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -150,7 +150,10 @@ func copyFile(src string, dst string) error {
 		return err
 	}
 	defer dstFile.Close()
-	dstFile.ReadFrom(srcFile)
+	_, err = dstFile.ReadFrom(srcFile)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -217,8 +220,12 @@ func createPackageDir(cfg pkgConfig, output string) error {
 	}
 
 	if cfg.Fips != nil {
-		file(cfg.Fips.Module, "fips", "fips.so")
-		file(cfg.Fips.Config, "fips", "fipsmodule.cnf")
+		if err := file(cfg.Fips.Module, "fips", "fips.so"); err != nil {
+			return err
+		}
+		if err := file(cfg.Fips.Config, "fips", "fipsmodule.cnf"); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Rename `hwloc` binaries created by bazel to match cmake. Also added gha workflow to lint go code.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none