### PR TITLE
sr: Perform initial read on only one shard

### DIFF
--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -126,31 +126,32 @@ ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
 }
 
 ss::future<> seq_writer::wait_for(model::offset offset) {
-    return container().invoke_on(0, _smp_opts, [offset](seq_writer& seq) {
-        if (auto waiters = seq._wait_for_sem.waiters(); waiters != 0) {
-            vlog(plog.trace, "wait_for waiting for {} waiters", waiters);
-        }
-        return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
-            if (offset > seq._loaded_offset) {
-                vlog(
-                  plog.debug,
-                  "wait_for dirty!  Reading {}..{}",
-                  seq._loaded_offset,
-                  offset);
+    return container().invoke_on(
+      reader_shard, _smp_opts, [offset](seq_writer& seq) {
+          if (auto waiters = seq._wait_for_sem.waiters(); waiters != 0) {
+              vlog(plog.trace, "wait_for waiting for {} waiters", waiters);
+          }
+          return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
+              if (offset > seq._loaded_offset) {
+                  vlog(
+                    plog.debug,
+                    "wait_for dirty!  Reading {}..{}",
+                    seq._loaded_offset,
+                    offset);
 
-                return kafka::client::make_client_fetch_batch_reader(
-                         seq._client.local(),
-                         model::schema_registry_internal_tp,
-                         seq._loaded_offset + model::offset{1},
-                         offset + model::offset{1})
-                  .consume(
-                    consume_to_store{seq._store, seq}, model::no_timeout);
-            } else {
-                vlog(plog.trace, "wait_for clean (offset  {})", offset);
-                return ss::make_ready_future<>();
-            }
-        });
-    });
+                  return kafka::client::make_client_fetch_batch_reader(
+                           seq._client.local(),
+                           model::schema_registry_internal_tp,
+                           seq._loaded_offset + model::offset{1},
+                           offset + model::offset{1})
+                    .consume(
+                      consume_to_store{seq._store, seq}, model::no_timeout);
+              } else {
+                  vlog(plog.trace, "wait_for clean (offset  {})", offset);
+                  return ss::make_ready_future<>();
+              }
+          });
+      });
 }
 
 /// Helper for write methods that need to check + retry if their
@@ -191,7 +192,7 @@ ss::future<bool> seq_writer::produce_and_apply(
 ss::future<> seq_writer::advance_offset(model::offset offset) {
     auto remote = [offset](seq_writer& s) { s.advance_offset_inner(offset); };
 
-    return container().invoke_on(0, _smp_opts, remote);
+    return container().invoke_on(reader_shard, _smp_opts, remote);
 }
 
 void seq_writer::advance_offset_inner(model::offset offset) {

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -28,6 +28,9 @@ static const int max_retries = 4;
 
 class seq_writer final : public ss::peering_sharded_service<seq_writer> {
 public:
+    // All reads of the topic must occur on shard 0
+    static constexpr ss::shard_id reader_shard = 0;
+
     seq_writer(
       model::node_id node_id,
       ss::smp_service_group smp_group,
@@ -133,9 +136,9 @@ private:
               });
         };
 
-        return container().invoke_on(0, _smp_opts, remote).then([](auto res) {
-            return std::move(res).value();
-        });
+        return container()
+          .invoke_on(reader_shard, _smp_opts, remote)
+          .then([](auto res) { return std::move(res).value(); });
     }
 
     /// The part of sequenced_write that runs on shard zero

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -412,7 +412,9 @@ ss::future<> service::do_start() {
     }
     co_await container().invoke_on_all(_ctx.smp_sg, [](service& s) {
         s._is_started = true;
-        return s.fetch_internal_topic();
+        return ss::this_shard_id() == seq_writer::reader_shard
+                 ? s.fetch_internal_topic()
+                 : ss::now();
     });
 }
 


### PR DESCRIPTION
Except for start up, SR only reads data from the `_schemas` topic on shard 0, however `do_start` performs the read on all shards.  This could lead to inconsistent behavior in SR where some shards may read ahead of others resulting in inconsitent state.

For example, say schema A depends on schema B, however schema B occurs later on in the `_schemas` topic (situation can only be caused by tooling writing directly to the `_schemas` topic).  In a single shard read, schema A should fail to load, however if one shard has "read ahead" and loaded schema B, then schema A would load successfully.

This change ensures consistent load behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Addresses startup behavior in SR that may result in inconsistent SR state between nodes
