### PR TITLE
s3: Add timeout to credentials fetching operation

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -29,6 +29,7 @@ using namespace std::chrono_literals;
 namespace {
 constexpr auto self_configure_attempts = 3;
 constexpr auto self_configure_backoff = 1s;
+constexpr auto self_config_timeout = 15s;
 } // namespace
 
 namespace cloud_storage_clients {
@@ -263,7 +264,13 @@ client_pool::acquire(ss::abort_source& as) {
         if (std::optional<ssx::semaphore_units> u = ss::try_get_units(
               _self_config_barrier, 1);
             !u.has_value()) {
-            u = co_await ss::get_units(_self_config_barrier, 1);
+            // Timeout exception will be thrown if the credentials are not
+            // refreshed yet. The code in the 'remote' class handles this
+            // exception. Most of the time this exception means that the
+            // IAM-roles (or other source of credentials) is not configured
+            // properly.
+            u = co_await ss::get_units(
+              _self_config_barrier, 1, self_config_timeout);
         }
 
         while (!client.has_value() && !_gate.is_closed()

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -17,6 +17,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/core/smp.hh>
+#include <seastar/core/timed_out_error.hh>
 
 #include <algorithm>
 #include <chrono>
@@ -269,8 +270,15 @@ client_pool::acquire(ss::abort_source& as) {
             // exception. Most of the time this exception means that the
             // IAM-roles (or other source of credentials) is not configured
             // properly.
-            u = co_await ss::get_units(
-              _self_config_barrier, 1, self_config_timeout);
+            try {
+                u = co_await ss::get_units(
+                  _self_config_barrier, 1, self_config_timeout);
+            } catch (const ss::timed_out_error&) {
+                vlog(
+                  pool_log.error,
+                  "Failed to acquire credentials within timeout");
+                throw;
+            }
         }
 
         while (!client.has_value() && !_gate.is_closed()


### PR DESCRIPTION
The s3_client uses credentials propagated by the
`cloud_storage::remote`. In case if IAM-roles are used the credentials are fetched by the background operation which is started right after startup.

Normally, this is not a lengthy process. The credentials are acquired within first few hundred milliseconds after Redpanda starts. The client pool performs self configuration while holding units from the `_self_config_barier` semaphore.

If the credentials can't be acquired the `auth_refresh_bg_op` will log it and will never create a 'cloud_roles::refresh_credentials' instances. This means that the credentials will never be populated and any attempt to start upload will stuck waiting for self configuration.

The problem is that in this case Redpanda fails to stop gracefully. The `ntp_archiver` attempts to upload the manifest right before the leadership transfer. Because of that if the `s3_client_pool` is stuck waiting for self configuration to finish and at the same time node decomissioning starts the node will never decomission correctly because it will fail to stop partition.

When the `cluster::partition` is stopped it invokes `stop` method of the `ntp_archiver`. Prior to that it invokes graceful leadership transfer method which forces `ntp_archiver` to upload the manifest. This operation is getting stuck indefinitely because of the self configuration problem. The graceful leadership transfer in the `ntp_archiver` is time bound. After 5s interval it will give up and the `cluster::partition::stop` method will be invoked. It will invoke `ntp_archiver::stop` method which in turn will try to close the gate. But the gate will be held indefinitely by the manifest upload which got stuck. As the result the `partition_manager` will not be able to stop the partition.

This PR fixes the problem by adding a timeout to the acquisition of units from the `_self_config_barier`. With this change the manifest upload will eventually timeout and release the gate.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none