### PR TITLE
bazel/ci: ignore git owner mismatches

### DIFF
--- a/tools/docker/bazel.dockerfile
+++ b/tools/docker/bazel.dockerfile
@@ -15,3 +15,7 @@ RUN wget -O /usr/local/bin/bazel \
 
 # run after wget installation to take advantage of pkg cache cleaning
 RUN CLEAN_PKG_CACHE=true /install-deps.sh && rm /install-deps.sh
+
+# CI will run this container as root, but a non-root user will clone the repo and set it up,
+# so we should just ignore these warnings for now.
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
CI runs containers as root and also runs as a non root user, so we need
to ignore the cloned repos being owned by another user.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
