### PR TITLE
datalake: benchmark zstd compressed batch translation

### DIFF
--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -419,6 +419,7 @@ redpanda_cc_bench(
         "//src/v/model",
         "//src/v/serde/avro/tests:data_generator",
         "//src/v/serde/protobuf/tests:data_generator",
+        "//src/v/storage:parser_utils",
         "@seastar",
         "@seastar//:benchmark",
     ],

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -19,10 +19,12 @@
 #include "datalake/tests/record_generator.h"
 #include "datalake/tests/test_data_writer.h"
 #include "datalake/tests/test_utils.h"
+#include "model/compression.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "serde/avro/tests/data_generator.h"
 #include "serde/protobuf/tests/data_generator.h"
+#include "storage/parser_utils.h"
 
 #include <seastar/testing/perf_tests.hh>
 
@@ -283,18 +285,25 @@ public:
       T gen_config,
       std::string schema,
       size_t batches,
-      size_t records_per_batch) {
+      size_t records_per_batch,
+      model::compression compression_type = model::compression::none) {
         if constexpr (std::is_same_v<T, ::testing::protobuf_generator_config>) {
             _batch_data = co_await generate_protobuf_batches(
               records_per_batch,
               batches,
+              compression_type,
               "proto_schema",
               schema,
               {0},
               gen_config);
         } else {
             _batch_data = co_await generate_avro_batches(
-              records_per_batch, batches, "avro_schema", schema, gen_config);
+              records_per_batch,
+              batches,
+              compression_type,
+              "avro_schema",
+              schema,
+              gen_config);
         }
     }
 
@@ -374,9 +383,10 @@ private:
     ss::future<chunked_vector<model::record_batch>> generate_batches(
       size_t records_per_batch,
       size_t batches,
+      model::compression compression_type,
       std::function<ss::future<
         checked<std::nullopt_t, datalake::tests::record_generator::error>>(
-        storage::record_batch_builder&)> add_batch) {
+        storage::record_batch_builder&)> add_record) {
         chunked_vector<model::record_batch> ret;
         ret.reserve(batches);
 
@@ -387,7 +397,7 @@ private:
 
             // Add some records per batch.
             for (size_t r = 0; r < records_per_batch; ++r) {
-                auto res = co_await add_batch(batch_builder);
+                auto res = co_await add_record(batch_builder);
                 ++o;
 
                 if (res.has_error()) [[unlikely]] {
@@ -395,7 +405,12 @@ private:
                       fmt::format("unable to add record: {}", res.error()));
                 }
             }
+
             auto batch = std::move(batch_builder).build();
+            if (compression_type != model::compression::none) {
+                batch = co_await storage::internal::compress_batch(
+                  compression_type, std::move(batch));
+            }
             ret.emplace_back(std::move(batch));
         }
 
@@ -405,13 +420,14 @@ private:
     ss::future<chunked_vector<model::record_batch>> generate_protobuf_batches(
       size_t records_per_batch,
       size_t batches,
+      model::compression compression_type,
       std::string schema_name,
       std::string proto_schema,
       std::vector<int32_t> msg_idx,
       ::testing::protobuf_generator_config gen_config) {
         co_await try_add_protobuf_schema(schema_name, proto_schema);
         co_return co_await generate_batches(
-          records_per_batch, batches, [&](auto& bb) {
+          records_per_batch, batches, compression_type, [&](auto& bb) {
               return _record_gen.add_random_protobuf_record(
                 bb, schema_name, msg_idx, std::nullopt, gen_config);
           });
@@ -420,12 +436,13 @@ private:
     ss::future<chunked_vector<model::record_batch>> generate_avro_batches(
       size_t records_per_batch,
       size_t batches,
+      model::compression compression_type,
       std::string schema_name,
       std::string avro_schema,
       ::testing::avro_generator_config gen_config) {
         co_await try_add_avro_schema(schema_name, avro_schema);
         co_return co_await generate_batches(
-          records_per_batch, batches, [&](auto& bb) {
+          records_per_batch, batches, compression_type, [&](auto& bb) {
               return _record_gen.add_random_avro_record(
                 bb, schema_name, std::nullopt, gen_config);
           });
@@ -447,113 +464,231 @@ static constexpr size_t records_per_batch = 10;
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, protobuf_381_byte_message_linear_1_field) {
-    static ::testing::protobuf_generator_config gen_config = {
-      .string_length_range{302, 302}};
-    static std::string proto_schema = generate_linear_proto(1);
-
     co_await configure_bench(
-      gen_config, proto_schema, batches, records_per_batch);
+      ::testing::protobuf_generator_config{.string_length_range{302, 302}},
+      generate_linear_proto(1),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_381_byte_message_linear_1_field_zstd) {
+    co_await configure_bench(
+      ::testing::protobuf_generator_config{.string_length_range{302, 302}},
+      generate_linear_proto(1),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture,
   protobuf_381_byte_message_linear_40_fields) {
-    static ::testing::protobuf_generator_config gen_config = {
-      .string_length_range{5, 5}};
-    static std::string proto_schema = generate_linear_proto(40);
-
     co_await configure_bench(
-      gen_config, proto_schema, batches, records_per_batch);
+      ::testing::protobuf_generator_config{.string_length_range{5, 5}},
+      generate_linear_proto(40),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_381_byte_message_linear_40_fields_zstd) {
+    co_await configure_bench(
+      ::testing::protobuf_generator_config{.string_length_range{5, 5}},
+      generate_linear_proto(40),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture,
   protobuf_381_byte_message_linear_80_fields) {
-    static ::testing::protobuf_generator_config gen_config = {
-      .string_length_range{1, 1}};
-    static std::string proto_schema = generate_linear_proto(80);
-
     co_await configure_bench(
-      gen_config, proto_schema, batches, records_per_batch);
+      ::testing::protobuf_generator_config{.string_length_range{1, 1}},
+      generate_linear_proto(80),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_381_byte_message_linear_80_fields_zstd) {
+    co_await configure_bench(
+      ::testing::protobuf_generator_config{.string_length_range{1, 1}},
+      generate_linear_proto(80),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture,
   protobuf_384_byte_message_nested_24_levels) {
-    static ::testing::protobuf_generator_config gen_config = {
-      .string_length_range{7, 7}, .max_nesting_level = 40};
-    static std::string proto_schema = generate_nested_proto(24);
-
     co_await configure_bench(
-      gen_config, proto_schema, batches, records_per_batch);
+      ::testing::protobuf_generator_config{
+        .string_length_range{7, 7}, .max_nesting_level = 40},
+      generate_nested_proto(24),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_384_byte_message_nested_24_levels_zstd) {
+    co_await configure_bench(
+      ::testing::protobuf_generator_config{
+        .string_length_range{7, 7}, .max_nesting_level = 40},
+      generate_nested_proto(24),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture,
   protobuf_386_byte_message_nested_31_levels) {
-    static ::testing::protobuf_generator_config gen_config = {
-      .string_length_range{4, 4}, .max_nesting_level = 40};
-    static std::string proto_schema = generate_nested_proto(31);
     co_await configure_bench(
-      gen_config, proto_schema, batches, records_per_batch);
+      ::testing::protobuf_generator_config{
+        .string_length_range{4, 4}, .max_nesting_level = 40},
+      generate_nested_proto(31),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  protobuf_386_byte_message_nested_31_levels_zstd) {
+    co_await configure_bench(
+      ::testing::protobuf_generator_config{
+        .string_length_range{4, 4}, .max_nesting_level = 40},
+      generate_nested_proto(31),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, avro_385_byte_message_linear_1_field) {
-    static ::testing::avro_generator_config gen_config = {
-      .string_length_range{308, 308}};
-    static std::string avro_schema = generate_linear_avro(1);
-
     co_await configure_bench(
-      gen_config, avro_schema, batches, records_per_batch);
+      ::testing::avro_generator_config{.string_length_range{308, 308}},
+      generate_linear_avro(1),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture, avro_385_byte_message_linear_1_field_zstd) {
+    co_await configure_bench(
+      ::testing::avro_generator_config{.string_length_range{308, 308}},
+      generate_linear_avro(1),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, avro_385_byte_message_linear_31_fields) {
-    static ::testing::avro_generator_config gen_config = {
-      .string_length_range{9, 9}};
-    static std::string avro_schema = generate_linear_avro(31);
-
     co_await configure_bench(
-      gen_config, avro_schema, batches, records_per_batch);
+      ::testing::avro_generator_config{.string_length_range{9, 9}},
+      generate_linear_avro(31),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  avro_385_byte_message_linear_31_fields_zstd) {
+    co_await configure_bench(
+      ::testing::avro_generator_config{.string_length_range{9, 9}},
+      generate_linear_avro(31),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, avro_385_byte_message_linear_62_fields) {
-    static ::testing::avro_generator_config gen_config = {
-      .string_length_range{4, 4}};
-    static std::string avro_schema = generate_linear_avro(62);
-
     co_await configure_bench(
-      gen_config, avro_schema, batches, records_per_batch);
+      ::testing::avro_generator_config{.string_length_range{4, 4}},
+      generate_linear_avro(62),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  avro_385_byte_message_linear_62_fields_zstd) {
+    co_await configure_bench(
+      ::testing::avro_generator_config{.string_length_range{4, 4}},
+      generate_linear_avro(62),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, avro_385_byte_message_nested_31_levels) {
-    static ::testing::avro_generator_config gen_config = {
-      .string_length_range{9, 9}, .max_nesting_level = 40};
-    static std::string avro_schema = generate_nested_avro(31);
-
     co_await configure_bench(
-      gen_config, avro_schema, batches, records_per_batch);
+      ::testing::avro_generator_config{
+        .string_length_range{9, 9}, .max_nesting_level = 40},
+      generate_nested_avro(31),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  avro_385_byte_message_nested_31_levels_zstd) {
+    co_await configure_bench(
+      ::testing::avro_generator_config{
+        .string_length_range{9, 9}, .max_nesting_level = 40},
+      generate_nested_avro(31),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }
 
 PERF_TEST_CN(
   record_multiplexer_bench_fixture, avro_385_byte_message_nested_62_levels) {
-    static ::testing::avro_generator_config gen_config = {
-      .string_length_range{4, 4}, .max_nesting_level = 40};
-    static std::string avro_schema = generate_nested_avro(62);
-
     co_await configure_bench(
-      gen_config, avro_schema, batches, records_per_batch);
+      ::testing::avro_generator_config{
+        .string_length_range{4, 4}, .max_nesting_level = 40},
+      generate_nested_avro(62),
+      batches,
+      records_per_batch);
+    co_return co_await run_bench();
+}
+
+PERF_TEST_CN(
+  record_multiplexer_bench_fixture,
+  avro_385_byte_message_nested_62_levels_zstd) {
+    co_await configure_bench(
+      ::testing::avro_generator_config{
+        .string_length_range{4, 4}, .max_nesting_level = 40},
+      generate_nested_avro(62),
+      batches,
+      records_per_batch,
+      model::compression::zstd);
     co_return co_await run_bench();
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds new cases for compressed batches to the existing record_multiplexer microbenchmarks. Local results are below and show a 30-70% reduction in throughput when records have to be de-compressed before translating.

 | test                                                                             |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |                                        
  | -                                                                                |           - |           - |           - |           - |           - |           - |           - |           - |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_1_field        |    42393000 |     9.042ns |     0.023ns |     8.988ns |     9.075ns |       0.278 |       0.000 |       150.9 |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_1_field_zstd   |    27106861 |    13.214ns |     0.035ns |    13.176ns |    13.304ns |       0.368 |       0.000 |       219.7 |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_40_fields      |     6522000 |    49.149ns |     0.127ns |    48.883ns |    49.276ns |       0.718 |       0.001 |       757.0 |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_40_fields_zstd |     5977749 |    65.556ns |     0.180ns |    65.333ns |    66.850ns |       0.941 |       0.001 |      1012.1 |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_80_fields      |     3261000 |    88.399ns |     0.208ns |    86.749ns |    88.607ns |       1.107 |       0.001 |      1349.1 |                                        
  | record_multiplexer_bench_fixture.protobuf_381_byte_message_linear_80_fields_zstd |     2027327 |   141.223ns |     0.104ns |   141.119ns |   143.230ns |       1.781 |       0.002 |      2191.9 |                                        
  | record_multiplexer_bench_fixture.protobuf_384_byte_message_nested_24_levels      |     3291000 |    61.630ns |     0.328ns |    61.205ns |    62.041ns |       2.109 |       0.002 |      1011.5 |                                        
  | record_multiplexer_bench_fixture.protobuf_384_byte_message_nested_24_levels_zstd |     2681885 |   121.966ns |     0.535ns |   121.295ns |   125.012ns |       4.142 |       0.003 |      2026.0 |                                        
  | record_multiplexer_bench_fixture.protobuf_386_byte_message_nested_31_levels      |     3311000 |    77.869ns |     0.444ns |    76.786ns |    78.313ns |       2.646 |       0.002 |      1266.4 |                                        
  | record_multiplexer_bench_fixture.protobuf_386_byte_message_nested_31_levels_zstd |     2525039 |   185.178ns |     0.344ns |   184.442ns |   185.765ns |       6.248 |       0.006 |      3041.1 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_1_field            |    59418000 |     8.796ns |     0.010ns |     8.786ns |     8.879ns |       0.262 |       0.000 |       145.5 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_1_field_zstd       |    35586952 |    12.801ns |     0.004ns |    12.788ns |    12.849ns |       0.346 |       0.000 |       210.9 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_31_fields          |    13204000 |    41.687ns |     0.005ns |    41.682ns |    41.774ns |       0.857 |       0.001 |       696.1 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_31_fields_zstd     |    12323420 |    56.794ns |     0.064ns |    56.713ns |    57.100ns |       1.149 |       0.001 |       951.7 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_62_fields          |     6602000 |    78.196ns |     0.125ns |    77.944ns |    79.723ns |       1.438 |       0.001 |      1229.3 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_linear_62_fields_zstd     |     5161882 |   111.318ns |     0.178ns |   110.989ns |   111.561ns |       2.024 |       0.002 |      1750.1 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_31_levels          |     3301000 |    74.283ns |     0.474ns |    73.627ns |    75.200ns |       2.512 |       0.003 |      1221.7 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_31_levels_zstd     |     2464729 |    99.565ns |     0.102ns |    99.461ns |   100.258ns |       3.365 |       0.004 |      1655.6 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_62_levels          |     3301000 |   149.677ns |     0.653ns |   148.640ns |   150.788ns |       4.772 |       0.009 |      2374.4 |                                        
  | record_multiplexer_bench_fixture.avro_385_byte_message_nested_62_levels_zstd     |     3284825 |   212.800ns |     0.463ns |   211.724ns |   213.631ns |       6.714 |       0.012 |      3361.1 |

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
