### PR TITLE
CORE-9553 crash_tracker: record arch into crash reports

### DIFF
--- a/src/v/cluster/crash_reporter.cc
+++ b/src/v/cluster/crash_reporter.cc
@@ -142,6 +142,7 @@ crash_reporter::build_crash_report_payload(
             r.stacktrace = ss::sstring{report.crash->stacktrace.c_str()};
             r.reason = fmt::format("{}", report.crash->type);
             r.app_version = report.crash->app_version;
+            r.arch = report.crash->arch;
 
             if (
               report.crash->type
@@ -302,6 +303,8 @@ void rjson_serialize(
     w.String(report.description);
     w.Key("app_version");
     w.String(report.app_version);
+    w.Key("arch");
+    w.String(report.arch);
     w.EndObject();
 }
 

--- a/src/v/cluster/crash_reporter.h
+++ b/src/v/cluster/crash_reporter.h
@@ -38,6 +38,7 @@ public:
             ss::sstring reason;
             ss::sstring description;
             ss::sstring app_version;
+            ss::sstring arch;
         };
 
         ss::sstring cluster_uuid;

--- a/src/v/crash_tracker/BUILD
+++ b/src/v/crash_tracker/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_library(
         "//src/v/serde:iobuf",
         "//src/v/serde:sstring",
         "//src/v/serde:vector",
+        "//src/v/utils:arch",
         "//src/v/utils:directory_walker",
         "//src/v/utils:file_io",
         "//src/v/version",

--- a/src/v/crash_tracker/CMakeLists.txt
+++ b/src/v/crash_tracker/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     v::serde
     v::hashing
     v::random
+    v::utils
     v::version
 )
 

--- a/src/v/crash_tracker/prepared_writer.cc
+++ b/src/v/crash_tracker/prepared_writer.cc
@@ -15,6 +15,7 @@
 #include "crash_tracker/types.h"
 #include "hashing/xx.h"
 #include "model/timestamp.h"
+#include "utils/arch.h"
 #include "version/version.h"
 
 #include <seastar/core/file-types.hh>
@@ -79,6 +80,7 @@ prepared_writer::initialize(std::filesystem::path crash_file_path) {
     }
 
     _prepared_cd.app_version = ss::sstring{redpanda_version()};
+    _prepared_cd.arch = ss::sstring{util::cpu_arch::current().name};
 
     // Update _state as the last step in initialize() to make earlier changes
     // visible across threads.

--- a/src/v/crash_tracker/tests/BUILD
+++ b/src/v/crash_tracker/tests/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_gtest(
         "//src/v/crash_tracker",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "//src/v/utils:arch",
         "//src/v/version",
         "@fmt",
         "@googletest//:gtest",

--- a/src/v/crash_tracker/tests/CMakeLists.txt
+++ b/src/v/crash_tracker/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ rp_test(
   BINARY_NAME limiter_test
   SOURCES
     limiter_test.cc
-  LIBRARIES v::gtest_main v::crash_tracker v::version Seastar::seastar
+  LIBRARIES v::gtest_main v::crash_tracker v::version v::utils Seastar::seastar
   ARGS "-- -c 1"
 )
 

--- a/src/v/crash_tracker/tests/limiter_test.cc
+++ b/src/v/crash_tracker/tests/limiter_test.cc
@@ -12,6 +12,7 @@
 #include "crash_tracker/recorder.h"
 #include "crash_tracker/types.h"
 #include "model/timestamp.h"
+#include "utils/arch.h"
 #include "version/version.h"
 
 #include <seastar/core/sstring.hh>
@@ -37,6 +38,7 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
         res.stacktrace = crash_description::reserved_string_t{
           "0xaaaaaaaa 0xbbbbbbbb"};
         res.app_version = ss::sstring{redpanda_version()};
+        res.arch = ss::sstring{util::cpu_arch::current().name};
         return recorder::recorded_crash{"", std::move(res), {}};
     };
 
@@ -46,18 +48,19 @@ TEST_F(LimiterTest, TestDescribeCrashes) {
 
     auto expected = fmt::format(
       R"(The following crashes have been recorded:
-Crash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #2 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #3 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #4 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #5 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #1 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #2 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #3 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #4 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #5 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
     ...
-Crash #7 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #8 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #9 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #10 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
-Crash #11 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.)",
-      fmt::arg("version", redpanda_version()));
+Crash #7 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #8 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #9 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #10 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.
+Crash #11 at 1970-01-01 00:00:00 UTC - Redpanda version: {version}. Arch: {arch}. Assertion error Backtrace: 0xaaaaaaaa 0xbbbbbbbb.)",
+      fmt::arg("version", redpanda_version()),
+      fmt::arg("arch", util::cpu_arch::current().name));
 
     EXPECT_EQ(crash_tracker::impl::describe_crashes(crashes), expected);
 }

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -35,8 +35,12 @@ std::ostream& operator<<(std::ostream& os, crash_type ct) {
 }
 
 std::ostream& operator<<(std::ostream& os, const crash_description& cd) {
-    fmt::print(os, "Redpanda version: {}. ", cd.app_version);
-    fmt::print(os, "{}", cd.crash_message.c_str());
+    fmt::print(
+      os,
+      "Redpanda version: {}. Arch: {}. {}",
+      cd.app_version,
+      cd.arch,
+      cd.crash_message.c_str());
 
     const auto opt_stacktrace = cd.stacktrace.c_str();
     const auto has_stacktrace = strlen(opt_stacktrace) > 0;

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -128,12 +128,13 @@ struct crash_description
     reserved_string_t crash_message;
     reserved_string_t stacktrace;
     ss::sstring app_version;
+    ss::sstring arch;
 
     crash_description() = default;
 
     auto serde_fields() {
         return std::tie(
-          type, crash_time, crash_message, stacktrace, app_version);
+          type, crash_time, crash_message, stacktrace, app_version, arch);
     }
 
     friend std::ostream& operator<<(std::ostream&, const crash_description&);

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -106,6 +106,13 @@ class CrashLoopChecksTest(RedpandaTest):
         assert len(crash_reports) > 0, "No crash reports found"
         report = next(iter(crash_reports.values()))
         self.logger.debug(f'First report: {report}')
+
+        # Run some standard checks across all crash reports we read
+        assert len(report['app_version']) > 0, \
+            f'Unexpected empty app_version for report: {report}'
+        assert len(report['arch']) > 0, \
+            f'Unexpected empty arch for report: {report}'
+
         return report
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG)
@@ -234,8 +241,6 @@ class CrashLoopChecksTest(RedpandaTest):
             'crash_message'], f'Unexpected crash message: {report["crash_message"]}'
         assert len(report['stacktrace']) > 0, \
             f'Unexpected empty stacktrace for report: {report}'
-        assert len(report['app_version']) > 0, \
-            f'Unexpected empty app_version for report: {report}'
 
     @cluster(num_nodes=1, log_allow_list=CRASH_LOOP_LOG + SIGNAL_CRASH_LOG)
     @matrix(signo=[signal.SIGSEGV, signal.SIGABRT, signal.SIGILL],

--- a/tests/rptest/tests/crash_reporter_test.py
+++ b/tests/rptest/tests/crash_reporter_test.py
@@ -92,3 +92,5 @@ class CrashReporterTest(RedpandaTest):
             f"Unexpected: {crash['description']}"
         assert len(crash['app_version']) > 0, \
             f"Unexpected: {crash['app_version']}"
+        assert len(crash['arch']) > 0, \
+            f"Unexpected: {crash['arch']}"

--- a/tools/offline_log_viewer/crash_report.py
+++ b/tools/offline_log_viewer/crash_report.py
@@ -9,5 +9,6 @@ def decode_crash_report(path: str) -> dict[str, Any]:
             'timestamp': rdr.read_int64(),
             'crash_message': rdr.read_string(),
             'stacktrace': rdr.read_string(),
-            'app_version': rdr.read_string()
+            'app_version': rdr.read_string(),
+            'arch': rdr.read_string()
         })


### PR DESCRIPTION
Adding the architecture (amd64/arm64) into the crash reports and telemetry makes it easier to decode the stacktraces in the crash reports.

Fixes https://redpandadata.atlassian.net/browse/CORE-9553

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
