### PR TITLE
`datalake`: call `finally()` on reader in early return path

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -415,8 +415,10 @@ public:
             _discard_translated_state = false;
         }
         if (_discard_translated_state) {
-            return ss::make_exception_future(
-              "state changed, reset translation");
+            return std::move(reader).release()->finally().then([] {
+                return ss::make_exception_future(
+                  "state changed, reset translation");
+            });
         }
         return _in_progress_translation->translate_once(std::move(reader), as);
     }


### PR DESCRIPTION
Otherwise, this can fail with an assert during destruction of the unconsumed reader:

```
ERROR 2025-03-13 00:38:12,810 [shard 1:data] assert - Assert failure: (redpanda/src/v/storage/log_reader.h:146) '!_iterator.reader' log reader destroyed with live reader
```

Seen in https://buildkite.com/redpanda/redpanda/builds/63010#01958cc6-7080-4fd7-bd95-e5bfa6c0f7d5.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
