### PR TITLE
pandaproxy/sr: Re-purpose schema_registry_normalize_on_startup config

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3601,11 +3601,14 @@ configuration::configuration()
       "Per-shard capacity of the cache for validating schema IDs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       128)
-  , schema_registry_normalize_on_startup(
+  , schema_registry_always_normalize(
       *this,
-      "schema_registry_normalize_on_startup",
-      "Normalize schemas as they are read from the topic on startup.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      "schema_registry_always_normalize",
+      "Always normalize schemas. If set, this overrides the "
+      "normalize parameter in API requests.",
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
+       .aliases = {"schema_registry_normalize_on_startup"}},
       false)
   , schema_registry_protobuf_renderer_v2(
       *this, "schema_registry_protobuf_renderer_v2")

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -676,7 +676,7 @@ struct configuration final : public config_store {
       enable_schema_id_validation;
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
-    property<bool> schema_registry_normalize_on_startup;
+    property<bool> schema_registry_always_normalize;
     deprecated_property schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -45,7 +45,8 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>();
+    _store = std::make_unique<sharded_store>(
+      normalize{config::shard_local_cfg().schema_registry_always_normalize});
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -83,6 +83,7 @@ ss::future<> sharded_store::stop() { return _store.stop(); }
 
 ss::future<canonical_schema>
 sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
+    norm = norm || _always_normalize;
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -25,7 +25,8 @@ class store;
 /// subject or schema_id
 class sharded_store final : public schema_getter {
 public:
-    explicit sharded_store() = default;
+    explicit sharded_store(normalize always_normalize = normalize::no)
+      : _always_normalize(always_normalize) {}
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -239,6 +240,7 @@ private:
 
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
+    normalize _always_normalize;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3256,6 +3256,70 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                               subjects[subject]["schema_ids"],
                               subjects[subject]["subject_versions"])
 
+    @cluster(num_nodes=3)
+    def test_always_normalize_option(self):
+
+        # Post a schema with normalization set to off
+        result_raw = self._post_subjects_subject_versions(
+            subject="test_subject",
+            data=json.dumps({
+                "schema": imported_schema_proto_def,
+                "schemaType": "PROTOBUF"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup"
+
+        def test_schemas_ids_id(expected_schema):
+            result_raw = self._request("GET",
+                                       f"schemas/ids/1",
+                                       headers=HTTP_GET_HEADERS)
+            result = result_raw.json()["schema"].strip()
+            assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+                f"with content {result_raw.content}"
+            assert result == expected_schema, \
+                    f"Expected:\n{expected_schema}\ngot:\n{result}"
+
+        def test_subjects_subject(schema, expected_version=None, norm=False):
+            result_raw = self._post_subjects_subject(subject="test_subject",
+                                                     data=json.dumps({
+                                                         "schema":
+                                                         schema,
+                                                         "schemaType":
+                                                         "PROTOBUF",
+                                                     }),
+                                                     normalize=norm)
+            if expected_version:
+                assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+                    f"with content {result_raw.content}"
+                result = result_raw.json()["version"]
+                assert result == expected_version, \
+                        f"Expected version {expected_version} but got {result}"
+            else:
+                assert result_raw.status_code == 404, \
+                    f"Expected 404 but got {result_raw.status_code}, "\
+                    f"with content {result_raw.content}"
+
+        sanitized = imported_schema_sanitized_proto_def.strip()
+        normalized = imported_schema_normalized_proto_def.strip()
+
+        test_schemas_ids_id(sanitized)
+        test_subjects_subject(sanitized, expected_version=1)
+        test_subjects_subject(sanitized, expected_version=1, norm=True)
+        test_subjects_subject(normalized, expected_version=None)
+        test_subjects_subject(normalized, expected_version=1, norm=True)
+
+        #Update always_normalize and re-run all tests
+        self.redpanda.set_cluster_config(
+            {'schema_registry_always_normalize': True}, expect_restart=True)
+
+        test_schemas_ids_id(imported_schema_normalized_proto_def.strip())
+        test_subjects_subject(sanitized, expected_version=1)
+        test_subjects_subject(sanitized, expected_version=1, norm=True)
+        test_subjects_subject(normalized, expected_version=1)
+        test_subjects_subject(normalized, expected_version=1, norm=True)
+
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Implements: [CORE-9526](https://redpandadata.atlassian.net/browse/CORE-9526)

The new functionality allows to blanket-enable schema normalization in every SR operation.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-9526]: https://redpandadata.atlassian.net/browse/CORE-9526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ