### PR TITLE
datalake: clamp max collectible offset with log start offset

### DIFF
--- a/src/v/datalake/translation/utils.cc
+++ b/src/v/datalake/translation/utils.cc
@@ -12,8 +12,25 @@
 namespace datalake::translation {
 
 model::offset highest_log_offset_below_next(
-  ss::shared_ptr<storage::log> log, kafka::offset o) {
-    auto next_kafka_offset = kafka::next_offset(o);
+  ss::shared_ptr<storage::log> log, kafka::offset kafka_lto) {
+    /**
+     * If translated offset is smaller than the start offset of the log it means
+     * that the last translated offset is stored in cloud storage. We need to
+     * clamp max collectible offset. This can happen when fast partition
+     * movement.
+     */
+    auto log_start_offset = log->offsets().start_offset;
+    if (log_start_offset >= model::offset{0}) {
+        auto log_start_kafka_offset = model::offset_cast(
+          log->from_log_offset(log_start_offset));
+
+        if (log_start_kafka_offset >= kafka_lto) {
+            return log_start_offset;
+        }
+    }
+
+    auto next_kafka_offset = kafka::next_offset(kafka_lto);
+
     auto log_offset_for_next_kafka_offset = log->to_log_offset(
       kafka::offset_cast(next_kafka_offset));
     auto translated_log_offset = model::prev_offset(


### PR DESCRIPTION
When last translated offset falls into the range stored in Tiered Storage the state machine should not try to use local offset translator state to find the max collectible offset as the last translated offset is out of the offset translation range.

Added clamping max_collectible offset with log start offset if the last translated offset happens to be smaller than the local log start offset.

Fixes: CORE-8485

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
