### PR TITLE
[CORE-9524] Schema Registry/Protobuf: Remove protobuf_renderer config

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3608,11 +3608,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
   , schema_registry_protobuf_renderer_v2(
-      *this,
-      "schema_registry_protobuf_renderer_v2",
-      "Enables experimental protobuf renderer to support normalize=true.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
-      false)
+      *this, "schema_registry_protobuf_renderer_v2")
   , pp_sr_smp_max_non_local_requests(
       *this,
       "pp_sr_smp_max_non_local_requests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -677,7 +677,7 @@ struct configuration final : public config_store {
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
     property<bool> schema_registry_normalize_on_startup;
-    property<bool> schema_registry_protobuf_renderer_v2;
+    deprecated_property schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;
     bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -45,8 +45,7 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>(protobuf_renderer_v2{
-      config::shard_local_cfg().schema_registry_protobuf_renderer_v2});
+    _store = std::make_unique<sharded_store>();
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -590,13 +590,8 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
   schema_getter& store, canonical_schema schema, normalize norm) {
     auto refs = schema.def().refs();
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
-    auto v2_renderer = protobuf_renderer_v2::no;
-    if (auto* s = dynamic_cast<const sharded_store*>(&store); s != nullptr) {
-        v2_renderer = s->protobuf_v2_renderer();
-    }
-    // v2_renderer is the feature flag in case this breaks somebodies workflow.
     impl->fdp = co_await import_schema(
-      impl->_dp, store, std::move(schema), normalize(norm && v2_renderer));
+      impl->_dp, store, std::move(schema), normalize(norm));
 
     if (norm) {
         std::sort(refs.begin(), refs.end());

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -25,9 +25,7 @@ class store;
 /// subject or schema_id
 class sharded_store final : public schema_getter {
 public:
-    explicit sharded_store(
-      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no)
-      : _v2_renderer(v2_renderer) {}
+    explicit sharded_store() = default;
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -203,10 +201,6 @@ public:
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;
 
-    //// \brief Whether to use the experimental v2 protobuf renderer to support
-    //// normalize=true;
-    protobuf_renderer_v2 protobuf_v2_renderer() const { return _v2_renderer; }
-
 private:
     ss::future<compatibility_result> do_is_compatible(
       schema_version version, canonical_schema new_schema, verbose is_verbose);
@@ -237,7 +231,6 @@ private:
 
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
-    protobuf_renderer_v2 _v2_renderer;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -32,9 +32,8 @@ namespace pps = pp::schema_registry;
 namespace {
 
 struct simple_sharded_store {
-    explicit simple_sharded_store(
-      pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::no)
-      : store{proto_v2} {
+    explicit simple_sharded_store()
+      : store{} {
         store.start(pps::is_mutable::yes, ss::default_smp_service_group())
           .get();
     }
@@ -502,10 +501,8 @@ SEASTAR_THREAD_TEST_CASE(
 }
 
 auto sanitize(
-  std::string_view raw_proto,
-  pps::normalize norm = pps::normalize::no,
-  pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::no) {
-    simple_sharded_store s{proto_v2};
+  std::string_view raw_proto, pps::normalize norm = pps::normalize::no) {
+    simple_sharded_store s;
     iobuf buf = pps::make_canonical_protobuf_schema(
                   s.store,
                   pps::unparsed_schema{
@@ -520,10 +517,8 @@ auto sanitize(
     return parser.read_string(parser.bytes_left());
 }
 
-auto normalize(
-  std::string_view raw_proto,
-  pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::no) {
-    return sanitize(raw_proto, pps::normalize::yes, proto_v2);
+auto normalize(std::string_view raw_proto) {
+    return sanitize(raw_proto, pps::normalize::yes);
 }
 
 constexpr auto foobar_proto = R"(syntax = "proto3";
@@ -873,11 +868,8 @@ extend .google.protobuf.ServiceOptions {
 }
 
 )";
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      sanitized);
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), normalized);
+    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_nested_custom_options) {
@@ -994,11 +986,8 @@ extend .google.protobuf.MessageOptions {
 }
 
 )";
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      sanitized);
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), normalized);
+    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_message_custom_options) {
@@ -1069,11 +1058,8 @@ extend .google.protobuf.EnumValueOptions {
 
 )";
 
-    BOOST_REQUIRE_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      sanitized);
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), normalized);
+    BOOST_REQUIRE_EQUAL(sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_extension_ranges) {
@@ -1208,11 +1194,8 @@ extend .google.protobuf.ExtensionRangeOptions {
 
 )";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      sanitized);
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), normalized);
+    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_syntax) {
@@ -1337,9 +1320,7 @@ import weak "google/protobuf/any.proto";
 import "google/protobuf/api.proto";
 )";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/timestamp.proto";
@@ -1349,8 +1330,7 @@ import public "google/protobuf/duration.proto";
 
 
 )"));
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/api.proto";
@@ -1378,9 +1358,7 @@ message HasGoogleMap {
 }
 )";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/struct.proto";
@@ -1398,8 +1376,7 @@ message HasGoogleMap {
   map<string, .google.protobuf.Value> map_string_value = 1;
 }
 )"));
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/any.proto";
@@ -1445,9 +1422,7 @@ message HasMap {
 }
 )";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 message Value {
@@ -1460,8 +1435,7 @@ message HasMap {
 }
 
 )"));
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 message Value {
@@ -1496,9 +1470,7 @@ message SearchResponse {
   }
 })";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      (R"(syntax = "proto2";
+    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto2";
 
 message SearchResponse {
   repeated group Result = 1 {
@@ -1519,8 +1491,7 @@ message SearchResponse {
 }
 
 )"));
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto2";
+    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto2";
 
 message SearchResponse {
   repeated group Result = 1 {
@@ -1572,9 +1543,7 @@ message WithOneOf {
 }
 
 )";
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      expected_sanitized);
+    BOOST_CHECK_EQUAL(sanitize(schema), expected_sanitized);
     auto expected_normalized = R"(syntax = "proto3";
 
 package foo;
@@ -1590,8 +1559,7 @@ message WithOneOf {
 }
 
 )";
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), expected_normalized);
+    BOOST_CHECK_EQUAL(normalize(schema), expected_normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize) {
@@ -1695,9 +1663,7 @@ service FooService {
   rpc Foo(Bar) returns (Baz);
 })";
 
-    BOOST_CHECK_EQUAL(
-      sanitize(schema, pps::normalize::no, pps::protobuf_renderer_v2::yes),
-      (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/timestamp.proto";
@@ -1774,8 +1740,7 @@ service FooService {
   rpc Foo(.foo.Bar) returns (.foo.Baz);
 }
 )"));
-    BOOST_CHECK_EQUAL(
-      normalize(schema, pps::protobuf_renderer_v2::yes), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/any.proto";

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -27,9 +27,8 @@ namespace pps = pp::schema_registry;
 namespace {
 
 struct simple_sharded_store {
-    explicit simple_sharded_store(
-      pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::no)
-      : store{proto_v2} {
+    explicit simple_sharded_store()
+      : store{} {
         store.start(pps::is_mutable::yes, ss::default_smp_service_group())
           .get();
     }
@@ -63,11 +62,9 @@ struct simple_sharded_store {
 
 } // namespace
 
-std::string sanitize(
-  std::string_view raw_proto,
-  pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::yes,
-  pps::normalize norm = pps::normalize::no) {
-    simple_sharded_store s{proto_v2};
+std::string
+sanitize(std::string_view raw_proto, pps::normalize norm = pps::normalize::no) {
+    simple_sharded_store s;
     iobuf buf = pps::make_canonical_protobuf_schema(
                   s.store,
                   pps::unparsed_schema{
@@ -82,10 +79,8 @@ std::string sanitize(
     return parser.read_string(parser.bytes_left());
 }
 
-auto normalize(
-  std::string_view raw_proto,
-  pps::protobuf_renderer_v2 proto_v2 = pps::protobuf_renderer_v2::yes) {
-    return sanitize(raw_proto, proto_v2, pps::normalize::yes);
+auto normalize(std::string_view raw_proto) {
+    return sanitize(raw_proto, pps::normalize::yes);
 }
 
 enum class SchemaType { input, sanitized, normalized };

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -37,7 +37,6 @@ using default_to_global = ss::bool_class<struct default_to_global_tag>;
 using force = ss::bool_class<struct force_tag>;
 using normalize = ss::bool_class<struct normalize_tag>;
 using verbose = ss::bool_class<struct verbose_tag>;
-using protobuf_renderer_v2 = ss::bool_class<struct protobuf_renderer_v2_tag>;
 
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>


### PR DESCRIPTION
This configuration is no longer protecting a large code change with significant risk.

Remove the `schema_registry_protobuf_renderer_v2` configuration so that normalization for protobuf is always available.

## Backports Required

Happy to debate the backports

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
