### PR TITLE
[CORE-9110] Hold apply lock when starting shard balancer

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -585,14 +585,16 @@ ss::future<> controller::start(
     _tp_frontend.local().print_rf_warning_message();
 
     co_await cluster_creation_hook(discovery);
-
-    // start shard_balancer before controller_backend so that it bootstraps
-    // shard_placement_table and controller_backend can start with already
-    // initialized table.
-    co_await _shard_balancer.invoke_on(
-      shard_balancer::shard_id,
-      &shard_balancer::start,
-      conf_invariants.core_count);
+    {
+        auto u = _stm.local().lock_apply();
+        // start shard_balancer before controller_backend so that it bootstraps
+        // shard_placement_table and controller_backend can start with already
+        // initialized table.
+        co_await _shard_balancer.invoke_on(
+          shard_balancer::shard_id,
+          &shard_balancer::start,
+          conf_invariants.core_count);
+    }
 
     if (conf_invariants.core_count > ss::smp::count) {
         // Successfully starting shard_balancer with reduced core count means

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -209,4 +209,8 @@ ss::future<> controller_stm::apply_snapshot(
     });
 }
 
+ss::future<ssx::semaphore_units> controller_stm::lock_apply() {
+    return _apply_mtx.get_units();
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -82,6 +82,12 @@ public:
     /// peer of the more general maybe_make_snapshot
     ss::future<std::optional<iobuf>> maybe_make_join_snapshot();
 
+    /**
+     * By calling this function caller may take a lock and prevent applying any
+     * new updates to the controller state machine even if they are available.
+     */
+    ss::future<ssx::semaphore_units> lock_apply();
+
 private:
     ss::future<> on_batch_applied() final;
     void snapshot_timer_callback();

--- a/tests/rptest/tests/cluster_bootstrap_test.py
+++ b/tests/rptest/tests/cluster_bootstrap_test.py
@@ -7,12 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import concurrent.futures
+import threading
 import ducktape.errors
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from requests.exceptions import ConnectionError
+from rptest.clients.rpk import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RpkTool
 from rptest.services.redpanda_installer import (RedpandaInstaller,
                                                 wait_for_num_versions)
 from rptest.util import expect_exception
@@ -104,6 +107,52 @@ class ClusterBootstrapNew(RedpandaTest):
             expected_node_id = node_ids_per_idx[idx]
             node_id = self.redpanda.node_id(n)
             assert expected_node_id == node_id, f"Expected {expected_node_id} but got {node_id}"
+
+
+class ClusterBootstrapFiveNodes(RedpandaTest):
+    """
+    Tests verifying new cluster bootstrap in Seed Driven Cluster Bootstrap mode
+    """
+    def __init__(self, test_context):
+        super(ClusterBootstrapFiveNodes,
+              self).__init__(test_context=test_context, num_brokers=5)
+        self.admin = self.redpanda._admin
+
+    def setUp(self):
+        # Defer startup to test body.
+        pass
+
+    @cluster(num_nodes=5)
+    def test_topic_creation_during_bootstrap(self):
+        """
+        The test validates if the cluster is able to correctly bootstrap while 
+        executing operations during the bootstrap process.
+        """
+        stop_ev = threading.Event()
+        set_seeds_for_cluster(self.redpanda, 5)
+
+        def describe_group():
+            rpk = RpkTool(self.redpanda)
+            while not stop_ev.is_set():
+                try:
+                    topic = TopicSpec(partition_count=1, replication_factor=3)
+                    rpk.create_topic(topic.name, partitions=1, replicas=3)
+                    rpk.group_describe("test_group")
+                except:
+                    pass
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            fut = executor.submit(lambda: describe_group())
+            try:
+                for node in self.redpanda.nodes:
+                    self.redpanda.set_extra_node_conf(
+                        node, {"empty_seed_starts_cluster": False})
+
+                self.redpanda.start(auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
+            finally:
+                stop_ev.set()
+            fut.result(timeout=10)
 
 
 class ClusterBootstrapUpgrade(RedpandaTest):


### PR DESCRIPTION
Shard balancer is expected to start when there are no new updates to the
topic table, otherwise it might miss some notifications. Usually that
assumption is correct. The RPC services starts after the
`shard_balancer` is started so nothing new can be appended to the
controller log. The situation is different during the cluster bootstrap
where RPC services are started much earlier and the controller partition
may receive updates while the `shard_balancer` is starting. This
triggers an assertion in the `shard_balancer`. In order to allow the
balancer to operate in the state state we lock controller stm applies
for the time when balancer is started.

Fixes: CORE-9110
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none