### PR TITLE
[v25.1.x] http/client: 3-args ctor to use default max_idle_time=1s

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -72,6 +72,12 @@ client::client(
 client::client(
   const net::base_transport::configuration& cfg,
   const ss::abort_source* as,
+  ss::shared_ptr<client_probe> probe)
+  : client(cfg, as, std::move(probe), default_max_idle_time) {}
+
+client::client(
+  const net::base_transport::configuration& cfg,
+  const ss::abort_source* as,
   ss::shared_ptr<client_probe> probe,
   ss::lowres_clock::duration max_idle_time)
   : net::base_transport(cfg, &http_log)

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -108,8 +108,12 @@ public:
     client(
       const net::base_transport::configuration& cfg,
       const ss::abort_source* as,
+      ss::shared_ptr<client_probe> probe);
+    client(
+      const net::base_transport::configuration& cfg,
+      const ss::abort_source* as,
       ss::shared_ptr<client_probe> probe,
-      ss::lowres_clock::duration max_idle_time = {});
+      ss::lowres_clock::duration max_idle_time);
 
     /// Stop must be called before destroying the client object.
     ss::future<> stop();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25637
