### PR TITLE
bazel: add a stamp-full config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -110,6 +110,7 @@ build:release --copt -flto=thin --copt -ffat-lto-objects
 build:release --copt -g --strip=never
 
 build:stamp --stamp --workspace_status_command=./bazel/stamp_vars.sh
+build:stamp-full --stamp --workspace_status_command='./bazel/stamp_vars.sh full'
 
 # =================================
 # Coverage

--- a/bazel/stamp_vars.sh
+++ b/bazel/stamp_vars.sh
@@ -24,7 +24,12 @@ set -eo pipefail
 # not start with "STABLE_" are part of the volatile set, which will be used
 # but do not invalidate stamped targets.
 
-git_tag=$(git describe --always --abbrev=0 --match='v*')
+# In CI Bazel can sometimes be run from the vtools repo, so we need to ensure
+# that we're in the correct redpanda git repo.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="${SCRIPT_DIR}/.."
+
+git_tag=$(git -C "$WORKSPACE_DIR" describe --always --abbrev=0 --match='v*')
 echo "STABLE_GIT_LATEST_TAG ${git_tag}"
 
 # For CI builds we don't want to use the commit hash as that prevents caching of binaries,
@@ -36,11 +41,11 @@ if [[ $1 != "full" ]]; then
   exit 0
 fi
 
-git_rev=$(git rev-parse HEAD)
+git_rev=$(git -C "$WORKSPACE_DIR" rev-parse HEAD)
 echo "STABLE_GIT_COMMIT ${git_rev}"
 
 # Check whether there are any uncommitted changes
-if git diff-index --quiet HEAD --; then
+if git -C "$WORKSPACE_DIR" diff-index --quiet HEAD --; then
   echo "STABLE_GIT_TREE_DIRTY "
 else
   echo "STABLE_GIT_TREE_DIRTY -dirty"

--- a/bazel/stamp_vars.sh
+++ b/bazel/stamp_vars.sh
@@ -24,11 +24,20 @@ set -eo pipefail
 # not start with "STABLE_" are part of the volatile set, which will be used
 # but do not invalidate stamped targets.
 
-git_rev=$(git rev-parse HEAD)
-echo "STABLE_GIT_COMMIT ${git_rev}"
-
 git_tag=$(git describe --always --abbrev=0 --match='v*')
 echo "STABLE_GIT_LATEST_TAG ${git_tag}"
+
+# For CI builds we don't want to use the commit hash as that prevents caching of binaries,
+# ducktape generally only needs the tag anyways, so the hash we omit for everything except
+# full release builds.
+if [[ $1 != "full" ]]; then
+  echo "STABLE_GIT_COMMIT 000000"
+  echo "STABLE_GIT_TREE_DIRTY "
+  exit 0
+fi
+
+git_rev=$(git rev-parse HEAD)
+echo "STABLE_GIT_COMMIT ${git_rev}"
 
 # Check whether there are any uncommitted changes
 if git diff-index --quiet HEAD --; then


### PR DESCRIPTION
To improve caching in Bazel when we need to stamp binaries with versions
in CI, we add a seperate stamp configuration for when we only want the
tag encoded, not the full git commit sha.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
