### PR TITLE
rptest: fix flaky transaction test

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1139,6 +1139,17 @@ class RpkTool:
         return self._execute(cmd).strip()
 
     def cluster_config_set(self, key: str, value):
+        """
+        Note: This method returns without waiting for the configuration to be
+        applied to all shards/nodes. If you get the configuration immediately
+        after setting it, you may not see the new value yet. Similarly, if
+        interact with the cluster in a way which expects the new config to be
+        set (e.g. creating a topic with a new config), you may need to wait
+        for the configuration to be applied before proceeding.
+
+        Consider using `Redpanda.set_cluster_config` instead if you need to
+        wait for the configuration to be applied.
+        """
         cmd = [
             self._rpk_binary(), "--api-urls",
             self._admin_host(), "cluster", "config", "set", key,

--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -157,7 +157,8 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             ) == ck.KafkaError.INVALID_TRANSACTION_TIMEOUT, f"Unexpected error {kafka_error.code()}"
 
         # Bump timeout and check again.
-        rpk.cluster_config_set("transaction_max_timeout_ms", test_timeout_ms)
+        self.redpanda.set_cluster_config(
+            {"transaction_max_timeout_ms": test_timeout_ms})
         init_producer(test_timeout_ms)
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
The new timeout is not necessarily propagated when we try to init the transaction.

Saw this in an adhoc gcp cdt run.

Closes https://redpandadata.atlassian.net/issues/CORE-9024

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
