### PR TITLE
[v25.1.x] archival: Add concurrency control to segment_collector

### DIFF
--- a/src/v/cluster/archival/archival_policy.cc
+++ b/src/v/cluster/archival/archival_policy.cc
@@ -109,6 +109,8 @@ std::ostream& operator<<(std::ostream& os, candidate_creation_error err) {
         return os << "failed to get file range for candidate";
     case candidate_creation_error::zero_content_length:
         return os << "candidate has no content";
+    case candidate_creation_error::concurrency_error:
+        return os << "collected segments are modified concurrently";
     }
 }
 
@@ -122,6 +124,7 @@ ss::log_level log_level_for_error(const candidate_creation_error& error) {
     case candidate_creation_error::no_segment_for_begin_offset:
     case candidate_creation_error::failed_to_get_file_range:
     case candidate_creation_error::zero_content_length:
+    case candidate_creation_error::concurrency_error:
         return ss::log_level::debug;
     case candidate_creation_error::offset_inside_batch:
     case candidate_creation_error::missing_ntp_config:

--- a/src/v/cluster/archival/archival_policy.h
+++ b/src/v/cluster/archival/archival_policy.h
@@ -34,6 +34,7 @@ enum class candidate_creation_error {
     missing_ntp_config,
     failed_to_get_file_range,
     zero_content_length,
+    concurrency_error,
 };
 
 std::ostream& operator<<(std::ostream&, candidate_creation_error);

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -207,6 +207,8 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         }
 
         _segments.push_back(result.segment);
+        _generations.push_back(result.segment->get_generation_id()());
+        _sizes.push_back(result.segment->size_bytes());
         current_segment_end = result.segment->offsets().get_committed_offset();
         start = current_segment_end + model::offset{1};
         _collected_size += segment_size;
@@ -472,6 +474,43 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
 
     auto locks_resolved = co_await ss::when_all_succeed(
       locks.begin(), locks.end());
+
+    std::vector<uint64_t> current_gen;
+    current_gen.reserve(_segments.size());
+    std::transform(
+      _segments.begin(),
+      _segments.end(),
+      std::back_inserter(current_gen),
+      [](const auto& seg) { return seg->get_generation_id()(); });
+
+    if (_generations != current_gen) {
+        std::stringstream sstr;
+        for (size_t i = 0; i < _segments.size(); i++) {
+            if (_generations.at(i) != current_gen.at(i)) {
+                // Segment was updated concurrently while we were waiting
+                // for the locks.
+                fmt::print(
+                  sstr,
+                  "segment {}-{} (seq: {}, old gen: {}, new gen: {}, old size: "
+                  "{}, new size: {}); ",
+                  _segments.at(i)->offsets().get_base_offset(),
+                  _segments.at(i)->offsets().get_committed_offset(),
+                  i,
+                  _generations.at(i),
+                  current_gen.at(i),
+                  _sizes.at(i),
+                  _segments.at(i)->size_bytes());
+            }
+        }
+        // The segment was updated while we were waiting for the locks.
+        // It's a race condition so we should fail the upload and retry.
+        vlog(
+          archival_log.info,
+          "Segment generation mismatch for {}: {}",
+          _manifest.get_ntp(),
+          sstr.str());
+        co_return candidate_creation_error::concurrency_error;
+    }
 
     auto first = _segments.front();
     auto head_seek_result = co_await storage::convert_begin_offset_to_file_pos(

--- a/src/v/cluster/archival/segment_reupload.h
+++ b/src/v/cluster/archival/segment_reupload.h
@@ -36,6 +36,8 @@ enum class segment_collector_mode {
 class segment_collector {
 public:
     using segment_seq = std::vector<ss::lw_shared_ptr<storage::segment>>;
+    using generation_seq = std::vector<uint64_t>;
+    using sizes_seq = std::vector<uint64_t>;
 
     /// C-tor
     ///
@@ -125,6 +127,8 @@ private:
     const storage::log& _log;
     const storage::ntp_config* _ntp_cfg{};
     segment_seq _segments;
+    generation_seq _generations;
+    sizes_seq _sizes;
     bool _can_replace_manifest_segment{false};
 
     size_t _max_uploaded_segment_size;

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -8,22 +8,27 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "archival/archival_policy.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/types.h"
 #include "cluster/archival/adjacent_segment_merger.h"
 #include "cluster/archival/segment_reupload.h"
 #include "cluster/archival/tests/service_fixture.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "storage/log_manager.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/archival.h"
 #include "test_utils/tmp_dir.h"
 
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/test/tools/old/interface.hpp>
+
+#include <variant>
 
 using namespace archival;
 
@@ -1425,4 +1430,56 @@ SEASTAR_THREAD_TEST_CASE(test_adjacent_segment_collection_x_term) {
     BOOST_REQUIRE_EQUAL(run.num_segments, 2);
     BOOST_REQUIRE_EQUAL(run.meta.base_offset(), 0);
     BOOST_REQUIRE_EQUAL(run.meta.committed_offset(), 400);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_concurrent_compaction) {
+    cloud_storage::partition_manifest m;
+    m.update(
+       cloud_storage::manifest_format::json, make_manifest_stream(manifest))
+      .get();
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    // Local disk log starts before manifest and ends after manifest. First
+    // three segments are compacted.
+    populate_log(
+      b,
+      {.segment_starts = {0, 20, 30, 40},
+       .compacted_segment_indices = {},
+       .last_segment_num_records = 10});
+
+    // Should be aligned to the manifest segments.
+    archival::segment_collector collector{
+      model::offset{10},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size,
+      model::offset{39}};
+
+    collector.collect_segments(segment_collector_mode::collect_non_compacted);
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
+
+    // Simulate concurrent compaction.
+    // The collector already stores collected segments. After the compaction
+    // the segments are still valid, but segment sizes could be different so
+    // the collection should be retried.
+    for (auto& s : b.get_disk_log_impl().segments()) {
+        s->advance_generation();
+    }
+
+    // The three compacted segments are collected, with the begin and end
+    // markers set to align with manifest segment.
+    auto candidate
+      = collector.make_upload_candidate(ss::default_priority_class(), 1s).get();
+    BOOST_REQUIRE(std::holds_alternative<candidate_creation_error>(candidate));
+    BOOST_REQUIRE(
+      std::get<candidate_creation_error>(candidate)
+      == candidate_creation_error::concurrency_error);
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25647
