### PR TITLE
tests/setup: update ducktape ref

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@163187b8b2b0a226cb8ecf06119ed66300deac5a',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@b59b056fc4ba5b3d7155e0d4ad10c4935d72bcbc',
         'prometheus-client==0.9.0',
         'kafka-python==2.0.2',
         'crc32c==2.2',


### PR DESCRIPTION
point to new version that adds logic for stopping deflake retries based on the exception that was raised. ducktape accepts a new argument `--deflake-exclude-exception` that can be set in order to stop retries.

ref
https://github.com/redpanda-data/ducktape/pull/45

jira: [DEVPROD-2685]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[DEVPROD-2685]: https://redpandadata.atlassian.net/browse/DEVPROD-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ