### PR TITLE
http/client: 3-args ctor to use default max_idle_time=1s

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -72,6 +72,12 @@ client::client(
 client::client(
   const net::base_transport::configuration& cfg,
   const ss::abort_source* as,
+  ss::shared_ptr<client_probe> probe)
+  : client(cfg, as, std::move(probe), default_max_idle_time) {}
+
+client::client(
+  const net::base_transport::configuration& cfg,
+  const ss::abort_source* as,
   ss::shared_ptr<client_probe> probe,
   ss::lowres_clock::duration max_idle_time)
   : net::base_transport(cfg, &http_log)

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -108,8 +108,12 @@ public:
     client(
       const net::base_transport::configuration& cfg,
       const ss::abort_source* as,
+      ss::shared_ptr<client_probe> probe);
+    client(
+      const net::base_transport::configuration& cfg,
+      const ss::abort_source* as,
       ss::shared_ptr<client_probe> probe,
-      ss::lowres_clock::duration max_idle_time = {});
+      ss::lowres_clock::duration max_idle_time);
 
     /// Stop must be called before destroying the client object.
     ss::future<> stop();


### PR DESCRIPTION
`http::client` constructors are somewhat inconsistent: 1-arg and 2-args ones set `max_idle_time` to 1s, while the 4-args one accepts `max_idle_time` as the 4th argument with a default of 0.

@Lazin would you mind if I changed it to 1s as well if called with 3 arguments?

It is only called in `datalake::coordinator::rest_catalog_factory::create_catalog`. It was introduced [here](https://github.com/redpanda-data/redpanda/pull/25276/commits/48a4897297a971b2e5b21469f3d425e720676998#diff-6eada05a196cb5f9c88d4ae329f175b11d3c1561f7f1467155ec54a4af7da8ceL185-R193). @andrwng could you confirm you did not intend to reduce `max_idle_time` to 0?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
