### PR TITLE
selftest: Show network output in G/M/Kbit

### DIFF
--- a/src/go/rpk/pkg/system/utils.go
+++ b/src/go/rpk/pkg/system/utils.go
@@ -40,17 +40,17 @@ func UnameAndDistro(timeout time.Duration) (string, error) {
 // depending on how large the input is.
 func BitsToHuman(bytes float64) string {
 	bits := bytes * 8
-	asGib := bits / (1 << 30)
-	asMib := bits / (1 << 20)
-	asKib := bits / (1 << 10)
-	if asGib > 1.0 {
-		return fmt.Sprintf("%.2fGib", asGib)
+	asGb := bits / 1000000000
+	asMb := bits / 1000000
+	asKb := bits / 1000
+	if asGb > 1.0 {
+		return fmt.Sprintf("%.2fGbit", asGb)
 	}
-	if asMib > 1.0 {
-		return fmt.Sprintf("%.2fMib", asMib)
+	if asMb > 1.0 {
+		return fmt.Sprintf("%.2fMbit", asMb)
 	}
-	if asKib > 1.0 {
-		return fmt.Sprintf("%.2fKib", asKib)
+	if asKb > 1.0 {
+		return fmt.Sprintf("%.2fKbit", asKb)
 	}
-	return fmt.Sprintf("%v", bytes)
+	return fmt.Sprintf("%vbit", bits)
 }


### PR DESCRIPTION
It's the more typical unit for network speeds.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

