### PR TITLE
datalake: shutdown datalake managers before stopping partitions

### DIFF
--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -88,7 +88,7 @@ ss::future<> coordinator_manager::start() {
       });
 }
 
-ss::future<> coordinator_manager::stop() {
+ss::future<> coordinator_manager::shutdown() {
     if (manage_notifications_) {
         pm_.unregister_manage_notification(*manage_notifications_);
     }

--- a/src/v/datalake/coordinator/coordinator_manager.h
+++ b/src/v/datalake/coordinator/coordinator_manager.h
@@ -51,7 +51,7 @@ public:
     ~coordinator_manager();
 
     ss::future<> start();
-    ss::future<> stop();
+    ss::future<> shutdown();
 
     ss::lw_shared_ptr<coordinator> get(const model::ntp&) const;
 

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -273,7 +273,7 @@ ss::future<> datalake_manager::start() {
     co_await _backlog_controller->start();
 }
 
-ss::future<> datalake_manager::stop() {
+ss::future<> datalake_manager::shutdown() {
     vlog(datalake_log.debug, "Stopping datalake manager...");
     auto f = _gate.close();
     co_await _queue.shutdown();

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -72,7 +72,7 @@ public:
     ~datalake_manager();
 
     ss::future<> start();
-    ss::future<> stop();
+    ss::future<> shutdown();
 
     /*
      * Return the amount of disk space currently in use by the datalake

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -343,6 +343,18 @@ void application::shutdown() {
     if (cloud_io.local_is_initialized()) {
         cloud_io.invoke_on_all(&cloud_io::remote::request_stop).get();
     }
+    /**
+     * Shutdown the datalake services before stopping all the partitions.
+     */
+    if (_datalake_manager.local_is_initialized()) {
+        _datalake_manager.invoke_on_all(&datalake::datalake_manager::shutdown)
+          .get();
+    }
+    if (_datalake_coordinator_mgr.local_is_initialized()) {
+        _datalake_coordinator_mgr
+          .invoke_on_all(&datalake::coordinator::coordinator_manager::shutdown)
+          .get();
+    }
 
     // Stop all partitions before destructing the subsystems (transaction
     // coordinator, etc). This interrupts ongoing replication requests,


### PR DESCRIPTION
Datalake managers may cache the shared pointer to the state machines. When partitions are stopped the `raft::consensus` pointer is destroyed. This may lead to a situation in which a coordinator accesses a state machine with dangling pointer.

This needs a more systematic solution in the state machine itself but in order to quickly fix the problem and manage the services lifecycle correctly we simply stop the manager before stopping all partitions. This way no datalake services will try to access a `raft::consensus` instance that has already been removed.

Fixes: CORE-8380

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none