### PR TITLE
[CORE-8867] `rptest`: increase `initial.broker.registration.timeout.ms` from default

### DIFF
--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -21,8 +21,9 @@ class KafkaServiceAdapter(RedpandaServiceForClients):
     def start(self):
         return self._kafka_service.start()
 
-    def start(self, add_principals=""):
-        return self._kafka_service.start(add_principals)
+    def start(self, add_principals="", timeout_sec=60):
+        return self._kafka_service.start(add_principals,
+                                         timeout_sec=timeout_sec)
 
     def wait_until(self, *args, **kwargs):
         # RedpandaService does some helpful liveness checks to fail faster on crashes,

--- a/tests/rptest/tests/basic_kafka_compat_test.py
+++ b/tests/rptest/tests/basic_kafka_compat_test.py
@@ -45,12 +45,16 @@ class KafkaCompatTest(EndToEndTest):
         self.redpanda: RedpandaService = RedpandaService(self.test_context,
                                                          num_brokers=3)
 
+        server_prop_overrides = [[
+            "initial.broker.registration.timeout.ms", "180000"
+        ]]
         self.kafka = KafkaServiceAdapter(
             self.test_context,
             KafkaService(self.test_context,
                          num_nodes=3,
                          zk=None,
-                         version=KAFKA_VERSION))
+                         version=KAFKA_VERSION,
+                         server_prop_overrides=server_prop_overrides))
 
     def setUp(self):
         pass
@@ -59,7 +63,7 @@ class KafkaCompatTest(EndToEndTest):
         self.kafka.stop()
 
     def start_brokers(self):
-        self.kafka.start()
+        self.kafka.start(timeout_sec=180)
         if self.redpanda:
             self.redpanda.start()
 


### PR DESCRIPTION
This test fails often due to a broker failing to register in time:

```
[2025-03-12 22:50:14,012] ERROR [BrokerLifecycleManager id=1] Shutting down because we were unable to register with the controller quorum. (kafka.server.BrokerLifecycleManager)
```

It may be the case that the broker just needs more time than the default value of 60 seconds to be successful in joining the controller quorum.

Bump the timeout by setting it as a `server_prop_override`.

Also add a timeout parameter to `KafkaServiceAdapter.start()` to match.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
