### PR TITLE
archival: Enable archiver manager by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1921,7 +1921,7 @@ configuration::configuration()
       "cloud_storage_disable_archiver_manager",
       "Use legacy upload mode and do not start archiver_manager.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
-      true)
+      false)
   , cloud_storage_access_key(
       *this,
       "cloud_storage_access_key",


### PR DESCRIPTION
The archiver_manager component is currently disabled by default. When it's disabled the `ntp_archiver` instances are managed by the `cluster::partition`. When the partition is created it creates the archiver and starts it. The archiver is never stopped until the partition is stopped or some operations are performed. The operations are: unsafe manifest reset and topic config change (e.g. compaction is enabled).

During the leadership transfer the archiver is not stopped. Instead of that 'prepare_transfer_leadership' and 'complete_transfer_leadership' methods of the archiver are invoked. The methods are uploading the recent version of the manifest and making sure that there are no orphan segments in the cloud.

The 'archiver_manager' is a new component that manages 'ntp_archiver' instances separately from the 'cluster::partition'. With 'archiver_manager' some features (e.g. force flusing archiver) will not work at the moment. Also, the manager currently stops the archiver when the leadership is lost instead of transferring the leadership.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none