### PR TITLE
Pass in an abort source into replicate options

### DIFF
--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -81,7 +81,8 @@ coordinator_stm::sync(model::timeout_clock::duration timeout) {
 ss::future<checked<std::nullopt_t, coordinator_stm::errc>>
 coordinator_stm::replicate_and_wait(
   model::term_id term, model::record_batch batch, ss::abort_source& as) {
-    auto opts = raft::replicate_options{raft::consistency_level::quorum_ack};
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, std::ref(as));
     opts.set_force_flush();
     auto res = co_await _raft->replicate(term, std::move(batch), opts);
     if (res.has_error()) {

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -20,9 +20,11 @@
 #include <seastar/core/future.hh>
 
 namespace {
-raft::replicate_options make_replicate_options() {
-    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+raft::replicate_options make_replicate_options(ss::abort_source& as) {
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, std::ref(as));
     opts.set_force_flush();
+
     return opts;
 }
 
@@ -148,7 +150,7 @@ ss::future<std::error_code> translation_stm::reset_highest_translated_offset(
     auto result = co_await _raft->replicate(
       current_term,
       make_translation_state_batch(new_translated_offset, new_translated_ts),
-      make_replicate_options());
+      make_replicate_options(as));
     auto deadline = model::timeout_clock::now() + timeout;
     if (
       result

--- a/src/v/raft/replicate.h
+++ b/src/v/raft/replicate.h
@@ -23,15 +23,22 @@ namespace raft {
 enum class consistency_level { quorum_ack, leader_ack, no_ack };
 
 struct replicate_options {
-    explicit replicate_options(consistency_level l)
+    explicit replicate_options(
+      consistency_level l,
+      std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt)
       : consistency(l)
       , timeout(std::nullopt)
-      , _force_flush(false) {}
+      , _force_flush(false)
+      , as(as) {}
 
-    replicate_options(consistency_level l, std::chrono::milliseconds timeout)
+    replicate_options(
+      consistency_level l,
+      std::chrono::milliseconds timeout,
+      std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt)
       : consistency(l)
       , timeout(timeout)
-      , _force_flush(false) {}
+      , _force_flush(false)
+      , as(as) {}
 
     // Callers may choose to force flush on an individual replicate request
     // basis. This is useful if certain callers intend to override any
@@ -45,6 +52,7 @@ struct replicate_options {
     consistency_level consistency;
     std::optional<std::chrono::milliseconds> timeout;
     bool _force_flush;
+    std::optional<std::reference_wrapper<ss::abort_source>> as;
 };
 
 struct replicate_result {

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -33,6 +33,14 @@ replicate_stages replicate_batcher::replicate(
   std::optional<model::term_id> expected_term,
   chunked_vector<model::record_batch> batches,
   replicate_options opts) {
+    if (opts.as) [[unlikely]] {
+        if (opts.as->get().abort_requested()) {
+            return replicate_stages{
+              ss::make_exception_future<>(ss::abort_requested_exception()),
+              ss::make_ready_future<result<replicate_result>>(
+                errc::shutting_down)};
+        }
+    }
     ss::promise<> enqueued;
     auto enqueued_f = enqueued.get_future();
 

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -43,6 +43,15 @@ public:
             if (_replicate_opts.timeout) {
                 _timeout_timer.arm(_replicate_opts.timeout.value());
             }
+            if (_replicate_opts.as) {
+                auto& as = _replicate_opts.as->get();
+                if (as.abort_requested()) {
+                    mark_as_aborted();
+                } else {
+                    _abort_sub = as.subscribe(
+                      [this] noexcept { mark_as_aborted(); });
+                }
+            }
         };
 
         item(item&&) noexcept = default;
@@ -100,6 +109,15 @@ public:
                 _promise.set_value(errc::timeout);
             }
         }
+
+        void mark_as_aborted() {
+            if (!_ready) {
+                _ready = true;
+                _data.clear();
+                _units.return_all();
+                _promise.set_value(errc::shutting_down);
+            }
+        }
         size_t _record_count;
         chunked_vector<model::record_batch> _data;
         ssx::semaphore_units _units;
@@ -113,6 +131,7 @@ public:
         bool _ready{false};
         ss::timer<> _timeout_timer;
         ss::promise<result<replicate_result>> _promise;
+        ss::optimized_optional<ss::abort_source::subscription> _abort_sub;
     };
     using item_ptr = ss::lw_shared_ptr<item>;
     explicit replicate_batcher(consensus* ptr, size_t cache_size);

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1005,3 +1005,48 @@ TEST_F_CORO(raft_fixture, test_term_conditional_replication) {
       replicate_options(consistency_level::quorum_ack, 10s));
     ASSERT_FALSE_CORO(result_without_term.has_error());
 }
+
+TEST_F_CORO(raft_fixture, test_replicate_abort_source) {
+    co_await create_simple_group(3);
+    auto leader_id = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader_id);
+    // this should succeed as there were no leadership changes
+    auto result = co_await leader_node.raft()->replicate(
+      make_batches(10, 10, 128),
+      replicate_options(consistency_level::quorum_ack));
+    ASSERT_FALSE_CORO(result.has_error());
+
+    /**
+     * Block all append entries from leader to followers to prevent any
+     * subsequent replicate calls from finishing
+     */
+    leader_node.on_dispatch([](model::node_id, raft::msg_type mt) {
+        if (mt == raft::msg_type::append_entries) {
+            throw std::runtime_error("error");
+        }
+        return ss::now();
+    });
+    /**
+     * Abort after replicate
+     */
+    ss::abort_source as_1;
+    auto as_1_f = leader_node.raft()->replicate(
+      make_batches(1, 1, 128),
+      replicate_options(consistency_level::quorum_ack, std::ref(as_1)));
+    co_await ss::sleep(500ms);
+    ASSERT_FALSE_CORO(as_1_f.available());
+
+    as_1.request_abort();
+    auto r_1 = co_await std::move(as_1_f);
+    ASSERT_TRUE_CORO(r_1.has_error());
+    ASSERT_EQ_CORO(r_1.error(), raft::errc::shutting_down);
+    /**
+     * Already aborted
+     */
+    auto r_2 = co_await leader_node.raft()->replicate(
+      make_batches(1, 1, 128),
+      replicate_options(consistency_level::quorum_ack, std::ref(as_1)));
+
+    ASSERT_TRUE_CORO(r_2.has_error());
+    ASSERT_EQ_CORO(r_2.error(), raft::errc::replicate_first_stage_exception);
+}


### PR DESCRIPTION
Added an option to pass an external abort source to `raft::replicate_options`. This makes the Raft group lifecycle management much easier as the `replicate` caller doesn't have to rely on the Raft shutdown to abort waiting for replication to finish. That was previously a major issue as the Raft group abort source had to be triggered to interrupt waiting for replication result.

Now the caller can pass in an optional abort source reference to the `replicate` request to interrupt waiting for replication.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none