### PR TITLE
Improvments to `iobuf::append`

### DIFF
--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -76,6 +76,11 @@ public:
         return _buf.share(pos, len);
     }
 
+    // destructive move. most of the time share() will suffice.
+    ss::temporary_buffer<char> unoptimized_release() && {
+        _buf.trim(_used_bytes);
+        return std::move(_buf);
+    }
     /// destructive move. place special care when calling this method
     /// on a shared iobuf. most of the time you want share() instead of release
     ss::temporary_buffer<char> release() && {

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -370,7 +370,7 @@ private:
 #endif
 };
 
-inline void __attribute__((noinline)) dispose_io_fragment(io_fragment* f) {
+inline void dispose_io_fragment(io_fragment* f) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
     delete f; // NOLINT

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -189,7 +189,7 @@ public:
      * Since this call may perform zero-copy operations, the sharing-mutation
      * caveat in the class comment applies.
      */
-    void append(iobuf);
+    void append(iobuf&&);
 
     /*
      * Appends the contents of the passed buffer to this one.
@@ -389,14 +389,16 @@ iobuf::append(const uint8_t* src, size_t len) {
     }
     append(std::make_unique<fragment>(std::move(b)));
 }
+
 /// appends the contents of buffer; might pack values into existing space
-inline void iobuf::append(iobuf o) {
+inline void iobuf::append(iobuf&& o) {
     while (!o._frags.empty()) {
         fragment* f = &o._frags.front();
         o._frags.pop_front();
         append(f->share());
         details::dispose_io_fragment(f);
     }
+    o.clear();
 }
 
 inline void iobuf::append_fragments(iobuf o) {

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -250,6 +250,8 @@ private:
     void create_new_fragment(size_t);
     size_t last_allocation_size() const;
 
+    bool try_copy_append(const char* ptr, size_t size);
+
     container _frags;
     size_t _size{0};
     friend std::ostream& operator<<(std::ostream&, const iobuf&);
@@ -359,11 +361,10 @@ iobuf::append(const uint8_t* src, size_t len) {
     }
 }
 
-/// appends the contents of buffer; might pack values into existing space
-[[gnu::always_inline]] inline void iobuf::append(ss::temporary_buffer<char> b) {
-    if (unlikely(!b.size())) {
-        return;
-    }
+// tries to copy the buffer into the iobuf if the heuristic described below is
+// satisfied
+[[gnu::always_inline]] inline bool
+iobuf::try_copy_append(const char* ptr, size_t size) {
     const size_t last_asz = last_allocation_size();
     // The following is a heuristic to decide between copying and zero-copy
     // append of the source buffer. The rule we apply is if the buffer we are
@@ -375,11 +376,24 @@ iobuf::append(const uint8_t* src, size_t len) {
     // full-sized fragments is in practice a common operation when buffers
     // grow beyond the maximum fragment size.
     if (
-      b.size() <= last_asz
-      && b.size() < details::io_allocation_size::max_chunk_size) {
-        append(b.get(), b.size());
+      size <= last_asz && size < details::io_allocation_size::max_chunk_size) {
+        append(ptr, size);
+        return true;
+    }
+
+    return false;
+}
+
+/// appends the contents of buffer; might pack values into existing space
+[[gnu::always_inline]] inline void iobuf::append(ss::temporary_buffer<char> b) {
+    if (unlikely(!b.size())) {
         return;
     }
+
+    if (try_copy_append(b.get(), b.size())) {
+        return;
+    }
+
     if (available_bytes() > 0) {
         if (_frags.back().is_empty()) {
             pop_back();
@@ -392,11 +406,26 @@ iobuf::append(const uint8_t* src, size_t len) {
 
 /// appends the contents of buffer; might pack values into existing space
 inline void iobuf::append(iobuf&& o) {
-    while (!o._frags.empty()) {
-        fragment* f = &o._frags.front();
-        o._frags.pop_front();
-        append(f->share());
-        details::dispose_io_fragment(f);
+    for (auto& f : o._frags) {
+        auto fsize = f.size();
+
+        if (unlikely(!fsize)) {
+            continue;
+        }
+
+        if (try_copy_append(f.get(), fsize)) {
+            continue;
+        }
+
+        if (available_bytes() > 0) {
+            if (_frags.back().is_empty()) {
+                pop_back();
+            } else {
+                _frags.back().trim();
+            }
+        }
+
+        append(std::move(f).unoptimized_release());
     }
     o.clear();
 }

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -114,6 +114,8 @@ redpanda_cc_bench(
     deps = [
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/bytes:random",
         "//src/v/random:generators",
         "@seastar//:benchmark",
     ],

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -9,6 +9,8 @@
 
 #include "base/units.h"
 #include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "bytes/random.h"
 #include "random/generators.h"
 
 #include <seastar/testing/perf_tests.hh>
@@ -28,8 +30,36 @@ size_t move_bench() {
     perf_tests::stop_measuring_time();
     return inner_iters * 2;
 }
+
+// This microbench mocks common pattern in Redpanda where smaller iobufs will be
+// parsed out of a larger iobuf then appendded together. This pattern is heavily
+// used in the datalake impl.
+template<int Bufs, size_t BufSize>
+size_t append_bench() {
+    iobuf_parser parser(random_generators::make_iobuf(Bufs * BufSize));
+
+    std::vector<iobuf> buffers;
+    buffers.reserve(Bufs);
+    for (int i = 0; i < Bufs; i++) {
+        buffers.push_back(parser.share(BufSize));
+    }
+
+    iobuf res;
+    perf_tests::start_measuring_time();
+    for (int i = 0; i < Bufs; i++) {
+        res.append(std::move(buffers[i]));
+    }
+    perf_tests::stop_measuring_time();
+    perf_tests::do_not_optimize(res);
+
+    return Bufs;
+}
 } // namespace
 
 PERF_TEST(iobuf, move_bench_small) { return move_bench<71>(); }
 PERF_TEST(iobuf, move_bench_medium) { return move_bench<300_KiB>(); }
 PERF_TEST(iobuf, move_bench_large) { return move_bench<965_KiB>(); }
+
+PERF_TEST(iobuf, append_bench_small) { return append_bench<1'000, 4>(); }
+PERF_TEST(iobuf, append_bench_medium) { return append_bench<1'000, 40_KiB>(); }
+PERF_TEST(iobuf, append_bench_large) { return append_bench<1'000, 400_KiB>(); }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

During Iceberg performance testing `iobuf::append` could be seen consuming ~10% of overall reactor utilization; 
![image](https://github.com/user-attachments/assets/51983a00-3610-4574-a77b-94630c2a14d1)
This PR is an initial set of optimizations to `iobuf::append` aimed to reduce this utilization.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
