### PR TITLE
[v24.2.x] cluster/partition: Reword description for kafka_request_bytes_total.

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -202,6 +202,11 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
       partition_label(ntp.tp.partition()),
     };
 
+    const sm::description request_bytes_description(
+      "Total number of bytes read from or written to the partitions of a "
+      "topic. The total may include fetched bytes that are not returned to the "
+      "client.");
+
     _public_metrics.add_group(
       prometheus_sanitize::metrics_name("kafka"),
       {
@@ -251,7 +256,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "request_bytes_total",
           [this] { return _bytes_produced; },
-          sm::description("Total number of bytes produced per topic"),
+          request_bytes_description,
           {request_label("produce"),
            ns_label(ntp.ns()),
            topic_label(ntp.tp.topic()),
@@ -260,8 +265,7 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "request_bytes_total",
           [this] { return _bytes_fetched; },
-          sm::description("Total number of bytes fetched (not all "
-                          "might be returned to the client)"),
+          request_bytes_description,
           {request_label("consume"),
            ns_label(ntp.ns()),
            topic_label(ntp.tp.topic()),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25499
