### PR TITLE
CORE-9559 crash_tracker: handle exception while initializing

### DIFF
--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -66,6 +66,8 @@ public:
         return _crash_report_file_name;
     }
 
+    bool initialized() const { return _state != state::uninitialized; }
+
 private:
     enum class state { uninitialized, initialized, filled, written, released };
     friend std::ostream& operator<<(std::ostream&, state);

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -257,6 +257,13 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
         return;
     }
 
+    if (!_writer.initialized()) {
+        // We are unable to record any exceptions that happen before the writer
+        // has been initialized
+        print_skipping();
+        return;
+    }
+
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
         // The writer has already been consumed by another crash

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -94,6 +94,20 @@ TEST_F(RecorderTest, TestUploadMarkers) {
     }
 }
 
+TEST_F(RecorderTest, TestUninitializedCrashTracker) {
+    auto rec = get_test_recorder();
+
+    // Assume that there is an exception while starting the recorder. This could
+    // happen for example if the data directory is not writable while the
+    // recorder tries to create the crash reports directory.
+
+    // Now simulate that we attempt to record this exception. This should be
+    // gracefully skipped, since the crash recorder is not initialized.
+    const auto test_eptr = std::make_exception_ptr(
+      std::runtime_error{"Test filesystem error"});
+    ASSERT_NO_THROW(rec.record_crash_exception(test_eptr));
+}
+
 namespace {
 
 size_t count_upload_markers() {


### PR DESCRIPTION
Previously if there were an exception while trying to initialize the crash tracker, that would lead to an assertion failure. This is not ideal, we should handle these kinds of exceptions gracefully with better UX.

This PR changes the behaviour to skip writing a crash report if the crash tracker is not yet initialized.

A test is added to simulate this described behaviour.

Fixes https://redpandadata.atlassian.net/browse/CORE-9559

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
