### PR TITLE
Rpk/cloud configurations

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -7,7 +7,7 @@ replace github.com/hamba/avro/v2 => github.com/redpanda-data/go-avro/v2 v2.0.0-2
 
 require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250320090119-84779f9e5085.1
-	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250320090119-84779f9e5085.1
+	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a63ce18a889a.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250404200318-65f29ddd7b29.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.6-20250404200318-65f29ddd7b29.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -4,8 +4,8 @@ buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.6-20241220
 buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.6-20241220201140-4c5ba75caaf8.1/go.mod h1:TV9HU6+2Qe0EYQCSVjdfi1wr1LUGWXdLKhR+tNHwsz8=
 buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250320090119-84779f9e5085.1 h1:ihvEybwiBEY8u6zlhdK1Rnw4xHhDOx+VtayH2/KcPSk=
 buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250320090119-84779f9e5085.1/go.mod h1:T6/LzK1YJ2Sk5PtaDZv0BgLDgclmZLTVzpff+ZvZSAM=
-buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250320090119-84779f9e5085.1 h1:FNsch/i61jz7pvBhu1cGoWfqiqlXri6thSbjUz/awWY=
-buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250320090119-84779f9e5085.1/go.mod h1:RUUH9gPqxuRHYeNMFjrU5hboN4lPAz2kNeOi81gjQcI=
+buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a63ce18a889a.1 h1:1IoQnp5yDqhkxRiPTuWNHwy0zB5CsqNk7olowC+vfw0=
+buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a63ce18a889a.1/go.mod h1:RUUH9gPqxuRHYeNMFjrU5hboN4lPAz2kNeOi81gjQcI=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1 h1:PZG/e6nKfOkEIp45KoUIzReXRH6JpL9oKPe4tlJqD64=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1/go.mod h1:yA5Jg45dsAoOvAx1XHbDwwcWkkYW568MUeKJsa9bgrY=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250404200318-65f29ddd7b29.1 h1:iIj2C/0IDTFR0JtIgKfFHRtkCIb7YqQEdNylVab2pz0=

--- a/src/go/rpk/pkg/cli/cluster/config/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/config/BUILD
@@ -19,11 +19,20 @@ go_library(
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/publicapi",
+        "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
+        "@com_connectrpc_connect//:connect",
         "@com_github_kballard_go_shellquote//:go-shellquote",
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_google_genproto_googleapis_rpc//errdetails",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/fieldmaskpb",
+        "@org_golang_google_protobuf//types/known/structpb",
+        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -33,6 +42,7 @@ go_test(
     srcs = [
         "edit_test.go",
         "import_test.go",
+        "set_test.go",
     ],
     embed = [":config"],
     deps = [

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -10,11 +10,13 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"slices"
 	"strings"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	"connectrpc.com/connect"
@@ -83,89 +85,31 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			configs, err := parseArgs(args)
 			out.MaybeDieErr(err)
-
-			vp, err := p.LoadVirtualProfile(fs)
+			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			vp := cfg.VirtualProfile()
 
 			if vp.FromCloud {
 				if vp.CloudCluster.IsServerless() {
 					out.Die("rpk cluster config set is not supported for serverless clusters.")
 				}
-				cfg, err := p.Load(fs)
 				out.MaybeDie(err, "rpk unable to load config: %v", err)
-				operation, err := setCloudConfig(cmd, cfg, vp, configs)
+				operation, err := setCloudConfig(cmd.Context(), cfg, vp, configs)
 				out.MaybeDieErr(err)
 				fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
-				fmt.Printf("Operation ID: %s \n", operation.GetOperation().Id)
+				fmt.Printf("Operation ID: %s \n", operation.GetOperation().GetId())
 			} else {
-				var key, value string
-
-				// this validation is added to support the previous behavior, this will remove in next commits
-				if len(configs) > 1 {
-					out.Die("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>'", args)
-				}
-				// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
-				if key == "cloud_storage_enable_remote_write" && value == "false" {
-					if !noConfirm {
-						confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
-						out.MaybeDie(err, "unable to read user input: %v", err)
-						if confirmed {
-							out.Die("Aborted by user.")
-						}
-					}
-				}
-
-				split := strings.SplitN(configs[0], "=", 2)
-				key, value = split[0], split[1]
 				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
 				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
 				schema, err := client.ClusterConfigSchema(cmd.Context())
 				out.MaybeDie(err, "unable to query config schema: %v", err)
 
-				meta, ok := schema[key]
-
-				if !ok {
-					// loop over schema, try to find key in the Aliases,
-					for _, v := range schema {
-						if slices.Contains(v.Aliases, key) {
-							meta, ok = v, true
-							break
-						}
-					}
-					if !ok {
-						out.Die("Unknown property %q", key)
-					}
-				}
-
-				upsert := make(map[string]interface{})
-				remove := make([]string, 0)
-
-				// - For scalars, pass string values through to the REST
-				// API -- it will give more informative errors than we can
-				// about validation.  Special case strings for nullable
-				// properties ('null') and for resetting to default ('')
-				// - For arrays, make an effort: otherwise the REST API
-				// may interpret a scalar string as a list of length 1
-				// (via one_or_many_property).
-
-				if meta.Nullable && value == "null" {
-					// Nullable types may be explicitly set to null
-					upsert[key] = nil
-				} else if meta.Type != "string" && (value == "") {
-					// Non-string types that receive an empty string
-					// are reset to default
-					remove = append(remove, key)
-				} else if meta.Type == "array" {
-					var a anySlice
-					err = yaml.Unmarshal([]byte(value), &a)
-					out.MaybeDie(err, "invalid list syntax")
-					upsert[key] = a
-				} else {
-					upsert[key] = value
-				}
+				upsert, remove, err := validateConfigSelfHosted(schema, configs, noConfirm)
+				out.MaybeDieErr(err)
 
 				result, err := client.PatchClusterConfig(cmd.Context(), upsert, remove)
+
 				if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) {
 					// Special case 400 (validation) errors with friendly output
 					// about which configuration properties were invalid.
@@ -190,11 +134,76 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 			}
 		},
 	}
+
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
 }
 
-func setCloudConfig(cmd *cobra.Command, cfg *config.Config, p *config.RpkProfile, configs []string) (*controlplanev1.UpdateClusterOperation, error) {
+func validateConfigSelfHosted(schema rpadmin.ConfigSchema, args []string, noConfirm bool) (map[string]any, []string, error) {
+	upsert := make(map[string]any)
+	remove := make([]string, 0)
+
+	for _, arg := range args {
+		split := strings.SplitN(arg, "=", 2)
+		key, value := split[0], split[1]
+
+		// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
+		if key == "cloud_storage_enable_remote_write" && value == "false" {
+			if !noConfirm {
+				confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
+				out.MaybeDie(err, "unable to read user input: %v", err)
+				if confirmed {
+					out.Die("Aborted by user.")
+				}
+			}
+		}
+
+		meta, ok := schema[key]
+
+		if !ok {
+			// loop over schema, try to find key in the Aliases,
+			for _, v := range schema {
+				if slices.Contains(v.Aliases, key) {
+					meta, ok = v, true
+					break
+				}
+			}
+			if !ok {
+				return nil, nil, fmt.Errorf("unknown property %q", key)
+			}
+		}
+
+		// - For scalars, pass string values through to the REST
+		// API -- it will give more informative errors than we can
+		// about validation.  Special case strings for nullable
+		// properties ('null') and for resetting to default ('')
+		// - For arrays, make an effort: otherwise the REST API
+		// may interpret a scalar string as a list of length 1
+		// (via one_or_many_property).
+
+		if meta.Nullable && value == "null" {
+			// Nullable types may be explicitly set to null
+			upsert[key] = nil
+		} else if meta.Type != "string" && (value == "") {
+			// Non-string types that receive an empty string
+			// are reset to default
+			remove = append(remove, key)
+		} else if meta.Type == "array" {
+			var a anySlice
+			err := yaml.Unmarshal([]byte(value), &a)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid list syntax: %v", err)
+			}
+			upsert[key] = a
+		} else {
+			upsert[key] = value
+		}
+	}
+
+	return upsert, remove, nil
+}
+
+func setCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfile, configs []string) (*controlplanev1.UpdateClusterOperation, error) {
 	cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, p.CurrentAuth().AuthToken)
 
 	redpandaConfigs := make(map[string]any)
@@ -220,12 +229,12 @@ func setCloudConfig(cmd *cobra.Command, cfg *config.Config, p *config.RpkProfile
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: paths},
 	}
 
-	operation, err := cloudClient.Cluster.UpdateCluster(cmd.Context(), connect.NewRequest(req))
+	operation, err := cloudClient.Cluster.UpdateCluster(ctx, connect.NewRequest(req))
 	if err != nil {
 		var ce *connect.Error
 		if errors.As(err, &ce) {
 			if ce.Code() == connect.CodePermissionDenied {
-				return nil, fmt.Errorf("permission denied")
+				return nil, fmt.Errorf("this user does not have permission to update the cluster configuration, please check your role or contact admin")
 			}
 			if ce.Code() == connect.CodeNotFound {
 				return nil, fmt.Errorf("cluster not found. Please ensure the cluster exists in the cloud")

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -44,6 +44,18 @@ func (s *anySlice) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
+func parseArgs(args []string) ([]string, error) {
+	if len(args) == 2 && !strings.Contains(args[0], "=") {
+		args = []string{args[0] + "=" + args[1]}
+	}
+	for _, arg := range args {
+		if !strings.Contains(arg, "=") {
+			return nil, fmt.Errorf("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>', for empty values use 'rpk cluster config set <key>=\"\"' ", args)
+		}
+	}
+	return args, nil
+}
+
 func newSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var noConfirm bool
 	cmd := &cobra.Command{
@@ -64,12 +76,12 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var key, value string
-			if len(args) == 1 && strings.Contains(args[0], "=") {
-				kv := strings.SplitN(args[0], "=", 2)
-				key, value = kv[0], kv[1]
-			} else if len(args) == 2 {
-				key, value = args[0], args[1]
-			} else {
+			
+			configs, error := parseArgs(args)
+			out.MaybeDieErr(error)
+			
+			// this validation is added to support the previous behavior, this will remove in next commits
+			if len(configs) > 1 {
 				out.Die("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>'", args)
 			}
 			// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
@@ -82,6 +94,9 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 					}
 				}
 			}
+
+			split := strings.SplitN(configs[0], "=", 2)
+			key, value = split[0], split[1]
 
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -12,15 +12,21 @@ package config
 import (
 	"errors"
 	"fmt"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"slices"
 	"strings"
 
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"connectrpc.com/connect"
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 )
 
@@ -75,105 +81,177 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var key, value string
-			
-			configs, error := parseArgs(args)
-			out.MaybeDieErr(error)
-			
-			// this validation is added to support the previous behavior, this will remove in next commits
-			if len(configs) > 1 {
-				out.Die("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>'", args)
-			}
-			// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
-			if key == "cloud_storage_enable_remote_write" && value == "false" {
-				if !noConfirm {
-					confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
-					out.MaybeDie(err, "unable to read user input: %v", err)
-					if confirmed {
-						out.Die("Aborted by user.")
+			configs, err := parseArgs(args)
+			out.MaybeDieErr(err)
+
+			vp, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			if vp.FromCloud {
+				if vp.CloudCluster.IsServerless() {
+					out.Die("rpk cluster config set is not supported for serverless clusters.")
+				}
+				cfg, err := p.Load(fs)
+				out.MaybeDie(err, "rpk unable to load config: %v", err)
+				operation, err := setCloudConfig(cmd, cfg, vp, configs)
+				out.MaybeDieErr(err)
+				fmt.Print("Processing configuration, this operation may take up to 10 minutes. To check the status, run 'rpk cluster config status'\n\n")
+				fmt.Printf("Operation ID: %s \n", operation.GetOperation().Id)
+			} else {
+				var key, value string
+
+				// this validation is added to support the previous behavior, this will remove in next commits
+				if len(configs) > 1 {
+					out.Die("invalid arguments: %v, please use one of 'rpk cluster config set <key> <value>' or 'rpk cluster config set <key>=<value>'", args)
+				}
+				// Disabling Tiered Storage requires a confirmation from the user because it may lead to data loss.
+				if key == "cloud_storage_enable_remote_write" && value == "false" {
+					if !noConfirm {
+						confirmed, err := out.Confirm("Warning: disabling Tiered Storage may lead to data loss. If you only want to pause Tiered Storage temporarily, use the 'cloud_storage_enable_segment_uploads' option. Abort?")
+						out.MaybeDie(err, "unable to read user input: %v", err)
+						if confirmed {
+							out.Die("Aborted by user.")
+						}
 					}
 				}
-			}
 
-			split := strings.SplitN(configs[0], "=", 2)
-			key, value = split[0], split[1]
+				split := strings.SplitN(configs[0], "=", 2)
+				key, value = split[0], split[1]
+				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
+				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			p, err := p.LoadVirtualProfile(fs)
-			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitCloudAdmin(p)
+				schema, err := client.ClusterConfigSchema(cmd.Context())
+				out.MaybeDie(err, "unable to query config schema: %v", err)
 
-			client, err := adminapi.NewClient(cmd.Context(), fs, p)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+				meta, ok := schema[key]
 
-			schema, err := client.ClusterConfigSchema(cmd.Context())
-			out.MaybeDie(err, "unable to query config schema: %v", err)
+				if !ok {
+					// loop over schema, try to find key in the Aliases,
+					for _, v := range schema {
+						if slices.Contains(v.Aliases, key) {
+							meta, ok = v, true
+							break
+						}
+					}
+					if !ok {
+						out.Die("Unknown property %q", key)
+					}
+				}
 
-			meta, ok := schema[key]
+				upsert := make(map[string]interface{})
+				remove := make([]string, 0)
 
-			if !ok {
-				// loop over schema, try to find key in the Aliases,
-				for _, v := range schema {
-					if slices.Contains(v.Aliases, key) {
-						meta, ok = v, true
+				// - For scalars, pass string values through to the REST
+				// API -- it will give more informative errors than we can
+				// about validation.  Special case strings for nullable
+				// properties ('null') and for resetting to default ('')
+				// - For arrays, make an effort: otherwise the REST API
+				// may interpret a scalar string as a list of length 1
+				// (via one_or_many_property).
+
+				if meta.Nullable && value == "null" {
+					// Nullable types may be explicitly set to null
+					upsert[key] = nil
+				} else if meta.Type != "string" && (value == "") {
+					// Non-string types that receive an empty string
+					// are reset to default
+					remove = append(remove, key)
+				} else if meta.Type == "array" {
+					var a anySlice
+					err = yaml.Unmarshal([]byte(value), &a)
+					out.MaybeDie(err, "invalid list syntax")
+					upsert[key] = a
+				} else {
+					upsert[key] = value
+				}
+
+				result, err := client.PatchClusterConfig(cmd.Context(), upsert, remove)
+				if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) {
+					// Special case 400 (validation) errors with friendly output
+					// about which configuration properties were invalid.
+					if he.Response.StatusCode == 400 {
+						ve, err := formatValidationError(err, he)
+						out.MaybeDie(err, "error setting config: %v", err)
+						out.Die("No changes were made: %v", ve)
+					}
+				}
+
+				out.MaybeDie(err, "error setting property: %v", err)
+				fmt.Printf("Successfully updated configuration. New configuration version is %d.\n", result.ConfigVersion)
+
+				status, err := client.ClusterConfigStatus(cmd.Context(), true)
+				out.MaybeDie(err, "unable to check if the cluster needs to be restarted: %v\nCheck the status with 'rpk cluster config status'.", err)
+				for _, value := range status {
+					if value.Restart {
+						fmt.Print("\nCluster needs to be restarted. See more details with 'rpk cluster config status'.\n")
 						break
 					}
-				}
-				if !ok {
-					out.Die("Unknown property %q", key)
-				}
-			}
-
-			upsert := make(map[string]interface{})
-			remove := make([]string, 0)
-
-			// - For scalars, pass string values through to the REST
-			// API -- it will give more informative errors than we can
-			// about validation.  Special case strings for nullable
-			// properties ('null') and for resetting to default ('')
-			// - For arrays, make an effort: otherwise the REST API
-			// may interpret a scalar string as a list of length 1
-			// (via one_or_many_property).
-
-			if meta.Nullable && value == "null" {
-				// Nullable types may be explicitly set to null
-				upsert[key] = nil
-			} else if meta.Type != "string" && (value == "") {
-				// Non-string types that receive an empty string
-				// are reset to default
-				remove = append(remove, key)
-			} else if meta.Type == "array" {
-				var a anySlice
-				err = yaml.Unmarshal([]byte(value), &a)
-				out.MaybeDie(err, "invalid list syntax")
-				upsert[key] = a
-			} else {
-				upsert[key] = value
-			}
-
-			result, err := client.PatchClusterConfig(cmd.Context(), upsert, remove)
-			if he := (*rpadmin.HTTPResponseError)(nil); errors.As(err, &he) {
-				// Special case 400 (validation) errors with friendly output
-				// about which configuration properties were invalid.
-				if he.Response.StatusCode == 400 {
-					ve, err := formatValidationError(err, he)
-					out.MaybeDie(err, "error setting config: %v", err)
-					out.Die("No changes were made: %v", ve)
-				}
-			}
-
-			out.MaybeDie(err, "error setting property: %v", err)
-			fmt.Printf("Successfully updated configuration. New configuration version is %d.\n", result.ConfigVersion)
-
-			status, err := client.ClusterConfigStatus(cmd.Context(), true)
-			out.MaybeDie(err, "unable to check if the cluster needs to be restarted: %v\nCheck the status with 'rpk cluster config status'.", err)
-			for _, value := range status {
-				if value.Restart {
-					fmt.Print("\nCluster needs to be restarted. See more details with 'rpk cluster config status'.\n")
-					break
 				}
 			}
 		},
 	}
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
+}
+
+func setCloudConfig(cmd *cobra.Command, cfg *config.Config, p *config.RpkProfile, configs []string) (*controlplanev1.UpdateClusterOperation, error) {
+	cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, p.CurrentAuth().AuthToken)
+
+	redpandaConfigs := make(map[string]any)
+	paths := make([]string, 0)
+
+	for _, c := range configs {
+		split := strings.SplitN(c, "=", 2)
+		key, value := split[0], split[1]
+		redpandaConfigs[key] = value
+		paths = append(paths, fmt.Sprintf("cluster_configuration.custom_properties.%s", key))
+	}
+	customerProperties, err := structpb.NewStruct(redpandaConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("internal error while converting config to redpanda cloud configs: %v", err)
+	}
+	req := &controlplanev1.UpdateClusterRequest{
+		Cluster: &controlplanev1.ClusterUpdate{
+			Id: p.CloudCluster.ClusterID,
+			ClusterConfiguration: &controlplanev1.ClusterUpdate_ClusterConfiguration{
+				CustomProperties: customerProperties,
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: paths},
+	}
+
+	operation, err := cloudClient.Cluster.UpdateCluster(cmd.Context(), connect.NewRequest(req))
+	if err != nil {
+		var ce *connect.Error
+		if errors.As(err, &ce) {
+			if ce.Code() == connect.CodePermissionDenied {
+				return nil, fmt.Errorf("permission denied")
+			}
+			if ce.Code() == connect.CodeNotFound {
+				return nil, fmt.Errorf("cluster not found. Please ensure the cluster exists in the cloud")
+			}
+			if ce.Code() == connect.CodeInvalidArgument {
+				var errs []string
+				for _, detail := range ce.Details() {
+					c, _ := detail.Value()
+					switch d := c.(type) {
+					case *errdetails.BadRequest:
+						for _, violation := range d.FieldViolations {
+							errs = append(
+								errs,
+								fmt.Sprintf("Field violation, description: %s\n", violation.Description),
+							)
+						}
+					default:
+						// do nothing
+					}
+				}
+				if len(errs) > 0 {
+					return nil, fmt.Errorf("invalid arguments: %s", strings.Join(errs, "\n"))
+				}
+			}
+		}
+		return nil, fmt.Errorf("internal error while updating redpanda cloud configs: %v", err)
+	}
+	return operation.Msg, nil
 }

--- a/src/go/rpk/pkg/cli/cluster/config/set_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expected  []string
+		expectErr bool
+	}{
+		{
+			name:      "valid key=value format",
+			args:      []string{"key=value"},
+			expected:  []string{"key=value"},
+			expectErr: false,
+		},
+		{
+			name:      "valid key=value key2=value2 format",
+			args:      []string{"key=value", "key2=value2"},
+			expected:  []string{"key=value", "key2=value2"},
+			expectErr: false,
+		},
+		{
+			name:      "valid key and value as separate arguments",
+			args:      []string{"key", "value"},
+			expected:  []string{"key=value"},
+			expectErr: false,
+		},
+		{
+			name:      "invalid format without '='",
+			args:      []string{"key", "value1", "value2"},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "invalid single argument without '='",
+			args:      []string{"key"},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "invalid multiple arguments without '='",
+			args:      []string{"key", "value1", "key", "value2"},
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := parseArgs(test.args)
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -10,9 +10,22 @@
 package config
 
 import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"connectrpc.com/connect"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -33,31 +46,124 @@ a lower number shows that a node is out of sync, perhaps because it
 is offline.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
-			p, err := p.LoadVirtualProfile(fs)
+			vp, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitCloudAdmin(p)
 
-			client, err := adminapi.NewClient(cmd.Context(), fs, p)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+			if vp.FromCloud {
+				if !vp.CloudCluster.IsBYOC() {
+					out.Die("rpk cluster config set is not supported for serverless and dedicated clusters.")
+				}
+				cfg, err := p.Load(fs)
+				out.MaybeDie(err, "rpk unable to load config: %v", err)
+				ops, err := getCloudConfigStatus(cmd, cfg, vp)
+				out.MaybeDieErr(err)
+				tw := out.NewTable("OPERATION-ID", "STATUS", "STARTED", "COMPLETED")
+				defer tw.Flush()
+				for _, op := range ops {
+					tw.PrintStructFields(struct {
+						OperationID string
+						Status      string
+						Started     string
+						Completed   string
+					}{op.OperationID, op.Status, op.Started, op.Completed})
+				}
+			} else {
+				client, err := adminapi.NewClient(cmd.Context(), fs, vp)
+				out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
-			// GET the status endpoint
-			resp, err := client.ClusterConfigStatus(cmd.Context(), false)
-			out.MaybeDie(err, "error fetching status: %v", err)
+				// GET the status endpoint
+				resp, err := client.ClusterConfigStatus(cmd.Context(), false)
+				out.MaybeDie(err, "error fetching status: %v", err)
 
-			tw := out.NewTable("NODE", "CONFIG-VERSION", "NEEDS-RESTART", "INVALID", "UNKNOWN")
-			defer tw.Flush()
+				tw := out.NewTable("NODE", "CONFIG-VERSION", "NEEDS-RESTART", "INVALID", "UNKNOWN")
+				defer tw.Flush()
 
-			for _, node := range resp {
-				tw.PrintStructFields(struct {
-					ID      int64
-					Version int64
-					Restart bool
-					Invalid []string
-					Unknown []string
-				}{node.NodeID, node.ConfigVersion, node.Restart, node.Invalid, node.Unknown})
+				for _, node := range resp {
+					tw.PrintStructFields(struct {
+						ID      int64
+						Version int64
+						Restart bool
+						Invalid []string
+						Unknown []string
+					}{node.NodeID, node.ConfigVersion, node.Restart, node.Invalid, node.Unknown})
+				}
 			}
 		},
 	}
 
 	return cmd
+}
+
+type CloudStatusItem struct {
+	OperationID string
+	Status      string
+	Details     string
+	Started     string
+	Completed   string
+}
+
+func getCloudConfigStatus(cmd *cobra.Command, cfg *config.Config, p *config.RpkProfile) ([]CloudStatusItem, error) {
+	cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, p.CurrentAuth().AuthToken)
+
+	operation, err := cloudClient.Operations.ListOperations(cmd.Context(), connect.NewRequest(&controlplanev1.ListOperationsRequest{
+		Filter: &controlplanev1.ListOperationsRequest_Filter{
+			ResourceId: p.CloudCluster.ClusterID,
+			TypeIn: []controlplanev1.Operation_Type{
+				controlplanev1.Operation_TYPE_UPDATE_CLUSTER,
+			},
+		},
+		ReadMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"metadata", "id", "state", "started_at", "finished_at", "resource_id"},
+		},
+	}))
+	if err != nil {
+		var ce *connect.Error
+		if errors.As(err, &ce) {
+			if ce.Code() == connect.CodePermissionDenied {
+				return nil, fmt.Errorf("permission denied")
+			}
+		}
+		return nil, fmt.Errorf("internal error while updating redpanda cloud configs: %v", err)
+	}
+
+	cst := make([]CloudStatusItem, 0)
+
+	for _, op := range operation.Msg.Operations {
+		opm := controlplanev1.UpdateClusterMetadata{}
+		metadata := op.GetMetadata()
+		err = anypb.UnmarshalTo(metadata, &opm, proto.UnmarshalOptions{})
+		if err != nil {
+			zap.L().Debug("failed to unmarshal update operation metadata", zap.Error(err))
+		}
+		complete := ""
+		if op.FinishedAt != nil {
+			complete = op.FinishedAt.AsTime().Format("2006-01-02 15:04:05")
+		}
+		if opm.GetUpdateType() != nil {
+			if slices.Contains(opm.GetUpdateType(), controlplanev1.UpdateClusterMetadata_UPDATE_CLUSTER_TYPE_CUSTOMER_CONFIG) {
+				cst = append(cst, CloudStatusItem{
+					OperationID: op.Id,
+					Status:      mapOpsStateToState(op),
+					Details:     fmt.Sprintf("https://cloud.redpanda.com/operations/%s", op.Id),
+					Started:     op.GetStartedAt().AsTime().Format("2006-01-02 15:04:05"),
+					Completed:   complete,
+				})
+			}
+		}
+	}
+
+	return cst, nil
+}
+
+func mapOpsStateToState(op *controlplanev1.Operation) string {
+	switch op.GetState() {
+	case controlplanev1.Operation_STATE_COMPLETED:
+		return "COMPLETED"
+	case controlplanev1.Operation_STATE_FAILED:
+		return "FAILED"
+	case controlplanev1.Operation_STATE_IN_PROGRESS:
+		return "RUNNING"
+	default:
+		return "UNKNOWN"
+	}
 }

--- a/src/go/rpk/pkg/config/BUILD
+++ b/src/go/rpk/pkg/config/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//src/go/rpk/pkg/net",
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",
+        "@build_buf_gen_go_redpandadata_cloud_protocolbuffers_go//redpanda/api/controlplane/v1:controlplane",
         "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"time"
 
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
@@ -447,6 +448,10 @@ func (c *RpkCloudCluster) HasAuth(a RpkCloudAuth) bool {
 
 func (c *RpkCloudCluster) IsServerless() bool {
 	return c != nil && c.ClusterType == ServerlessClusterType
+}
+
+func (c *RpkCloudCluster) IsBYOC() bool {
+	return c != nil && c.ClusterType == controlplanev1.Cluster_TYPE_BYOC.String()
 }
 
 func (c *RpkCloudCluster) CheckClusterURL() (string, error) {

--- a/src/go/rpk/pkg/publicapi/controlplane.go
+++ b/src/go/rpk/pkg/publicapi/controlplane.go
@@ -31,6 +31,7 @@ type CloudClientSet struct {
 	Organization  iamv1connect.OrganizationServiceClient
 	ResourceGroup controlplanev1connect.ResourceGroupServiceClient
 	Serverless    controlplanev1connect.ServerlessClusterServiceClient
+	Operations    controlplanev1connect.OperationServiceClient
 }
 
 // NewCloudClientSet creates a Public API client set with the service
@@ -54,6 +55,7 @@ func NewCloudClientSet(host, authToken string, opts ...connect.ClientOption) *Cl
 		Organization:  iamv1connect.NewOrganizationServiceClient(httpCl, host, opts...),
 		ResourceGroup: controlplanev1connect.NewResourceGroupServiceClient(httpCl, host, opts...),
 		Serverless:    controlplanev1connect.NewServerlessClusterServiceClient(httpCl, host, opts...),
+		Operations:    controlplanev1connect.NewOperationServiceClient(httpCl, host, opts...),
 	}
 }
 


### PR DESCRIPTION
# Set redpanda configuration in BYOC clusters

This PR allows the setting of multiple redpanda configurations in the BYOC cloud cluster, but only one to self-hosted as previous implementation

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## command preview

#### Update non exist redpanda
```bash
rpk cluster config set space_management_enable=true
cluster not found. Please ensure the cluster exists in the cloud
```

#### Update cluster without permissions
```bash
rpk cluster config set space_management_enable=true
this user does not have permission to update the cluster configuration, please check your role or contact admin
```

#### Update non BYOC cluster
```bash
rpk cluster config set space_management_enable=true
rpk cluster config set is not supported for serverless and dedicated clusters.
```

#### Update cluster successfully
```bash
rpk cluster config set iceberg_enabled=true
Processing configuration. This operation can take up to X minutes. To check the status, run: 'rpk cluster config status'
Operation ID: cvmb6l4j2ojqu3dp5n20
```
