### PR TITLE
Follow up to recent raft changes allowing passing the abort source to replicate call

### DIFF
--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -23,6 +23,66 @@
 #include <optional>
 
 namespace raft {
+
+replicate_batcher::item::item(
+  size_t record_count,
+  chunked_vector<model::record_batch> batches,
+  ssx::semaphore_units u,
+  std::optional<model::term_id> expected_term,
+  replicate_options opts)
+  : _record_count(record_count)
+  , _data(std::move(batches))
+  , _units(std::move(u))
+  , _expected_term(expected_term)
+  , _replicate_opts(opts) {
+    _timeout_timer.set_callback([this] { expire_with_timeout(); });
+    if (_replicate_opts.timeout) {
+        _timeout_timer.arm(_replicate_opts.timeout.value());
+    }
+    if (_replicate_opts.as) {
+        auto& as = _replicate_opts.as->get();
+        if (as.abort_requested()) {
+            mark_as_aborted();
+        } else {
+            _abort_sub = as.subscribe([this] noexcept { mark_as_aborted(); });
+        }
+    }
+}
+
+void replicate_batcher::item::set_value(result<replicate_result> r) {
+    if (!_ready) {
+        _timeout_timer.cancel();
+        _ready = true;
+        _promise.set_value(r);
+    }
+}
+
+void replicate_batcher::item::set_exception(const std::exception_ptr& e) {
+    if (!_ready) {
+        _timeout_timer.cancel();
+        _ready = true;
+        _promise.set_exception(e);
+    }
+}
+
+void replicate_batcher::item::expire_with_timeout() {
+    if (!_ready) {
+        _ready = true;
+        _data.clear();
+        _units.return_all();
+        _promise.set_value(errc::timeout);
+    }
+}
+
+void replicate_batcher::item::mark_as_aborted() {
+    if (!_ready) {
+        _ready = true;
+        _data.clear();
+        _units.return_all();
+        _promise.set_value(errc::shutting_down);
+    }
+}
+
 using namespace std::chrono_literals; // NOLINT
 replicate_batcher::replicate_batcher(consensus* ptr, size_t cache_size)
   : _ptr(ptr)

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -39,12 +39,11 @@ replicate_batcher::item::item(
     if (_replicate_opts.timeout) {
         _timeout_timer.arm(_replicate_opts.timeout.value());
     }
-    if (_replicate_opts.as) {
-        auto& as = _replicate_opts.as->get();
-        if (as.abort_requested()) {
+    if (_replicate_opts.as) [[unlikely]] {
+        _abort_sub = _replicate_opts.as->get().subscribe(
+          [this] noexcept { mark_as_aborted(); });
+        if (!_abort_sub) {
             mark_as_aborted();
-        } else {
-            _abort_sub = as.subscribe([this] noexcept { mark_as_aborted(); });
         }
     }
 }

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -33,26 +33,7 @@ public:
           chunked_vector<model::record_batch> batches,
           ssx::semaphore_units u,
           std::optional<model::term_id> expected_term,
-          replicate_options opts)
-          : _record_count(record_count)
-          , _data(std::move(batches))
-          , _units(std::move(u))
-          , _expected_term(expected_term)
-          , _replicate_opts(opts) {
-            _timeout_timer.set_callback([this] { expire_with_timeout(); });
-            if (_replicate_opts.timeout) {
-                _timeout_timer.arm(_replicate_opts.timeout.value());
-            }
-            if (_replicate_opts.as) {
-                auto& as = _replicate_opts.as->get();
-                if (as.abort_requested()) {
-                    mark_as_aborted();
-                } else {
-                    _abort_sub = as.subscribe(
-                      [this] noexcept { mark_as_aborted(); });
-                }
-            }
-        };
+          replicate_options opts);
 
         item(item&&) noexcept = default;
         item& operator=(item&&) noexcept = delete;
@@ -78,21 +59,8 @@ public:
             return std::make_tuple(std::move(_data), std::move(_units));
         }
 
-        void set_value(result<replicate_result> r) {
-            if (!_ready) {
-                _timeout_timer.cancel();
-                _ready = true;
-                _promise.set_value(r);
-            }
-        }
-
-        void set_exception(const std::exception_ptr& e) {
-            if (!_ready) {
-                _timeout_timer.cancel();
-                _ready = true;
-                _promise.set_exception(e);
-            }
-        }
+        void set_value(result<replicate_result> r);
+        void set_exception(const std::exception_ptr& e);
 
         ss::future<result<replicate_result>> get_future() {
             return _promise.get_future();
@@ -101,23 +69,8 @@ public:
         bool ready() const { return _ready; }
 
     private:
-        void expire_with_timeout() {
-            if (!_ready) {
-                _ready = true;
-                _data.clear();
-                _units.return_all();
-                _promise.set_value(errc::timeout);
-            }
-        }
-
-        void mark_as_aborted() {
-            if (!_ready) {
-                _ready = true;
-                _data.clear();
-                _units.return_all();
-                _promise.set_value(errc::shutting_down);
-            }
-        }
+        void expire_with_timeout();
+        void mark_as_aborted();
         size_t _record_count;
         chunked_vector<model::record_batch> _data;
         ssx::semaphore_units _units;

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -13,7 +13,6 @@
 
 #include "base/outcome.h"
 #include "container/fragmented_vector.h"
-#include "model/record_batch_reader.h"
 #include "raft/types.h"
 #include "ssx/semaphore.h"
 #include "utils/mutex.h"


### PR DESCRIPTION
This PR changes the way the subscribe is handled when the `abort_source` is already aborted.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none