### PR TITLE
rpc_compiler slimming

### DIFF
--- a/src/v/finjector/hbadger.h
+++ b/src/v/finjector/hbadger.h
@@ -21,6 +21,10 @@
 namespace finjector {
 
 struct probe {
+    // The type of the bitmap use to represent which injection points
+    // are enabled.
+    using bitmap_type = uint64_t;
+
     probe() = default;
     virtual ~probe() = default;
     virtual std::vector<std::string_view> points() = 0;
@@ -28,7 +32,7 @@ struct probe {
     // Bits must be distinct across points. Implementations may
     // support a pattern or wildcard for 'point', which may return
     // multiple bits set here.
-    virtual uint32_t point_to_bit(std::string_view point) const = 0;
+    virtual bitmap_type point_to_bit(std::string_view point) const = 0;
 
     [[gnu::always_inline]] bool operator()() const {
 #ifndef NDEBUG
@@ -51,16 +55,16 @@ struct probe {
         _termination_methods |= point_to_bit(point);
     }
     void unset(std::string_view point) {
-        const uint32_t m = point_to_bit(point);
+        const auto m = point_to_bit(point);
         _exception_methods &= ~m;
         _delay_methods &= ~m;
         _termination_methods &= ~m;
     }
 
 protected:
-    uint32_t _exception_methods = 0;
-    uint32_t _delay_methods = 0;
-    uint32_t _termination_methods = 0;
+    bitmap_type _exception_methods = 0;
+    bitmap_type _delay_methods = 0;
+    bitmap_type _termination_methods = 0;
 };
 
 class honey_badger {

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -112,9 +112,15 @@ public:
          default: return nullptr;
        }
     }
+
+    {%- for method in methods %}
+    virtual ss::future<{{method.output_type}}>
+    {{method.name}}({{method.input_type}}, ::rpc::streaming_context&) = 0;
+    {%- endfor %}
+private:
     {%- for method in methods %}
     /// \\brief {{method.input_type}} -> {{method.output_type}}
-    virtual ss::future<::rpc::netbuf>
+    ss::future<::rpc::netbuf>
     raw_{{method.name}}(ss::input_stream<char>& in, ::rpc::streaming_context& ctx) {
       return execution_helper<{{method.input_type}},
                               {{method.output_type}},
@@ -124,10 +130,8 @@ public:
           return {{method.name}}(std::move(t), ctx);
       });
     }
-    virtual ss::future<{{method.output_type}}>
-    {{method.name}}({{method.input_type}}, ::rpc::streaming_context&) = 0;
     {%- endfor %}
-private:
+
     ss::scheduling_group _sc;
     ss::smp_service_group _ssg;
     std::array<::rpc::method, {{methods|length}}> _methods{%raw %}{{{% endraw %}

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -144,16 +144,14 @@ private:
     metrics::internal_metric_groups _metrics;
 };
 
-class {{service_name}}_client_protocol {
+class {{service_name}}_client_protocol {% if final_protocol %}final{% endif %} {
 public:
     explicit {{service_name}}_client_protocol(ss::lw_shared_ptr<::rpc::transport> t)
       : _transport(t) {
     }
 
-    virtual ~{{service_name}}_client_protocol() = default;
-
     {%- for method in methods %}
-    virtual inline ss::future<result<::rpc::client_context<{{method.output_type}}>>>
+    ss::future<result<::rpc::client_context<{{method.output_type}}>>>
     {{method.name}}({{method.input_type}}&& r, ::rpc::client_opts opts) {
        return _transport->send_typed<{{method.input_type}}, {{method.output_type}}>(std::move(r),
               {{service_name}}_service::{{method.name}}_method, std::move(opts));
@@ -222,10 +220,13 @@ private:
 } // namespace
 """
 
+# default values applied to service definition
+SERVICE_DEFAULTS = {"final_protocol": True}
+
 
 def _read_file(name: str):
     with open(name, 'r') as f:
-        return json.load(f)
+        return SERVICE_DEFAULTS | json.load(f)
 
 
 def _enrich_methods(service: Any):

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -58,8 +58,8 @@ RPC_TEMPLATE = """
 
 namespace {{namespace}} {
 
-template<typename Codec>
-class {{service_name}}_service_base : public ::rpc::service {
+class {{service_name}}_service : public ::rpc::service {
+    using Codec = ::rpc::default_message_codec;
 public:
     class failure_probes;
 
@@ -67,13 +67,13 @@ public:
     static constexpr ::rpc::method_info {{method.name}}_method = {"{{service_name}}::{{method.name}}", {{method.id}}};
     {%- endfor %}
 
-    {{service_name}}_service_base(ss::scheduling_group sc, ss::smp_service_group ssg)
+    {{service_name}}_service(ss::scheduling_group sc, ss::smp_service_group ssg)
        : _sc(sc), _ssg(ssg) {}
 
-    {{service_name}}_service_base({{service_name}}_service_base&& o) noexcept = delete;
-    {{service_name}}_service_base& operator=({{service_name}}_service_base&& o) noexcept = delete;
+    {{service_name}}_service({{service_name}}_service&& o) noexcept = delete;
+    {{service_name}}_service& operator=({{service_name}}_service&& o) noexcept = delete;
 
-    virtual ~{{service_name}}_service_base() noexcept = default;
+    virtual ~{{service_name}}_service() noexcept = default;
 
     void setup_metrics() final {
         namespace sm = ss::metrics;
@@ -140,8 +140,6 @@ private:
     metrics::internal_metric_groups _metrics;
 };
 
-using {{service_name}}_service = {{service_name}}_service_base<::rpc::default_message_codec>;
-
 class {{service_name}}_client_protocol {
 public:
     explicit {{service_name}}_client_protocol(ss::lw_shared_ptr<::rpc::transport> t)
@@ -162,8 +160,7 @@ private:
     ss::lw_shared_ptr<::rpc::transport> _transport;
 };
 
-template<typename Codec>
-class {{service_name}}_service_base<Codec>::failure_probes final : public finjector::probe {
+class {{service_name}}_service::failure_probes final : public finjector::probe {
 public:
     using type = finjector::probe::bitmap_type;
 

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -13,6 +13,7 @@ import sys
 import os
 import logging
 import json
+from typing import Any
 
 # 3rd party
 from jinja2 import Template
@@ -221,12 +222,12 @@ private:
 """
 
 
-def _read_file(name):
+def _read_file(name: str):
     with open(name, 'r') as f:
         return json.load(f)
 
 
-def _enrich_methods(service):
+def _enrich_methods(service: Any):
     logger.info(service)
 
     service["id"] = zlib.crc32(
@@ -244,7 +245,7 @@ def _enrich_methods(service):
     return service
 
 
-def _codegen(service, out):
+def _codegen(service: Any, out: str):
     logger.info(service)
     tpl = Template(RPC_TEMPLATE)
     with open(out, 'w') as f:

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -165,13 +165,13 @@ private:
 template<typename Codec>
 class {{service_name}}_service_base<Codec>::failure_probes final : public finjector::probe {
 public:
-    using type = uint32_t;
+    using type = finjector::probe::bitmap_type;
 
     static constexpr std::string_view name() { return "{{service_name}}_service::failure_probes"; }
 
-    enum class methods: type {
+    enum class methods : type {
     {%- for method in methods %}
-        {{method.name}} = 1 << {{loop.index}}{{ "," if not loop.last }}
+        {{method.name}} = 1ULL << {{loop.index}}{{ "," if not loop.last }}
     {%- endfor %}
     };
     type point_to_bit(std::string_view point) const final {

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -249,6 +249,9 @@ def _enrich_methods(service: Any):
 
 def _codegen(service: Any, out: str):
     logger.info(service)
+    # this limitation comes from the finjector bitmap which is a uint64_t
+    assert len(service["methods"]) <= 64, \
+        f"Service {service['service_name']} has too many methods to hold in a uint64_t"
     tpl = Template(RPC_TEMPLATE)
     with open(out, 'w') as f:
         f.write(tpl.render(service))

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -271,7 +271,7 @@ def main():
         return parser
 
     parser = generate_options()
-    options, program_options = parser.parse_known_args()
+    options = parser.parse_args()
     logger.info("%s" % options)
     _codegen(_enrich_methods(_read_file(options.service_file)),
              options.output_file)

--- a/src/v/rpc/test/cycling_service.json
+++ b/src/v/rpc/test/cycling_service.json
@@ -4,6 +4,7 @@
     "includes": [
         "rpc/test/rpc_gen_types.h"
     ],
+    "final_protocol": false,
     "methods": [
         {
             "name": "canyon",

--- a/src/v/rpc/test/echo_service.json
+++ b/src/v/rpc/test/echo_service.json
@@ -4,6 +4,7 @@
     "includes": [
         "rpc/test/rpc_gen_types.h"
     ],
+    "final_protocol": false,
     "methods": [
         {
             "name": "echo",

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -40,6 +40,48 @@
 
 using namespace std::chrono_literals; // NOLINT
 
+namespace rpc {
+
+template<typename Protocol>
+concept RpcClientProtocol
+  = std::constructible_from<Protocol, ss::lw_shared_ptr<rpc::transport>>;
+
+template<typename... Protocol>
+requires(RpcClientProtocol<Protocol> && ...)
+class client : public Protocol... {
+public:
+    explicit client(ss::lw_shared_ptr<rpc::transport> transport)
+      : Protocol(transport)...
+      , _transport(transport) {}
+
+    ss::future<> connect(rpc::clock_type::time_point connection_timeout) {
+        return _transport->connect(connection_timeout);
+    }
+    ss::future<> stop() { return _transport->stop(); };
+    void shutdown() { _transport->shutdown(); }
+
+    [[gnu::always_inline]] bool is_valid() const {
+        return _transport->is_valid();
+    }
+
+    const net::unresolved_address& server_address() const {
+        return _transport->server_address();
+    }
+
+private:
+    ss::lw_shared_ptr<rpc::transport> _transport{nullptr};
+};
+
+template<typename... Protocol>
+rpc::client<Protocol...> make_client(
+  transport_configuration cfg,
+  std::optional<connection_cache_label> label = std::nullopt,
+  const std::optional<model::node_id> node_id = std::nullopt) {
+    return client<Protocol...>(ss::make_lw_shared<rpc::transport>(
+      std::move(cfg), std::move(label), node_id));
+}
+} // namespace rpc
+
 // Test services
 struct movistar final : cycling::team_movistar_service {
     movistar(ss::scheduling_group& sc, ss::smp_service_group& ssg)

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -41,10 +41,9 @@
 using namespace std::chrono_literals; // NOLINT
 
 // Test services
-template<typename Codec>
-struct movistar final : cycling::team_movistar_service_base<Codec> {
+struct movistar final : cycling::team_movistar_service {
     movistar(ss::scheduling_group& sc, ss::smp_service_group& ssg)
-      : cycling::team_movistar_service_base<Codec>(sc, ssg) {}
+      : cycling::team_movistar_service(sc, ssg) {}
     ss::future<cycling::mount_tamalpais>
     ibis_hakka(cycling::san_francisco, rpc::streaming_context&) final {
         return ss::make_ready_future<cycling::mount_tamalpais>(

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -57,10 +57,9 @@ struct movistar final : cycling::team_movistar_service_base<Codec> {
     }
 };
 
-template<typename Codec>
-struct echo_impl final : echo::echo_service_base<Codec> {
+struct echo_impl final : echo::echo_service {
     echo_impl(ss::scheduling_group& sc, ss::smp_service_group& ssg)
-      : echo::echo_service_base<Codec>(sc, ssg) {}
+      : echo::echo_service(sc, ssg) {}
     ss::future<echo::echo_resp>
     prefix_echo(echo::echo_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
@@ -107,10 +106,9 @@ struct echo_impl final : echo::echo_service_base<Codec> {
     uint64_t cnt = 0;
 };
 
-template<typename Codec>
-struct echo_v2_impl final : echo_v2::echo_service_base<Codec> {
+struct echo_v2_impl final : echo_v2::echo_service {
     echo_v2_impl(ss::scheduling_group& sc, ss::smp_service_group& ssg)
-      : echo_v2::echo_service_base<Codec>(sc, ssg) {}
+      : echo_v2::echo_service(sc, ssg) {}
 
     ss::future<echo_v2::echo_resp>
     echo(echo_v2::echo_req req, rpc::streaming_context&) final {
@@ -125,9 +123,9 @@ public:
       : rpc_simple_integration_fixture(redpanda_rpc_port) {}
 
     void register_services() {
-        register_service<movistar<rpc::default_message_codec>>();
-        register_service<echo_impl<rpc::default_message_codec>>();
-        register_service<echo_v2_impl<rpc::default_message_codec>>();
+        register_service<movistar>();
+        register_service<echo_impl>();
+        register_service<echo_v2_impl>();
     }
 
     static constexpr uint16_t redpanda_rpc_port = 32147;
@@ -921,8 +919,8 @@ public:
       : rpc_fixture_swappable_proto(redpanda_rpc_port) {}
 
     void register_services() {
-        register_service<movistar<rpc::default_message_codec>>();
-        register_service<echo_impl<rpc::default_message_codec>>();
+        register_service<movistar>();
+        register_service<echo_impl>();
     }
 
     static constexpr uint16_t redpanda_rpc_port = 32147;
@@ -970,8 +968,7 @@ FIXTURE_TEST(rpc_add_service, rpc_sharded_fixture) {
     server()
       .invoke_on_all([this](rpc::rpc_server& s) {
           std::vector<std::unique_ptr<rpc::service>> service;
-          service.emplace_back(
-            std::make_unique<echo_impl<rpc::default_message_codec>>(_sg, _ssg));
+          service.emplace_back(std::make_unique<echo_impl>(_sg, _ssg));
           s.add_services(std::move(service));
       })
       .get();
@@ -1115,9 +1112,7 @@ FIXTURE_TEST(rpc_mt_add_service, rpc_sharded_fixture) {
           server()
             .invoke_on_all([this](rpc::rpc_server& s) {
                 std::vector<std::unique_ptr<rpc::service>> service;
-                service.emplace_back(
-                  std::make_unique<echo_impl<rpc::default_message_codec>>(
-                    _sg, _ssg));
+                service.emplace_back(std::make_unique<echo_impl>(_sg, _ssg));
                 s.add_services(std::move(service));
             })
             .get();
@@ -1142,9 +1137,7 @@ FIXTURE_TEST(rpc_mt_add_service, rpc_sharded_fixture) {
           server()
             .invoke_on_all([this](rpc::rpc_server& s) {
                 std::vector<std::unique_ptr<rpc::service>> service;
-                service.emplace_back(
-                  std::make_unique<movistar<rpc::default_message_codec>>(
-                    _sg, _ssg));
+                service.emplace_back(std::make_unique<movistar>(_sg, _ssg));
                 s.add_services(std::move(service));
             })
             .get();

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -449,42 +449,4 @@ transport::send_typed_versioned(
       });
 }
 
-template<typename Protocol>
-concept RpcClientProtocol
-  = std::constructible_from<Protocol, ss::lw_shared_ptr<rpc::transport>>;
-
-template<typename... Protocol>
-requires(RpcClientProtocol<Protocol> && ...)
-class client : public Protocol... {
-public:
-    explicit client(ss::lw_shared_ptr<rpc::transport> transport)
-      : Protocol(transport)...
-      , _transport(transport) {}
-
-    ss::future<> connect(rpc::clock_type::time_point connection_timeout) {
-        return _transport->connect(connection_timeout);
-    }
-    ss::future<> stop() { return _transport->stop(); };
-    void shutdown() { _transport->shutdown(); }
-
-    [[gnu::always_inline]] bool is_valid() const {
-        return _transport->is_valid();
-    }
-
-    const net::unresolved_address& server_address() const {
-        return _transport->server_address();
-    }
-
-private:
-    ss::lw_shared_ptr<rpc::transport> _transport{nullptr};
-};
-
-template<typename... Protocol>
-rpc::client<Protocol...> make_client(
-  transport_configuration cfg,
-  std::optional<connection_cache_label> label = std::nullopt,
-  const std::optional<model::node_id> node_id = std::nullopt) {
-    return client<Protocol...>(ss::make_lw_shared<rpc::transport>(
-      std::move(cfg), std::move(label), node_id));
-}
 } // namespace rpc

--- a/src/v/storage/failure_probes.h
+++ b/src/v/storage/failure_probes.h
@@ -23,7 +23,7 @@ namespace storage {
 
 class log_failure_probes final : public finjector::probe {
 public:
-    using type = uint32_t;
+    using type = finjector::probe::bitmap_type;
 
     static constexpr std::string_view name() {
         return "storage::log::failure_probes";


### PR DESCRIPTION
First stab at slimming down the generated RPC code.

This significantly reduces the on-disk size of some packages after
compilation, e.g., sizes for raft, kafka, cluster directories and
redpanda binary itself (from `du -sm` so in megabytes):

```
before:

688     bazel-bin/src/v/raft
3300    bazel-bin/src/v/cluster
4312    bazel-bin/src/v/kafka
497     bazel-bin/src/v/redpanda/redpanda
```

```
after:

630     bazel-bin/src/v/raft
2453    bazel-bin/src/v/cluster
4290    bazel-bin/src/v/kafka
494     bazel-bin/src/v/redpanda/redpanda
```

Presumably there is also a corresponding compile-time benefit, though I did not try to measure it.

See individual changes for details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none