### PR TITLE
Datalake Controller/Throttling improvements

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3974,16 +3974,16 @@ configuration::configuration()
       "to the backlog size error. More negative value means larger and faster "
       "changes in the number of shares in the datalake scheduling group.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      -0.0003)
+      -0.000008)
   , iceberg_target_backlog_size(
       *this,
       "iceberg_target_backlog_size",
-      "Average size of the datalake translation backlog, per partition, that "
+      "Total size of the datalake translation backlog that "
       "the backlog controller will try to maintain. When a backlog size is "
       "larger than the setpoint a backlog controller will increase the "
       "translation scheduling group priority.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      5_MiB,
+      100_MiB,
       {.min = 0, .max = std::numeric_limits<uint32_t>::max()})
   , iceberg_delete(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3973,7 +3973,15 @@ configuration::configuration()
       "shares assigned to the datalake scheduling group will be proportional "
       "to the backlog size error.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      0.000008)
+      0.00001)
+  , iceberg_backlog_controller_i_coeff(
+      *this,
+      "iceberg_backlog_controller_i_coeff",
+      "Integral coefficient for the Iceberg backlog controller. The error is "
+      "integrated (accumulated) over time and the aggregated value contributes "
+      "to the datalake translation priority with this coefficient.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.005)
   , iceberg_target_backlog_size(
       *this,
       "iceberg_target_backlog_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3971,10 +3971,9 @@ configuration::configuration()
       "iceberg_backlog_controller_p_coeff",
       "Proportional coefficient for the Iceberg backlog controller. Number of "
       "shares assigned to the datalake scheduling group will be proportional "
-      "to the backlog size error. More negative value means larger and faster "
-      "changes in the number of shares in the datalake scheduling group.",
+      "to the backlog size error.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      -0.000008)
+      0.000008)
   , iceberg_target_backlog_size(
       *this,
       "iceberg_target_backlog_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3992,6 +3992,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100_MiB,
       {.min = 0, .max = std::numeric_limits<uint32_t>::max()})
+  , iceberg_throttle_backlog_size_ratio(
+      *this,
+      "iceberg_throttle_backlog_size_ratio",
+      "Ration of the total backlog size to the disk space at which the "
+      "throttle to iceberg producers is applied",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0.3)
   , iceberg_delete(
       *this,
       "iceberg_delete",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -741,6 +741,7 @@ struct configuration final : public config_store {
     property<double> iceberg_backlog_controller_p_coeff;
     property<double> iceberg_backlog_controller_i_coeff;
     bounded_property<uint32_t> iceberg_target_backlog_size;
+    property<double> iceberg_throttle_backlog_size_ratio;
 
     property<bool> iceberg_delete;
     property<ss::sstring> iceberg_default_partition_spec;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -739,6 +739,7 @@ struct configuration final : public config_store {
     enum_property<datalake_catalog_auth_mode>
       iceberg_rest_catalog_authentication_mode;
     property<double> iceberg_backlog_controller_p_coeff;
+    property<double> iceberg_backlog_controller_i_coeff;
     bounded_property<uint32_t> iceberg_target_backlog_size;
 
     property<bool> iceberg_delete;

--- a/src/v/datalake/backlog_controller.cc
+++ b/src/v/datalake/backlog_controller.cc
@@ -20,7 +20,7 @@
 using namespace std::chrono_literals; // NOLINT
 
 namespace datalake {
-
+static ss::logger dl_ctrl_log{"dl_backlog_controller"};
 backlog_controller::backlog_controller(
   sampling_fn sampling_fn, ss::scheduling_group sg)
   : _sampling_f(std::move(sampling_fn))
@@ -71,7 +71,7 @@ void backlog_controller::update() {
     update = std::clamp(static_cast<int>(update), _min_shares, _max_shares);
 
     vlog(
-      datalake_log.trace,
+      dl_ctrl_log.trace,
       "state update: {{setpoint: {}, current_backlog: {:2f}, current_error: "
       "{:2f}, shares_update: {:2f}}}, total_err: {:2f}, i contribution: {:2f}",
       _setpoint(),

--- a/src/v/datalake/backlog_controller.cc
+++ b/src/v/datalake/backlog_controller.cc
@@ -54,7 +54,7 @@ void backlog_controller::update() {
 
     _current_sample = _sampling_f();
 
-    auto current_err = _setpoint() - _current_sample;
+    auto current_err = _current_sample - _setpoint();
     auto update = _proportional_coeff() * current_err;
 
     update = std::clamp(static_cast<int>(update), _min_shares, _max_shares);

--- a/src/v/datalake/backlog_controller.cc
+++ b/src/v/datalake/backlog_controller.cc
@@ -27,8 +27,14 @@ backlog_controller::backlog_controller(
   , _scheduling_group(sg)
   , _proportional_coeff(
       config::shard_local_cfg().iceberg_backlog_controller_p_coeff.bind())
+  , _integral_coeff(
+      config::shard_local_cfg().iceberg_backlog_controller_i_coeff.bind())
   , _setpoint(config::shard_local_cfg().iceberg_target_backlog_size.bind())
-  , _sampling_interval(5s) {}
+  , _sampling_interval(5s) {
+    _setpoint.watch([this] { reset(); });
+    _integral_coeff.watch([this] { reset(); });
+    _proportional_coeff.watch([this] { reset(); });
+}
 
 ss::future<> backlog_controller::start() {
     setup_metrics();
@@ -51,22 +57,29 @@ ss::future<> backlog_controller::stop() {
 
 void backlog_controller::update() {
     using namespace std::chrono_literals;
-
+    auto now = std::chrono::steady_clock::now();
     _current_sample = _sampling_f();
 
     auto current_err = _current_sample - _setpoint();
-    auto update = _proportional_coeff() * current_err;
+    _total_err += (current_err / ((now - _last_sample_time) / 1ms));
+    _last_sample_time = now;
+    // clamp the total error
+    _total_err = std::clamp<long double>(_total_err, 0, 1000000);
+    auto i = _integral_coeff() * _total_err;
+    auto update = _proportional_coeff() * current_err + i;
 
     update = std::clamp(static_cast<int>(update), _min_shares, _max_shares);
 
     vlog(
       datalake_log.trace,
       "state update: {{setpoint: {}, current_backlog: {:2f}, current_error: "
-      "{:2f}, shares_update: {:2f}}}",
+      "{:2f}, shares_update: {:2f}}}, total_err: {:2f}, i contribution: {:2f}",
       _setpoint(),
       _current_sample,
       current_err,
-      update);
+      update,
+      _total_err,
+      i);
 
     _scheduling_group.set_shares(static_cast<float>(update));
 }
@@ -88,4 +101,9 @@ void backlog_controller::setup_metrics() {
       });
 }
 
+void backlog_controller::reset() {
+    _total_err = 0;
+    _current_sample = 0;
+    _last_sample_time = std::chrono::steady_clock::now();
+}
 } // namespace datalake

--- a/src/v/datalake/backlog_controller.h
+++ b/src/v/datalake/backlog_controller.h
@@ -54,6 +54,7 @@ private:
      * group.
      */
     config::binding<double> _proportional_coeff;
+    config::binding<double> _integral_coeff;
     /**
      * The target backlog size for the controller to keep. The controller will
      * adjust the scheduling group shares keep the average backlog size close to
@@ -65,6 +66,9 @@ private:
     // Current value of the backlog (currently it is average size of data to
     // translate for datalake enabled partitions)
     long double _current_sample{0};
+    long double _total_err{0};
+    std::chrono::steady_clock::time_point _last_sample_time
+      = std::chrono::steady_clock::now();
     /**
      * Limits for controlled scheduling group shares.
      */
@@ -72,5 +76,6 @@ private:
     int _max_shares{1000};
     ss::abort_source _as;
     metrics::internal_metric_groups _metrics;
+    void reset();
 };
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -140,25 +140,12 @@ datalake_manager::datalake_manager(
   }) {}
 datalake_manager::~datalake_manager() = default;
 
-double datalake_manager::average_translation_backlog() {
-    size_t total_lag = 0;
-    size_t translators_with_backlog = 0;
-    const auto& translators = _scheduler.all_translators();
-    for (const auto& [_, translator] : translators) {
-        auto backlog_size = translator.status().translation_backlog;
-        // skip over translators that are not yet ready to report anything
-        if (!backlog_size) {
-            continue;
-        }
-        total_lag += backlog_size.value();
-        translators_with_backlog++;
+size_t datalake_manager::total_translation_backlog() const {
+    size_t total_backlog = 0;
+    for (const auto& [_, translator] : _scheduler.all_translators()) {
+        total_backlog += translator.status().translation_backlog.value_or(0);
     }
-
-    if (translators_with_backlog == 0) {
-        return 0;
-    }
-
-    return total_lag / translators_with_backlog;
+    return total_backlog;
 }
 
 ss::lw_shared_ptr<class translation_probe>
@@ -266,7 +253,7 @@ ss::future<> datalake_manager::start() {
 
     _schema_cache->start();
     _backlog_controller = std::make_unique<backlog_controller>(
-      [this] { return average_translation_backlog(); }, _sg);
+      [this] { return total_translation_backlog(); }, _sg);
     co_await _backlog_controller->start();
 }
 

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -112,12 +112,16 @@ public:
      */
     static ss::future<> prepare_staging_directory(std::filesystem::path);
 
+    /**
+     * Returns total number of bytes that are ready to be translated for all
+     * datalake enabled partitions on a current shard.
+     */
+    size_t total_translation_backlog() const;
+
 private:
     using translator = std::unique_ptr<translation::partition_translator>;
 
     ss::future<> handle_translator_state_change(const model::ntp&);
-
-    size_t total_translation_backlog() const;
 
     /// \note The probe is created on the first use.
     ss::lw_shared_ptr<translation_probe> get_or_create_probe(const model::ntp&);

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -117,7 +117,7 @@ private:
 
     ss::future<> handle_translator_state_change(const model::ntp&);
 
-    double average_translation_backlog();
+    size_t total_translation_backlog() const;
 
     /// \note The probe is created on the first use.
     ss::lw_shared_ptr<translation_probe> get_or_create_probe(const model::ntp&);

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -370,7 +370,9 @@ redpanda_cc_library(
         "//src/v/container:chunked_hash_map",
         "//src/v/metrics",
         "//src/v/ssx:future_util",
+        "//src/v/storage",
         "//src/v/utils:absl_sstring_hash",
+        "//src/v/utils:human",
         "@seastar",
     ],
 )

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -13,6 +13,7 @@
 #include "kafka/server/logger.h"
 #include "metrics/prometheus_sanitize.h"
 #include "ssx/future-util.h"
+#include "utils/human.h"
 namespace kafka {
 using namespace std::chrono_literals;
 namespace {
@@ -44,37 +45,41 @@ datalake_throttle_manager::status datalake_throttle_manager::status::operator+(
   const datalake_throttle_manager::status& o) const {
     return datalake_throttle_manager::status{
       .max_shares_assigned = max_shares_assigned || o.max_shares_assigned,
-      .overdue_translation_partition_count
-      = overdue_translation_partition_count
-        + o.overdue_translation_partition_count,
-      .partitions_translation_blocked = partitions_translation_blocked
-                                        + o.partitions_translation_blocked};
+      .total_translation_backlog = total_translation_backlog
+                                   + o.total_translation_backlog};
 }
 
-bool datalake_throttle_manager::status::needs_throttling() const {
-    return max_shares_assigned
-           && (overdue_translation_partition_count > 0 || partitions_translation_blocked > 0);
+bool datalake_throttle_manager::needs_throttling() const {
+    // check if disk space info is already available
+    if (!_disk_space_info) [[unlikely]] {
+        return false;
+    }
+    return _translation_status.max_shares_assigned
+           && _translation_status.total_translation_backlog
+                > _backlog_size_throttling_ratio() * _disk_space_info->total;
 }
 
 std::ostream&
 operator<<(std::ostream& o, const datalake_throttle_manager::status& s) {
     fmt::print(
       o,
-      "{{max_shares_assigned: {}, overdue_translation_partition_count: {}, "
-      "partitions_translation_blocked: {}}}",
+      "{{max_shares_assigned: {}, total_translation_backlog: {}}}",
       s.max_shares_assigned,
-      s.overdue_translation_partition_count,
-      s.partitions_translation_blocked);
+      human::bytes(s.total_translation_backlog));
     return o;
 }
 
 datalake_throttle_manager::datalake_throttle_manager(
   status_provider_fn status_provider,
+  ss::sharded<storage::node>& storage_node,
   config::binding<std::chrono::milliseconds> producer_gc_threshold,
-  config::binding<std::chrono::milliseconds> max_kafka_throttle)
+  config::binding<std::chrono::milliseconds> max_kafka_throttle,
+  config::binding<double> backlog_size_throttling_ratio)
   : _shard_status_provider(std::move(status_provider))
+  , _storage_node(storage_node)
   , _producer_gc_threshold(std::move(producer_gc_threshold))
-  , _max_kafka_throttle(std::move(max_kafka_throttle)) {
+  , _max_kafka_throttle(std::move(max_kafka_throttle))
+  , _backlog_size_throttling_ratio(std::move(backlog_size_throttling_ratio)) {
     _update_timer.set_callback([this] {
         ssx::spawn_with_gate(
           _gate, [this] { return gc_and_update_global_producers_map(); });
@@ -89,10 +94,21 @@ void datalake_throttle_manager::start() {
      */
     if (ss::this_shard_id() == 0) {
         _update_timer.arm_periodic(100ms);
+        // storage node is only available on shard 0
+        _storage_node_notification
+          = _storage_node.local().register_disk_notification(
+            storage::node::disk_type::data,
+            [this](storage::node::disk_space_info dsi) {
+                _disk_space_info = dsi;
+            });
     }
 }
 
 ss::future<> datalake_throttle_manager::stop() {
+    if (ss::this_shard_id() == 0) {
+        _storage_node.local().unregister_disk_notification(
+          storage::node::disk_type::data, _storage_node_notification);
+    }
     _update_timer.cancel();
     return _gate.close();
 }
@@ -116,10 +132,15 @@ ss::future<> datalake_throttle_manager::gc_and_update_global_producers_map() {
       },
       status{},
       [](status acc, status shard_status) { return acc + shard_status; });
-    if (!_translation_status.needs_throttling()) {
+
+    if (!needs_throttling()) {
         _last_no_issues_timestamp = clock_type::now();
     }
-    if (_translation_status.needs_throttling()) [[unlikely]] {
+    /*
+     * Info level log if throttling may be applied, this should be a rare
+     * condition.
+     */
+    if (needs_throttling()) [[unlikely]] {
         vlog(
           client_quota_log.info,
           "Translation status updated: {}, throttling may be applied.",
@@ -134,8 +155,10 @@ ss::future<> datalake_throttle_manager::gc_and_update_global_producers_map() {
       boost::irange(ss::smp::count), [this](auto shard_id) {
           return container().invoke_on(
             shard_id,
-            [status = _translation_status](datalake_throttle_manager& other) {
+            [status = _translation_status, disk_space_info = _disk_space_info](
+              datalake_throttle_manager& other) {
                 other._translation_status = status;
+                other._disk_space_info = disk_space_info;
                 return std::exchange(other._shard_local_producers, {});
             });
       });
@@ -155,7 +178,7 @@ datalake_throttle_manager::maybe_throttle_producer(
   std::optional<std::string_view> client_id) {
     // fast path, backlog is below the threshold
 
-    if (!_translation_status.needs_throttling()) [[likely]] {
+    if (!needs_throttling()) [[likely]] {
         co_return no_throttling;
     }
 
@@ -166,10 +189,15 @@ datalake_throttle_manager::maybe_throttle_producer(
               vlog(
                 client_quota_log.debug,
                 "Throttling producer {} for {}ms, current "
-                "status: {}",
+                "status: {}, disk total space: {}, translation backlog "
+                "throttling threshold: {}",
                 client_id,
                 throttle_ms,
-                shard_0_manager._translation_status);
+                shard_0_manager._translation_status,
+                human::bytes(shard_0_manager._disk_space_info->total),
+                human::bytes(
+                  shard_0_manager._backlog_size_throttling_ratio()
+                  * shard_0_manager._disk_space_info->total));
           }
           return throttle_ms;
       });
@@ -185,7 +213,7 @@ std::chrono::milliseconds datalake_throttle_manager::get_producer_throttle(
   const std::optional<std::string_view>& client_id) {
     vassert(
       ss::this_shard_id() == 0, "Throttle can only be calculate on shard 0");
-    if (!_translation_status.needs_throttling()) [[likely]] {
+    if (!needs_throttling()) [[likely]] {
         return no_throttling;
     }
     auto effective_client_id = get_effective_client_id(client_id);
@@ -203,29 +231,26 @@ std::chrono::milliseconds
 datalake_throttle_manager::calculate_throttle() const {
     vassert(
       ss::this_shard_id() == 0, "Throttle can only be calculate on shard 0");
-    if (_translation_status.partitions_translation_blocked > 0) {
-        // if translation is blocked (this should never really be the case),
-        // use max throttle
-        return _max_kafka_throttle();
+
+    if (!needs_throttling()) {
+        return no_throttling;
     }
     // Heuristic:
     // we apply the incremental throttle based on time spent in the degraded
     // translation state, the longer the time the more we throttle. The
-    // throttle is set to max after 5 minutes
+    // throttle is set to max after 50 minutes
+    auto time_in_degraded_state
+      = std::chrono::duration_cast<std::chrono::milliseconds>(
+        ss::lowres_clock::now() - _last_no_issues_timestamp);
 
-    if (_translation_status.overdue_translation_partition_count > 0) {
-        auto time_in_degraded_state
-          = std::chrono::duration_cast<std::chrono::milliseconds>(
-            ss::lowres_clock::now() - _last_no_issues_timestamp);
+    static constexpr auto max_throttle_time = std::chrono::milliseconds(50min);
+    const auto max_throttle_ratio = std::min(
+      static_cast<double>(time_in_degraded_state.count())
+        / max_throttle_time.count(),
+      1.0);
 
-        const auto max_throttle_ratio = std::min(
-          double(time_in_degraded_state.count()) / 300000, 1.0);
-
-        return std::chrono::milliseconds(static_cast<size_t>(
-          max_throttle_ratio * _max_kafka_throttle().count()));
-    }
-
-    return 0ms;
+    return std::chrono::milliseconds(
+      static_cast<size_t>(max_throttle_ratio * _max_kafka_throttle().count()));
 }
 
 void datalake_throttle_manager::setup_metrics() {

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -175,6 +175,9 @@ datalake_throttle_manager::maybe_throttle_producer(
       });
     // record throttle for exposing a metric
     _total_throttle += throttle_ms.count();
+    if (throttle_ms > 0ms) {
+        _throttled_requests++;
+    }
     co_return throttle_ms;
 }
 
@@ -238,6 +241,10 @@ void datalake_throttle_manager::setup_metrics() {
           [this] { return _total_throttle; },
           sm::description(
             "Total datalake producer throttle time in milliseconds")),
+        sm::make_counter(
+          "throttled_requests",
+          [this] { return _throttled_requests; },
+          sm::description("Number of requests throttled")),
       });
 }
 

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -12,6 +12,7 @@
 #include "config/property.h"
 #include "container/chunked_hash_map.h"
 #include "metrics/metrics.h"
+#include "storage/node.h"
 #include "utils/absl_sstring_hash.h"
 
 #include <seastar/core/future.hh>
@@ -36,10 +37,8 @@ class datalake_throttle_manager
 public:
     struct status {
         bool max_shares_assigned{false};
-        size_t overdue_translation_partition_count{0};
-        size_t partitions_translation_blocked{0};
+        size_t total_translation_backlog{0};
 
-        bool needs_throttling() const;
         status operator+(const status& o) const;
 
         friend std::ostream& operator<<(std::ostream&, const status&);
@@ -54,8 +53,10 @@ public:
 
     datalake_throttle_manager(
       status_provider_fn,
+      ss::sharded<storage::node>&,
       config::binding<std::chrono::milliseconds>,
-      config::binding<std::chrono::milliseconds>);
+      config::binding<std::chrono::milliseconds>,
+      config::binding<double>);
 
     void start();
     ss::future<> stop();
@@ -89,9 +90,13 @@ private:
 
     void setup_metrics();
 
+    bool needs_throttling() const;
+
     status_provider_fn _shard_status_provider;
+    ss::sharded<storage::node>& _storage_node;
     config::binding<std::chrono::milliseconds> _producer_gc_threshold;
     config::binding<std::chrono::milliseconds> _max_kafka_throttle;
+    config::binding<double> _backlog_size_throttling_ratio;
 
     // Timestamp marking a last time when the Iceberg translation reported no
     // issues. This timestamp is used to calculate the throttle, the longer the
@@ -108,6 +113,10 @@ private:
     size_t _total_throttle{0};
     size_t _throttled_requests{0};
     metrics::internal_metric_groups _metrics;
+    storage::node::notification_id _storage_node_notification;
+    // The disk space info is set by the notification on shard 0 and then
+    // propagated to other shards in the update task.
+    std::optional<storage::node::disk_space_info> _disk_space_info;
     ss::gate _gate;
 };
 } // namespace kafka

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -106,6 +106,7 @@ private:
     producers_map_t _shard_local_producers;
     ss::timer<clock_type> _update_timer;
     size_t _total_throttle{0};
+    size_t _throttled_requests{0};
     metrics::internal_metric_groups _metrics;
     ss::gate _gate;
 };

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -11,8 +11,7 @@ using namespace std::chrono_literals;
 
 struct shard_local_state {
     bool max_shares_assigned{false};
-    size_t blocked_translation{0};
-    size_t not_keeping_up{0};
+    size_t total_backlog{0};
     config::mock_property<std::chrono::milliseconds> producer_gc_threshold{
       1min};
     config::mock_property<std::chrono::milliseconds> max_throttle{30s};
@@ -21,30 +20,38 @@ struct shard_local_state {
 struct IcebergThrottlingManagerTest : ::testing::Test {
     void SetUp() override {
         shard_state.start().get();
+        storage_node.start(ss::sstring("/tmp"), ss::sstring("/tmp")).get();
         manager
           .start(
             [this] { return sample(); },
+            std::ref(storage_node),
             ss::sharded_parameter(
               [this] { return shard_state.local().max_throttle.bind(); }),
             ss::sharded_parameter([this] {
                 return shard_state.local().producer_gc_threshold.bind();
-            }))
+            }),
+            ss::sharded_parameter(
+              [] { return config::mock_binding<double>(0.01); }))
           .get();
         manager.invoke_on_all(&kafka::datalake_throttle_manager::start).get();
+        storage_node.local().set_disk_metrics(
+          storage::node::disk_type::data,
+          storage::node::disk_space_info{
+            .total = 8_GiB,
+            .free = 6_GiB,
+          });
     }
 
     void TearDown() override {
         manager.stop().get();
+        storage_node.stop().get();
         shard_state.stop().get();
     }
 
     ss::future<kafka::datalake_throttle_manager::status> sample() {
         co_return kafka::datalake_throttle_manager::status{
           .max_shares_assigned = shard_state.local().max_shares_assigned,
-          .overdue_translation_partition_count
-          = shard_state.local().not_keeping_up,
-          .partitions_translation_blocked
-          = shard_state.local().blocked_translation};
+          .total_translation_backlog = shard_state.local().total_backlog};
     }
 
     ss::future<> wait_for_producer_throttling(
@@ -70,7 +77,7 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
                 });
           });
     }
-
+    ss::sharded<storage::node> storage_node;
     ss::sharded<kafka::datalake_throttle_manager> manager;
     ss::sharded<shard_local_state> shard_state;
 };
@@ -95,8 +102,10 @@ TEST_F(IcebergThrottlingManagerTest, TestThrottlingIcebergEnabledProducer) {
       manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
     // set the backlog above the threshold on one shards, the throttling should
     // not be applied as no max shares is assigned
+
     shard_state
-      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up++; })
+      .invoke_on(
+        0, [](shard_local_state& state) { state.total_backlog = 200_MiB; })
       .get();
 
     ASSERT_EQ(
@@ -106,18 +115,18 @@ TEST_F(IcebergThrottlingManagerTest, TestThrottlingIcebergEnabledProducer) {
       .invoke_on(
         0, [](shard_local_state& state) { state.max_shares_assigned = true; })
       .get();
+    wait_for_producer_throttling("producer-20", 5ms).get();
+    // wait for some more time, the throttle should increase
     wait_for_producer_throttling("producer-20", 10ms).get();
 
-    // wait for some more time, the throttle should increase
-    wait_for_producer_throttling("producer-20", 100ms).get();
-
-    // // non iceberg producer should not be throttled
+    // non iceberg producer should not be throttled
     ASSERT_EQ(
       manager.local().maybe_throttle_producer("producer-20-other").get(), 0ms);
     // when translation status does not report any issues, the producer should
     // not be throttled
     shard_state
-      .invoke_on(0, [](shard_local_state& state) { state.not_keeping_up = 0; })
+      .invoke_on(
+        0, [](shard_local_state& state) { state.total_backlog = 10_MiB; })
       .get();
     wait_for_no_throttling("producer-20").get();
 }
@@ -131,10 +140,10 @@ TEST_F(IcebergThrottlingManagerTest, TestProducerEviction) {
         0,
         [](shard_local_state& state) {
             state.max_shares_assigned = true;
-            state.not_keeping_up++;
+            state.total_backlog = 100_MiB;
         })
       .get();
-    wait_for_producer_throttling("producer-20", 10ms).get();
+    wait_for_producer_throttling("producer-20", 3ms).get();
     shard_state
       .invoke_on_all([](shard_local_state& state) {
           state.producer_gc_threshold.update(1s);
@@ -161,40 +170,9 @@ TEST_F(IcebergThrottlingManagerTest, TestHandlingAnonymousProducers) {
         0,
         [](shard_local_state& state) {
             state.max_shares_assigned = true;
-            state.not_keeping_up++;
+            state.total_backlog = 100_MiB;
         })
       .get();
     // check if anonymous producer is throttled
-    wait_for_producer_throttling(std::nullopt, 10ms).get();
-}
-
-TEST_F(IcebergThrottlingManagerTest, TestHandlingBlockedPartitions) {
-    mark_producers_on_random_shards(manager, 100).get();
-    // wait for a while for state to propagate across shards
-    ss::sleep(500ms).get();
-    ASSERT_EQ(
-      manager.local().maybe_throttle_producer("producer-20").get(), 0ms);
-    // set the backlog above the threshold on one shards, the throttling should
-    // be applied
-    shard_state
-      .invoke_on(
-        0,
-        [](shard_local_state& state) {
-            state.max_shares_assigned = true;
-            state.blocked_translation++;
-        })
-      .get();
-    // the max throttle should be applied,
-    wait_for_producer_throttling("producer-20", 30s).get();
-
-    // // non iceberg producer should not be throttled
-    ASSERT_EQ(
-      manager.local().maybe_throttle_producer("producer-20-other").get(), 0ms);
-    // when translation status does not report any issues, the producer should
-    // not be throttled
-    shard_state
-      .invoke_on(
-        0, [](shard_local_state& state) { state.blocked_translation = 0; })
-      .get();
-    wait_for_no_throttling("producer-20").get();
+    wait_for_producer_throttling(std::nullopt, 3ms).get();
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1425,18 +1425,22 @@ void application::wire_up_runtime_services(
           [&mgr = _datalake_manager] {
               return ssx::now(kafka::datalake_throttle_manager::status{
                 .max_shares_assigned = mgr.local().max_shares_assigned(),
-                .overdue_translation_partition_count
-                = mgr.local().overdue_translation_partition_count(),
-                .partitions_translation_blocked
-                = mgr.local().partitions_with_translation_blocked(),
+                .total_translation_backlog
+                = mgr.local().total_translation_backlog(),
+
               });
           },
+          std::ref(storage_node),
           ss::sharded_parameter([] {
               return config::shard_local_cfg()
                 .max_kafka_throttle_delay_ms.bind();
           }),
           ss::sharded_parameter([] {
               return config::shard_local_cfg().quota_manager_gc_sec.bind();
+          }),
+          ss::sharded_parameter([] {
+              return config::shard_local_cfg()
+                .iceberg_throttle_backlog_size_ratio.bind();
           }))
           .get();
 

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -11,6 +11,7 @@ import re
 import time
 from rptest.clients.default import DefaultClient
 from rptest.clients.rpk import RpkTool, TopicSpec
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from random import randint
 
@@ -104,9 +105,21 @@ class DatalakeThrottlingTest(RedpandaTest):
                 "iceberg_target_backlog_size":
                 1000,
                 "iceberg_backlog_controller_p_coeff":
-                1.0
+                1.0,
+                "iceberg_throttle_backlog_size_ratio":
+                0.0005
             })
+            admin = Admin(self.redpanda)
 
+            # Set the disk space to relatively small value
+            new_total = 20 * (1024 * 1024 * 1024)
+            new_free = 10 * (1024 * 1024 * 1024)
+            admin.set_disk_stat_override(
+                "data",
+                self.redpanda.nodes[0],
+                total_bytes=new_total,
+                free_bytes=new_free,
+            )
             # Produce some more messages
             wait_until(lambda: self.producer_throttled(dl), timeout_sec=60)
 

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -92,7 +92,9 @@ class DatalakeThrottlingTest(RedpandaTest):
                 "datalake_scheduler_max_concurrent_translations":
                 0,
                 "iceberg_target_backlog_size":
-                1000
+                1000,
+                "iceberg_backlog_controller_p_coeff":
+                1.0
             })
 
             # Produce some more messages

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -58,14 +58,24 @@ class DatalakeThrottlingTest(RedpandaTest):
         sample = self.redpanda.metrics_sample("total_throttle")
         assert sample is not None, "total_throttle metric not found"
         for s in sample.samples:
-            self.logger.debug(f"metrics sample: {s}")
+            self.logger.debug(f"total throttle - metrics sample: {s}")
+            total += s.value
+        return total
+
+    def _throttled_requests(self):
+        total = 0
+        sample = self.redpanda.metrics_sample("throttled_requests")
+        assert sample is not None, "throttled_requests metric not found"
+        for s in sample.samples:
+            self.logger.debug(f"requests throttled - metrics sample: {s}")
             total += s.value
         return total
 
     def producer_throttled(self, dl: DatalakeServices):
         dl.produce_to_topic(self.topic_name, 128, 10240)
         throttle = self._total_throttle()
-        return throttle > 0
+        throttled_requests = self._throttled_requests()
+        return throttle > 0 and throttled_requests > 0
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types(),


### PR DESCRIPTION
## Backlog controller

Changed backlog controller to use the total translation backlog as a metric. The total translation backlog (amount of data ready to be translated) is proportional to the amount of work related with translation. Using the total backlog is better than using an average backlog as it can be very different for different partitions. The backlog size may depend on the schema type the produce rate, target lag. Using total backlog the controller adjust the CPU time dedicated for translation process and the scheduler redistributes the time based on the scheduling policy.

## Throttle manager

Changed the throttle manager to throttle based on the size of the translation backlog instead of the target lag. The target lat is a hint for the scheduler allowing it to prioritise the translation based on the user level settings. The throttling previously was checking if the partition translation overdue the lag. This mechanism was to sensitive for small traffic spikes and this way Redpanda was aggressively throttling Iceberg producers. Change the mechanism to throttle only if current total translation backlog is greater than the configurable percentage of the disk space. 


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none