### PR TITLE
Add memory_sampler_test to bazel

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -201,7 +201,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "YA64kzfEoBibr8F1Y14l6D2ukhdTl5w7ypC/9VajjyA=",
+        "bzlTransitiveDigest": "ihrfbumFrAj6CS088Sx17Iyu6TzvZW/HEhZNRDHoND0=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -378,9 +378,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
-              "strip_prefix": "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
-              "url": "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz"
+              "sha256": "963e40e474abc1db9930c7b6761d372347b427aa65958667a6a5a994cad361e1",
+              "strip_prefix": "seastar-5a4eeae48a2c8281f6e68544f335388f562b3dc8",
+              "url": "https://github.com/redpanda-data/seastar/archive/5a4eeae48a2c8281f6e68544f335388f562b3dc8.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -159,9 +159,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
-        strip_prefix = "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
-        url = "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz",
+        sha256 = "963e40e474abc1db9930c7b6761d372347b427aa65958667a6a5a994cad361e1",
+        strip_prefix = "seastar-5a4eeae48a2c8281f6e68544f335388f562b3dc8",
+        url = "https://github.com/redpanda-data/seastar/archive/5a4eeae48a2c8281f6e68544f335388f562b3dc8.tar.gz",
     )
 
     http_archive(

--- a/src/v/resource_mgmt/memory_sampling.cc
+++ b/src/v/resource_mgmt/memory_sampling.cc
@@ -62,7 +62,11 @@ ss::noncopyable_function<void(ss::memory::memory_diagnostics_writer)>
 memory_sampling::get_oom_diagnostics_callback() {
     // preallocate those so that we don't allocate on OOM
     std::vector<seastar::memory::allocation_site> allocation_sites(1000);
-    std::vector<char> format_buf(1000);
+    // a much smaller value around 1000 is generally sufficient to hold the
+    // output in release builds, but in debug or test binaries the stack traces
+    // are much larger, especially in the bazel build, due to every frame being
+    // prefixed with a large shared library path.
+    std::vector<char> format_buf(20000);
 
     return [allocation_sites = std::move(allocation_sites),
             format_buf = std::move(format_buf)](

--- a/src/v/resource_mgmt/tests/BUILD
+++ b/src/v/resource_mgmt/tests/BUILD
@@ -32,6 +32,30 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_btest(
+    name = "memory_sampling_tests",
+    timeout = "short",
+    srcs = [
+        "memory_sampling_tests.cc",
+    ],
+    target_compatible_with = select({
+        "@seastar//:use_system_allocator": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/v/config",
+        "//src/v/crash_tracker",
+        "//src/v/resource_mgmt:memory_sampling",
+        "//src/v/storage:batch_cache",
+        "//src/v/test_utils:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@fmt",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
     name = "storage_test",
     timeout = "short",
     srcs = [

--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -53,6 +53,6 @@ TEST_F(WasmTestFixture, WorksWithCpuProfiler) {
     std::vector<ss::cpu_profiler_trace> traces;
     ss::engine().profiler_results(traces);
     for (const auto& t : traces) {
-        std::cout << t.user_backtrace << "\n";
+        fmt::print("{}\n", t.user_backtrace);
     }
 }


### PR DESCRIPTION
The thrust of this change is to get memory_sampler_tests running in Bazel. To that end, this pull request includes several changes to update dependencies, improve memory diagnostics, and port existing tests to Bazel. The most important changes are summarized below:

Dependency Updates:
* Updated the `seastar` dependency in `bazel/repositories.bzl` with a new `sha256` checksum, `strip_prefix`, and `url` to point to the latest version.

Memory Diagnostics Improvements:
* Increased the size of the `format_buf` vector in `memory_sampling.cc` to 20000 to accommodate larger stack traces in debug or test binaries, especially in the bazel build.

Testing Enhancements:
* Added a new `memory_sampling_tests` target in `BUILD` to include tests for memory sampling functionality, ported from cmake side. This includes specifying sources and dependencies required for the tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
