### PR TITLE
[v24.2.x] `rptest`: deflake `java_compression_test.py` (Manual backport)

### DIFF
--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -128,6 +128,6 @@ class JavaCompressionTest(EndToEndTest):
         expected_num_segments = 4
         self.produce_until_segment_count(
             expected_num_segments, compression_type=compression_type.value)
-        self.wait_for_compacted_segments(expected_num_segments)
+        self.wait_for_compacted_segments(expected_num_segments - 1)
 
         self.consume()

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -85,15 +85,23 @@ class JavaCompressionTest(EndToEndTest):
                 assert False, f"Failed to consume messages"
 
     def get_compacted_segments(self):
-        return self.redpanda.metric_sum(
+        num_compacted_segments = self.redpanda.metric_sum(
             metric_name="vectorized_storage_log_compacted_segment_total",
             metrics_endpoint=MetricsEndpoint.METRICS,
             topic=self.topic_spec.name)
+        self.redpanda.logger.debug(
+            f"Saw {num_compacted_segments} compacted segments")
+        return num_compacted_segments
 
     def wait_for_compacted_segments(self, num_segments, timeout_sec=120):
-        wait_until(lambda: self.get_compacted_segments() >= num_segments,
-                   timeout_sec=timeout_sec,
-                   err_msg=f"Timed out waiting for compacted segments.")
+        self.redpanda.logger.debug(
+            f"Waiting for {num_segments} compacted segments")
+        wait_until(
+            lambda: self.get_compacted_segments() >= num_segments,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=f"Timed out waiting for {num_segments} compacted segments."
+        )
 
     @cluster(num_nodes=2)
     @matrix(compression_type=[

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -45,16 +45,20 @@ class JavaCompressionTest(EndToEndTest):
                                     count,
                                     compression_type,
                                     timeout_sec=120):
+        # Arbitrarily high key set cardinality
+        key_set_cardinality = 100000
         producer = VerifiableProducer(self.test_context,
                                       num_nodes=1,
                                       redpanda=self.redpanda,
                                       topic=self.topic_spec.name,
-                                      compression_types=[compression_type])
+                                      compression_types=[compression_type],
+                                      repeating_keys=key_set_cardinality)
         producer.start()
         try:
             wait_until(
                 lambda: self.partition_segments() >= count,
                 timeout_sec=timeout_sec,
+                backoff_sec=1,
                 err_msg=
                 f"Timed out waiting for {count} segments to be produced.")
         finally:
@@ -62,7 +66,7 @@ class JavaCompressionTest(EndToEndTest):
             producer.clean()
             producer.free()
 
-    def consume(self, num_messages=100, timeout_sec=120):
+    def consume(self, num_messages=10, timeout_sec=120):
         deadline = time() + timeout_sec
         consumer = KafkaConsumer(self.topic_spec.name,
                                  bootstrap_servers=self.redpanda.brokers(),


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/25227 to deflake ducktape test.

Cherry-pick conflict due to additional changes for test in original PR that is not present in `v24.2.x`.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
