### PR TITLE
rptest: Fix single partition test

### DIFF
--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -222,6 +222,7 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
         #   clean.
         # - 1 per upload round (i.e. per 1-4 segments) for updating the highest
         #   producer ID.
+        # - 1 per upload round (i.e. per 1-4 segments) for rw-fence
         # - 1 per raft term, for raft config batches written by new leaders
         #
         # This helps to assure us that ntp_archiver and archival_metadata_stm
@@ -242,12 +243,31 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
             f"Delta: {offset_delta}, Segments: {segment_count}, Last term {last_term}"
         )
 
-        # If we upload in batches of four segments at a time
-        min_offset_delta = (segment_count * 1.5) + last_term
+        # If we upload in batches of four segments at a time.
+        # Number of record batches per segment is calculated as:
+        # N = 7 records / 4 segments = 1.75 records per segment
+        # where 7 records are:
+        # 4 add_segment commands
+        # 1 rw_fence command
+        # 1 mark_clean command
+        # 1 update_highest_producer_id command
+        # We need to take term into account because we are replicating
+        # raft config batches in the beginning of each term.
+        min_offset_delta = (segment_count * 1.75) + last_term
 
-        # If we upload one segment at a time
-        max_offset_delta = (segment_count * 3) + last_term
-        assert min_offset_delta <= offset_delta <= max_offset_delta
+        # If we upload one segment at a time.
+        # Number of record batches per segment is calculated as:
+        # N = 4 records / 1 segments = 4 records per segment
+        # where 4 records are:
+        # 1 add_segment command
+        # 1 rw_fence command
+        # 1 mark_clean command
+        # 1 update_highest_producer_id command
+        # We need to take term into account because we are replicating
+        # raft config batches in the beginning of each term.
+        max_offset_delta = (segment_count * 4) + last_term
+        assert min_offset_delta <= offset_delta <= max_offset_delta, \
+            f"Offset delta {offset_delta} not in range {min_offset_delta} - {max_offset_delta}. Are any new archival_metadata_stm commands added recently?"
 
         # +3 because:
         # - 1 empty upload at start


### PR DESCRIPTION
The test is flaky because we added a new command. The test is trying to estimate the delta offset based on number of uploaded segments. The archiver adds one metadata record per segment. But also it adds one 'mark_clean' command and one 'update_highest_producer_id' command.

So the test assumes that if the througput is high the 'ntp_archiver' is uploading 4 segments in every iteration. This means that all these extra metadata records are added only once per iteration. Which is just two extra metadata records per four segment metadata records. Which gives us a value of 1.5 for the delta estimation.

If the throughput is not at the top the 'ntp_archiver' makes less than four segment uploads per iteration. In this case the metadata overhead is larger. The max overhead is two metadata records per every segment record. So the delta is number of segments multiplied by 3.

But because the additional command was introduced (rw-fence) this reasoning no longer holds. In order to estimate the bounds for the delta offset we need to multiply number of segments by 1.75 and 4.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none