### PR TITLE
cluster_restore_test: make spark lookup concurrent

### DIFF
--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -6,6 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
@@ -247,9 +248,19 @@ class DatalakeClusterRestoreTest(RedpandaTest):
         Returns a map from table name to max translated offset.
         """
         offsets = dict()
-        for t in tables:
-            offsets[t] = int(dl.spark().max_translated_offset(
-                "redpanda", t, 0))
+        with ThreadPoolExecutor() as executor:
+            table_and_offset_futs = {
+                executor.submit(
+                    lambda t:
+                    (t, int(dl.spark().max_translated_offset("redpanda", t, 0))
+                     ), t)
+                for t in tables
+            }
+
+            for fut in as_completed(table_and_offset_futs):
+                table, offset = fut.result()
+                offsets[table] = offset
+
         self.logger.info(f"Translated offsets: {offsets}")
         return offsets
 


### PR DESCRIPTION
This test uses a function that queries each table to look for the highest offset in each table. This lookup was done serially, and meant that the overarching function could take a couple of minutes. This resulted in test timeouts when waiting for the translated offsets to reach a certain point.

This commit parallelizes the function.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
