### PR TITLE
[CORE-9520] schema_registry/protobuf: Add test for map field

### DIFF
--- a/tests/protobuf/payload.proto
+++ b/tests/protobuf/payload.proto
@@ -48,6 +48,7 @@ message A {
                 message NestedPayload {
                     int32 val = 1;
                     google.protobuf.Timestamp timestamp = 2;
+                    map<string, string> properties = 3;
                 }
             }
         }


### PR DESCRIPTION
Add a test for map_entry


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
