### PR TITLE
[v25.1.x] CORE-9384 base/vassert: run registered callback only once

### DIFF
--- a/src/v/base/tests/assert_log_holder_test.cc
+++ b/src/v/base/tests/assert_log_holder_test.cc
@@ -28,17 +28,14 @@ TEST_F(AssertLogHolderTest, ValidateAssertLogHolder) {
     auto bt = ss::current_backtrace();
     base::register_event(bt, "This is a test event: test");
     EXPECT_TRUE(message.empty());
-    base::register_cb(cb);
-    base::register_event(bt, "This is a test event: test");
 
-    EXPECT_EQ(message, fmt::format("This is a test event: test"));
-    EXPECT_TRUE(unused_message.empty());
+    base::register_cb(cb);
 
     // Verify that a second call to `register_cb` does not replace the current
     // callback
     base::register_cb(unused_cb);
-    base::register_event(bt, "This is a second test event: test");
 
+    base::register_event(bt, "This is a second test event: test");
     EXPECT_EQ(message, fmt::format("This is a second test event: test"));
     EXPECT_TRUE(unused_message.empty());
 }

--- a/src/v/base/vassert-register.h
+++ b/src/v/base/vassert-register.h
@@ -31,6 +31,8 @@ using assert_cb_func = void (*)(std::string_view);
 // register_event calls.
 // Only the first registration has any effect, calls to this function do
 // nothing.
+// The callback is only called once, only for the first vassert crash. This is
+// to avoid a potential infinite loop if the callback triggers another vassert.
 void register_cb(assert_cb_func cb);
 
 /**

--- a/src/v/base/vassert.cc
+++ b/src/v/base/vassert.cc
@@ -27,6 +27,7 @@ namespace {
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 ss::logger assert_logger{"assert"};
 std::atomic<assert_cb_func> _cb_func{nullptr};
+std::once_flag _cb_func_onceflag{};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
 
 void assert_handler(const ss::saved_backtrace& bt, std::string_view text) {
@@ -35,7 +36,7 @@ void assert_handler(const ss::saved_backtrace& bt, std::string_view text) {
 
     auto cb_func = _cb_func.load();
     if (cb_func != nullptr) {
-        cb_func(text);
+        std::call_once(_cb_func_onceflag, [cb_func, text]() { cb_func(text); });
     }
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25532
