### PR TITLE
`iceberg`: fix compatibility for schemas with `map` type

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -446,6 +446,7 @@ redpanda_cc_library(
         "//src/v/iceberg:avro_utils",
         "//src/v/iceberg:compatibility_utils",
         "//src/v/iceberg:values",
+        "@abseil-cpp//absl/container:flat_hash_set",
         "@avro",
         "@protobuf",
         "@seastar",

--- a/src/v/datalake/record_translator.cc
+++ b/src/v/datalake/record_translator.cc
@@ -22,6 +22,7 @@
 #include "iceberg/values.h"
 #include "model/fundamental.h"
 
+#include <absl/container/flat_hash_set.h>
 #include <avro/Generic.hh>
 #include <avro/GenericDatum.hh>
 
@@ -195,9 +196,23 @@ structured_data_translator::build_type(std::optional<resolved_type> val_type) {
         // permissive allowance for schema evolution which is certainly a
         // superset superset of what any particular schema language allows.
         // TODO(iceberg): this behavior could be made configurable
+        //
+        // Keys must be marked as required per the Iceberg spec:
+        // https://iceberg.apache.org/spec/#nested-types.
+        // This approach of storing the `key` fields in a set below is
+        // guaranteed to work because `iceberg::for_each_field()` is a depth
+        // first traversal of the fields, i.e., the parent `map` field will be
+        // visited before the child `key` field.
+        absl::flat_hash_set<iceberg::nested_field*> map_keys;
         std::ignore = iceberg::for_each_field(
-          struct_type, [](iceberg::nested_field* f) {
-              f->required = iceberg::field_required::no;
+          struct_type, [&map_keys](iceberg::nested_field* f) {
+              f->required = map_keys.contains(f) ? iceberg::field_required::yes
+                                                 : iceberg::field_required::no;
+
+              if (std::holds_alternative<iceberg::map_type>(f->type)) {
+                  auto& kv = std::get<iceberg::map_type>(f->type);
+                  map_keys.insert(kv.key_field.get());
+              }
           });
         for (auto& field : struct_type.fields) {
             if (field->name == rp_struct_name) {

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -55,6 +55,19 @@ avro_schema_str = """
 }
 """
 
+avro_schema_with_map_str = """
+{
+    "type": "record",
+    "namespace": "com.redpanda.examples.avro",
+    "name": "ClickEvent",
+    "fields": [
+        {"name": "number", "type": "long"},
+        {"name": "timestamp_us", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+        {"name": "kv", "type": {"type": "map", "values": "long"}}
+    ]
+}
+"""
+
 AVRO_SCHEMA_TEST_CASES = {
     "basic":
     AvroSchema(
@@ -73,6 +86,30 @@ AVRO_SCHEMA_TEST_CASES = {
           'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>',
           None), ('number', 'bigint', None),
          ('timestamp_us', 'timestamp_ntz', None), ('', '', ''),
+         ('# Partitioning', '', ''),
+         ('Part 0', 'hours(redpanda.timestamp)', '')]),
+    "with_map":
+    AvroSchema(
+        schema_str=avro_schema_with_map_str,
+        record_generator=lambda t: {
+            "number": int(t),
+            "timestamp_us": int(t * 1000000),
+            "kv": {
+                str(t): int(t)
+            }
+        },
+        expected_trino=
+        [('redpanda',
+          'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)',
+          '', ''), ('number', 'bigint', '', ''),
+         ('timestamp_us', 'timestamp(6)', '', ''),
+         ('kv', 'map(varchar, bigint)', '', '')],
+        expected_spark=
+        [('redpanda',
+          'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>',
+          None), ('number', 'bigint', None),
+         ('timestamp_us', 'timestamp_ntz', None),
+         ('kv', 'map<string,bigint>', None), ('', '', ''),
          ('# Partitioning', '', ''),
          ('Part 0', 'hours(redpanda.timestamp)', '')]),
 }

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -30,6 +30,19 @@ from rptest.services.catalog_service import CatalogType
 from google import protobuf
 from google.protobuf import text_format as pb_text_format, json_format as pb_json_format
 
+
+class AvroSchema:
+    def __init__(self, schema_str, record_generator, expected_trino,
+                 expected_spark):
+        self.schema_str = schema_str
+        self.record_generator = record_generator
+        self.expected_trino = expected_trino
+        self.expected_spark = expected_spark
+
+    def generate_record(self, t):
+        return self.record_generator(t)
+
+
 avro_schema_str = """
 {
     "type": "record",
@@ -41,6 +54,28 @@ avro_schema_str = """
     ]
 }
 """
+
+AVRO_SCHEMA_TEST_CASES = {
+    "basic":
+    AvroSchema(
+        schema_str=avro_schema_str,
+        record_generator=lambda t: {
+            "number": int(t),
+            "timestamp_us": int(t * 1000000)
+        },
+        expected_trino=
+        [('redpanda',
+          'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)',
+          '', ''), ('number', 'bigint', '', ''),
+         ('timestamp_us', 'timestamp(6)', '', '')],
+        expected_spark=
+        [('redpanda',
+          'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>',
+          None), ('number', 'bigint', None),
+         ('timestamp_us', 'timestamp_ntz', None), ('', '', ''),
+         ('# Partitioning', '', ''),
+         ('Part 0', 'hours(redpanda.timestamp)', '')]),
+}
 
 
 class DatalakeE2ETests(RedpandaTest):
@@ -84,8 +119,10 @@ class DatalakeE2ETests(RedpandaTest):
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=supported_storage_types(),
             query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
-            catalog_type=supported_catalog_types())
-    def test_avro_schema(self, cloud_storage_type, query_engine, catalog_type):
+            catalog_type=supported_catalog_types(),
+            test_case=list(AVRO_SCHEMA_TEST_CASES.keys()))
+    def test_avro_schema(self, cloud_storage_type, query_engine, catalog_type,
+                         test_case):
         count = 100
         table_name = f"redpanda.{self.topic_name}"
 
@@ -95,43 +132,32 @@ class DatalakeE2ETests(RedpandaTest):
                               catalog_type=catalog_type) as dl:
             dl.create_iceberg_enabled_topic(
                 self.topic_name, iceberg_mode="value_schema_id_prefix")
-
-            schema = avro.loads(avro_schema_str)
+            schema = AVRO_SCHEMA_TEST_CASES[test_case]
+            raw_schema = avro.loads(schema.schema_str)
             producer = AvroProducer(
                 {
                     'bootstrap.servers': self.redpanda.brokers(),
                     'schema.registry.url':
                     self.redpanda.schema_reg().split(",")[0]
                 },
-                default_value_schema=schema)
+                default_value_schema=raw_schema)
             for _ in range(count):
                 t = time.time()
-                record = {"number": int(t), "timestamp_us": int(t * 1000000)}
+                record = schema.generate_record(t)
                 producer.produce(topic=self.topic_name, value=record)
             producer.flush()
             dl.wait_for_translation(self.topic_name, msg_count=count)
 
             if query_engine == QueryEngineType.TRINO:
                 trino = dl.trino()
-                trino_expected_out = [(
-                    'redpanda',
-                    'row(partition integer, offset bigint, timestamp timestamp(6), headers array(row(key varbinary, value varbinary)), key varbinary)',
-                    '', ''), ('number', 'bigint', '', ''),
-                                      ('timestamp_us', 'timestamp(6)', '', '')]
+                trino_expected_out = schema.expected_trino
                 trino_describe_out = trino.run_query_fetch_all(
                     f"describe {table_name}")
                 assert trino_describe_out == trino_expected_out, str(
                     trino_describe_out)
             else:
                 spark = dl.spark()
-                spark_expected_out = [(
-                    'redpanda',
-                    'struct<partition:int,offset:bigint,timestamp:timestamp_ntz,headers:array<struct<key:binary,value:binary>>,key:binary>',
-                    None), ('number', 'bigint', None),
-                                      ('timestamp_us', 'timestamp_ntz', None),
-                                      ('', '', ''), ('# Partitioning', '', ''),
-                                      ('Part 0', 'hours(redpanda.timestamp)',
-                                       '')]
+                spark_expected_out = schema.expected_spark
                 spark_describe_out = spark.run_query_fetch_all(
                     f"describe {table_name}")
                 assert spark_describe_out == spark_expected_out, str(


### PR DESCRIPTION
Keys are required per the Iceberg spec: https://iceberg.apache.org/spec/#nested-types.

Before this change, `redpanda` would fail to properly use schemas for tables created with a `map` in the schema, and would incorrectly try to evolve the schema due to the detected difference in `field_required` for the key field in a `map`.

After this fix, schemas with nested `map` types work as expected.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
