### PR TITLE
Updated broker pod name format for operator v1

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -261,7 +261,7 @@ class KubectlTool:
         if self._redpanda_operator_v2:
             return 'redpanda-broker-0'
         else:
-            return f'rp-{self._cluster_id}-0'
+            return f'rp-{self._cluster_id}-blue-a-0'
 
     def _ssh_cmd(
             self,


### PR DESCRIPTION
Updated broker pod name format for operator v1 in kubectl.py

pod names used to be: rp-{cluser_id}-{number} for example rp-cvhp624bjfqasv80p8u0-0  

AWS and GCP cloud tests got broken since clusters moved to new naming convention for blue/green upgrades
example of a new name: rp-cvhp624bjfqasv80p8u0-blue-a-0

notice how it also has -a- in the name. It is related to availability zones. In case of multi AZ, pools would be deployed in each AZ.

This PR fixes:
Module:      rptest.redpanda_cloud_tests.config_profile_verify_test
Class:       ConfigProfileVerifyTest
Method:      test_config_profile_verify

P.S.
Once Azure also moves to blue/green format, we will need to update operator v2 part


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
