### PR TITLE
bazel: Introduce odr-finder

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,6 +67,19 @@ build:sanitizer --@seastar//:system_allocator=True
 build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function
 
 # =================================
+# ODR Finder
+# =================================
+build:odr-finder --cxxopt -stdlib=libc++
+build:odr-finder --copt -g
+build:odr-finder --copt -O0
+build:odr-finder --linkopt -fuse-ld=gold
+build:odr-finder --linkopt -Wl,--detect-odr-violations
+build:odr-finder --linkopt -lc++
+build:odr-finder --linkopt -lc++abi
+build:odr-finder --strip never
+# build:odr-finder --@krb5//:linker=gold
+
+# =================================
 # clang-tidy
 # =================================
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect

--- a/.bazelrc
+++ b/.bazelrc
@@ -77,7 +77,7 @@ build:odr-finder --linkopt -Wl,--detect-odr-violations
 build:odr-finder --linkopt -lc++
 build:odr-finder --linkopt -lc++abi
 build:odr-finder --strip never
-# build:odr-finder --@krb5//:linker=gold
+build:odr-finder --@krb5//:linker=gold
 
 # =================================
 # clang-tidy

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -15,6 +15,12 @@ string_flag(
     make_variable = "SANITIZERS",
 )
 
+string_flag(
+    name = "linker",
+    build_setting_default = "lld",
+    make_variable = "LINKER",
+)
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
@@ -48,12 +54,10 @@ configure_make(
         "--disable-static",
         "--enable-asan=$(SANITIZERS)",
     ],
-    # Need to pass this additionally here because of a bug in the kerberos build where it doesn't properly pass the linker flag down
-    copts = [
-        "-fuse-ld=lld",
-    ],
     env = {
+        # Need to pass this additionally here because of a bug in the kerberos build where it doesn't properly pass the linker flag down
         "KRB5_BUILD_JOBS": "$(BUILD_JOBS)",
+        "LD": gold,
     },
     lib_source = ":srcs",
     out_shared_libs = [

--- a/bazel/thirdparty/krb5.BUILD
+++ b/bazel/thirdparty/krb5.BUILD
@@ -54,10 +54,13 @@ configure_make(
         "--disable-static",
         "--enable-asan=$(SANITIZERS)",
     ],
+    copts = [
+        "-fuse-ld=$LINKER",
+    ],
     env = {
         # Need to pass this additionally here because of a bug in the kerberos build where it doesn't properly pass the linker flag down
         "KRB5_BUILD_JOBS": "$(BUILD_JOBS)",
-        "LD": gold,
+        "LINKER": "$(LINKER)",
     },
     lib_source = ":srcs",
     out_shared_libs = [
@@ -70,6 +73,7 @@ configure_make(
     toolchains = [
         ":build_jobs",
         ":sanitizers",
+        ":linker",
     ],
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
ODR violations are evil.

ld.gold is also evil, but in this case it's more useful than other options, as it allows to detect ODR violations.

Usage:
```
bazel test --config=odr-finder //...
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
