### PR TITLE
[CORE-9519] utils/arch: Fix compilation failure

### DIFF
--- a/src/v/utils/arch.h
+++ b/src/v/utils/arch.h
@@ -36,7 +36,7 @@ inline constexpr cpu_arch cpu_arch::current() {
 #if defined(__x86_64__)
     return arch::AMD64;
 #elif defined(__aarch64__)
-    return arch::ARM64
+    return arch::ARM64;
 #else
 #error unknown arch
 #endif


### PR DESCRIPTION
Missing semicolon

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
