### PR TITLE
rptest: test with many partition translators

### DIFF
--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -167,10 +167,11 @@ class DatalakeServices():
                                      partitions=1,
                                      replicas=1,
                                      iceberg_mode="key_value",
-                                     target_lag_ms=10000,
+                                     target_lag_ms:int|None = None,
                                      config: dict[str, Any] = dict()):
         config[TopicSpec.PROPERTY_ICEBERG_MODE] = iceberg_mode
-        config[TopicSpec.PROPERTY_ICEBERG_TARGET_LAG_MS] = target_lag_ms
+        if target_lag_ms:
+            config[TopicSpec.PROPERTY_ICEBERG_TARGET_LAG_MS] = target_lag_ms
         rpk = RpkTool(self.redpanda)
         rpk.create_topic(topic=name,
                          partitions=partitions,

--- a/tests/rptest/tests/datalake/simple_connect_test.py
+++ b/tests/rptest/tests/datalake/simple_connect_test.py
@@ -63,6 +63,8 @@ class RedpandaConnectIcebergTest(RedpandaTest, DataMigrationTestMixin):
                 True,
                 "iceberg_catalog_commit_interval_ms":
                 self.FAST_COMMIT_INTVL_S * 1000,
+                "iceberg_target_lag_ms":
+                self.FAST_COMMIT_INTVL_S * 1000,
             },
             schema_registry_config=SchemaRegistryConfig())
         self.dl = DatalakeServices(

--- a/tests/rptest/tests/datalake/translators_stress_test.py
+++ b/tests/rptest/tests/datalake/translators_stress_test.py
@@ -1,0 +1,138 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+import time
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.services.catalog_service import CatalogType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings
+from rptest.services.redpanda_connect import RedpandaConnectService
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.util import firewall_blocked
+from rptest.utils.rpcn_utils import counter_stream_config
+from typing import Any
+
+
+class TranslatorsStressTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(TranslatorsStressTest,
+              self).__init__(test_ctx,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context=test_ctx),
+                             extra_rp_conf={
+                                 "iceberg_enabled": "true",
+                                 "iceberg_catalog_commit_interval_ms": 1000
+                             },
+                             schema_registry_config=SchemaRegistryConfig(),
+                             pandaproxy_config=PandaproxyConfig(),
+                             *args,
+                             **kwargs)
+        self.test_ctx = test_ctx
+        self.topic_name = "test"
+        self.rpcn = RedpandaConnectService(self.test_context, self.redpanda)
+
+    def setUp(self):
+        # NOTE: defer cluster startup to DatalakeServices.
+        self.rpcn.start()
+
+    def start_unstructured_topic_stream(
+        self,
+        dl: DatalakeServices,
+        topic: str,
+        replicas: int = 1,
+        partitions: int = 1,
+        create_topic: bool = True,
+        topic_config: dict[str, Any] = dict()) -> str:
+        """
+        Creates a RPCN stream ingesting to non-structured the given Iceberg
+        topic, optionally creating the topic. Returns the stream name.
+        """
+        # Send a low volume of records. We don't want to overwhelm the cluster.
+        rpcn_modest_interval_ms = 100
+        cfg = counter_stream_config(
+            self.redpanda,
+            topic,
+            "",  # subject
+            cnt=0,  # indefinite count
+            interval_ms=rpcn_modest_interval_ms)
+        if create_topic:
+            dl.create_iceberg_enabled_topic(topic,
+                                            replicas=replicas,
+                                            partitions=partitions,
+                                            iceberg_mode="key_value",
+                                            config=topic_config)
+        stream = f"{topic}_stream"
+        self.rpcn.start_stream(name=stream, config=cfg)
+        return stream
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_translation_intervals(self, cloud_storage_type):
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=CatalogType.REST_HADOOP) as dl:
+            max_lag_prop_name = "redpanda.iceberg.target.lag.ms"
+            realtime_topic = "rapidash"
+            laggy_topic = "slowpoke"
+            realtime_stream = self.start_unstructured_topic_stream(
+                dl,
+                realtime_topic,
+                partitions=200,
+                topic_config={max_lag_prop_name: 10000})
+            laggy_stream = self.start_unstructured_topic_stream(
+                dl,
+                laggy_topic,
+                partitions=200,
+                topic_config={max_lag_prop_name: 30000})
+
+            spark = dl.spark()
+
+            def max_offsets_by_partition(topic):
+                max_offsets_query =  \
+                  "select redpanda.partition, count(*) " \
+                  f"from redpanda.{topic} " \
+                  "group by redpanda.partition " \
+                  "order by redpanda.partition"
+                return dict(spark.run_query_fetch_all(max_offsets_query))
+
+            def all_partitions_translated(topic, partitions, count):
+                max_offsets = max_offsets_by_partition(topic)
+                self.redpanda.logger.debug(f"Current translated offsets for {topic}, has {len(max_offsets)}: {max_offsets}")
+                for p in range(partitions):
+                    if p not in max_offsets:
+                        self.redpanda.logger.debug(f"Missing {topic}/{p}")
+                        return False
+                    o = max_offsets[p]
+                    if o < count:
+                        self.redpanda.logger.debug(f"{topic}/{p} offset {o} < {count}")
+                        return False
+                return True
+
+            # time.sleep(30)
+            # s3_port = self.si_settings.cloud_storage_api_endpoint_port
+            # with firewall_blocked(self.redpanda.nodes, s3_port):
+            #     time.sleep(10)
+
+            # time.sleep(30)
+
+            # with firewall_blocked(self.redpanda.nodes, s3_port):
+            #     time.sleep(10)
+            time.sleep(80)
+
+            wait_until(
+                lambda: all_partitions_translated(realtime_topic, 200, 1),
+                timeout_sec=120,
+                backoff_sec=1)
+            wait_until(lambda: all_partitions_translated(laggy_topic, 200, 1),
+                       timeout_sec=120,
+                       backoff_sec=1)


### PR DESCRIPTION
Currently OOMs.

```
DEBUG 2025-03-20 20:07:18,366 [shard 1:data] seastar_memory - Failed to allocate 768 bytes at 0x88290c0 0x854542f 0x854b366 0x2a64e99 0x2a65768 0x2a645cc 0x2a61136 0x2a2a388 0x2a14b47 0x29f9e97 0x29f3056 0x29e8190 0x2b06d25 0x2b06986 0x2afe9cf 0x2ae3805 0x2ae3466 0x2ad0457 0x2a8c950 0x29b7c7c 0x299812f 0x85ea3f2 0x85eecd7 0x86551e9 0x8580202 /home/awong/xfs/vbuild/bazel-out/redpanda/libexec/../lib/libc.so.6+0x94ac2 /home/awong/xfs/vbuild/bazel-out/redpanda/libexec/../lib/libc.so.6+0x12684f
--------
seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_2, true>, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_2, true>>(seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_2, true>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_2, true>&, seastar::future_state<seastar::internal::monostate>&&), void>
--------
seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_3, false>, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_3, false>>(seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_3, false>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void>::finally_body<datalake::translation::partition_translator::run_one_translation_iteration(detail::base_named_type<long, kafka::kafka_offset_type, std::__1::integral_constant<bool, true>>)::$_3, false>&, seastar::future_state<seastar::internal::monostate>&&), void>
--------
seastar::internal::coroutine_traits_base<seastar::bool_class<datalake::translation::finish_immediately_tag>>::promise_type
--------
seastar::internal::coroutine_traits_base<void>::promise_type
--------
N7seastar12continuationINS_8internal22promise_base_with_typeIvEEZNS_6futureIvE16handle_exceptionIZZZN8datalake11translation20partition_translator4initERNS8_10scheduling24scheduling_notificationsERNSA_20reservations_trackerEENK3$_0clEvENKUlvE_clEvEUlRKSt13exception_ptrE_Qoooooosr3stdE16is_invocable_r_vINS4_IT_EETL0__SH_Eaaeqsr3stdE12tuple_size_vINSt3__111conditionalIXsr3stdE9is_same_vINS1_18future_stored_typeIJSL_EE4typeENS1_9monostateEEENSP_5tupleIJEEENSV_IJST_EEEE4typeEELi0Esr3stdE16is_invocable_r_vIvSO_SH_Eaaeqsr3stdE12tuple_size_vISZ_ELi1Esr3stdE16is_invocable_r_vISL_SO_SH_Eaagtsr3stdE12tuple_size_vISZ_ELi1Esr3stdE16is_invocable_r_vISZ_SO_SH_EEES5_OSL_EUlS10_E_ZNS5_17then_wrapped_nrvoIS5_S11_EENS_8futurizeISL_E4typeEOT0_EUlOS3_RS11_ONS_12future_stateISU_EEE_vEE
--------
seastar::continuation<seastar::internal::promise_base_with_type<void>, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0::operator()() const::'lambda'()::operator()() const::'lambda'(), seastar::future<void> seastar::future<void>::then_impl_nrvo<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0::operator()() const::'lambda'()::operator()() const::'lambda'(), seastar::future<void>>(datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0::operator()() const::'lambda'()::operator()() const::'lambda'()&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0::operator()() const::'lambda'()::operator()() const::'lambda'()&, seastar::future_state<seastar::internal::monostate>&&), void>
--------
N7seastar12continuationINS_8internal22promise_base_with_typeIvEEZNS_6futureIvE16handle_exceptionIZZZN3ssx35repeat_until_gate_closed_or_abortedIZN8datalake11translation20partition_translator4initERNSA_10scheduling24scheduling_notificationsERNSC_20reservations_trackerEE3$_0EEvRNS_4gateERNS_12abort_sourceEOT_ENUlvE_clEvENUlvE0_clEvEUlRKSt13exception_ptrE_Qoooooosr3stdE16is_invocable_r_vINS4_ISM_EETL0__SQ_Eaaeqsr3stdE12tuple_size_vINSt3__111conditionalIXsr3stdE9is_same_vINS1_18future_stored_typeIJSM_EE4typeENS1_9monostateEEENSX_5tupleIJEEENS13_IJS11_EEEE4typeEELi0Esr3stdE16is_invocable_r_vIvSW_SQ_Eaaeqsr3stdE12tuple_size_vIS17_ELi1Esr3stdE16is_invocable_r_vISM_SW_SQ_Eaagtsr3stdE12tuple_size_vIS17_ELi1Esr3stdE16is_invocable_r_vIS17_SW_SQ_EEES5_SN_EUlSN_E_ZNS5_17then_wrapped_nrvoIS5_S18_EENS_8futurizeISM_E4typeEOT0_EUlOS3_RS18_ONS_12future_stateIS12_EEE_vEE
--------
seastar::internal::do_until_state<void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()::operator()()::'lambda'(), void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()::operator()()::'lambda0'()>
--------
seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()>(seastar::gate::holder&&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'(), false>, seastar::futurize<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()>(seastar::gate::holder&&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'(), false>>(seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()>(seastar::gate::holder&&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'(), false>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::future<void>::finally_body<auto seastar::internal::invoke_func_with_gate<void ssx::repeat_until_gate_closed_or_aborted<datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0>(seastar::gate&, seastar::abort_source&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'()>(seastar::gate::holder&&, datalake::translation::partition_translator::init(datalake::translation::scheduling::scheduling_notifications&, datalake::translation::scheduling::reservations_tracker&)::$_0&&)::'lambda'(), false>&, seastar::future_state<seastar::internal::monostate>&&), void>
--------
seastar::internal::coroutine_traits_base<void>::promise_type
Recorded crash reason to crash file.
ERROR 2025-03-20 20:07:18,366 [shard 1:data] seastar_memory - Dumping seastar memory diagnostics
Used memory:   1G
Free memory:   0B
Total memory:  1G
Hard failures: 1
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
