### PR TITLE
iceberg/rest_client: use /v1/config endpoint

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3921,12 +3921,14 @@ configuration::configuration()
       {.visibility = visibility::user, .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
-  , iceberg_rest_catalog_prefix(
+  , iceberg_rest_catalog_warehouse(
       *this,
-      "iceberg_rest_catalog_prefix",
-      "Prefix part of the Iceberg REST catalog URL. Prefix is appended to the "
-      "catalog path f.e. '/v1/{prefix}/namespaces'",
-      {.visibility = visibility::user},
+      "iceberg_rest_catalog_warehouse",
+      "Warehouse to use for the Iceberg REST catalog. Redpanda will query the "
+      "catalog for configurations specific to the warehouse, for example, "
+      "using it to automatically configure the appropriate prefix.",
+      {.visibility = visibility::user,
+       .aliases = {"iceberg_rest_catalog_prefix"}},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_oauth2_server_uri(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -733,7 +733,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> iceberg_rest_catalog_trust;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl_file;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl;
-    property<std::optional<ss::sstring>> iceberg_rest_catalog_prefix;
+    property<std::optional<ss::sstring>> iceberg_rest_catalog_warehouse;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_oauth2_server_uri;
     enum_property<datalake_catalog_auth_mode>
       iceberg_rest_catalog_authentication_mode;

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -205,28 +205,27 @@ rest_catalog_factory::create_catalog() {
       = static_cast<std::unique_ptr<http::abstract_client>>(
         std::make_unique<http::client>(
           std::move(transport_config), nullptr, client_probe_));
-    auto prefix_path
-      = config_->iceberg_rest_catalog_prefix()
-          ? std::make_optional<iceberg::rest_client::prefix_path>(
-              config_->iceberg_rest_catalog_prefix().value())
-          : std::nullopt;
 
     auto creds_and_token = make_credentials_or_token();
 
+    auto warehouse = config_->iceberg_rest_catalog_warehouse()
+                       ? std::make_optional<iceberg::rest_client::warehouse>(
+                           *config_->iceberg_rest_catalog_warehouse())
+                       : std::nullopt;
     vlog(
       datalake_log.info,
-      "Creating rest Iceberg catalog connected to: {}, with base path: {} and "
-      "prefix: {}",
+      "Creating rest Iceberg catalog connected to: {}, with base path: {}, "
+      "warehouse: {}",
       endpoint_information.address,
       endpoint_information.base_path,
-      prefix_path);
+      warehouse);
     // TODO: support OAuth token here
     auto client = std::make_unique<iceberg::rest_client::catalog_client>(
       std::move(http_client),
       config_->iceberg_rest_catalog_endpoint().value(),
       std::move(creds_and_token.credentials),
       std::move(endpoint_information.base_path),           // base_path
-      std::move(prefix_path),                              // prefix
+      std::move(warehouse),                                // warehouse
       std::nullopt,                                        // api_version
       std::move(creds_and_token.token),                    // token
       nullptr,                                             // retry_policy

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -82,6 +82,7 @@ redpanda_cc_library(
     include_prefix = "iceberg/rest_client",
     deps = [
         ":error",
+        "//src/v/bytes:streambuf",
         "//src/v/http",
         "//src/v/net",
     ],

--- a/src/v/iceberg/rest_client/BUILD
+++ b/src/v/iceberg/rest_client/BUILD
@@ -3,6 +3,20 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/iceberg:__subpackages__"])
 
 redpanda_cc_library(
+    name = "catalog_config",
+    hdrs = [
+        "catalog_config.h",
+    ],
+    include_prefix = "iceberg/rest_client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_hash_map",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "client_probe",
     srcs = [
         "client_probe.cc",
@@ -48,6 +62,7 @@ redpanda_cc_library(
     ],
     include_prefix = "iceberg/rest_client",
     deps = [
+        ":catalog_config",
         ":oauth_token",
         "//src/v/iceberg:json_utils",
         "//src/v/json",

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -304,6 +304,8 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         if (!request.has_value()) {
             co_return tl::unexpected(request.error());
         }
+        auto request_target = ss::sstring{
+          request->target().begin(), request->target().end()};
 
         if (_probe) {
             _probe->register_request(endpoint);
@@ -321,6 +323,12 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         }
 
         auto& error = call_res.error();
+        vlog(
+          iceberg::log.warn,
+          "[{}] error: {}, message: '{}'",
+          request_target,
+          error.err,
+          error.err_msg);
         if (error.aborted) {
             co_return tl::unexpected(
               aborted_error{"Shutting down while evaluating retry"});

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -51,6 +51,7 @@ iobuf serialize_payload_as_json(const T& payload) {
 }
 static constexpr std::string_view json_content_type = "application/json";
 static constexpr std::string_view oauth_token_endpoint = "oauth/tokens";
+static constexpr std::string_view config_endpoint = "config";
 } // namespace
 
 namespace iceberg::rest_client {
@@ -95,7 +96,7 @@ catalog_client::catalog_client(
   ss::sstring endpoint,
   std::optional<credentials> credentials,
   std::optional<base_path> base_path,
-  std::optional<prefix_path> prefix,
+  std::optional<warehouse> warehouse,
   std::optional<api_version> api_version,
   std::optional<oauth_token> token,
   std::unique_ptr<retry_policy> retry_policy,
@@ -104,11 +105,72 @@ catalog_client::catalog_client(
   : _http_client(std::move(http_client))
   , _endpoint{std::move(endpoint)}
   , _credentials{std::move(credentials)}
-  , _path_components{std::move(base_path), std::move(prefix), std::move(api_version)}
+  , _path_components{std::move(base_path), std::move(api_version)}
+  , _warehouse(std::move(warehouse))
   , _oauth_token{std::move(token)}
   , _retry_policy{retry_policy ? std::move(retry_policy) : std::make_unique<default_retry_policy>()}
   , _auth_mode(auth_mode)
   , _probe(std::move(probe)) {}
+
+ss::future<expected<std::monostate>>
+catalog_client::maybe_configure(retry_chain_node& rtc) {
+    auto gh = _gate.hold();
+    if (_configured) {
+        co_return std::monostate{};
+    }
+    vlog(log.debug, "Configuring Iceberg REST catalog client");
+    auto http_request = http::request_builder{}
+                          .method(boost::beast::http::verb::get)
+                          .path(_path_components.config_api_path())
+                          .with_content_type(json_content_type);
+    if (_warehouse.has_value()) {
+        http_request.query_param_kv("warehouse", _warehouse.value()());
+    }
+    auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
+    if (!auth_result.has_value()) {
+        co_return tl::unexpected(auth_result.error());
+    }
+    auto config = (co_await perform_request(
+                     rtc,
+                     http_request,
+                     client_probe::endpoint::create_namespace,
+                     std::nullopt))
+                    .and_then(parse_json)
+                    .and_then(
+                      parse_as_expected("get_config", parse_catalog_config));
+    if (!config.has_value()) {
+        co_return tl::unexpected(config.error());
+    }
+    static constexpr auto prefix_prop_name = "prefix";
+    std::optional<prefix_path> prefix;
+    for (const auto& [k, v] : config->defaults) {
+        vlog(log.trace, "Default catalog config: '{}': '{}'", k, v);
+        if (k == prefix_prop_name && !v.empty()) {
+            prefix = prefix_path{v};
+            vlog(
+              log.debug,
+              "Iceberg default REST catalog 'prefix' value: {}",
+              *prefix);
+        }
+    }
+    for (const auto& [k, v] : config->overrides) {
+        vlog(log.trace, "Override catalog config: '{}': '{}'", k, v);
+        if (k == prefix_prop_name && !v.empty()) {
+            prefix = prefix_path{v};
+            vlog(
+              log.debug,
+              "Iceberg override REST catalog 'prefix' value: {}",
+              *prefix);
+        }
+    }
+    if (!prefix && _warehouse) {
+        prefix = prefix_path{*_warehouse};
+    }
+    // TODO: use the config for more than just prefix setting.
+    _path_components.reset_prefix(std::move(prefix));
+    _configured = true;
+    co_return std::monostate{};
+}
 
 ss::future<expected<oauth_token>>
 catalog_client::acquire_token(retry_chain_node& rtc) {
@@ -288,6 +350,10 @@ ss::future<expected<create_namespace_response>>
 catalog_client::create_namespace(
   create_namespace_request req, retry_chain_node& rtc) {
     auto gh = _gate.hold();
+    auto config_result = co_await maybe_configure(rtc);
+    if (!config_result.has_value()) {
+        co_return tl::unexpected(config_result.error());
+    }
     auto http_request = namespaces{root_path()}.create().with_content_type(
       json_content_type);
 
@@ -311,6 +377,10 @@ ss::future<expected<load_table_result>> catalog_client::create_table(
   create_table_request req,
   retry_chain_node& rtc) {
     auto gh = _gate.hold();
+    auto config_result = co_await maybe_configure(rtc);
+    if (!config_result.has_value()) {
+        co_return tl::unexpected(config_result.error());
+    }
     auto http_request = table{root_path(), ns}.create().with_content_type(
       json_content_type);
 
@@ -333,6 +403,10 @@ ss::future<expected<load_table_result>> catalog_client::load_table(
   const ss::sstring& table_name,
   retry_chain_node& rtc) {
     auto gh = _gate.hold();
+    auto config_result = co_await maybe_configure(rtc);
+    if (!config_result.has_value()) {
+        co_return tl::unexpected(config_result.error());
+    }
     auto http_request = table(root_path(), ns).get(table_name);
 
     auto auth_result = co_await maybe_add_bearer_auth(http_request, rtc);
@@ -352,6 +426,10 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
   std::optional<bool> purge_requested,
   retry_chain_node& rtc) {
     auto gh = _gate.hold();
+    auto config_result = co_await maybe_configure(rtc);
+    if (!config_result.has_value()) {
+        co_return tl::unexpected(config_result.error());
+    }
     http::rest_client::rest_entity::optional_query_params params;
     if (purge_requested.has_value()) {
         params.emplace();
@@ -377,6 +455,10 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
 ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
   commit_table_request commit_request, retry_chain_node& rtc) {
     auto gh = _gate.hold();
+    auto config_result = co_await maybe_configure(rtc);
+    if (!config_result.has_value()) {
+        co_return tl::unexpected(config_result.error());
+    }
     auto http_request = table(root_path(), commit_request.identifier.ns)
                           .update(commit_request.identifier.table)
                           .with_content_type(json_content_type);
@@ -397,14 +479,20 @@ ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
 }
 
 path_components::path_components(
-  std::optional<base_path> base,
-  std::optional<prefix_path> prefix,
-  std::optional<api_version> api_version)
+  std::optional<base_path> base, std::optional<api_version> api_version)
   : _base{trim_slashes(std::move(base), "")}
-  , _prefix{trim_slashes(std::move(prefix), "")}
   , _api_version{trim_slashes(std::move(api_version), "v1")} {}
 
+void path_components::reset_prefix(std::optional<prefix_path> path) {
+    _prefix = trim_slashes<prefix_path>(std::move(path), "");
+    vlog(
+      log.info, "Reset Iceberg REST catalog client prefix to '{}'", *_prefix);
+}
+
 ss::sstring path_components::root_path() const {
+    vassert(
+      _prefix.has_value(),
+      "Must call reset_prefix() before calling root_path()");
     std::vector<ss::sstring> parts;
     if (!_base().empty()) {
         parts.push_back(_base());
@@ -412,8 +500,8 @@ ss::sstring path_components::root_path() const {
 
     parts.push_back(_api_version());
 
-    if (!_prefix().empty()) {
-        parts.push_back(_prefix());
+    if (!_prefix.value()().empty()) {
+        parts.push_back(_prefix.value()());
     }
 
     return absl::StrJoin(parts, "/") + "/";
@@ -427,6 +515,16 @@ ss::sstring path_components::token_api_path() const {
 
     parts.push_back(_api_version());
     return absl::StrJoin(parts, "/") + "/" + std::string{oauth_token_endpoint};
+}
+
+ss::sstring path_components::config_api_path() const {
+    std::vector<ss::sstring> parts;
+    if (!_base().empty()) {
+        parts.push_back(_base());
+    }
+
+    parts.push_back(_api_version());
+    return absl::StrJoin(parts, "/") + "/" + std::string{config_endpoint};
 }
 
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -31,13 +31,13 @@ namespace iceberg::rest_client {
 
 using base_path = named_type<ss::sstring, struct base_path_t>;
 using prefix_path = named_type<ss::sstring, struct prefix_t>;
+using warehouse = named_type<ss::sstring, struct warehouse_t>;
 using api_version = named_type<ss::sstring, struct api_version_t>;
 
 // Holds parts of a root path used by catalog client
 struct path_components {
     path_components(
       std::optional<base_path> base = std::nullopt,
-      std::optional<prefix_path> prefix = std::nullopt,
       std::optional<api_version> api_version = std::nullopt);
 
     // Returns root path for use in API calls not related to oauth token, joins
@@ -49,9 +49,18 @@ struct path_components {
     // /api/catalog/v1/oauth/tokens
     ss::sstring token_api_path() const;
 
+    // Same as root path but does not include the prefix, e.g.
+    // /api/catalog/v1/config
+    ss::sstring config_api_path() const;
+
+    // Resets the prefix. Guaranteed to leave the prefix non-null.
+    void reset_prefix(std::optional<prefix_path> path);
+
 private:
     base_path _base;
-    prefix_path _prefix;
+
+    // Null if not yet initialized.
+    std::optional<prefix_path> _prefix;
     api_version _api_version;
 };
 
@@ -89,7 +98,7 @@ public:
       ss::sstring endpoint,
       std::optional<credentials> credentials = std::nullopt,
       std::optional<base_path> base_path = std::nullopt,
-      std::optional<prefix_path> prefix = std::nullopt,
+      std::optional<warehouse> warehouse = std::nullopt,
       std::optional<api_version> api_version = std::nullopt,
       std::optional<oauth_token> token = std::nullopt,
       std::unique_ptr<retry_policy> retry_policy = nullptr,
@@ -105,7 +114,6 @@ public:
      * Public method documentation will refer to the endpoints listed in the
      * specification.
      */
-
     /**
      * Create namespace API
      *
@@ -159,6 +167,13 @@ public:
     // Must be called before destroying the client to prevent resource leak
     ss::future<> shutdown();
 
+    // Configures this client based on configs from /v1/config in the catalog.
+    // Sets the prefix. Must be called before calls that use the prefix.
+    //
+    // TODO: honor more configs. As implemented, we only support getting the
+    // prefix.
+    ss::future<expected<std::monostate>> maybe_configure(retry_chain_node&);
+
 private:
     // The root url calculated from base url, prefix and api version. Given a
     // base url of "/b", an api version "v2" and a prefix of "x/y", the root url
@@ -195,10 +210,12 @@ private:
     ss::sstring _endpoint;
     std::optional<credentials> _credentials;
     path_components _path_components;
+    std::optional<warehouse> _warehouse;
     std::optional<oauth_token> _oauth_token{std::nullopt};
     std::unique_ptr<retry_policy> _retry_policy;
     config::datalake_catalog_auth_mode _auth_mode;
     ss::shared_ptr<client_probe> _probe;
+    bool _configured{false};
 
     friend class catalog_client_tester;
 };

--- a/src/v/iceberg/rest_client/catalog_config.h
+++ b/src/v/iceberg/rest_client/catalog_config.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace iceberg::rest_client {
+
+struct catalog_config {
+    // Properties that should be used as default configuration; applied before
+    // client configuration.
+    chunked_hash_map<ss::sstring, ss::sstring> defaults;
+
+    // Properties that should be used to override client configuration; applied
+    // after defaults and client configuration.
+    chunked_hash_map<ss::sstring, ss::sstring> overrides;
+
+    // TODO: optional: endpoints
+};
+
+} // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/client_probe.cc
+++ b/src/v/iceberg/rest_client/client_probe.cc
@@ -188,6 +188,20 @@ void client_probe::setup_public_metrics(
                           "endpoint that failed"),
           labels)
           .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_get_config_requests",
+          [this] { return num_get_config_requests; },
+          sm::description("Total number of requests sent to the "
+                          "config endpoint"),
+          labels)
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "num_get_config_requests_failed",
+          [this] { return num_get_config_requests_failed; },
+          sm::description("Number of requests sent to the config "
+                          "endpoint that failed"),
+          labels)
+          .aggregate({sm::shard_label}),
       });
 }
 
@@ -212,6 +226,9 @@ void client_probe::register_request(endpoint e) {
     case commit_table_update:
         ++num_commit_table_update_requests;
         return;
+    case get_config:
+        ++num_get_config_requests;
+        return;
     }
 }
 
@@ -235,6 +252,9 @@ void client_probe::register_failed_request(endpoint e) {
         return;
     case commit_table_update:
         ++num_commit_table_update_requests_failed;
+        return;
+    case get_config:
+        ++num_get_config_requests_failed;
         return;
     }
 }

--- a/src/v/iceberg/rest_client/client_probe.h
+++ b/src/v/iceberg/rest_client/client_probe.h
@@ -25,6 +25,7 @@ public:
         load_table,
         drop_table,
         commit_table_update,
+        get_config,
     };
     client_probe(
       net::public_metrics_disabled public_disable, ss::metrics::label_instance);
@@ -58,6 +59,9 @@ private:
 
     size_t num_commit_table_update_requests{0};
     size_t num_commit_table_update_requests_failed{0};
+
+    size_t num_get_config_requests{0};
+    size_t num_get_config_requests_failed{0};
 };
 
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/json.cc
+++ b/src/v/iceberg/rest_client/json.cc
@@ -43,4 +43,11 @@ oauth_token parse_oauth_token(const json::Document& doc) {
     return ret;
 }
 
+catalog_config parse_catalog_config(const json::Document& doc) {
+    catalog_config ret;
+    ret.defaults = parse_required_string_map(doc, "defaults");
+    ret.overrides = parse_required_string_map(doc, "overrides");
+    return ret;
+}
+
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/json.h
+++ b/src/v/iceberg/rest_client/json.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "iceberg/rest_client/catalog_config.h"
 #include "iceberg/rest_client/oauth_token.h"
 #include "json/document.h"
 
@@ -17,5 +18,7 @@ namespace iceberg::rest_client {
 
 // Parses oauth token from a JSON response sent from catalog server
 oauth_token parse_oauth_token(const json::Document& doc);
+// Parses the catalog configfrom a JSON response sent from catalog server
+catalog_config parse_catalog_config(const json::Document& doc);
 
 } // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/retry_policy.cc
+++ b/src/v/iceberg/rest_client/retry_policy.cc
@@ -10,9 +10,11 @@
 
 #include "iceberg/rest_client/retry_policy.h"
 
+#include "bytes/streambuf.h"
 #include "net/connection.h"
 
 #include <exception>
+#include <sstream>
 
 namespace {
 
@@ -82,8 +84,13 @@ default_retry_policy::should_retry(http::downloaded_response response) const {
 
     const auto can_be_retried = std::ranges::find(retriable_statuses, status)
                                 != retriable_statuses.end();
-    return tl::unexpected(
-      failure{.can_be_retried = can_be_retried, .err = status});
+    constexpr size_t max_msg_size = 400;
+    iobuf_istream is{response.body.share(
+      0, std::min(max_msg_size, response.body.size_bytes()))};
+    std::stringstream s;
+    s << is.istream().rdbuf();
+    return tl::unexpected(failure{
+      .can_be_retried = can_be_retried, .err = status, .err_msg = s.str()});
 }
 
 failure default_retry_policy::should_retry(std::exception_ptr ex) const {

--- a/src/v/iceberg/rest_client/retry_policy.h
+++ b/src/v/iceberg/rest_client/retry_policy.h
@@ -23,6 +23,7 @@ struct failure {
     // NOTE: takes precedence over can_be_retried.
     bool aborted{false};
     http_call_error err;
+    std::string err_msg;
     bool is_transport_error() const;
 };
 

--- a/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
+++ b/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
@@ -74,32 +74,65 @@ private:
 } // namespace iceberg::rest_client
 
 TEST(path_components, path_with_base_and_prefix) {
-    r::path_components pc{
-      r::base_path{"b"}, r::prefix_path{"pre"}, r::api_version{"v1"}};
+    r::path_components pc{r::base_path{"b"}, r::api_version{"v1"}};
+    pc.reset_prefix(r::prefix_path{"pre"});
     ASSERT_EQ(pc.root_path(), "b/v1/pre/");
     ASSERT_EQ(pc.token_api_path(), "b/v1/oauth/tokens");
 }
 
 TEST(path_components, path_with_no_optional_parts) {
     r::path_components pc{};
+    pc.reset_prefix(std::nullopt);
     ASSERT_EQ(pc.root_path(), "v1/");
     ASSERT_EQ(pc.token_api_path(), "v1/oauth/tokens");
 }
 
 TEST(path_components, path_with_prefix) {
-    r::path_components pc{std::nullopt, r::prefix_path{"pre"}};
+    r::path_components pc{};
+    pc.reset_prefix(r::prefix_path{"pre"});
     ASSERT_EQ(pc.root_path(), "v1/pre/");
     ASSERT_EQ(pc.token_api_path(), "v1/oauth/tokens");
 }
 
 TEST(client, root_url_computed) {
+    auto ret = [](
+                 [[maybe_unused]] bh::request_header<>&& r,
+                 [[maybe_unused]] std::optional<iobuf> payload,
+                 [[maybe_unused]] ss::lowres_clock::duration timeout) {
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = bh::status::ok, .body = iobuf::from(R"({
+              "defaults": {"prefix": "x"},
+              "overrides": {"prefix": ""}
+            })")});
+    };
+
     r::catalog_client cc{
-      make_http_client([](mock_client&) {}),
+      make_http_client([&ret](mock_client& m) {
+          EXPECT_CALL(
+            m,
+            request_and_collect_response(
+              AllOf(
+                Property(
+                  &boost::beast::http::request_header<>::target,
+                  EndsWith("/config?warehouse=x")),
+                Property(
+                  &boost::beast::http::request_header<>::method,
+                  Eq(boost::beast::http::verb::get))),
+              _,
+              _))
+            .WillRepeatedly(ret);
+      }),
       endpoint,
       credentials,
       r::base_path{"api/catalog/"},
-      r::prefix_path{"x"},
+      r::warehouse{"x"},
       r::api_version{"v2"}};
+    ss::abort_source as;
+    retry_chain_node rtc(as, 1s, 100ms);
+    auto conf_res = cc.maybe_configure(rtc).get();
+    ASSERT_TRUE(conf_res.has_value());
+
     r::catalog_client_tester t{cc};
     ASSERT_EQ(t.root_path(), "api/catalog/v2/x/");
 }

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -67,7 +67,7 @@ struct RestCatalogTest
           endpoint,
           get_credentials(),
           iceberg::rest_client::base_path{"/catalog"},
-          std::nullopt,
+          iceberg::rest_client::warehouse{"x"},
           iceberg::rest_client::api_version("v1"),
           std::nullopt,
           nullptr,
@@ -276,11 +276,38 @@ void setup_token_request_expectations(client_mock& mock) {
         _))
       .WillOnce(handle_token_request);
 }
+void setup_config_expectations(client_mock& mock) {
+    auto ret = [](
+                 [[maybe_unused]] boost::beast::http::request_header<>&& r,
+                 [[maybe_unused]] std::optional<iobuf> payload,
+                 [[maybe_unused]] ss::lowres_clock::duration timeout) {
+        return ss::make_ready_future<http::downloaded_response>(
+          http::downloaded_response{
+            .status = boost::beast::http::status::ok, .body = iobuf::from(R"({
+              "defaults": {"prefix": "x"},
+              "overrides": {"prefix": ""}
+            })")});
+    };
+    EXPECT_CALL(
+      mock,
+      request_and_collect_response(
+        AllOf(
+          Property(
+            &boost::beast::http::request_header<>::target,
+            EndsWith("/config?warehouse=x")),
+          Property(
+            &boost::beast::http::request_header<>::method,
+            Eq(boost::beast::http::verb::get))),
+        _,
+        _))
+      .WillRepeatedly(ret);
+}
 } // namespace
 
 TEST_F(RestCatalogTest, CheckLoadTableHappyPath) {
     auto client = make_catalog_client({[](client_mock& m) {
         setup_token_request_expectations(m);
+        setup_config_expectations(m);
 
         EXPECT_CALL(
           m,
@@ -321,6 +348,7 @@ ss::future<http::downloaded_response> handle_create_table(
 TEST_F(RestCatalogTest, CheckCreateTableHappyPath) {
     auto client = make_catalog_client({[](client_mock& m) {
         setup_token_request_expectations(m);
+        setup_config_expectations(m);
 
         EXPECT_CALL(
           m,
@@ -421,6 +449,7 @@ iceberg::table_metadata create_empty_table_metadata(const ss::sstring& bucket) {
 TEST_F(RestCatalogTest, CommitTxnHappyPath) {
     auto client = make_catalog_client({[](client_mock& m) {
         setup_token_request_expectations(m);
+        setup_config_expectations(m);
 
         EXPECT_CALL(
           m,
@@ -510,6 +539,7 @@ ss::future<http::downloaded_response> handle_load_table_check_concurrency(
 TEST_F(RestCatalogTest, TestConcurrentAccesses) {
     auto client = make_catalog_client({[](client_mock& m) {
         setup_token_request_expectations(m);
+        setup_config_expectations(m);
         // setup mock to always reply in a
         EXPECT_CALL(
           m,

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -36,7 +36,8 @@ from rptest.utils.rpcn_utils import counter_stream_config
 
 OOM_ALLOW_LIST = [
     # partitioning_writer.cc:65 - Failed to create new writer: Memory exhausted
-    re.compile("Failed to create new writer: Memory exhausted")
+    re.compile("Failed to create new writer: Memory exhausted"),
+    "UpdateRequirement\\$Assert",
 ]
 
 
@@ -318,7 +319,9 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 "translation_parquet_rows_added"] == msg_count
             assert metric2value_sum["translation_parquet_bytes_added"] > 0
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=[
+        "UpdateRequirement\\$Assert",
+    ])
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
     def test_spec_evolution(self, cloud_storage_type, catalog_type):
@@ -489,7 +492,9 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             ]
             assert describe_partitioning == expected_partitioning
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=7, log_allow_list=[
+        "UpdateRequirement\\$Assert",
+    ])
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
     def test_spec_evolution_rpcn(self, cloud_storage_type, catalog_type):

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -86,7 +86,7 @@ class DatalakeServices():
             })
         if self.catalog_service.catalog_type() == CatalogType.NESSIE:
             self.redpanda.add_extra_rp_conf({
-                "iceberg_rest_catalog_prefix":
+                "iceberg_rest_catalog_warehouse":
                 NessieCatalog.NESSIE_DEFAULT_WAREHOUSE,
                 "iceberg_disable_snapshot_tagging":
                 "true"

--- a/tests/rptest/tests/datalake/many_topics_test.py
+++ b/tests/rptest/tests/datalake/many_topics_test.py
@@ -97,7 +97,9 @@ class DatalakeManyTopicsTest(RedpandaTest):
 
         self._execute_in_parallel(topics, produce_batch)
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=8, log_allow_list=[
+        "UpdateRequirement\\$Assert",
+    ])
     @matrix(cloud_storage_type=supported_storage_types())
     def test_basic(self, cloud_storage_type):
         with DatalakeServices(self.test_context,

--- a/tests/rptest/tests/polaris_catalog_smoke_test.py
+++ b/tests/rptest/tests/polaris_catalog_smoke_test.py
@@ -85,8 +85,8 @@ class PolarisCatalogSmokeTest(RedpandaTest):
             client_secret,
             "iceberg_catalog_commit_interval_ms":
             10000,
-            "iceberg_rest_catalog_prefix":
-            catalog_prefix
+            "iceberg_rest_catalog_warehouse":
+            catalog_prefix,
         })
         if with_tls == "from_file":
             self.redpanda._extra_rp_conf.update({


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Changes the iceberg_rest_catalog_prefix to
iceberg_rest_catalog_warehouse, with the expectation that this more
closely aligns with pyiceberg and other tools that allow configuring the
"warehouse".

This works by sending a request to the /v1/config endpoint with the
warehouse as a query parameter, and using the 'prefix' field returned by
the catalog, if any.

If no prefix is returned and a warehouse was specified, the warehouse
will used as a prefix instead as a fallback.

I've updated existing tests to use the new iceberg_rest_catalog_warehouse
instead of prefix. I manually verified this against a Unity Catalog, whose
prefix was returned as "catalogs/warehouse_name".

More info about the config endpoint:

- REST OpenAPI spec https://github.com/apache/iceberg/blob/9199ab520b92084e058d7cf7101b15802eeefc7c/open-api/rest-catalog-open-api.yaml#L81-L102
- PyIceberg fetch config implementation https://github.com/apache/iceberg-python/blob/96e6d546f1ac017781bb94c5370f869cae31bd4c/pyiceberg/catalog/rest.py#L376-L394

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* The cluster property `iceberg_rest_catalog_prefix` is renamed to `iceberg_rest_catalog_warehouse` and will now use the given value to query the `/v1/config` endpoint to discover the appropriate REST prefix.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
