### PR TITLE
Do not enable translation stm when datalake is disabled

### DIFF
--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -229,8 +229,11 @@ void translation_stm::update_highest_translated_offset(
     _waiters_for_translated.notify(new_offset);
 }
 
+stm_factory::stm_factory(bool iceberg_enabled)
+  : _iceberg_enabled(iceberg_enabled) {}
+
 bool stm_factory::is_applicable_for(const storage::ntp_config& config) const {
-    return model::is_user_topic(config.ntp());
+    return _iceberg_enabled && model::is_user_topic(config.ntp());
 }
 
 void stm_factory::create(

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -113,9 +113,12 @@ private:
 
 class stm_factory : public cluster::state_machine_factory {
 public:
-    stm_factory() = default;
+    explicit stm_factory(bool is_iceberg_enabled);
     bool is_applicable_for(const storage::ntp_config&) const final;
     void create(raft::state_machine_manager_builder&, raft::consensus*) final;
+
+private:
+    bool _iceberg_enabled;
 };
 
 } // namespace datalake::translation

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2907,7 +2907,8 @@ void application::start_runtime_services(
             storage.local().kvs(),
             config::shard_local_cfg().rm_sync_timeout_ms.bind());
           pm.register_factory<datalake::coordinator::stm_factory>();
-          pm.register_factory<datalake::translation::stm_factory>();
+          pm.register_factory<datalake::translation::stm_factory>(
+            config::shard_local_cfg().iceberg_enabled());
           if (config::shard_local_cfg().development_enable_cloud_topics()) {
               pm.register_factory<experimental::cloud_topics::dl_stm_factory>();
           }


### PR DESCRIPTION
When `iceberg_enabled` cluster configuration property is set to false we do not have to create `datalake::translation::state_machine` for each partition. This way when datalake capabilities are disabled in the cluster we will not have to reply the whole log for the datalake state machine.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none