### PR TITLE
Only throttle if translation scheduling group reached max priority

### DIFF
--- a/src/v/datalake/backlog_controller.h
+++ b/src/v/datalake/backlog_controller.h
@@ -30,6 +30,14 @@ class backlog_controller {
 public:
     using sampling_fn = ss::noncopyable_function<long double()>;
     backlog_controller(sampling_fn, ss::scheduling_group sg);
+    /**
+     * Returns true if the datalake scheduling group has reached the maximum
+     * allowed priority. Indicates that translation backlog is growing and
+     * translators can not keep up.
+     */
+    bool max_shares_assigned() const {
+        return static_cast<int>(_scheduling_group.get_shares()) == _max_shares;
+    }
 
     ss::future<> start();
     ss::future<> stop();

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -436,7 +436,7 @@ ss::future<uint64_t> datalake_manager::disk_usage() {
     co_return total;
 }
 
-size_t datalake_manager::partitions_over_target_translation_backlog() const {
+size_t datalake_manager::overdue_translation_partition_count() const {
     auto now = translation::scheduling::clock::now();
     return std::ranges::count_if(
       _scheduler.all_translators(), [now](const auto& entry) {

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -436,6 +436,10 @@ ss::future<uint64_t> datalake_manager::disk_usage() {
     co_return total;
 }
 
+bool datalake_manager::max_shares_assigned() const {
+    return _backlog_controller->max_shares_assigned();
+}
+
 size_t datalake_manager::overdue_translation_partition_count() const {
     auto now = translation::scheduling::clock::now();
     return std::ranges::count_if(

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -86,7 +86,7 @@ public:
      * Returns the number of partitions that the translator is not able to keep
      * up with.
      */
-    size_t partitions_over_target_translation_backlog() const;
+    size_t overdue_translation_partition_count() const;
     /**
      * Returns count of partitions that translation is blocked. This value
      * should be 0 in normal conditions.

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -92,6 +92,10 @@ public:
      * should be 0 in normal conditions.
      */
     size_t partitions_with_translation_blocked() const;
+    /**
+     * Returns true if datalake translation runs with maximum allowed priority.
+     */
+    bool max_shares_assigned() const;
 
 private:
     using translator = std::unique_ptr<translation::partition_translator>;

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -42,6 +42,7 @@ void datalake_throttle_manager::merge_producer_maps(
 datalake_throttle_manager::status datalake_throttle_manager::status::operator+(
   const datalake_throttle_manager::status& o) const {
     return datalake_throttle_manager::status{
+      .max_shares_assigned = max_shares_assigned || o.max_shares_assigned,
       .overdue_translation_partition_count
       = overdue_translation_partition_count
         + o.overdue_translation_partition_count,
@@ -49,17 +50,18 @@ datalake_throttle_manager::status datalake_throttle_manager::status::operator+(
                                         + o.partitions_translation_blocked};
 }
 
-bool datalake_throttle_manager::status::has_no_issues() const {
-    return overdue_translation_partition_count == 0
-           && partitions_translation_blocked == 0;
+bool datalake_throttle_manager::status::needs_throttling() const {
+    return max_shares_assigned
+           && (overdue_translation_partition_count > 0 || partitions_translation_blocked > 0);
 }
 
 std::ostream&
 operator<<(std::ostream& o, const datalake_throttle_manager::status& s) {
     fmt::print(
       o,
-      "{{overdue_translation_partition_count: {}, "
+      "{{max_shares_assigned: {}, overdue_translation_partition_count: {}, "
       "partitions_translation_blocked: {}}}",
+      s.max_shares_assigned,
       s.overdue_translation_partition_count,
       s.partitions_translation_blocked);
     return o;
@@ -113,9 +115,16 @@ ss::future<> datalake_throttle_manager::gc_and_update_global_producers_map() {
       },
       status{},
       [](status acc, status shard_status) { return acc + shard_status; });
-    if (_translation_status.has_no_issues()) {
+    if (!_translation_status.needs_throttling()) {
         _last_no_issues_timestamp = clock_type::now();
     }
+    if (_translation_status.needs_throttling()) [[unlikely]] {
+        vlog(
+          client_quota_log.info,
+          "Translation status updated: {}, throttling may be applied.",
+          _translation_status);
+    }
+
     /**
      * Collect shard local maps and while iterating over the shards update the
      * total backlog
@@ -145,7 +154,7 @@ datalake_throttle_manager::maybe_throttle_producer(
   std::optional<std::string_view> client_id) {
     // fast path, backlog is below the threshold
 
-    if (_translation_status.has_no_issues()) [[likely]] {
+    if (!_translation_status.needs_throttling()) [[likely]] {
         co_return no_throttling;
     }
 
@@ -172,7 +181,7 @@ std::chrono::milliseconds datalake_throttle_manager::get_producer_throttle(
   const std::optional<std::string_view>& client_id) {
     vassert(
       ss::this_shard_id() == 0, "Throttle can only be calculate on shard 0");
-    if (_translation_status.has_no_issues()) [[likely]] {
+    if (!_translation_status.needs_throttling()) [[likely]] {
         return no_throttling;
     }
     auto effective_client_id = get_effective_client_id(client_id);

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -43,14 +43,15 @@ datalake_throttle_manager::backlog_status
 datalake_throttle_manager::backlog_status::operator+(
   const datalake_throttle_manager::backlog_status& o) const {
     return datalake_throttle_manager::backlog_status{
-      .partitions_backlog_limit_breached
-      = partitions_backlog_limit_breached + o.partitions_backlog_limit_breached,
+      .overdue_translation_partition_count
+      = overdue_translation_partition_count
+        + o.overdue_translation_partition_count,
       .partitions_translation_blocked = partitions_translation_blocked
                                         + o.partitions_translation_blocked};
 }
 
 bool datalake_throttle_manager::backlog_status::has_no_issues() const {
-    return partitions_backlog_limit_breached == 0
+    return overdue_translation_partition_count == 0
            && partitions_translation_blocked == 0;
 }
 
@@ -58,9 +59,9 @@ std::ostream& operator<<(
   std::ostream& o, const datalake_throttle_manager::backlog_status& s) {
     fmt::print(
       o,
-      "{{partitions_backlog_limit_breached: {}, "
+      "{{overdue_translation_partition_count: {}, "
       "partitions_translation_blocked: {}}}",
-      s.partitions_backlog_limit_breached,
+      s.overdue_translation_partition_count,
       s.partitions_translation_blocked);
     return o;
 }
@@ -202,7 +203,7 @@ datalake_throttle_manager::calculate_throttle() const {
     // translation state, the longer the time the more we throttle. The
     // throttle is set to max after 5 minutes
 
-    if (_translation_status.partitions_backlog_limit_breached > 0) {
+    if (_translation_status.overdue_translation_partition_count > 0) {
         auto time_in_degraded_state
           = std::chrono::duration_cast<std::chrono::milliseconds>(
             ss::lowres_clock::now() - _last_no_issues_timestamp);

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -39,10 +39,9 @@ void datalake_throttle_manager::merge_producer_maps(
     }
 }
 
-datalake_throttle_manager::backlog_status
-datalake_throttle_manager::backlog_status::operator+(
-  const datalake_throttle_manager::backlog_status& o) const {
-    return datalake_throttle_manager::backlog_status{
+datalake_throttle_manager::status datalake_throttle_manager::status::operator+(
+  const datalake_throttle_manager::status& o) const {
+    return datalake_throttle_manager::status{
       .overdue_translation_partition_count
       = overdue_translation_partition_count
         + o.overdue_translation_partition_count,
@@ -50,13 +49,13 @@ datalake_throttle_manager::backlog_status::operator+(
                                         + o.partitions_translation_blocked};
 }
 
-bool datalake_throttle_manager::backlog_status::has_no_issues() const {
+bool datalake_throttle_manager::status::has_no_issues() const {
     return overdue_translation_partition_count == 0
            && partitions_translation_blocked == 0;
 }
 
-std::ostream& operator<<(
-  std::ostream& o, const datalake_throttle_manager::backlog_status& s) {
+std::ostream&
+operator<<(std::ostream& o, const datalake_throttle_manager::status& s) {
     fmt::print(
       o,
       "{{overdue_translation_partition_count: {}, "
@@ -112,10 +111,8 @@ ss::future<> datalake_throttle_manager::gc_and_update_global_producers_map() {
       [](datalake_throttle_manager& instance) {
           return instance._shard_status_provider();
       },
-      backlog_status{},
-      [](backlog_status acc, backlog_status shard_status) {
-          return acc + shard_status;
-      });
+      status{},
+      [](status acc, status shard_status) { return acc + shard_status; });
     if (_translation_status.has_no_issues()) {
         _last_no_issues_timestamp = clock_type::now();
     }

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -34,14 +34,14 @@ namespace kafka {
 class datalake_throttle_manager
   : public ss::peering_sharded_service<datalake_throttle_manager> {
 public:
-    struct backlog_status {
+    struct status {
         size_t overdue_translation_partition_count{0};
         size_t partitions_translation_blocked{0};
 
         bool has_no_issues() const;
-        backlog_status operator+(const backlog_status& o) const;
+        status operator+(const status& o) const;
 
-        friend std::ostream& operator<<(std::ostream&, const backlog_status&);
+        friend std::ostream& operator<<(std::ostream&, const status&);
     };
 
     using clock_type = ss::lowres_clock;
@@ -49,8 +49,7 @@ public:
      * The function should return a number reflecting the current backlog of
      * Iceberg translation on a shard.
      */
-    using status_provider_fn
-      = ss::noncopyable_function<ss::future<backlog_status>()>;
+    using status_provider_fn = ss::noncopyable_function<ss::future<status>()>;
 
     datalake_throttle_manager(
       status_provider_fn,
@@ -100,7 +99,7 @@ private:
     // global producers are maintained only on shard 0.
     producers_map_t _global_producers;
     // backlog status, calculated on shard 0 but updated on every shard
-    backlog_status _translation_status;
+    status _translation_status;
     // shard local producers map used to quickly update the state of producer.
     // The global map is updated by the background task.
     producers_map_t _shard_local_producers;

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -35,10 +35,11 @@ class datalake_throttle_manager
   : public ss::peering_sharded_service<datalake_throttle_manager> {
 public:
     struct status {
+        bool max_shares_assigned{false};
         size_t overdue_translation_partition_count{0};
         size_t partitions_translation_blocked{0};
 
-        bool has_no_issues() const;
+        bool needs_throttling() const;
         status operator+(const status& o) const;
 
         friend std::ostream& operator<<(std::ostream&, const status&);

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -35,7 +35,7 @@ class datalake_throttle_manager
   : public ss::peering_sharded_service<datalake_throttle_manager> {
 public:
     struct backlog_status {
-        size_t partitions_backlog_limit_breached{0};
+        size_t overdue_translation_partition_count{0};
         size_t partitions_translation_blocked{0};
 
         bool has_no_issues() const;

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -10,6 +10,7 @@ using namespace testing;
 using namespace std::chrono_literals;
 
 struct shard_local_state {
+    bool max_shares_assigned{false};
     size_t blocked_translation{0};
     size_t not_keeping_up{0};
     config::mock_property<std::chrono::milliseconds> producer_gc_threshold{
@@ -22,7 +23,7 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
         shard_state.start().get();
         manager
           .start(
-            [this] { return sample_backlog(); },
+            [this] { return sample(); },
             ss::sharded_parameter(
               [this] { return shard_state.local().max_throttle.bind(); }),
             ss::sharded_parameter([this] {
@@ -37,8 +38,9 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
         shard_state.stop().get();
     }
 
-    ss::future<kafka::datalake_throttle_manager::status> sample_backlog() {
+    ss::future<kafka::datalake_throttle_manager::status> sample() {
         co_return kafka::datalake_throttle_manager::status{
+          .max_shares_assigned = shard_state.local().max_shares_assigned,
           .overdue_translation_partition_count
           = shard_state.local().not_keeping_up,
           .partitions_translation_blocked
@@ -92,9 +94,17 @@ TEST_F(IcebergThrottlingManagerTest, TestThrottlingIcebergEnabledProducer) {
     ASSERT_EQ(
       manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
     // set the backlog above the threshold on one shards, the throttling should
-    // be applied
+    // not be applied as no max shares is assigned
     shard_state
       .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .get();
+
+    ASSERT_EQ(
+      manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
+    // set max shares assigned, the throttling should be applied
+    shard_state
+      .invoke_on(
+        0, [](shard_local_state& state) { state.max_shares_assigned = true; })
       .get();
     wait_for_producer_throttling("producer-20", 10ms).get();
 
@@ -117,7 +127,12 @@ TEST_F(IcebergThrottlingManagerTest, TestProducerEviction) {
     // wait for state to propagate
     ss::sleep(500ms).get();
     shard_state
-      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .invoke_on(
+        0,
+        [](shard_local_state& state) {
+            state.max_shares_assigned = true;
+            state.not_keeping_up++;
+        })
       .get();
     wait_for_producer_throttling("producer-20", 10ms).get();
     shard_state
@@ -142,7 +157,12 @@ TEST_F(IcebergThrottlingManagerTest, TestHandlingAnonymousProducers) {
       .get();
 
     shard_state
-      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .invoke_on(
+        0,
+        [](shard_local_state& state) {
+            state.max_shares_assigned = true;
+            state.not_keeping_up++;
+        })
       .get();
     // check if anonymous producer is throttled
     wait_for_producer_throttling(std::nullopt, 10ms).get();
@@ -158,7 +178,11 @@ TEST_F(IcebergThrottlingManagerTest, TestHandlingBlockedPartitions) {
     // be applied
     shard_state
       .invoke_on(
-        0, [](shard_local_state& state) { state.blocked_translation++; })
+        0,
+        [](shard_local_state& state) {
+            state.max_shares_assigned = true;
+            state.blocked_translation++;
+        })
       .get();
     // the max throttle should be applied,
     wait_for_producer_throttling("producer-20", 30s).get();

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -40,7 +40,7 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
     ss::future<kafka::datalake_throttle_manager::backlog_status>
     sample_backlog() {
         co_return kafka::datalake_throttle_manager::backlog_status{
-          .partitions_backlog_limit_breached
+          .overdue_translation_partition_count
           = shard_state.local().not_keeping_up,
           .partitions_translation_blocked
           = shard_state.local().blocked_translation};

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -37,9 +37,8 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
         shard_state.stop().get();
     }
 
-    ss::future<kafka::datalake_throttle_manager::backlog_status>
-    sample_backlog() {
-        co_return kafka::datalake_throttle_manager::backlog_status{
+    ss::future<kafka::datalake_throttle_manager::status> sample_backlog() {
+        co_return kafka::datalake_throttle_manager::status{
           .overdue_translation_partition_count
           = shard_state.local().not_keeping_up,
           .partitions_translation_blocked

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1420,7 +1420,7 @@ void application::wire_up_runtime_services(
         construct_service(
           datalake_throttle_manager,
           [&mgr = _datalake_manager] {
-              return ssx::now(kafka::datalake_throttle_manager::backlog_status{
+              return ssx::now(kafka::datalake_throttle_manager::status{
                 .overdue_translation_partition_count
                 = mgr.local().overdue_translation_partition_count(),
                 .partitions_translation_blocked

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1421,6 +1421,7 @@ void application::wire_up_runtime_services(
           datalake_throttle_manager,
           [&mgr = _datalake_manager] {
               return ssx::now(kafka::datalake_throttle_manager::status{
+                .max_shares_assigned = mgr.local().max_shares_assigned(),
                 .overdue_translation_partition_count
                 = mgr.local().overdue_translation_partition_count(),
                 .partitions_translation_blocked

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1421,8 +1421,8 @@ void application::wire_up_runtime_services(
           datalake_throttle_manager,
           [&mgr = _datalake_manager] {
               return ssx::now(kafka::datalake_throttle_manager::backlog_status{
-                .partitions_backlog_limit_breached
-                = mgr.local().partitions_over_target_translation_backlog(),
+                .overdue_translation_partition_count
+                = mgr.local().overdue_translation_partition_count(),
                 .partitions_translation_blocked
                 = mgr.local().partitions_with_translation_blocked(),
               });

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -62,9 +62,8 @@ class DatalakeThrottlingTest(RedpandaTest):
             total += s.value
         return total
 
-    def producer_throttled(self):
-        rpk = RpkTool(self.redpanda)
-        rpk.produce(self.topic_name, "key", "value")
+    def producer_throttled(self, dl: DatalakeServices):
+        dl.produce_to_topic(self.topic_name, 128, 10240)
         throttle = self._total_throttle()
         return throttle > 0
 
@@ -89,11 +88,15 @@ class DatalakeThrottlingTest(RedpandaTest):
             ) == 0, "There should be no throttling in baseline conditions"
 
             # Block translation by setting the max number of translations to 0
-            self.redpanda.set_cluster_config(
-                {"datalake_scheduler_max_concurrent_translations": 0})
+            self.redpanda.set_cluster_config({
+                "datalake_scheduler_max_concurrent_translations":
+                0,
+                "iceberg_target_backlog_size":
+                1000
+            })
+
             # Produce some more messages
-            dl.produce_to_topic(self.topic_name, 1024, msg_cnt)
-            wait_until(lambda: self.producer_throttled(), timeout_sec=30)
+            wait_until(lambda: self.producer_throttled(dl), timeout_sec=60)
 
             # Validate that non Iceberg related producers are not throttled
             current_throttle = self._total_throttle()


### PR DESCRIPTION
Previously throttling was applied immediately after any partition has
breached the target lag. This throttling strategy is incorrect as
translation may be still keeping up but the target backlog as maintained
by the backlog controller wasn't reached.

Change the translation strategy to apply throttle only if translation
scheduling group is configured with max allowed shares.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none