### PR TITLE
cpu_profiler_test: do not customize memory, CPU resources

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -418,7 +418,7 @@ class ResourceSettings:
     def num_cpus(self):
         return self._num_cpus
 
-    def to_cli(self, *, dedicated_node):
+    def to_cli(self, *, dedicated_node: bool):
         """
 
         Generate Redpanda CLI flags based on the settings passed in at construction
@@ -439,12 +439,9 @@ class ResourceSettings:
         else:
             memory_mb = self._memory_mb
 
-        if self._bypass_fsync is None and not dedicated_node:
-            bypass_fsync = True
-        else:
-            bypass_fsync = self._bypass_fsync
+        bypass_fsync = True if dedicated_node else self._bypass_fsync
 
-        args = []
+        args: list[str] = []
         if not dedicated_node:
             args.extend([
                 "--kernel-page-cache=true", "--overprovisioned ",
@@ -459,9 +456,8 @@ class ResourceSettings:
             args.append(f"--smp={num_cpus}")
         if memory_mb is not None:
             args.append(f"--memory={memory_mb}M")
-        if bypass_fsync is not None:
-            args.append(
-                f"--unsafe-bypass-fsync={'1' if bypass_fsync else '0'}")
+
+        args.append(f"--unsafe-bypass-fsync={'1' if bypass_fsync else '0'}")
 
         return preamble, " ".join(args)
 

--- a/tests/rptest/tests/cpu_profiler_admin_api_test.py
+++ b/tests/rptest/tests/cpu_profiler_admin_api_test.py
@@ -45,12 +45,12 @@ def assert_profile_good_v2(profile: dict[str, Any],
 
 
 class CPUProfilerAdminAPITest(RedpandaTest):
-    topics = (TopicSpec(partition_count=30, replication_factor=3), )
+    topics = (TopicSpec(partition_count=30, replication_factor=1), )
 
     def __init__(self, test_context):
         super(CPUProfilerAdminAPITest, self).__init__(
             test_context=test_context,
-            num_brokers=3,
+            num_brokers=1,
             log_config=LoggingConfig('info',
                                      logger_levels={'resources': 'trace'}),
             extra_rp_conf={
@@ -60,7 +60,7 @@ class CPUProfilerAdminAPITest(RedpandaTest):
 
         self.admin = Admin(self.redpanda)
 
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=2)
     def test_get_cpu_profile_with_override(self):
         # Provide traffic so there is something to sample.
         with repeater_traffic(context=self.test_context,
@@ -72,7 +72,7 @@ class CPUProfilerAdminAPITest(RedpandaTest):
             profile = self.admin.get_cpu_profile(wait_ms=30 * 1_000)
             assert_profile_good_v2(profile)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=1)
     def test_get_cpu_profile_with_override_limits(self):
         try:
             self.admin.get_cpu_profile(wait_ms=16 * 60 * 1_000)
@@ -88,27 +88,11 @@ class CPUProfilerAdminAPITest(RedpandaTest):
         else:
             assert False, "call with wait_ms < 1ms should have failed"
 
-
-class CPUProfilerStressTest(RedpandaTest):
-    def __init__(self, test_context):
-        super().__init__(test_context=test_context,
-                         num_brokers=1,
-                         log_config=LoggingConfig(
-                             'info', logger_levels={'resources': 'trace'}),
-                         extra_rp_conf={
-                             "cpu_profiler_enabled": False,
-                             "cpu_profiler_sample_period_ms": 1,
-                         })
-
-        self.admin = Admin(self.redpanda)
-
-        self.redpanda.set_resource_settings(
-            ResourceSettings(memory_mb=4096, num_cpus=10))
-
     @cluster(num_nodes=1)
     def test_cpu_profile_stress(self):
         self.redpanda.set_cluster_config({
             "cpu_profiler_enabled": True,
+            "cpu_profiler_sample_period_ms": 1,
         })
 
         node0 = self.redpanda.nodes[0]
@@ -147,4 +131,3 @@ class CPUProfilerStressTest(RedpandaTest):
         # are some other frames outside of the recursive ones added by the stress
         # tool)
         assert max_frames == 64, f"max samples too low: {max_frames}"
-        # self.logger.warn(f"xxx\n {json.dumps(shard_sample, indent=2)}")


### PR DESCRIPTION
We hardcoded CPUs to 10, but any custom CPU number is fraught because
it has to work in an "unknown" CDT environment, docker CI environment
and localhost docker environment (which is not the same as CI as the
number of CPUs, for example is exposed from the host to the container).

So stop trying to do this and just make it a default resources test as
the other ones in this file.

Also, use 1 redpanda node for all of these tests as I see no benefit in
using a 3 node cluster.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
