### PR TITLE
[CORE-9521] config/property: Improve rendering of print

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -26,6 +26,8 @@
 
 #include <seastar/util/noncopyable_function.hh>
 
+#include <fmt/chrono.h>
+
 #include <algorithm>
 #include <chrono>
 #include <exception>
@@ -146,12 +148,10 @@ public:
     operator value_type() const { return value(); } // NOLINT
 
     void print(std::ostream& o) const override {
-        o << name() << ":";
-
         if (is_secret() && !is_default()) {
-            o << secret_placeholder;
+            fmt::print(o, "{}:{}", name(), secret_placeholder);
         } else {
-            o << _value;
+            fmt::print(o, "{}:{}", name(), _value);
         }
     }
 


### PR DESCRIPTION
During startup, config properties are rendered, but sometimes in a misleading way, especially durations:

```
redpanda.consumer_group_lag_collection_interval_sec:10000
```

The property type is seconds, with a value of 10. The value is correct, but during rendering there is a conversion to milliseconds and then the count is taken.

This commit improves the rendering, for example:

| before                                          | after                                         |
| ----------------------------------------------- | --------------------------------------------- |
| redpanda.aggregate_metrics:0                    | redpanda.aggregate_metrics:false              |
| redpanda.alive_timeout_ms:5000                  | redpanda.alive_timeout_ms:5000ms              |
| redpanda.group_offset_retention_sec:{604800000} | redpanda.group_offset_retention_sec:{604800s} |

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
