### PR TITLE
rptest: eagerly remove node from started set on stop

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4096,6 +4096,14 @@ class RedpandaService(RedpandaServiceBase):
             self.logger.warn(f"Error setting trace loggers: {e}")
 
     def stop_node(self, node, timeout=None, forced=False):
+        # Assume node is stopped once we enter this path. If stopping succeeds
+        # it is the obvious thing to do. If stopping fails we can't differentiate
+        # between a node that stopped or will eventually stop so for all intents
+        # and purposes we consider it stopped not to trip other logic that expects
+        # started to contain nodes that _must_ be running. E.g. crash detection
+        # at end of test which iterates through "started nodes".
+        self.remove_from_started_nodes(node)
+
         pid = self.redpanda_pid(node)
         if pid is not None:
             node.account.signal(pid,
@@ -4126,8 +4134,6 @@ class RedpandaService(RedpandaServiceBase):
             # I.e. `tar: redpanda.log: file changed as we read it`
             node.account.signal(pid, signal.SIGKILL, allow_fail=True)
             raise
-
-        self.remove_from_started_nodes(node)
 
     def remove_from_started_nodes(self, node):
         if node in self._started:


### PR DESCRIPTION
    rptest: eagerly remove node from started set on stop

    This avoids false positive crash detection at end of test if stopping
    fails and we hard kill a node during chaos tests/tests restarting nodes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
