### PR TITLE
CORE-9546: disable libpci dep for hwloc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,7 +77,9 @@ use_repo(non_module_dependencies, "hdrhistogram")
 use_repo(non_module_dependencies, "hwloc")
 use_repo(non_module_dependencies, "jsoncons")
 use_repo(non_module_dependencies, "krb5")
-use_repo(non_module_dependencies, "libpciaccess")
+
+# workaround for CORE-9546
+# use_repo(non_module_dependencies, "libpciaccess")
 use_repo(non_module_dependencies, "libprotobuf_mutator")
 use_repo(non_module_dependencies, "libxml2")
 use_repo(non_module_dependencies, "lksctp")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5471,7 +5471,7 @@
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//bazel/thirdparty/Cargo.lock": "931fa1bc55d0e5d2e5b6d96da399569a4c2254a4bb1d99c98f71bb4b98eead73",
           "@@//bazel/thirdparty/Cargo.toml": "cb23768a6e7edc8f97215921e956f5be06521ad93cc0ecf64a932e3a8caada54",
-          "@@//MODULE.bazel": "a0b096db5e19a7e9adc331973c7d02921286ef1cd592ec353e1cf656caee77bb",
+          "@@//MODULE.bazel": "ee9f1d098391040169f684adfebae01d68c603591bedbfb35dfccac5a83e3245",
           "@@//bazel/thirdparty/wasmtime.BUILD": "4b55deaf51f5b8be25fc3592f9bcf3d732f99632cd793c685436ddca9a177534",
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -48,7 +48,8 @@ configure_make(
         "//visibility:public",
     ],
     deps = [
-        "@libpciaccess",
+        # workaround for CORE-9546
+        # "@libpciaccess",
     ],
 )
 


### PR DESCRIPTION
Disable this temporarily as a workaround for CORE-9546.

As I understand it, this will just reduce hwloc capabilities as in the area of IO and PCI topology detection but that should be fine.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
