### PR TITLE
iceberg/rest_client: a couple fixes for oauth2

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3940,6 +3940,14 @@ configuration::configuration()
       {.visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , iceberg_rest_catalog_oauth2_scope(
+      *this,
+      "iceberg_rest_catalog_oauth2_scope",
+      "The OAuth scope used to retrieve access tokens for Iceberg catalog "
+      "authentication. Only meaningful when "
+      "`iceberg_rest_catalog_authentication_mode` is set to `oauth2`",
+      {.visibility = visibility::user},
+      "PRINCIPAL_ROLE:ALL")
   , iceberg_rest_catalog_authentication_mode(
       *this,
       "iceberg_rest_catalog_authentication_mode",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -735,6 +735,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> iceberg_rest_catalog_crl;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_warehouse;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_oauth2_server_uri;
+    property<ss::sstring> iceberg_rest_catalog_oauth2_scope;
     enum_property<datalake_catalog_auth_mode>
       iceberg_rest_catalog_authentication_mode;
     property<double> iceberg_backlog_controller_p_coeff;

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -171,7 +171,8 @@ rest_catalog_factory::make_credentials_or_token() {
           = std::make_optional<iceberg::rest_client::credentials>(
             config_->iceberg_rest_catalog_client_id().value(),
             config_->iceberg_rest_catalog_client_secret().value(),
-            config_->iceberg_rest_catalog_oauth2_server_uri());
+            config_->iceberg_rest_catalog_oauth2_server_uri(),
+            config_->iceberg_rest_catalog_oauth2_scope());
         break;
     }
     }

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -199,9 +199,7 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
       {"grant_type", "client_credentials"},
       {"client_id", creds.client_id},
       {"client_secret", creds.client_secret},
-      // TODO - parameterize this scope, the principal_role should be an input
-      // to the catalog client
-      {"scope", "PRINCIPAL_ROLE:ALL"},
+      {"scope", creds.oauth2_scope},
     });
     co_return (co_await perform_request(
                  rtc,

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -133,6 +133,7 @@ catalog_client::maybe_configure(retry_chain_node& rtc) {
     auto config = (co_await perform_request(
                      rtc,
                      http_request,
+                     _endpoint,
                      client_probe::endpoint::create_namespace,
                      std::nullopt))
                     .and_then(parse_json)
@@ -183,14 +184,17 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
 
     // Use the specified OAuth2 server uri if it has a value.
     // Otherwise, fall back to the deprecated /oauth/tokens catalog endpoint.
-    ss::sstring token_path = creds.oauth2_server_uri.value_or(
-      _path_components.token_api_path());
 
-    const auto token_request
+    auto token_request
       = http::request_builder{}
           .method(boost::beast::http::verb::post)
-          .path(token_path)
           .header("content-type", "application/x-www-form-urlencoded");
+    bool custom_oauth2_server = creds.oauth2_server_uri.has_value();
+    if (!custom_oauth2_server) {
+        // If there's no custom OAuth2 server specified, presume that the REST
+        // catalog has one built in.
+        token_request.path(_path_components.token_api_path());
+    }
     auto payload = http::form_encode_data({
       {"grant_type", "client_credentials"},
       {"client_id", creds.client_id},
@@ -202,6 +206,7 @@ catalog_client::acquire_token(retry_chain_node& rtc) {
     co_return (co_await perform_request(
                  rtc,
                  token_request,
+                 custom_oauth2_server ? *creds.oauth2_server_uri : _endpoint,
                  client_probe::endpoint::oauth_token,
                  std::move(payload)))
       .and_then(parse_json)
@@ -263,6 +268,7 @@ ss::future<expected<std::monostate>> catalog_client::maybe_add_bearer_auth(
 ss::future<expected<iobuf>> catalog_client::perform_request(
   retry_chain_node& rtc,
   http::request_builder request_builder,
+  const ss::sstring& host,
   client_probe::endpoint endpoint,
   std::optional<iobuf> payload) {
     if (payload.has_value()) {
@@ -300,7 +306,7 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
             co_return tl::unexpected(
               retries_exhausted{.errors = std::move(retriable_errors)});
         }
-        auto request = request_builder.host(_endpoint).build();
+        auto request = request_builder.host(host).build();
         if (!request.has_value()) {
             co_return tl::unexpected(request.error());
         }
@@ -373,6 +379,7 @@ catalog_client::create_namespace(
     co_return (co_await perform_request(
                  rtc,
                  http_request,
+                 _endpoint,
                  client_probe::endpoint::create_namespace,
                  serialize_payload_as_json(req)))
       .and_then(parse_json)
@@ -400,6 +407,7 @@ ss::future<expected<load_table_result>> catalog_client::create_table(
     co_return (co_await perform_request(
                  rtc,
                  http_request,
+                 _endpoint,
                  client_probe::endpoint::create_table,
                  serialize_payload_as_json(req)))
       .and_then(parse_json)
@@ -422,8 +430,9 @@ ss::future<expected<load_table_result>> catalog_client::load_table(
         co_return tl::unexpected(auth_result.error());
     }
 
-    co_return (co_await perform_request(
-                 rtc, http_request, client_probe::endpoint::load_table))
+    co_return (
+      co_await perform_request(
+        rtc, http_request, _endpoint, client_probe::endpoint::load_table))
       .and_then(parse_json)
       .and_then(parse_as_expected("load_table", parse_load_table_result));
 }
@@ -452,8 +461,9 @@ ss::future<expected<std::monostate>> catalog_client::drop_table(
         co_return tl::unexpected(auth_result.error());
     }
 
-    co_return (co_await perform_request(
-                 rtc, http_request, client_probe::endpoint::drop_table))
+    co_return (
+      co_await perform_request(
+        rtc, http_request, _endpoint, client_probe::endpoint::drop_table))
       .map([](iobuf&&) {
           // we expect empty response, discard it
           return std::monostate{};
@@ -479,6 +489,7 @@ ss::future<expected<commit_table_response>> catalog_client::commit_table_update(
     co_return (co_await perform_request(
                  rtc,
                  http_request,
+                 _endpoint,
                  client_probe::endpoint::commit_table_update,
                  serialize_payload_as_json(commit_request)))
       .and_then(parse_json)

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -208,7 +208,7 @@ private:
 
     ss::gate _gate;
     std::unique_ptr<http::abstract_client> _http_client;
-    ss::sstring _endpoint;
+    const ss::sstring _endpoint;
     std::optional<credentials> _credentials;
     path_components _path_components;
     std::optional<warehouse> _warehouse;

--- a/src/v/iceberg/rest_client/catalog_client.h
+++ b/src/v/iceberg/rest_client/catalog_client.h
@@ -202,6 +202,7 @@ private:
     ss::future<expected<iobuf>> perform_request(
       retry_chain_node& rtc,
       http::request_builder request_builder,
+      const ss::sstring& host,
       client_probe::endpoint endpoint,
       std::optional<iobuf> payload = std::nullopt);
 

--- a/src/v/iceberg/rest_client/credentials.h
+++ b/src/v/iceberg/rest_client/credentials.h
@@ -20,6 +20,7 @@ struct credentials {
     ss::sstring client_id;
     ss::sstring client_secret;
     std::optional<ss::sstring> oauth2_server_uri;
+    ss::sstring oauth2_scope;
 };
 
 }; // namespace iceberg::rest_client

--- a/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
+++ b/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
@@ -23,7 +23,10 @@ using namespace std::chrono_literals;
 using namespace testing;
 namespace {
 constexpr auto endpoint = "http://localhost:8181";
-const r::credentials credentials{.client_id = "id", .client_secret = "secret"};
+const r::credentials credentials{
+  .client_id = "id",
+  .client_secret = "secret",
+  .oauth2_scope = "PRINCIPAL_ROLE:ALL"};
 
 template<typename Variant, typename Outer>
 void assert_type_and_value(Outer input, Variant expected) {

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -45,6 +45,7 @@ iceberg::rest_client::credentials get_credentials() {
     return {
       .client_id = "redpanda",
       .client_secret = "being_cute",
+      .oauth2_scope = "PRINCIPAL_ROLE:ALL",
     };
 }
 struct RestCatalogTest


### PR DESCRIPTION

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
In manually testing against Unity Catalog, I found that:
- `iceberg_rest_catalog_oauth2_server_uri` didn't quite work as expected when specifying the full URI of the OAuth2 server. This updates the endpoint used when sending token requests.
- Unity Catalog doesn't love `PRINCIPAL_ROLES:ALL` as the scope. This adds a new config to allow users to customize the scope.

More details are in the individual commit messages, but with these changes, I'm able to connect to Unity Catalog with the following configs in the dev_cluster.py config:

```
iceberg_rest_catalog_authentication_mode: str = "oauth2"
iceberg_disable_snapshot_tagging = True
iceberg_rest_catalog_endpoint = "https://foo-db.com/api/2.1/unity-catalog/iceberg-rest"
iceberg_rest_catalog_oauth2_server_uri = "https://foo-db.com/oidc/v1/token"
iceberg_rest_catalog_oauth2_scope = "all-apis"
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
