### PR TITLE
Iceberg custom partitioning: spec evolution

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -64,6 +64,15 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
         co_return errc::topic_invalid_config;
     }
 
+    if (
+      cmd.value.cfg.properties.iceberg_mode != model::iceberg_mode::disabled
+      && !cmd.value.cfg.properties.iceberg_partition_spec) {
+        // Remember partition spec default at time of creation - i.e. make it a
+        // sticky config.
+        cmd.value.cfg.properties.iceberg_partition_spec
+          = config::shard_local_cfg().iceberg_default_partition_spec();
+    }
+
     std::optional<model::initial_revision_id> remote_revision
       = cmd.value.cfg.properties.remote_topic_properties
           ? std::make_optional(
@@ -973,6 +982,35 @@ void incremental_update(
     }
 }
 
+void incremental_update(
+  model::iceberg_mode& property,
+  std::optional<ss::sstring>& partition_spec_property,
+  property_update<model::iceberg_mode> override,
+  model::iceberg_mode default_value) {
+    switch (override.op) {
+    case incremental_update_operation::remove:
+        // remove override, fallback to default
+        property = default_value;
+        return;
+    case incremental_update_operation::set: {
+        // set new value and remember the current partition spec default if we
+        // are enabling iceberg.
+        auto old_property = property;
+        property = override.value;
+        if (
+          old_property == model::iceberg_mode::disabled
+          && property != old_property && !partition_spec_property) {
+            partition_spec_property
+              = config::shard_local_cfg().iceberg_default_partition_spec();
+        }
+        return;
+    }
+    case incremental_update_operation::none:
+        // do nothing
+        return;
+    }
+}
+
 template<typename T>
 void incremental_update(
   tristate<T>& property, property_update<tristate<T>> override) {
@@ -1093,6 +1131,7 @@ topic_properties topic_table::update_topic_properties(
     incremental_update(updated_properties.flush_bytes, overrides.flush_bytes);
     incremental_update(
       updated_properties.iceberg_mode,
+      updated_properties.iceberg_partition_spec,
       overrides.iceberg_mode,
       storage::ntp_config::default_iceberg_mode);
     incremental_update(
@@ -1103,7 +1142,9 @@ topic_properties topic_table::update_topic_properties(
       updated_properties.iceberg_delete, overrides.iceberg_delete);
     incremental_update(
       updated_properties.iceberg_partition_spec,
-      overrides.iceberg_partition_spec);
+      overrides.iceberg_partition_spec,
+      std::optional(
+        config::shard_local_cfg().iceberg_default_partition_spec()));
     incremental_update(
       updated_properties.iceberg_invalid_record_action,
       overrides.iceberg_invalid_record_action);

--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -179,48 +179,56 @@ catalog_schema_manager::ensure_table_schema(
           load_res.error(), fmt::format("Error loading table {}", table_id));
     }
 
+    iceberg::transaction txn(std::move(load_res.value()));
+
     // Check schema compatibility
     auto type_copy = desired_type.copy();
-    auto get_res = get_ids_from_table_meta(
-      table_id, load_res.value(), type_copy);
+    auto get_res = get_ids_from_table_meta(table_id, txn.table(), type_copy);
     if (get_res.has_error()) {
         co_return get_res.error();
     }
-    if (get_res.value()) {
-        // Success! The desired schema matches one already in the table.
-        co_return std::nullopt;
-    }
 
-    // The desired schema is backwards compatible with the current table schema.
-    // Add the schema to the table.
-    iceberg::transaction txn(std::move(load_res.value()));
-    auto update_res = co_await txn.set_schema(iceberg::schema{
-      .schema_struct = std::move(type_copy),
-      .schema_id = iceberg::schema::unassigned_id,
-      .identifier_field_ids = {},
-    });
-    if (update_res.has_error()) {
-        auto msg = fmt::format(
-          "Failed trying to apply schema update to table {}: {}",
-          table_id,
-          update_res.error());
-        switch (update_res.error()) {
-        case iceberg::action::errc::shutting_down:
-            vlog(datalake_log.debug, "{}", msg);
-            co_return errc::shutting_down;
-        case iceberg::action::errc::io_failed:
-        case iceberg::action::errc::unexpected_state:
-            vlog(datalake_log.warn, "{}", msg);
-            co_return errc::failed;
+    if (!get_res.value()) {
+        // The desired schema is backwards compatible with the current table
+        // schema. Add the schema to the table.
+        auto update_res = co_await txn.set_schema(iceberg::schema{
+          .schema_struct = std::move(type_copy),
+          .schema_id = iceberg::schema::unassigned_id,
+          .identifier_field_ids = {},
+        });
+        if (update_res.has_error()) {
+            auto msg = fmt::format(
+              "Failed trying to apply schema update to table {}: {}",
+              table_id,
+              update_res.error());
+            switch (update_res.error()) {
+            case iceberg::action::errc::shutting_down:
+                vlog(datalake_log.debug, "{}", msg);
+                co_return errc::shutting_down;
+            case iceberg::action::errc::io_failed:
+            case iceberg::action::errc::unexpected_state:
+                vlog(datalake_log.warn, "{}", msg);
+                co_return errc::failed;
+            }
         }
     }
-    auto commit_res = co_await catalog_.commit_txn(table_id, std::move(txn));
-    if (commit_res.has_error()) {
-        co_return log_and_convert_catalog_err(
-          commit_res.error(),
-          fmt::format(
-            "Error while committing schema update to table {}", table_id));
+
+    auto set_spec_res = co_await txn.set_partition_spec(partition_spec.copy());
+    if (set_spec_res.has_error()) {
+        co_return errc::failed;
     }
+
+    if (!txn.is_noop()) {
+        auto commit_res = co_await catalog_.commit_txn(
+          table_id, std::move(txn));
+        if (commit_res.has_error()) {
+            co_return log_and_convert_catalog_err(
+              commit_res.error(),
+              fmt::format(
+                "Error while committing schema update to table {}", table_id));
+        }
+    }
+
     co_return std::nullopt;
 }
 

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -985,6 +985,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":remove_snapshots_action",
         ":table_update_applier",
+        ":update_partition_spec_action",
         ":update_schema_action",
     ],
     include_prefix = "iceberg",
@@ -1075,6 +1076,28 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/container:fragmented_vector",
         "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "update_partition_spec_action",
+    srcs = [
+        "update_partition_spec_action.cc",
+    ],
+    hdrs = [
+        "update_partition_spec_action.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        ":table_requirement",
+        ":table_update",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":action",
+        ":table_metadata",
+        ":unresolved_partition_spec",
+        "//src/v/utils:prefix_logger",
     ],
 )
 

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -82,6 +82,7 @@ v_cc_library(
     transaction.cc
     transform_json.cc
     transform_utils.cc
+    update_partition_spec_action.cc
     update_schema_action.cc
     uri.cc
     values.cc

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -386,12 +386,18 @@ merge_append_action::maybe_merge_mfiles_and_new_data(
     chunked_vector<manifest_file> ret;
     if (to_merge.size() < default_min_to_merge_new_files) {
         // Upload and return. This bin is too small to merge.
-        auto new_mfile_res = co_await merge_mfiles(
-          {}, std::move(new_data_entries), max_schema_id_in_added, pspec, ctx);
-        if (new_mfile_res.has_error()) {
-            co_return new_mfile_res.error();
+        if (!new_data_files.empty()) {
+            auto new_mfile_res = co_await merge_mfiles(
+              {},
+              std::move(new_data_entries),
+              max_schema_id_in_added,
+              pspec,
+              ctx);
+            if (new_mfile_res.has_error()) {
+                co_return new_mfile_res.error();
+            }
+            ret.emplace_back(std::move(new_mfile_res.value()));
         }
-        ret.emplace_back(std::move(new_mfile_res.value()));
         std::move(to_merge.begin(), to_merge.end(), std::back_inserter(ret));
         co_return ret;
     }

--- a/src/v/iceberg/partition.h
+++ b/src/v/iceberg/partition.h
@@ -34,6 +34,8 @@ struct partition_field {
 
 struct partition_spec {
     using id_t = named_type<int32_t, struct spec_id_tag>;
+    static constexpr id_t unassigned_id{-1};
+
     id_t spec_id;
     chunked_vector<partition_field> fields;
 

--- a/src/v/iceberg/table_requirement.h
+++ b/src/v/iceberg/table_requirement.h
@@ -35,6 +35,10 @@ struct assert_last_assigned_partition_id {
     partition_field::id_t last_assigned_partition_id;
 };
 
+struct assert_default_spec_id {
+    partition_spec::id_t default_spec_id;
+};
+
 struct assert_ref_snapshot_id {
     ss::sstring ref;
     std::optional<snapshot_id> snapshot_id;
@@ -50,6 +54,7 @@ using requirement = std::variant<
   assert_ref_snapshot_id,
   assert_table_uuid,
   last_assigned_field_match,
-  assert_last_assigned_partition_id>;
+  assert_last_assigned_partition_id,
+  assert_default_spec_id>;
 
 } // namespace iceberg::table_requirement

--- a/src/v/iceberg/table_requirement_json.cc
+++ b/src/v/iceberg/table_requirement_json.cc
@@ -46,12 +46,20 @@ struct requirement_json_serializing_visitor {
         w.Key("last-assigned-field-id");
         w.Int(req.last_assigned_field_id);
     }
+
     void operator()(
       const iceberg::table_requirement::assert_last_assigned_partition_id&
         req) {
         serialize_type("assert-last-assigned-partition-id");
         w.Key("last-assigned-partition-id");
         w.Int(req.last_assigned_partition_id);
+    }
+
+    void
+    operator()(const iceberg::table_requirement::assert_default_spec_id& req) {
+        serialize_type("assert-default-spec-id");
+        w.Key("default-spec-id");
+        w.Int(req.default_spec_id);
     }
 
     void serialize_type(std::string_view type) {

--- a/src/v/iceberg/table_update.h
+++ b/src/v/iceberg/table_update.h
@@ -50,6 +50,11 @@ struct add_spec {
     }
 };
 
+struct set_default_spec {
+    partition_spec::id_t spec_id;
+    set_default_spec copy() const { return *this; }
+};
+
 struct add_snapshot {
     snapshot snapshot;
     add_snapshot copy() const {
@@ -86,7 +91,6 @@ struct set_snapshot_ref {
 // TODO: not yet implemented
 // - assign_uuid
 // - upgrade_format_version
-// - set_default_spec
 // - add_sort_order
 // - set_default_sort_order
 // - set_location
@@ -98,6 +102,7 @@ using update = std::variant<
   add_schema,
   set_current_schema,
   add_spec,
+  set_default_spec,
   add_snapshot,
   remove_snapshots,
   remove_snapshot_ref,

--- a/src/v/iceberg/table_update_applier.cc
+++ b/src/v/iceberg/table_update_applier.cc
@@ -77,7 +77,14 @@ struct update_applying_visitor {
             vlog(log.error, "Partition spec id {} already exists", sid);
             return outcome::unexpected_state;
         }
+
         meta.partition_specs.emplace_back(update.spec.copy());
+
+        for (const auto& field : update.spec.fields) {
+            meta.last_partition_id = std::max(
+              meta.last_partition_id, field.field_id);
+        }
+
         return outcome::success;
     }
     outcome operator()(const set_default_spec& update) {

--- a/src/v/iceberg/table_update_applier.cc
+++ b/src/v/iceberg/table_update_applier.cc
@@ -80,6 +80,31 @@ struct update_applying_visitor {
         meta.partition_specs.emplace_back(update.spec.copy());
         return outcome::success;
     }
+    outcome operator()(const set_default_spec& update) {
+        auto sid = update.spec_id;
+        if (sid() == partition_spec::unassigned_id) {
+            // -1 indicates that we should set the spec to the latest added one.
+            if (meta.partition_specs.empty()) {
+                vlog(
+                  log.error, "Can't set -1 when there are no partition specs");
+                return outcome::unexpected_state;
+            }
+            auto max_id = meta.partition_specs.front().spec_id;
+            for (const auto& s : meta.partition_specs) {
+                max_id = std::max(max_id, s.spec_id);
+            }
+            meta.default_spec_id = max_id;
+            return outcome::success;
+        }
+        auto spec = std::ranges::find(
+          meta.partition_specs, sid, &partition_spec::spec_id);
+        if (spec == meta.partition_specs.end()) {
+            vlog(log.error, "Partition spec {} doesn't exist", sid);
+            return outcome::unexpected_state;
+        }
+        meta.default_spec_id = update.spec_id;
+        return outcome::success;
+    }
     outcome operator()(const add_snapshot& update) {
         auto sid = update.snapshot.id;
         if (!meta.snapshots.has_value()) {

--- a/src/v/iceberg/table_update_json.cc
+++ b/src/v/iceberg/table_update_json.cc
@@ -35,6 +35,11 @@ struct table_update_json_serializing_visitor {
         w.Key("spec");
         json::rjson_serialize(w, update.spec);
     }
+    void operator()(const iceberg::table_update::set_default_spec& update) {
+        serialize_action("set-default-spec");
+        w.Key("spec-id");
+        w.Int(update.spec_id);
+    }
     void operator()(const iceberg::table_update::add_snapshot& update) {
         serialize_action("add-snapshot");
         w.Key("snapshot");

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -491,6 +491,21 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "update_partition_spec_action_test",
+    timeout = "short",
+    srcs = [
+        "update_partition_spec_action_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":test_schemas",
+        "//src/v/iceberg:transaction",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "update_schema_action_test",
     timeout = "short",
     srcs = [

--- a/src/v/iceberg/tests/CMakeLists.txt
+++ b/src/v/iceberg/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ rp_test(
     test_table_metadata.cc
     transform_json_test.cc
     transform_utils_test.cc
+    update_partition_spec_action_test.cc
     update_schema_action_test.cc
     values_test.cc
     values_avro_test.cc

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -648,7 +648,75 @@ TEST_F(MergeAppendActionTest, TestTagWithExpiration) {
     ASSERT_EQ(long_max, tag_snap.max_ref_age_ms.value());
 }
 
+// Test appending with multiple partition specs, but not enough files to trigger
+// merging.
 TEST_F(MergeAppendActionTest, TestMultiplePartitionSpecs) {
+    transaction tx(create_table());
+
+    {
+        // Append some files
+        auto files = create_data_files(tx.table(), "foo", 2, 3);
+        merge_append_and_check(tx, std::move(files), 1, 1);
+    }
+
+    {
+        // Add second spec
+        auto new_spec = unresolved_partition_spec{};
+        new_spec.fields.push_back(unresolved_partition_spec::field{
+          .source_name = {"baz"},
+          .transform = identity_transform{},
+          .name = "baz",
+        });
+        auto res = tx.set_partition_spec(std::move(new_spec)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        ASSERT_EQ(tx.table().partition_specs.size(), 2);
+    }
+
+    {
+        // Append some more files with the new spec
+        auto files = create_data_files(
+          tx.table(), "foo", 2, 3, boolean_value{true});
+        merge_append_and_check(tx, std::move(files), 2, 2);
+    }
+
+    {
+        // Add third spec
+        auto new_spec = unresolved_partition_spec{};
+        new_spec.fields.push_back(unresolved_partition_spec::field{
+          .source_name = {"foo"},
+          .transform = identity_transform{},
+          .name = "foo",
+        });
+        auto res = tx.set_partition_spec(std::move(new_spec)).get();
+        ASSERT_FALSE(res.has_error()) << res.error();
+        ASSERT_EQ(tx.table().partition_specs.size(), 3);
+    }
+
+    {
+        // Append files with every partition spec in one action.
+        chunked_vector<file_to_append> files;
+        auto add_files = [&](
+                           partition_spec::id_t spec_id,
+                           primitive_value pk_value) {
+            auto to_add = create_data_files(
+              tx.table(),
+              "foo",
+              1,
+              3,
+              std::move(pk_value),
+              std::nullopt,
+              spec_id);
+            std::move(to_add.begin(), to_add.end(), std::back_inserter(files));
+        };
+        add_files(partition_spec::id_t{0}, int_value{21});
+        add_files(partition_spec::id_t{1}, boolean_value{false});
+        add_files(partition_spec::id_t{2}, string_value{iobuf::from("aaa")});
+
+        merge_append_and_check(tx, std::move(files), 3, 5);
+    }
+}
+
+TEST_F(MergeAppendActionTest, TestMergeWithMultiplePartitionSpecs) {
     const size_t num_to_merge_at
       = merge_append_action::default_min_to_merge_new_files;
     const size_t files_per_man = 2;

--- a/src/v/iceberg/tests/table_requests_json_test.cc
+++ b/src/v/iceberg/tests/table_requests_json_test.cc
@@ -90,6 +90,7 @@ TEST(table_requests, serialize_commit_table_request) {
     req.updates.push_back(table_update::add_schema{});
     req.updates.push_back(table_update::set_current_schema{});
     req.updates.push_back(table_update::add_spec{});
+    req.updates.push_back(table_update::set_default_spec{});
     req.updates.push_back(table_update::add_snapshot{});
     req.updates.push_back(table_update::remove_snapshots{});
     req.updates.push_back(table_update::set_snapshot_ref{});
@@ -112,13 +113,14 @@ TEST(table_requests, serialize_commit_table_request) {
     ASSERT_EQ(d["identifier"]["name"].GetString(), req.identifier.table);
 
     ASSERT_TRUE(d["updates"].IsArray());
-    ASSERT_EQ(d["updates"].GetArray().Size(), 6);
+    ASSERT_EQ(d["updates"].GetArray().Size(), 7);
     ASSERT_EQ(d["updates"].GetArray()[0]["action"], "add-schema");
     ASSERT_EQ(d["updates"].GetArray()[1]["action"], "set-current-schema");
     ASSERT_EQ(d["updates"].GetArray()[2]["action"], "add-spec");
-    ASSERT_EQ(d["updates"].GetArray()[3]["action"], "add-snapshot");
-    ASSERT_EQ(d["updates"].GetArray()[4]["action"], "remove-snapshots");
-    ASSERT_EQ(d["updates"].GetArray()[5]["action"], "set-snapshot-ref");
+    ASSERT_EQ(d["updates"].GetArray()[3]["action"], "set-default-spec");
+    ASSERT_EQ(d["updates"].GetArray()[4]["action"], "add-snapshot");
+    ASSERT_EQ(d["updates"].GetArray()[5]["action"], "remove-snapshots");
+    ASSERT_EQ(d["updates"].GetArray()[6]["action"], "set-snapshot-ref");
 
     ASSERT_TRUE(d["requirements"].IsArray());
     ASSERT_EQ(d["requirements"].GetArray().Size(), 7);

--- a/src/v/iceberg/tests/table_requests_json_test.cc
+++ b/src/v/iceberg/tests/table_requests_json_test.cc
@@ -100,6 +100,7 @@ TEST(table_requests, serialize_commit_table_request) {
     req.requirements.push_back(table_requirement::last_assigned_field_match{});
     req.requirements.push_back(
       table_requirement::assert_last_assigned_partition_id{});
+    req.requirements.push_back(table_requirement::assert_default_spec_id{});
 
     auto json_str = to_json_str(req);
 
@@ -120,7 +121,7 @@ TEST(table_requests, serialize_commit_table_request) {
     ASSERT_EQ(d["updates"].GetArray()[5]["action"], "set-snapshot-ref");
 
     ASSERT_TRUE(d["requirements"].IsArray());
-    ASSERT_EQ(d["requirements"].GetArray().Size(), 6);
+    ASSERT_EQ(d["requirements"].GetArray().Size(), 7);
     ASSERT_EQ(d["requirements"].GetArray()[0]["type"], "assert-create");
     ASSERT_EQ(
       d["requirements"].GetArray()[1]["type"], "assert-current-schema-id");
@@ -132,6 +133,8 @@ TEST(table_requests, serialize_commit_table_request) {
     ASSERT_EQ(
       d["requirements"].GetArray()[5]["type"],
       "assert-last-assigned-partition-id");
+    ASSERT_EQ(
+      d["requirements"].GetArray()[6]["type"], "assert-default-spec-id");
 }
 
 TEST(table_requests, parsing_load_table_result) {

--- a/src/v/iceberg/tests/table_update_applier_test.cc
+++ b/src/v/iceberg/tests/table_update_applier_test.cc
@@ -146,24 +146,38 @@ TEST_F(UpdateApplyingVisitorTest, TestSetCurrentSchemaUnassigned) {
 
 TEST_F(UpdateApplyingVisitorTest, TestAddSpec) {
     auto table = create_table();
-    const auto make_update = [&](int32_t spec_id) -> table_update::update {
+    const auto make_update =
+      [&](
+        int32_t spec_id,
+        chunked_vector<partition_field> fields) -> table_update::update {
         return table_update::add_spec{
             .spec = partition_spec{
                 .spec_id = partition_spec::id_t{spec_id},
-                .fields = {},
+                .fields = std::move(fields),
             },
         };
     };
-    auto outcome = table_update::apply(make_update(0), table);
+    auto outcome = table_update::apply(make_update(0, {}), table);
     ASSERT_EQ(outcome, table_update::outcome::success);
     ASSERT_EQ(table.partition_specs.size(), 1);
+    ASSERT_EQ(table.last_partition_id, -1);
 
-    outcome = table_update::apply(make_update(1), table);
+    outcome = table_update::apply(
+      make_update(
+        1,
+        {partition_field{
+          .source_id = nested_field::id_t{1},
+          .field_id = partition_field::id_t{1001},
+          .name = "field",
+          .transform = identity_transform{},
+        }}),
+      table);
     ASSERT_EQ(outcome, table_update::outcome::success);
     ASSERT_EQ(table.partition_specs.size(), 2);
+    ASSERT_EQ(table.last_partition_id, 1001);
 
     // Adding an existing spec fails.
-    outcome = table_update::apply(make_update(1), table);
+    outcome = table_update::apply(make_update(1, {}), table);
     ASSERT_EQ(outcome, table_update::outcome::unexpected_state);
 }
 

--- a/src/v/iceberg/tests/table_update_applier_test.cc
+++ b/src/v/iceberg/tests/table_update_applier_test.cc
@@ -38,7 +38,7 @@ public:
           .schemas = std::move(schemas),
           .current_schema_id = schema::id_t{0},
           .partition_specs = {},
-          .default_spec_id = partition_spec::id_t{0},
+          .default_spec_id = partition_spec::id_t{-1},
           .last_partition_id = partition_field::id_t{-1},
         };
     }
@@ -348,4 +348,45 @@ TEST_F(UpdateApplyingVisitorTest, TestRemoveSnapshotReference) {
     ASSERT_EQ(outcome, table_update::outcome::success);
     ASSERT_EQ(99, table.refs->size());
     ASSERT_FALSE(table.current_snapshot_id.has_value());
+}
+
+TEST_F(UpdateApplyingVisitorTest, TestSetDefaultSpec) {
+    const auto make_update = [&](int32_t spec_id) -> table_update::update {
+        return table_update::set_default_spec{
+          .spec_id = partition_spec::id_t{spec_id},
+        };
+    };
+
+    auto table = create_table();
+    // add a couple of partition specs
+    table.partition_specs.push_back(partition_spec{
+      .spec_id = partition_spec::id_t{0},
+      .fields = {},
+    });
+    table.partition_specs.push_back(partition_spec{
+      .spec_id = partition_spec::id_t{1},
+      .fields = {},
+    });
+    table.default_spec_id = partition_spec::id_t{1};
+
+    // Sanity check for a no-op when setting to the current default spec.
+    auto outcome = table_update::apply(make_update(1), table);
+    ASSERT_EQ(outcome, table_update::outcome::success);
+    ASSERT_EQ(table.default_spec_id, 1);
+
+    // Now point to a different spec.
+    outcome = table_update::apply(make_update(0), table);
+    ASSERT_EQ(outcome, table_update::outcome::success);
+    ASSERT_EQ(table.default_spec_id, 0);
+
+    // Pointing at a spec that doesn't exist should fail.
+    outcome = table_update::apply(make_update(2), table);
+    ASSERT_EQ(outcome, table_update::outcome::unexpected_state);
+    ASSERT_EQ(table.default_spec_id, 0);
+
+    // Test setting to the latest added spec.
+    outcome = table_update::apply(
+      make_update(partition_spec::unassigned_id), table);
+    ASSERT_EQ(outcome, table_update::outcome::success);
+    ASSERT_EQ(table.default_spec_id, 1);
 }

--- a/src/v/iceberg/tests/update_partition_spec_action_test.cc
+++ b/src/v/iceberg/tests/update_partition_spec_action_test.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/tests/test_schemas.h"
+#include "iceberg/transaction.h"
+
+#include <gtest/gtest.h>
+
+using namespace iceberg;
+
+class UpdatePartitionSpecActionTest : public ::testing::Test {
+public:
+    // Create a simple table with no snapshots.
+    table_metadata create_table() {
+        auto s = schema{
+          .schema_struct = std::get<struct_type>(test_nested_schema_type()),
+          .schema_id = schema::id_t{0},
+          .identifier_field_ids = {},
+        };
+        chunked_vector<schema> schemas;
+        schemas.emplace_back(s.copy());
+
+        chunked_vector<partition_spec> specs;
+        specs.push_back(partition_spec{.spec_id = partition_spec::id_t{0}});
+
+        return table_metadata{
+          .format_version = format_version::v2,
+          .table_uuid = uuid_t::create(),
+          .location = uri("s3://foo/bar"),
+          .last_sequence_number = sequence_number{0},
+          .last_updated_ms = model::timestamp::now(),
+          .last_column_id = s.highest_field_id().value(),
+          .schemas = std::move(schemas),
+          .current_schema_id = schema::id_t{0},
+          .partition_specs = std::move(specs),
+          .default_spec_id = partition_spec::id_t{0},
+          .last_partition_id = partition_field::id_t{999},
+        };
+    }
+};
+
+TEST_F(UpdatePartitionSpecActionTest, TestAddSpec) {
+    transaction tx(create_table());
+    ASSERT_EQ(tx.table().partition_specs.size(), 1);
+
+    using field = unresolved_partition_spec::field;
+    chunked_vector<field> fields{field{
+      .source_name = {"bar"},
+      .transform = bucket_transform{.n = 16},
+      .name = "field1",
+    }};
+
+    {
+        // add a simple spec
+        auto res = tx.set_partition_spec(unresolved_partition_spec{
+                                           .fields = fields.copy(),
+                                         })
+                     .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 2);
+        ASSERT_EQ(tx.table().default_spec_id, 1);
+        const auto* spec = tx.table().get_partition_spec(
+          tx.table().default_spec_id);
+        ASSERT_TRUE(spec);
+        ASSERT_EQ(spec->fields.size(), 1);
+        ASSERT_EQ(spec->fields[0].name, "field1");
+        ASSERT_EQ(spec->fields[0].field_id, 1000);
+    }
+
+    {
+        // adding exactly the same spec is a no-op
+        auto res = tx.set_partition_spec(unresolved_partition_spec{
+                                           .fields = fields.copy(),
+                                         })
+                     .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 2);
+        ASSERT_EQ(tx.table().default_spec_id, 1);
+    }
+
+    {
+        // adding a field
+        fields.push_back(field{
+          .source_name = {"foo"},
+          .transform = identity_transform{},
+          .name = "field2",
+        });
+        auto res = tx.set_partition_spec(unresolved_partition_spec{
+                                           .fields = fields.copy(),
+                                         })
+                     .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 3);
+        ASSERT_EQ(tx.table().default_spec_id, 2);
+        const auto* spec = tx.table().get_partition_spec(
+          tx.table().default_spec_id);
+        ASSERT_TRUE(spec);
+        ASSERT_EQ(spec->fields.size(), 2);
+        ASSERT_EQ(spec->fields[0].name, "field1");
+        ASSERT_EQ(spec->fields[0].field_id, 1000);
+        ASSERT_EQ(spec->fields[1].name, "field2");
+        ASSERT_EQ(spec->fields[1].field_id, 1001);
+    }
+
+    {
+        // removing a field
+        fields = chunked_vector<field>(std::next(fields.begin()), fields.end());
+        auto res = tx.set_partition_spec(unresolved_partition_spec{
+                                           .fields = fields.copy(),
+                                         })
+                     .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 4);
+        ASSERT_EQ(tx.table().default_spec_id, 3);
+        const auto* spec = tx.table().get_partition_spec(
+          tx.table().default_spec_id);
+        ASSERT_TRUE(spec);
+        ASSERT_EQ(spec->fields.size(), 1);
+        ASSERT_EQ(spec->fields[0].name, "field2");
+        ASSERT_EQ(spec->fields[0].field_id, 1001);
+    }
+
+    {
+        // re-adding the same field (id must match the old one)
+        fields.push_back(field{
+          .source_name = {"bar"},
+          .transform = bucket_transform{.n = 16},
+          .name = "field1",
+        });
+        fields.push_back(field{
+          .source_name = {"baz"},
+          .transform = identity_transform{},
+          .name = "field3",
+        });
+        auto res = tx.set_partition_spec(unresolved_partition_spec{
+                                           .fields = fields.copy(),
+                                         })
+                     .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 5);
+        ASSERT_EQ(tx.table().default_spec_id, 4);
+        const auto* spec = tx.table().get_partition_spec(
+          tx.table().default_spec_id);
+        ASSERT_TRUE(spec);
+        ASSERT_EQ(spec->fields.size(), 3);
+        ASSERT_EQ(spec->fields[1].name, "field1");
+        ASSERT_EQ(spec->fields[1].field_id, 1000);
+    }
+
+    {
+        // set the spec to empty and then add a field, check that
+        // last_partition_id is honored.
+        auto res = tx.set_partition_spec(unresolved_partition_spec{}).get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 5);
+        ASSERT_EQ(tx.table().default_spec_id, 0);
+
+        fields.clear();
+        fields.push_back(field{
+          .source_name = {"person", "age"},
+          .transform = bucket_transform{.n = 16},
+          .name = "field4",
+        });
+        res = tx.set_partition_spec(unresolved_partition_spec{
+                                      .fields = fields.copy(),
+                                    })
+                .get();
+        ASSERT_FALSE(res.has_error());
+        ASSERT_EQ(tx.table().partition_specs.size(), 6);
+        ASSERT_EQ(tx.table().default_spec_id, 5);
+        const auto* spec = tx.table().get_partition_spec(
+          tx.table().default_spec_id);
+        ASSERT_TRUE(spec);
+        ASSERT_EQ(spec->fields.size(), 1);
+        ASSERT_EQ(spec->fields[0].name, "field4");
+        ASSERT_EQ(tx.table().last_partition_id, 1003);
+        ASSERT_EQ(spec->fields[0].field_id, 1003);
+    }
+}

--- a/src/v/iceberg/transaction.cc
+++ b/src/v/iceberg/transaction.cc
@@ -14,6 +14,7 @@
 #include "iceberg/schema.h"
 #include "iceberg/table_requirement.h"
 #include "iceberg/table_update_applier.h"
+#include "iceberg/update_partition_spec_action.h"
 #include "iceberg/update_schema_action.h"
 
 namespace iceberg {
@@ -66,6 +67,13 @@ transaction::txn_outcome transaction::update_metadata(updates_and_reqs ur) {
 
 ss::future<transaction::txn_outcome> transaction::set_schema(schema s) {
     auto a = std::make_unique<update_schema_action>(table_, std::move(s));
+    co_return co_await apply(std::move(a));
+}
+
+ss::future<transaction::txn_outcome>
+transaction::set_partition_spec(unresolved_partition_spec pspec) {
+    auto a = std::make_unique<update_partition_spec_action>(
+      table_, std::move(pspec));
     co_return co_await apply(std::move(a));
 }
 

--- a/src/v/iceberg/transaction.h
+++ b/src/v/iceberg/transaction.h
@@ -38,6 +38,11 @@ public:
     // is assigned based on the state of the table.
     ss::future<txn_outcome> set_schema(schema);
 
+    // Adds a new partition spec and sets it as the default one. Partition
+    // source fields are resolved using the current schema and existing
+    // partition fields are reused.
+    ss::future<txn_outcome> set_partition_spec(unresolved_partition_spec);
+
     // Adds the given data files to a new snapshot for the table, potentially
     // merging manifests to reduce manifest list size.
     //

--- a/src/v/iceberg/transaction.h
+++ b/src/v/iceberg/transaction.h
@@ -69,6 +69,11 @@ public:
 
     std::optional<action::errc> error() const { return error_; }
 
+    bool is_noop() const {
+        return !error_ && updates_.updates.empty()
+               && updates_.requirements.empty();
+    }
+
     // NOTE: it is up to the caller to ensure the transaction has not hit any
     // errors before calling these.
     const table_metadata& table() const { return table_; }

--- a/src/v/iceberg/unresolved_partition_spec.h
+++ b/src/v/iceberg/unresolved_partition_spec.h
@@ -38,6 +38,12 @@ struct unresolved_partition_spec {
       const unresolved_partition_spec&, const unresolved_partition_spec&)
       = default;
 
+    unresolved_partition_spec copy() const {
+        return {
+          .fields = fields.copy(),
+        };
+    }
+
     friend std::ostream&
     operator<<(std::ostream&, const unresolved_partition_spec&);
 };

--- a/src/v/iceberg/update_partition_spec_action.cc
+++ b/src/v/iceberg/update_partition_spec_action.cc
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/update_partition_spec_action.h"
+
+#include "iceberg/logger.h"
+
+namespace iceberg {
+
+update_partition_spec_action::update_partition_spec_action(
+  const table_metadata& table, unresolved_partition_spec new_spec)
+  : table_(table)
+  , new_spec_(std::move(new_spec))
+  , logger_(
+      log,
+      fmt::format(
+        "[table uuid: {}, location: {}]", table_.table_uuid, table_.location)) {
+}
+
+namespace {
+
+// If the key matches, the new field will be assigned the same id.
+struct field_key_t {
+    nested_field::id_t source_id;
+    transform transform;
+    ss::sstring name;
+
+    bool operator==(const field_key_t& other) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const field_key_t& k) {
+        return H::combine(std::move(h), k.source_id, k.name);
+    }
+};
+
+} // namespace
+
+ss::future<action::action_outcome>
+update_partition_spec_action::build_updates() && {
+    updates_and_reqs ret;
+
+    const auto* cur_schema = table_.get_schema(table_.current_schema_id);
+    if (!cur_schema) {
+        vlog(
+          logger_.error,
+          "can't get current schema (id: {})",
+          table_.current_schema_id);
+        co_return errc::unexpected_state;
+    }
+
+    const auto cur_spec_id = table_.default_spec_id;
+    auto highest_spec_id = partition_spec::id_t{-1};
+    chunked_hash_map<field_key_t, partition_field::id_t> field_key2id;
+    for (const auto& pspec : table_.partition_specs) {
+        highest_spec_id = std::max(highest_spec_id, pspec.spec_id);
+        for (const auto& field : pspec.fields) {
+            field_key2id[{field.source_id, field.transform, field.name}]
+              = field.field_id;
+        }
+    }
+
+    partition_spec resolved;
+    chunked_hash_set<ss::sstring> field_names_set;
+    const auto last_field_id = table_.last_partition_id;
+    auto next_field_id = last_field_id + 1;
+    for (const auto& field : new_spec_.fields) {
+        const auto* source_field = cur_schema->schema_struct.find_field_by_name(
+          field.source_name);
+        if (!source_field) {
+            vlog(
+              logger_.warn,
+              "failed to resolve source field {}",
+              fmt::join(field.source_name, "."));
+            co_return errc::unexpected_state;
+        }
+
+        bool added = field_names_set.insert(field.name).second;
+        if (!added) {
+            vlog(
+              logger_.warn,
+              "duplicate partition field name {} not allowed",
+              field.name);
+            co_return errc::unexpected_state;
+        }
+
+        partition_field resolved_field{
+          .source_id = source_field->id,
+          .name = field.name,
+          .transform = field.transform,
+        };
+        field_key_t field_key{
+          resolved_field.source_id,
+          resolved_field.transform,
+          resolved_field.name};
+        auto it = field_key2id.find(field_key);
+        if (it != field_key2id.end()) {
+            resolved_field.field_id = it->second;
+        } else {
+            resolved_field.field_id = next_field_id;
+            next_field_id += 1;
+        }
+        resolved.fields.push_back(std::move(resolved_field));
+    }
+
+    for (const auto& pspec : table_.partition_specs) {
+        if (pspec.fields == resolved.fields) {
+            if (pspec.spec_id == table_.default_spec_id) {
+                // no-op
+                co_return updates_and_reqs{};
+            }
+            // New spec matches an existing one. Just set it as default.
+            ret.updates.push_back(
+              table_update::set_default_spec{pspec.spec_id});
+            ret.requirements.push_back(
+              table_requirement::assert_default_spec_id{cur_spec_id});
+            co_return ret;
+        }
+    }
+
+    // we need to add the spec to the table
+    resolved.spec_id = partition_spec::id_t{highest_spec_id() + 1};
+    ret.updates.push_back(table_update::add_spec{.spec = std::move(resolved)});
+    ret.requirements.push_back(
+      table_requirement::assert_current_schema_id{table_.current_schema_id});
+    ret.requirements.push_back(
+      table_requirement::assert_last_assigned_partition_id{last_field_id});
+
+    // set newly added spec as the default one.
+    ret.updates.push_back(
+      table_update::set_default_spec{partition_spec::unassigned_id});
+    ret.requirements.push_back(
+      table_requirement::assert_default_spec_id{cur_spec_id});
+
+    co_return ret;
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/update_partition_spec_action.h
+++ b/src/v/iceberg/update_partition_spec_action.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "iceberg/action.h"
+#include "iceberg/table_metadata.h"
+#include "iceberg/unresolved_partition_spec.h"
+#include "utils/prefix_logger.h"
+
+namespace iceberg {
+
+// Action that adds a new partition spec to the table and sets it as a default
+// spec.
+class update_partition_spec_action : public action {
+public:
+    update_partition_spec_action(
+      const table_metadata& table, unresolved_partition_spec new_spec);
+
+protected:
+    ss::future<action_outcome> build_updates() && final;
+
+private:
+    const table_metadata& table_;
+    const unresolved_partition_spec new_spec_;
+    prefix_logger logger_;
+};
+
+} // namespace iceberg

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -372,11 +372,15 @@ create_topic_properties_update(
                 continue;
             }
             if (cfg.name == topic_property_iceberg_partition_spec) {
+                // Use std::identity as the "parser function" (i.e. pass through
+                // the raw string) because boost::lexical_cast<ss::sstring> (the
+                // default) doesn't allow spaces in the config value.
                 parse_and_set_optional(
                   update.properties.iceberg_partition_spec,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  iceberg_partition_spec_validator{});
+                  iceberg_partition_spec_validator{},
+                  std::identity{});
                 continue;
             }
             if (cfg.name == topic_property_iceberg_invalid_record_action) {

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1007,7 +1007,8 @@ config_response_container_t make_topic_configs(
           maybe_make_documentation(
             include_documentation,
             "Partition spec of the corresponding Iceberg table."),
-          &describe_as_string<ss::sstring>);
+          &describe_as_string<ss::sstring>,
+          true);
 
         add_topic_config_if_requested(
           config_keys,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -375,11 +375,15 @@ create_topic_properties_update(
                 continue;
             }
             if (cfg.name == topic_property_iceberg_partition_spec) {
+                // Use std::identity as the "parser function" (i.e. pass through
+                // the raw string) because boost::lexical_cast<ss::sstring> (the
+                // default) doesn't allow spaces in the config value.
                 parse_and_set_optional(
                   update.properties.iceberg_partition_spec,
                   cfg.value,
                   op,
-                  iceberg_partition_spec_validator{});
+                  iceberg_partition_spec_validator{},
+                  std::identity{});
                 continue;
             }
             if (cfg.name == topic_property_iceberg_invalid_record_action) {

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -21,11 +21,14 @@ from ducktape.mark import matrix
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.services.redpanda_connect import RedpandaConnectService
 from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.catalog_service_factory import supported_catalog_types
+from rptest.utils.rpcn_utils import counter_stream_config
 
 
 class DatalakeCustomPartitioningConfigTest(RedpandaTest):
@@ -399,3 +402,107 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 ('Part 0', 'days(redpanda.timestamp)', ''),
             ]
             assert describe_partitioning == expected_partitioning
+
+    @cluster(num_nodes=7)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_spec_evolution_rpcn(self, cloud_storage_type, catalog_type):
+        """
+        Test changing the partition spec with uninterrupted produce load
+        coming from redpanda connect.
+        """
+
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              catalog_type=catalog_type,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+            avro_schema = """
+{
+    "type": "record",
+    "namespace": "com.redpanda.examples.avro",
+    "name": "ClickEvent",
+    "fields": [
+        {"name": "event_type", "type": "int"},
+        {"name": "number", "type": "long"},
+        {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+        {"name": "verifier_string", "type": "string"}
+    ]
+}
+            """
+
+            rpk = RpkTool(self.redpanda)
+            rpk.create_schema_from_str("verifier_schema", avro_schema)
+
+            topic_name = "foo"
+            partitions = 5
+            dl.create_iceberg_enabled_topic(
+                topic_name,
+                partitions=partitions,
+                iceberg_mode="value_schema_id_prefix",
+                config={
+                    "redpanda.iceberg.partition.spec": "(hour(timestamp))"
+                })
+
+            connect = RedpandaConnectService(self.test_context, self.redpanda)
+            connect.start()
+
+            # Use stream config that will produce events until we stop it explicitly
+            timestamp = time.time()
+            num_event_types = 3
+            avro_stream_config = counter_stream_config(
+                self.redpanda,
+                topic_name,
+                "verifier_schema",
+                dict(
+                    event_type=f"random_int(min:1, max:{num_event_types})",
+                    number="this",
+                    timestamp=f"{int(timestamp * 1000)}",
+                    verifier_string="uuid_v4()",
+                ),
+                1_000_000,
+                interval_ms=1)
+            connect.start_stream(name="ducky_stream",
+                                 config=avro_stream_config)
+
+            verifier = DatalakeVerifier(self.redpanda, topic_name, dl.spark())
+            verifier.start()
+
+            dl.wait_for_iceberg_table("redpanda",
+                                      topic_name,
+                                      timeout=60,
+                                      backoff_sec=5)
+            self.redpanda.wait_until(
+                lambda: dl.spark().count_table("redpanda", topic_name) >= 1000,
+                timeout_sec=60,
+                backoff_sec=2)
+
+            def num_partitions():
+                partitions = set(dl.spark().run_query_fetch_all(
+                    f"select partition from redpanda.{topic_name}.files"))
+                self.logger.info(f"iceberg files partitions: {partitions}")
+                return len(partitions)
+
+            assert num_partitions() == 1
+
+            self.logger.info("altering topic partition spec...")
+            rpk.alter_topic_config(topic_name,
+                                   "redpanda.iceberg.partition.spec",
+                                   "(event_type)")
+
+            self.redpanda.wait_until(
+                lambda: num_partitions() == 1 + num_event_types,
+                timeout_sec=60,
+                backoff_sec=5,
+                err_msg="failed to wait for new partitions to appear")
+
+            expected_partitioning = [
+                ('# Partition Information', '', ''),
+                ('# col_name', 'data_type', 'comment'),
+                ('event_type', 'int', None),
+            ]
+            assert self.describe_partitioning(
+                dl, topic_name) == expected_partitioning
+
+            connect.stop_stream("ducky_stream", should_finish=False)
+            verifier.wait()

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -117,6 +117,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                              extra_rp_conf={
                                  "iceberg_enabled": True,
                                  "iceberg_catalog_commit_interval_ms": 5000,
+                                 "iceberg_target_lag_ms": 5000,
                              },
                              schema_registry_config=SchemaRegistryConfig(),
                              *args,
@@ -135,6 +136,26 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             'key.serializer': StringSerializer('utf_8'),
             'value.serializer': value_serializer,
         })
+
+    def produce(self, dl, producer, topic_name, msg_count, already_produced=0):
+        # Have all records share the same timestamp, so that they are
+        # guaranteed to end up in the same hour partition.
+        timestamp = time.time()
+        for i in range(msg_count):
+            ev_type = random.choice(["type_A", "type_B"])
+            record = {
+                "event_type": ev_type,
+                "number": already_produced + i,
+                "timestamp_us": int(timestamp * 1000000),
+            }
+            producer.produce(
+                topic=topic_name,
+                # key to ensure that all partitions get some records
+                key=str(uuid4()),
+                value=record)
+        producer.flush()
+        dl.wait_for_translation(topic_name,
+                                msg_count=already_produced + msg_count)
 
     def describe_partitioning(self, dl, topic_name):
         table_name = f"redpanda.{topic_name}"
@@ -173,24 +194,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 })
 
             producer = self.create_producer()
-
-            # Have all records share the same timestamp, so that they are
-            # guaranteed to end up in the same hour partition.
-            timestamp = time.time()
-            for i in range(msg_count):
-                ev_type = random.choice(["type_A", "type_B"])
-                record = {
-                    "event_type": ev_type,
-                    "number": i,
-                    "timestamp_us": int(timestamp * 1000000),
-                }
-                producer.produce(
-                    topic=topic_name,
-                    # key to ensure that all partitions get some records
-                    key=str(uuid4()),
-                    value=record)
-            producer.flush()
-            dl.wait_for_translation(topic_name, msg_count=msg_count)
+            self.produce(dl, producer, topic_name, msg_count)
 
             # Check that created table has the correct partition spec.
 
@@ -251,24 +255,9 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
             def produce():
                 nonlocal already_produced
-                # Have all records share the same timestamp, so that they are
-                # guaranteed to end up in the same hour partition.
-                timestamp = time.time()
-                for i in range(msg_count):
-                    ev_type = random.choice(["type_A", "type_B"])
-                    record = {
-                        "event_type": ev_type,
-                        "number": already_produced + i,
-                        "timestamp_us": int(timestamp * 1000000),
-                    }
-                    producer.produce(
-                        topic=topic_name,
-                        # key to ensure that all partitions get some records
-                        key=str(uuid4()),
-                        value=record)
-                producer.flush()
+                self.produce(dl, producer, topic_name, msg_count,
+                             already_produced)
                 already_produced += msg_count
-                dl.wait_for_translation(topic_name, msg_count=already_produced)
 
             produce()
 
@@ -328,5 +317,85 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 ('# Partition Information', '', ''),
                 ('# col_name', 'data_type', 'comment'),
                 ('event_type', 'string', None),
+            ]
+            assert describe_partitioning == expected_partitioning
+
+    @cluster(num_nodes=6)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_sticky_default(self, cloud_storage_type, catalog_type):
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              catalog_type=catalog_type,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+
+            self.redpanda.set_cluster_config(
+                {"iceberg_default_partition_spec": "()"})
+
+            # Create an iceberg topic and produce
+            # some data.
+
+            topic_name = "foo"
+            msg_count = 1000
+            partitions = 5
+            dl.create_iceberg_enabled_topic(
+                topic_name,
+                partitions=partitions,
+                iceberg_mode="value_schema_id_prefix")
+
+            producer = self.create_producer()
+
+            already_produced = 0
+
+            def produce(topic):
+                nonlocal already_produced
+                self.produce(dl, producer, topic, msg_count, already_produced)
+                already_produced += msg_count
+
+            produce(topic_name)
+
+            # partition spec should reflect the original value
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
+            assert describe_partitioning == []
+
+            self.logger.info("altering default partition spec...")
+            self.redpanda.set_cluster_config({
+                "iceberg_default_partition_spec":
+                "(hour(redpanda.timestamp))"
+            })
+
+            produce(topic_name)
+
+            # partition spec should reflect the original value
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
+            assert describe_partitioning == []
+
+            # create another topic, but don't enable iceberg just yet.
+            another_topic = "bar"
+            rpk = RpkTool(self.redpanda)
+            rpk.create_topic(topic=another_topic,
+                             partitions=partitions,
+                             replicas=3)
+
+            self.redpanda.set_cluster_config({
+                "iceberg_default_partition_spec":
+                "(day(redpanda.timestamp))"
+            })
+            rpk.alter_topic_config(another_topic, "redpanda.iceberg.mode",
+                                   "value_schema_id_prefix")
+
+            self.redpanda.set_cluster_config(
+                {"iceberg_default_partition_spec": "()"})
+
+            already_produced = 0
+            produce(another_topic)
+
+            # partition spec should reflect the value at the time iceberg was enabled
+            describe_partitioning = self.describe_partitioning(
+                dl, another_topic)
+            expected_partitioning = [
+                ('# Partitioning', '', ''),
+                ('Part 0', 'days(redpanda.timestamp)', ''),
             ]
             assert describe_partitioning == expected_partitioning

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -126,6 +126,28 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
         # redpanda will be started by DatalakeServices
         pass
 
+    def create_producer(self, schema=AVRO_SCHEMA_STR):
+        value_serializer = AvroSerializer(
+            SchemaRegistryClient(
+                {"url": self.redpanda.schema_reg().split(",")[0]}), schema)
+        return SerializingProducer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'key.serializer': StringSerializer('utf_8'),
+            'value.serializer': value_serializer,
+        })
+
+    def describe_partitioning(self, dl, topic_name):
+        table_name = f"redpanda.{topic_name}"
+        spark = dl.spark()
+        spark_describe_out = spark.run_query_fetch_all(
+            f"describe {table_name}")
+        # If there is just 1 field in the partition spec, partition info
+        # starts with '# Partition Information', if there is more, it starts
+        # with '# Partitioning'.
+        return list(
+            itertools.dropwhile(lambda r: not r[0].startswith('# Partition'),
+                                spark_describe_out))
+
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
@@ -150,18 +172,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                     "(hour(timestamp_us), event_type)"
                 })
 
-            value_serializer = AvroSerializer(
-                SchemaRegistryClient(
-                    {"url": self.redpanda.schema_reg().split(",")[0]}),
-                AVRO_SCHEMA_STR)
-            producer = SerializingProducer({
-                'bootstrap.servers':
-                self.redpanda.brokers(),
-                'key.serializer':
-                StringSerializer('utf_8'),
-                'value.serializer':
-                value_serializer,
-            })
+            producer = self.create_producer()
 
             # Have all records share the same timestamp, so that they are
             # guaranteed to end up in the same hour partition.
@@ -183,13 +194,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
             # Check that created table has the correct partition spec.
 
-            table_name = f"redpanda.{topic_name}"
-            spark = dl.spark()
-            spark_describe_out = spark.run_query_fetch_all(
-                f"describe {table_name}")
-            describe_partitioning = list(
-                itertools.dropwhile(lambda r: r[0] != "# Partitioning",
-                                    spark_describe_out))
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
             expected_partitioning = [
                 ('# Partitioning', '', ''),
                 ('Part 0', 'hours(timestamp_us)', ''),
@@ -199,6 +204,9 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
             # Check that files are correctly partitioned and that
             # spark can use this partitioning for a delete query.
+
+            table_name = f"redpanda.{topic_name}"
+            spark = dl.spark()
 
             files_before = set(
                 spark.run_query_fetch_all(
@@ -215,3 +223,110 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                     f"select file_path from {table_name}.files"))
             assert len(files_after) == partitions
             assert files_after.issubset(files_before)
+
+    @cluster(num_nodes=6)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_spec_evolution(self, cloud_storage_type, catalog_type):
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              catalog_type=catalog_type,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+            # Create an iceberg topic with a custom partition spec and produce
+            # some data.
+
+            topic_name = "foo"
+            msg_count = 1000
+            partitions = 5
+            dl.create_iceberg_enabled_topic(
+                topic_name,
+                partitions=partitions,
+                iceberg_mode="value_schema_id_prefix",
+                config={"redpanda.iceberg.partition.spec": "()"})
+
+            producer = self.create_producer()
+
+            already_produced = 0
+
+            def produce():
+                nonlocal already_produced
+                # Have all records share the same timestamp, so that they are
+                # guaranteed to end up in the same hour partition.
+                timestamp = time.time()
+                for i in range(msg_count):
+                    ev_type = random.choice(["type_A", "type_B"])
+                    record = {
+                        "event_type": ev_type,
+                        "number": already_produced + i,
+                        "timestamp_us": int(timestamp * 1000000),
+                    }
+                    producer.produce(
+                        topic=topic_name,
+                        # key to ensure that all partitions get some records
+                        key=str(uuid4()),
+                        value=record)
+                producer.flush()
+                already_produced += msg_count
+                dl.wait_for_translation(topic_name, msg_count=already_produced)
+
+            produce()
+
+            table_name = f"redpanda.{topic_name}"
+            spark = dl.spark()
+
+            # The translator for each partition should produce one file.
+            files1 = set(
+                spark.run_query_fetch_all(
+                    f"select file_path from {table_name}.files"))
+            assert len(files1) == partitions
+
+            # partition spec should reflect the original value
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
+            assert describe_partitioning == []
+
+            self.logger.info("adding a 2-field partition spec...")
+            rpk = RpkTool(self.redpanda)
+            rpk.alter_topic_config(topic_name,
+                                   "redpanda.iceberg.partition.spec",
+                                   "(hour(timestamp_us), event_type)")
+
+            produce()
+
+            # The translator for each partition should produce one file
+            # for each event type.
+            files2 = set(
+                spark.run_query_fetch_all(
+                    f"select file_path from {table_name}.files"))
+            assert len(files2) == partitions * 3
+
+            # partition spec should reflect the altered value
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
+            expected_partitioning = [
+                ('# Partitioning', '', ''),
+                ('Part 0', 'hours(timestamp_us)', ''),
+                ('Part 1', 'event_type', ''),
+            ]
+            assert describe_partitioning == expected_partitioning
+
+            self.logger.info("removing one field from partition spec...")
+            rpk.alter_topic_config(topic_name,
+                                   "redpanda.iceberg.partition.spec",
+                                   "(event_type)")
+
+            produce()
+
+            # The translator for each partition should produce one file
+            # for each event type.
+            files3 = set(
+                spark.run_query_fetch_all(
+                    f"select file_path from {table_name}.files"))
+            assert len(files3) == partitions * 5
+
+            describe_partitioning = self.describe_partitioning(dl, topic_name)
+            expected_partitioning = [
+                ('# Partition Information', '', ''),
+                ('# col_name', 'data_type', 'comment'),
+                ('event_type', 'string', None),
+            ]
+            assert describe_partitioning == expected_partitioning


### PR DESCRIPTION
* add missing table updates and requirements for evolving the partition spec
* implement `update_partition_spec_action`
* update the spec (if it changed) in `schema_manager::ensure_table_schema`
* implement "sticky default" for the spec topic config

Fixes https://redpandadata.atlassian.net/browse/CORE-8717

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
