### PR TITLE
k/topic_utils: do not iterate over the assignments set

### DIFF
--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -20,6 +20,8 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
 
+#include <ranges>
+
 namespace kafka {
 
 void append_cluster_results(
@@ -48,13 +50,17 @@ ss::future<> wait_for_leaders(
             // topic already deleted
             continue;
         }
+        /**
+         * Partition space is contiguous, use integer range to iterate over all
+         * topic partitions.
+         */
+        int32_t partition_count = md->get().get_assignments().size();
         co_await ss::max_concurrent_for_each(
-          md->get().get_assignments(),
+          std::views::iota(0, partition_count),
           64,
-          [&r, &md_cache, deadline](const auto& p_as) {
+          [&r, &md_cache, deadline](int32_t p_id) {
               return md_cache
-                .get_leader(
-                  model::ntp(r.tp_ns.ns, r.tp_ns.tp, p_as.second.id), deadline)
+                .get_leader(model::ntp(r.tp_ns.ns, r.tp_ns.tp, p_id), deadline)
                 .discard_result();
           });
     }


### PR DESCRIPTION
When iterating with `ss::max_concurrent_for_each` over the assignment set it may happen the assignment is removed. In this case a loop will cause Use-After-Free error. Fixed the issue by iterating over the range of integers. This is possible as the partition ids range is always contiguous.

Fixes: CORE-9327

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none