### PR TITLE
[CORE-8946] cloud_storage: Update process_anomalies method

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2657,7 +2657,7 @@ void partition_manifest::process_anomalies(
     auto& missing_spills = _detected_anomalies.missing_spillover_manifests;
 
     const auto archive_start_offset = get_archive_start_offset();
-    erase_if(
+    absl::erase_if(
       missing_spills, [this, &archive_start_offset](const auto& spill_comp) {
           // Remove the missing spill if lies below the start offset of the
           // archive or if it doesn't match with any of the entries in the
@@ -2669,16 +2669,23 @@ void partition_manifest::process_anomalies(
 
     auto first_kafka_offset = full_log_start_kafka_offset();
     auto& missing_segs = _detected_anomalies.missing_segments;
-    erase_if(missing_segs, [this, &first_kafka_offset](const auto& meta) {
-        if (meta.next_kafka_offset() <= first_kafka_offset) {
+    absl::erase_if(missing_segs, [this, first_kafka_offset](const auto& meta) {
+        // The correct kafka start offset value can't be computed without
+        // segments. But in this case it's safe to remove all missing segment
+        // anomalies because they're guaranteed to be false positives.
+        // The 'first_kafka_offset' is nullopt only if the list of segments
+        // is empty or all segments are below 'start-offset'.
+        if (
+          !first_kafka_offset.has_value()
+          || meta.next_kafka_offset() <= first_kafka_offset.value()) {
             return true;
         }
 
         if (meta.committed_offset >= get_start_offset()) {
             // The segment might have been missing because it was merged with
             // something else. If the offset range doesn't match a segment
-            // exactly, discard the anomaly. Only segments from the STM manifest
-            // may be merged/reuploaded.
+            // exactly, discard the anomaly. Only segments from the STM
+            // manifest may be merged/reuploaded.
             return !segment_with_offset_range_exists(
               meta.base_offset, meta.committed_offset);
         } else {
@@ -2689,7 +2696,7 @@ void partition_manifest::process_anomalies(
 
     auto& segment_meta_anomalies
       = _detected_anomalies.segment_metadata_anomalies;
-    erase_if(
+    absl::erase_if(
       segment_meta_anomalies,
       [this, &first_kafka_offset](const auto& anomaly_meta) {
           if (anomaly_meta.at.next_kafka_offset() <= first_kafka_offset) {


### PR DESCRIPTION
The current implementation has a bug. If the manifest is empty the filtering of false positives doesn't work for missing segments. This commit fixes the problem by filtering out all missing segments if the manifest is empty or if all segments in the manifest are below the start offset (which is the same thing).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none