### PR TITLE
ABS Testing (`cloud_storage_clients`: add logging to `abs_client`)

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -688,6 +688,12 @@ ss::future<> abs_client::do_put_object(
         status != created && !is_no_content_and_accepted) {
         const auto content_type = get_response_content_type(
           response_stream->get_headers());
+        if (content_type == response_content_type::unknown) {
+            vlog(
+              abs_log.debug,
+              "ABS response type is unknown for response with headers: {:l}",
+              response_stream->get_headers());
+        }
         auto buf = co_await util::drain_response_stream(
           std::move(response_stream));
         throw parse_rest_error_response(content_type, status, std::move(buf));


### PR DESCRIPTION
When the response type is unable to be determined, something has gone wrong. Log a `DEBUG` level output of the response headers to help debug.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
