### PR TITLE
dl/translation/tests: misc changes to tests

### DIFF
--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -452,7 +452,7 @@ TEST_F_CORO(partition_translator_fixture, test_batching) {
 
     std::exception_ptr ex = nullptr;
     try {
-        RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&test_ctx]() {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(20s, [&test_ctx]() {
             const auto& files = test_ctx.translated_files();
             const auto it = files.find(test_ctx.ntp().tp);
             if (it != files.end()) {

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -457,8 +457,7 @@ class DatalakeMetricsTest(RedpandaTest):
 
             dl.create_iceberg_enabled_topic(self.topic_name,
                                             partitions=1,
-                                            replicas=3,
-                                            target_lag_ms=10000)
+                                            replicas=3)
             topic_leader = self.redpanda.partitions(self.topic_name)[0].leader
             count = randint(12, 21)
             dl.produce_to_topic(self.topic_name, 1, msg_count=count)
@@ -508,8 +507,7 @@ class DatalakeMetricsTest(RedpandaTest):
 
             dl.create_iceberg_enabled_topic(self.topic_name,
                                             partitions=1,
-                                            replicas=3,
-                                            target_lag_ms=10000)
+                                            replicas=3)
             dl.produce_to_topic(self.topic_name, 1024, 10)
 
             # Wait until we have committed to the table -- this implies several
@@ -552,8 +550,7 @@ class DatalakeMetricsTest(RedpandaTest):
 
             dl.create_iceberg_enabled_topic(self.topic_name,
                                             partitions=1,
-                                            replicas=3,
-                                            target_lag_ms=10000)
+                                            replicas=3)
             dl.produce_to_topic(self.topic_name, 1024, 10)
             wait_until(lambda: self.redpanda.metric_sum(
                 timeouts_metric, MetricsEndpoint.PUBLIC_METRICS) > 0,

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -241,7 +241,7 @@ class DatalakeServices():
     def wait_for_translation(self,
                              topic,
                              msg_count,
-                             timeout=60,
+                             timeout=30,
                              backoff_sec=5,
                              table_override=None):
         table_name = topic

--- a/tests/rptest/tests/datalake/datalake_upgrade_test.py
+++ b/tests/rptest/tests/datalake/datalake_upgrade_test.py
@@ -61,7 +61,9 @@ class DatalakeUpgradeTest(RedpandaTest):
                 count = 100
                 dl.produce_to_topic(self.topic_name, 1024, msg_count=count)
                 total_count += count
-                dl.wait_for_translation(self.topic_name, msg_count=total_count)
+                dl.wait_for_translation(self.topic_name,
+                                        msg_count=total_count,
+                                        timeout=60)
 
             versions = self.load_version_range(self.initial_version)
             for v in self.upgrade_through_versions(versions_in=versions,


### PR DESCRIPTION
* Quick followup to Andrew's comments on #25310
* A flaky test timeout in bazel dbg build Tyler ran into.

No functional changes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
