### PR TITLE
datalake: add scratch space usage limit

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4087,6 +4087,40 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       32_MiB,
       {.min = 1_MiB})
+  , datalake_disk_space_monitor_enable(
+      *this,
+      "datalake_disk_space_monitor_enable",
+      "Option to explicitly disable enforcement of datalake disk space usage",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
+  , datalake_disk_space_monitor_interval(
+      *this,
+      "datalake_disk_space_monitor_interval",
+      "The amount of time between invocations of the datalake disk space usage "
+      "monitor which examines disk usage and dispatches requests to "
+      "translators to reduce their usage if it is above the configured "
+      "threshold.",
+      {.needs_restart = needs_restart::no,
+       .example = "3600000",
+       .visibility = visibility::tunable},
+      30s,
+      {.min = 2s})
+  , datalake_scratch_space_size_bytes(
+      *this,
+      "datalake_scratch_space_size_bytes",
+      "Size, in bytes, of the amount of scratch space datalake should use.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      5_GiB)
+  , datalake_disk_usage_overage_coeff(
+      *this,
+      "datalake_disk_usage_overage_coeff",
+      "The datalake disk usage monitor reclaims the overage multiplied by "
+      "this this coefficient to compensate for data that is written during the "
+      "idle period between control loop invocations.",
+      {.needs_restart = needs_restart::no,
+       .example = "1.8",
+       .visibility = visibility::tunable},
+      2.0)
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4084,7 +4084,7 @@ configuration::configuration()
       "Size, in bytes, of the amount of per translator data that may be "
       "flushed to disk before the translator will upload and remove its "
       "current on disk data.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       32_MiB,
       {.min = 1_MiB})
   , datalake_disk_space_monitor_enable(
@@ -4109,7 +4109,7 @@ configuration::configuration()
       *this,
       "datalake_scratch_space_size_bytes",
       "Size, in bytes, of the amount of scratch space datalake should use.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB)
   , datalake_disk_usage_overage_coeff(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -757,6 +757,11 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds>
       datalake_scheduler_time_slice_ms;
     bounded_property<size_t> datalake_translator_flush_bytes;
+    property<bool> datalake_disk_space_monitor_enable;
+    bounded_property<std::chrono::milliseconds>
+      datalake_disk_space_monitor_interval;
+    property<size_t> datalake_scratch_space_size_bytes;
+    property<double> datalake_disk_usage_overage_coeff;
 
     configuration();
 

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -29,6 +29,7 @@
 #include "utils/human.h"
 
 #include <memory>
+#include <ranges>
 
 constexpr std::chrono::milliseconds translation_jitter{500};
 constexpr std::chrono::milliseconds translation_jitter_base{5000};
@@ -134,10 +135,16 @@ datalake_manager::datalake_manager(
           .datalake_scheduler_max_concurrent_translations.bind(),
         std::chrono::duration_cast<translation::scheduling::clock::duration>(
           config::shard_local_cfg().datalake_scheduler_time_slice_ms())))
-  , _queue(sg, [](const std::exception_ptr& ex) {
-      vlog(
-        datalake_log.error, "unexpected error in managing translator: {}", ex);
-  }) {}
+  , _queue(
+      sg,
+      [](const std::exception_ptr& ex) {
+          vlog(
+            datalake_log.error,
+            "unexpected error in managing translator: {}",
+            ex);
+      })
+  , _disk_usage_interval(
+      config::shard_local_cfg().datalake_disk_space_monitor_interval.bind()) {}
 datalake_manager::~datalake_manager() = default;
 
 double datalake_manager::average_translation_backlog() {
@@ -268,6 +275,158 @@ ss::future<> datalake_manager::start() {
     _backlog_controller = std::make_unique<backlog_controller>(
       [this] { return average_translation_backlog(); }, _sg);
     co_await _backlog_controller->start();
+
+    /*
+     * Start the global disk space usage monitor loop
+     */
+    const ss::shard_id disk_space_monitor_core = 0;
+    if (ss::this_shard_id() == disk_space_monitor_core) {
+        ssx::spawn_with_gate(_gate, [this] { return disk_space_monitor(); });
+    }
+
+    _disk_usage_interval.watch([this] { _disk_space_monitor_sem.signal(); });
+}
+
+ss::future<> datalake_manager::disk_space_monitor() {
+    while (!_gate.is_closed()) {
+        const auto interval = _disk_usage_interval();
+        try {
+            co_await _disk_space_monitor_sem.wait(
+              interval, std::max(_disk_space_monitor_sem.current(), size_t(1)));
+        } catch (const ss::semaphore_timed_out& ex) {
+            std::ignore = ex;
+            // drop through to perform work
+        }
+
+        if (_disk_usage_interval() != interval) {
+            // configuration change
+            continue;
+        }
+
+        if (!config::shard_local_cfg().datalake_disk_space_monitor_enable()) {
+            continue;
+        }
+
+        try {
+            co_await check_and_manage_disk_space();
+        } catch (...) {
+            vlog(
+              datalake_log.info,
+              "Recoverable error checking datalake disk space: {}",
+              std::current_exception());
+        }
+    }
+}
+
+ss::future<> datalake_manager::check_and_manage_disk_space() {
+    using translator_id = translation::scheduling::translator_id;
+    using translator_info = std::pair<ss::shard_id, translator_id>;
+    using index_type = absl::btree_multimap<size_t, translator_info>;
+
+    /*
+     * Collect disk usage from all translators managed by the scheduler, and
+     * combine these usages from across all cores to create a global set of
+     * translators ordered by their disk usage.
+     */
+    auto usage = co_await container().map_reduce0(
+      [](datalake_manager& mgr) {
+          index_type usage;
+          for (const auto& it : mgr._scheduler.all_translators()) {
+              auto status = it.second.status();
+              auto size = status.disk_bytes_flushed.value_or(0);
+              usage.emplace(
+                size, std::make_tuple(ss::this_shard_id(), it.first));
+          }
+          return usage;
+      },
+      index_type{},
+      [](index_type acc, index_type usage) {
+          acc.merge(usage);
+          return acc;
+      });
+
+    const size_t target_size
+      = config::shard_local_cfg().datalake_scratch_space_size_bytes();
+
+    const auto total_bytes = std::reduce(
+      usage.begin(),
+      usage.end(),
+      size_t(0),
+      [](const auto acc, const auto& elem) { return acc + elem.first; });
+
+    // the amount of disk usage over the target
+    const auto real_target_excess = total_bytes < target_size
+                                      ? 0
+                                      : total_bytes - target_size;
+
+    /*
+     * do nothing if we are over the limit, but only by a "small" amount, which
+     * increases the chances of having meaningful work to do and avoid some
+     * thrashing scenarios. this is the same strategy used in space management
+     * to avoid thrashing (see resource_mgm/storage.cc).
+     */
+    const size_t min_size_threshold = 64_MiB;
+    if (real_target_excess <= min_size_threshold) {
+        vlog(
+          datalake_log.trace,
+          "Disk monitor total {} target {} excess",
+          human::bytes(total_bytes),
+          human::bytes(target_size),
+          human::bytes(real_target_excess));
+        co_return;
+    }
+
+    const double coeff
+      = config::shard_local_cfg().datalake_disk_usage_overage_coeff();
+
+    const auto adjusted_target_excess = static_cast<size_t>(
+      real_target_excess * coeff);
+
+    /*
+     * Generate a schedule of translators that should be finished immediately so
+     * that their on disk data is uploaded and deleted locally. Iteration is
+     * from largest usage to smallest usage, and that order is preserved in the
+     * per-core vector constructed for `scheduler::request_immediate_finish`.
+     */
+    size_t num_translators = 0;
+    size_t schedule_total_bytes = 0;
+    absl::flat_hash_map<
+      ss::shard_id,
+      chunked_vector<std::pair<translator_id, size_t>>>
+      schedule;
+    for (auto& it : std::ranges::reverse_view(usage)) {
+        if (schedule_total_bytes >= adjusted_target_excess) {
+            break;
+        }
+        schedule[it.second.first].push_back(
+          std::make_pair(it.second.second, it.first));
+        schedule_total_bytes += it.first;
+        num_translators++;
+    }
+
+    vlog(
+      datalake_log.info,
+      "Requesting {} translators to reclaim {}. Current total {} target {}/{} "
+      "excess {}",
+      num_translators,
+      human::bytes(schedule_total_bytes),
+      human::bytes(total_bytes),
+      human::bytes(target_size),
+      human::bytes(real_target_excess),
+      human::bytes(adjusted_target_excess));
+
+    /*
+     * Make the request to each core with translators in the schedule.
+     */
+    co_await ss::parallel_for_each(
+      schedule.begin(), schedule.end(), [this](auto& it) {
+          return container().invoke_on(
+            it.first,
+            [translators = std::move(it.second)](
+              datalake_manager& mgr) mutable {
+                mgr._scheduler.request_immediate_finish(std::move(translators));
+            });
+      });
 }
 
 ss::future<>
@@ -322,6 +481,7 @@ datalake_manager::prepare_staging_directory(std::filesystem::path path) {
 
 ss::future<> datalake_manager::shutdown() {
     vlog(datalake_log.debug, "Stopping datalake manager...");
+    _disk_space_monitor_sem.broken();
     auto f = _gate.close();
     co_await _queue.shutdown();
     if (_backlog_controller) {

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -122,6 +122,18 @@ private:
     /// \note The probe is created on the first use.
     ss::lw_shared_ptr<translation_probe> get_or_create_probe(const model::ntp&);
 
+    /*
+     * Background loop that periodically invokes `check_disk_space`.
+     */
+    ss::future<> disk_space_monitor();
+
+    /*
+     * Checks disk space usage across all translators, and if the total usage
+     * exceeds the configured limits for datalake, request schedulers to finish
+     * translations and free disk space.
+     */
+    ss::future<> check_and_manage_disk_space();
+
 private:
     model::node_id _self;
     ss::sharded<raft::group_manager>* _group_mgr;
@@ -153,6 +165,8 @@ private:
     std::filesystem::path _writer_scratch_space;
     translation::scheduling::scheduler _scheduler;
     ssx::work_queue _queue;
+    ssx::semaphore _disk_space_monitor_sem{0, "datalake::disk_space_monitor"};
+    config::binding<std::chrono::milliseconds> _disk_usage_interval;
 };
 
 } // namespace datalake

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -54,6 +54,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/utils:to_string",
+        "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@seastar",
     ],

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -278,10 +278,18 @@ partition_translator::run_one_translation_iteration(
     } catch (const translator_out_of_memory_error&) {
         // We just swallow the exception because the underlying result state
         // is still safe to be flushed.
-        vlog(
-          _logger.warn,
-          "Translation exceeded memory budget, result will be flushed "
-          "immediately");
+        if (_finish_translation_requested) {
+            vlog(_logger.debug, "Translation requested to finish immediately");
+        } else {
+            // `translator_out_of_memory_error is pulling double duty for
+            // preemption requests and out-of-memory requests. until stop
+            // translation is more expressive, we silence the out-of-memory
+            // warning if a finish translation request was also made.
+            vlog(
+              _logger.warn,
+              "Translation exceeded memory budget, result will be flushed "
+              "immediately");
+        }
         // We force a finish immediately to make forward progress and avoid
         // cases where the translator is stuck in this memory exhaustion loop.
         result = finish_immediately::yes;
@@ -411,7 +419,9 @@ ss::future<> partition_translator::translate_until_stopped() {
           [&needs_jitter] { needs_jitter = true; });
         // Clear the flag as it is a one-shot request, and since
         // translate_until_stopped can be restarted, for example if this
-        // workloop throws.
+        // workloop throws. This avoids clearing the flag before running
+        // run_one_translation_iteration which uses the flag to silence the
+        // out-of-memory warning message.
         auto clear_finish_request = ss::defer(
           [this] { _finish_translation_requested = false; });
 

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -397,13 +397,25 @@ ss::future<> partition_translator::translate_until_stopped() {
         // case the next iteration should see some jitter.
         auto scoped_set_jitter = ss::defer(
           [&needs_jitter] { needs_jitter = true; });
+        // Clear the flag as it is a one-shot request, and since
+        // translate_until_stopped can be restarted, for example if this
+        // workloop throws.
+        auto clear_finish_request = ss::defer(
+          [this] { _finish_translation_requested = false; });
 
         auto offsets = co_await fetch_translation_offsets(rcn);
-        if (!offsets) {
+        // this test of the finish translation request flag works here because
+        // we are executing in a polling loop.
+        auto finish_now = _finish_translation_requested
+                            ? finish_immediately::yes
+                            : finish_immediately::no;
+        if (finish_now) {
+            vlog(_logger.debug, "Requested for immediate finish");
+        }
+        if (!offsets && !finish_now) {
             continue;
         }
-        auto finish_now = finish_immediately::no;
-        if (offsets->next_translation_begin_offset) {
+        if (offsets->next_translation_begin_offset && !finish_now) {
             // new data is available to translate
             auto translate_f = co_await ss::coroutine::as_future(
               run_one_translation_iteration(
@@ -520,4 +532,13 @@ void partition_translator::stop_translation() {
     _inflight_translation_state->as.request_abort_ex(
       translator_out_of_memory_error{});
 }
+
+void partition_translator::set_finish_translation() {
+    _finish_translation_requested = true;
+}
+
+bool partition_translator::get_finish_translation() {
+    return _finish_translation_requested;
+}
+
 } // namespace datalake::translation

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -239,6 +239,18 @@ partition_translator::run_one_translation_iteration(
         co_await _ready_to_translate.wait(
           [this] { return _inflight_translation_state.has_value(); });
         auto& as = _inflight_translation_state->as;
+        /*
+         * before going to the trouble of building a reader and poking the
+         * translation context, check if an abort has been requested. this
+         * enables the scheduler to execute:
+         *
+         *    start_translation();
+         *    stop_translation();
+         *
+         * to realize a very fast responsiveness for driving a translator state
+         * change such as finishing the on-going translation.
+         */
+        as.check();
         auto reader = co_await _data_source->make_log_reader(
           begin_offset, datalake_priority(), as);
         if (!reader) {

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -96,6 +96,10 @@ public:
 
     void reconcile_properties() noexcept final;
 
+    void set_finish_translation() final;
+
+    bool get_finish_translation() final;
+
 private:
     /**
      * inflight_translation_state
@@ -203,5 +207,10 @@ private:
     // scheduler calls start_translation, waking up translate_when_notified as a
     // result.
     ss::condition_variable _ready_to_translate;
+
+    // true if this translator has been requested to finish. when set, the
+    // translator should work towards uploading and removing its staging data.
+    // the translator can clear this bit. it may be reset by future requests.
+    bool _finish_translation_requested{false};
 };
 } // namespace datalake::translation

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -331,7 +331,8 @@ void scheduler::notify_done(const translator_id& id) noexcept {
 }
 
 bool scheduler::requires_scheduling_actions() const {
-    return !_executor.waiting.empty() || _mem_tracker->memory_exhausted();
+    return !_executor.waiting.empty() || _mem_tracker->memory_exhausted()
+           || !_executor.translators_for_immediate_finish.empty();
 }
 
 void scheduler::notify_memory_exhausted() {
@@ -418,6 +419,11 @@ void scheduler::request_immediate_finish(
         _executor.translators_for_immediate_finish.emplace(
           i, std::move(translators[i].first));
     }
+    // there is no mechanism for backing out a request to finish, so there isn't
+    // any additional work that can be done if the requests are cleared.
+    if (!_executor.translators_for_immediate_finish.empty()) {
+        _state_changed_cvar.signal();
+    }
 }
 
 ss::future<> scheduler::main() {
@@ -428,9 +434,12 @@ ss::future<> scheduler::main() {
           [this] { return requires_scheduling_actions(); });
         vlog(
           datalake_log.trace,
-          "scheduler tick,  memory_exhausted: {}",
-          _mem_tracker->memory_exhausted());
-        if (_mem_tracker->memory_exhausted()) {
+          "scheduler tick,  memory_exhausted: {} finish: {}",
+          _mem_tracker->memory_exhausted(),
+          _executor.translators_for_immediate_finish.size());
+        if (
+          _mem_tracker->memory_exhausted()
+          || !_executor.translators_for_immediate_finish.empty()) {
             co_await _scheduling_policy->on_resource_exhaustion(
               _executor, *_mem_tracker);
         }

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -407,6 +407,19 @@ size_t scheduler::running_translators() const {
     return _executor.running.size();
 }
 
+void scheduler::request_immediate_finish(
+  chunked_vector<std::pair<translator_id, size_t>> translators) {
+    _executor.translators_for_immediate_finish.clear();
+    // `i` captures both priority (lowest is highest), and serves as a unique
+    // identifer. see `on_resource_exhaustion` for how this property is used.
+    for (size_t i = 0; i < translators.size(); ++i) {
+        // the flush size of the translator is thrown away here, but preserved
+        // at the scheduler API level for future use by the scheduler.
+        _executor.translators_for_immediate_finish.emplace(
+          i, std::move(translators[i].first));
+    }
+}
+
 ss::future<> scheduler::main() {
     vlog(datalake_log.trace, "Starting scheduling loop");
     auto holder = _executor.gate.hold();

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -19,6 +19,8 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
 
+#include <absl/container/btree_map.h>
+
 namespace datalake::translation::scheduling {
 
 using clock = ss::lowres_clock;
@@ -298,6 +300,13 @@ using translators = chunked_hash_map<translator_id, translator_executable>;
  *
  * For the most part there is no reason to loop through this map as all
  * operations are scoped to a particular translator instance.
+ *
+ * translators for immediate finish
+ *
+ * Set of translatored requested to immedidately finish. This is currently only
+ * used by the disk usage monitor. The key is an opaque priority (lower is
+ * higher priority) and identifier. See `on_resource_exhaustion` for how it's
+ * used for optimization.
  */
 struct executor {
     void start_translation(translator_executable&, clock::duration time_slice);
@@ -307,6 +316,15 @@ struct executor {
       running;
     intrusive_list<translator_executable, &translator_executable::_waiting_hook>
       waiting;
+
+    /*
+     * finish_priority captures the priority in which translators should be
+     * finished with lowest value being highest priority.
+     */
+    using finish_priority = size_t;
+    absl::btree_map<finish_priority, translator_id>
+      translators_for_immediate_finish;
+
     ss::gate gate;
     ss::abort_source as;
 };
@@ -380,6 +398,16 @@ public:
         return _mem_tracker;
     }
     const translators& all_translators() const { return _executor.translators; }
+
+    /*
+     * Request the scheduler to immediately finish and reclaim disk space for
+     * the provided scheduler. The scheduler will treat the ordering of vector
+     * as roughly highest to lowest priority. The second element of the pair is
+     * the total size of the translator which can be used to avoid requerying
+     * for the same information from the translator status API.
+     */
+    void request_immediate_finish(
+      chunked_vector<std::pair<translator_id, size_t>>);
 
 private:
     ss::future<> main();

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -182,6 +182,22 @@ public:
      * scheduling_notifications::notify_done when done.
      */
     virtual void stop_translation() = 0;
+
+    /**
+     * Request that the translator finish and upload its data. This is distinct
+     * from `stop_translation` in that it can be called on a translator no
+     * matter what stat it is in (e.g. running, waiting, idle). The translator
+     * is free to clear the request after taking action.
+     */
+    virtual void set_finish_translation() {}
+
+    /**
+     * Return true if the translator is still in the progress of satisfying the
+     * latest request made via a call to `finish_translation`. This method
+     * should return true immediately after a call to `finish_translation`, and
+     * then eventually return false.
+     */
+    virtual bool get_finish_translation() { return false; }
 };
 
 std::ostream& operator<<(std::ostream&, const translator&);

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -10,6 +10,7 @@
 
 #include "datalake/translation/scheduling_policies.h"
 
+#include "config/configuration.h"
 #include "datalake/logger.h"
 #include "random/generators.h"
 
@@ -289,8 +290,77 @@ ss::future<> fair_scheduling_policy::schedule_one_translation(
     }
 }
 
+/*
+ * when resource exhaustion is reported we seek to stop and/or finish
+ * translators in order to free up memory or disk usage.
+ *
+ * disk usage
+ * ==========
+ * this case is indicated below by a non-empty set of translators that have been
+ * requested to immediately finish (see datalake_manager::disk_space_monitor).
+ * in this case the translator with the most usage is selected to be finished
+ * immediately so that it will upload and delete its on disk staging data. there
+ * are three scenarios depending on the state of the translator:
+ *
+ * 1) running
+ *
+ * currently we prioritize translators in the running state (even over
+ * those with larger usages that are non-running) under the assumption that they
+ * are (a) in the requested set and (b) have the potential to make the situation
+ * worse since they are actively translating data.
+ *
+ * there are arguments against this policy. for instance, finishing a running
+ * translator may make the situation worse still because its in-memory state
+ * will be flushed to disk as part of the finishing process.
+ *
+ * 2) waiting
+ *
+ * when the translator is in the waiting state we start the translator, and
+ * arrange for it to immediately stop itself and finish (without building a
+ * reader or poking the translator context).
+ *
+ * 3) neither running nor waiting
+ *
+ * translator::finish_translation is used for this request. in the partition
+ * translator implementation the offset polling loop will test for this request
+ * and exit its polling loop when requested to finish.
+ *
+ * memory usage
+ * ============
+ *
+ * stop the running translator (if any exist) with the highest reported memory
+ * usage.
+ */
 ss::future<> fair_scheduling_policy::on_resource_exhaustion(
   executor& executor, const reservations_tracker& mem_tracker) {
+    /*
+     * run parallel finish requests.
+     */
+    while (true) {
+        const size_t max_parallel
+          = config::shard_local_cfg()
+              .datalake_scheduler_max_concurrent_translations();
+
+        std::vector<finish_choice_info> choices;
+        while (choices.size() < max_parallel) {
+            auto choice = choose_translator_to_finish(executor);
+            if (!choice) {
+                break;
+            }
+            choices.push_back(choice.value());
+        }
+
+        if (choices.empty()) {
+            // fall through to handle memory resources if necessary
+            break;
+        }
+
+        co_await ss::max_concurrent_for_each(
+          choices, max_parallel, [this, &executor](auto& choice) {
+              return finish_translator(executor, choice);
+          });
+    }
+
     if (!mem_tracker.memory_exhausted() || executor.running.empty()) {
         co_return;
     }
@@ -313,6 +383,143 @@ ss::future<> fair_scheduling_policy::on_resource_exhaustion(
 
     while (mem_tracker.memory_exhausted() && !executor.as.abort_requested()
            && executor.running.size() == num_running) {
+        co_await ss::sleep_abortable(polling_interval, executor.as);
+    }
+}
+
+enum fair_scheduling_policy::finish_choice_info::status
+fair_scheduling_policy::finish_choice_info::translator_status(
+  const translator_executable& exe) {
+    if (exe._running_hook.is_linked()) {
+        return finish_choice_info::status::running;
+    } else if (exe._waiting_hook.is_linked()) {
+        return finish_choice_info::status::waiting;
+    }
+    return finish_choice_info::status::idle;
+}
+
+std::optional<fair_scheduling_policy::finish_choice_info>
+fair_scheduling_policy::choose_translator_to_finish(executor& executor) {
+    auto& translators_to_finish = executor.translators_for_immediate_finish;
+    if (translators_to_finish.empty()) {
+        return std::nullopt;
+    }
+
+    // choice: the return value
+    //
+    // finish_key: index into `translators_to_finish` so that we can remove the
+    // final choice. we can't hold on to an iterator because the set is modified
+    // during iteration.
+    struct choice_info {
+        finish_choice_info info;
+        size_t finish_key;
+    };
+    std::optional<choice_info> choice;
+
+    // find highest priority running translator
+    for (auto it = translators_to_finish.begin();
+         it != translators_to_finish.end();) {
+        // map translator_id -> translator_executable
+        auto eit = executor.translators.find(it->second);
+        if (eit == executor.translators.end()) {
+            it = translators_to_finish.erase(it);
+            continue;
+        }
+
+        // potential return value for choice
+        const auto curr_info = finish_choice_info{
+          .id = eit->first,
+          .status = finish_choice_info::translator_status(eit->second),
+        };
+
+        // first choice is a running translator
+        if (curr_info.status == finish_choice_info::status::running) {
+            choice = choice_info{.info = curr_info, .finish_key = it->first};
+            break;
+        }
+
+        if (!choice.has_value()) {
+            choice = choice_info{.info = curr_info, .finish_key = it->first};
+            // continue looking for a running translator
+        }
+
+        ++it;
+    }
+
+    if (choice.has_value()) {
+        translators_to_finish.erase(choice->finish_key);
+        return choice->info;
+    }
+
+    return std::nullopt;
+}
+
+ss::future<> fair_scheduling_policy::finish_translator(
+  executor& executor, finish_choice_info choice) {
+    // because the translator may have disappeared
+    const auto eit = executor.translators.find(choice.id);
+    if (eit == executor.translators.end()) {
+        co_return;
+    }
+
+    auto& executable = eit->second;
+    executable.translator_ptr()->set_finish_translation();
+
+    /*
+     * it is possible that the status of the choice changed due to fiber
+     * scheduling. we aren't going to change our decision, but we do need to
+     * make sure that we handle the choice correctly below.
+     */
+    choice.status = finish_choice_info::translator_status(executable);
+
+    /*
+     * the translator needs special handling to finish promptly depending on its
+     * current state.
+     */
+    switch (choice.status) {
+    case finish_choice_info::status::running:
+        executor.stop_translation(executable);
+        break;
+
+    case finish_choice_info::status::waiting:
+        // this sets up the translator state such that when it starts it
+        // will immediately stop itself and finish. we piggy back on the
+        // out-of-memory exception which has "immediate finish"
+        // semantics rather than adding completely new states.
+        executor.start_translation(executable, _translation_time_quota);
+        executor.stop_translation(executable);
+        break;
+
+    case finish_choice_info::status::idle:
+        // no handling needed here. the translator is in a polling loop and will
+        // see that the finish bit is set.
+        break;
+    }
+
+    vlog(
+      datalake_log.debug,
+      "Scheduler requesting {} translator {} to finish",
+      choice.status_name(),
+      choice.id);
+
+    /*
+     * set_finish_translation is called on the choice, so wait for the
+     * translator to finish and clear the bit. this should work for translators
+     * in any state. see partition_translator::run_one_translation_iteration for
+     * the raii object that we use to make sure this bit is cleared eventually.
+     */
+    while (!executor.as.abort_requested()) {
+        // done if the translator disappeared
+        auto it = executor.translators.find(choice.id);
+        if (it == executor.translators.end()) {
+            break;
+        }
+
+        // done if the translator cleared its finish bit
+        if (!it->second.translator_ptr()->get_finish_translation()) {
+            break;
+        }
+
         co_await ss::sleep_abortable(polling_interval, executor.as);
     }
 }

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -142,14 +142,24 @@ fair_scheduling_policy::choose_random_translator_group() const {
 
 ss::future<> fair_scheduling_policy::schedule_one_translation(
   executor& executor, const reservations_tracker& mem_tracker) {
-    // Wait until an empty slot frees up.
+    // Wait until an empty slot frees up or control should yield back to the
+    // scheduling loop because, for example, resource exhaustion needs to be
+    // attended to.
+    //
+    // TODO: note that the polling interval here is 1s which is quite
+    // responsive. However, if it longer then one should consider not using a
+    // sleep here because it would degrade responsiveness to _state_changed_cvar
+    // signals.
     while (!executor.as.abort_requested() && !executor.waiting.empty()
            && !mem_tracker.memory_exhausted()
+           && executor.translators_for_immediate_finish.empty()
            && executor.running.size() >= _max_concurrent_translations()) {
         co_await ss::sleep_abortable(polling_interval, executor.as);
     }
 
-    if (executor.as.abort_requested() || mem_tracker.memory_exhausted()) {
+    if (
+      executor.as.abort_requested() || mem_tracker.memory_exhausted()
+      || !executor.translators_for_immediate_finish.empty()) {
         co_return;
     }
 

--- a/src/v/datalake/translation/scheduling_policies.h
+++ b/src/v/datalake/translation/scheduling_policies.h
@@ -120,6 +120,50 @@ private:
 
     config::binding<size_t> _max_concurrent_translations;
     clock::duration _translation_time_quota;
+
+    /*
+     * state maintained for tracking the choice of which translator to finish
+     * when servicing requests for immediate translator finish.
+     *
+     * id: translator id
+     * status: status of the chosen translator
+     */
+    struct finish_choice_info {
+        enum class status {
+            running,
+            waiting,
+            idle,
+        };
+
+        std::string_view status_name() const {
+            switch (status) {
+            case status::running:
+                return "running";
+            case status::waiting:
+                return "waiting";
+            case status::idle:
+                return "idle";
+            }
+        }
+
+        // return the status of the translator
+        static status translator_status(const translator_executable&);
+
+        translator_id id;
+        status status;
+    };
+
+    /*
+     * select a translator from the set of translators requested for immediate
+     * finish, if any. if a selection is made, it is removed from the
+     * translators_for_immediate_finish index.
+     */
+    std::optional<finish_choice_info> choose_translator_to_finish(executor&);
+
+    /*
+     * process a translator choice to finish immediately
+     */
+    ss::future<> finish_translator(executor&, finish_choice_info);
 };
 
 } // namespace datalake::translation::scheduling

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -501,6 +501,7 @@ ss::future<storage::usage_report> disk_space_manager::disk_usage() {
       = co_await datalake::datalake_manager::disk_usage();
     vlog(rlog.debug, "Datalake usage: {}", human::bytes(datalake_usage));
 
+    _probe.set_total_datalake_usage(datalake_usage);
     report.usage.data += datalake_usage;
 
     co_return report;
@@ -711,6 +712,11 @@ void disk_space_manager::probe::setup_metrics() {
       [this]() { return _total_usage; },
       sm::description(
         "Total amount of disk usage under control of space management.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "datalake_disk_usage_bytes",
+      [this]() { return _total_datalake_usage; },
+      sm::description("Total amount of disk usage by datalake.")));
 
     defs.emplace_back(sm::make_gauge(
       "retention_reclaimable_bytes",

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -258,6 +258,13 @@ private:
         void set_total_usage(size_t usage) noexcept { _total_usage = usage; }
 
         /*
+         * Total amount of scratch space used by datalake.
+         */
+        void set_total_datalake_usage(size_t usage) noexcept {
+            _total_datalake_usage = usage;
+        }
+
+        /*
          * This is the amount of data that is currently reclaimable by the
          * normal retention policy. Space management only kicks in when it needs
          * to reclaim more data than is available through the normal retention
@@ -340,6 +347,7 @@ private:
         disk_space_manager* _sm;
         metrics::internal_metric_groups _metrics;
         size_t _total_usage{0};
+        size_t _total_datalake_usage{0};
         size_t _retention_reclaimable{0};
         size_t _available_reclaimable{0};
         size_t _local_retention_reclaimable{0};

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1292,11 +1292,13 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
             ns: Any,
             metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
             namespace: str | None = None,
-            topic: str | None = None):
+            topic: str | None = None,
+            expect_metric: bool = False):
         '''Does the main work of the metric_sum() implementation given a list of ns to iterate over.
         '''
 
         count = 0
+        metric_seen = False
         for n in ns:
             metrics = self.metrics(n, metrics_endpoint=metrics_endpoint)
             for family in metrics:
@@ -1314,7 +1316,10 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
                         if labels.get("redpanda_topic",
                                       labels.get("topic")) != topic:
                             continue
+                    metric_seen = True
                     count += int(sample.value)
+        if expect_metric:
+            assert metric_seen, f"Metric {metric_name} was not observed"
         return count
 
 
@@ -1546,7 +1551,8 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
                    metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
                    namespace: str | None = None,
                    topic: str | None = None,
-                   nodes: Any = None):
+                   nodes: Any = None,
+                   expect_metric: bool = False):
         '''
         Pings the 'metrics_endpoint' of each node and returns the summed values
         of the given metric, optionally filtering by namespace and topic.
@@ -1555,8 +1561,12 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         if nodes is None:
             nodes = self.nodes
 
-        return self._metric_sum(metric_name, nodes, metrics_endpoint,
-                                namespace, topic)
+        return self._metric_sum(metric_name,
+                                nodes,
+                                metrics_endpoint,
+                                namespace,
+                                topic,
+                                expect_metric=expect_metric)
 
     def healthy(self):
         """

--- a/tests/rptest/tests/datalake/disk_budget_test.py
+++ b/tests/rptest/tests/datalake/disk_budget_test.py
@@ -1,0 +1,139 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+import time
+from rptest.services.catalog_service import CatalogType
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import SISettings
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.services.rpk_producer import RpkProducer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.mode_checks import skip_debug_mode
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from ducktape.utils.util import wait_until
+import ducktape.errors
+
+from ducktape.mark import matrix
+
+
+class DatalakeDiskUsageTest(RedpandaTest):
+    """
+    In this test we are going to configure redpanda initially to allow a large
+    amount of data to accumulate in the datalake staging directory.
+
+    After the data has accumulated we'll use published metrics to observe that
+    the size is not decreasing which we use to infer that none of the existing
+    triggers is forcing translation to finish (lag, flush bytes, disk space).
+
+    Finally we'll lower the target disk usage and expect that space usage
+    declines indicating that it was the target disk space usage monitor that was
+    controlling the usage.
+    """
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(DatalakeDiskUsageTest, self).__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx),
+            extra_rp_conf={
+                "iceberg_enabled": True,
+                "datalake_disk_space_monitor_enable": True,
+                # for reactivity
+                "datalake_scheduler_time_slice_ms": 5000,
+                "datalake_disk_space_monitor_interval": 5000,
+                # let translator accumulate staging data
+                "datalake_translator_flush_bytes": 16 * 2**30,
+                "iceberg_target_lag_ms": 10 * 60 * 1000,
+                "datalake_scratch_space_size_bytes": 60 * 2**30,
+            },
+            *args,
+            **kwargs)
+
+        self.test_ctx = test_ctx
+        self.topic_name = "test"
+
+    def datalake_staging_usage(self):
+        # returns number of bytes in datalake staging directory
+        metric_name = "vectorized_space_management_datalake_disk_usage_bytes"
+        return self.redpanda.metric_sum(metric_name, expect_metric=True)
+
+    def create_topic(self, num_partitions):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic(self.topic_name,
+                         partitions=num_partitions,
+                         replicas=1,
+                         config={TopicSpec.PROPERTY_ICEBERG_MODE: "key_value"})
+
+    def produce_until_staging_size(self, target_size):
+        # produce some data to the topic and then back off and let datalake do
+        # its thang. after that check back in with the broker and if we haven't
+        # translated enough data then try again.
+        timeout_sec = 120
+        start_time = time.time()
+        current_size = 0
+        while current_size < target_size:
+            producer = RpkProducer(
+                self.test_ctx,
+                self.redpanda,
+                self.topic_name,
+                2**13,
+                2**14,  # ~128mb
+                acks=-1)
+            producer.start()
+            producer.wait()
+            producer.free()
+            time.sleep(2)
+            current_size = self.datalake_staging_usage()
+            self.logger.info(f"Staging data usage {current_size}")
+            assert (
+                time.time() -
+                start_time) < timeout_sec, f"{current_size} < {target_size}"
+        return current_size
+
+    @cluster(num_nodes=2)
+    @skip_debug_mode
+    @matrix(num_partitions=[1, 2, 30],
+            concurrent_translations=[1, 4],
+            cloud_storage_type=supported_storage_types())
+    def test_idle_finish(self, num_partitions, concurrent_translations,
+                         cloud_storage_type):
+        self.redpanda.set_cluster_config({
+            "datalake_scheduler_max_concurrent_translations":
+            concurrent_translations,
+        })
+
+        # produce data until we have a nice bit of datalake staging data on disk
+        target_size = 2 * 2**30
+        self.create_topic(num_partitions)
+        idle_staging_size = self.produce_until_staging_size(target_size)
+
+        # based on the configuration (see __init__) we expect that the staging
+        # data is not finished and uploaded. so let's sanity check that.
+        try:
+            wait_until(
+                lambda: self.datalake_staging_usage() < idle_staging_size,
+                timeout_sec=30,
+                backoff_sec=2)
+            assert False, f"{self.datalake_staging_usage()} < {idle_staging_size}"
+        except ducktape.errors.TimeoutError:
+            # success, the data usage didn't shrink
+            pass
+
+        # now we will halve the target size and we expect to see that the
+        # staging directory usage decreases below this value.
+        new_target_size = target_size // 2
+        self.redpanda.set_cluster_config({
+            "datalake_scratch_space_size_bytes":
+            new_target_size,
+        })
+        wait_until(lambda: self.datalake_staging_usage() <= new_target_size,
+                   timeout_sec=60,
+                   backoff_sec=2)


### PR DESCRIPTION
This PR adds a disk space usage monitor in the datalake manager that is intended apply a soft limit to the amount of staging data generated on-disk by datalake. It is modeled after space management in that it (1) periodically calculates the current usage and (2) responds to overages by dispatching to each shard that certain resources be promptly released. In this case the resources are the flushed bytes that translators may be holding on to. Requests are satisfied by stopping translation, uploading the current flushed data, and removing that data from disk.

The primary components are:

### Datalake manager

* Simple datalake_manager control loop
* Calculates total usage by querying all translators for the current flushed bytes count
* Notably this avoids stat() system calls because the statistics are maintained in memory
* Selects the top disk usage translators necessary to meet the target disk usage size
* Dispatches requests to each translator selected to "finish" promptly

### Translator support for fast "finish"

The mechanism for a translator to finish early existed before this work in the form of preemption due to memory overage. When the preemption occurred the translator would stop, flush its state to disk, and then upload+delete the staged data.

This strategy works well for memory resources when translators are in a "running" state--stopping them releases the memory resources. However, this doesn't work for disk resources that exist independent of the state of the translator (e.g. waiting or idle). For waiting tasks the solution is relatively simple: put the translator into the running state and arrange for it to immediately execute the "finish" code path.

The solution is not so simple for idle translators that are neither running nor waiting. The complexity arises because the stop_translation interface is not designed to affect state change for an idle translator. In fact, in order for an idle translator to even start running it needs there to be new offsets ready for translation. That isn't good enough for disk space management because an idle partition may take up a lot of disk space and never be runnable.

To solve the problem for idle translators the solution was to add a bit of a "ugly" interface for this specific use case that to a certain extent depends on knowledge of the underlying partition translator implementation. The scheduler effectively sets a flag on the translator which is checked in its "new offsets" polling loop.

This narrow, "ugly" interface can certainly be eliminated by expanding the expressiveness of the existing translator interface to accommodate control over idle translators, but that may be a bit too much this late in the game.

TODO:
* been testing manually, will add ducktape tests next

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
