### PR TITLE
Add compression type metric

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -319,7 +319,7 @@ partition_produce_stages produce_topic_partition(
     auto dispatch = std::make_unique<ss::promise<>>();
     auto dispatch_f = dispatch->get_future();
     auto m = octx.rctx.probe().auto_produce_measurement();
-    octx.rctx.probe().record_batch(batch_size);
+    octx.rctx.probe().record_batch(batch_size, hdr.attrs.compression());
     auto timeout = octx.request.data.timeout_ms;
     if (timeout < 0ms) {
         static constexpr std::chrono::milliseconds max_timeout{

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -14,6 +14,7 @@
 #include "config/configuration.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
+#include "model/compression.h"
 #include "utils/log_hist.h"
 
 #include <seastar/core/metrics.hh>
@@ -61,6 +62,34 @@ public:
           },
           {},
           {sm::shard_label});
+
+        for (auto compress_type : model::all_batch_compression_types) {
+            auto compress_type_name = fmt::format("{}", compress_type);
+            auto compression_label = sm::label("compression_type")(
+              compress_type_name);
+
+            _metrics.add_group(
+              "kafka",
+              {
+                sm::make_counter(
+                  "produced_bytes",
+                  sm::description("Total bytes produced, broken down by "
+                                  "compression_type label."),
+                  {compression_label},
+                  [this, compress_type] {
+                      auto idx = (size_t)compress_type;
+                      // next check should "never" fail but just be extra
+                      // careful
+                      if (idx < _bytes_by_compression.size()) {
+                          // NOLINTNEXTLINE:clang-tidy(cppcoreguidelines-pro-bounds-constant-array-index)
+                          return _bytes_by_compression[idx];
+                      }
+                      return 0UL;
+                  }),
+              },
+              {},
+              {sm::shard_label});
+        }
 
         _metrics.add_group(
           "kafka",
@@ -125,7 +154,14 @@ public:
         _fetch_latency.record(micros.count());
     }
 
-    void record_batch(uint64_t size) { _batch_size.record(size); }
+    void record_batch(uint64_t size, model::compression compression) {
+        _batch_size.record(size);
+        if (auto idx = (size_t)compression;
+            idx < _bytes_by_compression.size()) {
+            // NOLINTNEXTLINE:clang-tidy(cppcoreguidelines-pro-bounds-constant-array-index)
+            _bytes_by_compression[idx] += size;
+        }
+    }
 
 private:
     // for testing
@@ -137,6 +173,11 @@ private:
     hist_t _fetch_latency;
     // non partition or topic related as that is too expensive for histograms
     batch_size_hist _batch_size;
+
+    // track the number of produced bytes using each compression type
+    std::array<uint64_t, (size_t)model::compression::count>
+      _bytes_by_compression{};
+
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -63,6 +63,7 @@ redpanda_test_cc_library(
         "//src/v/kafka/protocol/schemata:offset_for_leader_epoch_request",
         "//src/v/kafka/protocol/schemata:offset_for_leader_epoch_response",
         "//src/v/kafka/protocol/schemata:produce_request",
+        "//src/v/model",
         "//src/v/storage:record_batch_builder",
         "//src/v/utils:to_string",
         "@seastar",

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -12,12 +12,11 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/produce.h"
-#include "kafka/protocol/wire.h"
 #include "kafka/server/handlers/produce.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "kafka/server/tests/delete_records_utils.h"
-#include "kafka/server/tests/offset_for_leader_epoch_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
+#include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "random/generators.h"
@@ -172,6 +171,10 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
     uint32_t produce_bad_ts_count() {
         return kafka_probe()._produce_bad_create_time;
     };
+
+    uint64_t bytes_by_compression(model::compression compression_type) {
+        return kafka_probe()._bytes_by_compression.at((size_t)compression_type);
+    }
 
     std::vector<model::offset> fetch_offsets;
     std::vector<kafka::client::transport> consumers;
@@ -901,4 +904,47 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
       std::optional<std::chrono::milliseconds>{});
     produce_messages(-365 * 24h);
     BOOST_CHECK_EQUAL(bad_timestamps_metric, produce_bad_ts_count());
+}
+
+FIXTURE_TEST(test_compression_metrics, prod_consume_fixture) {
+    using ctype = model::compression;
+
+    wait_for_controller_leadership().get();
+    start();
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+
+    auto producer = tests::kafka_produce_transport(make_kafka_client().get());
+    producer.start().get();
+
+    auto produce_messages = [&](ctype compression) {
+        producer
+          .produce_to_partition(
+            ntp.tp.topic,
+            ntp.tp.partition,
+            {{"key0", "val0"}},
+            std::nullopt,
+            compression)
+          .get();
+    };
+
+    for (auto c : model::all_batch_compression_types) {
+        BOOST_TEST_INFO("initially all bytes zero for " << c);
+        BOOST_CHECK_EQUAL(0, bytes_by_compression(c));
+    }
+
+    // this compression type and those greater are expected to have zero bytes
+    // produced, but lower ones should have non-zero bytes produced
+    for (ctype last_nonzero : model::all_batch_compression_types) {
+        produce_messages(last_nonzero);
+        for (auto ctype : model::all_batch_compression_types) {
+            if (ctype <= last_nonzero) {
+                BOOST_TEST_INFO(
+                  "testing non-zero bytes in metric for " << ctype);
+                BOOST_CHECK_GT(bytes_by_compression(ctype), 0);
+            } else {
+                BOOST_TEST_INFO("testing zero bytes in metric for " << ctype);
+                BOOST_CHECK_EQUAL(0, bytes_by_compression(ctype));
+            }
+        }
+    }
 }

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -66,6 +66,29 @@ kafka_produce_transport::produce(
     co_return ret;
 }
 
+ss::future<model::offset> kafka_produce_transport::produce_to_partition(
+  model::topic topic_name,
+  model::partition_id pid,
+  std::vector<kv_t> records,
+  std::optional<model::timestamp> ts) {
+    pid_to_kvs_map_t m;
+    m.emplace(pid, std::move(records));
+    auto ret_m = co_await produce(topic_name, std::move(m), ts);
+    if (ret_m.size() != 1) {
+        throw std::runtime_error(fmt::format(
+          "unexpected produce results {}/{}: {} results",
+          topic_name(),
+          pid(),
+          ret_m.size()));
+    }
+    auto it = ret_m.find(pid);
+    if (it == ret_m.end()) {
+        throw std::runtime_error(fmt::format(
+          "produce result missing partition {}/{}", topic_name(), pid()));
+    }
+    co_return it->second;
+}
+
 chunked_vector<kafka::partition_produce_data>
 kafka_produce_transport::produce_partition_requests(
   const pid_to_kvs_map_t& records_per_partition,
@@ -188,6 +211,23 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
         }
     }
     co_return ret;
+}
+
+ss::future<std::vector<kv_t>> kafka_consume_transport::consume_from_partition(
+  model::topic topic_name,
+  model::partition_id pid,
+  model::offset kafka_offset_inclusive) {
+    auto m = co_await consume(topic_name, {pid}, kafka_offset_inclusive);
+    if (m.empty()) {
+        throw std::runtime_error(
+          fmt::format("empty fetch {}/{}", topic_name(), pid()));
+    }
+    auto it = m.find(pid);
+    if (it == m.end()) {
+        throw std::runtime_error(fmt::format(
+          "fetch result missing partition {}/{}", topic_name(), pid()));
+    }
+    co_return it->second;
 }
 
 } // namespace tests

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -39,10 +39,12 @@ ss::future<kafka_produce_transport::pid_to_offset_map_t>
 kafka_produce_transport::produce(
   model::topic topic_name,
   pid_to_kvs_map_t records_per_partition,
-  std::optional<model::timestamp> ts) {
+  std::optional<model::timestamp> ts,
+  model::compression compression_type) {
     kafka::produce_request::topic tp;
     tp.name = topic_name;
-    tp.partitions = produce_partition_requests(records_per_partition, ts);
+    tp.partitions = produce_partition_requests(
+      records_per_partition, ts, compression_type);
     chunked_vector<kafka::produce_request::topic> topics;
     topics.push_back(std::move(tp));
     kafka::produce_request req(std::nullopt, -1, std::move(topics));
@@ -70,10 +72,12 @@ ss::future<model::offset> kafka_produce_transport::produce_to_partition(
   model::topic topic_name,
   model::partition_id pid,
   std::vector<kv_t> records,
-  std::optional<model::timestamp> ts) {
+  std::optional<model::timestamp> ts,
+  model::compression compression_type) {
     pid_to_kvs_map_t m;
     m.emplace(pid, std::move(records));
-    auto ret_m = co_await produce(topic_name, std::move(m), ts);
+    auto ret_m = co_await produce(
+      topic_name, std::move(m), ts, compression_type);
     if (ret_m.size() != 1) {
         throw std::runtime_error(fmt::format(
           "unexpected produce results {}/{}: {} results",
@@ -92,13 +96,14 @@ ss::future<model::offset> kafka_produce_transport::produce_to_partition(
 chunked_vector<kafka::partition_produce_data>
 kafka_produce_transport::produce_partition_requests(
   const pid_to_kvs_map_t& records_per_partition,
-  std::optional<model::timestamp> ts) {
+  std::optional<model::timestamp> ts,
+  model::compression compression_type) {
     chunked_vector<kafka::partition_produce_data> ret;
     ret.reserve(records_per_partition.size());
     for (const auto& [pid, records] : records_per_partition) {
         storage::record_batch_builder builder(
           model::record_batch_type::raft_data, model::offset(0));
-        kafka::produce_request::partition partition;
+        builder.set_compression(compression_type);
         for (auto& kv : records) {
             const auto& k = kv.key;
             const auto& v_opt = kv.val;
@@ -114,6 +119,7 @@ kafka_produce_transport::produce_partition_requests(
         if (ts.has_value()) {
             builder.set_timestamp(ts.value());
         }
+        kafka::produce_request::partition partition;
         partition.partition_index = pid;
         partition.records.emplace(std::move(builder).build());
         ret.emplace_back(std::move(partition));

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -9,12 +9,9 @@
  */
 #pragma once
 
-#include "bytes/iobuf.h"
 #include "container/fragmented_vector.h"
 #include "kafka/client/transport.h"
-#include "kafka/protocol/produce.h"
 #include "kafka/protocol/schemata/produce_request.h"
-#include "storage/record_batch_builder.h"
 
 namespace tests {
 
@@ -90,24 +87,7 @@ public:
       model::topic topic_name,
       model::partition_id pid,
       std::vector<kv_t> records,
-      std::optional<model::timestamp> ts = std::nullopt) {
-        pid_to_kvs_map_t m;
-        m.emplace(pid, std::move(records));
-        auto ret_m = co_await produce(topic_name, std::move(m), ts);
-        if (ret_m.size() != 1) {
-            throw std::runtime_error(fmt::format(
-              "unexpected produce results {}/{}: {} results",
-              topic_name(),
-              pid(),
-              ret_m.size()));
-        }
-        auto it = ret_m.find(pid);
-        if (it == ret_m.end()) {
-            throw std::runtime_error(fmt::format(
-              "produce result missing partition {}/{}", topic_name(), pid()));
-        }
-        co_return it->second;
-    }
+      std::optional<model::timestamp> ts = std::nullopt);
 
 private:
     // Convert the given records-per-partition mapping to a set of per-partition
@@ -137,19 +117,7 @@ public:
     ss::future<std::vector<kv_t>> consume_from_partition(
       model::topic topic_name,
       model::partition_id pid,
-      model::offset kafka_offset_inclusive) {
-        auto m = co_await consume(topic_name, {pid}, kafka_offset_inclusive);
-        if (m.empty()) {
-            throw std::runtime_error(
-              fmt::format("empty fetch {}/{}", topic_name(), pid()));
-        }
-        auto it = m.find(pid);
-        if (it == m.end()) {
-            throw std::runtime_error(fmt::format(
-              "fetch result missing partition {}/{}", topic_name(), pid()));
-        }
-        co_return it->second;
-    }
+      model::offset kafka_offset_inclusive);
 
 private:
     kafka::client::transport _transport;

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -12,6 +12,9 @@
 #include "container/fragmented_vector.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/schemata/produce_request.h"
+#include "model/compression.h"
+
+#include <optional>
 
 namespace tests {
 
@@ -80,14 +83,16 @@ public:
     ss::future<pid_to_offset_map_t> produce(
       model::topic topic_name,
       pid_to_kvs_map_t records_per_partition,
-      std::optional<model::timestamp> ts = std::nullopt);
+      std::optional<model::timestamp> ts = std::nullopt,
+      model::compression compression_type = model::compression::none);
 
     // Produces the given records to the given topic partition.
     ss::future<model::offset> produce_to_partition(
       model::topic topic_name,
       model::partition_id pid,
       std::vector<kv_t> records,
-      std::optional<model::timestamp> ts = std::nullopt);
+      std::optional<model::timestamp> ts = std::nullopt,
+      model::compression compression_type = model::compression::none);
 
 private:
     // Convert the given records-per-partition mapping to a set of per-partition
@@ -97,7 +102,8 @@ private:
     static chunked_vector<kafka::partition_produce_data>
     produce_partition_requests(
       const pid_to_kvs_map_t& records_per_partition,
-      std::optional<model::timestamp> ts);
+      std::optional<model::timestamp> ts,
+      model::compression compression_type);
 
     kafka::client::transport _transport;
 };

--- a/src/v/model/compression.h
+++ b/src/v/model/compression.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
@@ -43,10 +44,21 @@ enum class compression : uint8_t {
     lz4 = 3,
     zstd = 4,
 
+    // the number of batch compression types (put new types above this)
+    count,
+
     // values below must not intersect with the value range used to encode
     // compression codecs in kafka batch attributes.
     producer = std::numeric_limits<std::underlying_type_t<compression>>::max()
 };
+
+constexpr auto all_batch_compression_types = [] {
+    std::array<compression, static_cast<size_t>(compression::count)> types{};
+    for (int c = 0; c < static_cast<int>(compression::count); ++c) {
+        types[c] = static_cast<compression>(c);
+    }
+    return types;
+}();
 
 /// operators needed for boost::lexical_cast<compression>
 /// inline to prevent library depdency with the v::compression module

--- a/src/v/model/tests/lexical_cast_tests.cc
+++ b/src/v/model/tests/lexical_cast_tests.cc
@@ -9,7 +9,6 @@
 
 #include "model/record.h"
 
-#include <boost/test/tools/old/interface.hpp>
 #define BOOST_TEST_MODULE model
 #include "model/compression.h"
 #include "model/metadata.h"
@@ -18,6 +17,16 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
+
+// sanity checks on all_batch_compression_types array
+static_assert(
+  model::all_batch_compression_types.front() == model::compression::none);
+static_assert(
+  model::all_batch_compression_types.back() == model::compression::zstd);
+static_assert(
+  (size_t)model::all_batch_compression_types.back()
+    - (size_t)model::all_batch_compression_types.front() + 1
+  == (size_t)model::compression::count);
 
 BOOST_AUTO_TEST_CASE(test_cast_from_string) {
     BOOST_CHECK_EQUAL(
@@ -42,6 +51,15 @@ BOOST_AUTO_TEST_CASE(test_cast_from_string) {
       boost::bad_lexical_cast,
       [](const boost::bad_lexical_cast&) { return true; });
 };
+
+BOOST_AUTO_TEST_CASE(lexical_cast_roundtrip_fmt) {
+    for (auto compress_type : model::all_batch_compression_types) {
+        auto stringy = fmt::format("{}", compress_type);
+        BOOST_CHECK_EQUAL(
+          compress_type, boost::lexical_cast<model::compression>(stringy));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(removing_compression) {
     model::record_batch_attributes attr(std::numeric_limits<uint16_t>::max());
     attr.remove_compression();


### PR DESCRIPTION
This pull request introduces compression type metrics in the Kafka server, along with corresponding tests. The changes span multiple files (wow!) and include modifications to record batch handling, metric collection, and test cases. The changes are best reviewed change by change.

### Key Changes:

#### Compression Type Tracking:
* [`src/v/kafka/server/handlers/produce.cc`](diffhunk://#diff-057947c463347b74bf5eef62d2b15f6efcc2ff244c53ac3f93892a4a9ff0546fL325-R325): Updated `record_batch` method to include compression type in the metrics ([src/v/kafka/server/handlers/produce.ccL325-R325](diffhunk://#diff-057947c463347b74bf5eef62d2b15f6efcc2ff244c53ac3f93892a4a9ff0546fL325-R325)).
* [`src/v/kafka/server/kafka_probe.h`](diffhunk://#diff-59ee5cf42c426821f4ef6506b70cd4b7e7b9c53ab2e9a54fce3f197c5ca98a5bR17-R26): Added new metrics to track produced bytes by compression type and updated the `record_batch` method to record these metrics ([[1]](diffhunk://#diff-59ee5cf42c426821f4ef6506b70cd4b7e7b9c53ab2e9a54fce3f197c5ca98a5bR17-R26), [[2]](diffhunk://#diff-59ee5cf42c426821f4ef6506b70cd4b7e7b9c53ab2e9a54fce3f197c5ca98a5bR78-R105), [[3]](diffhunk://#diff-59ee5cf42c426821f4ef6506b70cd4b7e7b9c53ab2e9a54fce3f197c5ca98a5bL109-R161)).

#### Test Enhancements:
* [`src/v/kafka/server/tests/produce_consume_test.cc`](diffhunk://#diff-e8d653f263151c0e02263e5eedac76b412b60f5ca1ef9bf074f6201f4131f6e8R167-R174): Added a new test `test_compression_metrics` to verify the compression metrics functionality ([[1]](diffhunk://#diff-e8d653f263151c0e02263e5eedac76b412b60f5ca1ef9bf074f6201f4131f6e8R167-R174), [[2]](diffhunk://#diff-e8d653f263151c0e02263e5eedac76b412b60f5ca1ef9bf074f6201f4131f6e8R916-R958)).
* [`src/v/kafka/server/tests/produce_consume_utils.cc`](diffhunk://#diff-45692cc6c2c91a50c1084963800092e8e868c6025f74bb32e0e5abbd8f61ba20L42-R47): Updated produce methods to accept and handle compression types ([[1]](diffhunk://#diff-45692cc6c2c91a50c1084963800092e8e868c6025f74bb32e0e5abbd8f61ba20L42-R47), [[2]](diffhunk://#diff-45692cc6c2c91a50c1084963800092e8e868c6025f74bb32e0e5abbd8f61ba20R71-R106), [[3]](diffhunk://#diff-45692cc6c2c91a50c1084963800092e8e868c6025f74bb32e0e5abbd8f61ba20R122), [[4]](diffhunk://#diff-45692cc6c2c91a50c1084963800092e8e868c6025f74bb32e0e5abbd8f61ba20R222-R238)).

#### Miscellaneous:
* [`src/v/model/compression.h`](diffhunk://#diff-832f232527066047b14b0f6303b6a7bd1a64ebc4346ad4a3fbed6496f46698ccR14): Added a new `count` value to the `compression` enum and an array `all_batch_compression_types` for iterating over all compression types ([[1]](diffhunk://#diff-832f232527066047b14b0f6303b6a7bd1a64ebc4346ad4a3fbed6496f46698ccR14), [[2]](diffhunk://#diff-832f232527066047b14b0f6303b6a7bd1a64ebc4346ad4a3fbed6496f46698ccR47-R62)).
* [src/v/model/tests/lexical_cast_tests.cc](diffhunk://#diff-70eb9e148f3b64f91cc1f50a64c3eb8e12d5255ac662ce07d844186d2e713431L12): Added tests to ensure the new compression types array is correctly defined and can be round-tripped through string conversion ([[1]](diffhunk://#diff-70eb9e148f3b64f91cc1f50a64c3eb8e12d5255ac662ce07d844186d2e713431L12), [[2]](diffhunk://#diff-70eb9e148f3b64f91cc1f50a64c3eb8e12d5255ac662ce07d844186d2e713431R21-R30), [[3]](diffhunk://#diff-70eb9e148f3b64f91cc1f50a64c3eb8e12d5255ac662ce07d844186d2e713431R54-R62)).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Features

* A new metric, vectorized_kafka_produced_bytes, is added to the /metrics endpoint which breaks down bytes produced to Redpanda at the Kafka API by batch compression type. 

