### PR TITLE
CORE-9267: Add support for RFC2253

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -201,7 +201,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "wZeD6sSspF3lcgBgZrFkjygVWijH7rIylGV/KUlDAaU=",
+        "bzlTransitiveDigest": "YA64kzfEoBibr8F1Y14l6D2ukhdTl5w7ypC/9VajjyA=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -378,12 +378,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "d12be25cebdd06ad91a70b950f9ab61a4fd43d27b119a943e95911f5b25bdf97",
-              "strip_prefix": "seastar-534c1a88bccacd2bcd8a35a062e929001ecda279",
-              "url": "https://github.com/redpanda-data/seastar/archive/534c1a88bccacd2bcd8a35a062e929001ecda279.tar.gz",
-              "patch_args": [
-                "-p1"
-              ]
+              "sha256": "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
+              "strip_prefix": "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
+              "url": "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -159,10 +159,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "d12be25cebdd06ad91a70b950f9ab61a4fd43d27b119a943e95911f5b25bdf97",
-        strip_prefix = "seastar-534c1a88bccacd2bcd8a35a062e929001ecda279",
-        url = "https://github.com/redpanda-data/seastar/archive/534c1a88bccacd2bcd8a35a062e929001ecda279.tar.gz",
-        patch_args = ["-p1"],
+        sha256 = "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
+        strip_prefix = "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
+        url = "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz",
     )
 
     http_archive(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1613,6 +1613,17 @@ configuration::configuration()
       "authorization is disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , tls_certificate_name_format(
+      *this,
+      "tls_certificate_name_format",
+      "The format of the certificates's distinguished name to use for mTLS "
+      "principal mapping.  Legacy format would appear as "
+      "'C=US,ST=California,L=San Francisco,O=Redpanda,CN=redpanda', while "
+      "rfc2253 format would appear as 'CN=redpanda,O=Redpanda,L=San "
+      "Francisco,ST=California,C=US'.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      tls_name_format::legacy,
+      {tls_name_format::legacy, tls_name_format::rfc2253})
   , kafka_mtls_principal_mapping_rules(
       *this,
       "kafka_mtls_principal_mapping_rules",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -341,6 +341,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<std::chrono::milliseconds>>
       kafka_sasl_max_reauth_ms;
     property<std::optional<bool>> kafka_enable_authorization;
+    enum_property<tls_name_format> tls_certificate_name_format;
     property<std::optional<std::vector<ss::sstring>>>
       kafka_mtls_principal_mapping_rules;
     property<bool> kafka_enable_partition_reassignment;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -719,4 +719,25 @@ struct convert<config::datalake_catalog_auth_mode> {
     }
 };
 
+template<>
+struct convert<config::tls_name_format> {
+    static Node encode(const config::tls_name_format& rhs) {
+        return Node(fmt::format("{}", rhs));
+    }
+
+    static bool decode(const Node& node, config::tls_name_format& rhs) {
+        static constexpr auto acceptable_values
+          = config::acceptable_tls_name_format_values();
+        auto value = node.as<std::string>();
+        if (
+          std::find(acceptable_values.cbegin(), acceptable_values.cend(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+        std::istringstream iss(value);
+        iss >> rhs;
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -14,6 +14,7 @@
 #include "base/type_traits.h"
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
+#include "config/tls_config.h"
 #include "config/types.h"
 #include "container/intrusive_list_helpers.h"
 #include "features/enterprise_feature_messages.h"
@@ -695,6 +696,8 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::is_same_v<
                            type,
                            config::datalake_catalog_auth_mode>) {
+        return "string";
+    } else if constexpr (std::is_same_v<type, config::tls_name_format>) {
         return "string";
     } else {
         static_assert(

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -11,6 +11,7 @@
 
 #include "config/tls_config.h"
 #include "config/types.h"
+#include "json/stringbuffer.h"
 #include "model/metadata.h"
 
 namespace json {
@@ -276,6 +277,11 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, config::datalake_catalog_auth_mode cam) {
     stringize(w, cam);
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, config::tls_name_format format) {
+    stringize(w, format);
 }
 
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -145,4 +145,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, config::datalake_catalog_auth_mode);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, config::tls_name_format);
+
 } // namespace json

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -193,4 +193,38 @@ operator>>(std::istream& is, datalake_catalog_auth_mode& cam) {
     return is;
 }
 
+enum class tls_name_format { legacy, rfc2253 };
+
+constexpr std::string_view to_string_view(tls_name_format format) {
+    switch (format) {
+    case tls_name_format::legacy:
+        return "legacy";
+    case tls_name_format::rfc2253:
+        return "rfc2253";
+    }
+}
+
+static constexpr auto acceptable_tls_name_format_values() {
+    return std::to_array(
+      {to_string_view(tls_name_format::legacy),
+       to_string_view(tls_name_format::rfc2253)});
+}
+
+inline std::ostream& operator<<(std::ostream& os, tls_name_format format) {
+    return os << to_string_view(format);
+}
+
+inline std::istream& operator>>(std::istream& is, tls_name_format& format) {
+    ss::sstring s;
+    is >> s;
+    format = string_switch<tls_name_format>(s)
+               .match(
+                 to_string_view(tls_name_format::legacy),
+                 tls_name_format::legacy)
+               .match(
+                 to_string_view(tls_name_format::rfc2253),
+                 tls_name_format::rfc2253);
+    return is;
+}
+
 } // namespace config

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -81,6 +81,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
+#include <seastar/net/tls.hh>
 #include <seastar/util/log.hh>
 
 #include <absl/algorithm/container.h>
@@ -284,8 +285,18 @@ config::broker_authn_method get_authn_method(const net::connection& conn) {
 ss::future<security::tls::mtls_state> get_mtls_principal_state(
   const security::tls::principal_mapper& pm, net::connection& conn) {
     using namespace std::chrono_literals;
+    auto format = [] {
+        auto fmt = config::shard_local_cfg().tls_certificate_name_format();
+        switch (fmt) {
+        case config::tls_name_format::legacy:
+            return ss::tls::dn_format::legacy;
+        case config::tls_name_format::rfc2253:
+            return ss::tls::dn_format::rfc2253;
+        }
+    }();
     return ss::with_timeout(
-             model::timeout_clock::now() + 5s, conn.get_distinguished_name())
+             model::timeout_clock::now() + 5s,
+             conn.get_distinguished_name(format))
       .then([&pm](std::optional<ss::session_dn> dn) {
           ss::sstring anonymous_principal;
           if (!dn.has_value()) {

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -67,8 +67,9 @@ public:
     ///
     /// The value can only be returned by the server socket and
     /// only in case if the client authentication is enabled.
-    ss::future<std::optional<ss::session_dn>> get_distinguished_name() {
-        return ss::tls::get_dn_information(_fd);
+    ss::future<std::optional<ss::session_dn>>
+    get_distinguished_name(ss::tls::dn_format format) {
+        return ss::tls::get_dn_information(_fd, format);
     }
 
     ss::future<> wait_for_input_shutdown() {

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1339,7 +1339,7 @@ class RpkTool:
             "acl",
             "create",
             "--allow-principal",
-            f"{principal_type}:{username}",
+            f"\"{principal_type}:{username}\"",
             "--operation",
             op,
             "--cluster",

--- a/tests/rptest/services/tls.py
+++ b/tests/rptest/services/tls.py
@@ -7,7 +7,7 @@ import os
 import string
 import random
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 _ca_config_tmpl = """
 # OpenSSL CA configuration file
@@ -309,6 +309,11 @@ class TLSKeyType(Enum):
     ECDSA = 1
 
 
+class DNFormat(IntEnum):
+    LEGACY = 0,
+    RFC2253 = 1
+
+
 class TLSCertManager:
     """
     When a TLSCertManager is instantiated a new CA is automatically created and
@@ -345,7 +350,7 @@ class TLSCertManager:
     def _with_dir(self, *args):
         return os.path.join(self._dir.name, *args)
 
-    def _exec(self, cmd):
+    def _exec(self, cmd) -> str:
         self._logger.info(f"Running command: {cmd}")
         retries = 0
         output = None
@@ -355,6 +360,7 @@ class TLSCertManager:
                                                  cwd=self._dir.name,
                                                  stderr=subprocess.STDOUT)
                 retries = 3  # Stop retry
+                return output.decode('utf-8')
             except subprocess.CalledProcessError as e:
                 self._logger.error(f"openssl error: {e.output}")
                 output = subprocess.check_output(
@@ -460,6 +466,21 @@ class TLSCertManager:
         cert = Certificate(cfg, key, crt, self.ca, p12_file, p12_password)
         self.certs[name] = cert
         return cert
+
+    def get_cert_subject_dn(self, cert: Certificate, format: DNFormat) -> str:
+        if format == DNFormat.LEGACY:
+            nameopt = "-nameopt esc_2253,esc_ctrl,esc_msb,utf8,dump_nostr,dump_unknown,dump_der,sep_comma_plus,sname"
+        elif format == DNFormat.RFC2253:
+            nameopt = "-nameopt rfc2253"
+        else:
+            raise ValueError(f"Unknown DN format: {format}")
+
+        resp = self._exec(
+            f'openssl x509 -in {cert.crt} -noout -subject {nameopt}')
+        assert resp.startswith(
+            "subject="
+        ), f'Output for DN command invalid: {resp}.  Should start with "subject="'
+        return resp[len("subject="):].strip()
 
     def generate_pkcs12_file(self,
                              p12_file: str,

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -16,7 +16,7 @@ from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.kcl import RawKCL
 from rptest.clients.rpk import RpkTool, ClusterAuthorizationError, RpkException, AclList
-from rptest.services.redpanda import SecurityConfig, TLSProvider
+from rptest.services.redpanda import LoggingConfig, SecurityConfig, TLSProvider
 from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
 from rptest.services import tls
 from typing import Optional
@@ -92,6 +92,8 @@ class AccessControlListTest(AccessControlListTestBase):
         super().__init__(*args,
                          num_brokers=3,
                          skip_if_no_redpanda_log=True,
+                         log_config=LoggingConfig(
+                             'info', logger_levels={'kafka': 'trace'}),
                          **kwargs)
         self.base_user_cert = None
         self.cluster_describe_user_cert = None
@@ -532,6 +534,38 @@ class AccessControlListTest(AccessControlListTestBase):
             pass_w_cluster_user=True,
             pass_w_super_user=True,
             err_msg='check_permissions failed after migration')
+
+    @cluster(num_nodes=3)
+    @matrix(dn_format=[tls.DNFormat.LEGACY, tls.DNFormat.RFC2253])
+    def test_tls_dn_format(self, dn_format: tls.DNFormat):
+        """
+        This test will verify that the selected format is applied in ACL rules
+        """
+        self.prepare_cluster(use_tls=True,
+                             use_sasl=False,
+                             enable_authz=True,
+                             authn_method="mtls_identity")
+
+        def get_name_format(format: tls.DNFormat):
+            if format == tls.DNFormat.LEGACY:
+                return "legacy"
+            elif format == tls.DNFormat.RFC2253:
+                return "rfc2253"
+            else:
+                raise ValueError(f"Unknown format: {format}")
+
+        dn_name = self.tls.get_cert_subject_dn(self.cluster_describe_user_cert,
+                                               format=dn_format)
+        self.logger.info(f"DN name: {dn_name}")
+        self.get_super_client().acl_create_allow_cluster(dn_name, "describe")
+
+        self.redpanda.set_cluster_config(
+            values={
+                'tls_certificate_name_format': get_name_format(dn_format),
+                'kafka_mtls_principal_mapping_rules': ['DEFAULT']
+            })
+        # Expect failure when set to RFC2253 format
+        self.check_permissions(pass_w_cluster_user=True)
 
 
 class AccessControlListTestUpgrade(AccessControlListTest):

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -728,6 +728,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             if name == "datalake_scheduler_time_slice_ms":
                 valid_value = random.choice(range(1000, 60000 + 1))
 
+            if name == "tls_certificate_name_format":
+                valid_value = random.choice(
+                    [e for e in p['enum_values'] if e != initial_value])
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Add support for RFC2253 name formatting.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Redpanda now supports selecting which format the client certificate's subject DN will be parsed in.  The new cluster config `tls_certificate_name_format` can take two options: `legacy` or `rfc2253`.  See documentation of the cluster config to understand the difference in how the an X.509 certificate's subject DN will be formatted.