### PR TITLE
Allow to get RPS/BPS per shard even with metric aggregation

### DIFF
--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -76,11 +76,6 @@ void handler_probe::setup_metrics(
       prometheus_sanitize::metrics_name("kafka_handler"),
       {
         sm::make_counter(
-          "requests_completed_total",
-          [this] { return _requests_completed; },
-          sm::description("Number of kafka requests completed"),
-          labels),
-        sm::make_counter(
           "requests_errored_total",
           [this] { return _requests_errored; },
           sm::description("Number of kafka requests errored"),
@@ -108,6 +103,18 @@ void handler_probe::setup_metrics(
       },
       {},
       {seastar::metrics::shard_label});
+
+    // Don't want to aggregate the shard label away so that we get per shard RPS
+    // in any case
+    metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka_handler"),
+      {
+        sm::make_counter(
+          "requests_completed_total",
+          [this] { return _requests_completed; },
+          sm::description("Number of kafka requests completed"),
+          labels),
+      });
 }
 
 // For public metrics we only expose a small subset of the metrics for produce

--- a/src/v/kafka/server/kafka_probe.h
+++ b/src/v/kafka/server/kafka_probe.h
@@ -71,9 +71,7 @@ public:
                 "Batch size across all topics measured at the kafka layer."),
               {},
               [this] { return _batch_size.batch_size_histogram_logform(); }),
-          },
-          {},
-          {sm::shard_label});
+          });
 
         _metrics.add_group(
           "kafka_rpc",


### PR DESCRIPTION
Removes shard label aggregation for BPS and RPS metrics such that we can get a per shard insight even with `aggregate_metrics` on.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none


