### PR TITLE
kafka/server: address issues in consumer group metrics test

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -97,7 +97,8 @@ class ConsumerGroupTest(RedpandaTest):
                          topic,
                          group,
                          static_members,
-                         consumer_properties={}):
+                         consumer_properties={},
+                         err_msg=""):
 
         consumers = []
         for i in range(0, consumer_count):
@@ -117,7 +118,7 @@ class ConsumerGroupTest(RedpandaTest):
             gr = rpk.group_describe(group=group, summary=True)
             return gr.members == consumer_count and gr.state == "Stable"
 
-        wait_until(group_is_ready, 60, 1)
+        wait_until(group_is_ready, 60, 1, err_msg)
         return consumers
 
     def consumed_at_least(consumers, count):
@@ -163,6 +164,7 @@ class ConsumerGroupTest(RedpandaTest):
         """
         self.create_topic(20)
         group = 'test-gr-1'
+
         # use 2 consumers
         consumers = self.create_consumers(2,
                                           self.topic_spec.name,
@@ -756,18 +758,21 @@ class ConsumerGroupTest(RedpandaTest):
         self.producer.free()
 
     @cluster(num_nodes=6)
-    @parametrize(enabled_group_metrics=[])
-    @parametrize(enabled_group_metrics=["group"])
-    @parametrize(enabled_group_metrics=["partition"])
-    @parametrize(enabled_group_metrics=["consumer_lag"])
-    @parametrize(enabled_group_metrics=["group", "partition"])
-    @parametrize(enabled_group_metrics=["group", "consumer_lag"])
-    @parametrize(enabled_group_metrics=["partition", "consumer_lag"])
-    @parametrize(enabled_group_metrics=["group", "partition", "consumer_lag"])
-    def test_group_metrics(self, enabled_group_metrics):
+    @parametrize(metrics=[])
+    @parametrize(metrics=["group"])
+    @parametrize(metrics=["partition"])
+    @parametrize(metrics=["consumer_lag"])
+    @parametrize(metrics=["group", "partition"])
+    @parametrize(metrics=["group", "consumer_lag"])
+    @parametrize(metrics=["partition", "consumer_lag"])
+    @parametrize(metrics=["group", "partition", "consumer_lag"])
+    def test_group_metrics(self, metrics):
         """
         Test validating the behavior of group metrics
         """
+        #Make a copy as we modify it later
+        enabled_group_metrics = metrics[:]
+
         def flip_option(option):
             if option in enabled_group_metrics:
                 enabled_group_metrics.remove(option)
@@ -778,12 +783,14 @@ class ConsumerGroupTest(RedpandaTest):
             {"enable_consumer_group_metrics": enabled_group_metrics})
 
         self.create_topic(20)
-        group = 'test-gr-1'
+        group = f'test-gr-{"-".join(metrics)}-{random.randint(1, 1000)}'
         # use 2 consumers
-        consumers = self.create_consumers(2,
-                                          self.topic_spec.name,
-                                          group,
-                                          static_members=False)
+        consumers = self.create_consumers(
+            2,
+            self.topic_spec.name,
+            group,
+            static_members=False,
+            err_msg=f"Failed to create consumers for group {group}")
 
         self.start_producer()
         # wait for some messages


### PR DESCRIPTION
Fixes: [CORE-9505](https://redpandadata.atlassian.net/browse/CORE-9505)

Parameterized value was being modified during the test. This messed up the reporting during the test. It is now copied to a local variable.

Always using the same group name made the test fragile. A hanging consumer on the first run would be picked up by consecutive reruns. Randomized the group name on every run.

Added error message in create_consumer function to be able to provide some context.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none



[CORE-9505]: https://redpandadata.atlassian.net/browse/CORE-9505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ