### PR TITLE
iceberg/rest_client: catch exception in retry() attempt

### DIFF
--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -129,6 +129,7 @@ redpanda_cc_library(
         "//src/v/iceberg:table_requests",
         "//src/v/iceberg:table_requests_json",
         "//src/v/json",
+        "//src/v/ssx:future_util",
         "//src/v/utils:named_type",
         "//src/v/utils:retry_chain_node",
         "@abseil-cpp//absl/strings",

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -22,6 +22,7 @@
 #include "iceberg/rest_client/json.h"
 #include "iceberg/table_requests_json.h"
 #include "json/istreamwrapper.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -198,7 +199,27 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
     std::vector<http_call_error> retriable_errors{};
 
     while (true) {
-        const auto permit = rtc.retry();
+        retry_permit permit{};
+        try {
+            permit = rtc.retry();
+        } catch (...) {
+            auto ex = std::current_exception();
+            auto msg = fmt::format("{}", ex);
+            bool is_shutdown = ssx::is_shutdown_exception(ex);
+            vlogl(
+              log,
+              is_shutdown ? ss::log_level::debug : ss::log_level::error,
+              "Exception during catalog request: {}",
+              msg);
+            if (is_shutdown) {
+                co_return tl::unexpected(aborted_error{msg});
+            }
+            // NOTE: we only expect shutdown errors. If that's not the case,
+            // conservatively return a non-aborted error so callers don't think
+            // we're shutting down when we're not.
+            co_return tl::unexpected(
+              retries_exhausted{.errors = std::move(retriable_errors)});
+        }
         if (!permit.is_allowed) {
             co_return tl::unexpected(
               retries_exhausted{.errors = std::move(retriable_errors)});


### PR DESCRIPTION
We previously saw error logs when perfoming Iceberg snapshot removal around shutdown:

```
WARN  2025-03-06 16:50:15,657 [shard 1:main] http - [/iceberg/v1/main/namespaces/redpanda/tables/test~dlq] - client.cc:143 - make_request timed-out connection attempt /iceberg/v1/main/namespaces/redpanda/tables/test~dlq
WARN  2025-03-06 16:50:15,657 [shard 1:main] iceberg - rest_catalog.cc:62 - error returned when executing load_table - http_call_error: Exception during retry sleep: seastar::sleep_aborted (Sleep is aborted)
ERROR 2025-03-06 16:50:15,657 [shard 1:main] datalake - coordinator.cc:125 - Coordinator hit exception while running in term 1: seastar::abort_requested_exception (abort requested)
```

The issue is that the retry_chain_node::retry call checks the abort source. This commit wraps this call with a catch to return an appropriate non-exceptional error type.

Without this, datalake/schema_evolution_test.py was very flaky. With this change it at least appears to run fine locally.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
