### PR TITLE
CORE-9384 base/vassert: run registered callback only once

### DIFF
--- a/src/v/base/tests/assert_log_holder_test.cc
+++ b/src/v/base/tests/assert_log_holder_test.cc
@@ -28,17 +28,14 @@ TEST_F(AssertLogHolderTest, ValidateAssertLogHolder) {
     auto bt = ss::current_backtrace();
     base::register_event(bt, "This is a test event: test");
     EXPECT_TRUE(message.empty());
-    base::register_cb(cb);
-    base::register_event(bt, "This is a test event: test");
 
-    EXPECT_EQ(message, fmt::format("This is a test event: test"));
-    EXPECT_TRUE(unused_message.empty());
+    base::register_cb(cb);
 
     // Verify that a second call to `register_cb` does not replace the current
     // callback
     base::register_cb(unused_cb);
-    base::register_event(bt, "This is a second test event: test");
 
+    base::register_event(bt, "This is a second test event: test");
     EXPECT_EQ(message, fmt::format("This is a second test event: test"));
     EXPECT_TRUE(unused_message.empty());
 }

--- a/src/v/base/vassert-register.h
+++ b/src/v/base/vassert-register.h
@@ -31,6 +31,8 @@ using assert_cb_func = void (*)(std::string_view);
 // register_event calls.
 // Only the first registration has any effect, calls to this function do
 // nothing.
+// The callback is only called once, only for the first vassert crash. This is
+// to avoid a potential infinite loop if the callback triggers another vassert.
 void register_cb(assert_cb_func cb);
 
 /**

--- a/src/v/base/vassert.cc
+++ b/src/v/base/vassert.cc
@@ -27,6 +27,7 @@ namespace {
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 ss::logger assert_logger{"assert"};
 std::atomic<assert_cb_func> _cb_func{nullptr};
+std::once_flag _cb_func_onceflag{};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 
 void assert_handler(const ss::saved_backtrace& bt, std::string_view text) {
@@ -35,7 +36,7 @@ void assert_handler(const ss::saved_backtrace& bt, std::string_view text) {
 
     auto cb_func = _cb_func.load();
     if (cb_func != nullptr) {
-        cb_func(text);
+        std::call_once(_cb_func_onceflag, [cb_func, text]() { cb_func(text); });
     }
 }
 


### PR DESCRIPTION
This is to avoid the theoretical possibility of an infinite loop if the registered callback triggers another vassert.

If the registered callback would trigger a vassert:
- Earlier: redpanda would eventually segfault when the stack overflowed.
- After this change: redpanda terminates while printing to the logs the stacktrace and assertion message for all encountered vassert failures, but only calling the registered callback for the first vassert failure.

Fixes https://redpandadata.atlassian.net/browse/CORE-9384

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
