### PR TITLE
`iobuf::append` improvements part 2

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -251,6 +251,11 @@ private:
     size_t last_allocation_size() const;
 
     bool try_copy_append(const char* ptr, size_t size);
+    // the pointer passed to this function should be "owning".
+    // iobuf will manage it's lifetime after its been passed.
+    // this function is only used internally by other `iobuf::append`
+    // functions in order to centralize some logic.
+    void append(fragment*);
 
     container _frags;
     size_t _size{0};
@@ -289,14 +294,15 @@ inline size_t iobuf::last_allocation_size() const {
     return _frags.empty() ? details::io_allocation_size::default_chunk_size
                           : _frags.back().capacity();
 }
-inline void iobuf::append(std::unique_ptr<fragment> f) {
+inline void iobuf::append(fragment* f) {
     if (!_frags.empty()) {
         _frags.back().trim();
     }
     // NOTE: this _must_ be size and _not_ capacity
     _size += f->size();
-    _frags.push_back(*f.release());
+    _frags.push_back(*f);
 }
+inline void iobuf::append(std::unique_ptr<fragment> f) { append(f.release()); }
 inline void iobuf::prepend(std::unique_ptr<fragment> f) {
     _size += f->size();
     _frags.push_front(*f.release());
@@ -406,14 +412,13 @@ iobuf::try_copy_append(const char* ptr, size_t size) {
 
 /// appends the contents of buffer; might pack values into existing space
 inline void iobuf::append(iobuf&& o) {
-    for (auto& f : o._frags) {
-        auto fsize = f.size();
+    while (!o._frags.empty()) {
+        fragment* f = &o._frags.front();
+        o._frags.pop_front();
 
-        if (unlikely(!fsize)) {
-            continue;
-        }
-
-        if (try_copy_append(f.get(), fsize)) {
+        auto fsize = f->size();
+        if (!fsize || try_copy_append(f->get(), fsize)) {
+            details::dispose_io_fragment(f);
             continue;
         }
 
@@ -425,7 +430,7 @@ inline void iobuf::append(iobuf&& o) {
             }
         }
 
-        append(std::move(f).unoptimized_release());
+        append(f);
     }
     o.clear();
 }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -400,12 +400,8 @@ iobuf::try_copy_append(const char* ptr, size_t size) {
         return;
     }
 
-    if (available_bytes() > 0) {
-        if (_frags.back().is_empty()) {
-            pop_back();
-        } else {
-            _frags.back().trim();
-        }
+    if (unlikely(available_bytes() > 0 && _frags.back().is_empty())) {
+        pop_back();
     }
     append(std::make_unique<fragment>(std::move(b)));
 }
@@ -422,12 +418,8 @@ inline void iobuf::append(iobuf&& o) {
             continue;
         }
 
-        if (available_bytes() > 0) {
-            if (_frags.back().is_empty()) {
-                pop_back();
-            } else {
-                _frags.back().trim();
-            }
+        if (unlikely(!_frags.empty() && _frags.back().is_empty())) {
+            pop_back();
         }
 
         append(f);

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -460,7 +460,7 @@ SEASTAR_THREAD_TEST_CASE(test_next_chunk_allocation_append_iobuf) {
     }
     // slow but tha'ts life.
     auto distance = std::distance(buf.begin(), buf.end());
-    BOOST_REQUIRE_EQUAL(distance, 323);
+    BOOST_REQUIRE_EQUAL(distance, 322);
     constexpr size_t sz = 40000 * 1024;
     auto msg = iobuf_as_scattered(std::move(buf));
     BOOST_REQUIRE_EQUAL(msg.size(), sz);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Changes `iobuf::append(iobuf&&)` to reduce fragment allocations by re-using fragments from the moved iobuf. Also reduces the number of duplicate checks. See commit messages for benchmarking results.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
