### PR TITLE
bazel: build setting tweaks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,7 +65,7 @@ build:sanitizer --//bazel:has_sanitizers=True
 # seastar has to be run with system allocator when using sanitizers
 build:sanitizer --@seastar//:system_allocator=True
 # krb5 is a foreign cc build and needs explicit list of sanitizers to build the shared library
-build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function
+build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function,alignment
 
 # =================================
 # clang-tidy

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,7 @@ build --@seastar//:debug=True
 # =================================
 # Sanitizer
 # =================================
+build:sanitizer --compilation_mode=dbg
 build:sanitizer --copt -fsanitize=address,undefined,vptr,function,alignment
 build:sanitizer --linkopt -fsanitize=address,undefined,vptr,function,alignment
 build:sanitizer --linkopt -fsanitize-link-c++-runtime

--- a/.bazelrc
+++ b/.bazelrc
@@ -75,7 +75,6 @@ build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_18_toolchain/
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 build:clang-tidy --copt -Wno-pragma-once-outside-header
 build:clang-tidy --output_groups=report
-build:clang-tidy --jobs=36
 
 # =================================
 # Security

--- a/.bazelrc
+++ b/.bazelrc
@@ -107,6 +107,7 @@ build:release --copt -mllvm --copt -inline-threshold=2500
 build:release --@seastar//:stack_guards=False --@seastar//:debug=False
 build:release --//src/v/redpanda:lto=True
 build:release --copt -flto=thin --copt -ffat-lto-objects
+build:release --copt -g --strip=never
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh
 


### PR DESCRIPTION
- **bazel: use debug compilation mode for sanitizers**
- **bazel: sync sanitizers for krb5**
- **bazel: restore default concurrency for clang-tidy**
- **bazel: add debug symbols in release builds**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
