### PR TITLE
cpu_profiler test fixes

### DIFF
--- a/src/v/resource_mgmt/BUILD
+++ b/src/v/resource_mgmt/BUILD
@@ -152,6 +152,7 @@ redpanda_cc_library(
         ":logger",
         "//src/v/base",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/random:generators",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",

--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -11,9 +11,7 @@
 
 #include "resource_mgmt/cpu_profiler.h"
 
-#include "random/generators.h"
 #include "resource_mgmt/logger.h"
-#include "ssx/future-util.h"
 #include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
@@ -24,7 +22,6 @@
 #include <seastar/util/later.hh>
 
 #include <chrono>
-#include <iterator>
 
 namespace resources {
 

--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -11,8 +11,8 @@
 
 #include "resource_mgmt/cpu_profiler.h"
 
+#include "container/chunked_hash_map.h"
 #include "resource_mgmt/logger.h"
-#include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/internal/cpu_profiler.hh>
@@ -94,18 +94,24 @@ ss::future<std::vector<cpu_profiler::shard_samples>> cpu_profiler::results(
 
 cpu_profiler::shard_samples cpu_profiler::shard_results(
   std::optional<ss::lowres_clock::time_point> filter_before) const {
-    size_t dropped_samples = 0;
-    absl::node_hash_map<ss::simple_backtrace, size_t> backtraces;
+    size_t dropped_samples = 0, total_samples = 0;
+    chunked_hash_map<ss::simple_backtrace, size_t> backtraces;
     for (auto& results_buffer : _results_buffers) {
         if (filter_before && results_buffer.polled_time < *filter_before) {
             continue;
         }
 
         dropped_samples += results_buffer.dropped_samples;
+        total_samples += results_buffer.samples.size();
         for (auto& result : results_buffer.samples) {
             backtraces[result.user_backtrace]++;
         }
     }
+
+    resourceslog.trace(
+      "shard_results returning {} total, {} unique results",
+      total_samples,
+      backtraces.size());
 
     std::vector<sample> results{};
     results.reserve(backtraces.size());

--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -87,6 +87,9 @@ ss::future<std::vector<cpu_profiler::shard_samples>> cpu_profiler::results(
                 std::move(shard_result.samples));
               return results;
           });
+        // sort by shard ID so the shard id lines up with the vector index
+        std::ranges::sort(
+          results, [](auto& l, auto& r) { return l.shard < r.shard; });
     }
 
     co_return results;

--- a/src/v/resource_mgmt/tests/cpu_profiler_test.cc
+++ b/src/v/resource_mgmt/tests/cpu_profiler_test.cc
@@ -17,17 +17,20 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/core/thread.hh>
 #include <seastar/core/timer.hh>
-#include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-#include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <memory>
 #include <optional>
+
+using shard_samples = resources::cpu_profiler::shard_samples;
+using sharded_profiler = ss::sharded<resources::cpu_profiler>;
 
 namespace {
 ss::future<> busy_loop(std::chrono::milliseconds duration) {
@@ -37,6 +40,28 @@ ss::future<> busy_loop(std::chrono::milliseconds duration) {
         co_await ss::coroutine::maybe_yield();
     }
 }
+
+// Creates a sharded_profiler, and destroys it when this object
+// is destructed (must be run in ss::thread).
+struct cp_holder {
+    std::unique_ptr<sharded_profiler> cp;
+
+    cp_holder(bool start_now, std::chrono::milliseconds interval)
+      : cp{std::make_unique<sharded_profiler>()} {
+        cp->start(
+            config::mock_binding(std::move(start_now)),
+            config::mock_binding(std::move(interval)))
+          .get();
+        cp->invoke_on_all(&resources::cpu_profiler::start).get();
+    }
+
+    ~cp_holder() {
+        if (cp) {
+            cp->stop().get();
+        }
+    }
+};
+
 } // namespace
 
 using namespace std::literals;
@@ -55,22 +80,24 @@ SEASTAR_THREAD_TEST_CASE(test_cpu_profiler) {
     BOOST_TEST(results.samples.size() >= 1);
 }
 
-SEASTAR_TEST_CASE(test_cpu_profiler_enable_override) {
+SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override) {
     // Ensure that overrides to the profiler will enable it and collect samples
     // for the specified period of time.
 
-    ss::sharded<resources::cpu_profiler> cp;
-    co_await cp.start(config::mock_binding(false), config::mock_binding(2ms));
-    co_await cp.invoke_on_all(&resources::cpu_profiler::start);
+    cp_holder holder(false, 2ms);
+    ss::sharded<resources::cpu_profiler>& cp = *holder.cp;
 
     auto wait_ms = 256ms + 10ms;
-    auto [results] = co_await ss::coroutine::all(
-      [&]() {
-          return cp.local().collect_results_for_period(wait_ms, std::nullopt);
-      },
-      [&]() {
-          return ss::smp::invoke_on_all([&]() { return busy_loop(wait_ms); });
-      });
+    auto [results] = ss::when_all_succeed(
+                       [&]() {
+                           return cp.local().collect_results_for_period(
+                             wait_ms, std::nullopt);
+                       },
+                       [&]() {
+                           return ss::smp::invoke_on_all(
+                             [&]() { return busy_loop(wait_ms); });
+                       })
+                       .get();
 
     for (auto& shard_results : results) {
         BOOST_TEST(shard_results.samples.size() >= 1);
@@ -78,12 +105,12 @@ SEASTAR_TEST_CASE(test_cpu_profiler_enable_override) {
 
     // CPU profiler should be disabled so if we wait some time and collect the
     // samples again there should be no new samples.
-    co_await busy_loop(wait_ms);
+    busy_loop(wait_ms).get();
 
     auto new_results = cp.local().shard_results();
     auto old_results = results[ss::this_shard_id()];
 
-    BOOST_REQUIRE(new_results.samples.size() == old_results.samples.size());
+    BOOST_REQUIRE_EQUAL(new_results.samples.size(), old_results.samples.size());
 
     for (size_t i = 0; i < old_results.samples.size(); i++) {
         BOOST_REQUIRE(
@@ -93,29 +120,28 @@ SEASTAR_TEST_CASE(test_cpu_profiler_enable_override) {
           new_results.samples[i].user_backtrace
           == old_results.samples[i].user_backtrace);
     }
-
-    co_await cp.stop();
 }
 
-SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_nested) {
+SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override_nested) {
     // Ensure that in cases with multiple on-going overrides that the shortest
     // override doesn't prematurely disable the profiler.
 
-    ss::sharded<resources::cpu_profiler> cp;
-    co_await cp.start(config::mock_binding(false), config::mock_binding(10ms));
-    co_await cp.invoke_on_all(&resources::cpu_profiler::start);
+    cp_holder holder(false, 10ms);
+    ss::sharded<resources::cpu_profiler>& cp = *holder.cp;
 
     auto wait_ms = 1s;
-    auto [results_p, results_10p] = co_await ss::coroutine::all(
-      [&]() {
-          return cp.local().collect_results_for_period(wait_ms, std::nullopt);
-      },
-
-      [&]() {
-          return cp.local().collect_results_for_period(
-            10 * wait_ms, std::nullopt);
-      },
-      [&]() { return busy_loop(10 * wait_ms); });
+    auto [results_p, results_10p]
+      = ss::when_all_succeed(
+          [&]() {
+              return cp.local().collect_results_for_period(
+                wait_ms, std::nullopt);
+          },
+          [&]() {
+              return cp.local().collect_results_for_period(
+                10 * wait_ms, std::nullopt);
+          },
+          [&]() { return busy_loop(10 * wait_ms); })
+          .get();
 
     auto samples_p = std::accumulate(
       results_p[ss::this_shard_id()].samples.begin(),
@@ -129,60 +155,59 @@ SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_nested) {
       [](auto acc, auto& s) { return acc + s.occurrences; });
 
     BOOST_REQUIRE_LT(samples_p, samples_10p);
-
-    co_await cp.stop();
 }
 
-SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_abort) {
+SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override_abort) {
     // Ensure that in cases that the profiler is stopped with on-going overrides
     // that those overrides do not delay the stop.
 
-    ss::sharded<resources::cpu_profiler> cp;
-    co_await cp.start(config::mock_binding(false), config::mock_binding(2ms));
-    co_await cp.invoke_on_all(&resources::cpu_profiler::start);
+    cp_holder holder(false, 2ms);
+    ss::sharded<resources::cpu_profiler>& cp = *holder.cp;
 
     std::chrono::milliseconds wait_ms = 100min;
     auto res_fut = cp.local().collect_results_for_period(wait_ms, std::nullopt);
 
     auto start = ss::steady_clock_type::now();
-    co_await cp.stop();
+    cp.stop().get();
     auto end = ss::steady_clock_type::now();
 
     BOOST_REQUIRE(end - start < 1min);
 }
 
-SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_filter_old_samples) {
+SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override_filter_old_samples) {
     // Ensures that cpu_profiler::override_and_get_results doesn't return
     // samples collected before the function is called.
 
     std::chrono::milliseconds sample_rate = 1ms;
     auto one_poll_dur = ss::max_number_of_traces * sample_rate;
 
-    ss::sharded<resources::cpu_profiler> cp;
-    co_await cp.start(
-      config::mock_binding(false),
-      config::mock_binding<std::chrono::milliseconds>(sample_rate));
-    co_await cp.invoke_on_all(&resources::cpu_profiler::start);
+    cp_holder holder(false, sample_rate);
+    ss::sharded<resources::cpu_profiler>& cp = *holder.cp;
 
     auto wait_ms = 2 * one_poll_dur;
-    auto [results] = co_await ss::coroutine::all(
-      [&]() {
-          return cp.local().collect_results_for_period(wait_ms, std::nullopt);
-      },
-      [&]() { return busy_loop(wait_ms); });
+    auto [results] = ss::when_all_succeed(
+                       [&]() {
+                           return cp.local().collect_results_for_period(
+                             wait_ms, std::nullopt);
+                       },
+                       [&]() { return busy_loop(wait_ms); })
+                       .get();
 
     BOOST_TEST(results[ss::this_shard_id()].samples.size() >= 1);
 
     ss::engine().set_cpu_profiler_period(std::chrono::seconds(10));
 
-    co_await busy_loop(2 * one_poll_dur);
+    busy_loop(2 * one_poll_dur).get();
 
     wait_ms = 1ms;
-    auto [override_results] = co_await ss::coroutine::all(
-      [&]() {
-          return cp.local().collect_results_for_period(wait_ms, std::nullopt);
-      },
-      [&]() { return busy_loop(wait_ms); });
+    auto [override_results]
+      = ss::when_all_succeed(
+          [&]() {
+              return cp.local().collect_results_for_period(
+                wait_ms, std::nullopt);
+          },
+          [&]() { return busy_loop(wait_ms); })
+          .get();
 
     // Since we waited less then one poll duration no samples should of been
     // returned. If samples were returned then they must've come from the
@@ -190,24 +215,22 @@ SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_filter_old_samples) {
     BOOST_TEST(override_results[ss::this_shard_id()].samples.size() == 0);
 }
 
-SEASTAR_TEST_CASE(test_cpu_profiler_enable_override_sub_collection_period) {
+SEASTAR_THREAD_TEST_CASE(
+  test_cpu_profiler_enable_override_sub_collection_period) {
     // Ensures that cpu_profiler::override_and_get_results returns results even
     // for periods shorter than `ss::max_number_of_traces * sample_rate`
 
-    std::chrono::milliseconds sample_rate = 100ms;
-
-    ss::sharded<resources::cpu_profiler> cp;
-    co_await cp.start(
-      config::mock_binding(false),
-      config::mock_binding<std::chrono::milliseconds>(sample_rate));
-    co_await cp.invoke_on_all(&resources::cpu_profiler::start);
+    cp_holder holder(false, 100ms);
+    ss::sharded<resources::cpu_profiler>& cp = *holder.cp;
 
     auto wait_ms = std::chrono::seconds(3);
-    auto [results] = co_await ss::coroutine::all(
-      [&]() {
-          return cp.local().collect_results_for_period(wait_ms, std::nullopt);
-      },
-      [&]() { return busy_loop(wait_ms); });
+    auto [results] = ss::when_all_succeed(
+                       [&]() {
+                           return cp.local().collect_results_for_period(
+                             wait_ms, std::nullopt);
+                       },
+                       [&]() { return busy_loop(wait_ms); })
+                       .get();
 
     BOOST_TEST(results[ss::this_shard_id()].samples.size() >= 1);
 }

--- a/src/v/resource_mgmt/tests/cpu_profiler_test.cc
+++ b/src/v/resource_mgmt/tests/cpu_profiler_test.cc
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-#include "config/configuration.h"
 #include "config/property.h"
 #include "resource_mgmt/cpu_profiler.h"
 
@@ -25,11 +24,9 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 
-#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
-#include <exception>
 #include <optional>
 
 namespace {
@@ -88,7 +85,7 @@ SEASTAR_TEST_CASE(test_cpu_profiler_enable_override) {
 
     BOOST_REQUIRE(new_results.samples.size() == old_results.samples.size());
 
-    for (int i = 0; i < old_results.samples.size(); i++) {
+    for (size_t i = 0; i < old_results.samples.size(); i++) {
         BOOST_REQUIRE(
           new_results.samples[i].occurrences
           == old_results.samples[i].occurrences);

--- a/src/v/resource_mgmt/tests/cpu_profiler_test.cc
+++ b/src/v/resource_mgmt/tests/cpu_profiler_test.cc
@@ -23,7 +23,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <memory>
@@ -99,8 +98,12 @@ SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override) {
                        })
                        .get();
 
-    for (auto& shard_results : results) {
+    BOOST_REQUIRE_EQUAL(ss::smp::count, results.size());
+
+    for (ss::shard_id shard_id = 0; shard_id < ss::smp::count; ++shard_id) {
+        auto& shard_results = results[shard_id];
         BOOST_TEST(shard_results.samples.size() >= 1);
+        BOOST_REQUIRE_EQUAL(shard_id, shard_results.shard);
     }
 
     // CPU profiler should be disabled so if we wait some time and collect the


### PR DESCRIPTION
This pull request includes several changes to the `cpu_profiler` and its associated tests in the `resource_mgmt` module. The changes focus on fixing flaky and always-failing tests as a precursor to enabling this module's tests in bazel.

### Dependency Updates:
* [`src/v/resource_mgmt/BUILD`](diffhunk://#diff-e774a16df9a1d97ffa8a612ff201525b48b00a40f32d2acb0d567f5e1af781acR155): Added `//src/v/container:chunked_hash_map` to the list of dependencies.
* [`src/v/resource_mgmt/cpu_profiler.cc`](diffhunk://#diff-9fc238f63327633b86706d3e7f1dac57b0bcbe603a1961960dbc056baaf7508aL14-L17): Replaced `absl::node_hash_map` with `chunked_hash_map` and removed unused headers. [[1]](diffhunk://#diff-9fc238f63327633b86706d3e7f1dac57b0bcbe603a1961960dbc056baaf7508aL14-L17) [[2]](diffhunk://#diff-9fc238f63327633b86706d3e7f1dac57b0bcbe603a1961960dbc056baaf7508aL27) [[3]](diffhunk://#diff-9fc238f63327633b86706d3e7f1dac57b0bcbe603a1961960dbc056baaf7508aL100-R115)

### Enhancements to `cpu_profiler`:
* [`src/v/resource_mgmt/cpu_profiler.cc`](diffhunk://#diff-9fc238f63327633b86706d3e7f1dac57b0bcbe603a1961960dbc056baaf7508aL100-R115): Added logging for the total and unique results in `shard_results` method.

### Test Improvements:
* [`src/v/resource_mgmt/tests/cpu_profiler_test.cc`](diffhunk://#diff-11937812872e946979fecfa705e327a2fea0ab4d8de20140d06896945b73c4ffR43-R64): Introduced `cp_holder` to manage the lifecycle of `sharded_profiler` in tests.
* Updated test cases to use `cp_holder` and replaced coroutine-based calls with synchronous calls using `.get()`. [[1]](diffhunk://#diff-11937812872e946979fecfa705e327a2fea0ab4d8de20140d06896945b73c4ffL61-R151) [[2]](diffhunk://#diff-11937812872e946979fecfa705e327a2fea0ab4d8de20140d06896945b73c4ffL135-R240)

CORE-7589.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
