### PR TITLE
[CORE-7129] `rptest`: deflake `wait_for_internal_scrub()`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5343,7 +5343,7 @@ class RedpandaService(RedpandaServiceBase):
             return len(waiting_for) == 0
 
         n_partitions = len(cloud_storage_partitions)
-        timeout = (n_partitions // 100) * 60 + 120
+        timeout = (n_partitions // 100) * 60 + 180
         wait_until(all_partitions_scrubbed, timeout_sec=timeout, backoff_sec=5)
 
         return all_anomalies

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5259,27 +5259,8 @@ class RedpandaService(RedpandaServiceBase):
             tolerate_stopped_nodes=True)
 
         unavailable = set()
-        for p in cloud_storage_partitions:
-            try:
-                leader_id = self._admin.await_stable_leader(topic=p.topic,
-                                                            partition=p.index)
-
-                self._admin.reset_scrubbing_metadata(
-                    namespace="kafka",
-                    topic=p.topic,
-                    partition=p.index,
-                    node=self.get_node_by_id(leader_id))
-            except HTTPError as he:
-                if he.response.status_code == 404:
-                    # Old redpanda, doesn't have this endpoint.  We can't
-                    # do our upload check.
-                    unavailable.add(p)
-                    continue
-                else:
-                    raise
-
-        cloud_storage_partitions -= unavailable
         scrubbed = set()
+        seen = set()
         all_anomalies = []
 
         allowed_keys = set([
@@ -5327,10 +5308,31 @@ class RedpandaService(RedpandaServiceBase):
                             detected.pop("segment_metadata_anomalies", None)
 
         def all_partitions_scrubbed():
-            waiting_for = cloud_storage_partitions - scrubbed
+            waiting_for = cloud_storage_partitions - scrubbed - unavailable
             self.logger.info(
                 f"Waiting for {len(waiting_for)} partitions to be scrubbed")
             for p in waiting_for:
+                if p not in seen:
+                    seen.add(p)
+                    # Reset scrubbing metadata the first time the partition is encountered.
+                    try:
+                        leader_id = self._admin.await_stable_leader(
+                            topic=p.topic, partition=p.index)
+
+                        self._admin.reset_scrubbing_metadata(
+                            namespace="kafka",
+                            topic=p.topic,
+                            partition=p.index,
+                            node=self.get_node_by_id(leader_id))
+                    except HTTPError as he:
+                        if he.response.status_code == 404:
+                            # Old redpanda, doesn't have this endpoint.  We can't
+                            # do our upload check.
+                            unavailable.add(p)
+                            continue
+                        else:
+                            raise
+
                 result = self._admin.get_cloud_storage_anomalies(
                     namespace="kafka", topic=p.topic, partition=p.index)
                 if "last_complete_scrub_at" in result:


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
