### PR TITLE
cloud_storage: improve remote partition finalizer

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1318,11 +1318,14 @@ struct finalize_data {
     model::offset insync_offset;
 };
 
-ss::future<> finalize_background(
+/// This function runs as a detached background fiber, so has no shutdown
+/// logic of its own: our remote operations will be shut down when the
+/// `remote` object is shut down.
+///
+/// Precondition: the caller must ensure that api object is valid for the
+/// duration of this function. I.e. hold a gate.
+ss::future<> finalize_in_background(
   remote& api, finalize_data data, remote_path_provider path_provider) {
-    // This function runs as a detached background fiber, so has no shutdown
-    // logic of its own: our remote operations will be shut down when the
-    // `remote` object is shut down.
     ss::abort_source& as = api.as();
 
     retry_chain_node local_rtc(as, finalize_timeout, finalize_backoff);
@@ -1429,7 +1432,7 @@ void remote_partition::finalize() {
       [&api = _api,
        data = std::move(data),
        pp = _manifest_view->path_provider().copy()]() mutable -> ss::future<> {
-          return finalize_background(api, std::move(data), pp.copy());
+          return finalize_in_background(api, std::move(data), pp.copy());
       });
 }
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1316,6 +1316,7 @@ struct finalize_data {
     cloud_storage_clients::bucket_name bucket;
     iobuf serialized_manifest;
     model::offset insync_offset;
+    bool remote_manifest_expected;
 };
 
 /// This function runs as a detached background fiber, so has no shutdown
@@ -1330,8 +1331,13 @@ ss::future<> finalize_in_background(
 
     retry_chain_node local_rtc(as, finalize_timeout, finalize_backoff);
 
+    // Start with an empty manifest.
     partition_manifest remote_manifest(data.ntp, data.revision);
 
+    // Try downloading the remote manifest unconditionally. Although locally we
+    // might believe it does not exist (e.g. because we are a replica and
+    // haven't received yet the command informing us that remote manifest is
+    // clean), it might exist and we should try to use it if so.
     partition_manifest_downloader dl(
       data.bucket, path_provider, data.ntp, data.revision, api);
     auto manifest_get_result = co_await dl.download_manifest(
@@ -1344,16 +1350,28 @@ ss::future<> finalize_in_background(
           manifest_get_result.error());
         co_return;
     }
+
     if (
       manifest_get_result.value()
       == find_partition_manifest_outcome::no_matching_manifest) {
-        vlog(
-          cst_log.error,
-          "[{}] Failed to fetch manifest during finalize(). Not found",
-          data.ntp);
-        co_return;
+        if (data.remote_manifest_expected) {
+            // Log an error if manifest doesn't exist but we expected it to.
+            // This is a bug.
+            vlog(
+              cst_log.error,
+              "[{}] Failed to fetch manifest during finalize(). Not found",
+              data.ntp);
+            co_return;
+        } else {
+            vlog(
+              cst_log.debug,
+              "[{}] Failed to fetch manifest during finalize(). Not found. "
+              "Will upload a new one.",
+              data.ntp);
+        }
     }
 
+    // Note: We might get here with empty remote_manifest (default constructed).
     if (remote_manifest.get_insync_offset() > data.insync_offset) {
         // Our local manifest is behind the remote: return a copy of the
         // remote manifest for use in deletion
@@ -1405,7 +1423,7 @@ ss::future<> finalize_in_background(
     }
 }
 
-void remote_partition::finalize() {
+void remote_partition::finalize(bool remote_manifest_expected) {
     vlog(_ctxlog.info, "Finalizing remote storage state...");
 
     // We do this in the background, because
@@ -1425,7 +1443,9 @@ void remote_partition::finalize() {
       .revision = stm_manifest.get_revision_id(),
       .bucket = _bucket,
       .serialized_manifest = std::move(serialized_manifest),
-      .insync_offset = stm_manifest.get_insync_offset()};
+      .insync_offset = stm_manifest.get_insync_offset(),
+      .remote_manifest_expected = remote_manifest_expected,
+    };
 
     ssx::spawn_with_gate(
       _api.gate(),

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -125,7 +125,7 @@ public:
 
     /// Do background flush metadata to object storage, prior to a topic
     /// deletion
-    void finalize();
+    void finalize(bool remote_manifest_expected);
 
     enum class erase_result { erased, failed };
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1043,12 +1043,15 @@ ss::future<> partition::finalize_remote_partition(ss::abort_source& as) {
         const auto finalize = co_await should_finalize(
           as, _raft->self(), group_configuration());
 
+        const bool remote_manifest_expected
+          = _archival_meta_stm->get_last_clean_at() != model::offset();
+
         if (finalize) {
             vlog(
               clusterlog.debug,
               "Finalizing remote metadata on partition delete {}",
               ntp());
-            _cloud_storage_partition->finalize();
+            _cloud_storage_partition->finalize(remote_manifest_expected);
         }
     }
 }

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -37,7 +37,6 @@ import re
 
 MIGRATION_LOG_ALLOW_LIST = [
     'Error during log recovery: cloud_storage::missing_partition_exception',
-    re.compile("cloud_storage.*Failed to fetch manifest during finalize().*"),
 ] + Finjector.LOG_ALLOW_LIST
 
 

--- a/tests/rptest/tests/node_pool_migration_test.py
+++ b/tests/rptest/tests/node_pool_migration_test.py
@@ -30,8 +30,6 @@ from enum import Enum
 TS_LOG_ALLOW_LIST = [
     re.compile(
         "archival_metadata_stm.*Replication wait for archival STM timed out"),
-    # topic deletion may happen before data were uploaded
-    re.compile("cloud_storage.*Failed to fetch manifest during finalize().*")
 ]
 
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -487,8 +487,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         quiesce_uploads(self.redpanda, [topic_name], timeout_sec=60)
 
     @skip_debug_mode  # Rely on timely uploads during leader transfers
-    @cluster(num_nodes=4,
-             log_allow_list=['Failed to fetch manifest during finalize()'])
+    @cluster(num_nodes=4)
     def topic_delete_installed_snapshots_test(self):
         """
         Test the case where a partition had remote snapshots installed prior
@@ -778,8 +777,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             raise AssertionError(f"Found unexpected lifecycle marker {marker}")
 
     @skip_debug_mode  # Rely on timely uploads during leader transfers
-    @cluster(num_nodes=5,
-             log_allow_list=['Failed to fetch manifest during finalize()'])
+    @cluster(num_nodes=5)
     @matrix(disable_delete=[False, True],
             cloud_storage_type=get_cloud_storage_type())
     def topic_delete_cloud_storage_test(self, disable_delete,

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -175,7 +175,7 @@ def read_topic_config(rdr: Reader, version):
         'replication_factor':
         rdr.read_int16(),
         'properties':
-        rdr.read_envelope(read_topic_properties_serde, reader_version=10),
+        rdr.read_envelope(read_topic_properties_serde, reader_version=11),
     }
     if version < 1:
         # see https://github.com/redpanda-data/redpanda/pull/6613


### PR DESCRIPTION

- Log an error only if manifest is expected to exist but we couldn't
  find it. This would be a bug.
- Otherwise, upload a new one. This would happen when we create a
  partition then quickly delete it and archive service didn't have time
  to upload a manifest.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
