### PR TITLE
[v25.1.x] `kafka`: call `finally()` on `_underlying` in `txn_reader`

### DIFF
--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -219,8 +219,11 @@ read_committed_reader::do_load_slice(
     }
     // Mark stream as filtered by deleting the tracker.
     _tracker = nullptr;
+
+    co_await _underlying->finally();
     _underlying = make_txn_filtered_reader(
       std::move(batches), aborted_txn_markers);
+
     co_return co_await _underlying->do_load_slice(deadline);
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25495
