### PR TITLE
r/stm_manager: do not populate batch cache when background apply happens

### DIFF
--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -455,6 +455,11 @@ ss::future<> state_machine_manager::background_apply_fiber(
           entry->stm->next(),
           _next,
           entry->name);
+        /**
+         * As the STM is catching up and not reading the tip of the log it is
+         * pointless to populate the batch cache with the read batches.
+         */
+        config.skip_batch_cache = true;
         bool error = false;
         try {
             model::record_batch_reader reader = co_await _raft->make_reader(


### PR DESCRIPTION
When `raft::state_machine_manager` executes the background fiber apply it reads batches that are not at the tip of the log as for the background fiber to start the STM must be out of date.

Previously we populated the `batch_cache` with one hit wonders coming from state machine catching up. This increased the CPU usage a lot when state machines were executing `apply` logic. For the large topics the main most of the CPU cycles are burned in the batch cache reclaimer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none