### PR TITLE
CORE-9185 k/server/conn_ctx: prevent out of order responses

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -37,6 +37,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/scattered_message.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
@@ -921,6 +922,12 @@ ss::future<> connection_context::client_protocol_state::handle_response(
 ss::future<ss::stop_iteration>
 connection_context::client_protocol_state::do_process_responses(
   ss::lw_shared_ptr<connection_context> connection_ctx) {
+    // Because this method may be called from multiple background fibres
+    // concurrently, this semaphore ensures that scheduling points inside this
+    // method cannot lead to responses being writtent to the connection out of
+    // order.
+    auto units = co_await ss::get_units(_resp_sem, 1);
+
     auto it = _responses.find(_next_response);
     if (it == _responses.end()) {
         co_return ss::stop_iteration::yes;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -30,6 +30,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/socket_defs.hh>
@@ -389,6 +390,7 @@ private:
 
         sequence_id _next_response;
         sequence_id _seq_idx;
+        ssx::semaphore _resp_sem{1, "k/conn_ctx/response"};
         map_t _responses;
     };
 


### PR DESCRIPTION
This fixes a bug where kafka responses could get out-of-order with respect to request order on the same connection. This would surface as CorrelationIdMismatchException exceptions at the kafka client side.

Responses are sent from background fibres spawned per request. And each background fibre tries to send all of the available responses. Reordering could happen because there is a scheduling point on the path from updating the _next_response counter and the point where the response is written out to the connection/

For example:
1. One fibre could take a fetch request off the response queue and start to send it, but it would run into a scheduling delay before it's able to put the response on the wire here: https://github.com/redpanda-data/redpanda/blob/52f4eba1bc11105b45c88e4c6340d6e772c84008/src/v/kafka/server/connection_context.cc#L929-L941

2. Meanwhile, another fibre takes the next request off the queue and gets it on the wire earlier than the previous fetch.

This commit fixes this issue by introducing a semaphore to sequence the sending of each request.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes https://redpandadata.atlassian.net/browse/CORE-9185

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* This fixes a bug where kafka responses could get out-of-order with respect to request order on the same connection. This would surface as CorrelationIdMismatchException exceptions at the kafka client side.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
