### PR TITLE
[v25.1.x] [CORE-9530] kafka/lag_metrics/test: Increase produce count

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -863,7 +863,7 @@ class ConsumerGroupTest(RedpandaTest):
         group = 'test-lag-metrics-group'
         # Use a small batch size to ensure that fetches are distributed across all partitions
         batch_size = 1
-        produce_msg_cnt_min = 50
+        produce_msg_cnt_min = 1000
         consume_count = (topic_count * partition_count *
                          produce_msg_cnt_min) // (2 * consumer_count)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25435
