### PR TITLE
tests/dl: made custom partitioning assertions more robust

### DIFF
--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -6,7 +6,9 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+from collections import defaultdict
 import itertools
+import re
 import time
 import random
 from uuid import uuid4
@@ -172,6 +174,31 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             itertools.dropwhile(lambda r: not r[0].startswith('# Partition'),
                                 spark_describe_out))
 
+    def partition_paths_from_files(self, spark, table_name):
+        partition_path_pattern = re.compile(
+            r".*/data/(?P<partition_path>.*)/.*parquet")
+        empty_partition_path_pattern = re.compile(r".*/data/.*parquet")
+        all_files = spark.run_query_fetch_all(
+            f"select file_path from {table_name}.files")
+        all_partitions = defaultdict(int)
+        for f in all_files:
+            m = partition_path_pattern.match(f[0])
+            if m:
+                partition_path = m.group("partition_path")
+                # remove the partition path from the file name
+                all_partitions[partition_path] += 1
+            else:
+                empty_match = empty_partition_path_pattern.match(f[0])
+                assert empty_match, f"unexpected file path: {f[0]}"
+                all_partitions[""] += 1
+        self.logger.debug("%s partition paths: %s", table_name, all_partitions)
+        return all_partitions
+
+    def assert_at_least_n_files_per_iceberg_partition(
+            self, files_per_partition: dict, n: int):
+        for partition, file_cnt in files_per_partition.items():
+            assert file_cnt >= n, f"partition {partition} has {file_cnt} files, expected at least {n}"
+
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
@@ -215,21 +242,24 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             table_name = f"redpanda.{topic_name}"
             spark = dl.spark()
 
-            files_before = set(
-                spark.run_query_fetch_all(
-                    f"select file_path from {table_name}.files"))
             # The translator for each partition should produce a file for
             # each of 2 event types.
-            assert len(files_before) == partitions * 2
+            partitions_before = self.partition_paths_from_files(
+                spark, table_name)
 
+            assert len(partitions_before) == 2
+            self.assert_at_least_n_files_per_iceberg_partition(
+                partitions_before, partitions)
             spark.make_client().cursor().execute(
                 f"delete from {table_name} where event_type='type_A'")
 
-            files_after = set(
-                spark.run_query_fetch_all(
-                    f"select file_path from {table_name}.files"))
-            assert len(files_after) == partitions
-            assert files_after.issubset(files_before)
+            partitions_after = self.partition_paths_from_files(
+                spark, table_name)
+            assert len(partitions_after) == 1
+            self.assert_at_least_n_files_per_iceberg_partition(
+                partitions_after, partitions)
+            assert set(partitions_after.keys()).issubset(
+                set(partitions_before.keys()))
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
@@ -268,10 +298,10 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             spark = dl.spark()
 
             # The translator for each partition should produce one file.
-            files1 = set(
-                spark.run_query_fetch_all(
-                    f"select file_path from {table_name}.files"))
-            assert len(files1) == partitions
+            partitions_1 = self.partition_paths_from_files(spark, table_name)
+            assert len(partitions_1) == 1
+            self.assert_at_least_n_files_per_iceberg_partition(
+                partitions_1, partitions)
 
             # partition spec should reflect the original value
             describe_partitioning = self.describe_partitioning(dl, topic_name)
@@ -287,10 +317,10 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
             # The translator for each partition should produce one file
             # for each event type.
-            files2 = set(
-                spark.run_query_fetch_all(
-                    f"select file_path from {table_name}.files"))
-            assert len(files2) == partitions * 3
+            partitions_2 = self.partition_paths_from_files(spark, table_name)
+            assert len(partitions_2) == 3
+            self.assert_at_least_n_files_per_iceberg_partition(
+                partitions_2, partitions)
 
             # partition spec should reflect the altered value
             describe_partitioning = self.describe_partitioning(dl, topic_name)
@@ -310,11 +340,10 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
 
             # The translator for each partition should produce one file
             # for each event type.
-            files3 = set(
-                spark.run_query_fetch_all(
-                    f"select file_path from {table_name}.files"))
-            assert len(files3) == partitions * 5
-
+            partitions_3 = self.partition_paths_from_files(spark, table_name)
+            assert len(partitions_3) == 5
+            self.assert_at_least_n_files_per_iceberg_partition(
+                partitions_3, partitions)
             describe_partitioning = self.describe_partitioning(dl, topic_name)
             expected_partitioning = [
                 ('# Partition Information', '', ''),
@@ -478,8 +507,8 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 backoff_sec=2)
 
             def num_partitions():
-                partitions = set(dl.spark().run_query_fetch_all(
-                    f"select partition from redpanda.{topic_name}.files"))
+                partitions = self.partition_paths_from_files(
+                    dl.spark(), f"redpanda.{topic_name}")
                 self.logger.info(f"iceberg files partitions: {partitions}")
                 return len(partitions)
 


### PR DESCRIPTION
Previously the test was assuming that there is exactly one parquet data file per Iceberg partition, with the new batching there may be more than one file. Changed the test to verify the partitions itself and min number of files per partition.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none