### PR TITLE
Consumer Groups logging improvements

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -128,7 +128,7 @@ group::group(
   , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets, _lag_metrics)
-  , _ctxlog(klog, *this)
+  , _ctxlog(cg_klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
   , _term(term)
@@ -169,7 +169,7 @@ group::group(
   , _catchup_lock(std::move(catchup_lock))
   , _partition(std::move(partition))
   , _probe(_members, _static_members, _offsets, _lag_metrics)
-  , _ctxlog(klog, *this)
+  , _ctxlog(cg_klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
   , _md_serializer(std::move(serializer))
   , _term(term)
@@ -2623,18 +2623,18 @@ ss::future<error_code> group::remove() {
           raft::replicate_options(raft::consistency_level::quorum_ack));
         if (result) {
             vlog(
-              klog.trace,
+              cg_klog.trace,
               "Replicated group delete record {} at offset {}",
               _id,
               result.value().last_offset);
         } else if (result.error() == raft::errc::shutting_down) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot replicate group {} delete records due to shutdown",
               _id);
         } else {
             vlog(
-              klog.warn,
+              cg_klog.warn,
               "Error occurred replicating group {} delete records {} ({})",
               _id,
               result.error().message(),
@@ -2642,7 +2642,7 @@ ss::future<error_code> group::remove() {
         }
     } catch (const std::exception& e) {
         vlog(
-          klog.error,
+          cg_klog.error,
           "Exception occurred replicating group {} delete records {}",
           _id,
           e);
@@ -2669,7 +2669,7 @@ ss::future<> group::remove_topic_partitions(
       in_state(group_state::empty) && _pending_offset_commits.empty()
       && _offsets.empty()) {
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "Marking group {} as dead at {} generation",
           _id,
           generation());
@@ -2691,7 +2691,10 @@ ss::future<> group::remove_topic_partitions(
     // create deletion records for offsets from deleted partitions
     for (auto& offset : removed) {
         vlog(
-          klog.trace, "Removing offset for group {} tp {}", _id, offset.first);
+          cg_klog.trace,
+          "Removing offset for group {} tp {}",
+          _id,
+          offset.first);
         add_offset_tombstone_record(_id, offset.first, builder);
     }
 
@@ -2709,19 +2712,19 @@ ss::future<> group::remove_topic_partitions(
           raft::replicate_options(raft::consistency_level::quorum_ack));
         if (result) {
             vlog(
-              klog.trace,
+              cg_klog.trace,
               "Replicated group cleanup record {} at offset {}",
               _id,
               result.value().last_offset);
         } else if (result.error() == raft::errc::shutting_down) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot replicate group {} cleanup records due to shutdown",
               _id);
         } else {
             // TODO: consider adding retries in this case
             vlog(
-              klog.warn,
+              cg_klog.warn,
               "Error occurred replicating group {} cleanup records {} ({})",
               _id,
               result.error().message(),
@@ -2729,7 +2732,7 @@ ss::future<> group::remove_topic_partitions(
         }
     } catch (const std::exception& e) {
         vlog(
-          klog.error,
+          cg_klog.error,
           "Exception occurred replicating group {} cleanup records {}",
           _id,
           e);
@@ -3423,7 +3426,7 @@ void group::update_subscriptions() {
             subs.merge(decode_consumer_subscriptions(std::move(data)));
         } catch (const std::out_of_range& e) {
             vlog(
-              klog.warn,
+              cg_klog.warn,
               "Parsing consumer:{} data for group {} member {} failed: {}",
               _protocol.value(),
               _id,

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -888,6 +888,14 @@ ss::future<> group_manager::handle_partition_leader_change(
                   std::nullopt);
                 auto expected_to_read = model::prev_offset(
                   p->partition->high_watermark());
+                vlog(
+                  cg_klog.info,
+                  "Recovering group state from {}, offset expected to read {}, "
+                  "log offsets: {}, raft protocol state: {}",
+                  p->partition->ntp(),
+                  expected_to_read,
+                  p->partition->log()->offsets(),
+                  p->partition->raft()->meta());
                 return p->partition->make_reader(reader_config)
                   .then([this, term, p, timeout, expected_to_read](
                           model::record_batch_reader reader) {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -257,7 +257,7 @@ std::optional<std::chrono::seconds> group_manager::offset_retention_enabled() {
      */
     if (_prev_offset_retention_enabled != enabled) {
         vlog(
-          klog.info,
+          cg_klog.info,
           "Group offset retention is now {} (prev {}). Legacy enabled {} "
           "retention_sec {} original version {}.",
           enabled ? "enabled" : "disabled",
@@ -303,7 +303,10 @@ ss::future<> group_manager::handle_offset_expiration() {
 
     if (total) {
         vlog(
-          klog.info, "Removed {} offsets from {} groups", total, groups.size());
+          cg_klog.info,
+          "Removed {} offsets from {} groups",
+          total,
+          groups.size());
     }
 }
 
@@ -332,7 +335,7 @@ ss::future<size_t> group_manager::delete_offsets(
 
     for (auto& offset : offsets) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "Preparing tombstone for expired group offset {}:{}",
           group,
           offset);
@@ -346,7 +349,7 @@ ss::future<size_t> group_manager::delete_offsets(
             _groups.erase(it);
             if (group->generation() > 0) {
                 vlog(
-                  klog.trace,
+                  cg_klog.trace,
                   "Preparing tombstone for dead group following offset "
                   "expiration {}",
                   group);
@@ -374,7 +377,7 @@ ss::future<size_t> group_manager::delete_offsets(
 
         if (result) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Wrote {} tombstone records for group {} expired offsets",
               offsets.size(),
               group);
@@ -382,19 +385,19 @@ ss::future<size_t> group_manager::delete_offsets(
 
         } else if (result.error() == raft::errc::shutting_down) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot replicate tombstone records for group {}: shutting down",
               group);
 
         } else if (result.error() == raft::errc::not_leader) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot replicate tombstone records for group {}: not leader",
               group);
 
         } else {
             vlog(
-              klog.error,
+              cg_klog.error,
               "Cannot replicate tombstone records for group {}: {} {}",
               group,
               result.error().message(),
@@ -403,7 +406,7 @@ ss::future<size_t> group_manager::delete_offsets(
 
     } catch (...) {
         vlog(
-          klog.error,
+          cg_klog.error,
           "Exception occurred replicating tombstones for group {}: {}",
           group,
           std::current_exception());
@@ -449,7 +452,7 @@ ss::future<> group_manager::stop() {
 }
 
 void group_manager::detach_partition(const model::ntp& ntp) {
-    klog.debug("detaching group metadata partition {}", ntp);
+    vlog(cg_klog.debug, "detaching group metadata partition {}", ntp);
     ssx::spawn_with_gate(_gate, [this, _ntp{ntp}]() mutable {
         return do_detach_partition(std::move(_ntp));
     });
@@ -487,7 +490,7 @@ ss::future<> group_manager::do_detach_partition(model::ntp ntp) {
 }
 
 void group_manager::attach_partition(ss::lw_shared_ptr<cluster::partition> p) {
-    klog.debug("attaching group metadata partition {}", p->ntp());
+    vlog(cg_klog.debug, "attaching group metadata partition {}", p->ntp());
     auto attached = ss::make_lw_shared<attached_partition>(p);
     auto res = _partitions.try_emplace(p->ntp(), attached);
     // TODO: this is not a forever assertion. this should just generally never
@@ -524,7 +527,7 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
                     if (it->second != g) {
                         return ss::now();
                     }
-                    vlog(klog.trace, "Removed group {}", g);
+                    vlog(cg_klog.trace, "Removed group {}", g);
                     _groups.erase(it);
                     _groups.rehash(0);
                     return ss::now();
@@ -561,7 +564,7 @@ void group_manager::handle_topic_delta(
                 });
           })
           .handle_exception([](std::exception_ptr e) {
-              vlog(klog.warn, "Topic clean-up encountered error: {}", e);
+              vlog(cg_klog.warn, "Topic clean-up encountered error: {}", e);
           });
 }
 
@@ -624,7 +627,7 @@ ss::future<std::error_code> group_manager::inject_noop(
 
 ss::future<>
 group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
-    vlog(klog.trace, "Removing groups of {}", p->partition->ntp());
+    vlog(cg_klog.trace, "Removing groups of {}", p->partition->ntp());
 
     /**
      * since this operation is destructive for partitions group we hold a
@@ -638,7 +641,7 @@ group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
     for (auto it = _groups.begin(); it != _groups.end();) {
         if (it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(it->second);
-            vlog(klog.trace, "Removed group {}", it->second);
+            vlog(cg_klog.trace, "Removed group {}", it->second);
             _groups.erase(it++);
             continue;
         }
@@ -702,7 +705,7 @@ ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
     snapshots.emplace_back();
     auto* cur_snap = &snapshots.back();
     cur_snap->offsets_topic_pid = ntp.tp.partition;
-    vlog(klog.debug, "Snapshotting {} groups from {}", groups.size(), ntp);
+    vlog(cg_klog.debug, "Snapshotting {} groups from {}", groups.size(), ntp);
     for (const auto& [group_id, group] : groups) {
         group_offsets go;
         go.group_id = group_id();
@@ -718,7 +721,7 @@ ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
             go.offsets.emplace_back(t, std::move(ps));
         }
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "Snapshotting offsets for {} topics from group {}",
           go.offsets.size(),
           go.group_id);
@@ -743,7 +746,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
       snap.offsets_topic_pid,
     };
     vlog(
-      klog.info,
+      cg_klog.info,
       "Received request to recover {} groups from snapshot on partition {}",
       snap.groups.size(),
       offsets_ntp);
@@ -763,7 +766,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
     auto lock = co_await attached_partition->catchup_lock->hold_write_lock();
 
     vlog(
-      klog.info,
+      cg_klog.info,
       "Proceeding to recover {} groups on {}",
       snap.groups.size(),
       offsets_ntp);
@@ -778,7 +781,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
             // begun using ths group, and we can't overwrite the commits since
             // this is a destructive operation.
             vlog(
-              klog.info,
+              cg_klog.info,
               "Skipping restore of group {} from snapshot on {}, already "
               "exists in state {}",
               kafka_r.data.group_id,
@@ -801,7 +804,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
             co_await ss::maybe_yield();
         }
         vlog(
-          klog.info,
+          cg_klog.info,
           "Recovering group {} from snapshot on {}",
           kafka_r.data.group_id,
           offsets_ntp);
@@ -813,7 +816,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
             for (const auto& kafka_p : kafka_t.partitions) {
                 if (kafka_p.error_code != kafka::error_code::none) {
                     vlog(
-                      klog.warn,
+                      cg_klog.warn,
                       "Error on {}/{} while recovering group {} on {}: {}",
                       kafka_t.name,
                       kafka_p.partition_index,
@@ -842,7 +845,7 @@ ss::future<> group_manager::handle_partition_leader_change(
         return gc_partition_state(p);
     }
 
-    vlog(klog.trace, "Recovering groups of {}", p->partition->ntp());
+    vlog(cg_klog.trace, "Recovering groups of {}", p->partition->ntp());
 
     p->loading = true;
     auto timeout
@@ -860,7 +863,7 @@ ss::future<> group_manager::handle_partition_leader_change(
             .then([this, term, timeout, p](std::error_code error) {
                 if (error) {
                     vlog(
-                      klog.warn,
+                      cg_klog.warn,
                       "error injecting partition {} linearizable barrier - {}",
                       p->partition->ntp(),
                       error.message());
@@ -896,7 +899,7 @@ ss::future<> group_manager::handle_partition_leader_change(
                                 group_recovery_consumer_state state) {
                             if (state.last_read_offset < expected_to_read) {
                                 vlog(
-                                  klog.error,
+                                  cg_klog.error,
                                   "error recovering group state from {}. "
                                   "Expected to read up to {} but last offset "
                                   "consumed is equal to {}",
@@ -939,7 +942,7 @@ ss::future<> group_manager::recover_partition(
      */
     if (!ctx.has_offset_retention_feature_fence) {
         vlog(
-          klog.info,
+          cg_klog.info,
           "Scheduling write of offset retention feature fence for partition {}",
           p->partition);
         ssx::spawn_with_gate(
@@ -968,9 +971,13 @@ ss::future<> group_manager::do_recover_group(
     if (group_stm.has_data()) {
         auto group = get_group(group_id);
         vlog(
-          klog.info, "Recovering {} - {}", group_id, group_stm.get_metadata());
+          cg_klog.info,
+          "Recovering {} - {}",
+          group_id,
+          group_stm.get_metadata());
         for (const auto& member : group_stm.get_metadata().members) {
-            vlog(klog.debug, "Recovering group {} member {}", group_id, member);
+            vlog(
+              cg_klog.debug, "Recovering group {} member {}", group_id, member);
         }
 
         if (!group) {
@@ -1030,7 +1037,8 @@ ss::future<> group_manager::do_recover_group(
 
         if (group_stm.is_removed()) {
             if (group_stm.offsets().size() > 0) {
-                klog.warn(
+                vlog(
+                  cg_klog.warn,
                   "Unexpected active group unload {} while loading {}",
                   group_id,
                   p->partition->ntp());
@@ -1065,7 +1073,7 @@ ss::future<> group_manager::write_version_fence(
 
             if (result) {
                 vlog(
-                  klog.info,
+                  cg_klog.info,
                   "Prepared partition {} for consumer offset retention feature "
                   "during upgrade",
                   p->partition->ntp());
@@ -1073,7 +1081,7 @@ ss::future<> group_manager::write_version_fence(
 
             } else if (result.error() == raft::errc::shutting_down) {
                 vlog(
-                  klog.debug,
+                  cg_klog.debug,
                   "Cannot write offset retention version fence for partition "
                   "{}: shutting down",
                   p->partition->ntp());
@@ -1081,7 +1089,7 @@ ss::future<> group_manager::write_version_fence(
 
             } else if (result.error() == raft::errc::not_leader) {
                 vlog(
-                  klog.debug,
+                  cg_klog.debug,
                   "Cannot write offset retention version fence for partition "
                   "{}: not leader",
                   p->partition->ntp());
@@ -1089,7 +1097,7 @@ ss::future<> group_manager::write_version_fence(
 
             } else {
                 vlog(
-                  klog.warn,
+                  cg_klog.warn,
                   "Could not write offset retention feature fence for "
                   "partition {}: {} {}",
                   p->partition->ntp(),
@@ -1098,7 +1106,7 @@ ss::future<> group_manager::write_version_fence(
             }
         } catch (const ss::gate_closed_exception&) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot write offset retention version fence for partition {}: "
               "partition shutting down",
               p->partition->ntp());
@@ -1106,7 +1114,7 @@ ss::future<> group_manager::write_version_fence(
 
         } catch (const ss::abort_requested_exception&) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Cannot write offset retention version fence for partition {}: "
               "partition abort requested",
               p->partition->ntp());
@@ -1114,7 +1122,7 @@ ss::future<> group_manager::write_version_fence(
 
         } catch (...) {
             vlog(
-              klog.error,
+              cg_klog.error,
               "Exception occurred writing offset retention feature fence for "
               "partition {}: {}",
               p->partition,
@@ -1137,7 +1145,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
       r.data.session_timeout_ms < _conf.group_min_session_timeout_ms()
       || r.data.session_timeout_ms > _conf.group_max_session_timeout_ms()) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "Join group {} rejected for invalid session timeout {} valid range "
           "[{},{}]. Request {}",
           r.data.group_id,
@@ -1158,7 +1166,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
         // not exist we should reject the request.</kafka>
         if (r.data.member_id != unknown_member_id) {
             vlog(
-              klog.trace,
+              cg_klog.trace,
               "Join group {} rejected for known member {} joining unknown "
               "group. Request {}",
               r.data.group_id,
@@ -1175,7 +1183,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
             // gone. this is generally not going to be a scenario that can
             // happen until we have rebalancing / partition deletion feature.
             vlog(
-              klog.trace,
+              cg_klog.trace,
               "Join group {} rejected for unavailable ntp {}",
               r.data.group_id,
               r.ntp);
@@ -1196,7 +1204,8 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
         _groups.emplace(r.data.group_id, group);
         _groups.rehash(0);
         is_new_group = true;
-        vlog(klog.trace, "Created new group {} while joining", r.data.group_id);
+        vlog(
+          cg_klog.trace, "Created new group {} while joining", r.data.group_id);
     }
 
     auto ret = group->handle_join_group(std::move(r), is_new_group);
@@ -1230,7 +1239,7 @@ group::sync_group_stages group_manager::sync_group(sync_group_request&& r) {
           stages.result.finally([group] {}));
     } else {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "Cannot handle sync group request for unknown group {}",
           r.data.group_id);
         return group::sync_group_stages(
@@ -1256,7 +1265,7 @@ ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
     }
 
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "Cannot handle heartbeat request for unknown group {}",
       r.data.group_id);
 
@@ -1276,7 +1285,7 @@ group_manager::leave_group(leave_group_request&& r) {
         return group->handle_leave_group(std::move(r)).finally([group] {});
     } else {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "Cannot handle leave group request for unknown group {}",
           r.data.group_id);
         if (r.version < api_version(3)) {
@@ -1649,7 +1658,7 @@ group_manager::describe_group(const model::ntp& ntp, const kafka::group_id& g) {
 
 group_manager::partition_producers
 group_manager::describe_partition_producers(const model::ntp& ntp) {
-    vlog(klog.debug, "describe producers: {}", ntp);
+    vlog(cg_klog.debug, "describe producers: {}", ntp);
     partition_producers response;
     response.partition_index = ntp.tp.partition;
     auto it = _partitions.find(ntp);
@@ -1774,14 +1783,17 @@ error_code group_manager::validate_group_status(
   const model::ntp& ntp, const group_id& group, api_key api) {
     if (!valid_group_id(group, api)) {
         vlog(
-          klog.debug, "Group name {} is invalid for operation {}", group, api);
+          cg_klog.debug,
+          "Group name {} is invalid for operation {}",
+          group,
+          api);
         return error_code::invalid_group_id;
     }
 
     if (const auto it = _partitions.find(ntp); it != _partitions.end()) {
         if (!it->second->partition->is_leader()) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Group {} operation {} sent to non-leader coordinator {}",
               group,
               api,
@@ -1791,7 +1803,7 @@ error_code group_manager::validate_group_status(
 
         if (it->second->loading) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "Group {} operation {} sent to loading coordinator {}",
               group,
               api,
@@ -1816,7 +1828,7 @@ error_code group_manager::validate_group_status(
     }
 
     vlog(
-      klog.debug,
+      cg_klog.debug,
       "Group {} operation {} misdirected to non-coordinator {}",
       group,
       api,
@@ -1917,7 +1929,7 @@ group_manager::get_group_producers_locally(
 }
 
 ss::future<> group_manager::collect_consumer_lag_metrics() {
-    vlog(klog.trace, "group_manager::collect_consumer_lag_metrics");
+    vlog(cg_klog.trace, "group_manager::collect_consumer_lag_metrics");
 
     using lag = size_t;
     partition_offsets_request request;

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -30,7 +30,7 @@ group_recovery_consumer::handle_raft_data(model::record_batch batch) {
 ss::future<> group_recovery_consumer::handle_tx_offsets(
   model::record_batch_header hdr, kafka::group_tx::offsets_metadata data) {
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "[group: {}] recovered update tx offsets: {}",
       data.group_id,
       data);
@@ -44,7 +44,7 @@ ss::future<> group_recovery_consumer::handle_fence_v0(
     auto pid = model::producer_identity{
       header.producer_id, header.producer_epoch};
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "[group: {}] recovered tx fence version: {} for producer: {}",
       data.group_id,
       group::fence_control_record_v0_version,
@@ -59,7 +59,7 @@ ss::future<> group_recovery_consumer::handle_fence_v1(
     auto pid = model::producer_identity{
       header.producer_id, header.producer_epoch};
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "[group: {}] recovered tx fence version: {} for producer: {} - {}",
       data.group_id,
       group::fence_control_record_v1_version,
@@ -83,7 +83,7 @@ ss::future<> group_recovery_consumer::handle_fence(
     auto group_it = _state.groups.find(data.group_id);
     if (group_it == _state.groups.end()) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "[group: {}] group does not exist, ignoring tx fence version: {} for "
           "producer: {} - {}",
           data.group_id,
@@ -93,7 +93,7 @@ ss::future<> group_recovery_consumer::handle_fence(
         co_return;
     }
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "[group: {}] recovered tx fence version: {} for producer: {} - {}",
       data.group_id,
       group::fence_control_record_version,
@@ -116,7 +116,7 @@ ss::future<> group_recovery_consumer::handle_abort(
     auto group_it = _state.groups.find(data.group_id);
     if (group_it == _state.groups.end()) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "[group: {}] group does not exist, ignoring abort for "
           "producer: {} - sequence {}",
           data.group_id,
@@ -125,7 +125,7 @@ ss::future<> group_recovery_consumer::handle_abort(
         co_return;
     }
     vlog(
-      klog.trace,
+      cg_klog.trace,
       "[group: {}] recovered abort tx_seq: {}",
       data.group_id,
       data.tx_seq);
@@ -140,21 +140,21 @@ ss::future<> group_recovery_consumer::handle_commit(
     auto group_it = _state.groups.find(data.group_id);
     if (group_it == _state.groups.end()) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "[group: {}] group does not exist, ignoring commit for "
           "producer: {}",
           data.group_id,
           pid);
         co_return;
     }
-    vlog(klog.trace, "[group: {}] recovered commit tx", data.group_id);
+    vlog(cg_klog.trace, "[group: {}] recovered commit tx", data.group_id);
     group_it->second.commit(pid);
     co_return;
 }
 
 ss::future<> group_recovery_consumer::handle_version_fence(
   features::feature_table::version_fence fence) {
-    vlog(klog.trace, "recovered version fence");
+    vlog(cg_klog.trace, "recovered version fence");
     if (
       fence.active_version
       >= to_cluster_version(features::release_version::v23_1_1)) {
@@ -192,7 +192,7 @@ void group_recovery_consumer::handle_record(model::record r) {
         __builtin_unreachable();
     } catch (...) {
         vlog(
-          klog.error,
+          cg_klog.error,
           "error handling group metadata record - {}",
           std::current_exception());
     }
@@ -203,14 +203,16 @@ void group_recovery_consumer::handle_group_metadata(group_metadata_kv md) {
         // until we switch over to a compacted topic or use raft snapshots,
         // always take the latest entry in the log.
         vlog(
-          klog.trace, "[group: {}] recovered group metadata", md.key.group_id);
+          cg_klog.trace,
+          "[group: {}] recovered group metadata",
+          md.key.group_id);
 
         auto [group_it, _] = _state.groups.try_emplace(
           md.key.group_id, group_stm());
         group_it->second.overwrite_metadata(std::move(*md.value));
     } else {
         // tombstone
-        vlog(klog.trace, "[group: {}] recovered tombstone", md.key.group_id);
+        vlog(cg_klog.trace, "[group: {}] recovered tombstone", md.key.group_id);
         _state.groups.erase(md.key.group_id);
     }
 }
@@ -219,7 +221,7 @@ void group_recovery_consumer::handle_offset_metadata(offset_metadata_kv md) {
     model::topic_partition tp(md.key.topic, md.key.partition);
     if (md.value) {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "[group: {}] recovered {}/{} committed offset: {}",
           md.key.group_id,
           md.key.topic,
@@ -236,7 +238,7 @@ void group_recovery_consumer::handle_offset_metadata(offset_metadata_kv md) {
           tp, _batch_base_offset, std::move(*md.value));
     } else {
         vlog(
-          klog.trace,
+          cg_klog.trace,
           "[group: {}] recovered {}/{} committed offset tombstone",
           md.key.group_id,
           md.key.topic,

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -32,7 +32,8 @@ auto group_router::route(Request&& r, FwdFunc func) {
 
     auto m = shard_for(r.data.group_id);
     if (!m) {
-        vlog(klog.trace, "in route() not coordinator for {}", r.data.group_id);
+        vlog(
+          cg_klog.trace, "in route() not coordinator for {}", r.data.group_id);
         return ss::make_ready_future<resp_type>(
           resp_type(r, error_code::not_coordinator));
     }

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -58,7 +58,7 @@ void group_tx_tracker_stm::maybe_add_tx_begin_offset(
     auto it = _all_txs.find(group);
     if (it == _all_txs.end()) {
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "[{}] group not found, ignoring fence of type: {} at offset: {}",
           group,
           fence_type,
@@ -74,7 +74,7 @@ void group_tx_tracker_stm::maybe_end_tx(
     auto it = _all_txs.find(group);
     if (it == _all_txs.end()) {
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "[{}] group not found, ignoring end transaction for pid: {} at "
           "offset: {}",
           group,
@@ -86,7 +86,7 @@ void group_tx_tracker_stm::maybe_end_tx(
     auto p_it = group_data.producer_states.find(pid);
     if (p_it == group_data.producer_states.end()) {
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "[{}] ignoring end transaction, no in progress transaction for pid: "
           "{} at offset: {}",
           group,
@@ -184,12 +184,12 @@ ss::future<> group_tx_tracker_stm::handle_raft_data(model::record_batch batch) {
 
 void group_tx_tracker_stm::handle_group_metadata(group_metadata_kv md) {
     if (md.value) {
-        vlog(klog.trace, "[group: {}] update", md.key.group_id);
+        vlog(cg_klog.trace, "[group: {}] update", md.key.group_id);
         // A group may checkpoint periodically as the member's state changes,
         // here we retain the group state if the group already exists.
         _all_txs.try_emplace(md.key.group_id, per_group_state{});
     } else {
-        vlog(klog.trace, "[group: {}] tombstone", md.key.group_id);
+        vlog(cg_klog.trace, "[group: {}] tombstone", md.key.group_id);
         // A tombstone indicates all the group state can be purged and
         // any transactions can be ignored. Although care must be taken
         // to ensure there are no open transactions before tombstoning
@@ -282,7 +282,7 @@ group_tx_tracker_stm_factory::group_tx_tracker_stm_factory(
 void group_tx_tracker_stm_factory::create(
   raft::state_machine_manager_builder& builder, raft::consensus* raft) {
     auto stm = builder.create_stm<kafka::group_tx_tracker_stm>(
-      klog, raft, _feature_table);
+      cg_klog, raft, _feature_table);
     raft->log()->stm_manager()->add_stm(stm);
 }
 
@@ -302,7 +302,7 @@ void group_tx_tracker_stm::per_group_state::maybe_add_tx_begin(
           .timeout = tx_timeout};
         if (p_state.expired_deprecated_fence_tx()) {
             vlog(
-              klog.debug,
+              cg_klog.debug,
               "[{}] Ignoring stale tx_fence batch at offset: {}, considering "
               "it expired",
               group,
@@ -310,7 +310,7 @@ void group_tx_tracker_stm::per_group_state::maybe_add_tx_begin(
             return;
         }
         vlog(
-          klog.debug,
+          cg_klog.debug,
           "[{}] Adding begin tx : {}, pid: {} at offset: {}, ts: {} with "
           "timeout: {}",
           group,
@@ -330,7 +330,7 @@ void group_tx_tracker_stm::per_group_state::gc_expired_tx_fence_transactions() {
     while (it != producer_states.end()) {
         if (it->second.expired_deprecated_fence_tx()) {
             vlog(
-              klog.warn,
+              cg_klog.warn,
               "Expiring stale tx_fence based begin tx at offset: {} for "
               "producer: {}",
               it->second.begin_offset,

--- a/src/v/kafka/server/logger.cc
+++ b/src/v/kafka/server/logger.cc
@@ -21,4 +21,5 @@ seastar::logger client_quota_log("kafka_quotas");
 static constexpr size_t max_log_line_bytes = 128_KiB;
 truncating_logger kwire(klog, max_log_line_bytes);
 
+seastar::logger cg_klog("kafka-cg");
 } // namespace kafka

--- a/src/v/kafka/server/logger.h
+++ b/src/v/kafka/server/logger.h
@@ -21,4 +21,5 @@
 namespace kafka {
 extern truncating_logger kwire;
 extern ss::logger client_quota_log;
+extern ss::logger cg_klog;
 } // namespace kafka


### PR DESCRIPTION
Couple of improvements in consumer group related logging: 
- added separate logger
- detailed log about group state recovery

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none