### PR TITLE
rptest: update test parametrization to have stable test ids

### DIFF
--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -481,10 +481,12 @@ class DataTransformsTest(BaseDataTransformsTest):
     @matrix(offset=[
         "+0",
         "-1",
-        f"@{int(time.time() * 1000)}",
+        "__current_time__",
         "+9223372036854775807",  # int64_max - should clamp to start at latest
     ])
     def test_consume_from_offset(self, offset):
+        if offset == "__current_time__":
+            offset = f"@{int(time.time() * 1000)}"
         '''
         Verify that offset-delta based and timestamp based consumption works as expected.
         That is, records produced prior to deployment should still be accessible given an
@@ -533,12 +535,14 @@ class DataTransformsTest(BaseDataTransformsTest):
         "@9223372036854775807",  # int64_max (out of range for millis)
         "+NaN",  # lexical cast error (literal NaN)
         "-9223372036854775808",  # lexical cast error (int64 overflow)
-        f"@{time.time() * 1000}",  # lexical cast error (float value)
+        "__current_time__",
         "@-10",  # illegal negative value
         "--10",  # illegal negative value
         "+-10",  # illegal negative value
     ])
     def test_consume_junk_off(self, offset):
+        if offset == "__current_time__":
+            offset = f"@{time.time() * 1000}"  # lexical cast error (float value)
         '''
         Tests for junk data. Deployment should fail cleanly in the admin API or rpk.
         '''


### PR DESCRIPTION
Parametrization is used for generating test ids. It is better for these to be stable across different invocations so that we can build reports on pass rate, duration either via buildkite or adhoc using our own test results database.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
