### PR TITLE
r/consensus: adjust learner initial offset to batch boundary

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1242,6 +1242,47 @@ consensus::remove_member(vnode node, model::revision_id new_revision) {
       });
 }
 
+std::optional<model::offset> consensus::adjust_learner_initial_offset(
+  std::optional<model::offset> learner_start_offset) {
+    if (!learner_start_offset) {
+        return learner_start_offset;
+    }
+    /**
+     * We need to adjust the offset to the full batch boundary. This
+     * is required as the last offset included in the snapshot MUST be
+     * the last offset in a batch. If that wouldn't be the case Raft
+     * leader would not be able to recover follower as Raft delivers
+     * whole batches not individual records. We are looking for the last offset
+     * of a batch that is smaller than the requested learner_start_offset.
+     *
+     *
+     * The following invariant MUST hold:
+     * adjusted_offset <= last_included_offset
+     */
+    auto adjusted_learner_initial_offset
+      = _log->index_batch_base_offset_lower_bound(*learner_start_offset);
+    if (!adjusted_learner_initial_offset) {
+        vlog(
+          _ctxlog.warn,
+          "failed to adjust last included offset {} to the batch "
+          "boundary. Log offsets: {}",
+          learner_start_offset,
+          _log->offsets());
+        return std::nullopt;
+    }
+
+    if (adjusted_learner_initial_offset != learner_start_offset) {
+        vlog(
+          _ctxlog.info,
+          "Adjusted learner start offset {} to the batch boundary. "
+          "Adjusted offset: {}.",
+          learner_start_offset,
+          *adjusted_learner_initial_offset);
+    }
+
+    return adjusted_learner_initial_offset;
+}
+
 ss::future<std::error_code> consensus::replace_configuration(
   std::vector<vnode> nodes,
   model::revision_id new_revision,
@@ -1251,6 +1292,8 @@ ss::future<std::error_code> consensus::replace_configuration(
         group_configuration current) mutable {
           auto old = current;
           try_updating_configuration_version(current);
+          learner_start_offset = adjust_learner_initial_offset(
+            learner_start_offset);
           current.replace(nodes, new_revision, learner_start_offset);
           vlog(
             _ctxlog.debug,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -798,6 +798,9 @@ private:
 
     void validate_offset_translator_delta(
       const protocol_metadata&, const storage::offset_stats& lstats);
+
+    std::optional<model::offset>
+      adjust_learner_initial_offset(std::optional<model::offset>);
     // args
     vnode _self;
     raft::group_id _group;

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -155,6 +155,12 @@ failure_injectable_log::index_lower_bound(model::offset o) const {
     return _underlying_log->index_lower_bound(o);
 }
 
+std::optional<model::offset>
+failure_injectable_log::index_batch_base_offset_lower_bound(
+  model::offset o) const {
+    return _underlying_log->index_batch_base_offset_lower_bound(o);
+}
+
 ss::future<model::offset>
 failure_injectable_log::monitor_eviction(ss::abort_source& as) {
     return _underlying_log->monitor_eviction(as);

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -84,8 +84,10 @@ public:
 
     std::optional<model::offset>
       get_term_last_offset(model::term_id) const final;
-
     std::optional<model::offset> index_lower_bound(model::offset o) const final;
+
+    std::optional<model::offset>
+    index_batch_base_offset_lower_bound(model::offset o) const final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
 

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -215,7 +215,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
       [this, consistency_lvl](raft_node_instance& leader_node) {
           return leader_node.raft()
             ->replicate(
-              make_random_batches(), replicate_options(consistency_lvl))
+              make_batches(100, 100, 128), replicate_options(consistency_lvl))
             .then([this](::result<replicate_result> r) {
                 if (!r) {
                     return ss::make_ready_future<::result<model::offset>>(
@@ -264,9 +264,16 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
     std::optional<model::offset> learner_start_offset;
     if (use_learner_start_offset) {
         learner_start_offset = co_await with_leader(
-          30s, [](raft_node_instance& leader_node) {
-              return leader_node.random_batch_base_offset(
-                leader_node.raft()->dirty_offset() - model::offset(1));
+          30s, [this](raft_node_instance& leader_node) {
+              return leader_node
+                .random_batch_base_offset(
+                  leader_node.raft()->dirty_offset() - model::offset(1),
+                  std::max(
+                    model::offset(300), leader_node.raft()->start_offset()))
+                .then([this](model::offset base_offset) {
+                    logger().info("Random batch base offset: {}", base_offset);
+                    return base_offset;
+                });
           });
         if (learner_start_offset != model::offset{}) {
             start_offset = *learner_start_offset;
@@ -392,7 +399,8 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         ASSERT_TRUE_CORO(cfg.current_config().learners.empty());
 
         if (learner_start_offset && added_nodes.contains(n.get_vnode())) {
-            ASSERT_EQ_CORO(n.raft()->start_offset(), learner_start_offset);
+            ASSERT_LE_CORO(n.raft()->start_offset(), learner_start_offset);
+            ASSERT_GT_CORO(n.raft()->start_offset(), model::offset(0));
         }
     }
 
@@ -669,4 +677,104 @@ TEST_F_CORO(raft_fixture, test_force_reconfiguration) {
           o,
           kafka_offsets);
     }
+}
+
+TEST_F_CORO(raft_fixture, test_initial_learner_offset_adjustment) {
+    // create a group with 1 node
+    co_await create_simple_group(1);
+    auto leader = co_await wait_for_leader(10s);
+    // replicate some data
+    while (node(leader).raft()->dirty_offset() < model::offset(10000)) {
+        auto leader_opt = get_leader();
+        if (!leader_opt) {
+            vlog(logger().info, "no leader");
+            co_await ss::sleep(100ms);
+            continue;
+        }
+        leader = leader_opt.value();
+        co_await node(leader)
+          .raft()
+          ->replicate(
+            make_batches(10, 10, 128),
+            replicate_options(raft::consistency_level::quorum_ack))
+          .then([this](result<replicate_result> result) {
+              if (result.has_error()) {
+                  vlog(
+                    logger().info,
+                    "error(replicating): {}",
+                    result.error().message());
+              }
+          });
+    }
+
+    auto current_nodes = all_vnodes();
+
+    absl::flat_hash_set<raft::vnode> added_nodes;
+    co_await ss::coroutine::parallel_for_each(boost::irange(4), [&](int i) {
+        auto& n = add_node(model::node_id(i + 1), model::revision_id(0));
+        current_nodes.push_back(n.get_vnode());
+        added_nodes.emplace(n.get_vnode());
+        return n.init_and_start({});
+    });
+
+    model::offset learner_start_offset{random_generators::get_int(2000, 6000)};
+    // update group configuration
+    auto success = co_await retry_with_leader(
+      model::timeout_clock::now() + 30s,
+      [current_nodes, learner_start_offset](raft_node_instance& leader_node) {
+          return leader_node.raft()
+            ->replace_configuration(
+              current_nodes, model::revision_id(0), learner_start_offset)
+            .then([](std::error_code ec) {
+                if (ec) {
+                    return ::result<bool>(ec);
+                }
+                return ::result<bool>(true);
+            });
+      });
+    ASSERT_TRUE_CORO(success);
+    co_await with_leader(30s, [this](raft_node_instance& leader_node) {
+        return wait_for_committed_offset(
+          leader_node.raft()->committed_offset(), 30s);
+    });
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(60s, [this] {
+        for (auto& [id, node] : nodes()) {
+            if (
+              node->raft()->config().get_state()
+              != raft::configuration_state::simple) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    absl::flat_hash_set<raft::vnode> current_nodes_set(
+      current_nodes.begin(), current_nodes.end());
+    model::offset start_offset = model::offset(0);
+    // validate configuration
+    for (auto& [id, n] : nodes()) {
+        auto cfg = n->raft()->config();
+        auto cfg_vnodes = cfg.all_nodes();
+        ASSERT_EQ_CORO(
+          current_nodes_set,
+          absl::flat_hash_set<raft::vnode>(
+            cfg_vnodes.begin(), cfg_vnodes.end()));
+        ASSERT_FALSE_CORO(cfg.old_config().has_value());
+        ASSERT_TRUE_CORO(cfg.current_config().learners.empty());
+
+        if (learner_start_offset && added_nodes.contains(n->get_vnode())) {
+            ASSERT_LE_CORO(n->raft()->start_offset(), learner_start_offset);
+            ASSERT_GT_CORO(n->raft()->start_offset(), model::offset(0));
+            start_offset = std::max(start_offset, n->raft()->start_offset());
+        }
+    }
+
+    co_await assert_logs_equal(start_offset);
+
+    std::vector<raft_node_instance*> current_node_ptrs;
+    for (auto& [id, node] : nodes()) {
+        current_node_ptrs.push_back(node.get());
+    }
+    assert_offset_translator_state_is_consistent(current_node_ptrs);
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2785,7 +2785,6 @@ disk_log_impl::get_term_last_offset(model::term_id term) const {
 
     return std::nullopt;
 }
-
 std::optional<model::offset>
 disk_log_impl::index_lower_bound(model::offset o) const {
     if (unlikely(_segs.empty())) {
@@ -2805,6 +2804,26 @@ disk_log_impl::index_lower_bound(model::offset o) const {
     }
     if (auto entry = idx.find_nearest(o)) {
         return model::prev_offset(entry->offset);
+    }
+    return std::nullopt;
+}
+
+std::optional<model::offset>
+disk_log_impl::index_batch_base_offset_lower_bound(model::offset o) const {
+    if (unlikely(_segs.empty())) {
+        return std::nullopt;
+    }
+    if (o == model::offset{}) {
+        return std::nullopt;
+    }
+    auto it = _segs.lower_bound(o);
+    if (it == _segs.end()) {
+        return std::nullopt;
+    }
+    auto& idx = (*it)->index();
+    // find nearest always returns a base offset.
+    if (auto entry = idx.find_nearest(o)) {
+        return entry->offset;
     }
     return std::nullopt;
 }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -139,6 +139,9 @@ public:
     std::optional<model::offset>
     get_term_last_offset(model::term_id term) const final;
     std::optional<model::offset> index_lower_bound(model::offset o) const final;
+    std::optional<model::offset>
+    index_batch_base_offset_lower_bound(model::offset o) const final;
+
     std::ostream& print(std::ostream&) const final;
 
     // Must be called while _segments_rolling_lock is held.

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -141,6 +141,13 @@ public:
     index_lower_bound(model::offset o) const = 0;
 
     /**
+     * Returns a max base offset of the indexed batch that is smaller than or
+     * equal to the requested offset.
+     */
+    virtual std::optional<model::offset>
+    index_batch_base_offset_lower_bound(model::offset o) const = 0;
+
+    /**
      * \brief Returns a future that resolves when log eviction is scheduled
      *
      * Important note: The api may throw ss::abort_requested_exception when

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -133,6 +133,10 @@ public:
     virtual std::optional<model::term_id> get_term(model::offset) const = 0;
     virtual std::optional<model::offset>
       get_term_last_offset(model::term_id) const = 0;
+    /**
+     * Returns the last offset of a batch that base offset is smaller than or
+     * equal to the requested value and bach is indexed.
+     */
     virtual std::optional<model::offset>
     index_lower_bound(model::offset o) const = 0;
 


### PR DESCRIPTION
Redpanda Raft protocol implementation operates on batches. The batch is the smallest unit leader can send in append entries request to the followers. The fact that the batch is the smallest unit Raft operates at forces the snapshots to be taken at batch boundaries. In other words the last snapshot included offset must be a last offset of a batch.

Described invariant may not always be true when controller backend request fast reconfiguration and the offset provided is bounded by max_collectible_offset. The `max_collectible_offset` may be in the middle of the batch. (an example of state machine returning offset in the middle of the batch is datalake translation state machine which operates at the record level).

Added code that will adjust the requested learner start offset to batch boundary. The adjusted offset may not the first possible batch last offset because it uses index lower bound. (Index is sparse and using 32 KiB steps)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none