### PR TITLE
`rptest`: basic `avro` schema generation and `iceberg` testing

### DIFF
--- a/tests/rptest/tests/datalake/schema_scale_test.py
+++ b/tests/rptest/tests/datalake/schema_scale_test.py
@@ -1,0 +1,205 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+import random
+from confluent_kafka import avro
+from confluent_kafka.avro import AvroProducer
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import PandaproxyConfig, SISettings, SchemaRegistryConfig
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.schemas.schema_generator import SchemaGenerator
+from rptest.tests.datalake.schemas.data_types import ProducerType, ALL_PRIMITIVE_DATA_TYPES
+from ducktape.mark import matrix
+
+QUERY_ENGINES = [
+    QueryEngineType.SPARK,
+    QueryEngineType.TRINO,
+]
+
+
+def get_random_primitive_field(schema_json):
+    fully_qualified_prim_field_names = []
+    avro_data_types = [t.to_avro() for t in ALL_PRIMITIVE_DATA_TYPES]
+
+    def traverse_fields(fields, qualified_name=""):
+        for field in fields:
+            if isinstance(field["type"],
+                          str) and field["type"] in avro_data_types:
+                fully_qualified_prim_field_names.append(
+                    (f"{qualified_name}{field['name']}", field["type"]))
+            elif isinstance(field["type"], dict):
+                if "fields" in field["type"]:
+                    traverse_fields(field["type"]["fields"],
+                                    f"{qualified_name}{field['name']}.")
+
+    traverse_fields(schema_json["fields"])
+    return random.choice(fully_qualified_prim_field_names)
+
+
+class SchemaScaleTester:
+    def __init__(self, redpanda, topic_name):
+        self.redpanda = redpanda
+        self.topic_name = topic_name
+        self.table_name = f"redpanda.{self.topic_name}"
+        self.schema = None
+        self.schema_fields = None
+        self.schema_template = None
+        self.partition_spec = None
+        self.total = 0
+
+    def _make_schema(self, use_partition_spec: bool = False):
+        sg = SchemaGenerator(ProducerType.AVRO, max_depth=15, max_fields=150)
+        schema, template = sg.generate_schema_fields()
+        self.schema = schema
+        self.schema_fields = sg.fields
+        self.schema_template = template
+
+        self.redpanda.logger.debug(
+            f"Using randomly generated schema: {json.dumps(self.schema.to_json(), indent=2)}"
+        )
+
+        if use_partition_spec:
+            random_primitive_field = get_random_primitive_field(
+                self.schema.to_json())
+            self.partition_spec = f"({random_primitive_field[0]})"
+            self.redpanda.logger.debug(
+                f"Using randomly selected field for partition spec: {random_primitive_field}"
+            )
+
+    def _make_avro_producer(self) -> AvroProducer:
+        self.avro_producer = AvroProducer(
+            {
+                'bootstrap.servers': self.redpanda.brokers(),
+                'schema.registry.url': self.redpanda.schema_reg().split(",")[0]
+            },
+            default_value_schema=avro.loads(json.dumps(self.schema.to_json())))
+
+    def _make_random_record(self, validate: bool = False):
+        assert self.schema and self.schema_fields and self.schema_template, "Need to set schema before _make_random_record() is called"
+        return SchemaGenerator.make_random_record(self.schema,
+                                                  self.schema_fields,
+                                                  self.schema_template,
+                                                  validate=validate)
+
+    def produce(
+        self,
+        dl: DatalakeServices,
+        topic_name: str,
+        count: int,
+        should_translate: bool = True,
+        mode: ProducerType = ProducerType.AVRO,
+    ):
+
+        for i in range(count):
+            record = self._make_random_record(validate=True)
+            if i == 0:
+                self.redpanda.logger.debug(
+                    f"Producing randomly generated record: {record}")
+            self.avro_producer.produce(topic=topic_name, value=record)
+
+        self.avro_producer.flush()
+        if should_translate:
+            dl.wait_for_translation(topic_name, msg_count=self.total + count)
+            self.total += count
+
+    def log_table_schema(
+        self,
+        dl: DatalakeServices,
+        query_engine: QueryEngineType,
+    ):
+        qe = dl.spark() if query_engine == QueryEngineType.SPARK else dl.trino(
+        )
+        table = qe.run_query_fetch_all(f"describe {self.table_name}")
+        self.redpanda.logger.debug(f"Describe table result: {table}")
+
+    def check_no_dlq_table(self, dl: DatalakeServices):
+        # For only valid records produced, no DLQ table should be created.
+        dlq_table_name = f"{self.topic_name}~dlq"
+        assert not dl.table_exists(
+            dlq_table_name), "Expected no DLQ table in catalog"
+
+    def do_test_schema_scale(self, dl: DatalakeServices,
+                             query_engine: QueryEngineType,
+                             use_partition_spec: bool):
+        config = {
+            TopicSpec.PROPERTY_ICEBERG_INVALID_RECORD_ACTION: "dlq_table",
+            TopicSpec.PROPERTY_CLEANUP_POLICY: TopicSpec.CLEANUP_COMPACT_DELETE
+        }
+        if self.partition_spec is not None:
+            config["redpanda.iceberg.partition.spec"] = self.partition_spec
+
+        dl.create_iceberg_enabled_topic(self.topic_name,
+                                        iceberg_mode="value_schema_id_prefix",
+                                        config=config,
+                                        partitions=10)
+
+        # Generate a random schema
+        self._make_schema(use_partition_spec)
+
+        # Make an Avro producer for the generated schema
+        self._make_avro_producer()
+
+        rpk = RpkTool(self.redpanda)
+        schema_str = json.dumps(self.schema.to_json())
+        r = rpk.create_schema_from_str(f"{self.topic_name}_schema", schema_str)
+
+        for _ in range(3):
+            self.produce(dl, self.topic_name, 5000)
+
+        self.log_table_schema(dl, query_engine)
+        self.check_no_dlq_table(dl)
+
+
+class SchemaScaleTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(SchemaScaleTest,
+              self).__init__(test_ctx,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context=test_ctx),
+                             extra_rp_conf={
+                                 "iceberg_enabled": "true",
+                                 "iceberg_catalog_commit_interval_ms": 5000,
+                                 "log_compaction_interval_ms": 5000,
+                                 "min_cleanable_dirty_ratio": 0.0
+                             },
+                             schema_registry_config=SchemaRegistryConfig(),
+                             pandaproxy_config=PandaproxyConfig(),
+                             *args,
+                             **kwargs)
+        self.test_ctx = test_ctx
+
+    def setUp(self):
+        # redpanda will be started by DatalakeServices
+        pass
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            query_engine=QUERY_ENGINES,
+            catalog_type=supported_catalog_types(),
+            use_partition_spec=[False])
+    def schema_scale_test(self, cloud_storage_type, query_engine, catalog_type,
+                          use_partition_spec):
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
+            # Test 5 randomly generated schemas.
+            for i in range(5):
+                topic_name = f"test_{i}"
+                tester = SchemaScaleTester(self.redpanda, topic_name)
+                tester.do_test_schema_scale(dl, query_engine,
+                                            use_partition_spec)

--- a/tests/rptest/tests/datalake/schemas/data_type_generator.py
+++ b/tests/rptest/tests/datalake/schemas/data_type_generator.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import string
+import random
+
+from collections import defaultdict
+
+from rptest.tests.datalake.schemas.data_types import GenericDataType, GenericRecord, GenericArray, GenericMap, GenericEnum, GenericUnion, GenericOptional, GenericPrimitive, ALL_PRIMITIVE_DATA_TYPES
+
+
+class DataTypeGenerator:
+    """
+    TODO(willem): Split apart avro and protobuf schema generation, leave this class generic.
+    """
+    @staticmethod
+    def generate_random_data_type(schema_generator, data_type: GenericDataType,
+                                  num_sub_fields):
+        if data_type in ALL_PRIMITIVE_DATA_TYPES:
+            return DataTypeGenerator.generate_primitive_type(
+                schema_generator, data_type)
+        elif data_type == GenericRecord:
+            return DataTypeGenerator.generate_random_record(
+                schema_generator, num_sub_fields)
+        elif data_type == GenericArray:
+            return DataTypeGenerator.generate_random_array(
+                schema_generator, num_sub_fields)
+        elif data_type == GenericMap:
+            return DataTypeGenerator.generate_random_map(
+                schema_generator, num_sub_fields)
+        elif data_type == GenericEnum:
+            return DataTypeGenerator.generate_random_enum(
+                schema_generator, num_sub_fields)
+        elif data_type == GenericUnion:
+            return DataTypeGenerator.generate_random_union(
+                schema_generator, num_sub_fields)
+        elif data_type == GenericOptional:
+            return DataTypeGenerator.generate_random_optional(
+                schema_generator, num_sub_fields)
+        else:
+            raise NotImplementedError(f"Unknown data type {data_type.name()}")
+
+    @staticmethod
+    def generate_field(schema_generator, num_sub_fields):
+        schema_generator.current_depth += 1
+        num_sub_fields -= 1
+        schema_generator.num_fields += 1
+        data_type = schema_generator.get_random_data_type(num_sub_fields)
+        field, template = DataTypeGenerator.generate_random_data_type(
+            schema_generator, data_type, num_sub_fields)
+        schema_generator.current_depth -= 1
+        if data_type == GenericEnum:
+            schema_generator.fields[field["name"]] = (data_type,
+                                                      field["type"]["symbols"])
+        else:
+            schema_generator.fields[field["name"]] = (data_type, None)
+        return field, template
+
+    @staticmethod
+    def generate_primitive_type(schema_generator,
+                                data_type: GenericDataType) -> dict:
+        ret = dict()
+        template = dict()
+        field_name = f"field_{schema_generator.num_fields}"
+        template[field_name] = "{{ %s }}" % f"{field_name}"
+        ret["name"] = field_name
+        ret["type"] = data_type.to_producer_type(
+            schema_generator.producer_type)
+        return ret, template
+
+    @staticmethod
+    def generate_random_record(schema_generator, num_sub_fields) -> dict:
+        ret = dict()
+        template = dict()
+        field_name = f"field_{schema_generator.num_fields}"
+        template = {}
+        template[field_name] = {}
+        ret["name"] = field_name
+        ret["type"] = dict()
+        ret["type"]["name"] = f"{field_name}_record"
+        ret["type"]["type"] = GenericRecord.to_producer_type(
+            schema_generator.producer_type)
+        ret["type"]["fields"] = []
+        while num_sub_fields > 0:
+            next_num_sub_fields = random.randint(1, num_sub_fields)
+            num_sub_fields -= next_num_sub_fields
+
+            field = dict()
+            field["name"] = f"field_{schema_generator.num_fields}"
+            sub_field, field_temp = DataTypeGenerator.generate_field(
+                schema_generator, next_num_sub_fields)
+            field.update(sub_field)
+            template[field_name].update(field_temp)
+
+            ret["type"]["fields"].append(field)
+        return ret, template
+
+    @staticmethod
+    def generate_random_array(schema_generator, num_sub_fields) -> dict:
+        ret = dict()
+        template = dict()
+        field_name = f"field_{schema_generator.num_fields}"
+        ret["name"] = field_name
+        ret["type"] = dict()
+        ret["type"]["type"] = GenericArray.to_producer_type(
+            schema_generator.producer_type)
+        field, field_temp = DataTypeGenerator.generate_field(
+            schema_generator, num_sub_fields)
+        ret["type"]["items"] = field["type"]
+        template[field_name] = [v for v in field_temp.values()]
+        return ret, template
+
+    @staticmethod
+    def generate_random_map(schema_generator, num_sub_fields) -> dict:
+        ret = dict()
+        template = dict()
+        field_name = f"field_{schema_generator.num_fields}"
+        template[field_name] = {}
+        ret["name"] = field_name
+        ret["type"] = dict()
+        ret["type"]["type"] = GenericMap.to_producer_type(
+            schema_generator.producer_type)
+        field, field_temp = DataTypeGenerator.generate_field(
+            schema_generator, num_sub_fields)
+        ret["type"]["values"] = field["type"]
+        template[field_name].update(field_temp)
+        return ret, template
+
+    @staticmethod
+    def generate_random_enum(schema_generator, num_sub_fields) -> dict:
+        ret = dict()
+        template = dict()
+        field_name = f"field_{schema_generator.num_fields}"
+        template[field_name] = "{{ %s }}" % f"{field_name}"
+        ret["name"] = field_name
+        ret["type"] = dict()
+        ret["type"]["name"] = f"{field_name}_enum"
+        ret["type"]["type"] = GenericEnum.to_producer_type(
+            schema_generator.producer_type)
+        ret["type"]["symbols"] = [
+            GenericEnum.make_valid_enum_name(10,
+                                             schema_generator.producer_type)
+            for _ in range(0, num_sub_fields)
+        ]
+
+        return ret, template
+
+    @staticmethod
+    def generate_random_union(schema_generator, num_sub_fields) -> dict:
+        # TODO(willem): Implement union generation
+        pass
+
+    @staticmethod
+    def generate_random_optional(schema_generator, num_sub_fields) -> dict:
+        # TODO(willem): Implement optional generation
+        pass

--- a/tests/rptest/tests/datalake/schemas/data_types.py
+++ b/tests/rptest/tests/datalake/schemas/data_types.py
@@ -1,0 +1,349 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from enum import Enum
+import string
+import random
+
+
+class ProducerType(str, Enum):
+    AVRO = 'avro'
+    PROTO2 = 'proto2'
+    PROTO3 = 'proto3'
+
+
+class GenericDataType:
+    @classmethod
+    def to_producer_type(cls, producer_type: ProducerType):
+        if producer_type == ProducerType.AVRO:
+            return cls.to_avro()
+        elif producer_type == ProducerType.PROTO2:
+            return cls.to_proto()
+        elif producer_type == ProducerType.PROTO3:
+            return cls.to_proto()
+        else:
+            raise NotImplementedError(f"Unknown ProducerType {producer_type}")
+
+    @staticmethod
+    def name() -> str:
+        raise NotImplementedError(
+            f"Not implemented in GenericDataType base class")
+
+    @staticmethod
+    def to_avro() -> str:
+        raise NotImplementedError(
+            f"Not implemented in GenericDataType base class")
+
+    @staticmethod
+    def to_proto() -> str:
+        raise NotImplementedError(
+            f"Not implemented in GenericDataType base class")
+
+
+class GenericRecord(GenericDataType):
+    """
+    A generic record type. In Avro, this is a 'record', in Protobuf, this is a 'message'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_record"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "record"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "message"
+
+
+class GenericArray(GenericDataType):
+    """
+    A generic array type. In Avro, this is an 'array', in Protobuf, this is a 'repeated'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_array"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "array"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "repeated"
+
+
+class GenericMap(GenericDataType):
+    """
+    A generic map type. In Avro, this is a 'map', in Protobuf, this is a 'map'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_map"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "map"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "map"
+
+
+class GenericEnum(GenericDataType):
+    """
+    A generic enum type. In Avro, this is an 'enum', in Protobuf, this is an 'enum'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_enum"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "enum"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "enum"
+
+    @staticmethod
+    def random(enum_symbols) -> str:
+        return str(random.choice(enum_symbols))
+
+    @staticmethod
+    def make_valid_enum_name(n: int, producer_type: ProducerType) -> str:
+        def make_avro_enum(n: int):
+            """
+            start with [A-Za-z_], subsequently contain only [A-Za-z0-9_]
+            https://avro.apache.org/docs/1.11.1/specification/#names
+            """
+            first_char = random.choice(string.ascii_letters + '_')
+            rest_of_name = random.choices(string.ascii_letters +
+                                          string.digits + '_',
+                                          k=n - 1)
+            return first_char + ''.join(rest_of_name)
+
+        if producer_type == ProducerType.AVRO:
+            return make_avro_enum(n)
+
+
+class GenericUnion(GenericDataType):
+    """
+    A generic union type. In Avro, this is a 'union', in Protobuf, this is a 'union'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_union"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "union"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "oneof"
+
+
+class GenericOptional(GenericDataType):
+    """
+    A generic optional type. In Avro, this is a regular field type with the default value of 'null', in Protobuf, this is an 'optional'.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_optional"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "value_with_null_default"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "optional"
+
+
+class GenericPrimitive(GenericDataType):
+    @staticmethod
+    def name() -> str:
+        return "generic_primitive"
+
+
+#TODO(willem): implement all complex data types
+ALL_COMPLEX_DATA_TYPES = [
+    GenericRecord,
+    GenericArray,
+    GenericMap,
+    GenericEnum,
+    #GenericUnion,
+    #GenericOptional,
+    GenericPrimitive
+]
+
+
+class GenericBool(GenericDataType):
+    """
+    A generic bool type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_bool"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "boolean"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "bool"
+
+    @staticmethod
+    def random() -> bool:
+        return random.choice([False, True])
+
+
+class GenericInt(GenericDataType):
+    """
+    A generic int type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_int"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "int"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "int32"
+
+    @staticmethod
+    def random(mn: int, mx: int) -> int:
+        return random.randint(mn, mx)
+
+
+class GenericLong(GenericDataType):
+    """
+    A generic long type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_long"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "long"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "int64"
+
+    @staticmethod
+    def random(mn: int, mx: int) -> int:
+        return random.randint(mn, mx)
+
+
+class GenericFloat(GenericDataType):
+    """
+    A generic float type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_float"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "float"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "float"
+
+    @staticmethod
+    def random(mn: int, mx: int) -> float:
+        return random.uniform(mn, mx)
+
+
+class GenericDouble(GenericDataType):
+    """
+    A generic double type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_double"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "double"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "double"
+
+    @staticmethod
+    def random(mn: int, mx: int) -> float:
+        return random.uniform(mn, mx)
+
+
+class GenericBytes(GenericDataType):
+    """
+    A generic bytes type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_bytes"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "bytes"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "bytes"
+
+    @staticmethod
+    def random(n: int = 10) -> str:
+        return ''.join(
+            random.choices(string.ascii_lowercase + string.ascii_uppercase +
+                           string.digits,
+                           k=n))
+
+
+class GenericString(GenericDataType):
+    """
+    A generic string type.
+    """
+    @staticmethod
+    def name() -> str:
+        return "generic_string"
+
+    @staticmethod
+    def to_avro() -> str:
+        return "string"
+
+    @staticmethod
+    def to_proto() -> str:
+        return "string"
+
+    @staticmethod
+    def random(n: int = 10) -> str:
+        # Prefix string with 's' to prevent inappropriate conversion to integer types
+        # in schema template, see make_random_record() in schema_generator.py
+        return "s" + ''.join(
+            random.choices(string.ascii_lowercase + string.ascii_uppercase +
+                           string.digits,
+                           k=n - 1))
+
+
+ALL_PRIMITIVE_DATA_TYPES = [
+    GenericBool, GenericInt, GenericLong, GenericFloat, GenericDouble,
+    GenericString
+]
+
+ALL_PRIMITIVE_DATA_TYPES_AND_ENUM = ALL_PRIMITIVE_DATA_TYPES + [GenericEnum]

--- a/tests/rptest/tests/datalake/schemas/schema_generator.py
+++ b/tests/rptest/tests/datalake/schemas/schema_generator.py
@@ -1,0 +1,151 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from avro.schema import parse
+
+import json
+import random
+import jinja2
+
+from rptest.tests.datalake.schemas.data_types import ProducerType, GenericDataType, GenericPrimitive, GenericBool, GenericInt, GenericLong, GenericFloat, GenericDouble, GenericString, GenericEnum, ALL_COMPLEX_DATA_TYPES, ALL_PRIMITIVE_DATA_TYPES, ALL_PRIMITIVE_DATA_TYPES_AND_ENUM
+
+from rptest.tests.datalake.schemas.data_type_generator import DataTypeGenerator
+
+
+class SchemaGenerator:
+    def __init__(
+            self,
+            producer_type: ProducerType,
+            complex_types: list[GenericDataType] = ALL_COMPLEX_DATA_TYPES,
+            complex_type_probabilities: list[float] = None,
+            primitive_types: list[GenericDataType] = ALL_PRIMITIVE_DATA_TYPES,
+            primitive_type_probabilities: list[float] = None,
+            max_depth: int = 5,
+            max_fields: int = 10,
+            max_fields_per_type: int = 10):
+        if complex_type_probabilities is None:
+            complex_type_probabilities: list[float] = [
+                1.0 / len(complex_types)
+            ] * len(complex_types)
+        if primitive_type_probabilities is None:
+            primitive_type_probabilities = [1.0 / len(primitive_types)
+                                            ] * len(primitive_types)
+
+        assert len(complex_types) == len(
+            complex_type_probabilities
+        ), f"complex_type_probabilities should be of length {len(complex_types)}, is of length {len(complex_type_probabilities)}"
+        assert len(primitive_types) == len(
+            primitive_type_probabilities
+        ), f"primitive_type_probabilities should be of length {len(primitive_types)}, is of length {len(primitive_type_probabilities)}"
+
+        self.producer_type = producer_type
+        self.max_depth = max_depth
+        self.complex_types = complex_types
+        self.complex_type_probabilities = complex_type_probabilities
+        self.primitive_types = primitive_types
+        self.primitive_type_probabilities = primitive_type_probabilities
+        self.max_fields = max_fields
+        self.max_fields_per_type = max_fields_per_type
+        self.num_fields = 0
+        self.current_depth = 0
+        self.fields = dict()
+
+    def num_fields_left(self) -> int:
+        return self.max_fields - self.num_fields
+
+    def num_sub_fields_for_field(self) -> int:
+        return min(self.num_fields_left(),
+                   random.randint(1, self.max_fields_per_type))
+
+    def can_recurse(self) -> bool:
+        return self.current_depth < self.max_depth
+
+    def get_random_data_type(self, num_sub_fields) -> GenericDataType:
+        data_type = GenericPrimitive
+        if self.can_recurse() and num_sub_fields > 1:
+            data_type = random.choices(
+                self.complex_types, weights=self.complex_type_probabilities)[0]
+        if data_type is GenericPrimitive:
+            data_type = random.choices(
+                self.primitive_types,
+                weights=self.primitive_type_probabilities)[0]
+        return data_type
+
+    def _make_avro_schema(self):
+        fields = []
+        template = {}
+        while self.num_fields < self.max_fields:
+            field, field_temp = DataTypeGenerator.generate_field(
+                self, self.num_sub_fields_for_field())
+            fields.append(field)
+            template.update(field_temp)
+        raw_schema = dict()
+        raw_schema["name"] = "schema"
+        raw_schema["type"] = "record"
+        raw_schema["fields"] = fields
+
+        # Validate the schema with the avro library.
+        schema = parse(json.dumps(raw_schema))
+        return schema, jinja2.Template(json.dumps(template))
+
+    def _make_proto_schema(self):
+        pass
+
+    def generate_schema_fields(self):
+        if self.producer_type == ProducerType.AVRO:
+            return self._make_avro_schema()
+        else:
+            return self._make_proto_schema()
+
+    @staticmethod
+    def make_random_record(schema,
+                           schema_fields: dict,
+                           schema_template,
+                           validate: bool = False):
+        field_values = {}
+        for k, v in schema_fields.items():
+            t, maybe_syms = v
+            if t in ALL_PRIMITIVE_DATA_TYPES_AND_ENUM:
+                if t == GenericEnum:
+                    field_values[k] = t.random(maybe_syms)
+                elif t == GenericString:
+                    field_values[k] = t.random(random.randint(1, 100))
+                elif t in [
+                        GenericInt, GenericLong, GenericFloat, GenericDouble
+                ]:
+                    field_values[k] = t.random(0, 100)
+                else:
+                    field_values[k] = t.random()
+
+        tmpl = schema_template.render(field_values)
+
+        # Jinja template renders all values as strings. Have to fix the types here.
+        def fix_types(obj):
+            if isinstance(obj, str):
+                try:
+                    return int(obj)
+                except:
+                    try:
+                        return float(obj)
+                    except:
+                        return obj
+            elif isinstance(obj, dict):
+                return {k: fix_types(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [fix_types(v) for v in obj]
+            else:
+                return obj
+
+        ret = json.loads(tmpl, object_hook=fix_types)
+
+        if validate:
+            # Validate the generated record with the schema
+            schema.validate(ret)
+
+        return ret


### PR DESCRIPTION
Adds a schema generation framework (WIP, currently targeting the `avro` spec, no `protobuf` code yet) and a `schema_scale_test` that simply produces to an `iceberg` enabled topic and waits for translation to occur. 

The randomly generated schema can be controlled in terms of maximum depth, number of fields, and even the likeliness of primitive/complex data types in the schema. A template record is constructed that allows for the random generation of a schema-compatible record for producing to `redpanda`. This record is verified using the schema before being produced.

Parts of the random schema generation framework are still quite a work in progress- not all complex data types are supported, and the implementation (which hopes to be generic) is fairly hardcoded for the `avro` spec currently.

Future work entails teasing the framework apart to de-couple the generic bits away from a specific format, and add new abstraction layers on top for `protobuf` and `avro` respectively.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
