### PR TITLE
kafka/server/group_manager: Reset group metrics on remove

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1374,7 +1374,15 @@ void group::remove_pending_member(kafka::member_id member_id) {
     }
 }
 
+void group::pre_shutdown() {
+    _probe.reset();
+    for (auto& p : _offsets) {
+        p.second->probe.reset();
+    }
+}
+
 ss::future<> group::shutdown() {
+    pre_shutdown();
     _auto_abort_timer.cancel();
     co_await _gate.close();
     // cancel join timer

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -706,6 +706,8 @@ public:
       const std::optional<group_instance_id>&,
       const ss::sstring&) const;
 
+    // Cancel metrics to prevent double_mtrics registration;
+    void pre_shutdown();
     // shutdown group. cancel all pending operations
     ss::future<> shutdown();
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -472,6 +472,7 @@ ss::future<> group_manager::do_detach_partition(model::ntp ntp) {
     for (auto g_it = _groups.begin(); g_it != _groups.end();) {
         if (g_it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(g_it->second);
+            g_it->second->pre_shutdown();
             _groups.erase(g_it++);
             continue;
         }
@@ -528,6 +529,7 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
                         return ss::now();
                     }
                     vlog(cg_klog.trace, "Removed group {}", g);
+                    it->second->pre_shutdown();
                     _groups.erase(it);
                     _groups.rehash(0);
                     return ss::now();
@@ -642,6 +644,7 @@ group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
         if (it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(it->second);
             vlog(cg_klog.trace, "Removed group {}", it->second);
+            it->second->pre_shutdown();
             _groups.erase(it++);
             continue;
         }
@@ -1751,6 +1754,7 @@ ss::future<std::vector<deletable_group_result>> group_manager::delete_groups(
         // - batch tombstones same backing partition
         error = co_await group->remove();
         if (error == error_code::none) {
+            group->pre_shutdown();
             _groups.erase(group_info.second);
         }
         results.push_back(deletable_group_result{

--- a/src/v/kafka/server/group_probe.h
+++ b/src/v/kafka/server/group_probe.h
@@ -78,6 +78,11 @@ public:
     }
     void deregister_public_metrics() { _public_metrics.reset(); }
 
+    void reset() {
+        deregister_metrics();
+        deregister_public_metrics();
+    }
+
 private:
     void _setup_metrics(
       const kafka::group_id& group_id, const model::topic_partition& tp) {
@@ -189,6 +194,11 @@ public:
 
     void deregister_consumer_lag_metrics() {
         _public_consumer_lag_metrics.reset();
+    }
+
+    void reset() {
+        deregister_group_metrics();
+        deregister_consumer_lag_metrics();
     }
 
 private:


### PR DESCRIPTION
Prevent this error
```
seastar::metrics::double_registration (registering metrics twice for metrics: kafka_consumer_group_consumers)
```

`group_manager::_groups` holds `group` via `ss::lw_shared_ptr<group>`.

When the group is removed from the map, it's lifetime can be extended during asynchronous calls.

When a new group is created, `_groups` is checked, but when its not found, an existing group could still exist through doing asynchronous such as shutdown.

A new group with the same id can then be constructed, resulting in a `double_registration`.

Fix that by synchronously resetting metrics when removing from `_groups`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

### Bug Fixes

* kafka/server/group_manager: Prevent metrics::double_registration during group management.

