### PR TITLE
[UX-99] rpk: support OIDC for Schema Registry Client in Serverless clusters.

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/list.go
+++ b/src/go/rpk/pkg/cli/registry/schema/list.go
@@ -52,7 +52,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 			if len(subjects) == 0 {
 				subjects, err = cl.Subjects(ctx)
-				out.MaybeDieErr(err)
+				out.MaybeDie(err, "unable to list all subjects: %v", err)
 			}
 
 			type res struct {

--- a/src/go/rpk/pkg/schemaregistry/BUILD
+++ b/src/go/rpk/pkg/schemaregistry/BUILD
@@ -6,8 +6,11 @@ go_library(
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/net",
+        "//src/go/rpk/pkg/oauth",
+        "//src/go/rpk/pkg/oauth/providers/auth0",
         "@com_github_spf13_afero//:afero",
         "@com_github_twmb_franz_go_pkg_sr//:sr",
     ],

--- a/src/go/rpk/pkg/schemaregistry/client.go
+++ b/src/go/rpk/pkg/schemaregistry/client.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/net"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/spf13/afero"
 	"github.com/twmb/franz-go/pkg/sr"
 )
@@ -52,8 +55,31 @@ func NewClient(fs afero.Fs, p *config.RpkProfile) (*sr.Client, error) {
 		opts = append(opts, sr.DialTLSConfig(tc))
 	}
 
-	if p.HasSASLCredentials() {
+	switch {
+	case p.HasSASLCredentials() && p.KafkaAPI.SASL.Mechanism != adminapi.CloudOIDC:
 		opts = append(opts, sr.BasicAuth(p.KafkaAPI.SASL.User, p.KafkaAPI.SASL.Password))
+	case p.KafkaAPI.SASL != nil && p.KafkaAPI.SASL.Mechanism == adminapi.CloudOIDC:
+		a := p.CurrentAuth()
+		if a == nil || len(a.AuthToken) == 0 {
+			return nil, errors.New("no current cloud token found in your profile, please login with 'rpk cloud login'")
+		}
+		expired, err := oauth.ValidateToken(
+			a.AuthToken,
+			auth0.NewClient(p.DevOverrides()).Audience(),
+			a.ClientID,
+		)
+		if err != nil {
+			if errors.Is(err, oauth.ErrMissingToken) {
+				return nil, err
+			}
+			return nil, fmt.Errorf("unable to validate cloud token, please login again using 'rpk cloud login': %v", err)
+		}
+		if expired {
+			return nil, fmt.Errorf("your cloud token has expired, please login again using 'rpk cloud login'")
+		}
+		opts = append(opts, sr.BearerToken(a.AuthToken))
+	default:
+		// do nothing
 	}
 	return sr.NewClient(opts...)
 }


### PR DESCRIPTION
This PR adds OIDC support to the Schema Registry client, allowing users to do:
```
$ rpk cloud login 
# Select their cluster, rpk creates a profile.

$ rpk registry <any-command>
```

Without further authentication as long as they have a valid token in their profile.

Fixes UX-99
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* `rpk registry` now authenticates with your cloud credentials for Serverless Clusters.