### PR TITLE
CORE-8555 k/quota_mgr: take now parameter explicitly 

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -939,7 +939,9 @@ connection_context::client_protocol_state::do_process_responses(
     auto msg = response_as_scattered(std::move(resp_and_res.response));
     if (resp_and_res.resources->request_data.request_key == fetch_api::key) {
         co_await connection_ctx->_server.quota_mgr().record_fetch_tp(
-          resp_and_res.resources->request_data.client_id, msg.size());
+          resp_and_res.resources->request_data.client_id,
+          msg.size(),
+          quota_manager::clock::now());
     }
     // Respose sizes only take effect on throttling at the next
     // request processing. The better way was to measure throttle

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -276,6 +276,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
         co_return co_await ctx.respond(std::move(resp));
     }
 
+    const auto now = quota_manager::clock::now();
     valid_range_end = co_await validate_range_async(
       request.data.topics.begin(),
       valid_range_end,
@@ -284,7 +285,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
          ? error_code::throttling_quota_exceeded
          : error_code::unknown_server_error),
       "Too many partition mutations requested",
-      [&ctx, &resp](const create_partitions_topic& tp) {
+      [&ctx, &resp, now](const create_partitions_topic& tp) {
           const auto cfg = ctx.metadata_cache().get_topic_cfg(
             model::topic_namespace_view(model::kafka_namespace, tp.name));
           vassert(cfg, "Topic exist check has already occurred");
@@ -293,7 +294,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
             "Sanity check for request increase partition count failed");
           const auto mutations = (tp.count - cfg->partition_count);
           return ctx.quota_mgr()
-            .record_partition_mutations(ctx.header().client_id, mutations)
+            .record_partition_mutations(ctx.header().client_id, mutations, now)
             .then([&resp](std::chrono::milliseconds delay) {
                 resp.data.throttle_time_ms = std::max(
                   resp.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -378,13 +378,14 @@ ss::future<response_ptr> create_topics_handler::handle(
 
     // Record the number of partition mutations in each requested topic,
     // calulcating throttle delay if necessary
+    const auto now = quota_manager::clock::now();
     auto quota_exceeded_it = co_await ssx::partition(
-      begin, valid_range_end, [&ctx, &response](const creatable_topic& t) {
+      begin, valid_range_end, [&ctx, &response, now](const creatable_topic& t) {
           /// Capture before next scheduling point below
           auto& response_ref = response;
           return ctx.quota_mgr()
             .record_partition_mutations(
-              ctx.header().client_id, t.num_partitions)
+              ctx.header().client_id, t.num_partitions, now)
             .then([&response_ref](std::chrono::milliseconds delay) {
                 response_ref.data.throttle_time_ms = std::max(
                   response_ref.data.throttle_time_ms, delay);

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -274,6 +274,7 @@ void quota_manager::update_client_quotas() {
 }
 
 ss::future<> quota_manager::do_update_client_quotas() {
+    vlog(client_quota_log.debug, "Updating client quotas");
     constexpr auto set_bucket = [](
                                   std::optional<atomic_token_bucket>& bucket,
                                   std::optional<uint64_t> rate,
@@ -332,7 +333,7 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
         _probe->record_throttle_time(value.rule, ctx.q_type, 0ms);
         vlog(
           client_quota_log.trace,
-          "request: ctx:{}, key:{}, value:{}, mutations: {}, delay:{}"
+          "request: ctx:{}, key:{}, value:{}, mutations: {}, delay:{}, "
           "capped_delay:{}",
           ctx,
           key,
@@ -360,7 +361,7 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
     _probe->record_throttle_time(value.rule, ctx.q_type, capped_delay);
     vlog(
       client_quota_log.trace,
-      "request: ctx:{}, key:{}, value:{}, mutations: {}, delay:{}"
+      "request: ctx:{}, key:{}, value:{}, mutations: {}, delay:{}, "
       "capped_delay:{}",
       ctx,
       key,

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -100,17 +100,16 @@ public:
     ss::future<clock::duration> record_produce_tp_and_throttle(
       std::optional<std::string_view> client_id,
       uint64_t bytes,
-      clock::time_point now = clock::now());
+      clock::time_point now);
 
     // record a new observation
     ss::future<> record_fetch_tp(
       std::optional<std::string_view> client_id,
       uint64_t bytes,
-      clock::time_point now = clock::now());
+      clock::time_point now);
 
     ss::future<clock::duration> throttle_fetch_tp(
-      std::optional<std::string_view> client_id,
-      clock::time_point now = clock::now());
+      std::optional<std::string_view> client_id, clock::time_point now);
 
     // Used to record new number of partitions mutations
     // Only for use with the quotas introduced by KIP-599, namely to track
@@ -119,7 +118,7 @@ public:
     ss::future<std::chrono::milliseconds> record_partition_mutations(
       std::optional<std::string_view> client_id,
       uint32_t mutations,
-      clock::time_point now = clock::now());
+      clock::time_point now);
 
     const std::optional<global_map_t>& get_global_map_for_testing() const;
 

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1353,17 +1353,18 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
 
     // Measure the partition mutation rate
     auto resp_delay = 0ms;
+    const auto now = quota_manager::clock::now();
     auto quota_exceeded_it = co_await ssx::partition(
       request.data.topic_names.begin(),
       request.data.topic_names.end(),
-      [&ctx, &resp_delay](const model::topic& t) {
+      [&ctx, &resp_delay, now](const model::topic& t) {
           const auto cfg = ctx.metadata_cache().get_topic_cfg(
             model::topic_namespace_view(model::kafka_namespace, t));
           const auto mutations = cfg ? cfg->partition_count : 0;
           /// Capture before next scheduling point below
           auto& resp_delay_ref = resp_delay;
           return ctx.quota_mgr()
-            .record_partition_mutations(ctx.header().client_id, mutations)
+            .record_partition_mutations(ctx.header().client_id, mutations, now)
             .then([&resp_delay_ref](std::chrono::milliseconds delay) {
                 resp_delay_ref = std::max(delay, resp_delay_ref);
                 return delay == 0ms;

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -23,6 +23,8 @@
 #include <optional>
 #include <vector>
 
+namespace kafka {
+
 static const auto fixed_client_id = "shared-client-id";
 static const size_t total_requests{3 << 20};
 static const size_t unique_client_id_count = 1000;
@@ -38,8 +40,7 @@ std::vector<ss::sstring> initialize_client_ids() {
 
 std::vector<ss::sstring> unique_client_ids = initialize_client_ids();
 
-ss::future<>
-send_requests(kafka::quota_manager& qm, size_t count, bool use_unique) {
+ss::future<> send_requests(quota_manager& qm, size_t count, bool use_unique) {
     auto offset = ss::this_shard_id() * count;
     for (size_t i = 0; i < count; ++i) {
         auto cid_idx = (offset + i) % unique_client_id_count;
@@ -64,13 +65,13 @@ send_requests(kafka::quota_manager& qm, size_t count, bool use_unique) {
 
 ss::future<> test_quota_manager(size_t count, bool use_unique) {
     ss::sharded<cluster::client_quota::store> quota_store;
-    ss::sharded<kafka::quota_manager> sqm;
+    ss::sharded<quota_manager> sqm;
     co_await quota_store.start();
     co_await sqm.start(std::ref(quota_store));
-    co_await sqm.invoke_on_all(&kafka::quota_manager::start);
+    co_await sqm.invoke_on_all(&quota_manager::start);
 
     perf_tests::start_measuring_time();
-    co_await sqm.invoke_on_all([count, use_unique](kafka::quota_manager& qm) {
+    co_await sqm.invoke_on_all([count, use_unique](quota_manager& qm) {
         return send_requests(qm, count, use_unique);
     });
     perf_tests::stop_measuring_time();
@@ -148,10 +149,10 @@ static const size_t n_repeats = 100;
 
 future<size_t> run_latency_test(latency_test_case tc) {
     ss::sharded<cluster::client_quota::store> quota_store;
-    ss::sharded<kafka::quota_manager> sqm;
+    ss::sharded<quota_manager> sqm;
     co_await quota_store.start();
     co_await sqm.start(std::ref(quota_store));
-    co_await sqm.invoke_on_all(&kafka::quota_manager::start);
+    co_await sqm.invoke_on_all(&quota_manager::start);
 
     unsigned shard = tc.on_shard_0 ? 0 : 1;
     BOOST_ASSERT_MSG(
@@ -176,7 +177,7 @@ future<size_t> run_latency_test(latency_test_case tc) {
                 });
           }
 
-          auto now = kafka::quota_manager::clock::now();
+          auto now = quota_manager::clock::now();
 
           // Have a non-trivial number of existing clients in the map
           for (int i = 0; i < tc.n_other_clients; i++) {
@@ -463,3 +464,4 @@ PERF_TEST_CN(latency_group, default_configs_fetch_worst) {
       .no_quotas = true,
     });
 }
+} // namespace kafka

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -50,12 +50,14 @@ ss::future<> send_requests(quota_manager& qm, size_t count, bool use_unique) {
         // Have a mixed workload of produce and fetch to highlight any cache
         // contention on produce/fetch token buckets for the same client id
         if (ss::this_shard_id() % 2 == 0) {
-            co_await qm.record_fetch_tp(client_id, 1);
-            auto delay = co_await qm.throttle_fetch_tp(client_id);
+            co_await qm.record_fetch_tp(
+              client_id, 1, quota_manager::clock::now());
+            auto delay = co_await qm.throttle_fetch_tp(
+              client_id, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         } else {
             auto delay = co_await qm.record_produce_tp_and_throttle(
-              client_id, 1);
+              client_id, 1, quota_manager::clock::now());
             perf_tests::do_not_optimize(delay);
         }
         co_await maybe_yield();

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -29,20 +29,22 @@ using cluster::client_quota::entity_value;
 
 static const auto default_key = entity_key(
   entity_key::client_id_default_match{});
-static const auto client_id = "franz-go";
+static const auto cid = "franz-go";
 static const auto franz_go_key = entity_key{
   entity_key::client_id_prefix_match{"franz-go"}};
 static const auto not_franz_go_key = entity_key{
   entity_key::client_id_prefix_match{"not-franz-go"}};
 
+namespace kafka {
+
 struct fixture {
     ss::sharded<cluster::client_quota::store> quota_store;
-    ss::sharded<kafka::quota_manager> sqm;
+    ss::sharded<quota_manager> sqm;
 
     fixture() {
         quota_store.start().get();
         sqm.start(std::ref(quota_store)).get();
-        sqm.invoke_on_all(&kafka::quota_manager::start).get();
+        sqm.invoke_on_all(&quota_manager::start).get();
     }
 
     ~fixture() {
@@ -86,8 +88,8 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_no_throttling) {
     auto& qm = f.sqm.local();
 
     // Test that if fetch throttling is disabled, we don't throttle
-    qm.record_fetch_tp(client_id, 10000000000000).get();
-    auto delay = qm.throttle_fetch_tp(client_id).get();
+    qm.record_fetch_tp(cid, 10000000000000).get();
+    auto delay = qm.throttle_fetch_tp(cid).get();
 
     BOOST_CHECK_EQUAL(0ms, delay);
 }
@@ -102,25 +104,25 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_throttling) {
 
     auto& qm = f.sqm.local();
 
-    auto now = kafka::quota_manager::clock::now();
+    auto now = quota_manager::clock::now();
 
     // Test that below the fetch quota we don't throttle
-    qm.record_fetch_tp(client_id, 99, now).get();
-    auto delay = qm.throttle_fetch_tp(client_id, now).get();
+    qm.record_fetch_tp(cid, 99, now).get();
+    auto delay = qm.throttle_fetch_tp(cid, now).get();
 
     BOOST_CHECK_EQUAL(delay, 0ms);
 
     // Test that above the fetch quota we throttle
-    qm.record_fetch_tp(client_id, 10, now).get();
-    delay = qm.throttle_fetch_tp(client_id, now).get();
+    qm.record_fetch_tp(cid, 10, now).get();
+    delay = qm.throttle_fetch_tp(cid, now).get();
 
     BOOST_CHECK_GT(delay, 0ms);
 
     // Test that once we wait out the throttling delay, we don't
     // throttle again (as long as we stay under the limit)
     now += 1s;
-    qm.record_fetch_tp(client_id, 10, now).get();
-    delay = qm.throttle_fetch_tp(client_id, now).get();
+    qm.record_fetch_tp(cid, 10, now).get();
+    delay = qm.throttle_fetch_tp(cid, now).get();
 
     BOOST_CHECK_EQUAL(delay, 0ms);
 }
@@ -146,11 +148,11 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
     // discover segfaults caused by data races/use-after-free
     f.sqm
       .invoke_on_all(
-        ss::coroutine::lambda([](kafka::quota_manager& qm) -> ss::future<> {
+        ss::coroutine::lambda([](quota_manager& qm) -> ss::future<> {
             for (size_t i = 0; i < 1000; ++i) {
-                co_await qm.record_fetch_tp(client_id, 1);
+                co_await qm.record_fetch_tp(cid, 1);
                 auto delay [[maybe_unused]] = co_await qm.throttle_fetch_tp(
-                  client_id);
+                  cid);
                 co_await ss::maybe_yield();
             }
         }))
@@ -158,8 +160,6 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(static_config_test) {
-    using k_client_id = kafka::k_client_id;
-    using k_group_name = kafka::k_group_name;
     fixture f;
 
     f.set_basic_quotas();
@@ -211,9 +211,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(update_test) {
-    using clock = kafka::quota_manager::clock;
-    using k_group_name = kafka::k_group_name;
-    using k_client_id = kafka::k_client_id;
+    using clock = quota_manager::clock;
     fixture f;
 
     f.set_basic_quotas();
@@ -319,3 +317,4 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         BOOST_CHECK_EQUAL(it->second->tp_fetch_rate->rate(), 16384);
     }
 }
+} // namespace kafka

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -86,10 +86,11 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_no_throttling) {
     fixture f;
 
     auto& qm = f.sqm.local();
+    const auto now = quota_manager::clock::now();
 
     // Test that if fetch throttling is disabled, we don't throttle
-    qm.record_fetch_tp(cid, 10000000000000).get();
-    auto delay = qm.throttle_fetch_tp(cid).get();
+    qm.record_fetch_tp(cid, 10000000000000, now).get();
+    auto delay = qm.throttle_fetch_tp(cid, now).get();
 
     BOOST_CHECK_EQUAL(0ms, delay);
 }
@@ -150,9 +151,10 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
       .invoke_on_all(
         ss::coroutine::lambda([](quota_manager& qm) -> ss::future<> {
             for (size_t i = 0; i < 1000; ++i) {
-                co_await qm.record_fetch_tp(cid, 1);
+                co_await qm.record_fetch_tp(
+                  cid, 1, quota_manager::clock::now());
                 auto delay [[maybe_unused]] = co_await qm.throttle_fetch_tp(
-                  cid);
+                  cid, quota_manager::clock::now());
                 co_await ss::maybe_yield();
             }
         }))
@@ -165,14 +167,15 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     f.set_basic_quotas();
 
     auto& buckets_map = f.sqm.local().get_global_map_for_testing();
+    const auto now = quota_manager::clock::now();
 
     BOOST_REQUIRE_EQUAL(buckets_map->size(), 0);
 
     {
         ss::sstring client_id = "franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 1).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
-        f.sqm.local().record_partition_mutations(client_id, 1).get();
+        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
+        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
+        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
         auto it = buckets_map->find(k_group_name{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
@@ -183,9 +186,9 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     }
     {
         ss::sstring client_id = "not-franz-go";
-        f.sqm.local().record_fetch_tp(client_id, 1).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
-        f.sqm.local().record_partition_mutations(client_id, 1).get();
+        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
+        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
+        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
         auto it = buckets_map->find(k_group_name{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
@@ -196,9 +199,9 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     }
     {
         ss::sstring client_id = "unconfigured";
-        f.sqm.local().record_fetch_tp(client_id, 1).get();
-        f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
-        f.sqm.local().record_partition_mutations(client_id, 1).get();
+        f.sqm.local().record_fetch_tp(client_id, 1, now).get();
+        f.sqm.local().record_produce_tp_and_throttle(client_id, 1, now).get();
+        f.sqm.local().record_partition_mutations(client_id, 1, now).get();
         auto it = buckets_map->find(k_client_id{client_id});
         BOOST_REQUIRE(it != buckets_map->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());


### PR DESCRIPTION
Fixes a class of bugs where delays in handling a request could cause
request parts to be throttled separately instead of as a unit.

For example, with a partition mutation quota limit of 10, a
create_partitions request adding 11 partitions to topic foo and 1
partition to topic baz should result in the baz part failing due to
quota limits. However, scheduling delays while updating the quota state
for foo could cause the baz request part to be processed later,
bypassing throttling. This inconsistent behavior is confusing
externally, so this commit ensures a single shared now timestamp is used
across a request, preventing such cases.

This fixes flakiness in the test_partition_throttle_mechanism test.

Fixes https://redpandadata.atlassian.net/browse/CORE-8555

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes

* Apply the `controller_mutation_rate` quota to all parts of a partition mutation request using a consistent timestamp to prevent scheduling delays during request processing from affecting the throttling outcome.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
