### PR TITLE
[CORE-9205] kafka/groups: Improve log message

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -48,6 +48,8 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
+#include <fmt/ranges.h>
+
 #include <chrono>
 #include <system_error>
 
@@ -287,26 +289,34 @@ ss::future<> group_manager::handle_offset_expiration() {
      * build a light-weight snapshot of the groups to process. the snapshot
      * allows us to avoid concurrent modifications to _groups container.
      */
-    fragmented_vector<group_ptr> groups;
+    fragmented_vector<std::pair<group_ptr, size_t>> groups;
     for (auto& group : _groups) {
-        groups.push_back(group.second);
+        groups.emplace_back(group.second, 0);
     }
 
-    size_t total = 0;
     co_await ss::max_concurrent_for_each(
       groups,
       max_concurrent_expirations,
-      [this, &total, retention_period = retention_period.value()](auto group) {
-          return delete_expired_offsets(group, retention_period)
-            .then([&total](auto removed) { total += removed; });
+      [this, retention_period = retention_period.value()](auto& group_count) {
+          return delete_expired_offsets(group_count.first, retention_period)
+            .then(
+              [&group_count](auto removed) { group_count.second = removed; });
       });
 
-    if (total) {
+    auto groups_with_expired_offsets
+      = groups | std::ranges::views::filter([](auto& group_count) {
+            return group_count.second > 0;
+        })
+        | std::ranges::views::transform([](auto& group_count) {
+              return std::pair<std::string_view, size_t>(
+                group_count.first->id()(), group_count.second);
+          });
+
+    if (!groups_with_expired_offsets.empty()) {
         vlog(
           cg_klog.info,
-          "Removed {} offsets from {} groups",
-          total,
-          groups.size());
+          "Removed (group, offsets) {} due to offset retention",
+          groups_with_expired_offsets);
     }
 }
 


### PR DESCRIPTION
Improve the log message, e.g:

Before:
```
[shard 0:main] kafka-cg - group_manager.cc:319 - Removed 3 offsets from 2 groups
[shard 1:main] kafka-cg - group_manager.cc:319 - Removed 4 offsets from 2 groups
```
After
```
[shard 0:main] kafka-cg - group_manager.cc:319 - Removed (group, offsets) [("TEST4", 1), ("TEST1", 2)] due to offset retention
[shard 1:main] kafka-cg - group_manager.cc:319 - Removed (group. offsets) [("TEST2", 3), ("TEST3", 1)] due to offset retention
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Kafka/server: Improve logging for group removal due to retention.
