### PR TITLE
`cluster`: `cloudcheck` tweaks

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -92,6 +92,31 @@ cloudcheck::run(cloudcheck_opts opts) {
       _opts.sg, [this]() mutable { return run_benchmarks(); });
 }
 
+ss::future<>
+cloudcheck::clear_self_test_folder(cloud_storage_clients::bucket_name bucket) {
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+    const cloud_storage::remote::list_result object_list
+      = co_await _cloud_storage_api.local().list_objects(
+        bucket, rtc, self_test_prefix);
+
+    if (object_list && !object_list.value().contents.empty()) {
+        std::vector<cloud_storage_clients::object_key> objects_to_delete;
+        objects_to_delete.reserve(object_list.value().contents.size());
+        for (auto& object : object_list.value().contents) {
+            objects_to_delete.push_back(
+              cloud_storage_clients::object_key{std::move(object.key)});
+        }
+
+        std::ignore = co_await _cloud_storage_api.local().delete_objects(
+          bucket, objects_to_delete, rtc);
+    }
+
+    // Also delete the self_test_prefix- this will no-op for cloud providers
+    // that lack the concept of a "folder".
+    std::ignore = co_await _cloud_storage_api.local().delete_object(
+      bucket, self_test_prefix, rtc);
+}
+
 template<typename Test, typename... Args, typename R>
 R cloudcheck::do_run_test(Test test, Args&&... args) {
     const auto start = ss::lowres_system_clock::now();
@@ -110,6 +135,7 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
     const auto bucket = cloud_storage_clients::bucket_name{
       cloud_storage::configuration::get_bucket_config()().value()};
 
+    co_await clear_self_test_folder(bucket);
 
     const auto uuid = cloud_storage_clients::object_key{
       ss::sstring{uuid_t::create()}};
@@ -208,6 +234,8 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
     auto deletes_test_result = co_await do_run_test(
       &cloudcheck::verify_deletes, bucket, num_default_objects);
     results.push_back(std::move(deletes_test_result.test_result));
+
+    co_await clear_self_test_folder(bucket);
 
     co_return results;
 }

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -23,8 +23,10 @@
 
 namespace cluster::self_test {
 
-cloudcheck::cloudcheck(ss::sharded<cloud_storage::remote>& cloud_storage_api)
-  : _rtc(_as)
+cloudcheck::cloudcheck(
+  model::node_id self, ss::sharded<cloud_storage::remote>& cloud_storage_api)
+  : _self(self)
+  , _rtc(_as)
   , _cloud_storage_api(cloud_storage_api) {}
 
 ss::future<> cloudcheck::start() { return ss::make_ready_future<>(); }
@@ -108,8 +110,6 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
     const auto bucket = cloud_storage_clients::bucket_name{
       cloud_storage::configuration::get_bucket_config()().value()};
 
-    const auto self_test_prefix = cloud_storage_clients::object_key{
-      "self-test/"};
 
     const auto uuid = cloud_storage_clients::object_key{
       ss::sstring{uuid_t::create()}};

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -134,7 +134,7 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
       = (is_uploaded) ? self_test_prefix
                       : std::optional<cloud_storage_clients::object_key>{};
     auto list_test_result_pair = co_await do_run_test(
-      &cloudcheck::verify_list, bucket, list_prefix, num_default_objects);
+      &cloudcheck::verify_list, bucket, list_prefix, 1);
     auto& [object_list, list_test_result] = list_test_result_pair;
     if (is_uploaded && object_list) {
         // Check that uploaded object exists in object_list contents.

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -16,6 +16,7 @@
 #include "cloud_storage/types.h"
 #include "cluster/self_test/metrics.h"
 #include "cluster/self_test_rpc_types.h"
+#include "model/fundamental.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
@@ -35,7 +36,9 @@ public:
 
 class cloudcheck {
 public:
-    cloudcheck(ss::sharded<cloud_storage::remote>& cloud_storage_api);
+    cloudcheck(
+      model::node_id self,
+      ss::sharded<cloud_storage::remote>& cloud_storage_api);
 
     /// Initialize the benchmark
     ss::future<> start();
@@ -145,13 +148,14 @@ private:
 private:
     static constexpr size_t num_default_objects = 5;
     bool _cancelled{false};
+    model::node_id _self;
     ss::abort_source _as;
     ss::gate _gate;
     retry_chain_node _rtc;
     cloudcheck_opts _opts;
 
     const cloud_storage_clients::object_key self_test_prefix
-      = cloud_storage_clients::object_key{"self-test/"};
+      = cloud_storage_clients::object_key{fmt::format("self-test-{}/", _self)};
 
 private:
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -77,6 +77,9 @@ private:
       iobuf& payload,
       retry_chain_node& rtc);
 
+    ss::future<>
+    clear_self_test_folder(cloud_storage_clients::bucket_name bucket);
+
     // Wrapper around verify_tests for timing purposes, regardless of test
     // failure or success.
     template<

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -155,7 +155,8 @@ private:
     cloudcheck_opts _opts;
 
     const cloud_storage_clients::object_key self_test_prefix
-      = cloud_storage_clients::object_key{fmt::format("self-test-{}/", _self)};
+      = cloud_storage_clients::object_key{
+        fmt::format("self-test-{}-{}/", _self, ss::sstring{uuid_t::create()})};
 
 private:
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -35,7 +35,7 @@ self_test_backend::self_test_backend(
   , _st_sg(sg)
   , _disk_test(nlm)
   , _network_test(self, connections)
-  , _cloud_test(cloud_storage_api) {}
+  , _cloud_test(self, cloud_storage_api) {}
 
 ss::future<> self_test_backend::start() {
     co_await _disk_test.start();


### PR DESCRIPTION
### Motivation

Link to CDT failures: https://ci-artifacts.dev.vectorized.cloud/vtools/21249/0195b526-95aa-4463-9da6-7e67bf60d612/vbuild/ducktape/results/2025-03-20--001/report.html

There seem to be occasional failures in the `cloudcheck` self-test, such as 

```
"error": "Uploaded key/payload could not be found in cloud storage item list."
```

This could be due to reuse of the same `self-test/` prefix for all nodes performing the `cloudcheck` stage of the cluster self test, and across multiple runs if the `cloudcheck` needs to be retried.

This likely fixes https://redpandadata.atlassian.net/browse/CORE-7104, https://redpandadata.atlassian.net/issues/CORE-7664

### Changes

A few commits to:
* Use the `node_id` in the self test prefix folder in tiered storage.
* Use a random `uuid` in the self test prefix folder in tiered storage.
* Limit `max_keys` for `cloudcheck::verify_list()` to `1` to be more stringent about the successful case.
* Clear the self test prefix folder before and after each `cloudcheck` run to prevent flakes from retried runs and to do a better job of cleaning up the tiered storage bucket.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
