### PR TITLE
[v24.1.x] kafka/server/group_manager: Reset group metrics on remove

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -83,6 +83,11 @@ public:
             labels)});
     }
 
+    void reset() {
+        _metrics.clear();
+        _public_metrics.clear();
+    }
+
 private:
     model::offset& _offset;
     metrics::internal_metric_groups _metrics;
@@ -136,6 +141,8 @@ public:
              sm::description("Number of topics in a group"),
              labels)});
     }
+
+    void reset() { _public_metrics.clear(); }
 
 private:
     member_map& _members;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1302,7 +1302,15 @@ void group::remove_pending_member(kafka::member_id member_id) {
     }
 }
 
+void group::pre_shutdown() {
+    _probe.reset();
+    for (auto& p : _offsets) {
+        p.second->probe.reset();
+    }
+}
+
 ss::future<> group::shutdown() {
+    pre_shutdown();
     _auto_abort_timer.cancel();
     co_await _gate.close();
     // cancel join timer

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -671,6 +671,8 @@ public:
       const std::optional<group_instance_id>&,
       const ss::sstring&) const;
 
+    // Cancel metrics to prevent double_mtrics registration;
+    void pre_shutdown();
     // shutdown group. cancel all pending operations
     ss::future<> shutdown();
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -435,6 +435,7 @@ ss::future<> group_manager::do_detach_partition(model::ntp ntp) {
     for (auto g_it = _groups.begin(); g_it != _groups.end();) {
         if (g_it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(g_it->second);
+            g_it->second->pre_shutdown();
             _groups.erase(g_it++);
             continue;
         }
@@ -491,6 +492,7 @@ ss::future<> group_manager::cleanup_removed_topic_partitions(
                         return ss::now();
                     }
                     vlog(klog.trace, "Removed group {}", g);
+                    it->second->pre_shutdown();
                     _groups.erase(it);
                     _groups.rehash(0);
                     return ss::now();
@@ -605,6 +607,7 @@ group_manager::gc_partition_state(ss::lw_shared_ptr<attached_partition> p) {
         if (it->second->partition()->ntp() == p->partition->ntp()) {
             groups_for_shutdown.push_back(it->second);
             vlog(klog.trace, "Removed group {}", it->second);
+            it->second->pre_shutdown();
             _groups.erase(it++);
             continue;
         }
@@ -1630,6 +1633,7 @@ ss::future<std::vector<deletable_group_result>> group_manager::delete_groups(
         // - batch tombstones same backing partition
         error = co_await group->remove();
         if (error == error_code::none) {
+            group->pre_shutdown();
             _groups.erase(group_info.second);
         }
         results.push_back(deletable_group_result{


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25496

Closes https://github.com/redpanda-data/redpanda/issues/25521