### PR TITLE
CORE-9245 dt: deflake crash tracker signal tests

### DIFF
--- a/tests/rptest/remote_scripts/tgkill.py
+++ b/tests/rptest/remote_scripts/tgkill.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+"""
+This script sends a signal to a specific thread within a thread group using the `tgkill` syscall.
+
+The `tgkill` system call is used to send signals to specific threads in a thread group by
+specifying the thread group ID (tgid), thread ID (tid), and the signal number (sig). See the man
+page of `tgkill` for details.
+
+Usage:
+    python3 <script_name> <tgid> <tid> <signal>
+
+Arguments:
+    tgid (int): The thread group ID of the target thread group.
+    tid (int): The thread ID of the target thread within the group.
+    sig (int): The signal number to send to the thread.
+"""
+
+import sys
+import ctypes
+import os
+import platform
+
+
+def get_tgkill_syscall_number():
+    # Source: https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#cross_arch-numbers
+    # syscall name | x86_64 | arm | arm64 | x86
+    # tgkill       | 234    | 268 | 131   | 270
+    machine = platform.machine()
+    if machine == "x86_64":
+        return 234
+    elif machine == "aarch64":
+        return 131
+    else:
+        raise NotImplementedError(
+            f"tgkill syscall number not known for architecture: {machine}")
+
+
+def tgkill(tgid, tid, sig):
+    SYS_tgkill = get_tgkill_syscall_number()
+    libc = ctypes.CDLL(None, use_errno=True)
+    ret = libc.syscall(SYS_tgkill, tgid, tid, sig)
+    if ret != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    return ret
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: {} <tgid> <tid> <signal>".format(sys.argv[0]))
+        sys.exit(1)
+    try:
+        tgid = int(sys.argv[1])
+        tid = int(sys.argv[2])
+        sig = int(sys.argv[3])
+    except ValueError:
+        print("Error: tgid, tid, and signal must be integers.")
+        sys.exit(1)
+    try:
+        tgkill(tgid, tid, sig)
+        print(
+            f"Successfully sent signal {sig} to thread {tid} in group {tgid}.")
+    except OSError as e:
+        print(f"Error sending signal: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3162,17 +3162,25 @@ class RedpandaService(RedpandaServiceBase):
         """
         if thread is None:
             pid = self.redpanda_pid(node)
-        else:
-            pid = self.redpanda_tid(node, thread)
-        if pid is None:
-            if idempotent and signal in {signal.SIGKILL, signal.SIGTERM}:
-                return
-            else:
-                raise RuntimeError(
-                    f"Can't signal redpanda on node {node.name}, it isn't running"
-                )
+            if pid is None:
+                if idempotent and signal in {signal.SIGKILL, signal.SIGTERM}:
+                    return
+                else:
+                    raise RuntimeError(
+                        f"Can't signal redpanda on node {node.name}, it isn't running"
+                    )
 
-        node.account.signal(pid, signal, allow_fail=False)
+            node.account.signal(pid, signal, allow_fail=False)
+        else:
+            tgid, tid = self.redpanda_tid(node, thread)
+            script_path = inject_remote_script(node, "tgkill.py")
+            cmd = shlex.join([
+                "python3", script_path,
+                str(tgid),
+                str(tid),
+                str(signal.value)
+            ])
+            node.account.ssh(cmd, allow_fail=False)
 
     def sockets_clear(self, node: RemoteClusterNode):
         """
@@ -4227,7 +4235,7 @@ class RedpandaService(RedpandaServiceBase):
             raise e
 
     def redpanda_tid(self, node, thread):
-        """Return the thread ID of the given thread"""
+        """Return the thread group ID and thread ID of the given thread"""
         cmd = "ps -C redpanda -T"
         for line in node.account.ssh_capture(cmd, timeout_sec=10):
             # Example line:
@@ -4237,7 +4245,7 @@ class RedpandaService(RedpandaServiceBase):
             parts = line.split()
             thread_name = parts[4]
             if thread == thread_name:
-                return int(parts[1])
+                return int(parts[0]), int(parts[1])
         return None
 
     def started_nodes(self) -> List[ClusterNode]:

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -289,10 +289,11 @@ class CrashLoopChecksTest(RedpandaTest):
             else:
                 assert False, "Test failure: not yet implemented"
 
-        assert self.redpanda.search_log_node(
-            broker,
-            f"Crash #4 at 20.* - Redpanda version: .*. {signo_prefix()} on shard {signal_shard}. Backtrace: "
-        )
+        for i in range(1, CrashLoopChecksTest.CRASH_LOOP_LIMIT + 2):
+            assert self.redpanda.search_log_node(
+                broker,
+                f"Crash #{i} at 20.* - Redpanda version: .*. {signo_prefix()} on shard {signal_shard}. Backtrace: "
+            ), f"The #{i} crash description in the crash loop limit log message is missing or malformed"
 
         report = self.read_first_crash_report()
         assert len(report['stacktrace']) > 0, \


### PR DESCRIPTION
This fixes the flakiness in the signal-based crash loop tracking tests by using `tgkill` instead of `kill` to send the signal to the targeted redpanda thread for testing. This is a test-only change to make the test more reliable.

See the commit messages for details.

I could consistently reproduce the flakiness locally (~3% failure rate), which is gone after the changes in this PR. I will also run this through CDT to verify that it works well there as well.

Fixes https://redpandadata.atlassian.net/browse/CORE-9245

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
