### PR TITLE
olv: Fix ordering of __consumer_offsets output

### DIFF
--- a/tools/offline_log_viewer/consumer_offsets.py
+++ b/tools/offline_log_viewer/consumer_offsets.py
@@ -181,16 +181,12 @@ class OffsetsLog:
         self.ntp = ntp
 
     def __iter__(self):
-        paths = []
-        for path in self.ntp.segments:
-            paths.append(path)
-        paths.sort()
         # 1 - raft_data - regular offset commits
         # 10 - tx_fence - tx offset commits
         # 15 - group_commit_tx
         # 16 - group_abort_tx
         accepted_batch_types = set([1, 10, 15, 16])
-        for path in paths:
+        for path in self.ntp.segments:
             s = Segment(path)
             for b in s:
                 if b.header.type not in accepted_batch_types:


### PR DESCRIPTION
Ref: https://redpandadata.slack.com/archives/C08HU8GGFCP/p1743434166762709

Within `Ntp` we already perform a smart sort of the segments that's aware of the filename format and sorts numerically. The call to `.sort()` in the CO specific logic was redundant, but actually produced a worse result as it was a straight lexicographic sort.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

