### PR TITLE
[Testing] dt: noop for testing

### DIFF
--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -230,6 +230,7 @@ class CrashLoopChecksTest(RedpandaTest):
                                  expect_fail=True)
 
         report = self.read_first_crash_report()
+        report2 = self.read_first_crash_report()
         assert 'Failure during startup: std::__1::system_error (error C-Ares:4, unreachable_host.com: Not found)' == report[
             'crash_message'], f'Unexpected crash message: {report["crash_message"]}'
         assert len(report['stacktrace']) > 0, \


### PR DESCRIPTION
PR for testing in CDT to try to reproduce [CORE-9396](https://redpandadata.atlassian.net/browse/CORE-9396).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-9396]: https://redpandadata.atlassian.net/browse/CORE-9396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ