### PR TITLE
GitHub Workflow: Add v25.1.x as backport

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v25.1.x
 - [ ] v24.3.x
 - [ ] v24.2.x
 - [ ] v24.1.x


### PR DESCRIPTION


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
