### PR TITLE
fix: update rust target to wasm32-wasip1

### DIFF
--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -130,19 +130,17 @@ func buildRust(ctx context.Context, fs afero.Fs, cfg project.Config, extraArgs [
 		return fmt.Errorf("unable to query cargo metadata: %v", err)
 	}
 	// Cargo does not support named outputs for building, so we have to do the mv ourselves.
-	buildArgs := []string{"build", "--release", "--target=wasm32-wasi"}
+	buildArgs := []string{"build", "--release"}
 	buildArgs = append(buildArgs, extraArgs...)
 	cmd = exec.CommandContext(ctx, cargo, buildArgs...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-	// Enable SIMD acceleration
-	cmd.Env = append(os.Environ(), "RUSTFLAGS=-Ctarget-feature=+simd128")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("build failed %v", err)
 	}
 	fileName := fmt.Sprintf("%s.wasm", cfg.Name)
-	buildArtifact := path.Join(meta.TargetDir, "wasm32-wasi", "release", fileName)
+	buildArtifact := path.Join(meta.TargetDir, "wasm32-wasip1", "release", fileName)
 	if err = fs.Rename(buildArtifact, fileName); err != nil {
 		return fmt.Errorf("unable to move build artifact: %v", err)
 	}

--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -216,6 +216,9 @@ func generateManifest(p transformProject) (map[string][]genFile, error) {
 			path.Join(p.Path, "src"): {
 				genFile{name: "main.rs", content: template.WasmRustMain()},
 			},
+			path.Join(p.Path, ".cargo"): {
+				genFile{name: "config.toml", content: template.WasmRustConfig()},
+			},
 		}, nil
 	case project.WasmLangJavaScript:
 		return map[string][]genFile{
@@ -304,7 +307,8 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		} else if err != nil {
 			return fmt.Errorf("unable to lookup rustup executable: %v", err)
 		}
-		if err := runCli(rustup, "target", "add", "wasm32-wasi"); err != nil {
+		if err := runCli(rustup, "target", "add", "wasm32-wasip1"); err != nil {
+			fmt.Println("rust recently renamed the 'wasm32-wasi' target to 'wasm32-wasip1', please update your version of rust if this target is not found")
 			return fmt.Errorf("unable to install wasm toolchain: %v", err)
 		}
 		cargo, err := exec.LookPath("cargo")

--- a/src/go/rpk/pkg/cli/transform/template/BUILD
+++ b/src/go/rpk/pkg/cli/transform/template/BUILD
@@ -17,6 +17,7 @@ go_library(
         "js/tsconfig.json",
         "rust/README.md",
         "rust/main.rustsrc",
+        "rust/config.toml",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/template",
     visibility = ["//visibility:public"],

--- a/src/go/rpk/pkg/cli/transform/template/rust/config.toml
+++ b/src/go/rpk/pkg/cli/transform/template/rust/config.toml
@@ -1,3 +1,5 @@
 [build]
-rustflags = ["-Ctarget-feature=+simd128"]
 target = "wasm32-wasip1"
+
+[target.wasm32-wasip1]
+rustflags = ["-Ctarget-feature=+simd128"]

--- a/src/go/rpk/pkg/cli/transform/template/rust/config.toml
+++ b/src/go/rpk/pkg/cli/transform/template/rust/config.toml
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["-Ctarget-feature=+simd128"]
+target = "wasm32-wasip1"

--- a/src/go/rpk/pkg/cli/transform/template/rust_template.go
+++ b/src/go/rpk/pkg/cli/transform/template/rust_template.go
@@ -39,3 +39,10 @@ var wasmRustReadme string
 func WasmRustReadme() string {
 	return wasmRustReadme
 }
+
+//go:embed rust/config.toml
+var wasmRustConfig string
+
+func WasmRustConfig() string {
+	return wasmRustConfig
+}

--- a/src/transform-sdk/rust/examples/jaq/README.md
+++ b/src/transform-sdk/rust/examples/jaq/README.md
@@ -7,8 +7,8 @@ This example transform supports defining an environment variable `FILTER` that d
 ## Example Usage
 
 ```
-cargo build --release --target=wasm32-wasi
-rpk transform deploy ../../target/wasm32-wasi/release/jaq.wasm \
+cargo build --release --target=wasm32-wasip1
+rpk transform deploy ../../target/wasm32-wasip1/release/jaq.wasm \
     --name=email-redaction-transform \
     --input-topic=$MY_INPUT_TOPIC \
     --output-topic=$MY_OUTPUT_TOPIC \

--- a/src/transform-sdk/rust/src/lib.rs
+++ b/src/transform-sdk/rust/src/lib.rs
@@ -19,7 +19,7 @@
 //! that require you to redact credit card numbers or convert JSON to Avro.
 //!
 //! Data transforms use a WebAssembly (Wasm) engine inside a Redpanda broker.
-//! Thus, transforms must compile to WebAssembly via `--target=wasm32-wasi`.
+//! Thus, transforms must compile to WebAssembly via `--target=wasm32-wasip1`.
 //! A Wasm function acts on a single record in an input topic.
 //! You can develop and manage data transforms with `rpk transform` commands.
 //!


### PR DESCRIPTION
update the rust target from wasm32-wasi to wasm32-wasip1, because the target name has changed in the latest versions of rust and the old name is no longer valid.

Fixes #25509 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* change rust target to new name

### Bug Fixes

* Rust target has changed and this updates it