### PR TITLE
Use partition max collectible offset to gate FPM

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -577,8 +577,7 @@ controller_backend::calculate_learner_initial_offset(
         return std::nullopt;
     }
 
-    const auto cloud_storage_safe_offset
-      = p->archival_meta_stm()->max_collectible_offset();
+    const auto max_collectible_offset = p->max_collectible_offset();
     /**
      * Last offset uploaded to the cloud is target learner retention upper
      * bound. We can not start retention recover from the point which is not yet
@@ -592,10 +591,10 @@ controller_backend::calculate_learner_initial_offset(
       *retention_offset,
       p->archival_meta_stm()->manifest().get_last_offset(),
       p->archival_meta_stm()->get_last_clean_at(),
-      cloud_storage_safe_offset);
+      max_collectible_offset);
 
     return model::next_offset(
-      std::min(cloud_storage_safe_offset, *retention_offset));
+      std::min(max_collectible_offset, *retention_offset));
 }
 
 void controller_backend::process_delta(const topic_table::ntp_delta& d) {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1579,6 +1579,10 @@ partition::archival_meta_stm() const {
     return _archival_meta_stm;
 }
 
+model::offset partition::max_collectible_offset() {
+    return _raft->log()->stm_manager()->max_collectible_offset();
+}
+
 std::optional<model::offset> partition::kafka_start_offset_override() const {
     if (_log_eviction_stm && !is_read_replica_mode_enabled()) {
         auto o = _log_eviction_stm->kafka_start_offset_override();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -173,6 +173,13 @@ public:
     ss::future<std::error_code>
       transfer_leadership(raft::transfer_leadership_request);
 
+    /**
+     * Returns the maximum offset that may not be delivered to the newly joining
+     * learners as claimed by the state machines implemented on top of this
+     * partition.
+     */
+    model::offset max_collectible_offset();
+
     ss::future<std::error_code> update_replica_set(
       std::vector<raft::broker_revision> brokers,
       model::revision_id new_revision_id);


### PR DESCRIPTION
Fast partition movement rely on data being in the tiered storage to skip
delivering all locally available segments over the network and speed up
cluster day two operations. Previously the `archival_metadata_stm` was
the only one relevant for the FPM mechanism. As all the data that are
skipped from being deliver over the network must have been already
uploaded to the cloud.

Now with the datalake state machine it is relevant to gate the max
offset used for FPM with the max collectible offset from all the state
machines including `datalake_translation_stm`.

Fixes: CORE-8485

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none