### PR TITLE
Murmur3 iobuf

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,8 +56,8 @@ build --@seastar//:debug=True
 # =================================
 # Sanitizer
 # =================================
-build:sanitizer --copt -fsanitize=address,undefined,vptr,function
-build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function
+build:sanitizer --copt -fsanitize=address,undefined,vptr,function,alignment
+build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function,alignment
 build:sanitizer --linkopt -fsanitize-link-c++-runtime
 build:sanitizer --copt -O1
 build:sanitizer --//bazel:has_sanitizers=True

--- a/src/v/bytes/random.cc
+++ b/src/v/bytes/random.cc
@@ -13,6 +13,7 @@
 #include "random/generators.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
 
 namespace random_generators {
 
@@ -35,6 +36,27 @@ iobuf make_iobuf(size_t n) {
     iobuf io;
     io.append(b.data(), n);
     return io;
+}
+
+iobuf split_as_iobuf(std::string_view str, int n_fragments) {
+    auto remaining_len = str.length();
+    std::vector<size_t> fragment_lengths;
+    fragment_lengths.reserve(n_fragments);
+    for (int i = 0; i < n_fragments - 1; ++i) {
+        size_t fragment_len = get_int(remaining_len);
+        fragment_lengths.push_back(fragment_len);
+        remaining_len -= fragment_len;
+    }
+    fragment_lengths.push_back(remaining_len);
+    std::ranges::shuffle(fragment_lengths, internal::gen);
+
+    iobuf res;
+    auto cur = str.begin();
+    for (auto fragment_len : fragment_lengths) {
+        res.append(ss::temporary_buffer<char>(cur, fragment_len));
+        cur += fragment_len;
+    }
+    return res;
 }
 
 } // namespace random_generators

--- a/src/v/bytes/random.h
+++ b/src/v/bytes/random.h
@@ -13,6 +13,8 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 
+#include <string_view>
+
 namespace random_generators {
 
 bytes get_bytes(size_t n = 128 * 1024);
@@ -21,5 +23,7 @@ bytes get_crypto_bytes(size_t n = 128 * 1024, bool use_private_rng = false);
 
 // Makes an random alphanumeric string, encoded in an iobuf.
 iobuf make_iobuf(size_t n = 128);
+
+iobuf split_as_iobuf(std::string_view str, int n_fragments);
 
 } // namespace random_generators

--- a/src/v/coding-style.md
+++ b/src/v/coding-style.md
@@ -12,7 +12,7 @@ in an `includes` directory within the library they belong to. For example, a lib
 
 Test files go in the `tests` directory of the library they belong to. That is,
 the tests for a feature named `foo` and located in `src/v/foo` will be located
-in `src/v/foo/tests`.
+in `src/v/foo/tests`. Where possible prefer Gtest over Boost for new tests.
 
 Use `snake_case` naming convention by default for files and language identifiers.
 

--- a/src/v/hashing/BUILD
+++ b/src/v/hashing/BUILD
@@ -67,6 +67,9 @@ redpanda_cc_library(
     ],
     include_prefix = "hashing",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes:iobuf",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/hashing/murmur.cc
+++ b/src/v/hashing/murmur.cc
@@ -57,40 +57,25 @@ getblock64(const uint64_t* p, int i) {
 
 } // namespace internal
 
-uint32_t murmurhash3_x86_32(const void* key, std::size_t len, uint32_t seed) {
-    const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 4;
+namespace {
+namespace x86_32 {
+const uint32_t c1 = 0xcc9e2d51;
+const uint32_t c2 = 0x1b873593;
 
-    uint32_t h1 = seed;
+void consume_block(uint32_t& h1, uint32_t block) {
+    block *= c1;
+    block = internal::rotl32(block, 15);
+    block *= c2;
 
-    const uint32_t c1 = 0xcc9e2d51;
-    const uint32_t c2 = 0x1b873593;
+    h1 ^= block;
+    h1 = internal::rotl32(h1, 13);
+    h1 = h1 * 5 + 0xe6546b64;
+}
 
-    //----------
-    // body
-
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
-
-    for (int i = -nblocks; i; i++) {
-        uint32_t k1 = internal::getblock32(blocks, i);
-
-        k1 *= c1;
-        k1 = internal::rotl32(k1, 15);
-        k1 *= c2;
-
-        h1 ^= k1;
-        h1 = internal::rotl32(h1, 13);
-        h1 = h1 * 5 + 0xe6546b64;
-    }
-
-    //----------
-    // tail
-
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
-
+void consume_tail(uint32_t& h1, const uint8_t* tail, int len) {
     uint32_t k1 = 0;
 
-    switch (len & 3) {
+    switch (len) {
     case 3:
         k1 ^= tail[2] << 16;
     case 2:
@@ -102,13 +87,35 @@ uint32_t murmurhash3_x86_32(const void* key, std::size_t len, uint32_t seed) {
         k1 *= c2;
         h1 ^= k1;
     };
+}
 
-    //----------
-    // finalization
-
+void finalize(uint32_t& h1, int len) {
     h1 ^= len;
-
     h1 = internal::fmix32(h1);
+}
+} // namespace x86_32
+} // namespace
+
+uint32_t murmurhash3_x86_32(const void* key, std::size_t len, uint32_t seed) {
+    const uint8_t* data = (const uint8_t*)key;
+    const int nblocks = len / 4;
+
+    uint32_t h1 = seed;
+
+    auto blocks = reinterpret_cast<const uint32_t*>(data + nblocks * 4);
+
+    for (int i = -nblocks; i; i++) {
+        uint32_t k1 = internal::getblock32(blocks, i);
+        x86_32::consume_block(h1, k1);
+    }
+
+    const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+    x86_32::consume_tail(h1, tail, len & 3);
+
+    x86_32::finalize(h1, len);
+
+    return h1;
+}
 
     return h1;
 }

--- a/src/v/hashing/murmur.cc
+++ b/src/v/hashing/murmur.cc
@@ -117,6 +117,54 @@ uint32_t murmurhash3_x86_32(const void* key, std::size_t len, uint32_t seed) {
     return h1;
 }
 
+uint32_t murmurhash3_x86_32(const iobuf& data, uint32_t seed) {
+    uint32_t h1 = seed;
+
+    uint32_t torn_block; // murmur block split between iobuf fragments
+    auto torn_block_begin = reinterpret_cast<char*>(&torn_block);
+    auto torn_block_end = torn_block_begin + 4;
+    auto torn_block_data_end = torn_block_begin;
+
+    for (const auto& fragment : data) {
+        auto frag_begin = fragment.get();
+        auto frag_size = fragment.size();
+        auto frag_end = frag_begin + frag_size;
+
+        // torn block
+        size_t torn_remaining_capacity = torn_block_end - torn_block_data_end;
+        if (fragment.size() < torn_remaining_capacity) {
+            torn_block_data_end = std::copy(
+              frag_begin, frag_end, torn_block_data_end);
+            continue;
+        }
+
+        std::copy(
+          frag_begin,
+          frag_begin + torn_remaining_capacity,
+          torn_block_data_end);
+        x86_32::consume_block(h1, torn_block);
+
+        // rest of full blocks in fragment
+        auto blocks_begin = frag_begin + torn_remaining_capacity;
+        const ssize_t blocks_size = fragment.size() - torn_remaining_capacity;
+        auto nblocks = blocks_size / 4;
+        auto blocks_end = blocks_begin + nblocks * 4;
+        auto blocks = reinterpret_cast<const uint32_t*>(blocks_end);
+        for (ssize_t i = -nblocks; i; i++) {
+            uint32_t k1 = internal::getblock32(blocks, i);
+            x86_32::consume_block(h1, k1);
+        }
+
+        // next torn block
+        torn_block_data_end = std::copy(blocks_end, frag_end, torn_block_begin);
+    }
+
+    auto tail = reinterpret_cast<const uint8_t*>(torn_block_begin);
+    x86_32::consume_tail(
+      h1, tail, static_cast<int>(torn_block_data_end - torn_block_begin));
+
+    x86_32::finalize(h1, data.size_bytes());
+
     return h1;
 }
 

--- a/src/v/hashing/murmur.cc
+++ b/src/v/hashing/murmur.cc
@@ -44,11 +44,15 @@ inline __attribute__((always_inline)) uint64_t fmix64(uint64_t k) {
 // handle aligned reads, do the conversion here
 inline __attribute__((always_inline)) uint32_t
 getblock32(const uint32_t* p, int i) {
-    return p[i];
+    uint32_t k;
+    std::memcpy(&k, reinterpret_cast<const char*>(p + i), sizeof(k));
+    return k;
 }
 inline __attribute__((always_inline)) uint64_t
 getblock64(const uint64_t* p, int i) {
-    return p[i];
+    uint64_t k;
+    std::memcpy(&k, reinterpret_cast<const char*>(p + i), sizeof(k));
+    return k;
 }
 
 } // namespace internal
@@ -129,7 +133,7 @@ void murmurhash3_x86_128(
     //----------
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 16);
+    auto blocks = reinterpret_cast<const uint32_t*>(data + nblocks * 16);
 
     for (int i = -nblocks; i; i++) {
         uint32_t k1 = internal::getblock32(blocks, i * 4 + 0);

--- a/src/v/hashing/murmur.cc
+++ b/src/v/hashing/murmur.cc
@@ -12,7 +12,7 @@
 // adapted from original:
 // https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.h
 
-namespace internal {
+namespace {
 inline uint32_t rotl32(uint32_t x, int8_t r) {
     return (x << r) | (x >> (32 - r));
 }
@@ -54,21 +54,17 @@ getblock64(const uint64_t* p, int i) {
     std::memcpy(&k, reinterpret_cast<const char*>(p + i), sizeof(k));
     return k;
 }
-
-} // namespace internal
-
-namespace {
 namespace x86_32 {
 const uint32_t c1 = 0xcc9e2d51;
 const uint32_t c2 = 0x1b873593;
 
 void consume_block(uint32_t& h1, uint32_t block) {
     block *= c1;
-    block = internal::rotl32(block, 15);
+    block = rotl32(block, 15);
     block *= c2;
 
     h1 ^= block;
-    h1 = internal::rotl32(h1, 13);
+    h1 = rotl32(h1, 13);
     h1 = h1 * 5 + 0xe6546b64;
 }
 
@@ -83,7 +79,7 @@ void consume_tail(uint32_t& h1, const uint8_t* tail, int len) {
     case 1:
         k1 ^= tail[0];
         k1 *= c1;
-        k1 = internal::rotl32(k1, 15);
+        k1 = rotl32(k1, 15);
         k1 *= c2;
         h1 ^= k1;
     };
@@ -91,7 +87,7 @@ void consume_tail(uint32_t& h1, const uint8_t* tail, int len) {
 
 void finalize(uint32_t& h1, int len) {
     h1 ^= len;
-    h1 = internal::fmix32(h1);
+    h1 = fmix32(h1);
 }
 } // namespace x86_32
 } // namespace
@@ -105,7 +101,7 @@ uint32_t murmurhash3_x86_32(const void* key, std::size_t len, uint32_t seed) {
     auto blocks = reinterpret_cast<const uint32_t*>(data + nblocks * 4);
 
     for (int i = -nblocks; i; i++) {
-        uint32_t k1 = internal::getblock32(blocks, i);
+        uint32_t k1 = getblock32(blocks, i);
         x86_32::consume_block(h1, k1);
     }
 
@@ -151,7 +147,7 @@ uint32_t murmurhash3_x86_32(const iobuf& data, uint32_t seed) {
         auto blocks_end = blocks_begin + nblocks * 4;
         auto blocks = reinterpret_cast<const uint32_t*>(blocks_end);
         for (ssize_t i = -nblocks; i; i++) {
-            uint32_t k1 = internal::getblock32(blocks, i);
+            uint32_t k1 = getblock32(blocks, i);
             x86_32::consume_block(h1, k1);
         }
 
@@ -191,44 +187,44 @@ void murmurhash3_x86_128(
     auto blocks = reinterpret_cast<const uint32_t*>(data + nblocks * 16);
 
     for (int i = -nblocks; i; i++) {
-        uint32_t k1 = internal::getblock32(blocks, i * 4 + 0);
-        uint32_t k2 = internal::getblock32(blocks, i * 4 + 1);
-        uint32_t k3 = internal::getblock32(blocks, i * 4 + 2);
-        uint32_t k4 = internal::getblock32(blocks, i * 4 + 3);
+        uint32_t k1 = getblock32(blocks, i * 4 + 0);
+        uint32_t k2 = getblock32(blocks, i * 4 + 1);
+        uint32_t k3 = getblock32(blocks, i * 4 + 2);
+        uint32_t k4 = getblock32(blocks, i * 4 + 3);
 
         k1 *= c1;
-        k1 = internal::rotl32(k1, 15);
+        k1 = rotl32(k1, 15);
         k1 *= c2;
         h1 ^= k1;
 
-        h1 = internal::rotl32(h1, 19);
+        h1 = rotl32(h1, 19);
         h1 += h2;
         h1 = h1 * 5 + 0x561ccd1b;
 
         k2 *= c2;
-        k2 = internal::rotl32(k2, 16);
+        k2 = rotl32(k2, 16);
         k2 *= c3;
         h2 ^= k2;
 
-        h2 = internal::rotl32(h2, 17);
+        h2 = rotl32(h2, 17);
         h2 += h3;
         h2 = h2 * 5 + 0x0bcaa747;
 
         k3 *= c3;
-        k3 = internal::rotl32(k3, 17);
+        k3 = rotl32(k3, 17);
         k3 *= c4;
         h3 ^= k3;
 
-        h3 = internal::rotl32(h3, 15);
+        h3 = rotl32(h3, 15);
         h3 += h4;
         h3 = h3 * 5 + 0x96cd1c35;
 
         k4 *= c4;
-        k4 = internal::rotl32(k4, 18);
+        k4 = rotl32(k4, 18);
         k4 *= c1;
         h4 ^= k4;
 
-        h4 = internal::rotl32(h4, 13);
+        h4 = rotl32(h4, 13);
         h4 += h1;
         h4 = h4 * 5 + 0x32ac3b17;
     }
@@ -251,7 +247,7 @@ void murmurhash3_x86_128(
     case 13:
         k4 ^= tail[12] << 0;
         k4 *= c4;
-        k4 = internal::rotl32(k4, 18);
+        k4 = rotl32(k4, 18);
         k4 *= c1;
         h4 ^= k4;
 
@@ -264,7 +260,7 @@ void murmurhash3_x86_128(
     case 9:
         k3 ^= tail[8] << 0;
         k3 *= c3;
-        k3 = internal::rotl32(k3, 17);
+        k3 = rotl32(k3, 17);
         k3 *= c4;
         h3 ^= k3;
 
@@ -277,7 +273,7 @@ void murmurhash3_x86_128(
     case 5:
         k2 ^= tail[4] << 0;
         k2 *= c2;
-        k2 = internal::rotl32(k2, 16);
+        k2 = rotl32(k2, 16);
         k2 *= c3;
         h2 ^= k2;
 
@@ -290,7 +286,7 @@ void murmurhash3_x86_128(
     case 1:
         k1 ^= tail[0] << 0;
         k1 *= c1;
-        k1 = internal::rotl32(k1, 15);
+        k1 = rotl32(k1, 15);
         k1 *= c2;
         h1 ^= k1;
     };
@@ -310,10 +306,10 @@ void murmurhash3_x86_128(
     h3 += h1;
     h4 += h1;
 
-    h1 = internal::fmix32(h1);
-    h2 = internal::fmix32(h2);
-    h3 = internal::fmix32(h3);
-    h4 = internal::fmix32(h4);
+    h1 = fmix32(h1);
+    h2 = fmix32(h2);
+    h3 = fmix32(h3);
+    h4 = fmix32(h4);
 
     h1 += h2;
     h1 += h3;
@@ -347,24 +343,24 @@ void murmurhash3_x64_128(
     const uint64_t* blocks = (const uint64_t*)(data);
 
     for (int i = 0; i < nblocks; i++) {
-        uint64_t k1 = internal::getblock64(blocks, i * 2 + 0);
-        uint64_t k2 = internal::getblock64(blocks, i * 2 + 1);
+        uint64_t k1 = getblock64(blocks, i * 2 + 0);
+        uint64_t k2 = getblock64(blocks, i * 2 + 1);
 
         k1 *= c1;
-        k1 = internal::rotl64(k1, 31);
+        k1 = rotl64(k1, 31);
         k1 *= c2;
         h1 ^= k1;
 
-        h1 = internal::rotl64(h1, 27);
+        h1 = rotl64(h1, 27);
         h1 += h2;
         h1 = h1 * 5 + 0x52dce729;
 
         k2 *= c2;
-        k2 = internal::rotl64(k2, 33);
+        k2 = rotl64(k2, 33);
         k2 *= c1;
         h2 ^= k2;
 
-        h2 = internal::rotl64(h2, 31);
+        h2 = rotl64(h2, 31);
         h2 += h1;
         h2 = h2 * 5 + 0x38495ab5;
     }
@@ -393,7 +389,7 @@ void murmurhash3_x64_128(
     case 9:
         k2 ^= ((uint64_t)tail[8]) << 0;
         k2 *= c2;
-        k2 = internal::rotl64(k2, 33);
+        k2 = rotl64(k2, 33);
         k2 *= c1;
         h2 ^= k2;
 
@@ -414,7 +410,7 @@ void murmurhash3_x64_128(
     case 1:
         k1 ^= ((uint64_t)tail[0]) << 0;
         k1 *= c1;
-        k1 = internal::rotl64(k1, 31);
+        k1 = rotl64(k1, 31);
         k1 *= c2;
         h1 ^= k1;
     };
@@ -428,8 +424,8 @@ void murmurhash3_x64_128(
     h1 += h2;
     h2 += h1;
 
-    h1 = internal::fmix64(h1);
-    h2 = internal::fmix64(h2);
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
 
     h1 += h2;
     h2 += h1;

--- a/src/v/hashing/murmur.h
+++ b/src/v/hashing/murmur.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "bytes/iobuf.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -22,6 +24,9 @@ constexpr static const uint32_t kDefaultHashingSeed = 0xFBA4C795;
 
 uint32_t murmurhash3_x86_32(
   const void* key, std::size_t len, uint32_t seed = kDefaultHashingSeed);
+
+uint32_t
+murmurhash3_x86_32(const iobuf& data, uint32_t seed = kDefaultHashingSeed);
 
 void murmurhash3_x86_128(
   const void* key,

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -31,7 +31,10 @@ redpanda_cc_bench(
         "hash_bench.cc",
     ],
     deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:random",
         "//src/v/hashing:crc32c",
+        "//src/v/hashing:murmur",
         "//src/v/hashing:xx",
         "//src/v/model",
         "//src/v/random:generators",

--- a/src/v/hashing/tests/BUILD
+++ b/src/v/hashing/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_btest_no_seastar")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_btest_no_seastar", "redpanda_cc_gtest")
 
 redpanda_cc_btest(
     name = "secure_hash_test",
@@ -22,6 +22,22 @@ redpanda_cc_btest_no_seastar(
     deps = [
         "//src/v/hashing:xx",
         "//src/v/utils:named_type",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "murmur_hash_test",
+    timeout = "short",
+    srcs = [
+        "murmur_tests.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/hashing:murmur",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/hashing/tests/CMakeLists.txt
+++ b/src/v/hashing/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ rp_test(
   BENCHMARK_TEST
   BINARY_NAME hashing_bench
   SOURCES hash_bench.cc
-  LIBRARIES Seastar::seastar_perf_testing v::hashing v::random absl::hash
+  LIBRARIES Seastar::seastar_perf_testing v::hashing v::random v::bytes_random absl::hash v::bytes
   LABELS hashing
 )

--- a/src/v/hashing/tests/CMakeLists.txt
+++ b/src/v/hashing/tests/CMakeLists.txt
@@ -9,6 +9,18 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  GTEST
+  BINARY_NAME murmur_hashes
+  SOURCES murmur_tests.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES
+    v::gtest_main
+    v::hashing
+  LABELS hashing
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME test_secure_hashing
   SOURCES secure_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -7,7 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/bytes.h"
+#include "bytes/random.h"
 #include "hashing/crc32c.h"
+#include "hashing/murmur.h"
 #include "hashing/xx.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
@@ -21,6 +24,8 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/string_view.h>
 #include <boost/crc.hpp>
+
+#include <cstdint>
 
 static constexpr size_t step_bytes = 57;
 
@@ -254,3 +259,49 @@ PERF_TEST(ntp_hash, absl_hash_of) {
 PERF_TEST(ntp_hash, absl_hash_value) {
     return ntp_body([](const ntp& v) { return absl::Hash<ntp>{}(v); });
 }
+
+namespace {
+
+constexpr auto BODY_LEN = 1000;
+constexpr auto TAIL_LEN = 3;
+
+bytes generate_data() {
+    bytes buf{bytes::initialized_later{}, BODY_LEN + TAIL_LEN};
+    vassert(
+      reinterpret_cast<uintptr_t>(buf.data()) % 4 == 0,
+      "bytes suddenly became unaligned; here it is only a test, but other code "
+      "(murmur2 calls?) may rely on it");
+    random_generators::fill_buffer_randomchars(
+      reinterpret_cast<char*>(buf.data()), buf.size());
+
+    perf_tests::do_not_optimize(buf);
+    return buf;
+}
+
+template<size_t... Offset>
+size_t murmurhash3_x86_32_continuous() {
+    auto buf = generate_data();
+    perf_tests::start_measuring_time();
+    for (auto i = inner_iters; i--;) {
+        (
+          [&buf]() {
+              auto s = murmurhash3_x86_32(buf.data() + Offset, BODY_LEN);
+              perf_tests::do_not_optimize(s);
+          }(),
+          ...);
+    }
+    perf_tests::stop_measuring_time();
+    return sizeof...(Offset) * inner_iters;
+}
+
+PERF_TEST(murmur_hash_x86_32, aligned) {
+    return murmurhash3_x86_32_continuous<0>();
+}
+
+PERF_TEST(murmur_hash_x86_32, unaligned) {
+    return murmurhash3_x86_32_continuous<1, 2, 3>();
+}
+
+}
+
+} // namespace

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -19,6 +19,7 @@
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
 #include <seastar/testing/perf_tests.hh>
 
 #include <absl/hash/hash.h>
@@ -26,6 +27,7 @@
 #include <boost/crc.hpp>
 
 #include <cstdint>
+#include <cstdlib>
 
 static constexpr size_t step_bytes = 57;
 
@@ -302,6 +304,17 @@ PERF_TEST(murmur_hash_x86_32, unaligned) {
     return murmurhash3_x86_32_continuous<1, 2, 3>();
 }
 
+PERF_TEST(murmur_hash_x86_32, iobuf) {
+    auto buf = generate_data();
+    iobuf split_buf = random_generators::split_as_iobuf(
+      {reinterpret_cast<const char*>(buf.data()), buf.size()}, 3);
+    perf_tests::start_measuring_time();
+    for (auto i = inner_iters; i--;) {
+        auto s = murmurhash3_x86_32(split_buf);
+        perf_tests::do_not_optimize(s);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters;
 }
 
 } // namespace

--- a/src/v/hashing/tests/murmur_tests.cc
+++ b/src/v/hashing/tests/murmur_tests.cc
@@ -1,0 +1,92 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "hashing/murmur.h"
+
+#include <seastar/core/temporary_buffer.hh>
+
+#include <base/seastarx.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <ranges>
+
+namespace {
+// assuming an non-decreasing input, cap all elements with `limit` and discard
+// repeating values after `limit` is returned first time
+constexpr auto capped_with(size_t limit, std::ranges::range auto input) {
+    std::vector<size_t> ret;
+    bool seen_limit = false;
+    for (const auto& item : input) {
+        if (item < limit) {
+            ret.push_back(item);
+        } else {
+            if (seen_limit) {
+                break;
+            }
+            seen_limit = true;
+            ret.push_back(limit);
+        }
+    }
+    return ret;
+}
+} // namespace
+
+TEST(MurmurTest, IobufEquivanetToContinuous) {
+    constexpr auto total_sizes = std::to_array<size_t>(
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 100, 1000, 1001, 1002, 1003});
+    constexpr auto chunk_sizes = std::to_array<size_t>(
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 100, 101, 102, 103, 104});
+
+    for (auto len : total_sizes) {
+        // char span
+        const std::vector continuous{
+          std::from_range,
+          std::views::iota(size_t{0}, len)
+            | std::views::transform([](char c) -> char { return c ^ 13; })};
+        auto continuous_hashed = murmurhash3_x86_32(
+          continuous.data(), continuous.size());
+
+        // 1-chunk iobuf
+        {
+            iobuf single_chunk{std::to_array({ss::temporary_buffer<char>{
+              continuous.data(), continuous.size()}})};
+            auto single_hashed = murmurhash3_x86_32(single_chunk);
+            ASSERT_EQ(continuous_hashed, single_hashed);
+        }
+
+        // 2-chunk iobuf
+        for (auto chunk1_size : capped_with(continuous.size(), chunk_sizes)) {
+            ss::temporary_buffer chunk1{continuous.data(), chunk1_size};
+            ss::temporary_buffer chunk2{
+              continuous.data() + chunk1_size, continuous.size() - chunk1_size};
+            iobuf double_chunk{
+              std::to_array({std::move(chunk1), std::move(chunk2)})};
+            auto double_hashed = murmurhash3_x86_32(double_chunk);
+            ASSERT_EQ(continuous_hashed, double_hashed);
+        }
+
+        // 3-chunk iobuf
+        for (auto chunk1_size : capped_with(continuous.size(), chunk_sizes)) {
+            for (auto chunk2_size :
+                 capped_with(continuous.size() - chunk1_size, chunk_sizes)) {
+                ss::temporary_buffer chunk1{continuous.data(), chunk1_size};
+                ss::temporary_buffer chunk2{
+                  continuous.data() + chunk1_size, chunk2_size};
+                ss::temporary_buffer chunk3{
+                  continuous.data() + chunk1_size + chunk2_size,
+                  continuous.size() - chunk1_size - chunk2_size};
+                iobuf triple_chunk{std::to_array(
+                  {std::move(chunk1), std::move(chunk2), std::move(chunk3)})};
+                auto triple_hashed = murmurhash3_x86_32(triple_chunk);
+                ASSERT_EQ(continuous_hashed, triple_hashed);
+            }
+        }
+    }
+} // namespace


### PR DESCRIPTION
Implement murmur3 hash for iobuf.

If buffers are oddly sized or allocated we access uint32_t numbers using a pointer which is not a multiple of 4 bytes. It is okay on x86 and aarch64 but not on some other architectures.

It'll be needed for bucketing strings in iceberg transformations

microbench results:
```
test                          iterations      median         mad         min         max      allocs       tasks        inst      cycles
murmur_hash_x86_32.aligned       4824000   203.608ns     0.130ns   203.018ns   203.961ns       0.000       0.000      2800.3      1115.3
murmur_hash_x86_32.unaligned     4827000   207.595ns     0.380ns   206.494ns   208.470ns       0.000       0.000      2798.8      1137.6
murmur_hash_x86_32.iobuf         4918000   202.882ns     0.079ns   202.637ns   203.302ns       0.000       0.000      3333.3      1111.5
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
