### PR TITLE
datalake: add more metrics to translation probe

### DIFF
--- a/src/v/datalake/translation/translation_probe.cc
+++ b/src/v/datalake/translation/translation_probe.cc
@@ -29,8 +29,72 @@ translation_probe::translation_probe(model::ntp ntp)
   : _ntp(std::move(ntp)) {
     if (!config::shard_local_cfg().disable_public_metrics()) {
         _public_metrics.emplace();
+        register_created_files_metrics();
         register_invalid_record_metric();
     }
+}
+
+void translation_probe::register_created_files_metrics() {
+    namespace sm = ss::metrics;
+
+    std::vector<sm::label_instance> labels{
+      namespace_label(_ntp.ns()),
+      topic_label(_ntp.tp.topic()),
+      partition_label(_ntp.tp.partition()),
+    };
+
+    _public_metrics->add_group(
+      group_name,
+      {
+        sm::make_counter(
+          "translations_finished",
+          _translations_finished,
+          sm::description("Number of finished translator executions"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_counter(
+          "files_created",
+          _files_created,
+          sm::description(
+            "Number of created parquet files (not counting the DLQ table)"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_counter(
+          "parquet_rows_added",
+          _parquet_rows_added,
+          sm::description("Number of rows in created parquet files (not "
+                          "counting the DLQ table)"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_counter(
+          "parquet_bytes_added",
+          _parquet_bytes_added,
+          sm::description("Number of bytes in created parquet files (not "
+                          "counting the DLQ table)"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_counter(
+          "dlq_files_created",
+          _dlq_files_created,
+          sm::description("Number of created parquet files for the DLQ table"),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+      });
 }
 
 void translation_probe::register_invalid_record_metric() {

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -36,6 +36,15 @@ public:
     explicit translation_probe(model::ntp ntp);
 
 public:
+    void on_translation_finished(
+      size_t files, size_t rows, size_t bytes, size_t dlq_files) {
+        _translations_finished += 1;
+        _files_created += files;
+        _parquet_rows_added += rows;
+        _parquet_bytes_added += bytes;
+        _dlq_files_created += dlq_files;
+    }
+
     void increment_invalid_record(invalid_record_cause cause) {
         counter_ref(cause)++;
     }
@@ -52,11 +61,18 @@ public:
     }
 
 private:
+    void register_created_files_metrics();
     void register_invalid_record_metric();
 
 private:
     model::ntp _ntp;
     std::optional<metrics::public_metric_groups> _public_metrics;
+
+    size_t _translations_finished = 0;
+    size_t _files_created = 0;
+    size_t _parquet_rows_added = 0;
+    size_t _parquet_bytes_added = 0;
+    size_t _dlq_files_created = 0;
 
     size_t _num_failed_kafka_schema_resolution = 0;
     size_t _num_failed_data_translation = 0;

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -278,6 +278,18 @@ translation_task::finish(
           fmt::join(write_result.data_files, ", "));
     }
 
+    size_t rows_added = 0;
+    size_t bytes_added = 0;
+    for (const auto& file : write_result.data_files) {
+        rows_added += file.local_file.row_count;
+        bytes_added += file.local_file.size_bytes;
+    }
+    _translation_probe->on_translation_finished(
+      write_result.data_files.size(),
+      rows_added,
+      bytes_added,
+      write_result.dlq_files.size());
+
     coordinator::translated_offset_range ret{
       .start_offset = write_result.start_offset,
       .last_offset = write_result.last_offset,

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -24,7 +24,7 @@ from ducktape.mark import matrix
 from rptest.services.catalog_service import CatalogType
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.services.redpanda import SISettings, SchemaRegistryConfig, MetricsEndpoint
 from rptest.services.redpanda_connect import RedpandaConnectService
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
@@ -288,6 +288,35 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 partitions_after, partitions)
             assert set(partitions_after.keys()).issubset(
                 set(partitions_before.keys()))
+
+            # Sanity-check translation metrics
+            metric_patterns = [
+                "translation_translations_finished",
+                "translation_files_created", "translation_parquet_rows_added",
+                "translation_parquet_bytes_added"
+            ]
+            metric2samples = self.redpanda.metrics_samples(
+                metric_patterns, self.redpanda.nodes,
+                MetricsEndpoint.PUBLIC_METRICS)
+            assert len(metric2samples) == len(metric_patterns)
+            metric2value_sum = dict()
+            for metric, samples in metric2samples.items():
+                value_sum = sum(
+                    s.value
+                    for s in samples.label_filter({
+                        "redpanda_topic": topic_name
+                    }).samples)
+                self.logger.info(f"metric {metric} {value_sum=}")
+                metric2value_sum[metric] = value_sum
+
+            num_files_created = sum(partitions_before.values())
+            assert metric2value_sum[
+                "translation_files_created"] == num_files_created
+            assert metric2value_sum[
+                "translation_translations_finished"] == num_files_created / 2
+            assert metric2value_sum[
+                "translation_parquet_rows_added"] == msg_count
+            assert metric2value_sum["translation_parquet_bytes_added"] > 0
 
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),


### PR DESCRIPTION
These metrics allow calculating the mean size of created iceberg files, as well as the mean number of files created per translation execution. These values can help to fine-tune translation scheduling and detect pathological cases like iceberg partition per kafka message.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none