### PR TITLE
Move the bad timestamp metric

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -199,7 +199,7 @@ auto validate_batch_timestamps(
   const model::ntp& ntp,
   const model::record_batch_header& header,
   model::timestamp_type timestamp_type,
-  net::server_probe& probe) -> std::optional<model::timestamp> {
+  kafka::kafka_probe& probe) -> std::optional<model::timestamp> {
     // we compute in std::chrono::timepoints, we print in model::timestamps
     auto broker_time = model::timestamp::now();
     auto broker_timepoint = model::duration_since_epoch(broker_time);
@@ -302,10 +302,7 @@ partition_produce_stages produce_topic_partition(
     // validate the batch timestamps by checking skew against broker time
     if (
       auto new_timestamp = validate_batch_timestamps(
-        ntp,
-        batch->header(),
-        cfg_ctx.timestamp_type,
-        octx.rctx.server_probe())) {
+        ntp, batch->header(), cfg_ctx.timestamp_type, octx.rctx.probe())) {
         batch->set_max_timestamp(
           model::timestamp_type::append_time, new_timestamp.value());
     }

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -21,6 +21,8 @@
 #include <chrono>
 #include <cstdint>
 
+struct prod_consume_fixture;
+
 namespace kafka {
 class kafka_probe {
 public:
@@ -109,6 +111,9 @@ public:
     void record_batch(uint64_t size) { _batch_size.record(size); }
 
 private:
+    // for testing
+    friend prod_consume_fixture;
+
     hist_t _produce_latency;
     hist_t _fetch_latency;
     // non partition or topic related as that is too expensive for histograms

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -74,6 +74,17 @@ public:
           },
           {},
           {sm::shard_label});
+
+        _metrics.add_group(
+          "kafka_rpc",
+          {sm::make_counter(
+            "produce_bad_create_time",
+            [this] { return _produce_bad_create_time; },
+            sm::description(
+              "number of produce requests with timestamps too far "
+              "in the future or in the past"))},
+          {},
+          {sm::shard_label});
     }
 
     void setup_public_metrics() {
@@ -100,6 +111,12 @@ public:
           });
     }
 
+    // metric used to signal a produce request with a timestamp too far into the
+    // future or too far in the past see configuration
+    // log_message_timestamp_alert_after_ms and
+    // log_message_timestamp_alert_before_ms
+    void produce_bad_create_time() { _produce_bad_create_time++; }
+
     std::unique_ptr<hist_t::measurement> auto_produce_measurement() {
         return _produce_latency.auto_measure();
     }
@@ -113,6 +130,8 @@ public:
 private:
     // for testing
     friend prod_consume_fixture;
+
+    uint32_t _produce_bad_create_time = 0;
 
     hist_t _produce_latency;
     hist_t _fetch_latency;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -118,11 +118,10 @@ public:
 
     protocol::decoder& reader() { return _reader; }
 
+    // Return the kafka_probe associated with the request, suitable for
+    // kafka-specific metrics which do not need to be tracked per NTP.
     kafka_probe& probe() { return _conn->server().kafka_probe(); }
     sasl_probe& sasl_probe() { return _conn->server().sasl_probe(); }
-
-    // used to reach for server_probe::produce_bad_timestamp
-    net::server_probe& server_probe() { return _conn->server().probe(); }
 
     kafka::usage_manager& usage_mgr() const {
         return _conn->server().usage_mgr();

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -165,6 +165,10 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         return fetch_next(consumers.front(), model::partition_id{0});
     }
 
+    kafka::kafka_probe& kafka_probe() {
+        return app._kafka_server.local().kafka_probe();
+    }
+
     std::vector<model::offset> fetch_offsets;
     std::vector<kafka::client::transport> consumers;
     std::vector<kafka::client::transport> producers;

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -169,6 +169,10 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         return app._kafka_server.local().kafka_probe();
     }
 
+    uint32_t produce_bad_ts_count() {
+        return kafka_probe()._produce_bad_create_time;
+    };
+
     std::vector<model::offset> fetch_offsets;
     std::vector<kafka::client::transport> consumers;
     std::vector<kafka::client::transport> producers;
@@ -862,51 +866,39 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
     };
 
     BOOST_TEST_INFO("expect produce_bad_create_time to be 0");
-    auto bad_timestamps_metric
-      = app._kafka_server.local().probe().get_produce_bad_create_time();
+    auto bad_timestamps_metric = produce_bad_ts_count();
     BOOST_CHECK_EQUAL(0, bad_timestamps_metric);
 
     BOOST_TEST_INFO("messages with no skew do not trigger the probe");
     produce_messages(0s);
-    BOOST_CHECK_EQUAL(
-      0, app._kafka_server.local().probe().get_produce_bad_create_time());
+    BOOST_CHECK_EQUAL(0, produce_bad_ts_count());
 
     BOOST_TEST_INFO(
       "messages with a skew towards the future trigger the probe");
     config::shard_local_cfg().log_message_timestamp_alert_after_ms.set_value(
       std::chrono::duration_cast<std::chrono::milliseconds>(1h));
     produce_messages(2h);
-    BOOST_CHECK_LT(
-      bad_timestamps_metric,
-      app._kafka_server.local().probe().get_produce_bad_create_time());
+    BOOST_CHECK_LT(bad_timestamps_metric, produce_bad_ts_count());
 
-    bad_timestamps_metric
-      = app._kafka_server.local().probe().get_produce_bad_create_time();
+    bad_timestamps_metric = produce_bad_ts_count();
 
     BOOST_TEST_INFO("messages with a skew towards the past trigger the probe");
     config::shard_local_cfg().log_message_timestamp_alert_before_ms.set_value(
       std::optional{std::chrono::duration_cast<std::chrono::milliseconds>(1h)});
     produce_messages(-2h);
-    BOOST_CHECK_LT(
-      bad_timestamps_metric,
-      app._kafka_server.local().probe().get_produce_bad_create_time());
+    BOOST_CHECK_LT(bad_timestamps_metric, produce_bad_ts_count());
 
-    bad_timestamps_metric
-      = app._kafka_server.local().probe().get_produce_bad_create_time();
+    bad_timestamps_metric = produce_bad_ts_count();
 
     BOOST_TEST_INFO("messages within the bounds to not trigger the probe");
     produce_messages(-30min);
     produce_messages(30min);
-    BOOST_CHECK_EQUAL(
-      bad_timestamps_metric,
-      app._kafka_server.local().probe().get_produce_bad_create_time());
+    BOOST_CHECK_EQUAL(bad_timestamps_metric, produce_bad_ts_count());
 
     BOOST_TEST_INFO("disabling the alert for the past allows messages in the "
                     "past without triggering the probe");
     config::shard_local_cfg().log_message_timestamp_alert_before_ms.set_value(
       std::optional<std::chrono::milliseconds>{});
     produce_messages(-365 * 24h);
-    BOOST_CHECK_EQUAL(
-      bad_timestamps_metric,
-      app._kafka_server.local().probe().get_produce_bad_create_time());
+    BOOST_CHECK_EQUAL(bad_timestamps_metric, produce_bad_ts_count());
 }

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -116,11 +116,6 @@ void server_probe::setup_metrics(
           sm::description(ssx::sformat(
             "{}: Number of connections are blocked by connection rate",
             proto))),
-        sm::make_counter(
-          "produce_bad_create_time",
-          [this] { return _produce_bad_create_time; },
-          sm::description("number of produce requests with timestamps too far "
-                          "in the future or in the past")),
       },
       {},
       {sm::shard_label});
@@ -186,9 +181,7 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
       << "corrupted headers: " << p._corrupted_headers << ", "
       << "method not found errors: " << p._method_not_found_errors << ", "
       << "requests blocked by memory: " << p._requests_blocked_memory << ", "
-      << "connections wait rate: " << p._connections_wait_rate << ", "
-      << "produce bad create time: " << p._produce_bad_create_time << ", "
-      << "}";
+      << "connections wait rate: " << p._connections_wait_rate << "}";
     return o;
 }
 

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -64,16 +64,6 @@ public:
 
     void waiting_for_conection_rate() { ++_connections_wait_rate; }
 
-    // metric used to signal a produce request with a timestamp too far into the
-    // future or too far in the past see configuration
-    // log_message_timestamp_alert_after_ms and
-    // log_message_timestamp_alert_before_ms
-    void produce_bad_create_time() { _produce_bad_create_time++; }
-    // for testing
-    auto get_produce_bad_create_time() const {
-        return _produce_bad_create_time;
-    }
-
     void
     setup_metrics(metrics::internal_metric_groups& mgs, std::string_view proto);
 
@@ -98,7 +88,6 @@ private:
     uint32_t _method_not_found_errors = 0;
     uint32_t _requests_blocked_memory = 0;
     uint32_t _connections_wait_rate = 0;
-    uint32_t _produce_bad_create_time = 0;
     friend std::ostream& operator<<(std::ostream& o, const server_probe& p);
 };
 


### PR DESCRIPTION
This metric is in the wrong probe: it is in the generic "server" probe which applies to all `net::server` classes, but it is a kafka specific concept and only ever incremented in the kafka server. So we have an always zero version of this metric for internal rpc.

Move it to the right place and do some associated cleanup.

The surviving metric name is unchanged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* The `vectorized_internal_rpc_produce_bad_create_time` metric has been removed. This metric was introduced in error and never had a value other than zero.
