### PR TITLE
iceberg/filesystem_catalog: create table with initialized snapshots

### DIFF
--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -228,7 +228,8 @@ TEST_F(FileCommitterTest, TestMissingTable) {
     load_res = catalog.load_table(table_ident).get();
     // The table should be created.
     ASSERT_FALSE(load_res.has_error());
-    ASSERT_FALSE(load_res.value().snapshots.has_value());
+    ASSERT_TRUE(load_res.value().snapshots.has_value());
+    ASSERT_EQ(0, load_res.value().snapshots->size());
 
     // Now try again with some data.
     state.topic_to_state[topic] = make_topic_state({{{0, 100}}});

--- a/src/v/iceberg/filesystem_catalog.cc
+++ b/src/v/iceberg/filesystem_catalog.cc
@@ -78,6 +78,7 @@ filesystem_catalog::create_table(
       .partition_specs = std::move(specs),
       .default_spec_id = partition_spec::id_t{0},
       .last_partition_id = highest_pid,
+      .snapshots = chunked_vector<snapshot>{},
       .sort_orders = std::move(sort_orders),
       .default_sort_order_id = sort_order::id_t{0},
     };


### PR DESCRIPTION
We've seen that some query engines (e.g. BigQuery) don't handle a missing 'snapshots' fields gracefully, despite it being optional in the spec. While we generally try to avoid special handling for specific engines, unconditionally serializing an empty list by default seems cheap enough to warrant just doing it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
