### PR TITLE
transforms: limit produced batch size

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -422,6 +422,12 @@ size_t transformed_data::memory_usage() const {
     return sizeof(*this) + _data.size_bytes();
 }
 
+size_t transformed_data::estimated_serialized_size() const {
+    // size, timestamp, and offset
+    size_t variant_max_size = vint::max_length * 3;
+    return sizeof(record_attributes) + variant_max_size + _data.size_bytes();
+}
+
 transformed_data transformed_data::copy() const {
     return transformed_data(_data.copy());
 }

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -337,7 +337,7 @@ model::record_batch transformed_data::make_batch(
     model::record_batch::compressed_records serialized_records;
     int32_t i = 0;
     for (model::transformed_data& r : records) {
-        serialized_records.append_fragments(std::move(r).to_serialized_record(
+        serialized_records.append(std::move(r).to_serialized_record(
           model::record_attributes(),
           /*timestamp_delta=*/0,
           /*offset_delta=*/i++));
@@ -404,7 +404,7 @@ iobuf transformed_data::to_serialized_record(
     bytes od = vint::to_bytes(offset_delta);
     out.append(od.data(), od.size());
 
-    out.append_fragments(std::move(_data));
+    out.append(std::move(_data));
 
     bytes encoded_size = vint::to_bytes(
       int64_t(out.size_bytes() - vint::max_length));

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -442,6 +442,11 @@ public:
      */
     size_t memory_usage() const;
 
+    /**
+     * the estimated size in bytes when serialized
+     */
+    size_t estimated_serialized_size() const;
+
     bool operator==(const transformed_data&) const = default;
 
     /**

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -465,8 +465,7 @@ bool processor::is_running() const {
 }
 
 int64_t processor::current_lag() const {
-    return *std::max_element(
-      _last_reported_lag.begin(), _last_reported_lag.end());
+    return *std::ranges::max_element(_last_reported_lag);
 }
 
 size_t transformed_output::memory_usage() const {

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -441,8 +441,9 @@ ss::future<> processor::when_all_shutdown(T&&... futs) {
 ss::future<> processor::handle_processor_task(ss::future<> fut) {
     try {
         co_await std::move(fut);
-    } catch (const processor_shutdown_exception&) {
+    } catch (const processor_shutdown_exception& e) {
         // Do nothing, this is an expected error on shutdown
+        std::ignore = e;
     } catch (const std::exception& ex) {
         vlog(_logger.warn, "error running transform: {}", ex);
         _state_callback(_id, _ntp, state::errored);

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -389,11 +389,27 @@ ss::future<> processor::run_producer_loop(
                   latest_offset = offset;
               });
         }
-        if (!records.empty()) {
-            // TODO(rockwood): Limit batch sizes so we don't overshoot
-            // max batch size limits.
+        while (!records.empty()) {
+            // TODO(rockwood): Lookup the output topic size instead of
+            // hardcoding the default value.
+            static constexpr size_t default_batch_size_limit = 1_MiB;
+            size_t current_size = 0;
+            ss::chunked_fifo<model::transformed_data> batch_records;
+            while (!records.empty()) {
+                auto& next = records.front();
+                size_t next_size = current_size
+                                   + next.estimated_serialized_size();
+                if (
+                  !batch_records.empty()
+                  && next_size > default_batch_size_limit) {
+                    break;
+                }
+                current_size = next_size;
+                batch_records.push_back(std::move(next));
+                records.pop_front();
+            }
             auto batch = model::transformed_data::make_batch(
-              model::timestamp::now(), std::move(records));
+              model::timestamp::now(), std::move(batch_records));
             if (_meta.compression_mode != model::compression::none) {
                 batch = co_await storage::internal::compress_batch(
                   _meta.compression_mode, std::move(batch));


### PR DESCRIPTION
- **model/transform: use append instead of forcing zero copy**
- **model/transform: add a method to estimate the record size**
- **transform: limit batch sizes**
- **transform: fix clang tidy warning**
- **transform: use std::ranges algorithm**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes an issue where data transforms could write batches larger than 1MiB, causing "Invalid request" errors due to batches being too large.
