### PR TITLE
metrics: Enable host_metrics_watcher by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4027,7 +4027,7 @@ configuration::configuration()
       "Enable exporting of some host metrics like /proc/diskstats, /proc/snmp "
       "and /proc/net/netstat",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
-      false)
+      true)
   , datalake_scheduler_block_size_bytes(
       *this,
       "datalake_scheduler_block_size_bytes",

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -17,4 +17,5 @@ cloud:
     - redpanda_cloud_tests/rolling_restart_test.py
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest
     - redpanda_cloud_tests/cloud_self_test.py
+    - tests/host_metrics_test.py
     - tests/services_self_test.py::SimpleSelfTest.test_cloud

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -8,15 +8,12 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.redpanda_test import RedpandaMixedTest
 
 
-class HostMetricsTest(RedpandaTest):
+class HostMetricsTest(RedpandaMixedTest):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,
-                         num_brokers=1,
-                         extra_rp_conf={"enable_host_metrics": True},
-                         **kwargs)
+        super().__init__(*args, min_brokers=1, **kwargs)
 
     @cluster(num_nodes=1)
     def test_basic_hoststats(self):


### PR DESCRIPTION
Disabled by default for 25.1, enable now such that we have a full
release time to gain confidence.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none


