### PR TITLE
`kafka`: call `finally()` on `_underlying` in `txn_reader`

### DIFF
--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -219,8 +219,11 @@ read_committed_reader::do_load_slice(
     }
     // Mark stream as filtered by deleting the tracker.
     _tracker = nullptr;
+
+    co_await _underlying->finally();
     _underlying = make_txn_filtered_reader(
       std::move(batches), aborted_txn_markers);
+
     co_return co_await _underlying->do_load_slice(deadline);
 }
 


### PR DESCRIPTION
### CI Failure

```
assert - Assert failure: (/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-03efe2aa80c8808b0-1/redpanda/redpanda/src/v/storage/log_reader.h:146) '!_iterator.reader' log reader destroyed with live reader
```

https://ci-artifacts.dev.vectorized.cloud/redpanda/63477/0195b6e5-f1e5-4ca1-a772-cef5d34aa67b/vbuild/ducktape/results/final/report.html

### Backtrace

```
void detail::assert_failed_thunk1<>(char const*, char const*) at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-03efe2aa80c8808b0-1/redpanda/redpanda/src/v/base/vassert.h:45
opt/redpanda/lib/libv_v_storage.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=a25ff7d5a2ec34bc5256f6447ace3c83d663da8e, stripped

storage::log_reader::~log_reader() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-03efe2aa80c8808b0-1/redpanda/redpanda/src/v/base/vassert.h:55
storage::log_reader::~log_reader() at /var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-03efe2aa80c8808b0-1/redpanda/redpanda/src/v/storage/log_reader.h:145
opt/redpanda/lib/libv_v_kafka_utils.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=3830e78b988e2da7ed76f2691b92250e9a6bd4c3, stripped
```

### Interpretation

Depending on the type of `model::record_batch_reader::impl` used in the `txn_reader`, not calling `finally()` before re-assigning its value later in the `do_load_slice()` function could lead to failed asserts (in the case of a `log_reader`).

### Fix

Call `_underlying->finally()` after consuming the reader impl with the `drainer` consumer to avoid these issues.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
