### PR TITLE
[bazel] use bazelisk-linux-$TARGETARCH in dockerfile

### DIFF
--- a/tools/docker/bazel.dockerfile
+++ b/tools/docker/bazel.dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE_OS_NAME=fedora
 ARG BASE_IMAGE_OS_VERSION=38
 FROM ${BASE_IMAGE_OS_NAME}:${BASE_IMAGE_OS_VERSION}
+ARG TARGETARCH
 
 COPY --chown=0:0 bazel/install-deps.sh /
 
@@ -9,7 +10,7 @@ RUN dnf install -y wget || { apt-get update && apt install -y wget; }
 # ubuntu already has this installed by default
 RUN dnf install -y procps-ng || true
 RUN wget -O /usr/local/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
+        https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${TARGETARCH} && \
         chmod +x /usr/local/bin/bazel
 
 # run after wget installation to take advantage of pkg cache cleaning


### PR DESCRIPTION
Further fixes for [DEVPROD-2622] (no longer always installs amd64 version of bazelisk in bazel.dockerfile).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[DEVPROD-2622]: https://redpandadata.atlassian.net/browse/DEVPROD-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ