### PR TITLE
[v25.1.x] datalake: add flush bytes limit control and flush bytes observability

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4078,6 +4078,15 @@ configuration::configuration()
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       30s,
       {.min = 1s, .max = 60s})
+  , datalake_translator_flush_bytes(
+      *this,
+      "datalake_translator_flush_bytes",
+      "Size, in bytes, of the amount of per translator data that may be "
+      "flushed to disk before the translator will upload and remove its "
+      "current on disk data.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      32_MiB,
+      {.min = 1_MiB})
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -756,6 +756,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> datalake_scheduler_max_concurrent_translations;
     bounded_property<std::chrono::milliseconds>
       datalake_scheduler_time_slice_ms;
+    bounded_property<size_t> datalake_translator_flush_bytes;
 
     configuration();
 

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -138,6 +138,7 @@ redpanda_cc_library(
         ":utils",
         "//src/v/base",
         "//src/v/cluster",
+        "//src/v/config",
         "//src/v/datalake:logger",
         "//src/v/features",
         "//src/v/model",

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -10,6 +10,7 @@
 
 #include "datalake/translation/partition_translator.h"
 
+#include "config/configuration.h"
 #include "datalake/logger.h"
 #include "resource_mgmt/io_priority.h"
 #include "utils/to_string.h"
@@ -23,14 +24,6 @@ namespace {
 using namespace std::chrono_literals;
 // A simple utility to conditionally retry with backoff on failures.
 constexpr model::timeout_clock::duration wait_timeout = 5s;
-
-// Purposefully set to a low-ish value (instead of 64/128_MiB) until space
-// management is fully integrated. The low value means less concurrent bytes
-// accumulated across all translators at any point which translates to less
-// pressure on space management enforce it's eviction policies. 32_MiB is still
-// a reasonable default compared to what we had before, but will be bumped soon.
-// note: this is _per_ (partition) translator.
-static constexpr size_t partition_flushed_bytes_limit = 32_MiB;
 
 template<
   typename Func,
@@ -137,6 +130,13 @@ partition_translator::checkpoint_translation_result(
       });
 }
 
+/*
+ * datalake_translator_flush_bytes (per partition): finish after a flush limit
+ * is reached. this is in place as a safety net for controlling disk usage.
+ * TODO: this limit can be removed and the configuration option be deprecated
+ * after we gain more confidence in the ability of space management to control
+ * datalake disk usage.
+ */
 bool partition_translator::should_finish_inflight_translation() const {
     auto bytes_flushed_pending_upload = _translation_ctx->flushed_bytes();
     auto lag_window_ended = _lag_tracking->should_finish_inflight_translation();
@@ -146,7 +146,8 @@ bool partition_translator::should_finish_inflight_translation() const {
       "window roll: {}",
       bytes_flushed_pending_upload,
       lag_window_ended);
-    return bytes_flushed_pending_upload >= partition_flushed_bytes_limit
+    return bytes_flushed_pending_upload
+             >= config::shard_local_cfg().datalake_translator_flush_bytes()
            || lag_window_ended;
 }
 

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -485,6 +485,7 @@ scheduling::translation_status partition_translator::status() const {
       .target_lag = _lag_tracking->target_lag(),
       .next_checkpoint_deadline = _lag_tracking->next_checkpoint_deadline(),
       .memory_bytes_reserved = _translation_ctx->buffered_bytes(),
+      .disk_bytes_flushed = _translation_ctx->flushed_bytes(),
       .translation_backlog = _lag_tracking->translation_backlog(),
     };
 }

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -97,6 +97,11 @@ struct translation_status {
     clock::time_point next_checkpoint_deadline;
     // Current memory byte reservation, if a translation is running
     std::optional<size_t> memory_bytes_reserved;
+    // Current bytes flushed to disk, if a translation is running. This is not
+    // an counter, and it is expected that if translators have subtracted from
+    // or otherwise reset this value then the translator has or is in the
+    // process of removing an equivalent amount of data (e.g. upload + delete).
+    std::optional<size_t> disk_bytes_flushed;
 
     std::optional<size_t> translation_backlog;
 };

--- a/src/v/datalake/translation/tests/scheduler_fixture.cc
+++ b/src/v/datalake/translation/tests/scheduler_fixture.cc
@@ -234,6 +234,7 @@ translation_status mock_translator::status() const {
     status.next_checkpoint_deadline = _next_checkpoint;
     if (_translation_state) {
         status.memory_bytes_reserved = total_bytes_reserved();
+        status.disk_bytes_flushed = total_bytes_reserved();
     }
     return status;
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25655
