### PR TITLE
[v25.1.x] config: relax schema_registry_always_normalize to not need restart

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3606,7 +3606,7 @@ configuration::configuration()
       "schema_registry_always_normalize",
       "Always normalize schemas. If set, this overrides the "
       "normalize parameter in API requests.",
-      {.needs_restart = needs_restart::yes,
+      {.needs_restart = needs_restart::no,
        .visibility = visibility::user,
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -45,8 +45,7 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>(
-      normalize{config::shard_local_cfg().schema_registry_always_normalize});
+    _store = std::make_unique<sharded_store>();
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -83,7 +83,9 @@ ss::future<> sharded_store::stop() { return _store.stop(); }
 
 ss::future<canonical_schema>
 sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
-    norm = norm || _always_normalize;
+    norm = norm
+           || normalize{
+             config::shard_local_cfg().schema_registry_always_normalize()};
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -25,8 +25,7 @@ class store;
 /// subject or schema_id
 class sharded_store final : public schema_getter {
 public:
-    explicit sharded_store(normalize always_normalize = normalize::no)
-      : _always_normalize(always_normalize) {}
+    explicit sharded_store() = default;
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -240,7 +239,6 @@ private:
 
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
-    normalize _always_normalize;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3312,7 +3312,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Update always_normalize and re-run all tests
         self.redpanda.set_cluster_config(
-            {'schema_registry_always_normalize': True}, expect_restart=True)
+            {'schema_registry_always_normalize': True})
 
         test_schemas_ids_id(imported_schema_normalized_proto_def.strip())
         test_subjects_subject(sanitized, expected_version=1)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25555
