### PR TITLE
rpk: Add guardrails for Tiered Storage properties

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -45,6 +45,7 @@ func (s *anySlice) UnmarshalYAML(n *yaml.Node) error {
 }
 
 func newSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var noConfirm bool
 	cmd := &cobra.Command{
 		Use:   "set [KEY] [VALUE]",
 		Short: "Set a single cluster configuration property",
@@ -57,7 +58,9 @@ You may also use <key>=<value> notation for setting configuration properties:
 
   rpk cluster config set log_retention_ms=-1
 
-If an empty string is given as the value, the property is reset to its default.`,
+If an empty string is given as the value, the property is reset to its default.
+Use the flag '--no-confirm' to avoid the confirmation prompt.`,
+
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var key, value string
@@ -68,6 +71,16 @@ If an empty string is given as the value, the property is reset to its default.`
 				key, value = args[0], args[1]
 			} else {
 				out.Die("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>'", args)
+			}
+			// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
+			if key == "cloud_storage_enable_remote_write" && value == "false" {
+				if !noConfirm {
+					confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
+					out.MaybeDie(err, "unable to read user input: %v", err)
+					if confirmed {
+						out.Die("Aborted by user.")
+					}
+				}
 			}
 
 			p, err := p.LoadVirtualProfile(fs)
@@ -146,6 +159,6 @@ If an empty string is given as the value, the property is reset to its default.`
 			}
 		},
 	}
-
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/topic/config.go
+++ b/src/go/rpk/pkg/cli/topic/config.go
@@ -29,7 +29,8 @@ func newAlterConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		appends   []string // key=val
 		subtracts []string // key=val
 
-		dry bool
+		dry       bool
+		noConfirm bool
 	)
 
 	cmd := &cobra.Command{
@@ -49,7 +50,7 @@ Incremental altering supports four operations:
 
 The --dry option will validate whether the requested configuration change is
 valid, but does not apply it.
-`,
+Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, topics []string) {
 			p, err := p.LoadVirtualProfile(fs)
@@ -103,6 +104,16 @@ valid, but does not apply it.
 				}
 
 				delete(setKVs, "redpanda.remote.write")
+			}
+			// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
+			if isRRW && wv == "false" {
+				if !noConfirm {
+					confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
+					out.MaybeDie(err, "unable to read user input: %v", err)
+					if confirmed {
+						out.Die("Aborted by user.")
+					}
+				}
 			}
 
 			req := kmsg.NewPtrIncrementalAlterConfigsRequest()
@@ -174,6 +185,7 @@ valid, but does not apply it.
 	cmd.Flags().StringArrayVar(&subtracts, "subtract", nil, "key=value; Value to remove from list-of-values key (repeatable)")
 
 	cmd.Flags().BoolVar(&dry, "dry", false, "Dry run: validate the alter request, but do not apply")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 
 	return cmd
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -749,7 +749,10 @@ class RpkTool:
         return res
 
     def alter_topic_config(self, topic, set_key, set_value):
-        cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
+        cmd = [
+            'alter-config', topic, "--set", f"{set_key}={set_value}",
+            "--no-confirm"
+        ]
         out = self._run_topic(cmd)
         lines = out.splitlines()
         lines = list(map(lambda x: x.strip(), lines))
@@ -1153,7 +1156,7 @@ class RpkTool:
         cmd = [
             self._rpk_binary(), "--api-urls",
             self._admin_host(), "cluster", "config", "set", key,
-            str(value)
+            str(value), "--no-confirm"
         ]
         return self._execute(cmd)
 


### PR DESCRIPTION
Prompt the user for confirmation if they are trying to set `cloud_storage_enable_remote_write` cluster config to 'false'. Do the same if they're trying to set topic property `redpanda.remote.write` to 'false'. This operation is potentially unsafe because the data loss might occur if the Tiered Storage was active. In both cases the message says `Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?` and the default choice is `Yes`. So the warning suggests a safe alternative and in order to use non-safe option the user have to chose it explicitly. 

This is a part of the safe pause/resume feature - https://github.com/redpanda-data/docs/pull/1017 (docs PR).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none