### PR TITLE
iceberg: REST client metrics

### DIFF
--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -125,6 +125,7 @@ redpanda_cc_library(
         "//src/v/iceberg:filesystem_catalog",
         "//src/v/iceberg:rest_catalog",
         "//src/v/iceberg/rest_client:client",
+        "//src/v/iceberg/rest_client:client_probe",
         "//src/v/net",
         "//src/v/thirdparty/ada",
         "@abseil-cpp//absl/strings",

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -16,6 +16,7 @@
 #include "iceberg/filesystem_catalog.h"
 #include "iceberg/rest_catalog.h"
 #include "iceberg/rest_client/catalog_client.h"
+#include "iceberg/rest_client/client_probe.h"
 #include "net/tls.h"
 #include "net/tls_certificate_probe.h"
 #include "thirdparty/ada/ada.h"
@@ -135,8 +136,14 @@ filesystem_catalog_factory::create_catalog() {
       *remote_, bucket_, config_->iceberg_catalog_base_location());
 }
 
-rest_catalog_factory::rest_catalog_factory(config::configuration& config)
-  : config_(&config) {}
+rest_catalog_factory::~rest_catalog_factory() {}
+
+rest_catalog_factory::rest_catalog_factory(
+  config::configuration& config, ss::metrics::label_instance label)
+  : config_(&config)
+  , client_probe_(ss::make_shared<iceberg::rest_client::client_probe>(
+      net::public_metrics_disabled(config.disable_public_metrics()),
+      std::move(label))) {}
 
 rest_catalog_factory::credentials_and_token
 rest_catalog_factory::make_credentials_or_token() {
@@ -182,7 +189,8 @@ rest_catalog_factory::create_catalog() {
     }
     std::unique_ptr<http::abstract_client> http_client
       = static_cast<std::unique_ptr<http::abstract_client>>(
-        std::make_unique<http::client>(std::move(transport_config)));
+        std::make_unique<http::client>(
+          std::move(transport_config), nullptr, client_probe_));
     auto prefix_path
       = config_->iceberg_rest_catalog_prefix()
           ? std::make_optional<iceberg::rest_client::prefix_path>(
@@ -203,13 +211,13 @@ rest_catalog_factory::create_catalog() {
       std::move(http_client),
       config_->iceberg_rest_catalog_endpoint().value(),
       std::move(creds_and_token.credentials),
-      std::move(endpoint_information.base_path),          // base_path
-      std::move(prefix_path),                             // prefix
-      std::nullopt,                                       // api_version
-      std::move(creds_and_token.token),                   // token
-      nullptr,                                            // retry_policy
-      config_->iceberg_rest_catalog_authentication_mode() // auth_mode
-    );
+      std::move(endpoint_information.base_path),           // base_path
+      std::move(prefix_path),                              // prefix
+      std::nullopt,                                        // api_version
+      std::move(creds_and_token.token),                    // token
+      nullptr,                                             // retry_policy
+      config_->iceberg_rest_catalog_authentication_mode(), // auth_mode
+      client_probe_);
 
     co_return std::make_unique<iceberg::rest_catalog>(
       std::move(client),
@@ -219,14 +227,15 @@ rest_catalog_factory::create_catalog() {
 std::unique_ptr<catalog_factory> get_catalog_factory(
   config::configuration& config,
   cloud_io::remote& remote,
-  const cloud_storage_clients::bucket_name& bucket) {
+  const cloud_storage_clients::bucket_name& bucket,
+  ss::metrics::label_instance label) {
     if (
       config.iceberg_catalog_type()
       == config::datalake_catalog_type::object_storage) {
         return std::make_unique<filesystem_catalog_factory>(
           config, remote, bucket);
     } else {
-        return std::make_unique<rest_catalog_factory>(config);
+        return std::make_unique<rest_catalog_factory>(config, std::move(label));
     }
 }
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/catalog_factory.h
+++ b/src/v/datalake/coordinator/catalog_factory.h
@@ -17,6 +17,9 @@ class catalog;
 class filesystem_catalog;
 class rest_catalog;
 } // namespace iceberg
+namespace iceberg::rest_client {
+class client_probe;
+} // namespace iceberg::rest_client
 
 namespace datalake::coordinator {
 
@@ -31,7 +34,9 @@ public:
  */
 class rest_catalog_factory : public catalog_factory {
 public:
-    explicit rest_catalog_factory(config::configuration& config);
+    explicit rest_catalog_factory(
+      config::configuration& config, ss::metrics::label_instance);
+    ~rest_catalog_factory() override;
 
     ss::future<std::unique_ptr<iceberg::catalog>> create_catalog() final;
 
@@ -45,6 +50,7 @@ private:
     credentials_and_token make_credentials_or_token();
 
     config::configuration* config_;
+    ss::shared_ptr<iceberg::rest_client::client_probe> client_probe_;
 };
 /**
  * Filesystem catalog factory, the will use provided cloud_io::remote and bucket
@@ -67,10 +73,13 @@ private:
 
 /**
  * Returns a catalog factory based on the configuration provided.
+ * The given metrics label instance should distinguish metrics from different
+ * instances of catalog factory instances.
  */
 std::unique_ptr<catalog_factory> get_catalog_factory(
   config::configuration& config,
   cloud_io::remote& remote,
-  const cloud_storage_clients::bucket_name& bucket);
+  const cloud_storage_clients::bucket_name& bucket,
+  ss::metrics::label_instance label);
 
 } // namespace datalake::coordinator

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -93,6 +93,7 @@ v_cc_library(
     rest_client/catalog_client.cc
     rest_client/entities.cc
     rest_client/error.cc
+    rest_client/client_probe.cc
   DEPS
     Avro::avro
     v::bytes

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -3,6 +3,23 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/iceberg:__subpackages__"])
 
 redpanda_cc_library(
+    name = "client_probe",
+    srcs = [
+        "client_probe.cc",
+    ],
+    hdrs = [
+        "client_probe.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/http",
+        "//src/v/metrics",
+        "//src/v/net",
+    ],
+)
+
+redpanda_cc_library(
     name = "error",
     srcs = [
         "error.cc",

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -125,6 +125,7 @@ redpanda_cc_library(
     include_prefix = "iceberg/rest_client",
     visibility = ["//visibility:public"],
     deps = [
+        ":client_probe",
         ":credentials",
         ":entities",
         ":error",

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -207,6 +207,9 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
     while (true) {
         const auto permit = rtc.retry();
         if (!permit.is_allowed) {
+            if (!retriable_errors.empty() && _probe) {
+                _probe->register_timeout();
+            }
             co_return tl::unexpected(
               retries_exhausted{.errors = std::move(retriable_errors)});
         }

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -136,7 +136,11 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
       // to the catalog client
       {"scope", "PRINCIPAL_ROLE:ALL"},
     });
-    co_return (co_await perform_request(rtc, token_request, std::move(payload)))
+    co_return (co_await perform_request(
+                 rtc,
+                 token_request,
+                 client_probe::endpoint::oauth_token,
+                 std::move(payload)))
       .and_then(parse_json)
       .and_then(parse_as_expected("oauth_token", parse_oauth_token));
 }
@@ -192,6 +196,7 @@ ss::future<expected<std::monostate>> catalog_client::maybe_add_bearer_auth(
 ss::future<expected<iobuf>> catalog_client::perform_request(
   retry_chain_node& rtc,
   http::request_builder request_builder,
+  client_probe::endpoint endpoint,
   std::optional<iobuf> payload) {
     if (payload.has_value()) {
         request_builder.with_content_length(payload.value().size_bytes());
@@ -210,6 +215,9 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
             co_return tl::unexpected(request.error());
         }
 
+        if (_probe) {
+            _probe->register_request(endpoint);
+        }
         auto response_f = co_await ss::coroutine::as_future(
           _http_client->request_and_collect_response(
             std::move(request.value()),
@@ -226,6 +234,11 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         if (error.aborted) {
             co_return tl::unexpected(
               aborted_error{"Shutting down while evaluating retry"});
+        }
+        if (_probe) {
+            // NOTE: aborted, above, implies Redpanda itself is shutting down,
+            // so don't count them towards failed requests.
+            _probe->register_failed_request(endpoint);
         }
         if (!error.can_be_retried) {
             co_return tl::unexpected(std::move(error.err));
@@ -255,7 +268,10 @@ catalog_client::create_namespace(
     }
 
     co_return (co_await perform_request(
-                 rtc, http_request, serialize_payload_as_json(req)))
+                 rtc,
+                 http_request,
+                 client_probe::endpoint::create_namespace,
+                 serialize_payload_as_json(req)))
       .and_then(parse_json)
       .and_then(
         parse_as_expected("create_namespace", parse_create_namespace_response));
@@ -274,7 +290,10 @@ ss::future<expected<load_table_result>> catalog_client::create_table(
     }
 
     co_return (co_await perform_request(
-                 rtc, http_request, serialize_payload_as_json(req)))
+                 rtc,
+                 http_request,
+                 client_probe::endpoint::create_table,
+                 serialize_payload_as_json(req)))
       .and_then(parse_json)
       .and_then(parse_as_expected("create_table", parse_load_table_result));
 }
@@ -290,7 +309,8 @@ ss::future<expected<load_table_result>> catalog_client::load_table(
         co_return tl::unexpected(auth_result.error());
     }
 
-    co_return (co_await perform_request(rtc, http_request))
+    co_return (co_await perform_request(
+                 rtc, http_request, client_probe::endpoint::load_table))
       .and_then(parse_json)
       .and_then(parse_as_expected("load_table", parse_load_table_result));
 }
@@ -314,10 +334,12 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
         co_return tl::unexpected(auth_result.error());
     }
 
-    co_return (co_await perform_request(rtc, http_request)).map([](iobuf&&) {
-        // we expect empty response, discard it
-        return std::monostate{};
-    });
+    co_return (co_await perform_request(
+                 rtc, http_request, client_probe::endpoint::drop_table))
+      .map([](iobuf&&) {
+          // we expect empty response, discard it
+          return std::monostate{};
+      });
 }
 
 ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
@@ -332,7 +354,10 @@ ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
     }
 
     co_return (co_await perform_request(
-                 rtc, http_request, serialize_payload_as_json(commit_request)))
+                 rtc,
+                 http_request,
+                 client_probe::endpoint::commit_table_update,
+                 serialize_payload_as_json(commit_request)))
       .and_then(parse_json)
       .and_then(
         parse_as_expected("commit_table_update", parse_commit_table_response));

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -98,14 +98,16 @@ catalog_client::catalog_client(
   std::optional<api_version> api_version,
   std::optional<oauth_token> token,
   std::unique_ptr<retry_policy> retry_policy,
-  config::datalake_catalog_auth_mode auth_mode)
+  config::datalake_catalog_auth_mode auth_mode,
+  ss::shared_ptr<client_probe> probe)
   : _http_client(std::move(http_client))
   , _endpoint{std::move(endpoint)}
   , _credentials{std::move(credentials)}
   , _path_components{std::move(base_path), std::move(prefix), std::move(api_version)}
   , _oauth_token{std::move(token)}
   , _retry_policy{retry_policy ? std::move(retry_policy) : std::make_unique<default_retry_policy>()}
-  , _auth_mode(auth_mode) {}
+  , _auth_mode(auth_mode)
+  , _probe(std::move(probe)) {}
 
 ss::future<expected<oauth_token>>
 catalog_client::acquire_token(retry_chain_node& rtc) {

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -14,6 +14,7 @@
 #include "config/types.h"
 #include "http/client.h"
 #include "http/request_builder.h"
+#include "iceberg/rest_client/client_probe.h"
 #include "iceberg/rest_client/credentials.h"
 #include "iceberg/rest_client/error.h"
 #include "iceberg/rest_client/oauth_token.h"
@@ -93,7 +94,8 @@ public:
       std::optional<oauth_token> token = std::nullopt,
       std::unique_ptr<retry_policy> retry_policy = nullptr,
       config::datalake_catalog_auth_mode auth_mode
-      = config::datalake_catalog_auth_mode::none);
+      = config::datalake_catalog_auth_mode::none,
+      ss::shared_ptr<client_probe> probe = nullptr);
     /**
      * The REST client allows interaction with Iceberg REST catalog implementing
      * the Iceberg Catalog OpenApi Specification as stated here:
@@ -194,6 +196,7 @@ private:
     std::optional<oauth_token> _oauth_token{std::nullopt};
     std::unique_ptr<retry_policy> _retry_policy;
     config::datalake_catalog_auth_mode _auth_mode;
+    ss::shared_ptr<client_probe> _probe;
 
     friend class catalog_client_tester;
 };

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -187,6 +187,7 @@ private:
     ss::future<expected<iobuf>> perform_request(
       retry_chain_node& rtc,
       http::request_builder request_builder,
+      client_probe::endpoint endpoint,
       std::optional<iobuf> payload = std::nullopt);
 
     std::unique_ptr<http::abstract_client> _http_client;

--- a/src/v/iceberg/rest_client/client_probe.cc
+++ b/src/v/iceberg/rest_client/client_probe.cc
@@ -97,6 +97,14 @@ void client_probe::setup_public_metrics(
           labels)
           .aggregate({sm::shard_label}),
         sm::make_counter(
+          "num_request_timeouts",
+          [this] { return num_request_timeouts; },
+          sm::description(
+            "Total number of catalog requests that could no longer be retried "
+            "because they timed out. This may occur if the catalog is down"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
           "num_oauth_token_requests",
           [this] { return num_oauth_token_requests; },
           sm::description(

--- a/src/v/iceberg/rest_client/client_probe.cc
+++ b/src/v/iceberg/rest_client/client_probe.cc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "iceberg/rest_client/client_probe.h"
+
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+namespace iceberg::rest_client {
+
+namespace {
+const auto group_name = prometheus_sanitize::metrics_name(
+  "iceberg:rest_client");
+} // namespace
+
+client_probe::client_probe(
+  net::public_metrics_disabled public_disable,
+  ss::metrics::label_instance label)
+  : http::client_probe() {
+    setup_public_metrics(public_disable, std::move(label));
+}
+
+void client_probe::setup_public_metrics(
+  net::public_metrics_disabled disable, ss::metrics::label_instance label) {
+    namespace sm = ss::metrics;
+    if (disable) {
+        return;
+    }
+
+    std::vector<sm::label_instance> labels;
+    labels.emplace_back(std::move(label));
+    _public_metrics.add_group(
+      group_name,
+      {
+        sm::make_counter(
+          "total_puts",
+          [this] { return get_total_put_requests(); },
+          sm::description("Number of completed PUT requests"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "total_gets",
+          [this] { return get_total_get_requests(); },
+          sm::description("Number of completed GET requests"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "total_requests",
+          [this] { return get_total_requests(); },
+          sm::description(
+            "Number of completed HTTP requests (includes PUT and GET)"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "active_puts",
+          [this] { return get_active_put_requests(); },
+          sm::description("Number of active PUT requests at the moment"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "active_gets",
+          [this] { return get_active_get_requests(); },
+          sm::description("Number of active GET requests at the moment"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "active_requests",
+          [this] { return get_active_requests(); },
+          sm::description("Number of active HTTP requests at the moment "
+                          "(includes PUT and GET)"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "total_inbound_bytes",
+          [this] { return get_inbound_bytes(); },
+          sm::description(
+            "Total number of bytes received from the Iceberg REST catalog"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "total_outbound_bytes",
+          [this] { return get_outbound_bytes(); },
+          sm::description(
+            "Total number of bytes sent to the Iceberg REST catalog"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_transport_errors",
+          [this] { return get_transport_errors(); },
+          sm::description("Total number of transport errors (TCP and TLS)"),
+          labels)
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/client_probe.cc
+++ b/src/v/iceberg/rest_client/client_probe.cc
@@ -96,7 +96,138 @@ void client_probe::setup_public_metrics(
           sm::description("Total number of transport errors (TCP and TLS)"),
           labels)
           .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_oauth_token_requests",
+          [this] { return num_oauth_token_requests; },
+          sm::description(
+            "Total number of requests sent to the oauth_token endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_oauth_token_requests_failed",
+          [this] { return num_oauth_token_requests_failed; },
+          sm::description(
+            "Number of requests sent to the oauth_token endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_create_namespace_requests",
+          [this] { return num_create_namespace_requests; },
+          sm::description(
+            "Total number of requests sent to the create_namespace endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_create_namespace_requests_failed",
+          [this] { return num_create_namespace_requests_failed; },
+          sm::description("Number of requests sent to the create_namespace "
+                          "endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_create_table_requests",
+          [this] { return num_create_table_requests; },
+          sm::description(
+            "Total number of requests sent to the create_table endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_create_table_requests_failed",
+          [this] { return num_create_table_requests_failed; },
+          sm::description(
+            "Number of requests sent to the create_table endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_load_table_requests",
+          [this] { return num_load_table_requests; },
+          sm::description(
+            "Total number of requests sent to the load_table endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_load_table_requests_failed",
+          [this] { return num_load_table_requests_failed; },
+          sm::description(
+            "Number of requests sent to the load_table endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_drop_table_requests",
+          [this] { return num_drop_table_requests; },
+          sm::description(
+            "Total number of requests sent to the drop_table endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_drop_table_requests_failed",
+          [this] { return num_drop_table_requests_failed; },
+          sm::description(
+            "Number of requests sent to the drop_table endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_commit_table_update_requests",
+          [this] { return num_commit_table_update_requests; },
+          sm::description("Total number of requests sent to the "
+                          "commit_table_update endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_commit_table_update_requests_failed",
+          [this] { return num_commit_table_update_requests_failed; },
+          sm::description("Number of requests sent to the commit_table_update "
+                          "endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
       });
 }
 
+void client_probe::register_request(endpoint e) {
+    switch (e) {
+        using enum endpoint;
+    case oauth_token:
+        ++num_oauth_token_requests;
+        return;
+    case create_namespace:
+        ++num_create_namespace_requests;
+        return;
+    case create_table:
+        ++num_create_table_requests;
+        return;
+    case load_table:
+        ++num_load_table_requests;
+        return;
+    case drop_table:
+        ++num_drop_table_requests;
+        return;
+    case commit_table_update:
+        ++num_commit_table_update_requests;
+        return;
+    }
+}
+
+void client_probe::register_failed_request(endpoint e) {
+    switch (e) {
+        using enum endpoint;
+    case oauth_token:
+        ++num_oauth_token_requests_failed;
+        return;
+    case create_namespace:
+        ++num_create_namespace_requests_failed;
+        return;
+    case create_table:
+        ++num_create_table_requests_failed;
+        return;
+    case load_table:
+        ++num_load_table_requests_failed;
+        return;
+    case drop_table:
+        ++num_drop_table_requests_failed;
+        return;
+    case commit_table_update:
+        ++num_commit_table_update_requests_failed;
+        return;
+    }
+}
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/client_probe.h
+++ b/src/v/iceberg/rest_client/client_probe.h
@@ -31,12 +31,15 @@ public:
 
     void register_request(endpoint e);
     void register_failed_request(endpoint e);
+    void register_timeout() { ++num_request_timeouts; }
 
 private:
     void setup_public_metrics(
       net::public_metrics_disabled disable, ss::metrics::label_instance);
 
     metrics::public_metric_groups _public_metrics;
+
+    size_t num_request_timeouts{0};
 
     size_t num_oauth_token_requests{0};
     size_t num_oauth_token_requests_failed{0};

--- a/src/v/iceberg/rest_client/client_probe.h
+++ b/src/v/iceberg/rest_client/client_probe.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "http/probe.h"
+#include "metrics/metrics.h"
+#include "net/types.h"
+
+namespace iceberg::rest_client {
+
+class client_probe : public http::client_probe {
+public:
+    client_probe(
+      net::public_metrics_disabled public_disable, ss::metrics::label_instance);
+
+private:
+    void setup_public_metrics(
+      net::public_metrics_disabled disable, ss::metrics::label_instance);
+
+    metrics::internal_metric_groups _public_metrics;
+};
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/client_probe.h
+++ b/src/v/iceberg/rest_client/client_probe.h
@@ -18,14 +18,43 @@ namespace iceberg::rest_client {
 
 class client_probe : public http::client_probe {
 public:
+    enum class endpoint {
+        oauth_token,
+        create_namespace,
+        create_table,
+        load_table,
+        drop_table,
+        commit_table_update,
+    };
     client_probe(
       net::public_metrics_disabled public_disable, ss::metrics::label_instance);
+
+    void register_request(endpoint e);
+    void register_failed_request(endpoint e);
 
 private:
     void setup_public_metrics(
       net::public_metrics_disabled disable, ss::metrics::label_instance);
 
-    metrics::internal_metric_groups _public_metrics;
+    metrics::public_metric_groups _public_metrics;
+
+    size_t num_oauth_token_requests{0};
+    size_t num_oauth_token_requests_failed{0};
+
+    size_t num_create_namespace_requests{0};
+    size_t num_create_namespace_requests_failed{0};
+
+    size_t num_create_table_requests{0};
+    size_t num_create_table_requests_failed{0};
+
+    size_t num_load_table_requests{0};
+    size_t num_load_table_requests_failed{0};
+
+    size_t num_drop_table_requests{0};
+    size_t num_drop_table_requests_failed{0};
+
+    size_t num_commit_table_update_requests{0};
+    size_t num_commit_table_update_requests_failed{0};
 };
 
 } // namespace iceberg::rest_client

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1347,7 +1347,10 @@ void application::wire_up_runtime_services(
             [bucket](cloud_io::remote& remote)
               -> std::unique_ptr<datalake::coordinator::catalog_factory> {
                 return datalake::coordinator::get_catalog_factory(
-                  config::shard_local_cfg(), remote, *bucket);
+                  config::shard_local_cfg(),
+                  remote,
+                  *bucket,
+                  ss::metrics::label_instance{"role", "coordinator"});
             },
             std::ref(cloud_io)),
           std::ref(cloud_io),
@@ -1382,7 +1385,10 @@ void application::wire_up_runtime_services(
             [bucket](cloud_io::remote& remote)
               -> std::unique_ptr<datalake::coordinator::catalog_factory> {
                 return datalake::coordinator::get_catalog_factory(
-                  config::shard_local_cfg(), remote, *bucket);
+                  config::shard_local_cfg(),
+                  remote,
+                  *bucket,
+                  ss::metrics::label_instance{"role", "translator"});
             },
             std::ref(cloud_io)),
           _schema_registry.get(),

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -13,7 +13,7 @@ from random import randint
 
 from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
-from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings
+from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings, MetricsEndpoint
 from rptest.services.redpanda import CloudStorageType, SISettings
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.datalake_services import DatalakeServices
@@ -417,3 +417,68 @@ class DatalakeMetricsTest(RedpandaTest):
                               DatalakeMetricsTest.commit_lag,
                               0,
                               timeout_sec=45)
+
+    @cluster(num_nodes=5)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_rest_catalog_metrics(self, cloud_storage_type):
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[],
+                              catalog_type=CatalogType.REST_JDBC) as dl:
+            commit_table_metric = "redpanda_iceberg_rest_client_num_commit_table_update_requests_total"
+            create_table_metric = "redpanda_iceberg_rest_client_num_create_table_requests_total"
+            load_table_metric = "redpanda_iceberg_rest_client_num_load_table_requests_total"
+            drop_table_metric = "redpanda_iceberg_rest_client_num_drop_table_requests_total"
+            timeouts_metric = "redpanda_iceberg_rest_client_num_request_timeouts_total"
+
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            partitions=1,
+                                            replicas=3)
+            dl.produce_to_topic(self.topic_name, 1024, 10)
+
+            # Wait until we have committed to the table -- this implies several
+            # other metrics should be ticked as well.
+            wait_until(lambda: self.redpanda.metric_sum(
+                commit_table_metric, MetricsEndpoint.PUBLIC_METRICS) > 0,
+                       timeout_sec=30,
+                       backoff_sec=1)
+
+            create_metric_val = self.redpanda.metric_sum(
+                create_table_metric, MetricsEndpoint.PUBLIC_METRICS)
+            assert create_metric_val > 0, f"Expected >0 for {create_table_metric}: {create_metric_val}"
+
+            load_metric_val = self.redpanda.metric_sum(
+                load_table_metric, MetricsEndpoint.PUBLIC_METRICS)
+            assert load_metric_val > 0, f"Expected >0 for {load_table_metric}: {load_metric_val}"
+
+            # The metric for dropped tables should not show up until we drop
+            # the topic.
+            drop_metric_val = self.redpanda.metric_sum(
+                drop_table_metric, MetricsEndpoint.PUBLIC_METRICS)
+            assert drop_metric_val == 0, f"Expected ==0 for {drop_table_metric}: {drop_metric_val}"
+
+            rpk = RpkTool(self.redpanda)
+            rpk.delete_topic(self.topic_name)
+
+            wait_until(lambda: self.redpanda.metric_sum(
+                drop_table_metric, MetricsEndpoint.PUBLIC_METRICS) > 0,
+                       timeout_sec=30,
+                       backoff_sec=1)
+
+            # Stop the catalog to halt the translation flow
+            dl.catalog_service.stop()
+
+            # Our topic is deleted, so we shouldn't see any errors until we
+            # start producing again.
+            timeouts_metric_val = self.redpanda.metric_sum(
+                timeouts_metric, MetricsEndpoint.PUBLIC_METRICS)
+            assert timeouts_metric_val == 0, f"Expected ==0 for {timeouts_metric}: {timeouts_metric_val}"
+
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            partitions=1,
+                                            replicas=3)
+            dl.produce_to_topic(self.topic_name, 1024, 10)
+            wait_until(lambda: self.redpanda.metric_sum(
+                timeouts_metric, MetricsEndpoint.PUBLIC_METRICS) > 0,
+                       timeout_sec=30,
+                       backoff_sec=1)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR introduces a few REST client metrics that should be useful in debugging issues interacting with REST catalogs.

Metrics introduced are:
- basic HTTP client metrics, included by the existing HTTP client probe
- counts/failures of each request type called
- requests that timed out

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
