### PR TITLE
[CORE-9551] admin: Disallow superuser removing themself

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1601,10 +1601,18 @@ void config_multi_property_validation(
             // Some superusers must be defined, or nobody will be able
             // to use the admin API after this request.
             errors["admin_api_require_auth"] = "No superusers defined";
-        } else if (!superusers_set.contains(username) && !auth_was_enabled) {
-            // When enabling auth, user making the change must be in the list of
-            // superusers, or they would be locking themselves out.
-            errors["admin_api_require_auth"] = "May only be set by a superuser";
+        } else if (!superusers_set.contains(username)) {
+            if (!auth_was_enabled) {
+                // When enabling auth, user making the change must be in the
+                // list of superusers, or they would be locking themselves out.
+                errors["admin_api_require_auth"]
+                  = "May only be set by a superuser";
+            } else {
+                // When auth is enabled, user making the change must be in the
+                // list of superusers, or they would be locking themselves out.
+                errors["superusers"] = "superusers must contain the user "
+                                       "making the change when auth is enabled";
+            }
         }
     }
 

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -199,6 +199,27 @@ class AdminApiAuthEnablementTest(RedpandaTest):
             [self.redpanda.SUPERUSER_CREDENTIALS.username, ALICE.username]
         })
 
+    @cluster(num_nodes=3)
+    def test_superuser_remove_self(self):
+        """
+        Check that a superuser cannot remove themself if auth is enabled.
+        """
+        superuser_admin = Admin(self.redpanda,
+                                auth=(ALICE.username, ALICE.password))
+
+        create_user_and_wait(self.redpanda, superuser_admin, ALICE)
+
+        self.redpanda.set_cluster_config({
+            "admin_api_require_auth":
+            True,
+            "superusers":
+            [self.redpanda.SUPERUSER_CREDENTIALS.username, ALICE.username]
+        })
+
+        with expect_http_error(400):
+            superuser_admin.patch_cluster_config(
+                {"superusers": [self.redpanda.SUPERUSER_CREDENTIALS.username]})
+
 
 class AdminApiListUsersTest(PandaProxyEndpoints):
     def __init__(self, context):


### PR DESCRIPTION
When admin_api_require_auth is true, disallow a user from removing themself from superusers.

This change makes it more difficult for a user to lock themself out of the cluster.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [x] v24.1.x

## Release Notes

### Improvements

* admin: Disallow a superuser from removing themself.
