### PR TITLE
datalake: clear staging directory on startup

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -202,6 +202,7 @@ redpanda_cc_library(
         "//src/v/ssx:semaphore",
         "//src/v/ssx:work_queue",
         "//src/v/utils:directory_walker",
+        "//src/v/utils:human",
         "@fmt",
         "@seastar",
     ],

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -26,6 +26,7 @@
 #include "raft/group_manager.h"
 #include "schema/registry.h"
 #include "utils/directory_walker.h"
+#include "utils/human.h"
 
 #include <memory>
 
@@ -170,25 +171,6 @@ datalake_manager::get_or_create_probe(const model::ntp& ntp) {
 }
 
 ss::future<> datalake_manager::start() {
-    /*
-     * Ensure that datalake scratch space directory exists. This is run on each
-     * core (as opposed to only on core-0) because shard initialization happens
-     * in parallel, but the race is handled by ignoring EEXIST.
-     */
-    try {
-        co_await ss::make_directory(
-          config::node().datalake_staging_path().string());
-    } catch (const std::filesystem::filesystem_error& e) {
-        if (e.code() != std::errc::file_exists) {
-            vlog(
-              datalake_log.error,
-              "Could not create datalake staging directory: {}: {}",
-              config::node().datalake_staging_path(),
-              e);
-            throw;
-        }
-    }
-
     _catalog = co_await _catalog_factory->create_catalog();
     _schema_mgr = std::make_unique<catalog_schema_manager>(*_catalog);
     // partition managed notification, this is particularly
@@ -286,6 +268,56 @@ ss::future<> datalake_manager::start() {
     _backlog_controller = std::make_unique<backlog_controller>(
       [this] { return average_translation_backlog(); }, _sg);
     co_await _backlog_controller->start();
+}
+
+ss::future<>
+datalake_manager::prepare_staging_directory(std::filesystem::path path) {
+    try {
+        co_await ss::make_directory(path.string());
+    } catch (const std::filesystem::filesystem_error& e) {
+        if (e.code() != std::errc::file_exists) {
+            vlog(
+              datalake_log.error,
+              "Could not create datalake staging directory: {}: {}",
+              config::node().datalake_staging_path(),
+              e);
+            throw;
+        }
+    }
+
+    chunked_vector<std::filesystem::path> files;
+    co_await directory_walker::walk(
+      path.string(), [&files, path](const ss::directory_entry& de) {
+          if (de.type == ss::directory_entry_type::regular) {
+              files.push_back(path / std::filesystem::path(de.name));
+          }
+          return ss::now();
+      });
+
+    uint64_t total = 0;
+    co_await ss::max_concurrent_for_each(
+      files.begin(),
+      files.end(),
+      config::shard_local_cfg().space_management_max_log_concurrency(),
+      [&total](const std::filesystem::path& path) {
+          return ss::file_size(path.string())
+            .then([&total](uint64_t size) { total += size; })
+            .finally([path] { return ss::remove_file(path.string()); })
+            .handle_exception([path](std::exception_ptr e) {
+                vlog(
+                  datalake_log.warn,
+                  "Error clearing datalake staging file {}: {}",
+                  path,
+                  e);
+            });
+      });
+
+    if (total) {
+        vlog(
+          datalake_log.info,
+          "Cleared datalake staging directory: {}",
+          human::bytes(total));
+    }
 }
 
 ss::future<> datalake_manager::shutdown() {

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -71,7 +71,14 @@ public:
       size_t memory_limit);
     ~datalake_manager();
 
+    /*
+     * Call prepare_staging_directory before starting. Preparation involves
+     * clearing out the directory, and since start() will be invoked on all
+     * cores we expect the caller to prepare the directory to avoid potential
+     * affects of concurrent file creates and deletes.
+     */
     ss::future<> start();
+
     ss::future<> shutdown();
 
     /*
@@ -96,6 +103,14 @@ public:
      * Returns true if datalake translation runs with maximum allowed priority.
      */
     bool max_shares_assigned() const;
+
+    /*
+     * Ensure that the datalake scratch directory exists and is empty. The
+     * directory isn't required to be empty when starting up, but there is no
+     * way for translators to resume processing files so clearing the directory
+     * is a convenient way to deal with orphaned files.
+     */
+    static ss::future<> prepare_staging_directory(std::filesystem::path);
 
 private:
     using translator = std::unique_ptr<translation::partition_translator>;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1414,6 +1414,9 @@ void application::wire_up_runtime_services(
           sched_groups.datalake_sg(),
           memory_groups().datalake_max_memory())
           .get();
+        datalake::datalake_manager::prepare_staging_directory(
+          config::node().datalake_staging_path())
+          .get();
         _datalake_manager.invoke_on_all(&datalake::datalake_manager::start)
           .get();
 


### PR DESCRIPTION
Datalake translators don't have any way to resume their work, so clear out any files in the staging directory at bootup as a convenient time to deal with orphaned files.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
