### PR TITLE
`datalake`: fix missing parameter in log line

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -736,7 +736,8 @@ public:
               _partition->ntp().path(),
               log_offset,
               size_after_translated,
-              _partition->last_stable_offset());
+              _partition->last_stable_offset(),
+              size_after_max_translatable);
             return std::nullopt;
         }
 


### PR DESCRIPTION
See https://ci-artifacts.dev.vectorized.cloud/redpanda/63363/0195af93-d84d-4b5b-8d54-f5dce2d4a28f/vbuild/ducktape/results/final/report.html for an example of this failing.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
