### PR TITLE
`config`: edit `iceberg` authentication cluster property descriptions

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3846,14 +3846,16 @@ configuration::configuration()
       "iceberg_rest_catalog_client_id",
       "Iceberg REST catalog user ID. This ID is used to query "
       "the catalog API for the OAuth token. Required if catalog type is set to "
-      "`rest`",
+      "`rest` and `iceberg_rest_catalog_authentication_mode` is set to "
+      "`oauth2`.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt)
   , iceberg_rest_catalog_client_secret(
       *this,
       "iceberg_rest_catalog_client_secret",
       "Secret to authenticate against Iceberg REST catalog. Required if "
-      "catalog type is set to `rest`",
+      "catalog type is set to `rest` and "
+      "`iceberg_rest_catalog_authentication_mode` is set to `oauth2`.",
       {.needs_restart = needs_restart::yes,
        .visibility = visibility::user,
        .secret = is_secret::yes},
@@ -3861,9 +3863,8 @@ configuration::configuration()
   , iceberg_rest_catalog_token(
       *this,
       "iceberg_rest_catalog_token",
-      "Token used to access the REST Iceberg catalog. If the token is present, "
-      "Redpanda ignores credentials stored in the properties "
-      "iceberg_rest_catalog_client_id and iceberg_rest_catalog_client_secret",
+      "Token used to access the REST Iceberg catalog. Required if "
+      "`iceberg_rest_catalog_authentication_mode` is set to `bearer`.",
       {.needs_restart = needs_restart::yes,
        .visibility = visibility::user,
        .secret = is_secret::yes},


### PR DESCRIPTION
To be more specific about what config properties are required for which authentication modes.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
