### PR TITLE
[Testing] k/quotas: more logging around partition quotas

### DIFF
--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -346,9 +346,16 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
     auto delay = co_await maybe_add_and_retrieve_quota(
       key, now, [now, mutations](quota_manager::client_quota& cq) {
           if (!cq.pm_rate.has_value()) {
+              vlog(
+                client_quota_log.trace,
+                "no partition mutation quota configured");
               return clock::duration::zero();
           }
           auto& pm_rate_tracker = cq.pm_rate.value();
+          vlog(
+            client_quota_log.trace,
+            "partition mutation quota rate: {}",
+            pm_rate_tracker.rate());
           auto result
             = pm_rate_tracker.update_and_calculate_delay<clock::duration>(
               now, 0);


### PR DESCRIPTION
CDT testing for https://redpandadata.atlassian.net/browse/CORE-8555

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
