### PR TITLE
[CORE-9036] `archival`: fix invalid iterator dereference in `retention_calculator`

### DIFF
--- a/src/v/cluster/archival/retention_calculator.cc
+++ b/src/v/cluster/archival/retention_calculator.cc
@@ -107,12 +107,14 @@ std::optional<retention_calculator> retention_calculator::factory(
           model::timestamp::now().value()
           - ntp_config.retention_duration()->count()};
 
-        if (
-          manifest.size() > 0
-          && manifest.first_addressable_segment()->max_timestamp
-               < oldest_allowed_timestamp) {
-            strats.push_back(
-              std::make_unique<time_based_strategy>(oldest_allowed_timestamp));
+        if (manifest.size() > 0) {
+            auto first_seg = manifest.first_addressable_segment();
+            if (
+              first_seg != manifest.end()
+              && first_seg->max_timestamp < oldest_allowed_timestamp) {
+                strats.push_back(std::make_unique<time_based_strategy>(
+                  oldest_allowed_timestamp));
+            }
         }
     }
     auto start_kafka_override = manifest.get_start_kafka_offset_override();

--- a/src/v/cluster/archival/tests/retention_strategy_test.cc
+++ b/src/v/cluster/archival/tests/retention_strategy_test.cc
@@ -34,6 +34,15 @@ struct size_based_retention_test_spec {
 const auto delta_10_min = model::timestamp{
   model::timestamp::now().value() - std::chrono::milliseconds{10min}.count()};
 
+namespace {
+segment_spec make_segment_spec_with_uninitialized_start_offset() {
+    auto ret = segment_spec(0, 9, 1024);
+    ret.start_offset = model::offset{};
+    return ret;
+}
+
+} // namespace
+
 const std::vector<size_based_retention_test_spec> retention_tests{
   // retention disabled
   size_based_retention_test_spec{
@@ -196,6 +205,15 @@ const std::vector<size_based_retention_test_spec> retention_tests{
     .retention_duration = tristate<std::chrono::milliseconds>{5min},
     .desired_start_offset = tristate<kafka::offset>{kafka::offset(42)},
     .next_start_offset = model::offset{40}},
+
+  // Remote segment with uninitalized start offset and all sorts of retention
+  // enabled.
+  size_based_retention_test_spec{
+    .remote_segments = {make_segment_spec_with_uninitialized_start_offset()},
+    .retention_bytes = tristate<size_t>{1024},
+    .retention_duration = tristate<std::chrono::milliseconds>{100ms},
+    .desired_start_offset = tristate<kafka::offset>{},
+    .next_start_offset = std::nullopt},
 };
 
 SEASTAR_THREAD_TEST_CASE(test_retention_strategies) {


### PR DESCRIPTION
PR https://github.com/redpanda-data/redpanda/pull/24434 introduced the use of `first_addressable_segment()` for calculating time based retention in `archival::retention_calculator`.

We missed adding a sanity check here that the iterator was valid, and not `== partition_manifest.end()`.

Add a check that ensures the iterator is valid in order to avoid hitting a `vassert()`.

No backports or release notes needed (this was caught before first tagged release in `v25.1`)

Fixes JIRAs: 

https://redpandadata.atlassian.net/issues/CORE-8814
https://redpandadata.atlassian.net/issues/CORE-9036
https://redpandadata.atlassian.net/issues/CORE-9184

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
