### PR TITLE
dl/parquet_writer: ensure stream closure in all cases

### DIFF
--- a/src/v/datalake/local_parquet_file_writer.cc
+++ b/src/v/datalake/local_parquet_file_writer.cc
@@ -30,8 +30,9 @@ local_parquet_file_writer::local_parquet_file_writer(
 ss::future<checked<std::nullopt_t, writer_error>>
 local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
     vlog(datalake_log.info, "Writing Parquet file to {}", _output_file_path);
+    ss::file output_file;
     try {
-        _output_file = co_await ss::open_file_dma(
+        output_file = co_await ss::open_file_dma(
           _output_file_path().string(),
           ss::open_flags::create | ss::open_flags::truncate
             | ss::open_flags::wo);
@@ -45,7 +46,7 @@ local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
     }
 
     auto fut = co_await ss::coroutine::as_future(
-      ss::make_file_output_stream(_output_file));
+      ss::make_file_output_stream(std::move(output_file)));
 
     if (fut.failed()) {
         vlog(
@@ -53,7 +54,6 @@ local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
           "Error making output stream for file {} - {}",
           _output_file_path,
           fut.get_exception());
-        co_await _output_file.close();
         co_return writer_error::file_io_error;
     }
 
@@ -68,6 +68,9 @@ ss::future<writer_error> local_parquet_file_writer::add_data_struct(
     if (!_initialized) {
         co_return writer_error::file_io_error;
     }
+    if (_error != writer_error::ok) {
+        co_return _error;
+    }
     auto write_result = co_await _writer->add_data_struct(
       std::move(data), sz, as);
     if (write_result != writer_error::ok) {
@@ -76,8 +79,7 @@ ss::future<writer_error> local_parquet_file_writer::add_data_struct(
           "Error writing data to file {} - {}",
           _output_file_path,
           write_result);
-
-        co_await abort();
+        _error = write_result;
         co_return write_result;
     }
     _raw_bytes_count += sz;
@@ -98,6 +100,9 @@ ss::future<writer_error> local_parquet_file_writer::flush() {
     if (!_initialized) {
         co_return writer_error::flush_error;
     }
+    if (_error != writer_error::ok) {
+        co_return _error;
+    }
     auto result = co_await ss::coroutine::as_future(_writer->flush());
     if (result.failed()) {
         auto ex = result.get_exception();
@@ -112,12 +117,28 @@ local_parquet_file_writer::finish() {
     if (!_initialized) {
         co_return writer_error::file_io_error;
     }
-    auto result = co_await _writer->finish();
-    if (result != writer_error::ok) {
-        co_await abort();
-        co_return result;
-    }
     _initialized = false;
+    auto writer_ec = writer_error::ok;
+    try {
+        writer_ec = co_await _writer->finish();
+    } catch (...) {
+        vlog(
+          datalake_log.warn,
+          "Error closing writer instance {} for path {}",
+          std::current_exception(),
+          _output_file_path);
+        writer_ec = writer_error::file_io_error;
+    }
+    if (_error == writer_error::ok && writer_ec != writer_error::ok) {
+        _error = writer_ec;
+    }
+    if (_error != writer_error::ok) {
+        auto exists = co_await ss::file_exists(_output_file_path().string());
+        if (exists) {
+            co_await ss::remove_file(_output_file_path().string());
+        }
+        co_return _error;
+    }
     try {
         auto f_size = co_await ss::file_size(_output_file_path().string());
 
@@ -134,18 +155,6 @@ local_parquet_file_writer::finish() {
           std::current_exception());
         co_return writer_error::file_io_error;
     }
-}
-
-ss::future<> local_parquet_file_writer::abort() {
-    if (!_initialized) {
-        co_return;
-    }
-    co_await _output_file.close();
-    auto exists = co_await ss::file_exists(_output_file_path().string());
-    if (exists) {
-        co_await ss::remove_file(_output_file_path().string());
-    }
-    _initialized = false;
 }
 
 local_path local_parquet_file_writer_factory::create_filename() const {

--- a/src/v/datalake/local_parquet_file_writer.h
+++ b/src/v/datalake/local_parquet_file_writer.h
@@ -40,13 +40,14 @@ public:
 
     ss::future<writer_error> flush() final;
 
+    /**
+     * Must be called in all cases, including write errors for proper
+     * cleanup of resources.
+     */
     ss::future<result<local_file_metadata, writer_error>> finish() final;
 
 private:
-    ss::future<> abort();
-
     local_path _output_file_path;
-    ss::file _output_file;
     size_t _row_count{0};
     size_t _raw_bytes_count{0};
 
@@ -54,6 +55,8 @@ private:
     ss::shared_ptr<parquet_ostream_factory> _writer_factory;
     writer_mem_tracker& _mem_tracker;
     bool _initialized{false};
+    // set once the writer ran into an error, fences further writes.
+    writer_error _error{writer_error::ok};
 };
 
 class local_parquet_file_writer_factory : public parquet_file_writer_factory {

--- a/src/v/datalake/tests/local_parquet_file_writer_test.cc
+++ b/src/v/datalake/tests/local_parquet_file_writer_test.cc
@@ -27,6 +27,9 @@ struct test_writer : datalake::parquet_ostream {
       : error_after_rows_(error_after_rows)
       , error_on_finish_(error_on_finish)
       , os_(std::move(os)) {}
+    ~test_writer() {
+        vassert(stream_closed_, "Ensure output stream is closed in all cases");
+    }
     ss::future<datalake::writer_error>
     add_data_struct(iceberg::struct_value, size_t, ss::abort_source&) final {
         if (rows_ >= error_after_rows_) {
@@ -42,16 +45,18 @@ struct test_writer : datalake::parquet_ostream {
     ss::future<> flush() final { return ss::make_ready_future<>(); }
 
     ss::future<datalake::writer_error> finish() final {
+        co_await os_.close();
+        stream_closed_ = true;
         if (error_on_finish_) {
             co_return datalake::writer_error::file_io_error;
         }
-        co_await os_.close();
         co_return datalake::writer_error::ok;
     }
 
     size_t error_after_rows_;
     bool error_on_finish_;
     size_t rows_{0};
+    bool stream_closed_;
     ss::output_stream<char> os_;
 };
 


### PR DESCRIPTION
If the write fails for some reason, abort() is called which marks _initialized=false.
This means the underling _writer->finish() is never called leaving the output stream open.

```
redpanda: /vectorized/include/seastar/core/iostream.hh:420: seastar::output_stream<char>::~output_stream() [CharType = char]: Assertion `!_end && !_zc_bufs && "Was this stream properly closed?"' failed.
``` 

Also cleaned up the writer a bit, we donot need to keep a copy of ss:file. Moving it to the create stream function also
closes it on all errors and stream closure.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
