### PR TITLE
[CORE-9073] `rptest`: deflake `log_compaction_test`

### DIFF
--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -256,13 +256,16 @@ class LogCompactionTest(LogCompactionTestBase, PreallocNodesTest,
         else:
             assert self.get_chunked_compaction_runs() == 0
 
-        # There should be no dirty segments left
-        assert self.get_dirty_segment_bytes() == 0
-        # This could race if the cleanup.policy was compact,delete,
-        # so only assert for compact topic
-        if cleanup_policy == TopicSpec.CLEANUP_COMPACT:
-            assert self.get_closed_segment_bytes() > 0
-        assert self.get_dirty_ratio() < 1.0e-6
+        def log_is_fully_clean():
+            # There should be no dirty segments left
+            return self.get_dirty_segment_bytes() == 0
+
+        wait_until(
+            log_is_fully_clean,
+            timeout_sec=120,
+            backoff_sec=self.extra_rp_conf['log_compaction_interval_ms'] /
+            1000,
+            err_msg="Did not see a fully clean log.")
 
         consumer = KgoVerifierSeqConsumer(self.test_context,
                                           self.redpanda,


### PR DESCRIPTION
This assertion on dirty bytes could race with a segment roll.

Turn the dirty bytes `assert` into a `wait_until()`, and remove some asserts that were less pertinent to ensuring compaction is complete.

Also fixes https://redpandadata.atlassian.net/issues/CORE-9091

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
