### PR TITLE
rpk container: tag and error improvements

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -36,7 +36,7 @@ import (
 var (
 	tag               = "latest"
 	redpandaImageBase = "redpandadata/redpanda:" + tag
-	consoleImageBase  = "redpandadata/console:latest"
+	consoleImageBase  = "redpandadata/console:v2.8.5"
 )
 
 const (

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -443,6 +443,10 @@ func restartCluster(
 	if len(states) == 0 {
 		return nil, nil
 	}
+	// If we only have one stranded Console container, the user must purge it.
+	if len(states) == 1 && states[0].Console {
+		return nil, fmt.Errorf("stranded Redpanda Console container detected; please run 'rpk container purge' and try again")
+	}
 	grp, _ := errgroup.WithContext(context.Background())
 	mu := sync.Mutex{}
 	var (

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -515,7 +515,7 @@ func restartCluster(
 		return nil, fmt.Errorf("%v\n\nErrors reported from the Docker container:\n%v", err, errStr)
 	}
 
-	if !consoleState.Running {
+	if consoleState != nil && !consoleState.Running {
 		ctx, _ := common.DefaultCtx()
 		err = c.ContainerStart(ctx, consoleState.ContainerID, container.StartOptions{})
 		if err != nil {
@@ -529,11 +529,14 @@ func restartCluster(
 	}
 	err = waitForCluster(checkConsole(consoleNode), retries)
 	if err != nil {
-		errStr, cErr := getContainerErr(consoleState, c)
-		if cErr != nil {
-			return nil, fmt.Errorf("%v\nunable to get Docker container logs: %v", err, cErr)
+		if consoleState != nil {
+			errStr, cErr := getContainerErr(consoleState, c)
+			if cErr != nil {
+				return nil, fmt.Errorf("%v\nunable to get Docker container logs: %v", err, cErr)
+			}
+			return nil, fmt.Errorf("%v\n\nErrors reported from the Docker container:\n%v", err, errStr)
 		}
-		return nil, fmt.Errorf("%v\n\nErrors reported from the Docker container:\n%v", err, errStr)
+		return nil, fmt.Errorf("error restarting the console cluster: %v; you may run 'rpk container purge' and start again", err)
 	}
 	return rpNodes, nil
 }

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -390,15 +390,30 @@ func startCluster(
 	fmt.Println("Waiting for the cluster to be ready...")
 	err = waitForCluster(check(nodes), retries)
 	if err != nil {
-		state, sErr := common.GetState(c, nodes[0].id, false)
-		if sErr != nil {
-			return false, fmt.Errorf("%v\nunable to get Docker container logs: %v", err, sErr)
+		var failedNodeState *common.NodeState
+		for _, n := range nodes {
+			state, sErr := common.GetState(c, n.id, false)
+			if sErr != nil {
+				return false, fmt.Errorf("%v\nunable to get Docker container (%v) logs: %v", n.id, err, sErr)
+			}
+			if !state.Running {
+				failedNodeState = state
+			}
 		}
-		errStr, cErr := getContainerErr(state, c)
+		// Sanity check: If the cluster didn't start but all the containers are
+		// running. Maybe the cluster is not ready yet and the user needs to
+		// increase the retries.
+		if failedNodeState == nil {
+			return false, fmt.Errorf("unable to start the cluster on time: %v; you may run 'rpk container purge' and start again increasing the number of retries with the '--retries' flag", err)
+		}
+
+		errStr, cErr := getContainerErr(failedNodeState, c)
 		if cErr != nil {
 			return false, fmt.Errorf("%v\nunable to get Docker container logs: %v", err, cErr)
 		}
-		return false, fmt.Errorf("%v\n\nErrors reported from the Docker container:\n\n%v", err, errStr)
+		// Docker usually truncates the container ID to 12 characters.
+		shortID := fmt.Sprintf("%.*s", 12, failedNodeState.ContainerID)
+		return false, fmt.Errorf("%v\n\nErrors reported from the Docker container with ID %v:\n\n%v", err, shortID, errStr)
 	}
 	fmt.Println("Cluster ready!")
 


### PR DESCRIPTION
Fixes UX-97

53a2ac8e35565f6618a8cad0b7365556a81f1375 Fixes the tag to v2.8.5 while we complete UX-31 and to prevent shipping a missing configuration once Console releases the upcoming version.

The rest of the commit addresses UX-97 and improves the error message in failure scenarios, examples below: 

Stranded container scenario:
```
# Before
$ rpk container start
Waiting for the cluster to be ready...

unable to start cluster: config erroneously has no seed brokers

Errors reported from the Docker container:

# Now:
$ rpk container start 
unable to start cluster: stranded Console container detected; please run 'rpk container purge' and try again
```

Error in one of the containers:
```
$ rpk container start -n 5
Checking for a local image...
Creating network "redpanda"
Starting cluster...
Waiting for the cluster to be ready...
unable to start cluster: expected 5 nodes, got 3

Errors reported from the Docker container with ID 1e1929f478ae:

+ '[' '' = true ']'
+ exec /usr/bin/rpk redpanda start --node-id 2 --kafka-addr internal://0.0.0.0:9092,external://172.24.1.4:19092 --advertise-kafka-addr internal://172.24.1.4:9092,external://127.0.0.1:11092 --pandaproxy-addr internal://0.0.0.0:8082,external://172.24.1.4:18082 --advertise-pandaproxy-addr internal://172.24.1.4:8082,external://127.0.0.1:10082 --schema-registry-addr 172.24.1.4:8081 --rpc-addr 172.24.1.4:33145 --advertise-rpc-addr 172.24.1.4:33145 --mode dev-container --seeds 172.24.1.2:33145
WARNING: This is a setup for development purposes only; in this mode your clusters may run unrealistically fast and data can be corrupted any time your computer shuts down uncleanly.
WARN  2025-03-29 00:26:55,197 seastar - Requested AIO slots too large, please increase request capacity in /proc/sys/fs/aio-max-nr. configured:65536 available:0 requested:22052
Could not initialize seastar: std::runtime_error (Could not setup Async I/O: Not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application)
```

^ In the past, we used to print only the logs of the first container and not the one that failed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
