### PR TITLE
`misc`: PR followup multiplexing

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -357,7 +357,9 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         if (is_not_set(current_log.flags, bflags::should_compact)) {
             // Still perform gc() here on a regular `log_compaction_interval_ms`
             // basis. Use `try_get_units()` to avoid concurrent garbage
-            // collection with `gc_loop()`.
+            // collection with `gc_loop()`- if we fail to obtain units,
+            // it is because urgent garbage collection is already underway for
+            // this log.
             auto units = current_log.housekeeping_lock.try_get_units();
             if (units.has_value()) {
                 co_await current_log.handle->gc(

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -501,11 +501,7 @@ ss::future<> log_manager::gc_loop() {
      * data older than this threshold may be garbage collected
      */
     while (true) {
-        try {
-            co_await _gc_sem.wait(std::max(_gc_sem.current(), size_t(1)));
-        } catch (const ss::semaphore_timed_out&) {
-            // time for some chores
-        }
+        co_await _gc_sem.wait(std::max(_gc_sem.current(), size_t(1)));
 
         /*
          * When we are in a low disk space situation we would like to reclaim

--- a/tests/rptest/remote_scripts/stream_verifier_txn.py
+++ b/tests/rptest/remote_scripts/stream_verifier_txn.py
@@ -954,6 +954,7 @@ class StreamVerifier():
                 # Retry the command with some backoff to allow partition leadership to settle if this
                 # is encountered.
                 num_retries = 10
+                err = None
                 while num_retries > 0:
                     num_retries -= 1
                     try:
@@ -962,8 +963,11 @@ class StreamVerifier():
                                                            cached=False)
                         break
                     except ck.KafkaException as e:
+                        err = e
                         # Backoff
                         sleep(1)
+                else:
+                    raise err
 
                 hwms[p.partition] = hi
             return hwms

--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -36,8 +36,7 @@ class CompactionGapsTest(RedpandaTest):
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "datalake_coordinator_snapshot_max_delay_secs": 10,
                 "log_compaction_interval_ms": 10000,
-                "min_cleanable_dirty_ratio": 0.0,
-                "cloud_storage_enable_remote_read": "false"
+                "min_cleanable_dirty_ratio": 0.0
             },
             *args,
             **kwargs)
@@ -128,6 +127,9 @@ class CompactionGapsTest(RedpandaTest):
 
 class CompactionTest(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):
+        # Tiered storage read permissions are disabled in order to ensure that
+        # the KgoVerifierSeqConsumer used does not fail to validate a perfectly compacted
+        # local log due to reads of un-compacted data in TS.
         self.extra_rp_conf = {
             "iceberg_enabled": "true",
             "iceberg_catalog_commit_interval_ms": 5000,
@@ -135,7 +137,8 @@ class CompactionTest(RedpandaTest):
             "log_compaction_interval_ms": 4000,
             "log_segment_size": 2 * 1024**2,  # 2 MiB
             "compacted_log_segment_size": 1024**2,  # 1 MiB
-            "min_cleanable_dirty_ratio": 0.0
+            "min_cleanable_dirty_ratio": 0.0,
+            "cloud_storage_enable_remote_read": "false"
         }
 
         super(CompactionTest,


### PR DESCRIPTION
Requested follow-ups from various PRs, each in individual commits:

### https://github.com/redpanda-data/redpanda/pull/25370
1. [Correct](https://github.com/redpanda-data/redpanda/pull/25370#discussion_r1996422086) and clarify use of `cloud_storage_enable_remote_read = false` in `datalake/compaction_test.py`- somehow this was added to `CompactionGapsTest` and not `CompactionTest` :sweat:

### https://github.com/redpanda-data/redpanda/pull/25134:
1. [Remove](https://github.com/redpanda-data/redpanda/pull/25134#discussion_r2002164810) unneeded try/catch block in `log_manager::gc_loop()`
2. [Improve](https://github.com/redpanda-data/redpanda/pull/25134#discussion_r2002171495) comment in `log_manager::housekeeping_scan()` to discuss use of `try_get_units()`

### https://github.com/redpanda-data/redpanda/pull/25225
1. [Improve](https://github.com/redpanda-data/redpanda/pull/25225#discussion_r1976692698) error handling by raising error if retries are exhausted in `get_high_watermarks()`

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
