### PR TITLE
rpk: add cloud_environment to profile

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin_test.go
+++ b/src/go/rpk/pkg/adminapi/admin_test.go
@@ -137,7 +137,7 @@ func writeRpkProfileToFs(t *testing.T, fs afero.Fs, p *config.RpkProfile) *confi
 	p.Name = "test"
 	rpkyaml := config.RpkYaml{
 		CurrentProfile: "test",
-		Version:        6,
+		Version:        7,
 		Profiles:       []config.RpkProfile{*p},
 	}
 	err := rpkyaml.Write(fs)

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -71,6 +71,7 @@ const (
 	xAdminClientKey            = "admin.tls.key"
 	xCloudClientID             = "cloud.client_id"
 	xCloudClientSecret         = "cloud.client_secret"
+	xCloudEnvironment          = "cloud_environment"
 	xSchemaRegistryHosts       = "registry.hosts"
 	xSchemaRegistryTLSEnabled  = "registry.tls.enabled"
 	xSchemaRegistryTLSInsecure = "registry.tls.insecure_skip_verify"
@@ -85,7 +86,7 @@ const (
 	xkindGlobal           // configuration for rpk.yaml globals
 )
 
-const currentRpkYAMLVersion = 6
+const currentRpkYAMLVersion = 7
 
 type xflag struct {
 	path        string
@@ -389,6 +390,27 @@ var xflags = map[string]xflag{
 			return nil
 		},
 	},
+	xCloudEnvironment: {
+		"cloud_environment",
+		"production", // We don't want to document the values.
+		xkindProfile,
+		func(v string, y *RpkYaml) error {
+			p := y.Profile(y.CurrentProfile)
+			if p != nil {
+				switch strings.ToLower(v) {
+				case "integration", "ign":
+					p.CloudEnvironment = CloudEnvironmentIntegration
+				case "preprod", "ppd":
+					p.CloudEnvironment = CloudEnvironmentPreprod
+				case "production", "prod":
+					// Do nothing. Production is the default.
+				default:
+					return fmt.Errorf("invalid cloud environment %q", v)
+				}
+			}
+			return nil // TODO: check for an empty rpk.yaml
+		},
+	},
 
 	"globals.prompt": {
 		"globals.prompt",
@@ -464,6 +486,29 @@ var xflags = map[string]xflag{
 			y.Globals.KafkaProtocolReqClientID = v
 			return nil
 		},
+	},
+}
+
+var cloudEnvConfig = map[string]struct {
+	PublicAPIURL         string
+	CloudAPIURL          string
+	CloudAuthAppClientID string
+	CloudAuthURL         string
+	CloudAuthAudience    string
+}{
+	CloudEnvironmentIntegration: {
+		PublicAPIURL:         "https://api.ign.cloud.redpanda.com",
+		CloudAPIURL:          "https://cloud-api.ign.cloud.redpanda.com",
+		CloudAuthAppClientID: "OQJLrKFCXuCMfGfMfnIqzgiwiyDfoxEV",
+		CloudAuthURL:         "https://integration-cloudv2.us.auth0.com",
+		CloudAuthAudience:    "cloudv2-ign.redpanda.cloud",
+	},
+	CloudEnvironmentPreprod: {
+		PublicAPIURL:         "https://api.ppd.cloud.redpanda.com",
+		CloudAPIURL:          "https://cloud-api.ppd.cloud.redpanda.com",
+		CloudAuthAppClientID: "i6CrcBD8XX719XVeBtf574WSeAEdPjo7",
+		CloudAuthURL:         "https://preprod-cloudv2.us.auth0.com",
+		CloudAuthAudience:    "cloudv2-preprod.redpanda.cloud",
 	},
 }
 
@@ -966,6 +1011,7 @@ func (p *Params) Load(fs afero.Fs) (*Config, error) {
 	c.addUnsetRedpandaDefaults(false) // merge from Virtual redpanda.yaml redpanda section to rpk section (picks up original redpanda.yaml defaults)
 	c.mergeRedpandaIntoRpk()          // merge from redpanda.yaml rpk section back to rpk.yaml, picks up final redpanda.yaml defaults
 	c.fixSchemePorts()                // strip any scheme, default any missing ports
+	c.loadCloudEnvToOverrides()       // load cloud environment to overrides
 	c.parseDevOverrides()
 
 	if !c.rpkYaml.Globals.NoDefaultCluster {
@@ -1717,6 +1763,29 @@ func (c *Config) migrateProfileNamespace() {
 		if c.rpkYamlActual.Profiles[i].CloudCluster.Namespace != "" && c.rpkYamlActual.Profiles[i].CloudCluster.ResourceGroup == "" {
 			c.rpkYamlActual.Profiles[i].CloudCluster.ResourceGroup = c.rpkYamlActual.Profiles[i].CloudCluster.Namespace
 			c.rpkYamlActual.Profiles[i].CloudCluster.Namespace = ""
+		}
+	}
+}
+
+func (c *Config) loadCloudEnvToOverrides() {
+	if p := c.VirtualProfile(); p != nil {
+		if env := p.CloudEnvironment; env != "" {
+			switch env {
+			case "ign", CloudEnvironmentIntegration:
+				env = CloudEnvironmentIntegration
+			case "ppd", CloudEnvironmentPreprod:
+				env = CloudEnvironmentPreprod
+			}
+			if override, ok := cloudEnvConfig[env]; ok {
+				c.devOverrides.PublicAPIURL = override.PublicAPIURL
+				c.devOverrides.CloudAPIURL = override.CloudAPIURL
+				c.devOverrides.CloudAuthAppClientID = override.CloudAuthAppClientID
+				c.devOverrides.CloudAuthURL = override.CloudAuthURL
+				c.devOverrides.CloudAuthAudience = override.CloudAuthAudience
+				// The BYOC plugin uses a different environment var to set the
+				// cloud URL, and it's not part of the overrides.
+				os.Setenv("CLOUD_URL", fmt.Sprintf("%v/api/v1", override.CloudAPIURL))
+			}
 		}
 	}
 }

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -744,7 +744,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 6
+			expVirtualRpk: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -842,7 +842,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			expVirtualRpk: `version: 6
+			expVirtualRpk: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -884,7 +884,7 @@ cloud_auth:
 		// * admin api is defaulted, using kafka broker ip
 		{
 			name: "rpk.yaml exists",
-			rpkYaml: `version: 6
+			rpkYaml: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -944,7 +944,7 @@ rpk:
 pandaproxy: {}
 schema_registry: {}
 `,
-			expVirtualRpk: `version: 6
+			expVirtualRpk: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1008,7 +1008,7 @@ rpk:
     tune_disk_write_cache: true
     tune_disk_irq: true
 `,
-			rpkYaml: `version: 6
+			rpkYaml: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1063,7 +1063,7 @@ rpk:
     tune_disk_irq: true
 `,
 
-			expVirtualRpk: `version: 6
+			expVirtualRpk: `version: 7
 globals:
     prompt: ""
     no_default_cluster: false
@@ -1168,6 +1168,7 @@ func TestConfig_parseDevOverrides(t *testing.T) {
 func TestParamsHelpComplete(t *testing.T) {
 	h := ParamsHelp()
 	m := maps.Clone(xflags)
+	delete(m, xCloudEnvironment) // We leave this out of the list and docs on purpose.
 	for _, line := range strings.Split(h, "\n") {
 		key := strings.Split(line, "=")[0]
 		delete(m, key)
@@ -1180,6 +1181,7 @@ func TestParamsHelpComplete(t *testing.T) {
 func TestParamsListComplete(t *testing.T) {
 	h := ParamsList()
 	m := maps.Clone(xflags)
+	delete(m, xCloudEnvironment) // We leave this out of the list and docs on purpose.
 	for _, line := range strings.Split(h, "\n") {
 		key := strings.Split(line, "=")[0]
 		delete(m, key)

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -37,7 +37,7 @@ func defaultVirtualRpkYaml() (RpkYaml, error) {
 	path, _ := DefaultRpkYamlPath() // if err is non-nil, we fail in Write
 	y := RpkYaml{
 		fileLocation: path,
-		Version:      6,
+		Version:      currentRpkYAMLVersion,
 		Profiles:     []RpkProfile{DefaultRpkProfile()},
 		CloudAuths:   []RpkCloudAuth{DefaultRpkCloudAuth()},
 	}
@@ -68,7 +68,7 @@ func DefaultRpkCloudAuth() RpkCloudAuth {
 
 func emptyVirtualRpkYaml() RpkYaml {
 	return RpkYaml{
-		Version: 6,
+		Version: currentRpkYAMLVersion,
 	}
 }
 
@@ -141,6 +141,10 @@ type (
 		AdminAPI     RpkAdminAPI          `json:"admin_api" yaml:"admin_api"`
 		SR           RpkSchemaRegistryAPI `json:"schema_registry" yaml:"schema_registry"`
 		LicenseCheck *LicenseStatusCache  `json:"license_check,omitempty" yaml:"license_check,omitempty"`
+
+		// This is an internal configuration, not to be documented nor set
+		// as part of the RpkCloudCluster.
+		CloudEnvironment string `json:"cloud_environment,omitempty" yaml:"cloud_environment,omitempty"`
 
 		// We stash the config struct itself so that we can provide
 		// the logger / dev overrides.
@@ -293,10 +297,12 @@ func (y *RpkYaml) CurrentAuth() *RpkCloudAuth {
 }
 
 const (
-	CloudAuthUninitialized     = ""
-	CloudAuthSSO               = "sso"
-	CloudAuthClientCredentials = "client-credentials"
-	ServerlessClusterType      = "TYPE_SERVERLESS" // Configuration setting to identify a serverless cluster.
+	CloudAuthUninitialized      = ""
+	CloudAuthSSO                = "sso"
+	CloudAuthClientCredentials  = "client-credentials"
+	ServerlessClusterType       = "TYPE_SERVERLESS" // Configuration setting to identify a serverless cluster.
+	CloudEnvironmentIntegration = "integration"
+	CloudEnvironmentPreprod     = "preprod"
 )
 
 ///////////

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,7 +25,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		expsha = "f3d394e88ba4a6a668d15b74208f32d71c82f8a0e9b6e6445defcdd64df1e37f" // 24-07-24
+		expsha = "a043498b545452d74638188611ade0b85b41a07d914284aecd2c0f8757a69f70" // 25-03-07
 	)
 
 	if shastr != expsha {

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -137,7 +137,7 @@ func TestLoadFlow(t *testing.T) {
 				hasClientID = true
 			}
 
-			expFile := fmt.Sprintf(`version: 6
+			expFile := fmt.Sprintf(`version: 7
 globals:
     prompt: ""
     no_default_cluster: false


### PR DESCRIPTION
To switch between Redpanda Cloud environments in profiles.

### Example

```
rpk cloud login -X cloud_environment=ign
```

```
RPK_CLOUD_ENVIRONMENT=ign rpk cloud login
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
