### PR TITLE
[v24.3.x] pandaproxy/sr: Re-purpose schema_registry_normalize_on_startup config

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3566,11 +3566,14 @@ configuration::configuration()
       "Per-shard capacity of the cache for validating schema IDs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       128)
-  , schema_registry_normalize_on_startup(
+  , schema_registry_always_normalize(
       *this,
-      "schema_registry_normalize_on_startup",
-      "Normalize schemas as they are read from the topic on startup.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      "schema_registry_always_normalize",
+      "Always normalize schemas. If set, this overrides the "
+      "normalize parameter in API requests.",
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
+       .aliases = {"schema_registry_normalize_on_startup"}},
       false)
   , schema_registry_protobuf_renderer_v2(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -664,7 +664,7 @@ struct configuration final : public config_store {
       enable_schema_id_validation;
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
-    property<bool> schema_registry_normalize_on_startup;
+    property<bool> schema_registry_always_normalize;
     property<bool> schema_registry_protobuf_renderer_v2;
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
     bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -45,8 +45,10 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>(protobuf_renderer_v2{
-      config::shard_local_cfg().schema_registry_protobuf_renderer_v2});
+    _store = std::make_unique<sharded_store>(
+      protobuf_renderer_v2{
+        config::shard_local_cfg().schema_registry_protobuf_renderer_v2},
+      normalize{config::shard_local_cfg().schema_registry_always_normalize});
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -83,6 +83,7 @@ ss::future<> sharded_store::stop() { return _store.stop(); }
 
 ss::future<canonical_schema>
 sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
+    norm = norm || _always_normalize;
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -26,8 +26,10 @@ class store;
 class sharded_store final : public schema_getter {
 public:
     explicit sharded_store(
-      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no)
-      : _v2_renderer(v2_renderer) {}
+      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no,
+      normalize always_normalize = normalize::no)
+      : _v2_renderer(v2_renderer)
+      , _always_normalize(always_normalize) {}
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -246,6 +248,7 @@ private:
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
     protobuf_renderer_v2 _v2_renderer;
+    normalize _always_normalize;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3255,6 +3255,74 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                               subjects[subject]["schema_ids"],
                               subjects[subject]["subject_versions"])
 
+    @cluster(num_nodes=3)
+    def test_always_normalize_option(self):
+
+        self.redpanda.set_cluster_config(
+            {'schema_registry_protobuf_renderer_v2': True},
+            expect_restart=True)
+
+        # Post a schema with normalization set to off
+        result_raw = self._post_subjects_subject_versions(
+            subject="test_subject",
+            data=json.dumps({
+                "schema": imported_schema_proto_def,
+                "schemaType": "PROTOBUF"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup"
+
+        def test_schemas_ids_id(expected_schema):
+            result_raw = self._request("GET",
+                                       f"schemas/ids/1",
+                                       headers=HTTP_GET_HEADERS)
+            result = result_raw.json()["schema"].strip()
+            assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+                f"with content {result_raw.content}"
+            assert result == expected_schema, \
+                    f"Expected:\n{expected_schema}\ngot:\n{result}"
+
+        def test_subjects_subject(schema, expected_version=None, norm=False):
+            result_raw = self._post_subjects_subject(subject="test_subject",
+                                                     data=json.dumps({
+                                                         "schema":
+                                                         schema,
+                                                         "schemaType":
+                                                         "PROTOBUF",
+                                                     }),
+                                                     normalize=norm)
+            if expected_version:
+                assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+                    f"with content {result_raw.content}"
+                result = result_raw.json()["version"]
+                assert result == expected_version, \
+                        f"Expected version {expected_version} but got {result}"
+            else:
+                assert result_raw.status_code == 404, \
+                    f"Expected 404 but got {result_raw.status_code}, "\
+                    f"with content {result_raw.content}"
+
+        sanitized = imported_schema_sanitized_proto_def.strip()
+        normalized = imported_schema_normalized_proto_def.strip()
+
+        test_schemas_ids_id(sanitized)
+        test_subjects_subject(sanitized, expected_version=1)
+        test_subjects_subject(sanitized, expected_version=1, norm=True)
+        test_subjects_subject(normalized, expected_version=None)
+        test_subjects_subject(normalized, expected_version=1, norm=True)
+
+        #Update always_normalize and re-run all tests
+        self.redpanda.set_cluster_config(
+            {'schema_registry_always_normalize': True}, expect_restart=True)
+
+        test_schemas_ids_id(imported_schema_normalized_proto_def.strip())
+        test_subjects_subject(sanitized, expected_version=1)
+        test_subjects_subject(sanitized, expected_version=1, norm=True)
+        test_subjects_subject(normalized, expected_version=1)
+        test_subjects_subject(normalized, expected_version=1, norm=True)
+
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
Backport: #25429
Closes: #25518

The new functionality allows to blanket-enable schema normalization in every SR operation.

(cherry picked from commit a17d27353d5437b96959349acca0f6570b825461)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
