### PR TITLE
rpk: disable fetch sessions

### DIFF
--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -734,6 +734,7 @@ func (c *consumer) markPartitionEnded(t string, p int32) (done bool) {
 func (c *consumer) intoOptions(topics []string) ([]kgo.Opt, error) {
 	opts := []kgo.Opt{
 		kgo.ConsumeResetOffset(c.resetOffset),
+		kgo.DisableFetchSessions(),
 	}
 
 	if c.group != "" {


### PR DESCRIPTION
There is no reason to use fetch sessions in a CLI client; this creates state on the broker that is unneeded for the standard short lived CLI session.

Closes UX-35.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none