### PR TITLE
[CORE-9572] `storage`: prevent use after free for concurrent housekeeping in `log_manager`

### DIFF
--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -32,6 +32,7 @@ struct log_housekeeping_meta {
     ss::lowres_clock::time_point last_compaction;
     // Mutex used for handling concurrency between housekeeping and gc fibres
     mutex housekeeping_lock{"housekeeping_lock"};
+    ss::gate housekeeping_gate;
 
     intrusive_list_hook link;
 };

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -208,8 +208,11 @@ ss::future<> log_manager::stop() {
 
     co_await _gate.close();
     co_await ss::coroutine::parallel_for_each(
-      _logs, [this](logs_type::value_type& entry) {
-          return clean_close(entry.second->handle);
+      _logs, [this](logs_type::value_type& entry) -> ss::future<> {
+          auto close_fut = entry.second->housekeeping_gate.close();
+          return clean_close(entry.second->handle)
+            .then(
+              [f = std::move(close_fut)]() mutable { return std::move(f); });
       });
     co_await _batch_cache.stop();
     co_await ssx::async_clear(_logs);
@@ -264,6 +267,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _logs_list.shift_forward();
 
         current_log.flags |= bflags::lifetime_checked;
+
+        // Hold the housekeeping gate to prevent issues with concurrent removal
+        // of the log meta.
+        auto gate = current_log.housekeeping_gate.hold();
 
         // Obtain housekeeping lock to prevent concurrency of
         // log->apply_segment_ms() with gc fibre.
@@ -353,6 +360,10 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         _logs_list.shift_forward();
 
         current_log.flags |= bflags::compaction_checked;
+
+        // Hold the housekeeping gate to prevent issues with concurrent removal
+        // of the log meta.
+        auto gate = current_log.housekeeping_gate.hold();
 
         if (is_not_set(current_log.flags, bflags::should_compact)) {
             // Still perform gc() here on a regular `log_compaction_interval_ms`
@@ -540,6 +551,11 @@ ss::future<> log_manager::gc_loop() {
                  * applying segment.ms will make reclaimable data from the
                  * active segment visible.
                  */
+
+                // Hold the housekeeping gate to prevent issues with concurrent
+                // removal of the log meta.
+                auto gate = log_meta.housekeeping_gate.hold();
+
                 auto housekeeping_lock_holder
                   = co_await log_meta.housekeeping_lock.get_units();
                 if (!log_meta.link.is_linked()) {
@@ -586,6 +602,10 @@ ss::future<> log_manager::gc_loop() {
                       return ss::now();
                   }
 
+                  // Hold the housekeeping gate to prevent issues with
+                  // concurrent removal of the log meta.
+                  auto gate = log_meta->housekeeping_gate.hold();
+
                   auto& housekeeping_lock = log_meta->housekeeping_lock;
                   auto units = housekeeping_lock.try_get_units();
                   if (!units.has_value()) {
@@ -595,7 +615,8 @@ ss::future<> log_manager::gc_loop() {
                   return log
                     ->gc(gc_config(
                       lowest_ts_to_retain(), _config.retention_bytes()))
-                    .finally([units = std::move(units)] {});
+                    .finally(
+                      [units = std::move(units), g = std::move(gate)] {});
               });
         }
     }
@@ -744,7 +765,11 @@ ss::future<> log_manager::shutdown(model::ntp ntp) {
         co_return;
     }
 
+    auto close_fut = handle->second->housekeeping_gate.close();
+
     co_await clean_close(handle.value().second->handle);
+
+    co_await std::move(close_fut);
     vlog(stlog.debug, "Shutdown: {}", ntp);
 }
 
@@ -756,6 +781,8 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     if (!handle) {
         co_return;
     }
+
+    auto close_fut = handle->second->housekeeping_gate.close();
 
     // 'ss::shared_ptr<>' make a copy
     auto lg = handle.value().second->handle;
@@ -796,6 +823,8 @@ ss::future<> log_manager::remove(model::ntp ntp) {
     // We always dispatch topic directory deletion to core 0 as requests may
     // come from different cores
     co_await dispatch_topic_dir_deletion(topic_dir);
+
+    co_await std::move(close_fut);
 }
 
 ss::future<> remove_orphan_partition_files(

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -540,6 +540,12 @@ ss::future<> log_manager::gc_loop() {
                  * applying segment.ms will make reclaimable data from the
                  * active segment visible.
                  */
+                auto housekeeping_lock_holder
+                  = co_await log_meta.housekeeping_lock.get_units();
+                if (!log_meta.link.is_linked()) {
+                    continue;
+                }
+
                 co_await log_meta.handle->apply_segment_ms();
                 if (!log_meta.link.is_linked()) {
                     continue;


### PR DESCRIPTION
### Report 

Use-after-free log reported here: https://ci-artifacts.dev.vectorized.cloud/redpanda/63402/0195b1b0-ba28-4c12-bd98-1417f92e48c3/vbuild/ducktape/results/final/report.html

### Explanation

There is an existing concurrency issue with the removal of `ntp`s with the housekeeping and garbage collection loop, following the sequence of events on fibres 1 and 2:

- F1: `log_manager::remove(ntp)` is called, `auto handle = _logs.extract(ntp)` invoked. The `handle` is a `std::unique_ptr`, which when it goes out of scope, will destruct the `housekeeping_lock`. We yield at many points in this function after extracting `handle` and closing the underlying `log`.

- F2: In `log_manager::housekeeping_scan()`, we obtain units from the `housekeeping_lock` and store them in `housekeeping_lock_holder`.

- F2: `disk_log_impl::apply_segment_ms()` is called from `housekeeping_scan()`. We yield.

- F1: We return back to `log_manager::remove(ntp)`, and have finished up all of our work. The function completes, and on exiting the scope the `std::unique_ptr<> handle` and its contained member variables, including `housekeeping_lock`, are destructed.

- F2: In `disk_log_impl::apply_segment_ms()`, the `_compaction_housekeeping_gate` or `_segments_rolling_lock` will be closed at this point, so we can expect an early return due to an exception being thrown.

- F2: Back in `log_manager::housekeeping_scan()`, we exit the scope, destructing `housekeeping_lock_holder`. This destructor calls `return_all()`, which in turn calls `_sem->signal()`, which is now a use-after-free.

This sort of concurrency issue is present everywhere we have added a new call site to `housekeeping_lock.get_units()`.

### Fix

One solution would be to check `link.is_linked()` after each scheduling point past the time `housekeeping_lock.get_units()` is called, and call `release()` on the holder to prevent attempting to call to `_sem->signal()` in case it has been freed already. However, this is quite a bit of repetitive code.

To better avoid this problem, ensure that a newly added `housekeeping_gate` is held during asynchronous housekeeping functions in the `log_manager`. Then, ensure we await `gate.close()` in functions that remove `log_housekeeping_meta` objects from `_logs`.

We already wait for compaction to complete within `disk_log_impl::remove()` and `disk_log_impl::close()` in the existing implementation, so this is not a regression in behavior in terms of the speed at which these removal functions complete in `log_manager`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
