### PR TITLE
[v25.1.x] Conservative validation in `kafka::group`

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2175,6 +2175,35 @@ void group::update_store_offset_builder(
       offset_metadata_kv{.key = std::move(key), .value = std::move(value)});
     builder.add_raw_kv(std::move(kv.key), std::move(kv.value));
 }
+bool group::try_upsert_offset(
+  const model::topic_partition& tp, offset_metadata md) {
+    if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
+        if (o_it->second->metadata.log_offset < md.log_offset) {
+            if (o_it->second->metadata.offset > md.offset) [[unlikely]] {
+                vlog(
+                  _ctxlog.info,
+                  "Requested commited offset for {} to be smaller than "
+                  "previously committed value - previous: {} requested: {}",
+                  tp,
+                  o_it->second->metadata.offset,
+                  md.offset);
+            }
+            o_it->second->metadata = std::move(md);
+            return true;
+        }
+        return false;
+    } else {
+        _offsets.emplace(
+          tp,
+          std::make_unique<offset_metadata_with_probe>(
+            std::move(md),
+            _id,
+            tp,
+            _conf.enable_consumer_group_metrics.bind(
+              std::function{enabled_metrics::from_vector})));
+        return true;
+    }
+}
 
 group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
     cluster::simple_batch_builder builder(

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -651,25 +651,7 @@ public:
     }
 
     bool
-    try_upsert_offset(const model::topic_partition& tp, offset_metadata md) {
-        if (auto o_it = _offsets.find(tp); o_it != _offsets.end()) {
-            if (o_it->second->metadata.log_offset < md.log_offset) {
-                o_it->second->metadata = std::move(md);
-                return true;
-            }
-            return false;
-        } else {
-            _offsets.emplace(
-              tp,
-              std::make_unique<offset_metadata_with_probe>(
-                std::move(md),
-                _id,
-                tp,
-                _conf.enable_consumer_group_metrics.bind(
-                  std::function{enabled_metrics::from_vector})));
-            return true;
-        }
-    }
+    try_upsert_offset(const model::topic_partition& tp, offset_metadata md);
 
     void
     insert_ongoing_tx(model::producer_identity pid, ongoing_transaction tx);

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1812,6 +1812,23 @@ error_code group_manager::validate_group_status(
               ntp);
             return error_code::not_coordinator;
         }
+        /**
+         * Check if term changed, this can happen if a node that stepped down
+         * became a leader again.
+         */
+        if (it->second->partition->term() != it->second->term()) {
+            vlog(
+              cg_klog.info,
+              "Group {} operation {} for partition {} processed while term "
+              "changed. "
+              "Group term: {} current term: {}",
+              group,
+              api,
+              ntp,
+              it->second->term(),
+              it->second->partition->term());
+            return error_code::not_coordinator;
+        }
 
         if (it->second->loading) {
             vlog(

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -34,7 +34,8 @@ ss::future<> group_recovery_consumer::handle_tx_offsets(
       "[group: {}] recovered update tx offsets: {}",
       data.group_id,
       data);
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
+    auto [group_it, _] = _state.groups.try_emplace(
+      data.group_id, data.group_id);
     group_it->second.update_tx_offset(hdr.last_offset(), data);
     co_return;
 }
@@ -49,7 +50,8 @@ ss::future<> group_recovery_consumer::handle_fence_v0(
       data.group_id,
       group::fence_control_record_v0_version,
       pid);
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
+    auto [group_it, _] = _state.groups.try_emplace(
+      data.group_id, data.group_id);
     group_it->second.try_set_fence(pid.get_id(), pid.get_epoch());
     co_return;
 }
@@ -65,7 +67,8 @@ ss::future<> group_recovery_consumer::handle_fence_v1(
       group::fence_control_record_v1_version,
       pid,
       data);
-    auto [group_it, _] = _state.groups.try_emplace(data.group_id);
+    auto [group_it, _] = _state.groups.try_emplace(
+      data.group_id, data.group_id);
     group_it->second.try_set_fence(
       pid.get_id(),
       pid.get_epoch(),
@@ -208,7 +211,7 @@ void group_recovery_consumer::handle_group_metadata(group_metadata_kv md) {
           md.key.group_id);
 
         auto [group_it, _] = _state.groups.try_emplace(
-          md.key.group_id, group_stm());
+          md.key.group_id, md.key.group_id);
         group_it->second.overwrite_metadata(std::move(*md.value));
     } else {
         // tombstone
@@ -230,7 +233,7 @@ void group_recovery_consumer::handle_offset_metadata(offset_metadata_kv md) {
         // until we switch over to a compacted topic or use raft snapshots,
         // always take the latest entry in the log.
         auto [group_it, _] = _state.groups.try_emplace(
-          md.key.group_id, group_stm());
+          md.key.group_id, md.key.group_id);
         if (_state.has_offset_retention_feature_fence) {
             md.value->non_reclaimable = false;
         }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -2,6 +2,7 @@
 
 #include "cluster/logger.h"
 #include "kafka/server/group_metadata.h"
+#include "kafka/server/logger.h"
 #include "model/record.h"
 
 namespace kafka {
@@ -19,8 +20,27 @@ void group_stm::update_offset(
   const model::topic_partition& key,
   model::offset offset,
   offset_metadata_value&& meta) {
-    _offsets[key] = logged_metadata{
+    logged_metadata logged_md{
       .log_offset = offset, .metadata = std::move(meta)};
+
+    auto it = _offsets.find(key);
+    if (it == _offsets.end()) {
+        _offsets.emplace(key, std::move(logged_md));
+        return;
+    }
+    if (it->second.metadata.offset > logged_md.metadata.offset) {
+        vlog(
+          cg_klog.info,
+          "[group: {}] offset metadata for {}/{} is older than the one "
+          "already stored, stored offset: {}, new offset: {}. Log offset: {}",
+          _group_id,
+          key.topic,
+          key.partition,
+          it->second.metadata.offset,
+          logged_md.metadata.offset,
+          logged_md.log_offset);
+    }
+    it->second = std::move(logged_md);
 }
 
 void group_stm::update_tx_offset(

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -44,6 +44,9 @@ public:
         model::producer_epoch epoch;
         std::unique_ptr<ongoing_tx> tx;
     };
+    explicit group_stm(ss::sstring group_id)
+      : _group_id(std::move(group_id)) {}
+
     void overwrite_metadata(group_metadata_value&&);
 
     void update_offset(
@@ -81,7 +84,7 @@ public:
 private:
     chunked_hash_map<model::topic_partition, logged_metadata> _offsets;
     chunked_hash_map<model::producer_id, producer> _producers;
-
+    ss::sstring _group_id;
     group_metadata_value _metadata;
     bool _is_loaded{false};
     bool _is_removed{false};

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -276,10 +276,11 @@ TEST_F_CORO(cg_recovery_test_fixture, test_single_group_recovery) {
     auto state = co_await recover_from_batches(std::move(batches));
     const auto gr = meta.key.group_id;
     EXPECT_EQ(state.groups.size(), 1);
-    EXPECT_EQ(state.groups[gr].get_metadata(), meta.value);
-    EXPECT_EQ(state.groups[gr].offsets().size(), 2);
+    auto& group_state = state.groups.find(gr)->second;
+    EXPECT_EQ(group_state.get_metadata(), meta.value);
+    EXPECT_EQ(group_state.offsets().size(), 2);
     expect_committed_offsets(
-      state.groups[gr].offsets(), "test-1/0@1024", "test-2/10@256");
+      group_state.offsets(), "test-1/0@1024", "test-2/10@256");
 }
 
 TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
@@ -324,12 +325,15 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
     const auto gr_1 = g_1_metadata.key.group_id;
     const auto gr_2 = g_2_metadata.key.group_id;
     EXPECT_EQ(state.groups.size(), 2);
-    EXPECT_EQ(state.groups[gr_1].get_metadata(), g_1_metadata.value);
+    auto& gr_1_state = state.groups.find(gr_1)->second;
+    EXPECT_EQ(gr_1_state.get_metadata(), g_1_metadata.value);
     expect_committed_offsets(
-      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+      gr_1_state.offsets(), "test-1/0@1024", "test-2/10@256");
 
     expect_committed_offsets(
-      state.groups[gr_2].offsets(), "test-20/2@123", "test-123/10@45");
+      state.groups.find(gr_2)->second.offsets(),
+      "test-20/2@123",
+      "test-123/10@45");
 
     // add group 1 tombstone
     auto g_1_ts_kv = group_metadata_kv{
@@ -357,7 +361,8 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
       std::move(batches_with_tombstones));
     EXPECT_EQ(state_new.groups.size(), 1);
     EXPECT_FALSE(state_new.groups.contains(gr_1));
-    EXPECT_FALSE(state_new.groups[gr_2].offsets().contains(
+    auto& gr_2_state = state_new.groups.find(gr_2)->second;
+    EXPECT_FALSE(gr_2_state.offsets().contains(
       model::topic_partition(model::topic("t-20"), model::partition_id(2))));
 }
 
@@ -389,31 +394,34 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
         .offsets = std::vector<group_tx::partition_offset>{
           make_tx_offset("test-1", 0, 2048),
           make_tx_offset("topic-3", 12, 1)}}));
+    {
+        auto state = co_await recover_from_batches(copy_batches(batches));
+        EXPECT_EQ(state.groups.size(), 1);
+        auto& gr_1_state = state.groups.find(gr_1)->second;
+        EXPECT_EQ(gr_1_state.producers().size(), 1);
+        // tx is ongoing offsets included in the transaction should not be
+        // visible in state machine
 
-    auto state = co_await recover_from_batches(copy_batches(batches));
-    EXPECT_EQ(state.groups[gr_1].producers().size(), 1);
-    // tx is ongoing offsets included in the transaction should not be
-    // visible in state machine
+        expect_committed_offsets(
+          gr_1_state.offsets(), "test-1/0@1024", "test-2/10@256");
 
-    EXPECT_EQ(state.groups.size(), 1);
-    expect_committed_offsets(
-      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+        batches.push_back(make_tx_batch(
+          model::record_batch_type::group_commit_tx,
+          0,
+          pid,
+          group_tx::commit_metadata{.group_id = gr_1}));
+    }
+    {
+        auto state = co_await recover_from_batches(copy_batches(batches));
+        auto& gr_1_state = state.groups.find(gr_1)->second;
+        EXPECT_EQ(gr_1_state.producers().size(), 1);
 
-    batches.push_back(make_tx_batch(
-      model::record_batch_type::group_commit_tx,
-      0,
-      pid,
-      group_tx::commit_metadata{.group_id = gr_1}));
-
-    state = co_await recover_from_batches(copy_batches(batches));
-
-    EXPECT_EQ(state.groups[gr_1].producers().size(), 1);
-
-    expect_committed_offsets(
-      state.groups[gr_1].offsets(),
-      "test-1/0@2048",
-      "test-2/10@256",
-      "topic-3/12@1");
+        expect_committed_offsets(
+          gr_1_state.offsets(),
+          "test-1/0@2048",
+          "test-2/10@256",
+          "topic-3/12@1");
+    }
 
     /**
      * try aborting already committed tx, this should fail
@@ -424,15 +432,13 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
       pid,
       group_tx::abort_metadata{.group_id = gr_1, .tx_seq = tx_seq}));
 
-    state = co_await recover_from_batches(copy_batches(batches));
+    auto state = co_await recover_from_batches(copy_batches(batches));
+    auto& gr_1_state = state.groups.find(gr_1)->second;
     expect_committed_offsets(
-      state.groups[gr_1].offsets(),
-      "test-1/0@2048",
-      "test-2/10@256",
-      "topic-3/12@1");
+      gr_1_state.offsets(), "test-1/0@2048", "test-2/10@256", "topic-3/12@1");
 
-    EXPECT_EQ(state.groups[gr_1].producers().size(), 1);
-    EXPECT_EQ(state.groups[gr_1].producers().begin()->second.tx, nullptr);
+    EXPECT_EQ(gr_1_state.producers().size(), 1);
+    EXPECT_EQ(gr_1_state.producers().begin()->second.tx, nullptr);
 }
 
 TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
@@ -472,11 +478,12 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
       pid,
       group_tx::abort_metadata{.group_id = gr_1, .tx_seq = tx_seq}));
     auto state = co_await recover_from_batches(copy_batches(batches));
-    EXPECT_EQ(state.groups[gr_1].producers().size(), 1);
-    EXPECT_EQ(state.groups[gr_1].producers().begin()->second.tx, nullptr);
+    auto& gr_1_state = state.groups.find(gr_1)->second;
+    EXPECT_EQ(gr_1_state.producers().size(), 1);
+    EXPECT_EQ(gr_1_state.producers().begin()->second.tx, nullptr);
 
     expect_committed_offsets(
-      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+      gr_1_state.offsets(), "test-1/0@1024", "test-2/10@256");
 
     // commit of aborted tx should be ignored
     batches.push_back(make_tx_batch(
@@ -485,9 +492,9 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
       pid,
       group_tx::commit_metadata{.group_id = gr_1}));
 
-    EXPECT_EQ(state.groups[gr_1].producers().size(), 1);
-    EXPECT_EQ(state.groups[gr_1].producers().begin()->second.tx, nullptr);
+    EXPECT_EQ(gr_1_state.producers().size(), 1);
+    EXPECT_EQ(gr_1_state.producers().begin()->second.tx, nullptr);
 
     expect_committed_offsets(
-      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+      gr_1_state.offsets(), "test-1/0@1024", "test-2/10@256");
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25533
