### PR TITLE
kafka/bench: make the fetch plan bench runnable in debug

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -561,6 +561,9 @@ cc_library(
         ":use_logger_compile_time_fmt": ["SEASTAR_LOGGER_COMPILE_TIME_FMT"],
         "//conditions:default": [],
     }) + select({
+        ":use_system_allocator": ["SEASTAR_DEFAULT_ALLOCATOR"],
+        "//conditions:default": [],
+    }) + select({
         ":with_debug": [
             "SEASTAR_DEBUG",
             "SEASTAR_DEBUG_PROMISE",
@@ -602,9 +605,6 @@ cc_library(
         # split out into a separate cc_library, but we'd need to inherit all the
         # build settings. defining for all compilation units seems harmless.
         ":use_heap_profiling": ["SEASTAR_HEAPPROF"],
-        "//conditions:default": [],
-    }) + select({
-        ":use_system_allocator": ["SEASTAR_DEFAULT_ALLOCATOR"],
         "//conditions:default": [],
     }) + select({
         ":with_shuffle_task_queue": ["SEASTAR_SHUFFLE_TASK_QUEUE"],

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -51,7 +51,11 @@ struct fixture {
 
 struct fetch_plan_fixture : redpanda_thread_fixture {
     static constexpr size_t topic_name_length = 30;
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+    static constexpr size_t total_partition_count = 100;
+#else
     static constexpr size_t total_partition_count = 800;
+#endif
     static constexpr size_t session_partition_count = 100;
 
     model::topic t;


### PR DESCRIPTION
This enables the test working in Bazel with sanitizers on,
as we run these benchmarks with the system allocator, currently running
this benchmark with the system allocator fails because it tries to
create too many partitions (the system allocator hard codes 1GiB as the
total system memory available).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
