### PR TITLE
`datalake`: avoid double `get_exception()` in coordinator

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -118,15 +118,15 @@ ss::future<> coordinator::run_until_abort() {
         auto term_fut = co_await ss::coroutine::as_future(
           run_until_term_change(synced_term));
         if (term_fut.failed()) {
-            auto lvl = ssx::is_shutdown_exception(term_fut.get_exception())
-                         ? ss::log_level::debug
-                         : ss::log_level::error;
+            auto e = term_fut.get_exception();
+            auto lvl = ssx::is_shutdown_exception(e) ? ss::log_level::debug
+                                                     : ss::log_level::error;
             vlogl(
               datalake_log,
               lvl,
               "Coordinator exception in term {}: {}",
               synced_term,
-              term_fut.get_exception());
+              e);
             continue;
         }
         auto term_res = term_fut.get();


### PR DESCRIPTION
Calling `get_exception()` twice on a `ss::future<>` will trigger an assert:

https://github.com/scylladb/seastar/blob/89a89a56a1efe68f4a4e73aa32da852ecbbe0db7/include/seastar/core/future.hh#L518-L522

Refactor this code to only call `get_exception()` once to avoid triggering the assert.

See multitude of failures in: https://buildkite.com/redpanda/redpanda/builds/63588

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
