### PR TITLE
rptest: memoize arch with a lock

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -207,6 +207,7 @@ class RedpandaInstaller:
         }
 
         # memoize result of self.arch()
+        self._arch_lock = threading.Lock()
         self._arch = None
 
     def installed_version(self, node) -> RedpandaVersion:
@@ -670,15 +671,17 @@ class RedpandaInstaller:
 
     @property
     def arch(self):
-        if self._arch is None:
-            node = self._redpanda.nodes[0]
-            self._arch = "amd64"
-            uname = str(node.account.ssh_output("uname -m"))
-            if "aarch" in uname or "arm" in uname:
-                self._arch = "arm64"
-            self._redpanda.logger.debug(
-                f"{node.account.hostname} uname output: {uname}")
-        return self._arch
+        with self._arch_lock:
+            if self._arch is None:
+                node = self._redpanda.nodes[0]
+                uname = str(node.account.ssh_output("uname -m"))
+                if "aarch" in uname or "arm" in uname:
+                    self._arch = "arm64"
+                else:
+                    self._arch = "amd64"
+                self._redpanda.logger.debug(
+                    f"{node.account.hostname} uname output: {uname}")
+            return self._arch
 
     def download_on_node_unlocked(self, node, version) -> None:
         """


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/pull/25285 I introduced multi threading for downloading Redpanda releases on all nodes in parallel. This introduced a subtle race where the architecture was being set to default (amd64) by on thread while fetching the actual architecture which led to other threads believing that the work was already done.

Do it under a lock now. One thread will fetch the actual value while others will wait on the lock.

Also, don't set a default arch until we actually determine it. Without this, if one thread gets an exception the others could continue believing that the actual arch is amd64 while it is in fact arm64.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
