### PR TITLE
Bazilify resource_mgmt tests

### DIFF
--- a/src/v/resource_mgmt/tests/BUILD
+++ b/src/v/resource_mgmt/tests/BUILD
@@ -1,0 +1,65 @@
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest")
+
+redpanda_cc_btest(
+    name = "cpu_profiler_test",
+    timeout = "short",
+    srcs = [
+        "cpu_profiler_test.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/resource_mgmt:cpu_profiler",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "available_memory_test",
+    timeout = "short",
+    srcs = [
+        "available_memory_test.cc",
+    ],
+    deps = [
+        "//src/v/resource_mgmt:available_memory",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "storage_test",
+    timeout = "short",
+    srcs = [
+        "storage_test.cc",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/random:generators",
+        "//src/v/resource_mgmt:storage",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "memory_groups_test",
+    timeout = "short",
+    srcs = [
+        "memory_groups_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/resource_mgmt:memory_groups",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:human",
+        "@googletest//:gtest",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -120,6 +120,10 @@ redpanda_cc_library(
         "@fmt",
     ],
     include_prefix = "storage",
+    visibility = [
+        "//src/v/resource_mgmt/tests:__pkg__",
+        "//src/v/storage/tests:__pkg__",
+    ],
     deps = [
         "//src/v/base",
         "//src/v/container:intrusive",


### PR DESCRIPTION
Add the resource management tests to bazel, except memory sampling test.

In the storage packages, we needed to make batch_cache visible to this package as there is a test for it here.

Fixes CORE-7586.
Fixes CORE-7587.
Fixes CORE-7588.
Fixes CORE-7590.

This needs https://github.com/redpanda-data/redpanda/pull/25359 to go in first for this to pass bazel test CI.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
