### PR TITLE
[v24.3.x] `archival`: use `log_level_for_error()` in `find_reupload_candidate()` (manual backport)

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3324,8 +3324,10 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
                 std::move(units), std::move(upload_candidate));
           },
           [this](skip_offset_range& skip_offsets) -> ret_t {
-              vlog(
-                _rtclog.warn,
+              const auto log_level = log_level_for_error(skip_offsets.reason);
+              vlogl(
+                _rtclog,
+                log_level,
                 "Failed to make reupload candidate: {}",
                 skip_offsets.reason);
               return std::make_pair(std::nullopt, std::nullopt);


### PR DESCRIPTION
Cherry-pick conflict due to some changes around this call site not being present in `v24.3.x`.

Another call site was hardcoded to `WARN` level logging, instead of using this function to determine the appropriate logging level based on the reason contained in `skip_offset_range`.

Closes https://github.com/redpanda-data/redpanda/issues/25424.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
