### PR TITLE
rpk: enable serverless back for `rpk security user`

### DIFF
--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -102,7 +102,7 @@ acl help text for more info.
 				out.Die("unsupported mechanism %q", mechanism)
 			}
 
-			if p.FromCloud {
+			if p.FromCloud && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 				req := connect.NewRequest(

--- a/src/go/rpk/pkg/cli/security/user/delete.go
+++ b/src/go/rpk/pkg/cli/security/user/delete.go
@@ -53,7 +53,7 @@ delete any ACLs that may exist for this user.
 				out.Die("missing required username argument")
 			}
 
-			if p.FromCloud {
+			if p.FromCloud && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -35,7 +35,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
 			var users []string
-			if p.FromCloud {
+			if p.FromCloud && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 

--- a/src/go/rpk/pkg/cli/security/user/update.go
+++ b/src/go/rpk/pkg/cli/security/user/update.go
@@ -34,7 +34,7 @@ func newUpdateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			user := args[0]
-			if p.FromCloud {
+			if p.FromCloud && !p.CloudCluster.IsServerless() {
 				cl, err := publicapi.DataplaneClientFromRpkProfile(p)
 				out.MaybeDie(err, "unable to initialize cloud client: %v", err)
 


### PR DESCRIPTION
In 5e016b55 we introduced support for the public
API in `rpk security user`. However, we assumed
that serverless user were going to rely on this.

This was a bad assumption as serverless has a
special proxy for the API in Console and it's
already handled and added to the cloud profile.

So, a serverless cluster should create an Admin API client and perform the requests as any other
self-hosted client would do.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* rpk: fixes a bug that prevented serverless cloud profiles from using `rpk security user` commands.
