### PR TITLE
[v24.3.x] config: relax schema_registry_always_normalize to not need restart

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3571,7 +3571,7 @@ configuration::configuration()
       "schema_registry_always_normalize",
       "Always normalize schemas. If set, this overrides the "
       "normalize parameter in API requests.",
-      {.needs_restart = needs_restart::yes,
+      {.needs_restart = needs_restart::no,
        .visibility = visibility::user,
        .aliases = {"schema_registry_normalize_on_startup"}},
       false)

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -45,10 +45,8 @@ api::api(
 api::~api() noexcept = default;
 
 ss::future<> api::start() {
-    _store = std::make_unique<sharded_store>(
-      protobuf_renderer_v2{
-        config::shard_local_cfg().schema_registry_protobuf_renderer_v2},
-      normalize{config::shard_local_cfg().schema_registry_always_normalize});
+    _store = std::make_unique<sharded_store>(protobuf_renderer_v2{
+      config::shard_local_cfg().schema_registry_protobuf_renderer_v2});
     co_await _store->start(is_mutable(_cfg.mode_mutability), _sg);
     co_await _schema_id_validation_probe.start();
     co_await _schema_id_validation_probe.invoke_on_all(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -83,7 +83,9 @@ ss::future<> sharded_store::stop() { return _store.stop(); }
 
 ss::future<canonical_schema>
 sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
-    norm = norm || _always_normalize;
+    norm = norm
+           || normalize{
+             config::shard_local_cfg().schema_registry_always_normalize()};
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -26,10 +26,8 @@ class store;
 class sharded_store final : public schema_getter {
 public:
     explicit sharded_store(
-      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no,
-      normalize always_normalize = normalize::no)
-      : _v2_renderer(v2_renderer)
-      , _always_normalize(always_normalize) {}
+      protobuf_renderer_v2 v2_renderer = protobuf_renderer_v2::no)
+      : _v2_renderer(v2_renderer) {}
     ~sharded_store() override = default;
     ss::future<> start(is_mutable mut, ss::smp_service_group sg);
     ss::future<> stop();
@@ -248,7 +246,6 @@ private:
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
     protobuf_renderer_v2 _v2_renderer;
-    normalize _always_normalize;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3315,7 +3315,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Update always_normalize and re-run all tests
         self.redpanda.set_cluster_config(
-            {'schema_registry_always_normalize': True}, expect_restart=True)
+            {'schema_registry_always_normalize': True})
 
         test_schemas_ids_id(imported_schema_normalized_proto_def.strip())
         test_subjects_subject(sanitized, expected_version=1)


### PR DESCRIPTION
Backports: #25555
Closes: #25579

(cherry picked from commit 9d39d943107192c00443a4b992e49740b7ba2139)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

