### PR TITLE
DT: Fix --unsafe-bypass-fsync setting

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -439,8 +439,6 @@ class ResourceSettings:
         else:
             memory_mb = self._memory_mb
 
-        bypass_fsync = True if dedicated_node else self._bypass_fsync
-
         args: list[str] = []
         if not dedicated_node:
             args.extend([
@@ -457,7 +455,8 @@ class ResourceSettings:
         if memory_mb is not None:
             args.append(f"--memory={memory_mb}M")
 
-        args.append(f"--unsafe-bypass-fsync={'1' if bypass_fsync else '0'}")
+        args.append(
+            f"--unsafe-bypass-fsync={'1' if self._bypass_fsync else '0'}")
 
         return preamble, " ".join(args)
 


### PR DESCRIPTION
We were now unconditionally setting it for dedicated nodes while that's
not something we did before (and is wrong).

Broken in 2181cba35cff84d709d7b8ace6421b84bbe0eea6

Detected by CPD.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
