### PR TITLE
datalake: add support for value_subject_latest iceberg_mode

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -300,7 +300,7 @@ metrics_reporter::build_metrics_snapshot() {
         case model::iceberg_mode::variant::value_schema_id_prefix:
             ++snapshot.topics_with_iceberg_sr;
             break;
-        case model::iceberg_mode::variant::latest_protobuf_value:
+        case model::iceberg_mode::variant::value_subject_latest:
             ++snapshot.topics_with_iceberg_pb;
             break;
         }

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -291,14 +291,17 @@ metrics_reporter::build_metrics_snapshot() {
 
         snapshot.topic_count++;
         snapshot.partition_count += md.get_configuration().partition_count;
-        switch (md.get_configuration().properties.iceberg_mode) {
-        case model::iceberg_mode::disabled:
+        switch (md.get_configuration().properties.iceberg_mode.kind()) {
+        case model::iceberg_mode::variant::disabled:
             break;
-        case model::iceberg_mode::key_value:
+        case model::iceberg_mode::variant::key_value:
             ++snapshot.topics_with_iceberg_kv;
             break;
-        case model::iceberg_mode::value_schema_id_prefix:
+        case model::iceberg_mode::variant::value_schema_id_prefix:
             ++snapshot.topics_with_iceberg_sr;
+            break;
+        case model::iceberg_mode::variant::latest_protobuf_value:
+            ++snapshot.topics_with_iceberg_pb;
             break;
         }
     }
@@ -608,6 +611,8 @@ void rjson_serialize(
     w.Uint64(snapshot.topics_with_iceberg_kv);
     w.Key("topics_with_iceberg_value_schema_id_prefix");
     w.Uint64(snapshot.topics_with_iceberg_sr);
+    w.Key("topics_with_iceberg_latest_protobuf_value");
+    w.Uint64(snapshot.topics_with_iceberg_pb);
 
     w.Key("partition_count");
     w.Uint64(snapshot.partition_count);

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -96,6 +96,7 @@ public:
 
         uint32_t topics_with_iceberg_kv{0};
         uint32_t topics_with_iceberg_sr{0};
+        uint32_t topics_with_iceberg_pb{0};
 
         cluster_version active_logical_version{invalid_version};
         cluster_version original_logical_version{invalid_version};

--- a/src/v/compat/model_json.h
+++ b/src/v/compat/model_json.h
@@ -14,6 +14,8 @@
 #include "model/metadata.h"
 #include "model/record.h"
 
+#include <stdexcept>
+
 namespace json {
 
 inline void rjson_serialize(
@@ -320,6 +322,49 @@ inline void rjson_serialize(
 
 inline void read_value(const json::Value& rd, model::record_attributes& out) {
     out = model::record_attributes(rd.GetInt());
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& wr, const model::iceberg_mode& m) {
+    wr.StartObject();
+    wr.Key("kind");
+    rjson_serialize(wr, m.kind());
+    if (m.kind() == model::iceberg_mode::variant::latest_protobuf_value) {
+        wr.Key("protobuf_full_name");
+        rjson_serialize(wr, m.protobuf_full_name());
+    }
+    wr.EndObject();
+}
+
+inline void read_value(const json::Value& rd, model::iceberg_mode& m) {
+    const auto& obj = rd.GetObject();
+    auto it = obj.FindMember("kind");
+    if (it == obj.MemberEnd()) {
+        throw std::runtime_error("missing kind member from iceberg_mode json");
+    }
+    model::iceberg_mode::variant v = model::iceberg_mode::variant::disabled;
+    read_value(it->value, v);
+    switch (v) {
+    case model::iceberg_mode::variant::disabled:
+        m = model::iceberg_mode::disabled;
+        break;
+    case model::iceberg_mode::variant::key_value:
+        m = model::iceberg_mode::key_value;
+        break;
+    case model::iceberg_mode::variant::value_schema_id_prefix:
+        m = model::iceberg_mode::value_schema_id_prefix;
+        break;
+    case model::iceberg_mode::variant::latest_protobuf_value:
+        it = obj.FindMember("protobuf_full_name");
+        if (it == obj.MemberEnd()) {
+            throw std::runtime_error(
+              "missing protobuf_full_name member from iceberg_mode json");
+        }
+        ss::sstring name;
+        read_value(it->value, name);
+        m = model::iceberg_mode::latest_protobuf_value(name);
+        break;
+    }
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/model_json.h
+++ b/src/v/compat/model_json.h
@@ -329,9 +329,11 @@ inline void rjson_serialize(
     wr.StartObject();
     wr.Key("kind");
     rjson_serialize(wr, m.kind());
-    if (m.kind() == model::iceberg_mode::variant::latest_protobuf_value) {
+    if (m.kind() == model::iceberg_mode::variant::value_subject_latest) {
         wr.Key("protobuf_full_name");
-        rjson_serialize(wr, m.protobuf_full_name());
+        rjson_serialize(wr, m.protobuf_full_name().value_or(""));
+        wr.Key("subject_name");
+        rjson_serialize(wr, m.subject_name().value_or(""));
     }
     wr.EndObject();
 }
@@ -354,7 +356,7 @@ inline void read_value(const json::Value& rd, model::iceberg_mode& m) {
     case model::iceberg_mode::variant::value_schema_id_prefix:
         m = model::iceberg_mode::value_schema_id_prefix;
         break;
-    case model::iceberg_mode::variant::latest_protobuf_value:
+    case model::iceberg_mode::variant::value_subject_latest:
         it = obj.FindMember("protobuf_full_name");
         if (it == obj.MemberEnd()) {
             throw std::runtime_error(
@@ -362,7 +364,14 @@ inline void read_value(const json::Value& rd, model::iceberg_mode& m) {
         }
         ss::sstring name;
         read_value(it->value, name);
-        m = model::iceberg_mode::latest_protobuf_value(name);
+        it = obj.FindMember("subject_name");
+        if (it == obj.MemberEnd()) {
+            throw std::runtime_error(
+              "missing subject_name member from iceberg_mode json");
+        }
+        ss::sstring subject;
+        read_value(it->value, subject);
+        m = model::iceberg_mode::value_subject_latest(name, subject);
         break;
     }
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3812,6 +3812,14 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(1min),
       {.min = std::chrono::milliseconds{10s}})
+  , iceberg_latest_schema_cache_ttl_ms(
+      *this,
+      "iceberg_latest_schema_cache_ttl_ms",
+      "The TTL for the cache in translation that stores the latest schema when "
+      "using the `latest_protobuf_value` iceberg mode.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::chrono::milliseconds(5min),
+      {.min = std::chrono::milliseconds{1ms}})
   , iceberg_catalog_base_location(
       *this,
       "iceberg_catalog_base_location",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -716,6 +716,8 @@ struct configuration final : public config_store {
     enterprise<property<bool>> iceberg_enabled;
     bounded_property<std::chrono::milliseconds>
       iceberg_catalog_commit_interval_ms;
+    bounded_property<std::chrono::milliseconds>
+      iceberg_latest_schema_cache_ttl_ms;
     property<ss::sstring> iceberg_catalog_base_location;
     bounded_property<std::chrono::seconds>
       datalake_coordinator_snapshot_max_delay_secs;

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -423,7 +423,6 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/utils:chunked_kv_cache",
-        "//src/v/utils:mutex",
         "@seastar",
     ],
 )

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -423,6 +423,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/utils:chunked_kv_cache",
+        "//src/v/utils:mutex",
         "@seastar",
     ],
 )

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -409,7 +409,6 @@ redpanda_cc_library(
         ":schema_avro",
         ":schema_protobuf",
         ":schema_registry",
-        "//src/v/config",
         "//src/v/metrics",
         "//src/v/pandaproxy",
         "//src/v/schema:registry",
@@ -421,6 +420,7 @@ redpanda_cc_library(
     deps = [
         ":schema_identifier",
         "//src/v/base",
+        "//src/v/config",
         "//src/v/iceberg:datatypes",
         "//src/v/utils:chunked_kv_cache",
         "@seastar",

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -99,7 +99,6 @@ datalake_manager::datalake_manager(
   , _location_provider(cloud_io->local().provider(), bucket_name)
   , _schema_registry(schema::registry::make_default(sr_api))
   , _catalog_factory(std::move(catalog_factory))
-  , _type_resolver(std::make_unique<record_schema_resolver>(*_schema_registry))
   // TODO: The cache size is currently arbitrary. Figure out a more reasoned
   // size and allocate a share of the datalake memory semaphore to this cache.
   , _schema_cache(std::make_unique<chunked_schema_cache>(

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -40,29 +40,32 @@ namespace datalake {
 namespace {
 
 static std::unique_ptr<type_resolver> make_type_resolver(
-  model::iceberg_mode mode, schema::registry& sr, schema_cache& cache) {
-    switch (mode) {
-    case model::iceberg_mode::disabled:
+  const model::iceberg_mode& mode, schema::registry& sr, schema_cache& cache) {
+    switch (mode.kind()) {
+    case model::iceberg_mode::variant::disabled:
         vassert(
           false,
           "Cannot make record translator when iceberg is disabled, logic bug.");
-    case model::iceberg_mode::key_value:
+    case model::iceberg_mode::variant::key_value:
         return std::make_unique<binary_type_resolver>();
-    case model::iceberg_mode::value_schema_id_prefix:
+    case model::iceberg_mode::variant::value_schema_id_prefix:
         return std::make_unique<record_schema_resolver>(sr, cache);
+    case model::iceberg_mode::variant::latest_protobuf_value:
+        vassert(false, "TODO");
     }
 }
 
 static std::unique_ptr<record_translator>
-make_record_translator(model::iceberg_mode mode) {
-    switch (mode) {
-    case model::iceberg_mode::disabled:
+make_record_translator(const model::iceberg_mode& mode) {
+    switch (mode.kind()) {
+    case model::iceberg_mode::variant::disabled:
         vassert(
           false,
           "Cannot make record translator when iceberg is disabled, logic bug.");
-    case model::iceberg_mode::key_value:
+    case model::iceberg_mode::variant::key_value:
         return std::make_unique<key_value_translator>();
-    case model::iceberg_mode::value_schema_id_prefix:
+    case model::iceberg_mode::variant::value_schema_id_prefix:
+    case model::iceberg_mode::variant::latest_protobuf_value:
         return std::make_unique<structured_data_translator>();
     }
 }

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -54,13 +54,11 @@ static std::unique_ptr<type_resolver> make_type_resolver(
     case model::iceberg_mode::variant::value_schema_id_prefix:
         return std::make_unique<record_schema_resolver>(sr, cache);
     case model::iceberg_mode::variant::latest_protobuf_value:
-        static constexpr auto cache_duration = 5min;
         return std::make_unique<latest_protobuf_schema_resolver>(
           sr,
           topic_name,
           mode.protobuf_full_name(),
-          std::chrono::duration_cast<ss::lowres_clock::duration>(
-            cache_duration),
+          config::shard_local_cfg().iceberg_latest_schema_cache_ttl_ms.bind(),
           cache);
     }
 }

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -40,7 +40,10 @@ namespace datalake {
 namespace {
 
 static std::unique_ptr<type_resolver> make_type_resolver(
-  const model::iceberg_mode& mode, schema::registry& sr, schema_cache& cache) {
+  const model::iceberg_mode& mode,
+  model::topic_view topic_name,
+  schema::registry& sr,
+  schema_cache& cache) {
     switch (mode.kind()) {
     case model::iceberg_mode::variant::disabled:
         vassert(
@@ -51,7 +54,14 @@ static std::unique_ptr<type_resolver> make_type_resolver(
     case model::iceberg_mode::variant::value_schema_id_prefix:
         return std::make_unique<record_schema_resolver>(sr, cache);
     case model::iceberg_mode::variant::latest_protobuf_value:
-        vassert(false, "TODO");
+        static constexpr auto cache_duration = 5min;
+        return std::make_unique<latest_protobuf_schema_resolver>(
+          sr,
+          topic_name,
+          mode.protobuf_full_name(),
+          std::chrono::duration_cast<ss::lowres_clock::duration>(
+            cache_duration),
+          cache);
     }
 }
 
@@ -325,7 +335,7 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
 
     auto mode = topic_cfg->properties.iceberg_mode;
     auto type_resolver = make_type_resolver(
-      mode, *_schema_registry, *_schema_cache);
+      mode, ntp.tp.topic, *_schema_registry, *_schema_cache);
     auto record_translator = make_record_translator(mode);
     auto table_creator = translation::make_default_table_creator(
       _coordinator_frontend->local());

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -53,10 +53,15 @@ static std::unique_ptr<type_resolver> make_type_resolver(
         return std::make_unique<binary_type_resolver>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
         return std::make_unique<record_schema_resolver>(sr, cache);
-    case model::iceberg_mode::variant::latest_protobuf_value:
-        return std::make_unique<latest_protobuf_schema_resolver>(
+    case model::iceberg_mode::variant::value_subject_latest:
+        auto subject = pandaproxy::schema_registry::subject(
+          fmt::format("{}-value", topic_name));
+        if (auto explicit_subject = mode.subject_name()) {
+            subject = pandaproxy::schema_registry::subject(*explicit_subject);
+        }
+        return std::make_unique<latest_subject_schema_resolver>(
           sr,
-          topic_name,
+          subject,
           mode.protobuf_full_name(),
           config::shard_local_cfg().iceberg_latest_schema_cache_ttl_ms.bind(),
           cache);
@@ -73,7 +78,7 @@ make_record_translator(const model::iceberg_mode& mode) {
     case model::iceberg_mode::variant::key_value:
         return std::make_unique<key_value_translator>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
-    case model::iceberg_mode::variant::latest_protobuf_value:
+    case model::iceberg_mode::variant::value_subject_latest:
         return std::make_unique<structured_data_translator>();
     }
 }

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -108,7 +108,6 @@ private:
     std::unique_ptr<coordinator::catalog_factory> _catalog_factory;
     std::unique_ptr<iceberg::catalog> _catalog;
     std::unique_ptr<datalake::schema_manager> _schema_mgr;
-    std::unique_ptr<datalake::type_resolver> _type_resolver;
     std::unique_ptr<datalake::schema_cache> _schema_cache;
     std::unique_ptr<backlog_controller> _backlog_controller;
     chunked_hash_map<model::ntp, ss::lw_shared_ptr<class translation_probe>>

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -112,6 +112,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
         if (val_type_res.has_error()) {
             switch (val_type_res.error()) {
             case type_resolver::errc::registry_error:
+            case type_resolver::errc::invalid_config:
                 _error = writer_error::parquet_conversion_error;
                 co_return ss::stop_iteration::yes;
             case type_resolver::errc::bad_input:

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -338,7 +338,7 @@ latest_protobuf_schema_resolver::latest_protobuf_schema_resolver(
   schema::registry& sr,
   model::topic_view topic_name,
   ss::sstring full_message_name,
-  ss::lowres_clock::duration cache_duration,
+  config::binding<std::chrono::milliseconds> cache_duration,
   std::optional<std::reference_wrapper<schema_cache>> sc)
   : sr_(&sr)
   , subject_(fmt::format("{}-value", topic_name()))
@@ -379,9 +379,12 @@ checked<pb_descriptor_lookup_result, type_resolver::errc> lookup_descriptor(
 ss::future<checked<type_and_buf, type_resolver::errc>>
 latest_protobuf_schema_resolver::resolve_buf_type(
   std::optional<iobuf> b) const {
+    auto duration = std::chrono::duration_cast<ss::lowres_clock::duration>(
+      cache_duration_());
     if (
       latest_cached_schema_
-      && latest_cached_schema_->evict_deadline > ss::lowres_clock::now()) {
+      && latest_cached_schema_->created_time + duration
+           > ss::lowres_clock::now()) {
         co_return type_and_buf{
           .type = std::make_optional(latest_cached_schema_->type.copy()),
           .parsable_buf = std::move(b),
@@ -427,8 +430,7 @@ latest_protobuf_schema_resolver::resolve_buf_type(
           .type = std::move(type),
           .type_name = res.descriptor.get().name(),
         };
-        latest_cached_schema_.emplace(
-          resolved.copy(), ss::lowres_clock::now() + cache_duration_);
+        latest_cached_schema_.emplace(resolved.copy(), ss::lowres_clock::now());
         co_return type_and_buf{
           .type = std::move(resolved),
           .parsable_buf = std::move(b),

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -16,6 +16,7 @@
 #include "datalake/schema_identifier.h"
 #include "datalake/schema_protobuf.h"
 #include "datalake/schema_registry.h"
+#include "iceberg/datatypes.h"
 #include "metrics/prometheus_sanitize.h"
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/types.h"
@@ -27,7 +28,9 @@
 
 #include <google/protobuf/descriptor.h>
 
+#include <algorithm>
 #include <exception>
+#include <optional>
 
 namespace datalake {
 
@@ -173,6 +176,43 @@ struct from_identifier_visitor {
     }
 };
 
+ss::future<checked<shared_schema_t, type_resolver::errc>> get_schema(
+  schema::registry* sr,
+  std::optional<std::reference_wrapper<schema_cache>> cache,
+  ppsr::schema_id id) {
+    if (!sr->is_enabled()) {
+        vlog(datalake_log.warn, "Schema registry is not enabled");
+        // TODO: should we treat this as transient?
+        co_return type_resolver::errc::translation_error;
+    }
+    if (cache.has_value()) {
+        auto cached_schema = cache->get().get_value(id);
+
+        if (cached_schema) {
+            co_return std::move(*cached_schema);
+        }
+    }
+    auto schema_fut = co_await ss::coroutine::as_future(
+      sr->get_valid_schema(id));
+    if (schema_fut.failed()) {
+        vlog(
+          datalake_log.warn,
+          "Error getting schema from registry: {}",
+          schema_fut.get_exception());
+        co_return type_resolver::errc::registry_error;
+    }
+    auto resolved_schema = std::move(schema_fut.get());
+    if (!resolved_schema.has_value()) {
+        vlog(datalake_log.trace, "Schema ID {} not in registry", id);
+        co_return type_resolver::errc::bad_input;
+    }
+    auto shared_schema = ss::make_shared(std::move(resolved_schema.value()));
+    if (cache.has_value()) {
+        cache->get().try_insert(id, shared_schema);
+    }
+    co_return std::move(shared_schema);
+}
+
 } // namespace
 
 chunked_schema_cache::chunked_schema_cache(
@@ -229,6 +269,8 @@ std::ostream& operator<<(std::ostream& o, const type_resolver::errc& e) {
         return o << "type_resolver::errc::translation_error";
     case type_resolver::errc::bad_input:
         return o << "type_resolver::errc::bad_input";
+    case type_resolver::errc::invalid_config:
+        return o << "type_resolver::errc::invalid_config";
     }
 }
 
@@ -251,44 +293,6 @@ binary_type_resolver::resolve_identifier(schema_identifier) const {
     co_return type_resolver::errc::translation_error;
 }
 
-ss::future<checked<shared_schema_t, type_resolver::errc>>
-record_schema_resolver::get_schema(ppsr::schema_id id) const {
-    if (!sr_.is_enabled()) {
-        vlog(datalake_log.warn, "Schema registry is not enabled");
-        // TODO: should we treat this as transient?
-        co_return type_resolver::errc::translation_error;
-    }
-    if (cache_.has_value()) {
-        auto cached_schema = cache_->get().get_value(id);
-
-        if (cached_schema) {
-            co_return std::move(*cached_schema);
-        }
-    }
-    auto schema_fut = co_await ss::coroutine::as_future(
-      sr_.get_valid_schema(id));
-    if (schema_fut.failed()) {
-        vlog(
-          datalake_log.warn,
-          "Error getting schema from registry: {}",
-          schema_fut.get_exception());
-        co_return type_resolver::errc::registry_error;
-    }
-    auto resolved_schema = std::move(schema_fut.get());
-    if (!resolved_schema.has_value()) {
-        vlog(
-          datalake_log.trace,
-          "Schema ID {} not in registry; using binary type",
-          id);
-        co_return type_resolver::errc::bad_input;
-    }
-    auto shared_schema = ss::make_shared(std::move(resolved_schema.value()));
-    if (cache_.has_value()) {
-        cache_->get().try_insert(id, shared_schema);
-    }
-    co_return std::move(shared_schema);
-}
-
 ss::future<checked<type_and_buf, type_resolver::errc>>
 record_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     if (!b.has_value()) {
@@ -308,7 +312,7 @@ record_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     auto schema_id = schema_id_res.schema_id;
     auto buf_no_id = std::move(schema_id_res.shared_message_data);
 
-    auto schema_res = co_await get_schema(schema_id);
+    auto schema_res = co_await get_schema(&sr_, cache_, schema_id);
     if (schema_res.has_error()) {
         co_return schema_res.error();
     }
@@ -320,7 +324,7 @@ record_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
 
 ss::future<checked<resolved_type, type_resolver::errc>>
 record_schema_resolver::resolve_identifier(schema_identifier ident) const {
-    auto schema_res = co_await get_schema(ident.schema_id);
+    auto schema_res = co_await get_schema(&sr_, cache_, ident.schema_id);
     if (schema_res.has_error()) {
         co_return schema_res.error();
     }
@@ -330,4 +334,136 @@ record_schema_resolver::resolve_identifier(schema_identifier ident) const {
       from_identifier_visitor{std::move(ident), shared_schema});
 }
 
+latest_protobuf_schema_resolver::latest_protobuf_schema_resolver(
+  schema::registry& sr,
+  model::topic_view topic_name,
+  ss::sstring full_message_name,
+  ss::lowres_clock::duration cache_duration,
+  std::optional<std::reference_wrapper<schema_cache>> sc)
+  : sr_(&sr)
+  , subject_(fmt::format("{}-value", topic_name()))
+  , full_message_name_(std::move(full_message_name))
+  , cache_duration_(cache_duration)
+  , cache_(sc) {}
+
+namespace {
+
+struct pb_descriptor_lookup_result {
+    std::reference_wrapper<const google::protobuf::Descriptor> descriptor;
+    std::vector<int32_t> offsets;
+};
+
+checked<pb_descriptor_lookup_result, type_resolver::errc> lookup_descriptor(
+  const ppsr::protobuf_schema_definition& pb_def,
+  std::string_view message_full_name) {
+    auto d_res = ppsr::descriptor(pb_def, message_full_name);
+    if (d_res.has_error()) {
+        return type_resolver::errc::invalid_config;
+    }
+    // Build up the offsets by walking the descriptor tree
+    std::vector<int> offsets;
+    for (const google::protobuf::Descriptor* d = &d_res.value().get();
+         d != nullptr;
+         d = d->containing_type()) {
+        offsets.push_back(d->index());
+    }
+    std::ranges::reverse(offsets);
+    return pb_descriptor_lookup_result{
+      .descriptor = d_res.value(),
+      .offsets = std::move(offsets),
+    };
+}
+
+} // namespace
+
+ss::future<checked<type_and_buf, type_resolver::errc>>
+latest_protobuf_schema_resolver::resolve_buf_type(
+  std::optional<iobuf> b) const {
+    // Prevent multiple fibers from resolving the protobuf. Since the subject
+    // is fixed there would be no harm in letting them race either, but it seems
+    // better to not waste work.
+    auto _ = co_await mu_.get_units();
+    if (
+      latest_cached_schema_
+      && latest_cached_schema_->evict_deadline > ss::lowres_clock::now()) {
+        co_return type_and_buf{
+          .type = std::make_optional(latest_cached_schema_->type.copy()),
+          .parsable_buf = std::move(b),
+        };
+    } else {
+        latest_cached_schema_ = std::nullopt;
+    }
+    auto latest_schema_fut
+      = co_await ss::coroutine::as_future<ppsr::subject_schema>(
+        sr_->get_subject_schema(subject_, /*subject_version=*/std::nullopt));
+    if (latest_schema_fut.failed()) {
+        co_return type_resolver::errc::registry_error;
+    }
+    auto latest_schema = std::move(latest_schema_fut.get());
+    auto schema_res = co_await get_schema(sr_, cache_, latest_schema.id);
+    if (schema_res.has_error()) {
+        co_return schema_res.error();
+    }
+    auto shared_schema = schema_res.value();
+    auto pb_def_res = shared_schema->visit(ss::make_visitor(
+      [](const ppsr::protobuf_schema_definition& pb_def)
+        -> checked<ppsr::protobuf_schema_definition, type_resolver::errc> {
+          return pb_def;
+      },
+      [](const auto&)
+        -> checked<ppsr::protobuf_schema_definition, type_resolver::errc> {
+          return type_resolver::errc::invalid_config;
+      }));
+    if (pb_def_res.has_error()) {
+        co_return pb_def_res.error();
+    }
+    auto lookup_res = lookup_descriptor(pb_def_res.value(), full_message_name_);
+    if (lookup_res.has_error()) {
+        co_return lookup_res.error();
+    }
+    auto res = std::move(lookup_res.value());
+    try {
+        auto type = type_to_iceberg(res.descriptor).value();
+        auto resolved = resolved_type{
+          .schema = resolved_schema(res.descriptor, std::move(shared_schema)),
+          .id
+          = {.schema_id = latest_schema.id, .protobuf_offsets = std::move(res.offsets)},
+          .type = std::move(type),
+          .type_name = res.descriptor.get().name(),
+        };
+        latest_cached_schema_.emplace(
+          resolved.copy(), ss::lowres_clock::now() + cache_duration_);
+        co_return type_and_buf{
+          .type = std::move(resolved),
+          .parsable_buf = std::move(b),
+        };
+    } catch (...) {
+        vlog(
+          datalake_log.error,
+          "Protobuf schema translation failed: {}",
+          std::current_exception());
+        co_return type_resolver::errc::translation_error;
+    }
+}
+
+ss::future<checked<resolved_type, type_resolver::errc>>
+latest_protobuf_schema_resolver::resolve_identifier(
+  schema_identifier ident) const {
+    auto schema_res = co_await get_schema(sr_, cache_, ident.schema_id);
+    if (schema_res.has_error()) {
+        co_return schema_res.error();
+    }
+    auto shared_schema = schema_res.value();
+    co_return shared_schema->visit(
+      from_identifier_visitor{std::move(ident), shared_schema});
+}
+
+resolved_type resolved_type::copy() const {
+    return {
+      .schema = schema,
+      .id = id,
+      .type = iceberg::make_copy(type),
+      .type_name = type_name,
+    };
+}
 } // namespace datalake

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -379,10 +379,6 @@ checked<pb_descriptor_lookup_result, type_resolver::errc> lookup_descriptor(
 ss::future<checked<type_and_buf, type_resolver::errc>>
 latest_protobuf_schema_resolver::resolve_buf_type(
   std::optional<iobuf> b) const {
-    // Prevent multiple fibers from resolving the protobuf. Since the subject
-    // is fixed there would be no harm in letting them race either, but it seems
-    // better to not waste work.
-    auto _ = co_await mu_.get_units();
     if (
       latest_cached_schema_
       && latest_cached_schema_->evict_deadline > ss::lowres_clock::now()) {

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -334,26 +334,21 @@ record_schema_resolver::resolve_identifier(schema_identifier ident) const {
       from_identifier_visitor{std::move(ident), shared_schema});
 }
 
-latest_protobuf_schema_resolver::latest_protobuf_schema_resolver(
+latest_subject_schema_resolver::latest_subject_schema_resolver(
   schema::registry& sr,
-  model::topic_view topic_name,
-  ss::sstring full_message_name,
+  ppsr::subject subject,
+  std::optional<ss::sstring> protobuf_message_name,
   config::binding<std::chrono::milliseconds> cache_duration,
   std::optional<std::reference_wrapper<schema_cache>> sc)
   : sr_(&sr)
-  , subject_(fmt::format("{}-value", topic_name()))
-  , full_message_name_(std::move(full_message_name))
-  , cache_duration_(cache_duration)
+  , subject_(std::move(subject))
+  , protobuf_message_name_(std::move(protobuf_message_name))
+  , cache_duration_(std::move(cache_duration))
   , cache_(sc) {}
 
 namespace {
 
-struct pb_descriptor_lookup_result {
-    std::reference_wrapper<const google::protobuf::Descriptor> descriptor;
-    std::vector<int32_t> offsets;
-};
-
-checked<pb_descriptor_lookup_result, type_resolver::errc> lookup_descriptor(
+checked<std::vector<int32_t>, type_resolver::errc> compute_message_offsets(
   const ppsr::protobuf_schema_definition& pb_def,
   std::string_view message_full_name) {
     auto d_res = ppsr::descriptor(pb_def, message_full_name);
@@ -368,17 +363,13 @@ checked<pb_descriptor_lookup_result, type_resolver::errc> lookup_descriptor(
         offsets.push_back(d->index());
     }
     std::ranges::reverse(offsets);
-    return pb_descriptor_lookup_result{
-      .descriptor = d_res.value(),
-      .offsets = std::move(offsets),
-    };
+    return offsets;
 }
 
 } // namespace
 
 ss::future<checked<type_and_buf, type_resolver::errc>>
-latest_protobuf_schema_resolver::resolve_buf_type(
-  std::optional<iobuf> b) const {
+latest_subject_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     auto duration = std::chrono::duration_cast<ss::lowres_clock::duration>(
       cache_duration_());
     if (
@@ -396,6 +387,7 @@ latest_protobuf_schema_resolver::resolve_buf_type(
       = co_await ss::coroutine::as_future<ppsr::subject_schema>(
         sr_->get_subject_schema(subject_, /*subject_version=*/std::nullopt));
     if (latest_schema_fut.failed()) {
+        latest_schema_fut.ignore_ready_future();
         co_return type_resolver::errc::registry_error;
     }
     auto latest_schema = std::move(latest_schema_fut.get());
@@ -404,48 +396,45 @@ latest_protobuf_schema_resolver::resolve_buf_type(
         co_return schema_res.error();
     }
     auto shared_schema = schema_res.value();
-    auto pb_def_res = shared_schema->visit(ss::make_visitor(
-      [](const ppsr::protobuf_schema_definition& pb_def)
-        -> checked<ppsr::protobuf_schema_definition, type_resolver::errc> {
-          return pb_def;
+    auto resolve_res = shared_schema->visit(ss::make_visitor(
+      [this, &latest_schema, &shared_schema](
+        const ppsr::protobuf_schema_definition& pb_def)
+        -> checked<resolved_type, type_resolver::errc> {
+          std::vector<int32_t> offsets;
+          if (const auto& explicit_name = protobuf_message_name_) {
+              auto res = compute_message_offsets(pb_def, *explicit_name);
+              if (res.has_error()) {
+                  return res.error();
+              }
+              offsets = std::move(res.value());
+          } else {
+              offsets = {0};
+          }
+          return translate_protobuf_schema(
+            pb_def, latest_schema.id, offsets, std::move(shared_schema));
       },
-      [](const auto&)
-        -> checked<ppsr::protobuf_schema_definition, type_resolver::errc> {
+      [&latest_schema, &shared_schema](const ppsr::avro_schema_definition& def)
+        -> checked<resolved_type, type_resolver::errc> {
+          return translate_avro_schema(
+            def, latest_schema.id, std::move(shared_schema));
+      },
+      [](const ppsr::json_schema_definition&)
+        -> checked<resolved_type, type_resolver::errc> {
           return type_resolver::errc::invalid_config;
       }));
-    if (pb_def_res.has_error()) {
-        co_return pb_def_res.error();
+    if (resolve_res.has_error()) {
+        co_return resolve_res.error();
     }
-    auto lookup_res = lookup_descriptor(pb_def_res.value(), full_message_name_);
-    if (lookup_res.has_error()) {
-        co_return lookup_res.error();
-    }
-    auto res = std::move(lookup_res.value());
-    try {
-        auto type = type_to_iceberg(res.descriptor).value();
-        auto resolved = resolved_type{
-          .schema = resolved_schema(res.descriptor, std::move(shared_schema)),
-          .id
-          = {.schema_id = latest_schema.id, .protobuf_offsets = std::move(res.offsets)},
-          .type = std::move(type),
-          .type_name = res.descriptor.get().name(),
-        };
-        latest_cached_schema_.emplace(resolved.copy(), ss::lowres_clock::now());
-        co_return type_and_buf{
-          .type = std::move(resolved),
-          .parsable_buf = std::move(b),
-        };
-    } catch (...) {
-        vlog(
-          datalake_log.error,
-          "Protobuf schema translation failed: {}",
-          std::current_exception());
-        co_return type_resolver::errc::translation_error;
-    }
+    auto resolved = std::move(resolve_res.value());
+    latest_cached_schema_.emplace(resolved.copy(), ss::lowres_clock::now());
+    co_return type_and_buf{
+      .type = std::move(resolved),
+      .parsable_buf = std::move(b),
+    };
 }
 
 ss::future<checked<resolved_type, type_resolver::errc>>
-latest_protobuf_schema_resolver::resolve_identifier(
+latest_subject_schema_resolver::resolve_identifier(
   schema_identifier ident) const {
     auto schema_res = co_await get_schema(sr_, cache_, ident.schema_id);
     if (schema_res.has_error()) {

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -171,30 +171,29 @@ private:
     std::optional<std::reference_wrapper<schema_cache>> cache_;
 };
 
-// latest_protobuf_schema_resolver is a schema resolver that:
+// latest_subject_schema_resolver is a schema resolver that uses the latest
+// schema for a subject to parse records with a configurable cache duration.
 //
-// - assumes resolved schemas are protobuf
-// - looks the latest version up of a schema using topic name strategy
-// - for that schema, looks up a specific message descriptor
-// - use said message descriptor as the schema for the topic
-class latest_protobuf_schema_resolver : public type_resolver {
+// If the schema is protobuf then the first protobuf defined in the proto file
+// will be used to parse the record unless `protobuf_message_name` is specified,
+// then the protobuf with that specific name is used for parsing.
+class latest_subject_schema_resolver : public type_resolver {
 public:
-    latest_protobuf_schema_resolver(
+    latest_subject_schema_resolver(
       schema::registry& sr,
-      model::topic_view topic_name,
-      ss::sstring full_message_name,
+      pandaproxy::schema_registry::subject subject,
+      std::optional<ss::sstring> protobuf_message_name,
       config::binding<std::chrono::milliseconds> cache_duration,
       std::optional<std::reference_wrapper<schema_cache>> sc);
-    latest_protobuf_schema_resolver(const latest_protobuf_schema_resolver&)
+    latest_subject_schema_resolver(const latest_subject_schema_resolver&)
       = delete;
-    latest_protobuf_schema_resolver(latest_protobuf_schema_resolver&&) = delete;
-    latest_protobuf_schema_resolver&
-    operator=(const latest_protobuf_schema_resolver&)
+    latest_subject_schema_resolver(latest_subject_schema_resolver&&) = delete;
+    latest_subject_schema_resolver&
+    operator=(const latest_subject_schema_resolver&)
       = delete;
-    latest_protobuf_schema_resolver&
-    operator=(latest_protobuf_schema_resolver&&)
+    latest_subject_schema_resolver& operator=(latest_subject_schema_resolver&&)
       = delete;
-    ~latest_protobuf_schema_resolver() override = default;
+    ~latest_subject_schema_resolver() override = default;
 
     ss::future<checked<type_and_buf, type_resolver::errc>>
     resolve_buf_type(std::optional<iobuf> b) const override;
@@ -205,7 +204,7 @@ public:
 private:
     schema::registry* sr_;
     pandaproxy::schema_registry::subject subject_;
-    ss::sstring full_message_name_;
+    std::optional<ss::sstring> protobuf_message_name_;
     config::binding<std::chrono::milliseconds> cache_duration_;
     std::optional<std::reference_wrapper<schema_cache>> cache_;
     struct cached_schema {

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -15,8 +15,12 @@
 #include "metrics/metrics.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "utils/chunked_kv_cache.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/future.hh>
+
+#include <chrono>
+#include <type_traits>
 
 namespace schema {
 class registry;
@@ -99,6 +103,8 @@ struct resolved_type {
     // correspond to their final IDs in the catalog.
     iceberg::field_type type;
     ss::sstring type_name;
+
+    resolved_type copy() const;
 };
 
 struct type_and_buf {
@@ -120,16 +126,19 @@ public:
         registry_error,
         translation_error,
         bad_input,
+        invalid_config,
     };
     friend std::ostream& operator<<(std::ostream&, const errc&);
     virtual ss::future<checked<type_and_buf, errc>>
     resolve_buf_type(std::optional<iobuf> b) const = 0;
-
+    // TODO(iceberg): This should be it's own interface.
     virtual ss::future<checked<resolved_type, errc>>
       resolve_identifier(schema_identifier) const = 0;
     virtual ~type_resolver() = default;
 };
 
+// binary_type_resolver is the type resolver for the raw key_value mode of
+// iceberg.
 class binary_type_resolver : public type_resolver {
 public:
     ss::future<checked<type_and_buf, type_resolver::errc>>
@@ -140,6 +149,8 @@ public:
     ~binary_type_resolver() override = default;
 };
 
+// record_schema_resolver uses the schema registry wire format
+// to decode messages and resolve their schemas.
 class record_schema_resolver : public type_resolver {
 public:
     explicit record_schema_resolver(
@@ -158,9 +169,51 @@ public:
 private:
     schema::registry& sr_;
     std::optional<std::reference_wrapper<schema_cache>> cache_;
+};
 
-    ss::future<checked<shared_schema_t, type_resolver::errc>>
-      get_schema(pandaproxy::schema_registry::schema_id) const;
+// latest_protobuf_schema_resolver is a schema resolver that:
+//
+// - assumes resolved schemas are protobuf
+// - looks the latest version up of a schema using topic name strategy
+// - for that schema, looks up a specific message descriptor
+// - use said message descriptor as the schema for the topic
+class latest_protobuf_schema_resolver : public type_resolver {
+public:
+    latest_protobuf_schema_resolver(
+      schema::registry& sr,
+      model::topic_view topic_name,
+      ss::sstring full_message_name,
+      ss::lowres_clock::duration cache_duration,
+      std::optional<std::reference_wrapper<schema_cache>> sc);
+    latest_protobuf_schema_resolver(const latest_protobuf_schema_resolver&)
+      = delete;
+    latest_protobuf_schema_resolver(latest_protobuf_schema_resolver&&) = delete;
+    latest_protobuf_schema_resolver&
+    operator=(const latest_protobuf_schema_resolver&)
+      = delete;
+    latest_protobuf_schema_resolver&
+    operator=(latest_protobuf_schema_resolver&&)
+      = delete;
+    ~latest_protobuf_schema_resolver() override = default;
+
+    ss::future<checked<type_and_buf, type_resolver::errc>>
+    resolve_buf_type(std::optional<iobuf> b) const override;
+
+    ss::future<checked<resolved_type, errc>>
+      resolve_identifier(schema_identifier) const override;
+
+private:
+    schema::registry* sr_;
+    pandaproxy::schema_registry::subject subject_;
+    ss::sstring full_message_name_;
+    ss::lowres_clock::duration cache_duration_;
+    std::optional<std::reference_wrapper<schema_cache>> cache_;
+    struct cached_schema {
+        resolved_type type;
+        ss::lowres_clock::time_point evict_deadline;
+    };
+    mutable std::optional<cached_schema> latest_cached_schema_;
+    mutable mutex mu_{"latest_protobuf_schema_resolver"};
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -15,7 +15,6 @@
 #include "metrics/metrics.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "utils/chunked_kv_cache.h"
-#include "utils/mutex.h"
 
 #include <seastar/core/future.hh>
 
@@ -213,7 +212,6 @@ private:
         ss::lowres_clock::time_point evict_deadline;
     };
     mutable std::optional<cached_schema> latest_cached_schema_;
-    mutable mutex mu_{"latest_protobuf_schema_resolver"};
 };
 
 } // namespace datalake

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "config/property.h"
 #include "datalake/schema_identifier.h"
 #include "iceberg/datatypes.h"
 #include "metrics/metrics.h"
@@ -182,7 +183,7 @@ public:
       schema::registry& sr,
       model::topic_view topic_name,
       ss::sstring full_message_name,
-      ss::lowres_clock::duration cache_duration,
+      config::binding<std::chrono::milliseconds> cache_duration,
       std::optional<std::reference_wrapper<schema_cache>> sc);
     latest_protobuf_schema_resolver(const latest_protobuf_schema_resolver&)
       = delete;
@@ -205,11 +206,11 @@ private:
     schema::registry* sr_;
     pandaproxy::schema_registry::subject subject_;
     ss::sstring full_message_name_;
-    ss::lowres_clock::duration cache_duration_;
+    config::binding<std::chrono::milliseconds> cache_duration_;
     std::optional<std::reference_wrapper<schema_cache>> cache_;
     struct cached_schema {
         resolved_type type;
-        ss::lowres_clock::time_point evict_deadline;
+        ss::lowres_clock::time_point created_time;
     };
     mutable std::optional<cached_schema> latest_cached_schema_;
 };

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -287,6 +287,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/base",
         "//src/v/bytes",
+        "//src/v/config",
         "//src/v/datalake:logger",
         "//src/v/datalake:record_schema_resolver",
         "//src/v/iceberg:datatypes",

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -11,6 +11,7 @@
 #include "bytes/bytes.h"
 #include "datalake/logger.h"
 #include "datalake/record_schema_resolver.h"
+#include "gmock/gmock.h"
 #include "iceberg/datatypes.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "schema/tests/fake_registry.h"
@@ -82,14 +83,14 @@ public:
     void SetUp() override {
         auto avro_schema_id = sr
                                 ->create_schema(unparsed_schema{
-                                  subject{"foo"},
+                                  subject{"foo-value"},
                                   unparsed_schema_definition{
                                     avro_record_schema, schema_type::avro}})
                                 .get();
         ASSERT_EQ(1, avro_schema_id());
         auto pb_schema_id = sr
                               ->create_schema(unparsed_schema{
-                                subject{"foo"},
+                                subject{"foo-value"},
                                 unparsed_schema_definition{
                                   pb_record_schema, schema_type::protobuf}})
                               .get();
@@ -264,6 +265,39 @@ TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
     EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
 }
 
+TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema) {
+    using namespace std::chrono_literals;
+    iobuf buf;
+    buf.append(generate_dummy_body());
+
+    auto resolver = latest_protobuf_schema_resolver(
+      *sr,
+      model::topic("foo"),
+      "datalake.proto.nested_message.inner_message_t1",
+      0s,
+      std::nullopt);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    auto& resolved_buf = res.value();
+    ASSERT_TRUE(resolved_buf.type.has_value());
+    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+    EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
+    EXPECT_THAT(
+      resolved_buf.type->id.protobuf_offsets.value(),
+      testing::ElementsAre(2, 0));
+
+    const auto expected_type = field_type{[] {
+        auto expected_struct = struct_type{};
+        expected_struct.fields.emplace_back(nested_field::create(
+          1, "inner_label_1", field_required::no, string_type{}));
+        expected_struct.fields.emplace_back(nested_field::create(
+          2, "inner_number_1", field_required::no, int_type{}));
+        return expected_struct;
+    }()};
+    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
+}
+
 namespace {
 struct counting_store : public pandaproxy::schema_registry::schema_getter {
     counting_store(
@@ -357,14 +391,14 @@ std::unique_ptr<counting_registry> make_counting_sr() {
 
     auto avro_schema_id = sr
                             ->create_schema(unparsed_schema{
-                              subject{"foo"},
+                              subject{"foo-value"},
                               unparsed_schema_definition{
                                 avro_record_schema, schema_type::avro}})
                             .get();
     vassert(1 == avro_schema_id(), "failed to registry avro schema");
     auto pb_schema_id = sr
                           ->create_schema(unparsed_schema{
-                            subject{"foo"},
+                            subject{"foo-value"},
                             unparsed_schema_definition{
                               pb_record_schema, schema_type::protobuf}})
                           .get();
@@ -381,7 +415,7 @@ std::unique_ptr<counting_registry> make_counting_sr() {
     for (auto i = 3; i < 10; i++) {
         auto pb_schema_id = sr
                               ->create_schema(unparsed_schema{
-                                subject{"foo"},
+                                subject{"foo-value"},
                                 unparsed_schema_definition{
                                   get_simple_schema(i), schema_type::protobuf}})
                               .get();

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -9,6 +9,7 @@
  */
 #include "base/vassert.h"
 #include "bytes/bytes.h"
+#include "config/property.h"
 #include "datalake/logger.h"
 #include "datalake/record_schema_resolver.h"
 #include "gmock/gmock.h"
@@ -274,7 +275,7 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema) {
       *sr,
       model::topic("foo"),
       "datalake.proto.nested_message.inner_message_t1",
-      0s,
+      config::mock_binding(std::chrono::milliseconds(0s)),
       std::nullopt);
     auto res = resolver.resolve_buf_type(buf.copy()).get();
     ASSERT_FALSE(res.has_error());

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -96,6 +96,20 @@ public:
                                   pb_record_schema, schema_type::protobuf}})
                               .get();
         ASSERT_EQ(2, pb_schema_id());
+        avro_schema_id = sr
+                           ->create_schema(unparsed_schema{
+                             subject{"latest-avro"},
+                             unparsed_schema_definition{
+                               avro_record_schema, schema_type::avro}})
+                           .get();
+        ASSERT_EQ(1, avro_schema_id());
+        pb_schema_id = sr
+                         ->create_schema(unparsed_schema{
+                           subject{"latest-proto"},
+                           unparsed_schema_definition{
+                             pb_record_schema, schema_type::protobuf}})
+                         .get();
+        ASSERT_EQ(2, pb_schema_id());
     }
     std::unique_ptr<schema::fake_registry> sr;
 };
@@ -266,14 +280,39 @@ TEST_F(RecordSchemaResolverTest, TestSchemaRegistryError) {
     EXPECT_FALSE(resolved_buf.type->id.protobuf_offsets.has_value());
 }
 
-TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema) {
+TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf) {
     using namespace std::chrono_literals;
     iobuf buf;
     buf.append(generate_dummy_body());
 
-    auto resolver = latest_protobuf_schema_resolver(
+    auto resolver = latest_subject_schema_resolver(
       *sr,
-      model::topic("foo"),
+      subject("latest-proto"),
+      std::nullopt,
+      config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    auto& resolved_buf = res.value();
+    ASSERT_TRUE(resolved_buf.type.has_value());
+    EXPECT_EQ(2, resolved_buf.type->id.schema_id());
+    EXPECT_THAT(
+      resolved_buf.type->id.protobuf_offsets,
+      testing::Optional(testing::ElementsAre(0)));
+
+    const auto expected_type = field_type{struct_type{}};
+    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
+}
+
+TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Protobuf_MessageName) {
+    using namespace std::chrono_literals;
+    iobuf buf;
+    buf.append(generate_dummy_body());
+
+    auto resolver = latest_subject_schema_resolver(
+      *sr,
+      subject("latest-proto"),
       "datalake.proto.nested_message.inner_message_t1",
       config::mock_binding(std::chrono::milliseconds(0s)),
       std::nullopt);
@@ -282,10 +321,9 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema) {
     auto& resolved_buf = res.value();
     ASSERT_TRUE(resolved_buf.type.has_value());
     EXPECT_EQ(2, resolved_buf.type->id.schema_id());
-    EXPECT_TRUE(resolved_buf.type->id.protobuf_offsets.has_value());
     EXPECT_THAT(
-      resolved_buf.type->id.protobuf_offsets.value(),
-      testing::ElementsAre(2, 0));
+      resolved_buf.type->id.protobuf_offsets,
+      testing::Optional(testing::ElementsAre(2, 0)));
 
     const auto expected_type = field_type{[] {
         auto expected_struct = struct_type{};
@@ -293,6 +331,39 @@ TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema) {
           1, "inner_label_1", field_required::no, string_type{}));
         expected_struct.fields.emplace_back(nested_field::create(
           2, "inner_number_1", field_required::no, int_type{}));
+        return expected_struct;
+    }()};
+    EXPECT_EQ(resolved_buf.type->type, expected_type);
+    EXPECT_THAT(resolved_buf.parsable_buf, testing::Optional(std::ref(buf)));
+}
+
+TEST_F(RecordSchemaResolverTest, TestLatestSubjectSchema_Avro) {
+    // NOTE: we strongly should discourage avro users from using this mode, it's
+    // impossible to correctly evolve the schema this way without a stop the
+    // world pause.
+    using namespace std::chrono_literals;
+    iobuf buf;
+    buf.append(generate_dummy_body());
+
+    auto resolver = latest_subject_schema_resolver(
+      *sr,
+      subject("latest-avro"),
+      std::nullopt,
+      config::mock_binding(std::chrono::milliseconds(0s)),
+      std::nullopt);
+    auto res = resolver.resolve_buf_type(buf.copy()).get();
+    ASSERT_FALSE(res.has_error());
+    auto& resolved_buf = res.value();
+    ASSERT_TRUE(resolved_buf.type.has_value());
+    EXPECT_EQ(1, resolved_buf.type->id.schema_id());
+    EXPECT_EQ(resolved_buf.type->id.protobuf_offsets, std::nullopt);
+
+    const auto expected_type = field_type{[] {
+        auto expected_struct = struct_type{};
+        expected_struct.fields.emplace_back(
+          nested_field::create(0, "value", field_required::yes, long_type{}));
+        expected_struct.fields.emplace_back(
+          nested_field::create(0, "next", field_required::yes, int_type{}));
         return expected_struct;
     }()};
     EXPECT_EQ(resolved_buf.type->type, expected_type);

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1289,8 +1289,15 @@ FIXTURE_TEST(test_iceberg_property, alter_config_test_fixture) {
 
     {
         // alter the iceberg config of an existing topic, should work.
-        for (const auto& prop :
-             {"disabled", "key_value", "value_schema_id_prefix"}) {
+        for (const auto& prop : {
+               "disabled",
+               "key_value",
+               "value_schema_id_prefix",
+               "value_subject_latest",
+               "value_subject_latest:protobuf_name=com.redpanda.Example",
+               "value_subject_latest:protobuf_name=Example,subject=foo",
+               "value_subject_latest:subject=foo",
+             }) {
             absl::flat_hash_map<ss::sstring, ss::sstring> properties;
             properties.emplace("redpanda.iceberg.mode", prop);
 
@@ -1310,8 +1317,15 @@ FIXTURE_TEST(test_iceberg_property, alter_config_test_fixture) {
 
     {
         // same as above, with incremental alter
-        for (const auto& prop :
-             {"disabled", "key_value", "value_schema_id_prefix"}) {
+        for (const auto& prop : {
+               "disabled",
+               "key_value",
+               "value_schema_id_prefix",
+               "value_subject_latest",
+               "value_subject_latest:protobuf_name=com.redpanda.Example",
+               "value_subject_latest:protobuf_name=Example,subject=foo",
+               "value_subject_latest:subject=foo",
+             }) {
             absl::flat_hash_map<
               ss::sstring,
               std::pair<

--- a/src/v/model/BUILD
+++ b/src/v/model/BUILD
@@ -83,6 +83,7 @@ redpanda_cc_library(
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:node_hash_map",
         "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/strings",
         "@boost//:container_hash",
         "@boost//:iterator",
         "@boost//:range",

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -607,13 +607,12 @@ public:
         // are then interepted using the schema and the resulting columns are
         // mapped to appropriate iceberg types and corresponding table columns.
         value_schema_id_prefix = 2,
-        // Iceberg translation always uses the latest protobuf schema found in
-        // the topic's subject in schema registry using the name `<topic>-value`
-        // which is also known as the TopicNameStrategy in schema registry
-        // terms. The latest version is fetched at runtime, then the specified
-        // message within the file descriptor is used to decode the message
-        // value.
-        latest_protobuf_value = 3,
+        // Iceberg translation always uses the latest schema found in
+        // the topic's subject in schema registry. By default we assume the
+        // TopicNamingStrategy (<topic>-value) and if protobuf the 0th message
+        // in the file descriptor. However these can both be overridden by the
+        // user.
+        value_subject_latest = 3,
     };
     static iceberg_mode disabled;
 
@@ -623,9 +622,9 @@ public:
 
     // Creates a new iceberg mode with the latest protobuf value kind and the
     // protobuf full name.
-    static iceberg_mode
-    latest_protobuf_value(std::string_view protobuf_full_name) {
-        return {latest_protobuf_value_t{}, protobuf_full_name};
+    static iceberg_mode value_subject_latest(
+      std::string_view protobuf_full_name, std::string_view subject_name) {
+        return {latest_protobuf_value_t{}, protobuf_full_name, subject_name};
     }
 
     // Returns the kind of iceberg mode is being used.
@@ -633,11 +632,28 @@ public:
         return static_cast<variant>(_impl.index());
     }
 
-    // Returns the protobuf message's full name.
+    // Returns the protobuf message's full name if specified.
     //
     // Throws is variant() != variant::latest_protobuf_value
-    const ss::sstring& protobuf_full_name() const {
-        return std::get<latest_protobuf_value_impl>(_impl).message_full_name;
+    std::optional<ss::sstring> protobuf_full_name() const {
+        const auto& name
+          = std::get<latest_protobuf_value_impl>(_impl).message_full_name;
+        if (name.empty()) {
+            return std::nullopt;
+        }
+        return name;
+    }
+
+    // Returns the subject name if specified.
+    //
+    // Throws is variant() != variant::latest_protobuf_value
+    std::optional<ss::sstring> subject_name() const {
+        const auto& subject
+          = std::get<latest_protobuf_value_impl>(_impl).subject_name;
+        if (subject.empty()) {
+            return std::nullopt;
+        }
+        return subject;
     }
 
     bool operator==(const iceberg_mode&) const = default;
@@ -657,10 +673,14 @@ private:
     }
 
     struct latest_protobuf_value_t {};
-    iceberg_mode(latest_protobuf_value_t, std::string_view protobuf_full_name)
+    iceberg_mode(
+      latest_protobuf_value_t,
+      std::string_view protobuf_full_name,
+      std::string_view subject_name)
       : _impl(
           std::in_place_type<latest_protobuf_value_impl>,
-          ss::sstring(protobuf_full_name)) {}
+          ss::sstring(protobuf_full_name),
+          ss::sstring(subject_name)) {}
 
     struct disabled_impl {
         bool operator==(const disabled_impl&) const = default;
@@ -673,6 +693,7 @@ private:
     };
     struct latest_protobuf_value_impl {
         ss::sstring message_full_name;
+        ss::sstring subject_name;
         bool operator==(const latest_protobuf_value_impl&) const = default;
     };
 

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -31,6 +31,7 @@
 #include <boost/functional/hash.hpp>
 
 #include <compare>
+#include <cstddef>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -589,19 +590,98 @@ std::ostream& operator<<(std::ostream&, recovery_validation_mode);
 std::istream& operator>>(std::istream&, recovery_validation_mode&);
 
 // Iceberg enablement options for a topic
-enum class iceberg_mode : uint8_t {
-    // Iceberg is disabled
-    disabled = 0,
-    // Iceberg translation interprets record key and value as binary
-    // types and uses default Iceberg table schema.
-    key_value = 1,
-    // Iceberg translation interprets the record value using the schema
-    // id embedded in value. Kafka serializers embed a magic byte as the
-    // first byte of the value to indicate the presence of a schema id
-    // which is then resolved with the schema registry. The value bytes
-    // are then interepted using the schema and the resulting columns are
-    // mapped to appropriate iceberg types and corresponding table columns.
-    value_schema_id_prefix = 2
+class iceberg_mode {
+public:
+    iceberg_mode() = default;
+
+    enum class variant : uint8_t {
+        // Iceberg is disabled
+        disabled = 0,
+        // Iceberg translation interprets record key and value as binary
+        // types and uses default Iceberg table schema.
+        key_value = 1,
+        // Iceberg translation interprets the record value using the schema
+        // id embedded in value. Kafka serializers embed a magic byte as the
+        // first byte of the value to indicate the presence of a schema id
+        // which is then resolved with the schema registry. The value bytes
+        // are then interepted using the schema and the resulting columns are
+        // mapped to appropriate iceberg types and corresponding table columns.
+        value_schema_id_prefix = 2,
+        // Iceberg translation always uses the latest protobuf schema found in
+        // the topic's subject in schema registry using the name `<topic>-value`
+        // which is also known as the TopicNameStrategy in schema registry
+        // terms. The latest version is fetched at runtime, then the specified
+        // message within the file descriptor is used to decode the message
+        // value.
+        latest_protobuf_value = 3,
+    };
+    static iceberg_mode disabled;
+
+    static iceberg_mode key_value;
+
+    static iceberg_mode value_schema_id_prefix;
+
+    // Creates a new iceberg mode with the latest protobuf value kind and the
+    // protobuf full name.
+    static iceberg_mode
+    latest_protobuf_value(std::string_view protobuf_full_name) {
+        return {latest_protobuf_value_t{}, protobuf_full_name};
+    }
+
+    // Returns the kind of iceberg mode is being used.
+    variant kind() const noexcept {
+        return static_cast<variant>(_impl.index());
+    }
+
+    // Returns the protobuf message's full name.
+    //
+    // Throws is variant() != variant::latest_protobuf_value
+    const ss::sstring& protobuf_full_name() const {
+        return std::get<latest_protobuf_value_impl>(_impl).message_full_name;
+    }
+
+    bool operator==(const iceberg_mode&) const = default;
+
+    friend void write(iobuf& out, const iceberg_mode& m);
+
+    friend void read_nested(
+      iobuf_parser& in, iceberg_mode& m, const std::size_t bytes_left_limit);
+
+private:
+    template<variant v>
+    static iceberg_mode make() noexcept {
+        iceberg_mode m;
+        m._impl = decltype(m._impl){
+          std::in_place_index<static_cast<size_t>(v)>};
+        return m;
+    }
+
+    struct latest_protobuf_value_t {};
+    iceberg_mode(latest_protobuf_value_t, std::string_view protobuf_full_name)
+      : _impl(
+          std::in_place_type<latest_protobuf_value_impl>,
+          ss::sstring(protobuf_full_name)) {}
+
+    struct disabled_impl {
+        bool operator==(const disabled_impl&) const = default;
+    };
+    struct key_value_impl {
+        bool operator==(const key_value_impl&) const = default;
+    };
+    struct value_schema_id_prefix_impl {
+        bool operator==(const value_schema_id_prefix_impl&) const = default;
+    };
+    struct latest_protobuf_value_impl {
+        ss::sstring message_full_name;
+        bool operator==(const latest_protobuf_value_impl&) const = default;
+    };
+
+    std::variant<
+      disabled_impl,
+      key_value_impl,
+      value_schema_id_prefix_impl,
+      latest_protobuf_value_impl>
+      _impl;
 };
 
 std::ostream& operator<<(std::ostream&, const iceberg_mode&);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -16,7 +16,10 @@
 #include "model/record_batch_types.h"
 #include "model/timestamp.h"
 #include "model/validation.h"
+#include "serde/rw/enum.h"
 #include "serde/rw/rw.h"
+#include "serde/rw/sstring.h"
+#include "serde/serde_exception.h"
 #include "strings/string_switch.h"
 #include "utils/to_string.h"
 
@@ -582,27 +585,76 @@ std::istream& operator>>(std::istream& is, recovery_validation_mode& vm) {
     return is;
 }
 
+iceberg_mode iceberg_mode::disabled
+  = iceberg_mode::make<iceberg_mode::variant::disabled>();
+iceberg_mode iceberg_mode::key_value
+  = iceberg_mode::make<iceberg_mode::variant::key_value>();
+iceberg_mode iceberg_mode::value_schema_id_prefix
+  = iceberg_mode::make<iceberg_mode::variant::value_schema_id_prefix>();
+
+void write(iobuf& out, const iceberg_mode& m) {
+    using serde::write;
+    write(out, m.kind());
+    if (m.kind() == iceberg_mode::variant::latest_protobuf_value) {
+        write(out, m.protobuf_full_name());
+    }
+}
+
+void read_nested(
+  iobuf_parser& in, iceberg_mode& m, const std::size_t bytes_left_limit) {
+    using serde::read_nested;
+    iceberg_mode::variant v = iceberg_mode::variant::disabled;
+    read_nested(in, v, bytes_left_limit);
+    switch (v) {
+    case iceberg_mode::variant::disabled:
+        m = iceberg_mode::disabled;
+        return;
+    case iceberg_mode::variant::key_value:
+        m = iceberg_mode::key_value;
+        return;
+    case iceberg_mode::variant::value_schema_id_prefix:
+        m = iceberg_mode::value_schema_id_prefix;
+        return;
+    case iceberg_mode::variant::latest_protobuf_value:
+        ss::sstring s;
+        read_nested(in, s, bytes_left_limit);
+        m = iceberg_mode::latest_protobuf_value(s);
+        return;
+    }
+    throw serde::serde_exception(
+      fmt::format("unknown iceberg_mode variant: {}", std::to_underlying(v)));
+}
+
 std::ostream& operator<<(std::ostream& os, const iceberg_mode& mode) {
-    switch (mode) {
-    case iceberg_mode::disabled:
+    switch (mode.kind()) {
+    case iceberg_mode::variant::disabled:
         return os << "disabled";
-    case iceberg_mode::key_value:
+    case iceberg_mode::variant::key_value:
         return os << "key_value";
-    case iceberg_mode::value_schema_id_prefix:
+    case iceberg_mode::variant::value_schema_id_prefix:
         return os << "value_schema_id_prefix";
+    case iceberg_mode::variant::latest_protobuf_value:
+        return os << "latest_protobuf_value:" << mode.protobuf_full_name();
     }
 }
 
 std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
-    using enum iceberg_mode;
     ss::sstring s;
     is >> s;
-    try {
-        mode = string_switch<iceberg_mode>(s)
-                 .match("disabled", disabled)
-                 .match("key_value", key_value)
-                 .match("value_schema_id_prefix", value_schema_id_prefix);
-    } catch (const std::runtime_error&) {
+    if (s == "disabled") {
+        mode = iceberg_mode::disabled;
+    } else if (s == "key_value") {
+        mode = iceberg_mode::key_value;
+    } else if (s == "value_schema_id_prefix") {
+        mode = iceberg_mode::value_schema_id_prefix;
+    } else if (s.starts_with("latest_protobuf_value:")) {
+        s = s.substr(std::strlen("latest_protobuf_value:"));
+        if (s.empty()) {
+            is.setstate(std::ios::failbit);
+        } else {
+            mode = iceberg_mode::latest_protobuf_value(s);
+        }
+    } else {
         is.setstate(std::ios::failbit);
     }
     return is;

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -27,9 +27,12 @@
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/strings/str_split.h>
 #include <fmt/ostream.h>
 
 #include <iostream>
+#include <optional>
 #include <type_traits>
 
 namespace model {
@@ -595,8 +598,9 @@ iceberg_mode iceberg_mode::value_schema_id_prefix
 void write(iobuf& out, const iceberg_mode& m) {
     using serde::write;
     write(out, m.kind());
-    if (m.kind() == iceberg_mode::variant::latest_protobuf_value) {
-        write(out, m.protobuf_full_name());
+    if (m.kind() == iceberg_mode::variant::value_subject_latest) {
+        write(out, m.protobuf_full_name().value_or(""));
+        write(out, m.subject_name().value_or(""));
     }
 }
 
@@ -615,10 +619,12 @@ void read_nested(
     case iceberg_mode::variant::value_schema_id_prefix:
         m = iceberg_mode::value_schema_id_prefix;
         return;
-    case iceberg_mode::variant::latest_protobuf_value:
-        ss::sstring s;
-        read_nested(in, s, bytes_left_limit);
-        m = iceberg_mode::latest_protobuf_value(s);
+    case iceberg_mode::variant::value_subject_latest:
+        ss::sstring msg_name;
+        read_nested(in, msg_name, bytes_left_limit);
+        ss::sstring subject;
+        read_nested(in, subject, bytes_left_limit);
+        m = iceberg_mode::value_subject_latest(msg_name, subject);
         return;
     }
     throw serde::serde_exception(
@@ -633,10 +639,55 @@ std::ostream& operator<<(std::ostream& os, const iceberg_mode& mode) {
         return os << "key_value";
     case iceberg_mode::variant::value_schema_id_prefix:
         return os << "value_schema_id_prefix";
-    case iceberg_mode::variant::latest_protobuf_value:
-        return os << "latest_protobuf_value:" << mode.protobuf_full_name();
+    case iceberg_mode::variant::value_subject_latest:
+        os << "value_subject_latest";
+        bool delimiter = false;
+        auto emit_delimiter = [&delimiter, &os]() {
+            os << (delimiter ? "," : ":");
+            delimiter = true;
+        };
+        if (auto protobuf_name = mode.protobuf_full_name()) {
+            emit_delimiter();
+            os << "protobuf_name=" << protobuf_name.value();
+        }
+        if (auto subject = mode.subject_name()) {
+            emit_delimiter();
+            os << "subject=" << subject.value();
+        }
+        return os;
     }
 }
+
+namespace {
+// Parse configuration options for iceberg_mode's value_subject_latest, which
+// is a grammar like: `:(<name>=<value>)+`
+std::optional<absl::flat_hash_map<std::string, std::string>>
+parse_config_options(std::string_view str) {
+    if (str.empty()) {
+        return absl::flat_hash_map<std::string, std::string>{};
+    }
+    if (!absl::ConsumePrefix(&str, ":")) {
+        return std::nullopt;
+    }
+    if (str.empty()) {
+        return std::nullopt;
+    }
+    absl::flat_hash_map<std::string, std::string> result;
+    for (std::string_view pair : absl::StrSplit(str, ",")) {
+        auto [it, inserted] = result.insert(
+          absl::StrSplit(pair, absl::MaxSplits("=", 1)));
+        // Don't allow duplicates
+        if (!inserted) {
+            return std::nullopt;
+        }
+        // Don't allow empty keys or values
+        if (it->first.empty() || it->second.empty()) {
+            return std::nullopt;
+        }
+    }
+    return result;
+}
+} // namespace
 
 std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
     ss::sstring s;
@@ -647,13 +698,26 @@ std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
         mode = iceberg_mode::key_value;
     } else if (s == "value_schema_id_prefix") {
         mode = iceberg_mode::value_schema_id_prefix;
-    } else if (s.starts_with("latest_protobuf_value:")) {
-        s = s.substr(std::strlen("latest_protobuf_value:"));
-        if (s.empty()) {
+    } else if (s.starts_with("value_subject_latest")) {
+        s = s.substr(std::strlen("value_subject_latest"));
+        auto options = parse_config_options(s);
+        if (!options.has_value()) {
             is.setstate(std::ios::failbit);
-        } else {
-            mode = iceberg_mode::latest_protobuf_value(s);
+            return is;
         }
+        std::string_view protobuf_name;
+        std::string_view subject;
+        for (const auto& [key, value] : options.value()) {
+            if (key == "protobuf_name") {
+                protobuf_name = value;
+            } else if (key == "subject") {
+                subject = value;
+            } else {
+                is.setstate(std::ios::failbit);
+                return is;
+            }
+        }
+        mode = iceberg_mode::value_subject_latest(protobuf_name, subject);
     } else {
         is.setstate(std::ios::failbit);
     }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -573,6 +573,21 @@ descriptor(
     return *d;
 }
 
+::result<
+  std::reference_wrapper<const google::protobuf::Descriptor>,
+  kafka::error_code>
+descriptor(const protobuf_schema_definition& def, std::string_view full_name) {
+    if (full_name.empty()) {
+        return kafka::error_code::invalid_record;
+    }
+    const google::protobuf::Descriptor* d = def()._dp.FindMessageTypeByName(
+      full_name);
+    if (!d) {
+        return kafka::error_code::invalid_record;
+    }
+    return *d;
+}
+
 bool operator==(
   const protobuf_schema_definition& lhs,
   const protobuf_schema_definition& rhs) {

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -48,4 +48,15 @@ compatibility_result check_compatible(
   kafka::error_code>
 descriptor(const protobuf_schema_definition&, const std::vector<int>& fields);
 
+// Returns a reference to the `Descriptor` via the message's full name
+// specified by `full_name`.
+//
+// Note that the returned reference to is an object owned by
+// `protobuf_schema_definition` and therefore should only be used
+// while that object is alive.
+::result<
+  std::reference_wrapper<const google::protobuf::Descriptor>,
+  kafka::error_code>
+descriptor(const protobuf_schema_definition&, std::string_view full_name);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -11,6 +11,8 @@
 
 #include "schema/tests/fake_registry.h"
 
+#include "pandaproxy/schema_registry/types.h"
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
@@ -19,6 +21,13 @@ namespace {
 static ss::logger dummy_logger("schema_test_logger");
 
 namespace ppsr = pandaproxy::schema_registry;
+
+bool same_schema(
+  const ppsr::unparsed_schema& unparsed,
+  const ppsr::canonical_schema& canonical) {
+    // Wrong, but works good enough for our simple testing.
+    return unparsed.def().raw()() == canonical.def().raw()();
+}
 
 } // namespace
 
@@ -87,14 +96,19 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
     maybe_throw_injected_failure();
     // This is wrong, but simple for our testing.
     for (const auto& s : _store.schemas) {
-        if (s.schema.def().raw()() == unparsed.def().raw()()) {
+        if (
+          same_schema(unparsed, s.schema) && s.schema.sub() == unparsed.sub()) {
             co_return s.id;
         }
     }
+    auto id = ppsr::schema_id(int32_t(_store.schemas.size() + 1));
     auto version = ppsr::schema_version(0);
     for (const auto& s : _store.schemas) {
+        if (same_schema(unparsed, s.schema)) {
+            id = s.id;
+        }
         if (s.schema.sub() == unparsed.sub()) {
-            version = std::max(version, s.version);
+            version = std::max(version, s.version + 1);
         }
     }
     // TODO: validate references too
@@ -107,8 +121,8 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
           ppsr::canonical_schema_definition::raw_string{std::move(def)()},
           type,
           std::move(refs))),
-      .version = version + 1,
-      .id = ppsr::schema_id(int32_t(_store.schemas.size() + 1)),
+      .version = version,
+      .id = id,
       .deleted = ppsr::is_deleted::no,
     });
     co_return _store.schemas.back().id;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -33,8 +33,8 @@ public:
     // is handled during adl/serde decode).
     static constexpr bool default_remote_delete{true};
     static constexpr bool legacy_remote_delete{false};
-    static constexpr model::iceberg_mode default_iceberg_mode
-      = model::iceberg_mode::disabled;
+    static inline model::iceberg_mode default_iceberg_mode
+      = model::iceberg_mode{};
     static constexpr bool default_cloud_topic_enabled{false};
 
     static constexpr std::chrono::milliseconds read_replica_retention{3600000};

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1718,7 +1718,7 @@ class RpkTool:
         with tempfile.NamedTemporaryFile(suffix=f".{schema_suffix}") as tf:
             tf.write(bytes(schema, 'UTF-8'))
             tf.flush()
-            self.create_schema(subject, tf.name)
+            return self.create_schema(subject, tf.name)
 
     def get_schema(self,
                    subject=None,

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -146,7 +146,16 @@ class DatalakeE2ETests(RedpandaTest):
         count = 100
         table_name = f"redpanda.{self.topic_name}"
 
-        protobuf_schema = """
+        protobuf_schema_v1 = """
+        syntax = "proto3";
+
+        message Person {
+          string name = 1;
+          int32 id = 2;
+          string email = 3;
+        }
+        """
+        protobuf_schema_v2 = """
         syntax = "proto3";
 
         message Address {
@@ -191,18 +200,7 @@ class DatalakeE2ETests(RedpandaTest):
         person_desc = pool.FindMessageTypeByName("Person")
         Person = factory.GetPrototype(person_desc)
 
-        with DatalakeServices(self.test_ctx,
-                              redpanda=self.redpanda,
-                              include_query_engines=[query_engine],
-                              catalog_type=catalog_type) as dl:
-            rpk = RpkTool(self.redpanda)
-            registered_schema = rpk.create_schema_from_str(
-                subject=f"{self.topic_name}-value",
-                schema=protobuf_schema,
-                schema_suffix="proto",
-            )
-            dl.create_iceberg_enabled_topic(
-                self.topic_name, iceberg_mode="latest_protobuf_value:Person")
+        def produce_protos():
             producer = Producer({'bootstrap.servers': self.redpanda.brokers()})
             for i in range(count):
                 record = json.dumps({
@@ -221,7 +219,62 @@ class DatalakeE2ETests(RedpandaTest):
                 producer.produce(topic=self.topic_name,
                                  value=person_proto.SerializeToString())
             producer.flush()
+
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
+            rpk = RpkTool(self.redpanda)
+            rpk.create_schema_from_str(
+                subject=f"{self.topic_name}-value",
+                schema=protobuf_schema_v1,
+                schema_suffix="proto",
+            )
+            dl.create_iceberg_enabled_topic(
+                self.topic_name, iceberg_mode="latest_protobuf_value:Person")
+            produce_protos()
             dl.wait_for_translation(self.topic_name, msg_count=count)
+
+            if query_engine == QueryEngineType.TRINO:
+                trino = dl.trino()
+                trino_expected_out = [
+                    ('redpanda', 'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)', '', ''),
+                    ('name', 'varchar', '', ''),
+                    ('id', 'integer', '', ''),
+                    ('email', 'varchar', '', ''),
+                ] # yapf: disable
+                trino_describe_out = trino.run_query_fetch_all(
+                    f"describe {table_name}")
+                assert trino_describe_out == trino_expected_out, str(
+                    trino_describe_out)
+            else:
+                spark = dl.spark()
+                spark_expected_out = [
+                    ('redpanda', 'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>', None),
+                    ('name', 'string', None),
+                    ('id', 'int', None),
+                    ('email', 'string', None),
+                    ('', '', ''),
+                    ('# Partitioning', '', ''),
+                    ('Part 0', 'hours(redpanda.timestamp)', '')
+                ] # yapf: disable
+                spark_describe_out = spark.run_query_fetch_all(
+                    f"describe {table_name}")
+                assert spark_describe_out == spark_expected_out, str(
+                    spark_describe_out)
+
+            # Be absolutely sure that the latest schema is being used by the
+            # translator by waiting for the cache to expire the latest schema.
+            rpk.create_schema_from_str(
+                subject=f"{self.topic_name}-value",
+                schema=protobuf_schema_v2,
+                schema_suffix="proto",
+            )
+            rpk.cluster_config_set('iceberg_latest_schema_cache_ttl_ms', '500')
+            time.sleep(1)
+            produce_protos()
+            dl.wait_for_translation_until_offset(self.topic_name,
+                                                 2 * count - 1)
 
             if query_engine == QueryEngineType.TRINO:
                 trino = dl.trino()

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -231,7 +231,8 @@ class DatalakeE2ETests(RedpandaTest):
                 schema_suffix="proto",
             )
             dl.create_iceberg_enabled_topic(
-                self.topic_name, iceberg_mode="latest_protobuf_value:Person")
+                self.topic_name,
+                iceberg_mode="value_subject_latest:protobuf_name=Person")
             produce_protos()
             dl.wait_for_translation(self.topic_name, msg_count=count)
 

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -12,8 +12,9 @@ import time
 from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
 from random import randint
+import json
 
-from confluent_kafka import avro
+from confluent_kafka import avro, Producer
 from confluent_kafka.avro import AvroProducer
 from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings, MetricsEndpoint
 from rptest.services.redpanda import CloudStorageType, SISettings
@@ -26,6 +27,8 @@ from ducktape.mark import matrix, ignore
 from ducktape.utils.util import wait_until
 from rptest.services.metrics_check import MetricCheck
 from rptest.services.catalog_service import CatalogType
+from google import protobuf
+from google.protobuf import text_format as pb_text_format, json_format as pb_json_format
 
 avro_schema_str = """
 {
@@ -129,6 +132,122 @@ class DatalakeE2ETests(RedpandaTest):
                                       ('', '', ''), ('# Partitioning', '', ''),
                                       ('Part 0', 'hours(redpanda.timestamp)',
                                        '')]
+                spark_describe_out = spark.run_query_fetch_all(
+                    f"describe {table_name}")
+                assert spark_describe_out == spark_expected_out, str(
+                    spark_describe_out)
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
+            catalog_type=supported_catalog_types())
+    def test_latest_protobuf_schema(self, cloud_storage_type, query_engine,
+                                    catalog_type):
+        count = 100
+        table_name = f"redpanda.{self.topic_name}"
+
+        protobuf_schema = """
+        syntax = "proto3";
+
+        message Address {
+          string street = 1;
+          string city = 2;
+          string state = 3;
+          string zip = 4;
+        }
+
+        message Person {
+          string name = 1;
+          int32 id = 2;
+          string email = 3;
+          Address address = 4;  // Nested message
+        }
+        """
+        # The text format of the above protobuf as to not have to bother setting up protoc for this test.
+        protobuf_file_descriptor = """
+        name: "example.proto"
+        message_type {
+          name: "Address"
+          field { name: "street" number: 1 label: LABEL_OPTIONAL type: TYPE_STRING }
+          field { name: "city" number: 2 label: LABEL_OPTIONAL type: TYPE_STRING }
+          field { name: "state" number: 3 label: LABEL_OPTIONAL type: TYPE_STRING }
+          field { name: "zip" number: 4 label: LABEL_OPTIONAL type: TYPE_STRING }
+        }
+        message_type {
+          name: "Person"
+          field { name: "name" number: 1 label: LABEL_OPTIONAL type: TYPE_STRING }
+          field { name: "id" number: 2 label: LABEL_OPTIONAL type: TYPE_INT32 }
+          field { name: "email" number: 3 label: LABEL_OPTIONAL type: TYPE_STRING }
+          field { name: "address" number: 4 label: LABEL_OPTIONAL type: TYPE_MESSAGE type_name: ".Address" }
+        }
+        """
+
+        # Using the protobuf text format, parse the raw descriptor and create a dynamic message from it.
+        file_desc_pb = protobuf.descriptor_pb2.FileDescriptorProto()
+        pb_text_format.Merge(protobuf_file_descriptor, file_desc_pb)
+        pool = protobuf.descriptor_pool.DescriptorPool()
+        pool.Add(file_desc_pb)
+        factory = protobuf.message_factory.MessageFactory(pool)
+        person_desc = pool.FindMessageTypeByName("Person")
+        Person = factory.GetPrototype(person_desc)
+
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
+            rpk = RpkTool(self.redpanda)
+            registered_schema = rpk.create_schema_from_str(
+                subject=f"{self.topic_name}-value",
+                schema=protobuf_schema,
+                schema_suffix="proto",
+            )
+            dl.create_iceberg_enabled_topic(
+                self.topic_name, iceberg_mode="latest_protobuf_value:Person")
+            producer = Producer({'bootstrap.servers': self.redpanda.brokers()})
+            for i in range(count):
+                record = json.dumps({
+                    "name": f"Bob{i} Protopants",
+                    "id": 1 + i,
+                    "email": f"foobar{i}@gmail.com",
+                    "address": {
+                        "street": f"{i} Main St.",
+                        "city": "Protoville" if i % 2 == 0 else "Buftown",
+                        "state": "District 13" if i % 3 == 0 else "Hooli",
+                        "zip": "8675309" if i % 4 == 0 else "12345"
+                    }
+                })
+                person_proto = Person()
+                pb_json_format.Parse(record, person_proto)
+                producer.produce(topic=self.topic_name,
+                                 value=person_proto.SerializeToString())
+            producer.flush()
+            dl.wait_for_translation(self.topic_name, msg_count=count)
+
+            if query_engine == QueryEngineType.TRINO:
+                trino = dl.trino()
+                trino_expected_out = [
+                    ('redpanda', 'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)', '', ''),
+                    ('name', 'varchar', '', ''),
+                    ('id', 'integer', '', ''),
+                    ('email', 'varchar', '', ''),
+                    ('address', 'row(street varchar, city varchar, state varchar, zip varchar)', '', ''),
+                ] # yapf: disable
+                trino_describe_out = trino.run_query_fetch_all(
+                    f"describe {table_name}")
+                assert trino_describe_out == trino_expected_out, str(
+                    trino_describe_out)
+            else:
+                spark = dl.spark()
+                spark_expected_out = [
+                    ('redpanda', 'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>', None),
+                    ('name', 'string', None),
+                    ('id', 'int', None),
+                    ('email', 'string', None),
+                    ('address', 'struct<street:string,city:string,state:string,zip:string>', None),
+                    ('', '', ''),
+                    ('# Partitioning', '', ''),
+                    ('Part 0', 'hours(redpanda.timestamp)', '')
+                ] # yapf: disable
                 spark_describe_out = spark.run_query_fetch_all(
                     f"describe {table_name}")
                 assert spark_describe_out == spark_expected_out, str(

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -138,7 +138,7 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
     if version >= 10:
         topic_properties |= {
-            'iceberg_mode': rdr.read_serde_enum(),
+            'iceberg_mode': read_iceberg_mode(rdr),
             'leaders_preference': rdr.read_optional(read_leaders_preference),
             'cloud_topic_enabled': rdr.read_bool(),
             'delete_retention_ms': rdr.read_tristate(Reader.read_int64),
@@ -162,6 +162,14 @@ def read_topic_properties_serde(rdr: Reader, version):
         }
 
     return topic_properties
+
+
+def read_iceberg_mode(rdr: Reader):
+    variant = rdr.read_serde_enum()
+    protobuf_value = None
+    if variant == 3:
+        protobuf_value = rdr.read_string()
+    return {"variant": variant, "protobuf_value": protobuf_value}
 
 
 def read_topic_config(rdr: Reader, version):
@@ -319,7 +327,7 @@ def read_incremental_topic_update_serde(rdr: Reader):
             }
         if version >= 7:
             incr_obj |= {
-                'iceberg_mode': rdr.read_serde_enum(),
+                'iceberg_mode': read_iceberg_mode(rdr),
                 'leaders_preference':
                 rdr.read_optional(read_leaders_preference),
                 'iceberg_delete': rdr.read_optional(Reader.read_bool),


### PR DESCRIPTION
Add support for `value_subject_latest`.

This enables iceberg for users who don't use schema registry, but use protobuf and the backwards compatible nature of the wire format. Users will still have to register schemas with the schema registry, but data does not have be encoded seperately.

By default we assume that protobuf messages use the first message defined in the file descriptor and the subject is <topic>-value (matches SubjectNameStrategy). However both of these can be overridden using key=value syntax within the topic property. The syntax for this new iceberg mode something like: `value_subject_latest(:(<key>=<value>,)+)?` where the only defined keys are `subject` and `protobuf_name`.

Overall this PR has a rather small surface area:

The `iceberg_mode` enum is converted to a `struct`, but keeps a similar API to the enum so very little code needs to change. Additionally, the serde wire format is entirely backwards compatible.

We plug in a new implementation of the `type_resolver` interface for this behavior, then everything else is pretty straightforward.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Features

* Iceberg topics can be configured with `redpanda.iceberg.mode=value_subject_latest:protobuf_name=<full_protocol_buffer_message_name>,subject=<schema_registry_subject>` to read the latest schema from a subject in the schema registry, which allows one to use Iceberg topics with protobuf and not having to encode the messages using the Schema Registry wire format.
