### PR TITLE
metrics: Export host metrics from Redpanda 

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4021,6 +4021,13 @@ configuration::configuration()
       "its own.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , enable_host_metrics(
+      *this,
+      "enable_host_metrics",
+      "Enable exporting of some host metrics like /proc/diskstats, /proc/snmp "
+      "and /proc/net/netstat",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , datalake_scheduler_block_size_bytes(
       *this,
       "datalake_scheduler_block_size_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -746,6 +746,8 @@ struct configuration final : public config_store {
     property<bool> iceberg_disable_snapshot_tagging;
     property<bool> iceberg_disable_automatic_snapshot_expiry;
 
+    property<bool> enable_host_metrics;
+
     // datalake scheduler configs
     bounded_property<size_t> datalake_scheduler_block_size_bytes;
     bounded_property<size_t> datalake_scheduler_max_concurrent_translations;

--- a/src/v/metrics/BUILD
+++ b/src/v/metrics/BUILD
@@ -3,11 +3,13 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 redpanda_cc_library(
     name = "metrics",
     srcs = [
+        "host_metrics_watcher.cc",
         "metrics.cc",
         "metrics_registry.cc",
     ],
     hdrs = [
         "aggregate_metrics_watcher.h",
+        "host_metrics_watcher.h",
         "metrics.h",
         "metrics_registry.h",
         "prometheus_sanitize.h",
@@ -17,7 +19,9 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/config",
+        "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
+        "//src/v/utils:file_io",
         "//src/v/utils:hdr_hist",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@seastar",

--- a/src/v/metrics/CMakeLists.txt
+++ b/src/v/metrics/CMakeLists.txt
@@ -5,7 +5,9 @@ v_cc_library(
     "metrics.h"
     "metrics_registry.h"
     "aggregate_metrics_watcher.h"
+    "host_metrics_watcher.h"
   SRCS
+    host_metrics_watcher.cc
     metrics.cc
     metrics_registry.cc
   DEPS

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -1,0 +1,176 @@
+#include "host_metrics_watcher.h"
+
+#include "base/vlog.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/later.hh>
+
+#include <exception>
+#include <ranges>
+
+namespace metrics {
+
+namespace {
+static const std::
+  array<ss::sstring, host_metrics_watcher::diskstats_field_count>
+    diskstats_fields{
+      "reads",             // 0
+      "reads_merged",      // 1
+      "sectors_read",      // 2
+      "reads_ms",          // 3
+      "writes",            // 4
+      "writes_merged",     // 5
+      "sectors_written",   // 6
+      "writes_ms",         // 7
+      "io_in_progress",    // 8
+      "io_ms",             // 9
+      "io_weighted_ms",    // 10
+      "discards",          // 11
+      "discards_merged",   // 12
+      "sectors_discarded", // 13
+      "discards_ms",       // 14
+      "flushes",           // 15
+      "flushes_ms"         // 16
+    };
+}
+
+template<typename StatsWrapper, typename RefreshF, typename MetricsF>
+void setup_parser(
+  ss::logger& logger,
+  StatsWrapper& stats,
+  ss::sstring filename,
+  RefreshF refresh,
+  MetricsF setup_metrics) {
+    try {
+        stats.fd = ss::file_desc::open(filename, O_RDONLY);
+
+        refresh();
+
+        if (stats.errored) {
+            return;
+        }
+
+        setup_metrics();
+    } catch (...) {
+        stats.errored = true;
+        vlog(
+          logger.error,
+          "Error opening {} file: {}",
+          filename,
+          std::current_exception());
+    }
+}
+
+host_metrics_watcher::host_metrics_watcher(ss::logger& log)
+  : _logger(log) {
+    setup_parser(
+      _logger,
+      _diskstats,
+      "/proc/diskstats",
+      [this] { maybe_refresh_diskstats(); },
+      [this] {
+          // if more disks get added after startup we will be missing them.
+          // Unlikely to happen.
+          for (const auto& [diskname, _] : _diskstats.stats) {
+              setup_metrics_for_disk(diskname);
+          }
+      });
+}
+
+void host_metrics_watcher::setup_metrics_for_disk(const std::string& diskname) {
+    const auto& stats = _diskstats.stats[diskname];
+
+    auto disk_label = seastar::metrics::label("disk");
+    const std::vector<seastar::metrics::label_instance> labels = {
+      disk_label(diskname),
+    };
+
+    for (size_t i = 0; i < stats.size() && i < diskstats_fields.size(); i++) {
+        _metrics.add_group(
+          "host_diskstats",
+          {
+            seastar::metrics::make_gauge(
+              diskstats_fields[i],
+              [this, &stats, i] {
+                  maybe_refresh_diskstats();
+                  return stats[i];
+              },
+              seastar::metrics::description(
+                fmt::format("Host diskstat {}", diskstats_fields[i])),
+              labels),
+          });
+    }
+}
+
+void host_metrics_watcher::parse_diskstats(
+  std::string_view diskstats_lines, diskstats_map& diskstats) {
+    for (auto diskline : std::views::split(diskstats_lines, '\n')) {
+        auto fields_view = std::views::split(diskline, ' ')
+                           | std::views::filter(
+                             [](const auto& s) { return !s.empty(); });
+        auto fields = std::ranges::to<std::vector<std::string>>(fields_view);
+
+        if (fields.size() < 14) {
+            // min amount of fields is 14 in linux < 4.18
+            // abort if not enough fields, something is wrong
+            continue;
+        }
+
+        auto diskname = fields[2];
+
+        // skip major number, minor number and diskname
+        auto stat_fields = fields | std::views::drop(3);
+
+        for (auto [stats, new_stats] :
+             std::views::zip(diskstats[diskname], stat_fields)) {
+            stats = std::stoull(new_stats);
+        }
+    }
+}
+
+template<typename StatsWrapper, typename ParseF>
+void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
+    if (stats.errored) {
+        return;
+    }
+
+    if (stats.last_read + std::chrono::seconds(5) > ss::lowres_clock::now()) {
+        return;
+    }
+
+    try {
+        // These files aren't really big (2KiB max) so we just use a single
+        // buffer and don't dynamically read the full thing.
+        std::array<char, 16384> read_buffer;
+
+        // We are doing a blocking read here this is because you can't do
+        // dma_reads into /proc. Reading from /proc should never block so this
+        // should be ~fine~. From tracing the calls take less than 100us
+        // generally.
+        auto bytes_read = stats.fd->pread(
+          read_buffer.data(), read_buffer.size(), 0);
+        auto lines = std::string_view(read_buffer.data(), bytes_read);
+
+        parsef(lines);
+
+        stats.last_read = ss::lowres_clock::now();
+    } catch (...) {
+        stats.errored = true;
+        vlog(
+          logger.error,
+          "Error reading diskstats: {}",
+          std::current_exception());
+    }
+}
+
+void host_metrics_watcher::maybe_refresh_diskstats() {
+    refresh_stats(_diskstats, _logger, [this](const auto& stat_lines) {
+        parse_diskstats(stat_lines, _diskstats.stats);
+    });
+}
+
+} // namespace metrics

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -1,6 +1,7 @@
 #include "host_metrics_watcher.h"
 
 #include "base/vlog.h"
+#include "config/configuration.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -67,6 +68,12 @@ void setup_parser(
 
 host_metrics_watcher::host_metrics_watcher(ss::logger& log)
   : _logger(log) {
+    if (!config::shard_local_cfg().enable_host_metrics()) {
+        return;
+    }
+
+    vlog(log.info, "Setting up host metrics exporter");
+
     setup_parser(
       _logger,
       _diskstats,

--- a/src/v/metrics/host_metrics_watcher.cc
+++ b/src/v/metrics/host_metrics_watcher.cc
@@ -12,6 +12,7 @@
 
 #include <exception>
 #include <ranges>
+#include <unordered_map>
 
 namespace metrics {
 
@@ -86,6 +87,20 @@ host_metrics_watcher::host_metrics_watcher(ss::logger& log)
               setup_metrics_for_disk(diskname);
           }
       });
+
+    setup_parser(
+      _logger,
+      _netstats,
+      "/proc/net/netstat",
+      [this]() { maybe_refresh_netstat(); },
+      [this]() { setup_netstat_metrics(); });
+
+    setup_parser(
+      _logger,
+      _snmp_stats,
+      "/proc/net/snmp",
+      [this]() { maybe_refresh_snmp(); },
+      [this]() { setup_snmp_metrics(); });
 }
 
 void host_metrics_watcher::setup_metrics_for_disk(const std::string& diskname) {
@@ -113,6 +128,55 @@ void host_metrics_watcher::setup_metrics_for_disk(const std::string& diskname) {
     }
 }
 
+void host_metrics_watcher::setup_netstat_metrics() {
+    _metrics.add_group(
+      "host_netstat",
+      {
+        seastar::metrics::make_counter(
+          "bytes_received",
+          [this] {
+              maybe_refresh_netstat();
+              return _netstats.stats.bytes_received;
+          },
+          seastar::metrics::description("Host IP bytes received")),
+        seastar::metrics::make_counter(
+          "bytes_sent",
+          [this] {
+              maybe_refresh_netstat();
+              return _netstats.stats.bytes_sent;
+          },
+          seastar::metrics::description("Host IP bytes sent")),
+      });
+}
+
+void host_metrics_watcher::setup_snmp_metrics() {
+    _metrics.add_group(
+      "host_snmp",
+      {
+        seastar::metrics::make_counter(
+          "packets_received",
+          [this] {
+              maybe_refresh_snmp();
+              return _snmp_stats.stats.packets_received;
+          },
+          seastar::metrics::description("Host IP packets received")),
+        seastar::metrics::make_counter(
+          "packets_sent",
+          [this] {
+              maybe_refresh_snmp();
+              return _snmp_stats.stats.packets_sent;
+          },
+          seastar::metrics::description("Host IP packets sent")),
+        seastar::metrics::make_gauge(
+          "tcp_established",
+          [this] {
+              maybe_refresh_snmp();
+              return _snmp_stats.stats.tcp_established;
+          },
+          seastar::metrics::description("Host TCP established connections")),
+      });
+}
+
 void host_metrics_watcher::parse_diskstats(
   std::string_view diskstats_lines, diskstats_map& diskstats) {
     for (auto diskline : std::views::split(diskstats_lines, '\n')) {
@@ -137,6 +201,77 @@ void host_metrics_watcher::parse_diskstats(
             stats = std::stoull(new_stats);
         }
     }
+}
+
+std::unordered_map<ss::sstring, std::unordered_map<ss::sstring, uint64_t>>
+parse_net_like(std::string_view netstat_lines) {
+    // There doesn't seem to be good documentation around the netstat files and
+    // less clear whether they are stable so we are parse them in a bit more
+    // generic fashion.
+
+    // section -> fields -> values
+    std::unordered_map<ss::sstring, std::unordered_map<ss::sstring, uint64_t>>
+      netstat_map;
+
+    ss::sstring last_section;
+    std::vector<ss::sstring> last_fields;
+
+    // Files are basically like this:
+    // Foo: Header1 Header2 Header3
+    // Foo: Value1 Value2 Value3
+    // So we parse by going over each line and treat first line as headers and
+    // then next as values
+    for (auto line : std::views::split(netstat_lines, '\n')) {
+        auto fields_view = std::views::split(line, ' ')
+                           | std::views::filter(
+                             [](const auto& s) { return !s.empty(); });
+        auto fields = std::ranges::to<std::vector<std::string>>(fields_view);
+
+        if (fields.size() < 2) {
+            // Bogus: Need at least two columns (section and one header/value)
+            break;
+        }
+
+        if (last_section.empty()) {
+            // header line now
+            last_section = fields[0];
+            auto header_fields = fields | std::views::drop(1);
+            last_fields = std::ranges::to<std::vector<ss::sstring>>(
+              header_fields);
+        } else if (fields[0] != last_section) {
+            // bogus: section changed without values line
+            break;
+        } else {
+            // Parse values
+            auto stat_fields = fields | std::views::drop(1);
+            for (auto [field_name, value] :
+                 std::views::zip(last_fields, stat_fields)) {
+                netstat_map[fields[0]][field_name] = std::stoull(value);
+            }
+            last_section = "";
+            last_fields.clear();
+        }
+    }
+
+    return netstat_map;
+}
+
+// snmp stats are defined here: https://www.rfc-editor.org/rfc/rfc1213
+// For the Linux extensions I couldn't find a proper documentation.
+
+void host_metrics_watcher::parse_netstat(
+  std::string_view netstat_lines, netstat_stats& net_stats) {
+    auto netstat_map = parse_net_like(netstat_lines);
+    net_stats.bytes_received = netstat_map["IpExt:"]["InOctets"];
+    net_stats.bytes_sent = netstat_map["IpExt:"]["OutOctets"];
+}
+
+void host_metrics_watcher::parse_snmp(
+  std::string_view snmp_lines, snmp_stats& snmp_stats) {
+    auto snmp_map = parse_net_like(snmp_lines);
+    snmp_stats.packets_received = snmp_map["Ip:"]["InReceives"];
+    snmp_stats.packets_sent = snmp_map["Ip:"]["OutRequests"];
+    snmp_stats.tcp_established = snmp_map["Tcp:"]["CurrEstab"];
 }
 
 template<typename StatsWrapper, typename ParseF>
@@ -177,6 +312,18 @@ void refresh_stats(StatsWrapper& stats, ss::logger& logger, ParseF parsef) {
 void host_metrics_watcher::maybe_refresh_diskstats() {
     refresh_stats(_diskstats, _logger, [this](const auto& stat_lines) {
         parse_diskstats(stat_lines, _diskstats.stats);
+    });
+}
+
+void host_metrics_watcher::maybe_refresh_netstat() {
+    refresh_stats(_netstats, _logger, [this](const auto& stat_lines) {
+        parse_netstat(stat_lines, _netstats.stats);
+    });
+}
+
+void host_metrics_watcher::maybe_refresh_snmp() {
+    refresh_stats(_snmp_stats, _logger, [this](const auto& stat_lines) {
+        parse_snmp(stat_lines, _snmp_stats.stats);
     });
 }
 

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/log.hh>
+
+#include <base/seastarx.h>
+#include <metrics/metrics.h>
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace metrics {
+
+// Wrapper class that sets up metrics that export /proc/diskstats and a few
+// values from /proc/net/snmp. Usually this is a node_exporter job but often
+// it's hard to join metrics or we don't have access to that at all. Hence we
+// export the most important metrics ourselves.
+class host_metrics_watcher {
+public:
+    host_metrics_watcher(host_metrics_watcher&&) = delete;
+    host_metrics_watcher(const host_metrics_watcher&) = delete;
+    host_metrics_watcher& operator=(host_metrics_watcher&&) = delete;
+    host_metrics_watcher& operator=(const host_metrics_watcher&) = delete;
+
+    // https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+    // As of 5.5
+    // Not counting major number, minor number and device name
+    constexpr static uint64_t diskstats_field_count = 17;
+
+    using diskstats = std::array<uint64_t, diskstats_field_count>;
+
+    // diskname -> diskstats
+    using diskstats_map = std::unordered_map<ss::sstring, diskstats>;
+
+    explicit host_metrics_watcher(ss::logger& logger);
+
+    // needed for construct_service stuff in `application`
+    ss::future<> stop() { return ss::make_ready_future(); };
+
+    // parse the actual /proc/diskstats file. static method for testability
+    static void
+    parse_diskstats(std::string_view diskstats_lines, diskstats_map& stats);
+
+private:
+    void setup_metrics_for_disk(const std::string& diskname);
+    void maybe_refresh_diskstats();
+
+    ss::logger& _logger;
+
+    template<typename Stats>
+    struct metrics_file_info {
+        // fd to metrics file - optional because ss::file_desc not default
+        // constructible
+        std::optional<ss::file_desc> fd;
+        // timestamp of last read
+        ss::lowres_clock::time_point last_read
+          = ss::lowres_clock::time_point::min();
+        // indicating whether reading has errored out. No further reading will
+        // take place
+        bool errored = false;
+        // cached values from last read
+        Stats stats;
+    };
+
+    // /proc/diskstats
+    metrics_file_info<diskstats_map> _diskstats;
+
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace metrics

--- a/src/v/metrics/host_metrics_watcher.h
+++ b/src/v/metrics/host_metrics_watcher.h
@@ -48,6 +48,17 @@ public:
     // diskname -> diskstats
     using diskstats_map = std::unordered_map<ss::sstring, diskstats>;
 
+    struct netstat_stats {
+        uint64_t bytes_received = 0;
+        uint64_t bytes_sent = 0;
+    };
+
+    struct snmp_stats {
+        uint64_t tcp_established = 0;
+        uint64_t packets_received = 0;
+        uint64_t packets_sent = 0;
+    };
+
     explicit host_metrics_watcher(ss::logger& logger);
 
     // needed for construct_service stuff in `application`
@@ -57,9 +68,20 @@ public:
     static void
     parse_diskstats(std::string_view diskstats_lines, diskstats_map& stats);
 
+    // parse the actual /proc/net/netstat file. static method for testability
+    static void
+    parse_netstat(std::string_view netstat_lines, netstat_stats& stats);
+
+    // parse the actual /proc/net/snmp file. static method for testability
+    static void parse_snmp(std::string_view snmp_lines, snmp_stats& stats);
+
 private:
     void setup_metrics_for_disk(const std::string& diskname);
+    void setup_netstat_metrics();
+    void setup_snmp_metrics();
     void maybe_refresh_diskstats();
+    void maybe_refresh_netstat();
+    void maybe_refresh_snmp();
 
     ss::logger& _logger;
 
@@ -80,6 +102,12 @@ private:
 
     // /proc/diskstats
     metrics_file_info<diskstats_map> _diskstats;
+
+    // /proc/net/netstat
+    metrics_file_info<netstat_stats> _netstats;
+
+    // /proc/net/snmp
+    metrics_file_info<snmp_stats> _snmp_stats;
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/metrics/tests/BUILD
+++ b/src/v/metrics/tests/BUILD
@@ -1,0 +1,16 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "host_metrics_watcher_test",
+    timeout = "short",
+    srcs = [
+        "host_metrics_watcher_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/metrics",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/metrics/tests/host_metrics_watcher_test.cc
+++ b/src/v/metrics/tests/host_metrics_watcher_test.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "metrics/host_metrics_watcher.h"
+
+#include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
+
+namespace metrics {
+
+TEST(DiskStatsParser, ParseDiskStatsGood) {
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590 3838657 2151727147 62187634 0 12832786 96772628 375506 274438 6540552016 27659340 958797 3600058
+ 259       1 nvme0n1p1 1182 1570 22668 1480 2 0 2 0 0 8279 9695 28 0 8307432 8215 0 0
+ 259       2 nvme0n1p2 1862 6 283442 252 48 23 544 92 0 260 358 28 0 1348816 13 0 0
+ 259       3 nvme0n1p3 18583337 9755 1060648508 2128597 10636142 2286095 1057802375 24987800 0 3052155 44045693 224239 165418 3637228912 16929295 0 0
+ 259       4 nvme0n1p4 1219720 3526 42457635 159682 6416068 266854 267304519 22854958 0 8635715 25491689 37477 28523 1199395944 2477048 0 0
+ 259       5 nvme0n1p5 6956407 6051 325499183 1035572 8998278 1285685 826619707 14344527 0 1520717 23624869 113734 80497 1694270912 8244768 0 0
+ 253       0 dm-0 1217871 0 42450873 168534 6682917 0 267304519 81228952 0 9277885 127118565 66000 0 1199395944 45721079 0 0
+ 252       0 zram0 969732 0 7766128 3504 2911882 0 23295056 17249 0 70594 20753 0 0 0 0 0 0
+ 253       1 dm-1 18587723 0 1060641794 2394466 12922232 0 1057802375 1126028723 0 3504151 1562828774 389657 0 3637228912 434405585 0 10
+)"""";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
+
+    ASSERT_EQ(disk_stats.size(), 9);
+    ASSERT_EQ(disk_stats["nvme0n1"].size(), 17);
+    ASSERT_EQ(disk_stats["nvme0n1"][0], 26762678);
+    ASSERT_EQ(disk_stats["nvme0n1"][16], 3600058);
+
+    ASSERT_EQ(disk_stats["dm-1"].size(), 17);
+    ASSERT_EQ(disk_stats["dm-1"][0], 18587723);
+    ASSERT_EQ(disk_stats["dm-1"][16], 10);
+}
+
+TEST(DiskStatsParser, ParseDiskStatsOldKernel) {
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590 3838657 2151727147 62187634 0 12832786 96772628
+)"""";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
+
+    ASSERT_EQ(disk_stats.size(), 1);
+    ASSERT_EQ(disk_stats["nvme0n1"].size(), 17);
+    ASSERT_EQ(disk_stats["nvme0n1"][0], 26762678);
+    ASSERT_EQ(disk_stats["nvme0n1"][16], 0);
+}
+
+TEST(DiskStatsParser, ParseDiskStatsTooOld) {
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590
+)"""";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
+
+    ASSERT_EQ(disk_stats.size(), 0);
+}
+
+TEST(DiskStatsParser, ParseDiskStatsGarbage) {
+    std::string_view diskstats = R""""(
+ 259       0 nvme0n1 26762678 20908 1428918348 3325593 26050590 asdf 2151727147 62187634 0 12832786 96772628 375506 274438 6540552016 27659340 958797 3600058
+)"""";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    EXPECT_THROW(
+      host_metrics_watcher::parse_diskstats(diskstats, disk_stats),
+      std::invalid_argument);
+}
+
+TEST(DiskStatsParser, ParseDiskStatsEmpty) {
+    std::string_view diskstats = "";
+
+    host_metrics_watcher::diskstats_map disk_stats;
+    host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
+
+    ASSERT_EQ(disk_stats.size(), 0);
+}
+
+} // namespace metrics

--- a/src/v/metrics/tests/host_metrics_watcher_test.cc
+++ b/src/v/metrics/tests/host_metrics_watcher_test.cc
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 namespace metrics {
 
 TEST(DiskStatsParser, ParseDiskStatsGood) {
@@ -85,6 +87,106 @@ TEST(DiskStatsParser, ParseDiskStatsEmpty) {
     host_metrics_watcher::parse_diskstats(diskstats, disk_stats);
 
     ASSERT_EQ(disk_stats.size(), 0);
+}
+
+TEST(NetstatParser, ParseNetstatGood) {
+    std::string_view netstat
+      = R""""(TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPDelivered TCPDeliveredCE TCPAckCompressed TCPZeroWindowDrop TCPRcvQDrop TCPWqueueTooBig TCPFastOpenPassiveAltKey TcpTimeoutRehash TcpDuplicateDataRehash TCPDSACKRecvSegs TCPDSACKIgnoredDubious TCPMigrateReqSuccess TCPMigrateReqFailure TCPPLBRehash TCPAORequired TCPAOBad TCPAOKeyNotFound TCPAOGood TCPAODroppedIcmps
+TcpExt: 0 0 0 43 1050 0 0 2 0 0 209179 5 0 0 7171 1252323 354 16308 0 0 11695010 3728741 25084080 0 1010 0 12037 2 517 3 46 352 182 35411 0 29 3 4414 409 58359 10636 1210 0 21 0 287572 16570 159 7265 98 37111 981 0 732 0 0 0 0 289 164 3232 57 0 0 0 4760 6421 8428 0 0 0 0 0 0 0 0 0 2914786 170106 0 161 38 28 0 0 0 0 0 0 0 724 0 382763 674 674 37701 46427 42334561 292 22415 1038 133777 10 3305 1070 0 205 0 253 216961 0 0 42583879 0 69433 0 0 0 0 57406 35 7191 289 0 0 0 0 0 0 0 0
+IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+IpExt: 0 0 62439 170 8227 0 49809079466 39136412410 13744385 18736 714165 0 0 67558266 0 389832 1 0
+MPTcpExt: MPCapableSYNRX MPCapableSYNTX MPCapableSYNACKRX MPCapableACKRX MPCapableFallbackACK MPCapableFallbackSYNACK MPCapableSYNTXDrop MPCapableSYNTXDisabled MPCapableEndpAttempt MPFallbackTokenInit MPTCPRetrans MPJoinNoTokenFound MPJoinSynRx MPJoinSynBackupRx MPJoinSynAckRx MPJoinSynAckBackupRx MPJoinSynAckHMacFailure MPJoinAckRx MPJoinAckHMacFailure MPJoinSynTx MPJoinSynTxCreatSkErr MPJoinSynTxBindErr MPJoinSynTxConnectErr DSSNotMatching DSSCorruptionFallback DSSCorruptionReset InfiniteMapTx InfiniteMapRx DSSNoMatchTCP DataCsumErr OFOQueueTail OFOQueue OFOMerge NoDSSInWindow DuplicateData AddAddr AddAddrTx AddAddrTxDrop EchoAdd EchoAddTx EchoAddTxDrop PortAdd AddAddrDrop MPJoinPortSynRx MPJoinPortSynAckRx MPJoinPortAckRx MismatchPortSynRx MismatchPortAckRx RmAddr RmAddrDrop RmAddrTx RmAddrTxDrop RmSubflow MPPrioTx MPPrioRx MPFailTx MPFailRx MPFastcloseTx MPFastcloseRx MPRstTx MPRstRx RcvPruned SubflowStale SubflowRecover SndWndShared RcvWndShared RcvWndConflictUpdate RcvWndConflict MPCurrEstab Blackhole
+MPTcpExt: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+)"""";
+
+    host_metrics_watcher::netstat_stats stats;
+    host_metrics_watcher::parse_netstat(netstat, stats);
+
+    ASSERT_EQ(stats.bytes_received, 49809079466);
+    ASSERT_EQ(stats.bytes_sent, 39136412410);
+}
+
+TEST(NetstatParser, ParseNetstatGarbage) {
+    std::string_view netstat
+      = R""""(TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPDelivered TCPDeliveredCE TCPAckCompressed TCPZeroWindowDrop TCPRcvQDrop TCPWqueueTooBig TCPFastOpenPassiveAltKey TcpTimeoutRehash TcpDuplicateDataRehash TCPDSACKRecvSegs TCPDSACKIgnoredDubious TCPMigrateReqSuccess TCPMigrateReqFailure TCPPLBRehash TCPAORequired TCPAOBad TCPAOKeyNotFound TCPAOGood TCPAODroppedIcmps
+TcpExt: 0 0 0 43 1050 0 0 2 0 0 209179 5 0 0 7171 1252323 354 16308 0 0 11695010 3728741 25084080 0 1010 0 12037 2 517 3 46 352 182 35411 0 29 3 4414 409 58359 10636 1210 0 21 0 287572 16570 159 7265 98 37111 981 0 732 0 0 0 0 289 164 3232 57 0 0 0 4760 6421 8428 0 0 0 0 0 0 0 0 0 2914786 170106 0 161 38 28 0 0 0 0 0 0 0 724 0 382763 674 674 37701 46427 42334561 292 22415 1038 133777 10 3305 1070 0 205 0 253 216961 0 0 42583879 0 69433 0 0 0 0 57406 35 7191 289 0 0 0 0 0 0 0 0
+IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+IpExt: 0 0 62439 170 8227 0 asdf 39136412410 13744385 18736 714165 0 0 67558266 0 389832 1 0
+MPTcpExt: MPCapableSYNRX MPCapableSYNTX MPCapableSYNACKRX MPCapableACKRX MPCapableFallbackACK MPCapableFallbackSYNACK MPCapableSYNTXDrop MPCapableSYNTXDisabled MPCapableEndpAttempt MPFallbackTokenInit MPTCPRetrans MPJoinNoTokenFound MPJoinSynRx MPJoinSynBackupRx MPJoinSynAckRx MPJoinSynAckBackupRx MPJoinSynAckHMacFailure MPJoinAckRx MPJoinAckHMacFailure MPJoinSynTx MPJoinSynTxCreatSkErr MPJoinSynTxBindErr MPJoinSynTxConnectErr DSSNotMatching DSSCorruptionFallback DSSCorruptionReset InfiniteMapTx InfiniteMapRx DSSNoMatchTCP DataCsumErr OFOQueueTail OFOQueue OFOMerge NoDSSInWindow DuplicateData AddAddr AddAddrTx AddAddrTxDrop EchoAdd EchoAddTx EchoAddTxDrop PortAdd AddAddrDrop MPJoinPortSynRx MPJoinPortSynAckRx MPJoinPortAckRx MismatchPortSynRx MismatchPortAckRx RmAddr RmAddrDrop RmAddrTx RmAddrTxDrop RmSubflow MPPrioTx MPPrioRx MPFailTx MPFailRx MPFastcloseTx MPFastcloseRx MPRstTx MPRstRx RcvPruned SubflowStale SubflowRecover SndWndShared RcvWndShared RcvWndConflictUpdate RcvWndConflict MPCurrEstab Blackhole
+MPTcpExt: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+)"""";
+
+    host_metrics_watcher::netstat_stats stats;
+    EXPECT_THROW(
+      host_metrics_watcher::parse_netstat(netstat, stats),
+      std::invalid_argument);
+}
+
+TEST(NetstatParser, ParseNetstatNoValuesLine) {
+    std::string_view netstat
+      = R""""(TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPDelivered TCPDeliveredCE TCPAckCompressed TCPZeroWindowDrop TCPRcvQDrop TCPWqueueTooBig TCPFastOpenPassiveAltKey TcpTimeoutRehash TcpDuplicateDataRehash TCPDSACKRecvSegs TCPDSACKIgnoredDubious TCPMigrateReqSuccess TCPMigrateReqFailure TCPPLBRehash TCPAORequired TCPAOBad TCPAOKeyNotFound TCPAOGood TCPAODroppedIcmps
+TcpExt: 0 0 0 43 1050 0 0 2 0 0 209179 5 0 0 7171 1252323 354 16308 0 0 11695010 3728741 25084080 0 1010 0 12037 2 517 3 46 352 182 35411 0 29 3 4414 409 58359 10636 1210 0 21 0 287572 16570 159 7265 98 37111 981 0 732 0 0 0 0 289 164 3232 57 0 0 0 4760 6421 8428 0 0 0 0 0 0 0 0 0 2914786 170106 0 161 38 28 0 0 0 0 0 0 0 724 0 382763 674 674 37701 46427 42334561 292 22415 1038 133777 10 3305 1070 0 205 0 253 216961 0 0 42583879 0 69433 0 0 0 0 57406 35 7191 289 0 0 0 0 0 0 0 0
+IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+MPTcpExt: MPCapableSYNRX MPCapableSYNTX MPCapableSYNACKRX MPCapableACKRX MPCapableFallbackACK MPCapableFallbackSYNACK MPCapableSYNTXDrop MPCapableSYNTXDisabled MPCapableEndpAttempt MPFallbackTokenInit MPTCPRetrans MPJoinNoTokenFound MPJoinSynRx MPJoinSynBackupRx MPJoinSynAckRx MPJoinSynAckBackupRx MPJoinSynAckHMacFailure MPJoinAckRx MPJoinAckHMacFailure MPJoinSynTx MPJoinSynTxCreatSkErr MPJoinSynTxBindErr MPJoinSynTxConnectErr DSSNotMatching DSSCorruptionFallback DSSCorruptionReset InfiniteMapTx InfiniteMapRx DSSNoMatchTCP DataCsumErr OFOQueueTail OFOQueue OFOMerge NoDSSInWindow DuplicateData AddAddr AddAddrTx AddAddrTxDrop EchoAdd EchoAddTx EchoAddTxDrop PortAdd AddAddrDrop MPJoinPortSynRx MPJoinPortSynAckRx MPJoinPortAckRx MismatchPortSynRx MismatchPortAckRx RmAddr RmAddrDrop RmAddrTx RmAddrTxDrop RmSubflow MPPrioTx MPPrioRx MPFailTx MPFailRx MPFastcloseTx MPFastcloseRx MPRstTx MPRstRx RcvPruned SubflowStale SubflowRecover SndWndShared RcvWndShared RcvWndConflictUpdate RcvWndConflict MPCurrEstab Blackhole
+MPTcpExt: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+)"""";
+
+    host_metrics_watcher::netstat_stats stats;
+    host_metrics_watcher::parse_netstat(netstat, stats);
+
+    ASSERT_EQ(stats.bytes_received, 0);
+    ASSERT_EQ(stats.bytes_sent, 0);
+}
+
+TEST(NetstatParser, ParseNetstatNoHeaderLine) {
+    std::string_view netstat
+      = R""""(TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPDelivered TCPDeliveredCE TCPAckCompressed TCPZeroWindowDrop TCPRcvQDrop TCPWqueueTooBig TCPFastOpenPassiveAltKey TcpTimeoutRehash TcpDuplicateDataRehash TCPDSACKRecvSegs TCPDSACKIgnoredDubious TCPMigrateReqSuccess TCPMigrateReqFailure TCPPLBRehash TCPAORequired TCPAOBad TCPAOKeyNotFound TCPAOGood TCPAODroppedIcmps
+TcpExt: 0 0 0 43 1050 0 0 2 0 0 209179 5 0 0 7171 1252323 354 16308 0 0 11695010 3728741 25084080 0 1010 0 12037 2 517 3 46 352 182 35411 0 29 3 4414 409 58359 10636 1210 0 21 0 287572 16570 159 7265 98 37111 981 0 732 0 0 0 0 289 164 3232 57 0 0 0 4760 6421 8428 0 0 0 0 0 0 0 0 0 2914786 170106 0 161 38 28 0 0 0 0 0 0 0 724 0 382763 674 674 37701 46427 42334561 292 22415 1038 133777 10 3305 1070 0 205 0 253 216961 0 0 42583879 0 69433 0 0 0 0 57406 35 7191 289 0 0 0 0 0 0 0 0
+IpExt: 0 0 62439 170 8227 0 asdf 39136412410 13744385 18736 714165 0 0 67558266 0 389832 1 0
+MPTcpExt: MPCapableSYNRX MPCapableSYNTX MPCapableSYNACKRX MPCapableACKRX MPCapableFallbackACK MPCapableFallbackSYNACK MPCapableSYNTXDrop MPCapableSYNTXDisabled MPCapableEndpAttempt MPFallbackTokenInit MPTCPRetrans MPJoinNoTokenFound MPJoinSynRx MPJoinSynBackupRx MPJoinSynAckRx MPJoinSynAckBackupRx MPJoinSynAckHMacFailure MPJoinAckRx MPJoinAckHMacFailure MPJoinSynTx MPJoinSynTxCreatSkErr MPJoinSynTxBindErr MPJoinSynTxConnectErr DSSNotMatching DSSCorruptionFallback DSSCorruptionReset InfiniteMapTx InfiniteMapRx DSSNoMatchTCP DataCsumErr OFOQueueTail OFOQueue OFOMerge NoDSSInWindow DuplicateData AddAddr AddAddrTx AddAddrTxDrop EchoAdd EchoAddTx EchoAddTxDrop PortAdd AddAddrDrop MPJoinPortSynRx MPJoinPortSynAckRx MPJoinPortAckRx MismatchPortSynRx MismatchPortAckRx RmAddr RmAddrDrop RmAddrTx RmAddrTxDrop RmSubflow MPPrioTx MPPrioRx MPFailTx MPFailRx MPFastcloseTx MPFastcloseRx MPRstTx MPRstRx RcvPruned SubflowStale SubflowRecover SndWndShared RcvWndShared RcvWndConflictUpdate RcvWndConflict MPCurrEstab Blackhole
+MPTcpExt: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+)"""";
+
+    host_metrics_watcher::netstat_stats stats;
+    host_metrics_watcher::parse_netstat(netstat, stats);
+
+    ASSERT_EQ(stats.bytes_received, 0);
+    ASSERT_EQ(stats.bytes_sent, 0);
+}
+
+TEST(NetstatParser, ParseNetstatEmpty) {
+    std::string_view netstat = "";
+
+    host_metrics_watcher::netstat_stats stats;
+    host_metrics_watcher::parse_netstat(netstat, stats);
+
+    ASSERT_EQ(stats.bytes_received, 0);
+    ASSERT_EQ(stats.bytes_sent, 0);
+}
+
+// No need to test edge conditions as it shares the impl with the netstat one
+TEST(SnmpParser, ParseSnmpGood) {
+    std::string_view netstat
+      = R""""(Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates OutTransmits
+Ip: 1 64 47900296 0 0 0 0 0 47899998 40889375 0 764 0 0 0 0 0 0 0 40889375
+Icmp: InMsgs InErrors InCsumErrors InDestUnreachs InTimeExcds InParmProbs InSrcQuenchs InRedirects InEchos InEchoReps InTimestamps InTimestampReps InAddrMasks InAddrMaskReps OutMsgs OutErrors OutRateLimitGlobal OutRateLimitHost OutDestUnreachs OutTimeExcds OutParmProbs OutSrcQuenchs OutRedirects OutEchos OutEchoReps OutTimestamps OutTimestampReps OutAddrMasks OutAddrMaskReps
+Icmp: 20178 0 0 20178 0 0 0 0 0 0 0 0 0 0 20165 0 0 0 20164 0 0 0 0 1 0 0 0 0 0
+IcmpMsg: InType3 OutType3 OutType8
+IcmpMsg: 20178 20164 1
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 346431 163322 1382 2356 12 48326032 56291522 72272 19 105396 0
+Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+Udp: 677388 20139 0 635596 0 0 0 8037 0
+UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+UdpLite: 0 0 0 0 0 0 0 0 0
+)"""";
+
+    host_metrics_watcher::snmp_stats stats;
+    host_metrics_watcher::parse_snmp(netstat, stats);
+
+    ASSERT_EQ(stats.tcp_established, 12);
+    ASSERT_EQ(stats.packets_received, 47900296);
+    ASSERT_EQ(stats.packets_sent, 40889375);
 }
 
 } // namespace metrics

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1421,6 +1421,8 @@ void application::wire_up_runtime_services(
 
     construct_service(_debug_bundle_service, &storage.local().kvs()).get();
 
+    construct_single_service(_host_metrics_watcher, std::ref(_log));
+
     configure_admin_server();
 }
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -39,6 +39,7 @@
 #include "kafka/server/fwd.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "metrics/aggregate_metrics_watcher.h"
+#include "metrics/host_metrics_watcher.h"
 #include "metrics/metrics.h"
 #include "net/conn_quota.h"
 #include "net/fwd.h"
@@ -360,6 +361,8 @@ private:
     config::node_override_store _node_overrides{};
 
     std::unique_ptr<crash_tracker::service> _crash_tracker_service;
+
+    std::unique_ptr<metrics::host_metrics_watcher> _host_metrics_watcher;
 
     ss::sharded<ss::abort_source> _as;
 };

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class HostMetricsTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         num_brokers=1,
+                         extra_rp_conf={"enable_host_metrics": True},
+                         **kwargs)
+
+    @cluster(num_nodes=1)
+    def test_basic_hoststats(self):
+        """
+        Test that we export the host stats
+
+        """
+
+        metrics = list(self.redpanda.metrics(self.redpanda.nodes[0]))
+
+        count = 0
+        for family in metrics:
+            if family.name == "vectorized_host_diskstats_reads":
+                for sample in family.samples:
+                    count = int(sample.value)
+
+        assert count > 0, "Expected some reads"

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -27,10 +27,20 @@ class HostMetricsTest(RedpandaTest):
 
         metrics = list(self.redpanda.metrics(self.redpanda.nodes[0]))
 
-        count = 0
+        disk_count = 0
+        netstat_count = 0
+        snmp_count = 0
         for family in metrics:
             if family.name == "vectorized_host_diskstats_reads":
                 for sample in family.samples:
-                    count = int(sample.value)
+                    disk_count += int(sample.value)
+            if family.name == "vectorized_host_netstat_bytes_received":
+                for sample in family.samples:
+                    netstat_count += int(sample.value)
+            if family.name == "vectorized_host_snmp_packets_received":
+                for sample in family.samples:
+                    snmp_count += int(sample.value)
 
-        assert count > 0, "Expected some reads"
+        assert disk_count > 0, "Expected some disk reads"
+        assert netstat_count > 0, "Expected some received bytes"
+        assert snmp_count > 0, "Expected some received packets"


### PR DESCRIPTION
While it's fundamentally the job of node_exporter to export host metrics
there is a few practical problems with it:

 - Often we don't have node_exporter metrics, e.g.: in a debug bundle
 - node_exporter metrics might not export the right metrics, e.g.: when
   running on k8s with RP running a network namespace.
 - Joining node_exporter metrics with repdanda metrics can be tricky

Hence, this patch adds very basic support to export host metrics from RP
itself.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

