### PR TITLE
[CORE-9571] `storage`: add bytes before calling `release_appender()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1997,9 +1997,10 @@ ss::future<> disk_log_impl::force_roll(ss::io_priority_class iopc) {
     if (!ptr->has_appender()) {
         co_return co_await new_segment(next_offset, t, iopc);
     }
+
+    add_segment_bytes(ptr, ptr->size_bytes());
     co_return co_await ptr->release_appender(_readers_cache.get())
-      .then([this, ptr, next_offset, t, iopc] {
-          add_segment_bytes(ptr, ptr->size_bytes());
+      .then([this, next_offset, t, iopc] {
           return new_segment(next_offset, t, iopc);
       });
 }
@@ -2024,8 +2025,8 @@ ss::future<> disk_log_impl::maybe_roll_unlocked(
         size_should_roll = true;
     }
     if (t != term() || size_should_roll) {
-        co_await ptr->release_appender(_readers_cache.get());
         add_segment_bytes(ptr, ptr->size_bytes());
+        co_await ptr->release_appender(_readers_cache.get());
         co_await new_segment(next_offset, t, iopc);
     }
 }
@@ -2100,8 +2101,8 @@ ss::future<> disk_log_impl::apply_segment_ms() {
     auto pc = last->appender()
                 .get_priority_class(); // note: has_appender is true, the
                                        // bouncer condition checked this
-    co_await last->release_appender(_readers_cache.get());
     add_segment_bytes(last, last->size_bytes());
+    co_await last->release_appender(_readers_cache.get());
     auto offsets = last->offsets();
     auto new_so = model::next_offset(offsets.get_committed_offset());
     co_await new_segment(new_so, offsets.get_term(), pc);


### PR DESCRIPTION
### CI failure/Motivation:

https://redpandadata.atlassian.net/browse/CORE-9571

Here, the backtrace is caused by a call to `subtract_segment_bytes()` through `remove_segment_permanently("remove_prefix_full_segments"))`:

```
INFO  2025-03-20 16:17:17,263 [shard 0:main] storage - disk_log_impl.cc:2836 - Removing "/var/lib/redpanda/data/redpanda/controller/0_0/70-2-v1.log" (remove_prefix_full_segments, {offset_tracker:{term:2, base_offset:70, committed_offset:74, dirty_offset:74}, compacted_segment=0, finished_self_compaction=0, finished_windowed_compaction=0, generation=11, reader={/var/lib/redpanda/data/redpanda/controller/0_0/70-2-v1.log, (527 bytes)}, writer=nullptr, cache={cache_size=5, dirty tracker: {min: -9223372036854775808, max: -9223372036854775808}}, compaction_index:nullopt, closed=0, tombstone=0, index={file:/var/lib/redpanda/data/redpanda/controller/0_0/70-2-v1.base_index, offsets:70, index:{header_bitflags:0, base_offset:70, max_offset:74, base_timestamp:{timestamp: 1742487411153}, max_timestamp:{timestamp: 1742487436741}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{{timestamp: 1742487436742}}, num_compactible_records_appended:{4}, clean_compact_timestamp:{nullopt}, may_have_tombstone_records:1, index(1, 1, 1)}, step:32768, needs_persistence:0}})
ERROR 2025-03-20 16:17:17,263 [shard 0:main] assert - Assert failure: (/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-0193eae41f8fb6291-1/redpanda/redpanda/src/v/storage/disk_log_impl.cc:4180) '_dirty_segment_bytes >= 0' _dirty_segment_bytes must not be negative.
```

Suspiciously, this call site is where we do some funny business with releasing a write lock holder early, before allowing the `remove_segment_permanently()` future to resolve: https://github.com/redpanda-data/redpanda/blob/d281a76adf7f630a92cefefef186246e92376c35/src/v/storage/disk_log_impl.cc#L2923-L2929

### Interpretation

There still seem to be races with the removal of segments that have been "closed" (i.e don't have an appender) and the addition/subtraction of their bytes.

For example, it is possible that `release_appender()` is called, a segment's appender is released, but due to a concurrent race with prefix truncation, the end result is a segment's bytes being subtracted before they are added in the first place.

Fix this issue by adding the bytes before calling into `release_appender()` in order to guarantee that any bytes removed from a segment without an appender will have been added previously.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
