### PR TITLE
dl/translation: metrics for input throughput

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -108,9 +108,14 @@ ss::future<> record_multiplexer::multiplex(
 
 ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
   model::record_batch batch, kafka::offset start_offset, ss::abort_source& as) {
+    const auto raw_size_bytes = batch.size_bytes();
+    _translation_probe.increment_raw_bytes_processed(raw_size_bytes);
     if (batch.compressed()) {
         batch = co_await storage::internal::decompress_batch(std::move(batch));
     }
+    const auto decompressed_size_bytes = batch.size_bytes();
+    _translation_probe.increment_decompressed_bytes_processed(
+      decompressed_size_bytes);
     auto first_timestamp = batch.header().first_timestamp.value();
     auto it = model::record_batch_iterator::create(batch);
     while (it.has_next()) {

--- a/src/v/datalake/translation/translation_probe.cc
+++ b/src/v/datalake/translation/translation_probe.cc
@@ -31,12 +31,12 @@ translation_probe::translation_probe(model::ntp ntp)
         _public_metrics.emplace();
         register_created_files_metrics();
         register_invalid_record_metric();
+        register_throughput_metrics();
     }
 }
 
 void translation_probe::register_created_files_metrics() {
     namespace sm = ss::metrics;
-
     std::vector<sm::label_instance> labels{
       namespace_label(_ntp.ns()),
       topic_label(_ntp.tp.topic()),
@@ -97,6 +97,47 @@ void translation_probe::register_created_files_metrics() {
       });
 }
 
+void translation_probe::register_throughput_metrics() {
+    namespace sm = ss::metrics;
+    std::vector<sm::label_instance> labels{
+      namespace_label(_ntp.ns()),
+      topic_label(_ntp.tp.topic()),
+      partition_label(_ntp.tp.partition()),
+    };
+    _public_metrics->add_group(
+      group_name,
+      {{
+         sm::make_counter(
+           "raw_bytes_processed",
+           _raw_bytes_processed,
+           sm::description(
+             "Number of raw, potentially compressed bytes consumed for "
+             "processing that may or may not succeed in being processed. For "
+             "example, if we fail to communicate with the coordinator "
+             "preventing processing of a batch, this metric still ticks up."),
+           labels)
+           .aggregate({
+             sm::shard_label,
+             partition_label,
+           }),
+       },
+       {
+         sm::make_counter(
+           "decompressed_bytes_processed",
+           _decompressed_bytes_processed,
+           sm::description(
+             "Number of bytes post-decompression consumed for processing that "
+             "may or may not succeed in being processed. For example, if we "
+             "fail to communicate with the coordinator preventing processing "
+             "of a batch, this metric still ticks up."),
+           labels)
+           .aggregate({
+             sm::shard_label,
+             partition_label,
+           }),
+       }});
+}
+
 void translation_probe::register_invalid_record_metric() {
     namespace sm = ss::metrics;
 
@@ -142,5 +183,4 @@ operator<<(std::ostream& os, translation_probe::invalid_record_cause cause) {
         return os << "failed_iceberg_schema_resolution";
     }
 }
-
 }; // namespace datalake

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -49,6 +49,11 @@ public:
         counter_ref(cause)++;
     }
 
+    void increment_raw_bytes_processed(size_t b) { _raw_bytes_processed += b; }
+    void increment_decompressed_bytes_processed(size_t b) {
+        _decompressed_bytes_processed += b;
+    }
+
     size_t& counter_ref(invalid_record_cause cause) {
         switch (cause) {
         case invalid_record_cause::failed_kafka_schema_resolution:
@@ -63,6 +68,7 @@ public:
 private:
     void register_created_files_metrics();
     void register_invalid_record_metric();
+    void register_throughput_metrics();
 
 private:
     model::ntp _ntp;
@@ -77,6 +83,11 @@ private:
     size_t _num_failed_kafka_schema_resolution = 0;
     size_t _num_failed_data_translation = 0;
     size_t _num_failed_iceberg_schema_resolution = 0;
+
+    // NOTE: the accounting for bytes here is not strictly accurate and should
+    // only be used to get a rough sense for translation throughput.
+    size_t _raw_bytes_processed = 0;
+    size_t _decompressed_bytes_processed = 0;
 };
 
 std::ostream&


### PR DESCRIPTION
Adds some quick-and-dirty metrics for throughput of incoming Kafka data meant only for use in debugging.

E.g. this should not be used for usage based billing, given it doesn't account for commits into Iceberg, doesn't account for errors in the translation path, and gets reset when partitions are removed or shutdown.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
