### PR TITLE
fair_scheduler: make shares maps a class member

### DIFF
--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -93,10 +93,6 @@ operator<<(std::ostream& os, fair_scheduling_policy::translator_group group) {
     }
 }
 
-fair_scheduling_policy::group_shares_t fair_scheduling_policy::_group_to_shares;
-fair_scheduling_policy::group_intervals_t
-  fair_scheduling_policy::_group_intervals;
-
 void fair_scheduling_policy::initialize_group_shares() {
     _group_to_shares = {
       {other, fair_scheduling_policy::default_other_shares},

--- a/src/v/datalake/translation/scheduling_policies.h
+++ b/src/v/datalake/translation/scheduling_policies.h
@@ -113,9 +113,9 @@ private:
     using group_intervals_t
       = absl::flat_hash_map<translator_group, std::pair<double, double>>;
 
-    static group_shares_t _group_to_shares;
-    static group_intervals_t _group_intervals;
-    static void initialize_group_shares();
+    group_shares_t _group_to_shares;
+    group_intervals_t _group_intervals;
+    void initialize_group_shares();
 
     size_t _max_concurrent_translations;
     clock::duration _translation_time_quota;


### PR DESCRIPTION
They were made static instead of thread_local inadvertently that has led to all sorts of chaos. (UAF, double-free, unrelated crashes...)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
