### PR TITLE
config: make minimum Iceberg commit interval 10s

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3800,7 +3800,7 @@ configuration::configuration()
       "individual commits.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(1min),
-      {.min = 10ms})
+      {.min = std::chrono::milliseconds{10s}})
   , iceberg_catalog_base_location(
       *this,
       "iceberg_catalog_base_location",

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -37,6 +37,10 @@ class DatalakeServices():
                  warehouse_name: str = CatalogService.DEFAULT_WAREHOUSE_NAME):
         self.test_ctx = test_ctx
         self.redpanda = redpanda
+
+        # Tests may rely on setting frequent translations.
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"})
         si_settings = self.redpanda.si_settings
         assert si_settings
 


### PR DESCRIPTION
The previous minimum was not a safe bound (too low and we may end up overwhelming the catalog). This bumps the minimum to 10s, which seems like it shouldn't cause too much trouble. For reference, the minimum value for `iceberg_target_lag_ms` is also 10s.

Context: in discussions with configurations for cloud, it was raised that the previous min seemed dangerous for something user-configurable, hence the desire for something more reasonable as a safeguard.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
