### PR TITLE
Improve safe pause resume

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -419,6 +419,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
                   "anomalies",
                   sync_timeout.count(),
                   _start_term);
+                auto hold = _probe->register_archiver_on_hold(true);
                 co_await ss::sleep_abortable(sync_timeout, _as);
                 continue;
             }

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -408,10 +408,38 @@ ss::future<> ntp_archiver::upload_until_abort() {
             // The validation and printing of anomalies is happening
             // every time we start an archiver
             validator.maybe_print_scarry_log_message();
+
+            auto ok_to_skip = [&] {
+                // The gap anomalie is expected if the
+                // 'is_remote_allow_gaps_enabled' is true (either because the
+                // topic property or cluster global config).
+                int gap_anomalies = 0;
+                int ots_anomalies = 0;
+                for (const auto& anomaly : validator.get_anomalies()) {
+                    switch (anomaly.type) {
+                    case replica_state_anomaly_type::offsets_gap:
+                        gap_anomalies++;
+                        break;
+                    case replica_state_anomaly_type::ot_state:
+                        ots_anomalies++;
+                        break;
+                    }
+                }
+                if (ots_anomalies > 0) {
+                    return false;
+                }
+                return gap_anomalies == 0
+                       || _parent.get_ntp_config()
+                            .is_remote_allow_gaps_enabled();
+            }();
+
+            auto checks_disabled
+              = config::shard_local_cfg()
+                  .cloud_storage_disable_upload_consistency_checks();
+
             // Disable uploads and housekeeping if consistency
             // checks are not disabled
-            if (!config::shard_local_cfg()
-                   .cloud_storage_disable_upload_consistency_checks()) {
+            if (!checks_disabled && !ok_to_skip) {
                 // Consistency checks will not let us do anything anyway
                 vlog(
                   _rtclog.warn,
@@ -422,6 +450,16 @@ ss::future<> ntp_archiver::upload_until_abort() {
                 auto hold = _probe->register_archiver_on_hold(true);
                 co_await ss::sleep_abortable(sync_timeout, _as);
                 continue;
+            } else {
+                vlog(
+                  _rtclog.info,
+                  // The list of anomalies is logged separately
+                  "upload loop continuing in term {} with anomalies, "
+                  "consistency checks disabled: {}, gap anomalies are skipped: "
+                  "{}",
+                  _start_term,
+                  checks_disabled,
+                  ok_to_skip);
             }
         }
 

--- a/src/v/cluster/archival/probe.h
+++ b/src/v/cluster/archival/probe.h
@@ -83,6 +83,10 @@ public:
         return ss::defer(std::move(lmd));
     }
 
+    uint64_t get_num_paused_archivers() const noexcept {
+        return _num_paused_archivers;
+    }
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -2536,3 +2536,120 @@ FIXTURE_TEST(test_ntp_archiver_upload_loop_blocked, archiver_fixture) {
                && probe.value().get_num_paused_archivers() > 0;
     });
 }
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(
+  test_ntp_archiver_upload_loop_not_blocked_if_allow_gaps_set,
+  archiver_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(true);
+    // Allow-gaps is set to true so the
+    cfg.get("cloud_storage_enable_remote_allow_gaps").set_value(true);
+
+    std::vector<segment_desc> segments = {
+      // 0-99
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(0),
+       .term = model::term_id(1),
+       .num_records = 100},
+      // 100-199
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(100),
+       .term = model::term_id(1),
+       .num_records = 100},
+      // 200-299
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(200),
+       .term = model::term_id(2),
+       .num_records = 100},
+      // 300-399
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(300),
+       .term = model::term_id(2),
+       .num_records = 100},
+      // 400-499
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(400),
+       .term = model::term_id(2),
+       .num_records = 100},
+    };
+
+    init_storage_api_local(segments);
+
+    wait_for_partition_leadership(manifest_ntp);
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->last_stable_offset() >= model::offset(400);
+    }).get();
+
+    storage::log* partition_log
+      = get_local_storage_api().log_mgr().get(manifest_ntp).get();
+    partition_log
+      ->truncate_prefix(storage::truncate_prefix_config(
+        model::offset(300), ss::default_priority_class()))
+      .get();
+
+    BOOST_REQUIRE(partition_log->offsets().start_offset == model::offset(300));
+
+    vlog(
+      test_log.info,
+      "Partition is a leader, high-watermark: {}, partition: {}",
+      part->high_watermark(),
+      *part);
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+
+    // the local log is truncated and starts at offset 3000
+    std::vector<cloud_storage::segment_meta> meta;
+    meta.push_back(cloud_storage::segment_meta{
+      .is_compacted = false,
+      .size_bytes = 100,
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .delta_offset = model::offset_delta(0),
+      .segment_term = model::term_id{1},
+      .delta_offset_end = model::offset_delta(0),
+    });
+    part->archival_meta_stm()
+      ->add_segments(
+        meta,
+        std::nullopt,
+        model::producer_id{},
+        ss::lowres_clock::now() + 1s,
+        never_abort,
+        cluster::segment_validated::yes)
+      .get();
+
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(false);
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    auto initial_request = get_requests().size();
+    archiver.start().get();
+
+    // Wait until segments are uploaded
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        // Upload at least two segments (segment + index)
+        return get_requests().size() - initial_request > 4;
+    });
+}

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -34,6 +34,7 @@
 #include "storage/parser.h"
 #include "storage/storage_resources.h"
 #include "storage/tests/utils/disk_log_builder.h"
+#include "storage/types.h"
 #include "test_utils/archival.h"
 #include "test_utils/fixture.h"
 #include "test_utils/scoped_config.h"
@@ -2421,4 +2422,117 @@ FIXTURE_TEST(test_flush_with_leadership_change, archiver_fixture) {
     BOOST_REQUIRE(wait_res.get() == wait_result::lost_leadership);
 
     upload_future.get();
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_ntp_archiver_upload_loop_blocked, archiver_fixture) {
+    scoped_config cfg;
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(true);
+
+    std::vector<segment_desc> segments = {
+      // 0-99
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(0),
+       .term = model::term_id(1),
+       .num_records = 100},
+      // 100-199
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(100),
+       .term = model::term_id(1),
+       .num_records = 100},
+      // 200-299
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(200),
+       .term = model::term_id(2),
+       .num_records = 100},
+      // 300-399
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(300),
+       .term = model::term_id(2),
+       .num_records = 100},
+      // 400-499
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(400),
+       .term = model::term_id(2),
+       .num_records = 100},
+    };
+
+    init_storage_api_local(segments);
+
+    wait_for_partition_leadership(manifest_ntp);
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [part]() mutable {
+        return part->last_stable_offset() >= model::offset(400);
+    }).get();
+
+    storage::log* partition_log
+      = get_local_storage_api().log_mgr().get(manifest_ntp).get();
+    partition_log
+      ->truncate_prefix(storage::truncate_prefix_config(
+        model::offset(300), ss::default_priority_class()))
+      .get();
+
+    BOOST_REQUIRE(partition_log->offsets().start_offset == model::offset(300));
+
+    vlog(
+      test_log.info,
+      "Partition is a leader, high-watermark: {}, partition: {}",
+      part->high_watermark(),
+      *part);
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+
+    // the local log is truncated and starts at offset 3000
+    std::vector<cloud_storage::segment_meta> meta;
+    meta.push_back(cloud_storage::segment_meta{
+      .is_compacted = false,
+      .size_bytes = 100,
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .delta_offset = model::offset_delta(0),
+      .segment_term = model::term_id{1},
+      .delta_offset_end = model::offset_delta(0),
+    });
+    part->archival_meta_stm()
+      ->add_segments(
+        meta,
+        std::nullopt,
+        model::producer_id{},
+        ss::lowres_clock::now() + 1s,
+        never_abort,
+        cluster::segment_validated::yes)
+      .get();
+
+    cfg.get("cloud_storage_disable_upload_loop_for_tests").set_value(false);
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    archiver.start().get();
+
+    // Wait until blocked
+    auto& probe = get_probe(archiver);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        return probe.has_value()
+               && probe.value().get_num_paused_archivers() > 0;
+    });
 }

--- a/src/v/cluster/archival/tests/service_fixture.h
+++ b/src/v/cluster/archival/tests/service_fixture.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "cluster/archival/ntp_archiver_service.h"
+#include "cluster/archival/probe.h"
 #include "http/tests/http_imposter.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -170,6 +171,10 @@ public:
       archival::ntp_archiver&,
       archival::ntp_archiver::batch_result,
       std::optional<model::offset> lso = std::nullopt);
+
+    std::optional<ntp_level_probe>& get_probe(ntp_archiver& archiver) const {
+        return archiver._probe;
+    }
 
     ss::future<> upload_until_term_change(archival::ntp_archiver& archiver) {
         auto sync_timeout = config::shard_local_cfg()


### PR DESCRIPTION
The safe pause feature has the following problem.

If the uploads are paused with `redpanda.remote.allowgaps` set to `true` and the gaps  are actually created the new instance of the `ntp_archiver` can't be started after the leadership transfer. The `ntp_archiver` uses `replica_staet_validator` to check if the local partition didn't diverge to avoid poisoning data in the cloud storage. The validator doesn't take `allowgaps` property into account.

This PR fixes the problem. First, the `ntp_archiver` now tracks pause caused by the `replica_state_validator` using the same metric it uses to track paused archivers. Second, the `ntp_archiver` now takes 'allowgaps' property into account when it uses `replica_state_validator` after the leadership transfer. If the validator detected the gap anomaly and the 'allowgaps' property is set to 'true' the upload loop will be started normally.

This PR also adds new unit-tests that check the metric and the initial validation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none