### PR TITLE
Backlog calculation improvements

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -19,6 +19,7 @@
 #include "datalake/record_translator.h"
 #include "datalake/serde_parquet_writer.h"
 #include "datalake/translation/state_machine.h"
+#include "datalake/translation/utils.h"
 #include "datalake/translation_task.h"
 #include "kafka/data/partition_proxy.h"
 #include "kafka/utils/txn_reader.h"
@@ -756,20 +757,24 @@ public:
     std::optional<size_t> translation_backlog() const final {
         auto highest_translated_offset
           = _stm->cached_highest_translated_offset();
-        if (
-          !highest_translated_offset
-          || highest_translated_offset < kafka::offset{0}) {
+
+        if (!highest_translated_offset) {
             return std::nullopt;
         }
+
         auto min_offset_for_translation = calculate_min_offset_for_translation(
           _partition->is_read_replica_mode_enabled(), *_partition_proxy);
+
         if (highest_translated_offset <= min_offset_for_translation) {
             return _partition->size_bytes();
         }
         const auto highest_translated_log_offset
-          = _partition->log()->to_log_offset(
-            kafka::offset_cast(*highest_translated_offset));
-        const auto max_translatable_offset = _partition->last_stable_offset();
+          = highest_log_offset_below_next(
+            _partition->log(), *highest_translated_offset);
+
+        const auto max_translatable_offset = model::prev_offset(
+          _partition->last_stable_offset());
+
         if (highest_translated_log_offset == max_translatable_offset) {
             return 0;
         }

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -752,30 +752,47 @@ public:
         if (translated_offset >= _translation_target->offset) {
             _translation_target.reset();
         }
+        // Reset inflight translation lto. The lag tracker is notified about
+        // completed translation.
+        _inflight_translation_lto.reset();
+    }
+
+    void notify_inflight_translation_iteration(
+      std::optional<kafka::offset> translated_offset) final {
+        vlog(
+          datalake_log.trace,
+          "[{}] Inflight translation iteration with offset {} ",
+          _partition->ntp(),
+          translated_offset);
+        if (!translated_offset) {
+            _inflight_translation_lto.reset();
+            return;
+        }
+        _inflight_translation_lto.emplace(translated_offset.value());
     }
 
     std::optional<size_t> translation_backlog() const final {
-        auto highest_translated_offset
-          = _stm->cached_highest_translated_offset();
+        auto checkpointed_lto = _stm->cached_highest_translated_offset();
 
-        if (!highest_translated_offset) {
-            return std::nullopt;
-        }
+        const auto final_lto
+          = _inflight_translation_lto
+              ? std::max(checkpointed_lto, *_inflight_translation_lto)
+              : checkpointed_lto;
 
         auto min_offset_for_translation = calculate_min_offset_for_translation(
           _partition->is_read_replica_mode_enabled(), *_partition_proxy);
 
-        if (highest_translated_offset <= min_offset_for_translation) {
+        if (final_lto <= min_offset_for_translation) {
             return _partition->size_bytes();
         }
-        const auto highest_translated_log_offset
-          = highest_log_offset_below_next(
-            _partition->log(), *highest_translated_offset);
+
+        const auto log_lto = highest_log_offset_below_next(
+          _partition->log(), final_lto);
 
         const auto max_translatable_offset = model::prev_offset(
           _partition->last_stable_offset());
 
-        if (highest_translated_log_offset == max_translatable_offset) {
+        if (log_lto == max_translatable_offset) {
             return 0;
         }
         /**
@@ -783,12 +800,12 @@ public:
          * simply smaller than the highest translated offset. f.e. during the
          * partition movement. In such cases, we cannot calculate the backlog.
          */
-        if (highest_translated_log_offset > max_translatable_offset) {
+        if (log_lto > max_translatable_offset) {
             return std::nullopt;
         }
 
         auto size_after_translated = _partition->log()->size_bytes_after_offset(
-          highest_translated_log_offset);
+          log_lto);
 
         auto size_after_max_translatable
           = _partition->log()->size_bytes_after_offset(max_translatable_offset);
@@ -800,7 +817,7 @@ public:
               "greater than or equal to the size of log after max translatable "
               "offset({}): {}",
               _partition->ntp().path(),
-              highest_translated_log_offset,
+              log_lto,
               size_after_translated,
               max_translatable_offset,
               size_after_max_translatable);
@@ -853,6 +870,7 @@ private:
     // the corresponding record's write time, replicated when we translate
     // an offset meeting or exceeding target.offset.
     std::optional<timestamped_offset> _translation_target;
+    std::optional<kafka::offset> _inflight_translation_lto;
 };
 
 std::unique_ptr<translation_lag_tracker>

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -303,6 +303,19 @@ public:
     virtual void notify_data_translated(kafka::offset) = 0;
 
     /**
+     * Notifies the lag tracker about the data that is currently being
+     * translated.
+     * The inflight translation offset is used to calculate the translation
+     * backlog.
+     *
+     * This state is in memory only and may be lost if the translation state is
+     * discarded.
+     */
+    virtual void
+      notify_inflight_translation_iteration(std::optional<kafka::offset>)
+      = 0;
+
+    /**
      * Returns an estimated timestamp for the batch with requested
      * `kafka::offset`.
      *

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -193,6 +193,8 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
     }
 
     auto current_translation_lto = _translation_ctx->last_translated_offset();
+    _lag_tracking->notify_inflight_translation_iteration(
+      current_translation_lto);
     /**
      * If there is no current translation lto or checkpointed value is
      * greater than the current translation lto update it.

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -70,7 +70,7 @@ public:
      * not call state machine sync, risking to have the stale value if the
      * leadership changed.
      */
-    std::optional<kafka::offset> cached_highest_translated_offset() const {
+    kafka::offset cached_highest_translated_offset() const {
         return _highest_translated_offset;
     }
 

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -370,6 +370,9 @@ public:
 
     virtual void notify_data_translated(kafka::offset){};
 
+    virtual void
+      notify_inflight_translation_iteration(std::optional<kafka::offset>){};
+
     virtual std::optional<model::timestamp>
     get_translated_offset_timestamp_estimate(kafka::offset) {
         return model::timestamp::now();

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -116,3 +116,48 @@ class DatalakeThrottlingTest(RedpandaTest):
             dl.produce_to_topic(self.topic_name, 1024, msg_cnt)
             assert self._total_throttle(
             ) == current_throttle, "Total throttle should not increase as the translation is progressing"
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=supported_catalog_types())
+    def test_backlog_metric(self, cloud_storage_type, catalog_type):
+        def collect_backlog_metric():
+            sample = self.redpanda.metrics_sample(
+                "vectorized_iceberg_backlog_controller_backlog_size")
+            assert sample is not None, "iceberg_backlog metric not found"
+            total = 0
+            for s in sample.samples:
+                self.logger.info(f"backlog metrics sample : {s}")
+                total += s.value
+            return total
+
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=catalog_type) as dl:
+
+            dl.create_iceberg_enabled_topic(self.topic_name, partitions=1)
+            # execute few iterations to verify backlog calculation
+            for i in range(1, 5):
+                self.redpanda.set_cluster_config(
+                    {"datalake_scheduler_max_concurrent_translations": 0})
+                dl.produce_to_topic(self.topic_name, 1024, 20000)
+
+                wait_until(lambda: collect_backlog_metric() > 10240,
+                           timeout_sec=30,
+                           backoff_sec=2)
+
+                self.redpanda.set_cluster_config(
+                    {"datalake_scheduler_max_concurrent_translations": 10})
+                dl.wait_for_translation(self.topic_name, msg_count=i * 20000)
+                # after everything is translated reported backlog should be 0
+                wait_until(lambda: collect_backlog_metric() == 0,
+                           timeout_sec=30,
+                           backoff_sec=2)
+                # restart all nodes
+                self.redpanda.restart_nodes(self.redpanda.nodes)
+                # check backlog again
+                for _ in range(0, 5):
+                    assert collect_backlog_metric(
+                    ) == 0, "Backlog should be 0 as all data are translated"
+                    time.sleep(1)


### PR DESCRIPTION
The backlog calculation was not correct as the translation from kafka to
log offset was incorrectly made. Fixed the backlog calculation logic to
return '0' when all batches are translated.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none