### PR TITLE
[v25.1.x] CORE-9559 crash_tracker: handle exception while initializing

### DIFF
--- a/src/v/crash_tracker/prepared_writer.h
+++ b/src/v/crash_tracker/prepared_writer.h
@@ -66,6 +66,8 @@ public:
         return _crash_report_file_name;
     }
 
+    bool initialized() const { return _state != state::uninitialized; }
+
 private:
     enum class state { uninitialized, initialized, filled, written, released };
     friend std::ostream& operator<<(std::ostream&, state);

--- a/src/v/crash_tracker/recorder.cc
+++ b/src/v/crash_tracker/recorder.cc
@@ -257,6 +257,13 @@ void recorder::record_crash_exception(std::exception_ptr eptr) {
         return;
     }
 
+    if (!_writer.initialized()) {
+        // We are unable to record any exceptions that happen before the writer
+        // has been initialized
+        print_skipping();
+        return;
+    }
+
     auto* cd_opt = _writer.fill();
     if (!cd_opt) {
         // The writer has already been consumed by another crash

--- a/src/v/crash_tracker/tests/recorder_test.cc
+++ b/src/v/crash_tracker/tests/recorder_test.cc
@@ -94,6 +94,20 @@ TEST_F(RecorderTest, TestUploadMarkers) {
     }
 }
 
+TEST_F(RecorderTest, TestUninitializedCrashTracker) {
+    auto rec = get_test_recorder();
+
+    // Assume that there is an exception while starting the recorder. This could
+    // happen for example if the data directory is not writable while the
+    // recorder tries to create the crash reports directory.
+
+    // Now simulate that we attempt to record this exception. This should be
+    // gracefully skipped, since the crash recorder is not initialized.
+    const auto test_eptr = std::make_exception_ptr(
+      std::runtime_error{"Test filesystem error"});
+    ASSERT_NO_THROW(rec.record_crash_exception(test_eptr));
+}
+
 namespace {
 
 size_t count_upload_markers() {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25465
