### PR TITLE
rpk: make CLI and cluster versions explicit

### DIFF
--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -27,5 +27,5 @@ var (
 )
 
 func Pretty() string {
-	return fmt.Sprintf("%s (rev %s)", version, rev)
+	return fmt.Sprintf("(Redpanda CLI): %s (rev %s)", version, rev)
 }

--- a/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
+++ b/src/go/rpk/pkg/cli/version/versioncmd/versioncmd.go
@@ -106,7 +106,7 @@ To get only the rpk version, use 'rpk --version'.`,
 }
 
 func printRpkVersion(rv rpkVersion) {
-	fmt.Printf(`Version:     %s
+	fmt.Printf(`rpk version: %s
 Git ref:     %s
 Build date:  %s
 OS/Arch:     %s


### PR DESCRIPTION
This PR makes the CLI and cluster versions explicit to avoid a confusion from happening. 

```
$ rpk version
rpk version: v0.0.0-20250311gitd443084
Git ref:     d443084e99
Build date:  2025-03-11T02:42:35Z
OS/Arch:     linux/amd64
Go version:  go1.23.1

Redpanda Cluster
  node-0  v24.3.6 - 71b4e935f24364e4a32d7746de6a57292a515c12
```

```
$ rpk --version
rpk version (Redpanda CLI): v0.0.0-20250311gitd443084 (rev d443084e99)
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
