### PR TITLE
[CORE-9592] kafka/lag_metrics: Fix a race condition

### DIFF
--- a/src/v/kafka/server/consumer_group_lag_metrics_frontend.cc
+++ b/src/v/kafka/server/consumer_group_lag_metrics_frontend.cc
@@ -124,15 +124,19 @@ consumer_group_lag_metrics_frontend::get_partition_offsets(
 ss::future<partition_offsets_reply>
 consumer_group_lag_metrics_frontend::get_local_partition_offsets(
   partition_offsets_request req) {
-    auto ktps = request_as_ktps(req);
+    // const because don't share mutable state between threads.
+    const auto ktps = request_as_ktps(req);
 
     auto gate_holder = _gate.hold();
 
     // gather all cores
     co_return co_await container().map_reduce0(
-      [&ktps](auto& me) {
+      [ktps](auto& me) {
+          // take a copy of ktps since it is an input_range, which requires it
+          // to be mutated by for_each, and this lambda cannot be mutable.
+          auto copy = ktps;
           partition_offsets_reply reply;
-          std::ranges::for_each(ktps, [&](ktp_view ktp) {
+          std::ranges::for_each(copy, [&](ktp_view ktp) {
               auto part = make_partition_proxy(
                 ktp.ktp(), me._partition_manager.local());
               if (part.has_value()) {


### PR DESCRIPTION
The type of `ktps` is an `input_range`, due to being a `join_view`.

Since it's an `input_range`, it can only be iterated once.

Holding it by reference, resulted in a race condition as it was mutated during iteration on each shard.

Fix the race by taking a copy of the view onto each shard. The additional copy, `copy` is needed as `map_reduce` cannot take a mutable lambda.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
