### PR TITLE
`storage`: evict readers in `do_compact_adjacent_segments()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -982,6 +982,15 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
         co_await ss::remove_file(compact_index.string());
     }
 
+    // Evict segment readers and prevent new ones from being added to the cache.
+    std::vector<ss::future<readers_cache::range_lock_holder>> holder_futs;
+    holder_futs.reserve(segments.size());
+    for (auto& segment : segments) {
+        holder_futs.push_back(_readers_cache->evict_segment_readers(segment));
+    }
+    auto holders = co_await ss::when_all_succeed(
+      holder_futs.begin(), holder_futs.end());
+
     // lock the range. only metadata (e.g. open/rename/delete) i/o occurs with
     // these locks held so it is a relatively short duration. all of the data
     // copying and compaction i/o occurred above with no locks held. 5 retries
@@ -1033,6 +1042,7 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     // compaction to two segments, and we check that assumption here and use
     // simplified clean-up routine.
     locks.clear();
+    holders.clear();
     staging_to_clean.clear();
     vassert(segments.size() == 2, "Cannot compact more than two segments");
     auto it = std::find(_segs.begin(), _segs.end(), segment_to_remove);


### PR DESCRIPTION
In `do_compact_adjacent_segments()`, we perform a transfer of the `replacement` segment to the `target` segment while holding the write locks for each of the segments.

While this seems safe, unfortunately there is one consideration that is missing- the existing readers in the `readers_cache`.

For reference, in `do_self_compact_segment()`, [before swapping](https://github.com/redpanda-data/redpanda/blob/3aff26c98b954cfd9eb661fc193eec822083ebe9/src/v/storage/disk_log_impl.cc#L1491) the [data file handles](https://github.com/redpanda-data/redpanda/blob/3aff26c98b954cfd9eb661fc193eec822083ebe9/src/v/storage/disk_log_impl.cc#L1510), we make sure to call `readers_cache.evict_segment_readers()`:

https://github.com/redpanda-data/redpanda/blob/3aff26c98b954cfd9eb661fc193eec822083ebe9/src/v/storage/disk_log_impl.cc#L1491-L1510

It seems we were missing this call in `do_compact_adjacent_segments()` before performing the same operation.

This oversight could be the root cause for a number of issues with users of cached readers for segments undergoing adjacent compaction.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug in which cached readers for segments undergoing adjacent compaction would not be evicted from the `readers_cache`.
