### PR TITLE
CORE-9383 crash_tracker: minor improvements and cleanup

### DIFF
--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -58,7 +58,7 @@ prepared_writer::initialize(std::filesystem::path crash_file_path) {
 
     // Create the crash recorder file
     auto f = co_await ss::open_file_dma(
-      _crash_report_file_name.c_str(),
+      _crash_report_file_name->c_str(),
       ss::open_flags::create | ss::open_flags::rw | ss::open_flags::truncate
         | ss::open_flags::exclusive);
     co_await f.close();
@@ -68,14 +68,14 @@ prepared_writer::initialize(std::filesystem::path crash_file_path) {
     // API or higher-level C++ primitives because we need to be able to
     // manipulate the file using async-signal-safe, allocation-free functions
     // inside signal handlers.
-    _fd = ::open(_crash_report_file_name.c_str(), O_WRONLY);
+    _fd = ::open(_crash_report_file_name->c_str(), O_WRONLY);
     if (_fd == -1) {
         throw std::system_error(
           errno,
           std::system_category(),
           fmt::format(
             "Failed to open {} to record crash reason",
-            _crash_report_file_name));
+            *_crash_report_file_name));
     }
 
     _prepared_cd.app_version = ss::sstring{redpanda_version()};
@@ -183,8 +183,10 @@ ss::future<> prepared_writer::release() {
 
     ::close(_fd);
     _fd = -1;
-    co_await ss::remove_file(_crash_report_file_name.c_str());
-    vlog(ctlog.debug, "Deleted crash report file: {}", _crash_report_file_name);
+    co_await ss::remove_file(_crash_report_file_name->c_str());
+    vlog(
+      ctlog.debug, "Deleted crash report file: {}", *_crash_report_file_name);
+    _crash_report_file_name.reset();
 
     _state = state::released;
 
@@ -199,7 +201,7 @@ void prepared_writer::reset() {
     }
     _state = state::uninitialized;
     _serde_output.clear();
-    _crash_report_file_name.clear();
+    _crash_report_file_name.reset();
     _prepared_cd = crash_description{};
 }
 

--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -59,6 +59,13 @@ public:
     /// release()
     void reset();
 
+    /// Returns the writer's filename. It returns nullopt when the file does not
+    /// exist (eg. before initialization, or after the file has been deleted).
+    const std::optional<std::filesystem::path>&
+    get_crash_report_file_name() const {
+        return _crash_report_file_name;
+    }
+
 private:
     enum class state { uninitialized, initialized, filled, written, released };
     friend std::ostream& operator<<(std::ostream&, state);
@@ -76,7 +83,7 @@ private:
 
     crash_description _prepared_cd;
     iobuf _serde_output;
-    std::filesystem::path _crash_report_file_name;
+    std::optional<std::filesystem::path> _crash_report_file_name;
     int _fd{-1};
 };
 

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -336,13 +336,19 @@ recorder::recorded_crash::timestamp() const {
 
 namespace {
 ss::future<> recorded_crashes_walker_fn(
-  std::filesystem::path basedir,
+  const std::filesystem::path& basedir,
   ss::directory_entry entry,
   std::vector<recorder::recorded_crash>& result,
-  recorder::include_malformed_files incl_malformed) {
+  recorder::include_malformed_files incl_malformed,
+  recorder::include_current incl_current,
+  const std::optional<std::filesystem::path>& current_file) {
     const auto path = (basedir / std::string_view{entry.name}).string();
     if (!path.ends_with(crash_report_suffix)) {
         // Filter only for crash files
+        co_return;
+    }
+    if (
+      !incl_current && current_file && current_file->filename() == entry.name) {
         co_return;
     }
 
@@ -370,18 +376,26 @@ ss::future<> recorded_crashes_walker_fn(
 
 ss::future<std::vector<recorder::recorded_crash>>
 recorder::get_recorded_crashes(
-  recorder::include_malformed_files incl_malformed) const {
+  recorder::include_malformed_files incl_malformed,
+  include_current incl_current) const {
     auto result = std::vector<recorded_crash>{};
     auto crash_report_dir = config::node().crash_report_dir_path();
     if (!co_await ss::file_exists(crash_report_dir.string())) {
         co_return result;
     }
+    auto& current_file = _writer.get_crash_report_file_name();
 
     co_await directory_walker::walk(
       crash_report_dir.string(),
-      [crash_report_dir, &result, incl_malformed](ss::directory_entry entry) {
+      [crash_report_dir, &result, incl_malformed, incl_current, &current_file](
+        ss::directory_entry entry) {
           return recorded_crashes_walker_fn(
-            crash_report_dir, std::move(entry), result, incl_malformed);
+            crash_report_dir,
+            std::move(entry),
+            result,
+            incl_malformed,
+            incl_current,
+            current_file);
       });
 
     std::sort(

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -20,6 +20,7 @@
 #include "utils/directory_walker.h"
 #include "utils/file_io.h"
 
+#include <seastar/core/file-types.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
@@ -120,7 +121,9 @@ namespace {
 ss::future<> upload_marker_walker_fn(
   std::filesystem::path basedir, ss::directory_entry entry) {
     const auto path = (basedir / std::string_view{entry.name}).string();
-    if (!path.ends_with(recorder::upload_marker_suffix)) {
+    if (
+      !path.ends_with(recorder::upload_marker_suffix)
+      || entry.type != ss::directory_entry_type::regular) {
         // Not an upload marker
         co_return;
     }
@@ -343,7 +346,9 @@ ss::future<> recorded_crashes_walker_fn(
   recorder::include_current incl_current,
   const std::optional<std::filesystem::path>& current_file) {
     const auto path = (basedir / std::string_view{entry.name}).string();
-    if (!path.ends_with(crash_report_suffix)) {
+    if (
+      !path.ends_with(crash_report_suffix)
+      || entry.type != ss::directory_entry_type::regular) {
         // Filter only for crash files
         co_return;
     }

--- a/src/v/crash_tracker/recorder.h
+++ b/src/v/crash_tracker/recorder.h
@@ -42,6 +42,7 @@ public:
 
     using include_malformed_files
       = ss::bool_class<struct include_malformed_files_tag>;
+    using include_current = ss::bool_class<struct include_current_tag>;
 
     enum class recorded_signo { sigsegv, sigabrt, sigill };
 
@@ -72,9 +73,12 @@ public:
     void finish_oom_recording();
 
     /// Returns the list of recorded crashes in increasing crash_time order
+    ///  - incl_malformed: whether to include unparseable crash files
+    ///  - incl_current: whether to include the crash file corresponding to the
+    ///    current process
     ss::future<std::vector<recorded_crash>> get_recorded_crashes(
-      include_malformed_files incl_malformed
-      = include_malformed_files::no) const;
+      include_malformed_files incl_malformed = include_malformed_files::no,
+      include_current incl_current = include_current::no) const;
 
 private:
     recorder() = default;

--- a/src/v/crash_tracker/tests/crash_reporter_oom_test.cc
+++ b/src/v/crash_tracker/tests/crash_reporter_oom_test.cc
@@ -66,7 +66,11 @@ If you work at Redpanda please refer to https://vectorizedio.atlassian.net/l/cp/
       fmt::arg("total_memory", total_mem_str),
       fmt::arg("hard_failures", failed_allocs));
 
-    auto crashes = get_recorder().get_recorded_crashes().get();
+    auto crashes = get_recorder()
+                     .get_recorded_crashes(
+                       recorder::include_malformed_files::no,
+                       recorder::include_current::yes)
+                     .get();
     ASSERT_FALSE(crashes.empty());
     ASSERT_EQ(crashes.size(), 1);
     const auto& crash = crashes[0];

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -30,50 +30,33 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
       crash_tracker::impl::describe_crashes(crashes),
       "(No crash files have been recorded.)");
 
-    using with_additional_info
-      = ss::bool_class<struct with_additional_info_tag>;
-    auto make_crash = [](with_additional_info wai) {
+    auto make_crash = []() {
         auto res = crash_description{};
         res.crash_message = crash_description::reserved_string_t{
           "Assertion error"};
         res.stacktrace = crash_description::reserved_string_t{
           "0xaaaaaaaa 0xbbbbbbbb"};
-        if (wai) {
-            res.addition_info = crash_description::reserved_string_t{
-              "false != true at example.cc:123"};
-        }
         res.app_version = ss::sstring{redpanda_version()};
         return recorder::recorded_crash{"", std::move(res), {}};
     };
 
-    crashes.emplace_back(make_crash(with_additional_info::no));
-
-    EXPECT_EQ(
-      crash_tracker::impl::describe_crashes(crashes),
-      fmt::format(
-        // clang-format off
-        "The following crashes have been recorded:"
-        "\nCrash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.",
-        // clang-format on
-        redpanda_version()));
-
-    for (int i = 0; i < 10; i++) {
-        crashes.emplace_back(make_crash(with_additional_info::yes));
+    for (int i = 0; i < 11; i++) {
+        crashes.emplace_back(make_crash());
     }
 
     auto expected = fmt::format(
       R"(The following crashes have been recorded:
 Crash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #2 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #3 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #4 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #5 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
+Crash #2 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #3 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #4 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #5 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
     ...
-Crash #7 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #8 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #9 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #10 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123
-Crash #11 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb. false != true at example.cc:123)",
+Crash #7 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #8 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #9 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #10 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #11 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.)",
       fmt::arg("version", redpanda_version()));
 
     EXPECT_EQ(crash_tracker::impl::describe_crashes(crashes), expected);

--- a/src/v/crash_tracker/tests/report_generator.cc
+++ b/src/v/crash_tracker/tests/report_generator.cc
@@ -23,7 +23,7 @@
 
 int main(int ac, char* av[]) {
     int crash_type_int = static_cast<int>(crash_tracker::crash_type::unknown);
-    std::string message, stacktrace, additional_info;
+    std::string message, stacktrace;
     std::filesystem::path output_file;
     int64_t timestamp = 0;
     namespace po = boost::program_options;
@@ -34,9 +34,6 @@ int main(int ac, char* av[]) {
       "stacktrace",
       po::value<std::string>(&stacktrace),
       "Stack trace to print")(
-      "additional-info",
-      po::value<std::string>(&additional_info),
-      "additional information")(
       "output-file",
       po::value<std::filesystem::path>(&output_file),
       "output file")(
@@ -73,9 +70,6 @@ int main(int ac, char* av[]) {
             cd.stacktrace = crash_tracker::reserved_string<
               crash_tracker::crash_description::string_buffer_reserve>{
               stacktrace};
-            cd.addition_info = crash_tracker::reserved_string<
-              crash_tracker::crash_description::string_buffer_reserve>{
-              additional_info};
             cd.type = crash_type;
             iobuf buf;
             serde::write(buf, std::move(cd));

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -44,12 +44,6 @@ std::ostream& operator<<(std::ostream& os, const crash_description& cd) {
         fmt::print(os, " Backtrace: {}.", opt_stacktrace);
     }
 
-    const auto opt_add_info = cd.addition_info.c_str();
-    const auto has_add_info = strlen(opt_add_info) > 0;
-    if (has_add_info) {
-        fmt::print(os, " {}", opt_add_info);
-    }
-
     return os;
 }
 

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -120,31 +120,20 @@ struct crash_description
     constexpr static size_t string_buffer_reserve = 4096;
     constexpr static size_t overhead_overestimate = 1024;
     constexpr static size_t serde_size_overestimate
-      = overhead_overestimate + 3 * string_buffer_reserve;
+      = overhead_overestimate + 2 * string_buffer_reserve;
     using reserved_string_t = reserved_string<string_buffer_reserve>;
 
     crash_type type{};
     model::timestamp crash_time;
     reserved_string_t crash_message;
     reserved_string_t stacktrace;
-
-    /// Extension to the crash_message. It can be used to add further
-    /// information about the crash that is useful for debugging but is too
-    /// verbose for telemetry.
-    /// Eg. top-N allocations
-    reserved_string_t addition_info;
     ss::sstring app_version;
 
     crash_description() = default;
 
     auto serde_fields() {
         return std::tie(
-          type,
-          crash_time,
-          crash_message,
-          stacktrace,
-          addition_info,
-          app_version);
+          type, crash_time, crash_message, stacktrace, app_version);
     }
 
     friend std::ostream& operator<<(std::ostream&, const crash_description&);

--- a/tools/offline_log_viewer/crash_report.py
+++ b/tools/offline_log_viewer/crash_report.py
@@ -9,6 +9,5 @@ def decode_crash_report(path: str) -> dict[str, Any]:
             'timestamp': rdr.read_int64(),
             'crash_message': rdr.read_string(),
             'stacktrace': rdr.read_string(),
-            'additional_info': rdr.read_string(),
             'app_version': rdr.read_string()
         })


### PR DESCRIPTION
See the commit messages for details:
* [crash_tracker: filter out current crash report](https://github.com/redpanda-data/redpanda/commit/d333b772e410e88596d5584cf2a505eea96b4fbf) 
* [crash_tracker: filter out non-files from walkers](https://github.com/redpanda-data/redpanda/commit/a47e42fd1896af9a589c52e1757a92ba9fe82beb) -- addresses https://github.com/redpanda-data/redpanda/pull/25130#discussion_r1970605838 
* [crash_tracker: remove unused additional_info](https://github.com/redpanda-data/redpanda/commit/641dc1bffee9dc0b2f9ed45576c12e94dc345caf)

Fixes https://redpandadata.atlassian.net/browse/CORE-9383

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
