### PR TITLE
`archival`: use `log_level_for_error()` in `find_reupload_candidate()`

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3314,8 +3314,10 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
           },
           [this](
             skip_offset_range& skip_offsets) -> find_reupload_candidate_result {
-              vlog(
-                _rtclog.warn,
+              const auto log_level = log_level_for_error(skip_offsets.reason);
+              vlogl(
+                _rtclog,
+                log_level,
                 "Failed to make reupload candidate: {}",
                 skip_offsets.reason);
               return {std::nullopt, std::nullopt, {}};


### PR DESCRIPTION
Another call site was hardcoded to `WARN` level logging, instead of using this function to determine the appropriate logging level based on the reason contained in `skip_offset_range`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none