### PR TITLE
[v25.1.x] iceberg/rest_client: protect client requests with gate

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -118,9 +118,13 @@ ss::future<> coordinator::run_until_abort() {
         auto term_fut = co_await ss::coroutine::as_future(
           run_until_term_change(synced_term));
         if (term_fut.failed()) {
-            vlog(
-              datalake_log.error,
-              "Coordinator hit exception while running in term {}: {}",
+            auto lvl = ssx::is_shutdown_exception(term_fut.get_exception())
+                         ? ss::log_level::debug
+                         : ss::log_level::error;
+            vlogl(
+              datalake_log,
+              lvl,
+              "Coordinator exception in term {}: {}",
               synced_term,
               term_fut.get_exception());
             continue;

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -149,7 +149,11 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
 ss::sstring catalog_client::root_path() const {
     return _path_components.root_path();
 }
-
+ss::future<> catalog_client::shutdown() {
+    auto gate_f = _gate.close();
+    co_await _http_client->shutdown_and_stop();
+    co_await std::move(gate_f);
+}
 ss::future<expected<ss::sstring>>
 catalog_client::ensure_token(retry_chain_node& rtc) {
     const bool need_token = !_oauth_token.has_value()
@@ -283,6 +287,7 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
 ss::future<expected<create_namespace_response>>
 catalog_client::create_namespace(
   create_namespace_request req, retry_chain_node& rtc) {
+    auto gh = _gate.hold();
     auto http_request = namespaces{root_path()}.create().with_content_type(
       json_content_type);
 
@@ -305,6 +310,7 @@ ss::future<expected<load_table_result>> catalog_client::create_table(
   const chunked_vector<ss::sstring>& ns,
   create_table_request req,
   retry_chain_node& rtc) {
+    auto gh = _gate.hold();
     auto http_request = table{root_path(), ns}.create().with_content_type(
       json_content_type);
 
@@ -326,6 +332,7 @@ ss::future<expected<load_table_result>> catalog_client::load_table(
   const chunked_vector<ss::sstring>& ns,
   const ss::sstring& table_name,
   retry_chain_node& rtc) {
+    auto gh = _gate.hold();
     auto http_request = table(root_path(), ns).get(table_name);
 
     auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
@@ -344,6 +351,7 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
   const ss::sstring& table_name,
   std::optional<bool> purge_requested,
   retry_chain_node& rtc) {
+    auto gh = _gate.hold();
     http::rest_client::rest_entity::optional_query_params params;
     if (purge_requested.has_value()) {
         params.emplace();
@@ -368,6 +376,7 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
 
 ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
   commit_table_request commit_request, retry_chain_node& rtc) {
+    auto gh = _gate.hold();
     auto http_request = table(root_path(), commit_request.identifier.ns)
                           .update(commit_request.identifier.table)
                           .with_content_type(json_content_type);

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -157,7 +157,7 @@ public:
     commit_table_update(commit_table_request, retry_chain_node&);
 
     // Must be called before destroying the client to prevent resource leak
-    ss::future<> shutdown() { return _http_client->shutdown_and_stop(); }
+    ss::future<> shutdown();
 
 private:
     // The root url calculated from base url, prefix and api version. Given a
@@ -190,6 +190,7 @@ private:
       client_probe::endpoint endpoint,
       std::optional<iobuf> payload = std::nullopt);
 
+    ss::gate _gate;
     std::unique_ptr<http::abstract_client> _http_client;
     ss::sstring _endpoint;
     std::optional<credentials> _credentials;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25491
