### PR TITLE
Iceberg partition transforms: bucket and truncate

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -1060,6 +1060,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "truncate_transform_visitor",
+    srcs = [
+        "truncate_transform_visitor.cc",
+    ],
+    hdrs = [
+        "truncate_transform_visitor.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":values",
+        "//src/v/bytes:iobuf",
+        "@abseil-cpp//absl/numeric:int128",
+    ],
+)
+
+redpanda_cc_library(
     name = "transform_utils",
     srcs = [
         "transform_utils.cc",
@@ -1073,6 +1089,7 @@ redpanda_cc_library(
         ":datatypes",
         ":time_transform_visitor",
         ":transform",
+        ":truncate_transform_visitor",
         ":values",
         "//src/v/base",
         "@seastar",

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -1044,6 +1044,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "bucket_transform_hashing_visitor",
+    srcs = [
+        "bucket_transform_hashing_visitor.cc",
+    ],
+    hdrs = [
+        "bucket_transform_hashing_visitor.h",
+    ],
+    include_prefix = "iceberg",
+    deps = [
+        ":values",
+        "//src/v/hashing:murmur",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "transform_utils",
     srcs = [
         "transform_utils.cc",
@@ -1053,6 +1069,7 @@ redpanda_cc_library(
     ],
     include_prefix = "iceberg",
     deps = [
+        ":bucket_transform_hashing_visitor",
         ":datatypes",
         ":time_transform_visitor",
         ":transform",

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -84,6 +84,7 @@ v_cc_library(
     transform_json.cc
     transform_utils.cc
     update_partition_spec_action.cc
+    truncate_transform_visitor.cc
     update_schema_action.cc
     uri.cc
     values.cc

--- a/src/v/iceberg/CMakeLists.txt
+++ b/src/v/iceberg/CMakeLists.txt
@@ -40,6 +40,7 @@ v_cc_library(
   SRCS
     ${avro_hdrs}
     action.cc
+    bucket_transform_hashing_visitor.cc
     catalog.cc
     compatibility.cc
     compatibility_types.cc

--- a/src/v/iceberg/bucket_transform_hashing_visitor.cc
+++ b/src/v/iceberg/bucket_transform_hashing_visitor.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/bucket_transform_hashing_visitor.h"
+
+#include "hashing/murmur.h"
+
+namespace iceberg {
+namespace {
+uint32_t hash_long(int64_t v) {
+    const auto le = ss::cpu_to_le(v);
+    return murmurhash3_x86_32(&le, sizeof(le), 0);
+}
+} // namespace
+
+uint32_t bucket_transform_hashing_visitor::operator()(const int_value& value) {
+    return hash_long(value.val);
+}
+
+uint32_t bucket_transform_hashing_visitor::operator()(const long_value& value) {
+    return hash_long(value.val);
+}
+
+uint32_t bucket_transform_hashing_visitor::operator()(const time_value& value) {
+    return hash_long(value.val);
+}
+uint32_t bucket_transform_hashing_visitor::operator()(const date_value& value) {
+    return hash_long(value.val);
+}
+uint32_t
+bucket_transform_hashing_visitor::operator()(const timestamp_value& value) {
+    return hash_long(value.val);
+}
+uint32_t
+bucket_transform_hashing_visitor::operator()(const timestamptz_value& value) {
+    return hash_long(value.val);
+}
+uint32_t
+bucket_transform_hashing_visitor::operator()(const decimal_value& value) {
+    const auto low_val = ss::cpu_to_be(Int128Low64(value.val));
+    const auto high_val = ss::cpu_to_be(Int128High64(value.val));
+
+    std::array<uint8_t, 16> value_bytes{0};
+
+    /**
+     * Both Java and PyIceberg implementations encode the decimal in big endian
+     * format and then they hash an array with the smallest size required to
+     * represent the decimal
+     */
+    for (uint8_t i = 0; i < 8; i++) {
+        const auto h_byte = (high_val >> (i * 8)) & 0xFF;
+        const auto l_byte = (low_val >> (i * 8)) & 0xFF;
+
+        value_bytes[i] = h_byte;
+        value_bytes[i + 8] = l_byte;
+    }
+    /**
+     * Limit the size of the array to the smallest size required to represent
+     * the number
+     */
+    auto offset = 0;
+    for (int i = 0; i < 15; ++i) {
+        if (value_bytes[i] == 0x00 && (value_bytes[i + 1] & 0x80) == 0x00) {
+            offset++;
+        } else if (
+          value_bytes[i] == 0xFF && (value_bytes[i + 1] & 0x80) == 0x80) {
+            offset++;
+        } else {
+            break;
+        }
+    }
+
+    return murmurhash3_x86_32(value_bytes.data() + offset, 16 - offset, 0);
+}
+
+uint32_t
+bucket_transform_hashing_visitor::operator()(const string_value& value) {
+    return murmurhash3_x86_32(value.val, 0);
+}
+uint32_t
+bucket_transform_hashing_visitor::operator()(const fixed_value& value) {
+    return murmurhash3_x86_32(value.val, 0);
+}
+uint32_t
+bucket_transform_hashing_visitor::operator()(const binary_value& value) {
+    return murmurhash3_x86_32(value.val, 0);
+}
+uint32_t bucket_transform_hashing_visitor::operator()(const uuid_value& v) {
+    const auto& data = v.val.uuid().data;
+    return murmurhash3_x86_32(
+      static_cast<const uint8_t*>(data), sizeof(data), 0);
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/bucket_transform_hashing_visitor.h
+++ b/src/v/iceberg/bucket_transform_hashing_visitor.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "iceberg/values.h"
+
+namespace iceberg {
+struct bucket_transform_hashing_visitor {
+    uint32_t operator()(const int_value&);
+    uint32_t operator()(const long_value&);
+    uint32_t operator()(const time_value&);
+    uint32_t operator()(const date_value&);
+    uint32_t operator()(const timestamp_value&);
+    uint32_t operator()(const timestamptz_value&);
+    uint32_t operator()(const decimal_value&);
+    uint32_t operator()(const string_value&);
+    uint32_t operator()(const fixed_value&);
+    uint32_t operator()(const binary_value&);
+    uint32_t operator()(const uuid_value&);
+
+    uint32_t operator()(const auto& value) {
+        throw std::invalid_argument(fmt::format(
+          "value {} must be of type supported by the bucket transform", value));
+    };
+};
+} // namespace iceberg

--- a/src/v/iceberg/partition_key.cc
+++ b/src/v/iceberg/partition_key.cc
@@ -34,7 +34,7 @@ partition_key partition_key::create(
         }
         const auto& field_val = *field_val_opt;
         const auto& transform = partition_field.transform;
-        ret_val->fields.emplace_back(apply_transform(field_val, transform));
+        ret_val->fields.push_back(apply_transform(field_val, transform));
     }
     return partition_key{std::move(ret_val)};
 }

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -485,6 +485,7 @@ redpanda_cc_gtest(
         "//src/v/iceberg:values",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/numeric:int128",
         "@fmt",
         "@googletest//:gtest",
     ],

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -480,10 +480,12 @@ redpanda_cc_gtest(
         "transform_utils_test.cc",
     ],
     deps = [
+        "//src/v/bytes:random",
         "//src/v/iceberg:transform",
         "//src/v/iceberg:transform_utils",
         "//src/v/iceberg:values",
         "//src/v/model",
+        "//src/v/random:generators",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/numeric:int128",
         "@fmt",

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -480,7 +480,9 @@ redpanda_cc_gtest(
         "transform_utils_test.cc",
     ],
     deps = [
+        "//src/v/bytes:iobuf",
         "//src/v/bytes:random",
+        "//src/v/iceberg:bucket_transform_hashing_visitor",
         "//src/v/iceberg:transform",
         "//src/v/iceberg:transform_utils",
         "//src/v/iceberg:values",

--- a/src/v/iceberg/tests/transform_utils_bucket.py
+++ b/src/v/iceberg/tests/transform_utils_bucket.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python3
+"""
+This helper script was used to generate values for
+transform_utils_test.cc
+"""
+
+import codecs
+from decimal import Decimal
+import mmh3
+import struct
+from typing import Optional, Union
+import uuid
+
+
+def bucket_transform(hash_func, num_buckets, v):
+    hash = hash_func(v)
+    bucket = (hash & 2147483647) % num_buckets
+    print("hash: {} value: {} bucket: {}".format(hash, v, bucket))
+
+
+def hash_int(v) -> int:
+    print(mmh3.hash(struct.pack("<q", v)))
+    return mmh3.hash(struct.pack("<q", v))
+
+
+bucket_transform(hash_int, 16, 321123)
+bucket_transform(hash_int, 128, 321123)
+bucket_transform(hash_int, 2025, 321123)
+bucket_transform(hash_int, 16, 321123321123)
+bucket_transform(hash_int, 128, 321123321123)
+bucket_transform(hash_int, 2025, 321123321123)
+
+bucket_transform(hash_int, 16, 1000)
+bucket_transform(hash_int, 128, 1000)
+bucket_transform(hash_int, 2025, 1000)
+
+bucket_transform(hash_int, 16, 1000000 * 60 * 60 * 10)
+bucket_transform(hash_int, 128, 1000000 * 60 * 60 * 10)
+bucket_transform(hash_int, 2025, 1000000 * 60 * 60 * 10)
+
+bucket_transform(hash_int, 16, 1741177530000000)
+bucket_transform(hash_int, 128, 1741177530000000)
+bucket_transform(hash_int, 2025, 1741177530000000)
+
+
+def decimal_to_unscaled(value: Decimal) -> int:
+    """Get an unscaled value given a Decimal value.
+
+    Args:
+        value (Decimal): A Decimal instance.
+
+    Returns:
+        int: The unscaled value.
+    """
+    sign, digits, _ = value.as_tuple()
+    return int(Decimal((sign, digits, 0)).to_integral_value())
+
+
+def bytes_required(value: Union[int, Decimal]) -> int:
+    """Return the minimum number of bytes needed to serialize a decimal or unscaled value.
+
+    Args:
+        value (int | Decimal): a Decimal value or unscaled int value.
+
+    Returns:
+        int: the minimum number of bytes needed to serialize the value.
+    """
+    if isinstance(value, int):
+        return (value.bit_length() + 8) // 8
+    elif isinstance(value, Decimal):
+        return (decimal_to_unscaled(value).bit_length() + 8) // 8
+
+    raise ValueError(f"Unsupported value: {value}")
+
+
+def decimal_to_bytes(value: Decimal,
+                     byte_length: Optional[int] = None) -> bytes:
+    """Return a byte representation of a decimal.
+
+    Args:
+        value (Decimal): a decimal value.
+        byte_length (int): The number of bytes.
+    Returns:
+        bytes: the unscaled value of the Decimal as bytes.
+    """
+    unscaled_value = decimal_to_unscaled(value)
+    if byte_length is None:
+        byte_length = bytes_required(unscaled_value)
+    return unscaled_value.to_bytes(byte_length, byteorder="big", signed=True)
+
+
+def uuid_to_bytes(value: uuid.UUID) -> bytes:
+    return value.bytes
+
+
+def hash_decimal(v: Decimal) -> int:
+    print(">>> {}".format(codecs.encode(decimal_to_bytes(v), 'hex')))
+    return mmh3.hash(decimal_to_bytes(v))
+
+
+def hash_string(v: str) -> int:
+    return mmh3.hash(v)
+
+
+def hash_uuid(v: uuid.UUID) -> int:
+    print(">>> {}".format(codecs.encode(uuid_to_bytes(v), 'hex')))
+    return mmh3.hash(uuid_to_bytes(v))
+
+
+def hash_bytes(v: bytes) -> int:
+    return mmh3.hash(v)
+
+
+bucket_transform(hash_decimal, 16, Decimal(123))
+bucket_transform(hash_decimal, 128, Decimal(123))
+bucket_transform(hash_decimal, 2025, Decimal(123))
+bucket_transform(hash_decimal, 16, Decimal(18446744073709551739))
+bucket_transform(hash_decimal, 128, Decimal(18446744073709551739))
+bucket_transform(hash_decimal, 2025, Decimal(18446744073709551739))
+bucket_transform(hash_decimal, 16, Decimal(116609477114555699131776463578))
+bucket_transform(hash_decimal, 128, Decimal(116609477114555699131776463578))
+bucket_transform(hash_decimal, 2025, Decimal(116609477114555699131776463578))
+bucket_transform(hash_decimal, 16, Decimal(-18446744073709551493))
+bucket_transform(hash_decimal, 128, Decimal(-18446744073709551493))
+bucket_transform(hash_decimal, 2025, Decimal(-18446744073709551493))
+bucket_transform(hash_decimal, 16, Decimal(-1012))
+bucket_transform(hash_decimal, 128, Decimal(-1012))
+bucket_transform(hash_decimal, 2025, Decimal(-1012))
+bucket_transform(hash_decimal, 16, Decimal(-5923679718586680004350836613))
+bucket_transform(hash_decimal, 128, Decimal(-5923679718586680004350836613))
+bucket_transform(hash_decimal, 2025, Decimal(-5923679718586680004350836613))
+bucket_transform(hash_string, 16, "non-latin to test UTF-8: Алексей")
+bucket_transform(hash_string, 128, "non-latin to test UTF-8: Алексей")
+bucket_transform(hash_string, 2025, "non-latin to test UTF-8: Алексей")
+bucket_transform(hash_uuid, 16,
+                 uuid.UUID("ab4ed576-b638-424f-89d8-4ea602393772"))
+bucket_transform(hash_uuid, 128,
+                 uuid.UUID("ab4ed576-b638-424f-89d8-4ea602393772"))
+bucket_transform(hash_uuid, 2025,
+                 uuid.UUID("ab4ed576-b638-424f-89d8-4ea602393772"))
+bucket_transform(hash_bytes, 16, bytes.fromhex('deadbeef'))
+bucket_transform(hash_bytes, 128, bytes.fromhex('deadbeef'))
+bucket_transform(hash_bytes, 2025, bytes.fromhex('deadbeef'))

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -13,9 +13,12 @@
 #include "iceberg/values.h"
 #include "model/timestamp.h"
 
+#include <absl/numeric/int128.h>
 #include <fmt/chrono.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <utility>
 #include <variant>
 
 using namespace iceberg;
@@ -289,4 +292,147 @@ TEST(TestTransformApplication, BucketTransform) {
     test_transform_3(test_values.decimal_val_4, 2, 50, 355);
     test_transform_3(test_values.decimal_val_5, 11, 123, 342);
     test_transform_3(test_values.decimal_val_6, 3, 3, 603);
+}
+
+TEST(TestTransformApplication, NumericTruncateTransform) {
+    auto test =
+      [](primitive_value input, uint32_t length, primitive_value expected) {
+          value input_wrapped{
+            std::in_place_type<primitive_value>, std::move(input)};
+          auto transformed = apply_transform(
+            std::move(input_wrapped), truncate_transform{.length = length});
+          ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
+          ASSERT_EQ(std::get<primitive_value>(transformed), expected);
+      };
+
+    constexpr auto min_signed = std::numeric_limits<int32_t>::min();
+    constexpr auto max_signed = std::numeric_limits<int32_t>::max();
+    constexpr uint32_t max_signed_u = max_signed;
+    constexpr uint32_t max_unsigned = std::numeric_limits<uint32_t>::max();
+    auto various_int32s = std::to_array(
+      {min_signed, -100, -1, 0, 1, 100, max_signed});
+    for (auto i : various_int32s) {
+        test(int_value{i}, 0, int_value{i});
+        test(int_value{i}, 1, int_value{i});
+    }
+    test(int_value{1000}, 5, int_value{1000});
+    test(int_value{1001}, 5, int_value{1000});
+    test(int_value{-1000}, 5, int_value{-1000});
+    test(int_value{-1001}, 5, int_value{-1005});
+    test(int_value{0}, max_signed_u, int_value{0});
+    test(int_value{1000}, max_signed_u, int_value{0});
+    test(int_value{-1000}, max_signed_u, int_value{-max_signed});
+    test(int_value{max_signed}, max_signed_u, int_value{max_signed});
+    test(int_value{min_signed + 1}, max_signed_u, int_value{min_signed + 1});
+    // underflow
+    test(int_value{min_signed}, max_signed_u, int_value{2});
+    for (auto i : various_int32s) {
+        for (auto len : std::to_array({max_signed_u + 1, max_unsigned})) {
+            test(int_value{i}, len, int_value{0});
+        }
+    }
+
+    constexpr auto min_signed_long = std::numeric_limits<int64_t>::min();
+    constexpr auto max_signed_long = std::numeric_limits<int64_t>::max();
+    auto various_int64s = std::to_array(
+      {min_signed_long,
+       int64_t{-100},
+       int64_t{-1},
+       int64_t{0},
+       int64_t{1},
+       int64_t{100},
+       max_signed_long});
+    for (auto i : various_int64s) {
+        test(long_value{i}, 0, long_value{i});
+        test(long_value{i}, 1, long_value{i});
+    }
+    test(long_value{100010001000}, 5, long_value{100010001000});
+    test(long_value{100010001001}, 5, long_value{100010001000});
+    test(long_value{-100010001000}, 5, long_value{-100010001000});
+    test(long_value{-100010001005}, 5, long_value{-100010001005});
+    test(long_value{0}, max_signed_u, long_value{0});
+    test(long_value{1000}, max_signed_u, long_value{0});
+    test(long_value{-1000}, max_signed_u, long_value{-max_signed});
+    test(long_value{max_signed}, max_signed_u, long_value{max_signed});
+    test(long_value{min_signed + 1}, max_signed_u, long_value{min_signed + 1});
+    test(
+      long_value{int64_t{max_signed} * 10},
+      max_signed_u,
+      long_value{int64_t{max_signed} * 10});
+    test(
+      long_value{int64_t{max_signed} * 10 + 1},
+      max_signed_u,
+      long_value{int64_t{max_signed} * 10});
+    test(
+      long_value{int64_t{max_signed} * 10 - 1},
+      max_signed_u,
+      long_value{int64_t{max_signed} * 9});
+    test(
+      long_value{-int64_t{max_signed} * 10},
+      max_signed_u,
+      long_value{-int64_t{max_signed} * 10});
+    test(
+      long_value{-int64_t{max_signed} * 10 + 1},
+      max_signed_u,
+      long_value{-int64_t{max_signed} * 10});
+    test(
+      long_value{-int64_t{max_signed} * 10 - 1},
+      max_signed_u,
+      long_value{-int64_t{max_signed} * 11});
+    // underflow
+    test(long_value{min_signed_long}, 3, long_value{max_signed_long});
+
+    constexpr auto min_signed_128 = std::numeric_limits<absl::int128>::min();
+    constexpr auto max_signed_128 = std::numeric_limits<absl::int128>::max();
+    auto various_int128s = std::to_array(
+      {min_signed_128,
+       absl::int128{-100},
+       absl::int128{-1},
+       absl::int128{0},
+       absl::int128{1},
+       absl::int128{100},
+       max_signed_128});
+    for (auto i : various_int128s) {
+        test(decimal_value{i}, 0, decimal_value{i});
+        test(decimal_value{i}, 1, decimal_value{i});
+    }
+    test(decimal_value{100010001000}, 5, decimal_value{100010001000});
+    test(decimal_value{100010001001}, 5, decimal_value{100010001000});
+    test(decimal_value{-100010001000}, 5, decimal_value{-100010001000});
+    test(decimal_value{-100010001005}, 5, decimal_value{-100010001005});
+    test(decimal_value{0}, max_signed_u, decimal_value{0});
+    test(decimal_value{1000}, max_signed_u, decimal_value{0});
+    test(decimal_value{-1000}, max_signed_u, decimal_value{-max_signed});
+    test(decimal_value{max_signed}, max_signed_u, decimal_value{max_signed});
+    test(
+      decimal_value{min_signed + 1},
+      max_signed_u,
+      decimal_value{min_signed + 1});
+    test(
+      decimal_value{max_signed * absl::int128{max_signed_long}},
+      max_signed_u,
+      decimal_value{max_signed * absl::int128{max_signed_long}});
+    test(
+      decimal_value{max_signed * absl::int128{max_signed_long} + 1},
+      max_signed_u,
+      decimal_value{max_signed * absl::int128{max_signed_long}});
+    test(
+      decimal_value{max_signed * absl::int128{max_signed_long} - 1},
+      max_signed_u,
+      decimal_value{max_signed * absl::int128{max_signed_long - 1}});
+    test(
+      decimal_value{-max_signed * absl::int128{max_signed_long}},
+      max_signed_u,
+      decimal_value{-max_signed * absl::int128{max_signed_long}});
+    test(
+      decimal_value{-max_signed * absl::int128{max_signed_long} + 1},
+      max_signed_u,
+      decimal_value{-max_signed * absl::int128{max_signed_long}});
+    test(
+      decimal_value{-max_signed * absl::int128{max_signed_long} - 1},
+      max_signed_u,
+      decimal_value{-max_signed * (absl::int128{max_signed_long} + 1)});
+    // underflow
+    test(
+      decimal_value{min_signed_128 + 1}, 5, decimal_value{max_signed_128 - 1});
 }

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -200,20 +200,24 @@ struct primitive_test_values {
     value timestamptz_val = primitive_value{
       timestamptz_value{1741177530000000}};
     value string_val = primitive_value{
-      string_value{iobuf::from("hello Iceberg")}};
+      string_value{iobuf::from("non-latin to test UTF-8: Алексей")}};
     value uuid_val = primitive_value{
       uuid_value{uuid_t::from_string("ab4ed576-b638-424f-89d8-4ea602393772")}};
     value fixed_val = primitive_value{
-      fixed_value{iobuf::from("fixed Iceberg")}};
-    value binary_val = primitive_value{binary_value{iobuf::from("bytes ?")}};
+      fixed_value{iobuf::from("\xDE\xAD\xBE\xEF")}};
+    value binary_val = primitive_value{
+      binary_value{iobuf::from("\xDE\xAD\xBE\xEF")}};
     value decimal_val = primitive_value{
       decimal_value{absl::MakeInt128(0, 123)}};
     value decimal_val_2 = primitive_value{
       decimal_value{absl::MakeInt128(1, 123)}};
     value decimal_val_3 = primitive_value{
       decimal_value{absl::MakeInt128(6321412421, 53441242)}};
-    value decimal_val_4 = primitive_value{
-      decimal_value{absl::MakeInt128(0, 123)}};
+    value decimal_val_4 = primitive_value{decimal_value{absl::int128(-1012)}};
+    value decimal_val_5 = primitive_value{
+      decimal_value{absl::MakeInt128(-1, 123)}};
+    value decimal_val_6 = primitive_value{
+      decimal_value{absl::MakeInt128(-321123321, 123)}};
 };
 
 TEST(TestTransformApplication, IdentityTransform) {
@@ -238,4 +242,51 @@ TEST(TestTransformApplication, IdentityTransform) {
     test_transform(test_values.fixed_val);
     test_transform(test_values.binary_val);
     test_transform(test_values.decimal_val);
+}
+
+TEST(TestTransformApplication, BucketTransform) {
+    primitive_test_values test_values;
+    auto test_transform =
+      [](const value& val, uint32_t buckets, int32_t expected) {
+          auto transformed = apply_transform(
+            val, bucket_transform{.n = buckets});
+          ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
+          const auto& p_val = std::get<primitive_value>(transformed);
+          ASSERT_TRUE(std::holds_alternative<int_value>(p_val));
+          auto bucket = std::get<int_value>(p_val).val;
+          ASSERT_EQ(expected, bucket) << fmt::format(
+            "Bucket {} for value: {} expected to be equal to {} (bucket count: "
+            "{})",
+            bucket,
+            val,
+            expected,
+            buckets);
+      };
+
+    auto test_transform_3 = [&](
+                              const value& val,
+                              int32_t expected_bucket_16,
+                              int32_t expected_bucket_128,
+                              int32_t expected_bucket_2025) {
+        test_transform(val, 16, expected_bucket_16);
+        test_transform(val, 128, expected_bucket_128);
+        test_transform(val, 2025, expected_bucket_2025);
+    };
+
+    test_transform_3(test_values.int_val, 13, 93, 976);
+    test_transform_3(test_values.long_val, 6, 118, 1283);
+    test_transform_3(test_values.date_val, 12, 12, 1270);
+    test_transform_3(test_values.time_val, 2, 66, 19);
+    test_transform_3(test_values.timestamp_val, 15, 15, 603);
+    test_transform_3(test_values.timestamptz_val, 15, 15, 603);
+    test_transform_3(test_values.string_val, 12, 28, 1337);
+    test_transform_3(test_values.uuid_val, 12, 108, 975);
+    test_transform_3(test_values.fixed_val, 10, 74, 197);
+    test_transform_3(test_values.binary_val, 10, 74, 197);
+    test_transform_3(test_values.decimal_val, 1, 49, 287);
+    test_transform_3(test_values.decimal_val_2, 5, 69, 439);
+    test_transform_3(test_values.decimal_val_3, 5, 21, 872);
+    test_transform_3(test_values.decimal_val_4, 2, 50, 355);
+    test_transform_3(test_values.decimal_val_5, 11, 123, 342);
+    test_transform_3(test_values.decimal_val_6, 3, 3, 603);
 }

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -8,16 +8,20 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/random.h"
 #include "iceberg/transform.h"
 #include "iceberg/transform_utils.h"
 #include "iceberg/values.h"
 #include "model/timestamp.h"
+#include "random/generators.h"
 
 #include <absl/numeric/int128.h>
 #include <fmt/chrono.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <limits>
+#include <ranges>
 #include <utility>
 #include <variant>
 
@@ -435,4 +439,72 @@ TEST(TestTransformApplication, NumericTruncateTransform) {
     // underflow
     test(
       decimal_value{min_signed_128 + 1}, 5, decimal_value{max_signed_128 - 1});
+}
+
+TEST(TestTransformApplication, BinaryTruncateTransform) {
+    for (int runs = 0; runs < 10; ++runs) {
+        int input_len = random_generators::get_int(100);
+        auto random_bytes = std::string(input_len, 0);
+        for (int i = 0; i < input_len; ++i) {
+            random_bytes[i] = random_generators::get_int(
+              std::numeric_limits<uint8_t>::max());
+        }
+        auto split = random_generators::split_as_iobuf(
+          random_bytes, random_generators::get_int(10));
+
+        uint32_t truncate_len = random_generators::get_int(input_len + 3);
+
+        std::string expected_truncated_str = random_bytes.substr(
+          0, truncate_len);
+        iobuf expected_truncated_iobuf;
+        expected_truncated_iobuf.append(
+          expected_truncated_str.data(), expected_truncated_str.size());
+        primitive_value expected{
+          std::in_place_type<binary_value>,
+          std::move(expected_truncated_iobuf)};
+
+        auto actual_truncated = apply_transform(
+          binary_value{std::move(split)},
+          truncate_transform{.length = truncate_len});
+
+        ASSERT_TRUE(std::holds_alternative<primitive_value>(actual_truncated));
+        ASSERT_EQ(std::get<primitive_value>(actual_truncated), expected);
+    }
+}
+
+TEST(TestTransformApplication, TextTruncateTransform) {
+    const std::vector<const std::string> available_symbols{
+      "\x01", "\t", "\n", "\r", " ", "A", "a", "@", "香", "😊", "⋀", "Ы"};
+
+    for (int runs = 0; runs < 10; ++runs) {
+        int input_len = random_generators::get_int(10);
+        std::vector<std::string_view> chosen_symbols;
+        chosen_symbols.reserve(input_len);
+        for (int i = 0; i < input_len; ++i) {
+            chosen_symbols.push_back(
+              random_generators::random_choice(available_symbols));
+        }
+        std::string str{std::from_range, chosen_symbols | std::views::join};
+        auto split = random_generators::split_as_iobuf(
+          str, random_generators::get_int(5));
+
+        uint32_t truncate_len = random_generators::get_int(input_len + 3);
+
+        std::string expected_truncated_str{
+          std::from_range,
+          chosen_symbols | std::views::take(truncate_len) | std::views::join};
+        iobuf expected_truncated_iobuf;
+        expected_truncated_iobuf.append(
+          expected_truncated_str.data(), expected_truncated_str.size());
+        primitive_value expected{
+          std::in_place_type<string_value>,
+          std::move(expected_truncated_iobuf)};
+
+        auto actual_truncated = apply_transform(
+          string_value{std::move(split)},
+          truncate_transform{.length = truncate_len});
+
+        ASSERT_TRUE(std::holds_alternative<primitive_value>(actual_truncated));
+        ASSERT_EQ(std::get<primitive_value>(actual_truncated), expected);
+    }
 }

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -48,7 +48,8 @@ TEST(TestTransforms, TestHourlyTransform) {
     auto start_time = std::chrono::system_clock::now();
 
     auto start_transformed = apply_transform(
-      make_timestamp_val(start_time), hour_transform{});
+                               make_timestamp_val(start_time), hour_transform{})
+                               .value();
 
     ASSERT_TRUE(std::holds_alternative<primitive_value>(start_transformed));
     ASSERT_TRUE(std::holds_alternative<int_value>(
@@ -63,8 +64,8 @@ TEST(TestTransforms, TestHourlyTransform) {
         .count());
 
     auto plus_1hr = start_time + 1h;
-    auto plus_1hr_transformed = apply_transform(
-      make_timestamp_val(plus_1hr), hour_transform{});
+    auto plus_1hr_transformed
+      = apply_transform(make_timestamp_val(plus_1hr), hour_transform{}).value();
     ASSERT_NE(start_transformed, plus_1hr_transformed);
     ASSERT_TRUE(std::holds_alternative<primitive_value>(plus_1hr_transformed));
     ASSERT_TRUE(std::holds_alternative<int_value>(
@@ -74,8 +75,9 @@ TEST(TestTransforms, TestHourlyTransform) {
     ASSERT_EQ(start_val.val + 1, plus_1hr_val.val);
 
     auto minus_1hr = start_time - 1h;
-    auto minus_1hr_transformed = apply_transform(
-      make_timestamp_val(minus_1hr), hour_transform{});
+    auto minus_1hr_transformed
+      = apply_transform(make_timestamp_val(minus_1hr), hour_transform{})
+          .value();
     ASSERT_NE(start_transformed, minus_1hr_transformed);
     ASSERT_TRUE(std::holds_alternative<primitive_value>(minus_1hr_transformed));
     ASSERT_TRUE(std::holds_alternative<int_value>(
@@ -164,7 +166,8 @@ TEST_P(TestTimeTransforms, TestConversion) {
     auto test_case = GetParam();
 
     auto transformed = apply_transform(
-      make_timestamp_val(test_case.time_shift), test_case.tr);
+                         make_timestamp_val(test_case.time_shift), test_case.tr)
+                         .value();
     ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
     ASSERT_TRUE(std::holds_alternative<int_value>(
       std::get<primitive_value>(transformed)));
@@ -178,7 +181,8 @@ TEST_P(TestDateTransforms, TestConversion) {
     auto test_case = GetParam();
 
     auto transformed = apply_transform(
-      make_date_val(test_case.time_shift), test_case.tr);
+                         make_date_val(test_case.time_shift), test_case.tr)
+                         .value();
     ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
     ASSERT_TRUE(std::holds_alternative<int_value>(
       std::get<primitive_value>(transformed)));
@@ -233,7 +237,7 @@ TEST(TestTransformApplication, IdentityTransform) {
     primitive_test_values test_values;
 
     auto test_transform = [](const value& val) {
-        auto transformed = apply_transform(val, identity_transform{});
+        auto transformed = apply_transform(val, identity_transform{}).value();
         ASSERT_EQ(val, transformed);
     };
 
@@ -257,8 +261,8 @@ TEST(TestTransformApplication, BucketTransform) {
     primitive_test_values test_values;
     auto test_transform =
       [](const value& val, uint32_t buckets, int32_t expected) {
-          auto transformed = apply_transform(
-            val, bucket_transform{.n = buckets});
+          auto transformed
+            = apply_transform(val, bucket_transform{.n = buckets}).value();
           ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
           const auto& p_val = std::get<primitive_value>(transformed);
           ASSERT_TRUE(std::holds_alternative<int_value>(p_val));
@@ -354,7 +358,9 @@ TEST(TestTransformApplication, NumericTruncateTransform) {
           value input_wrapped{
             std::in_place_type<primitive_value>, std::move(input)};
           auto transformed = apply_transform(
-            std::move(input_wrapped), truncate_transform{.length = length});
+                               std::move(input_wrapped),
+                               truncate_transform{.length = length})
+                               .value();
           ASSERT_TRUE(std::holds_alternative<primitive_value>(transformed));
           ASSERT_EQ(std::get<primitive_value>(transformed), expected);
       };
@@ -514,8 +520,9 @@ TEST(TestTransformApplication, BinaryTruncateTransform) {
           std::move(expected_truncated_iobuf)};
 
         auto actual_truncated = apply_transform(
-          binary_value{std::move(split)},
-          truncate_transform{.length = truncate_len});
+                                  binary_value{std::move(split)},
+                                  truncate_transform{.length = truncate_len})
+                                  .value();
 
         ASSERT_TRUE(std::holds_alternative<primitive_value>(actual_truncated));
         ASSERT_EQ(std::get<primitive_value>(actual_truncated), expected);
@@ -551,8 +558,9 @@ TEST(TestTransformApplication, TextTruncateTransform) {
           std::move(expected_truncated_iobuf)};
 
         auto actual_truncated = apply_transform(
-          string_value{std::move(split)},
-          truncate_transform{.length = truncate_len});
+                                  string_value{std::move(split)},
+                                  truncate_transform{.length = truncate_len})
+                                  .value();
 
         ASSERT_TRUE(std::holds_alternative<primitive_value>(actual_truncated));
         ASSERT_EQ(std::get<primitive_value>(actual_truncated), expected);

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -8,7 +8,9 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/iobuf.h"
 #include "bytes/random.h"
+#include "iceberg/bucket_transform_hashing_visitor.h"
 #include "iceberg/transform.h"
 #include "iceberg/transform_utils.h"
 #include "iceberg/values.h"
@@ -296,6 +298,54 @@ TEST(TestTransformApplication, BucketTransform) {
     test_transform_3(test_values.decimal_val_4, 2, 50, 355);
     test_transform_3(test_values.decimal_val_5, 11, 123, 342);
     test_transform_3(test_values.decimal_val_6, 3, 3, 603);
+}
+
+TEST(TestTransformApplication, BucketTransformHashingVisitor) {
+    // test individual hash values from
+    // https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements
+    auto test_hash = [&](const auto& val, int32_t expected) {
+        ASSERT_EQ(bucket_transform_hashing_visitor{}(val), expected);
+    };
+    test_hash(int_value{34}, 2017239379);
+    test_hash(long_value{34}, 2017239379);
+    test_hash(decimal_value{1420}, -500754589);
+    int32_t days_since_epoch_2017_11_16 = 17486;
+    test_hash(date_value{days_since_epoch_2017_11_16}, -653330422);
+    int64_t us_since_midnight_22_31_08 = int64_t{1000000}
+                                         * (8 + 60 * (31 + 60 * 22));
+    test_hash(time_value{us_since_midnight_22_31_08}, -662762989);
+    int64_t us_since_epoch_2017_11_16__22_31_08
+      = int64_t{days_since_epoch_2017_11_16} * 86400 * 1000000
+        + us_since_midnight_22_31_08;
+    test_hash(
+      timestamp_value{us_since_epoch_2017_11_16__22_31_08}, -2047944441);
+    test_hash(
+      timestamp_value{us_since_epoch_2017_11_16__22_31_08 + 1}, -1207196810);
+    test_hash(
+      timestamptz_value{us_since_epoch_2017_11_16__22_31_08}, -2047944441);
+    test_hash(
+      timestamptz_value{us_since_epoch_2017_11_16__22_31_08 + 1}, -1207196810);
+    {
+        iobuf ib;
+        uint8_t s[]{"iceberg"};
+        ib.append(s, sizeof(s) - 1);
+        test_hash(string_value{std::move(ib)}, 1210000089);
+    }
+    test_hash(
+      uuid_value{uuid_t::from_string("f79c3e09-677c-4bbd-a479-3f349cb785e7")},
+      1488055340);
+    {
+        iobuf ib;
+        uint8_t bytes[]{0x00, 0x01, 0x02, 0x03};
+        ib.append(bytes, sizeof(bytes));
+        test_hash(fixed_value{std::move(ib)}, -188683207);
+    }
+    {
+        iobuf ib;
+        uint8_t bytes[]{0x00, 0x01, 0x02, 0x03};
+        ib.append(bytes, sizeof(bytes));
+        test_hash(binary_value{std::move(ib)}, -188683207);
+    }
 }
 
 TEST(TestTransformApplication, NumericTruncateTransform) {

--- a/src/v/iceberg/tests/transform_utils_test.cc
+++ b/src/v/iceberg/tests/transform_utils_test.cc
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <utility>
 #include <variant>
@@ -233,12 +234,16 @@ struct primitive_test_values {
       decimal_value{absl::MakeInt128(-321123321, 123)}};
 };
 
-TEST(TestTransformApplication, IdentityTransform) {
+TEST(TestTransformApplication, IdentityAndVoidTransforms) {
     primitive_test_values test_values;
 
     auto test_transform = [](const value& val) {
-        auto transformed = apply_transform(val, identity_transform{}).value();
-        ASSERT_EQ(val, transformed);
+        auto id_transformed
+          = apply_transform(val, identity_transform{}).value();
+        ASSERT_EQ(val, id_transformed);
+
+        auto void_transformed = apply_transform(val, void_transform{});
+        ASSERT_EQ(void_transformed, std::nullopt);
     };
 
     test_transform(test_values.boolean_val);

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -17,6 +17,8 @@
 
 #include <seastar/util/variant_utils.hh>
 
+#include <optional>
+
 namespace iceberg {
 
 struct transform_applying_visitor {
@@ -73,7 +75,7 @@ struct transform_applying_visitor {
           truncate_transform_visitor{.length = tr.length}, *primitive);
     }
     std::optional<value> operator()(const void_transform&) {
-        throw std::runtime_error("not implemented");
+        return std::nullopt; // null
     }
 };
 

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -13,6 +13,7 @@
 #include "iceberg/bucket_transform_hashing_visitor.h"
 #include "iceberg/time_transform_visitor.h"
 #include "iceberg/transform.h"
+#include "iceberg/truncate_transform_visitor.h"
 
 #include <seastar/util/variant_utils.hh>
 
@@ -62,8 +63,14 @@ struct transform_applying_visitor {
         hash &= static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
         return int_value{static_cast<int32_t>(hash % tr.n)};
     }
-    value operator()(const truncate_transform&) {
-        return make_copy(source_val_);
+    value operator()(const truncate_transform& tr) {
+        auto primitive = std::get_if<primitive_value>(&source_val_);
+        if (!primitive) {
+            throw std::invalid_argument(
+              fmt::format("value {} must be primitive", source_val_));
+        }
+        return std::visit(
+          truncate_transform_visitor{.length = tr.length}, *primitive);
     }
     value operator()(const void_transform&) {
         throw std::runtime_error("not implemented");

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -10,6 +10,7 @@
 
 #include "iceberg/transform_utils.h"
 
+#include "iceberg/bucket_transform_hashing_visitor.h"
 #include "iceberg/time_transform_visitor.h"
 #include "iceberg/transform.h"
 
@@ -51,11 +52,21 @@ struct transform_applying_visitor {
           time_transform_visitor<std::chrono::years>{}, source_val_)};
         return v;
     }
-
-    template<typename T>
-    value operator()(const T&) {
-        throw std::invalid_argument(
-          "transform_applying_visitor not implemented for transform");
+    value operator()(const bucket_transform& tr) {
+        auto primitive = std::get_if<primitive_value>(&source_val_);
+        if (!primitive) {
+            throw std::invalid_argument(
+              fmt::format("value {} must be primitive", source_val_));
+        }
+        auto hash = std::visit(bucket_transform_hashing_visitor{}, *primitive);
+        hash &= static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        return int_value{static_cast<int32_t>(hash % tr.n)};
+    }
+    value operator()(const truncate_transform&) {
+        return make_copy(source_val_);
+    }
+    value operator()(const void_transform&) {
+        throw std::runtime_error("not implemented");
     }
 };
 

--- a/src/v/iceberg/transform_utils.cc
+++ b/src/v/iceberg/transform_utils.cc
@@ -24,7 +24,7 @@ struct transform_applying_visitor {
       : source_val_(source_val) {}
     const value& source_val_;
 
-    value operator()(const identity_transform&) {
+    std::optional<value> operator()(const identity_transform&) {
         auto primitive = std::get_if<primitive_value>(&source_val_);
         if (primitive) {
             return make_copy(*primitive);
@@ -33,27 +33,27 @@ struct transform_applying_visitor {
           fmt::format("value {} must be primitive", source_val_));
     }
 
-    value operator()(const hour_transform&) {
+    std::optional<value> operator()(const hour_transform&) {
         int_value v{std::visit(hour_transform_visitor{}, source_val_)};
         return v;
     }
 
-    value operator()(const day_transform&) {
+    std::optional<value> operator()(const day_transform&) {
         int_value v{
           std::visit(time_transform_visitor<std::chrono::days>{}, source_val_)};
         return v;
     }
-    value operator()(const month_transform&) {
+    std::optional<value> operator()(const month_transform&) {
         int_value v{std::visit(
           time_transform_visitor<std::chrono::months>{}, source_val_)};
         return v;
     }
-    value operator()(const year_transform&) {
+    std::optional<value> operator()(const year_transform&) {
         int_value v{std::visit(
           time_transform_visitor<std::chrono::years>{}, source_val_)};
         return v;
     }
-    value operator()(const bucket_transform& tr) {
+    std::optional<value> operator()(const bucket_transform& tr) {
         auto primitive = std::get_if<primitive_value>(&source_val_);
         if (!primitive) {
             throw std::invalid_argument(
@@ -63,7 +63,7 @@ struct transform_applying_visitor {
         hash &= static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
         return int_value{static_cast<int32_t>(hash % tr.n)};
     }
-    value operator()(const truncate_transform& tr) {
+    std::optional<value> operator()(const truncate_transform& tr) {
         auto primitive = std::get_if<primitive_value>(&source_val_);
         if (!primitive) {
             throw std::invalid_argument(
@@ -72,12 +72,13 @@ struct transform_applying_visitor {
         return std::visit(
           truncate_transform_visitor{.length = tr.length}, *primitive);
     }
-    value operator()(const void_transform&) {
+    std::optional<value> operator()(const void_transform&) {
         throw std::runtime_error("not implemented");
     }
 };
 
-value apply_transform(const value& source_val, const transform& transform) {
+std::optional<value>
+apply_transform(const value& source_val, const transform& transform) {
     return std::visit(transform_applying_visitor{source_val}, transform);
 }
 

--- a/src/v/iceberg/transform_utils.h
+++ b/src/v/iceberg/transform_utils.h
@@ -27,9 +27,8 @@ private:
 // Transforms the given value to its appropriate Iceberg value based on the
 // input transform.
 //
-// TODO: this is only implemented for the time transforms !
 // This will throw if used for anything else!
-value apply_transform(const value&, const transform&);
+std::optional<value> apply_transform(const value&, const transform&);
 
 // Returns true if the given transform can be applied to the given primitive
 checked<std::nullopt_t, partition_spec_field_error>

--- a/src/v/iceberg/truncate_transform_visitor.cc
+++ b/src/v/iceberg/truncate_transform_visitor.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "iceberg/truncate_transform_visitor.h"
+
+#include "bytes/iobuf.h"
+#include "iceberg/values.h"
+
+#include <absl/numeric/int128.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace iceberg {
+
+namespace {
+template<typename RemType, typename Val, typename Divider>
+Val round_towards_minus_infinity(Val val, Divider divisor) {
+    if (divisor == 0) [[unlikely]] {
+        return val;
+    }
+    // use larger type to avoid overflow
+    Val remainder = ((RemType{val} % divisor) + divisor) % divisor;
+    if (val < std::numeric_limits<Val>::min() + remainder) [[unlikely]] {
+        // simulate java underflow
+        return std::numeric_limits<Val>::max() - remainder + val + 1
+               - std::numeric_limits<Val>::min();
+    }
+    return val - remainder;
+}
+} // namespace
+
+value truncate_transform_visitor::operator()(const int_value& value) {
+    if (length > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()))
+      [[unlikely]] {
+        return int_value{0};
+    }
+    int32_t length_capped = length;
+    return int_value{
+      round_towards_minus_infinity<int64_t>(value.val, length_capped)};
+}
+
+value truncate_transform_visitor::operator()(const long_value& value) {
+    return long_value{round_towards_minus_infinity<int64_t>(value.val, length)};
+}
+
+value truncate_transform_visitor::operator()(const decimal_value& value) {
+    return decimal_value{
+      round_towards_minus_infinity<absl::int128>(value.val, length)};
+}
+
+value truncate_transform_visitor::operator()(const string_value& v) {
+    value ret{
+      std::in_place_type<primitive_value>, std::in_place_type<string_value>};
+    auto& ret_iobuf
+      = std::get<string_value>(std::get<primitive_value>(ret)).val;
+
+    auto remaining_allowance = length;
+
+    // assume valid UTF-8
+    // only tell apart between first and subsequent bytes in a codepoint
+    auto is_utf8_codepoint_initial_byte = [](const unsigned char c) {
+        return (c & 0b11000000) != 0b10000000;
+    };
+
+    for (const auto& frag : v.val) {
+        const auto frag_begin = frag.get();
+        const auto frag_len = frag.size();
+        const auto frag_end = frag_begin + frag_len;
+        for (auto cur = frag_begin; cur != frag_end; ++cur) {
+            if (is_utf8_codepoint_initial_byte(*cur)) {
+                if (remaining_allowance == 0) {
+                    // no allowance left for the new code point -> finalize
+                    size_t len_to_copy = cur - frag_begin;
+                    ret_iobuf.append(frag_begin, len_to_copy);
+                    return ret;
+                }
+                --remaining_allowance;
+            }
+        }
+        ret_iobuf.append(frag_begin, frag_len);
+    }
+    return ret;
+}
+
+value truncate_transform_visitor::operator()(const binary_value& v) {
+    auto desired_length = std::min(size_t{length}, v.val.size_bytes());
+    iobuf::iterator_consumer ic{v.val.cbegin(), v.val.cend()};
+    return binary_value{iobuf_copy(ic, desired_length)};
+}
+
+} // namespace iceberg

--- a/src/v/iceberg/truncate_transform_visitor.h
+++ b/src/v/iceberg/truncate_transform_visitor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "iceberg/values.h"
+
+namespace iceberg {
+struct truncate_transform_visitor {
+    uint32_t length;
+
+    value operator()(const int_value&);
+    value operator()(const long_value&);
+    value operator()(const decimal_value&);
+    value operator()(const string_value&);
+    value operator()(const binary_value&);
+
+    value operator()(const auto& value) {
+        throw std::invalid_argument(fmt::format(
+          "value {} must be of type supported by the bucket transform", value));
+    };
+};
+} // namespace iceberg


### PR DESCRIPTION
Implement missing transforms.

First 10 commits are reviewed in https://github.com/redpanda-data/redpanda/pull/25361, but due to time pressure I cannot open PRs one by one. If you have any concerns regarding murmur hash algorithm changes please comment there.

String truncation is performed according to UTF-8 rules, not [WTF-8](https://en.wikipedia.org/wiki/UTF-8#Surrogates), i.e. we treat a surrogate pair as two symbols. That's because:
- [Spec](https://iceberg.apache.org/spec/#partition-transforms) says we operate UTF-8
- Reference Java implementation has [special arrangements](https://github.com/apache/iceberg/blob/c07f2aabc0a1d02f068ecf1514d2479c0fbdd3b0/api/src/main/java/org/apache/iceberg/types/Comparators.java#L315) to support for UTF-8
- Python reference implementation does not seem to have any WTF-8 support, neither does python support WTF-8 internally:
```
$ python3 -c 'print(len("\ud83d\ude4f"))'
2
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* Bucket and truncate transformations enabled for Iceberg

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
