### PR TITLE
[CORE-9530] kafka/lag_metrics/test: Increase produce count

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -863,7 +863,7 @@ class ConsumerGroupTest(RedpandaTest):
         group = 'test-lag-metrics-group'
         # Use a small batch size to ensure that fetches are distributed across all partitions
         batch_size = 1
-        produce_msg_cnt_min = 50
+        produce_msg_cnt_min = 1000
         consume_count = (topic_count * partition_count *
                          produce_msg_cnt_min) // (2 * consumer_count)
 


### PR DESCRIPTION
Increase the number of messages consumed by the group so that all partitions get offsets committed.

Fixes CORE-9530
Fixes CORE-9395

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
