### PR TITLE
[CORE-9074] `cluster`: remove `node_health_report` logging

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -792,19 +792,14 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     for (auto& r : reports) {
         if (r) {
             const auto id = r.value().id;
-            vlog(
-              clusterlog.debug,
-              "collected node {} health report: {}",
-              id,
-              r.value());
+            vlog(clusterlog.debug, "collected node {} health report", id);
 
             std::optional<nhr_ptr> old_report;
             if (auto old_i = old_reports.find(id); old_i != old_reports.end()) {
                 vlog(
                   clusterlog.debug,
-                  "(previous node report from {}: {})",
-                  id,
-                  old_i->second);
+                  "(cache contains previous node report from {})",
+                  id);
                 old_report = old_i->second;
             } else {
                 vlog(clusterlog.debug, "(initial node report from {})", id);


### PR DESCRIPTION
For nodes with many topics/partitions, we may fail to allocate memory to output the entirety of a `node_health_report` to the `seastar` logger.

This was observed in crashes in `ManyPartitionsTest`, with an abridged backtrace like the following:

```
abort at ??:0
seastar::memory::on_allocation_failure(unsigned long) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:2163
seastar::memory::allocate(unsigned long) at /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1707
fmt::v9::detail::buffer<char>::try_reserve(unsigned long) at /vectorized/include/fmt/core.h:928
void seastar::logger::log<..., cluster::node_health_report&>(..., cluster::node_health_report&) at /vectorized/include/seastar/util/log.hh:304
cluster::health_monitor_backend::collect_cluster_health() at redpanda/src/v/cluster/health_monitor_backend.cc:453
```

Clearly, we are trying to output a lot of information to the logger, and it does not seem that writing the contents of the health report to `stdout` is very important for the end-user.

Amend the log lines to only output the `id` of the node the health report was collected from.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
