### PR TITLE
dl/translation: do not calculate the backlog if lso is not set

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -766,14 +766,27 @@ public:
         if (highest_translated_offset <= min_offset_for_translation) {
             return _partition->size_bytes();
         }
-        auto log_offset = _partition->log()->to_log_offset(
-          kafka::offset_cast(*highest_translated_offset));
+        const auto highest_translated_log_offset
+          = _partition->log()->to_log_offset(
+            kafka::offset_cast(*highest_translated_offset));
+        const auto max_translatable_offset = _partition->last_stable_offset();
+        if (highest_translated_log_offset == max_translatable_offset) {
+            return 0;
+        }
+        /**
+         * It is possible that the last stable offset is not yet established or
+         * simply smaller than the highest translated offset. f.e. during the
+         * partition movement. In such cases, we cannot calculate the backlog.
+         */
+        if (highest_translated_log_offset > max_translatable_offset) {
+            return std::nullopt;
+        }
+
         auto size_after_translated = _partition->log()->size_bytes_after_offset(
-          log_offset);
+          highest_translated_log_offset);
 
         auto size_after_max_translatable
-          = _partition->log()->size_bytes_after_offset(
-            _partition->last_stable_offset());
+          = _partition->log()->size_bytes_after_offset(max_translatable_offset);
 
         if (size_after_translated < size_after_max_translatable) {
             vlog(
@@ -782,9 +795,9 @@ public:
               "greater than or equal to the size of log after max translatable "
               "offset({}): {}",
               _partition->ntp().path(),
-              log_offset,
+              highest_translated_log_offset,
               size_after_translated,
-              _partition->last_stable_offset(),
+              max_translatable_offset,
               size_after_max_translatable);
             return std::nullopt;
         }


### PR DESCRIPTION
When partition is being moved the max translatable offset may not yet be known. In this case we should skip calculating the backlog as not all information required is present.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none