### PR TITLE
datalake: fine tune timeouts

### DIFF
--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -33,8 +33,6 @@
 
 constexpr std::chrono::milliseconds translation_jitter{500};
 constexpr std::chrono::milliseconds translation_jitter_base{5000};
-static constexpr std::chrono::milliseconds retry_initial_backoff{300};
-static constexpr std::chrono::milliseconds retry_max_timeout{3min};
 static constexpr std::string_view iceberg_data_path_prefix = "data";
 
 namespace datalake {
@@ -562,9 +560,7 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
       std::move(translation_ctx),
       std::move(lag_tracker),
       simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>{
-        translation_jitter_base, translation_jitter},
-      retry_max_timeout,
-      retry_initial_backoff);
+        translation_jitter_base, translation_jitter});
 
     auto add_f = co_await ss::coroutine::as_future(
       _scheduler.add_translator(std::move(translator)));

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -129,6 +129,9 @@ redpanda_cc_library(
     hdrs = [
         "partition_translator.h",
     ],
+    implementation_deps = [
+        "//src/v/ssx:watchdog",
+    ],
     include_prefix = "datalake/translation",
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -228,6 +228,8 @@ public:
     /**
      * Cleans up state and uploads data to cloud storage. Should be called in
      * all cases for appropriate cleanup.
+     * This is called outside of translation scheduler context so it does not
+     * block translation of other partitions.
      */
     virtual ss::future<
       checked<coordinator::translated_offset_range, translation_errc>>

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -13,6 +13,8 @@
 #include "config/configuration.h"
 #include "datalake/logger.h"
 #include "resource_mgmt/io_priority.h"
+#include "ssx/watchdog.h"
+#include "utils/retry_chain_node.h"
 #include "utils/to_string.h"
 
 #include <seastar/coroutine/as_future.hh>
@@ -367,8 +369,9 @@ ss::future<bool> partition_translator::finish_inflight_translation(
     }
 
     auto last_translated_offset = translation_result.last_offset;
+    auto checkpoint_rcn = retry_chain_node(1min, 100ms, &rcn);
     auto checkpoint_result = co_await checkpoint_translation_result(
-      rcn, std::move(translation_result));
+      checkpoint_rcn, std::move(translation_result));
     if (checkpoint_result.errc != coordinator::errc::ok) {
         vlog(
           _logger.warn,
@@ -390,9 +393,13 @@ ss::future<bool> partition_translator::finish_inflight_translation(
       last_translated_offset,
       translated_offset_ts);
 
+    // Generous timeout to let STM catch up and avoid throwing work away on slow
+    // operations. By this point we have accumulated translation data and
+    // erroring out here would mean we need to re-translate the data.
+    // Better wait a bit longer.
     auto replicate_result
       = co_await _data_source->replicate_highest_translated_offset(
-        last_translated_offset, translated_offset_ts, _term, wait_timeout, _as);
+        last_translated_offset, translated_offset_ts, _term, 1min, _as);
     if (replicate_result) {
         vlog(
           _logger.warn,
@@ -414,7 +421,6 @@ ss::future<> partition_translator::translate_until_stopped() {
         if (needs_jitter) {
             co_await ss::sleep_abortable(_jitter.next_duration(), _as);
         }
-        retry_chain_node rcn{_as, _retry_max_timeout, _retry_initial_backoff};
         // We'll keep track of if we exit early out of this iteration, in which
         // case the next iteration should see some jitter.
         auto scoped_set_jitter = ss::defer(
@@ -427,7 +433,8 @@ ss::future<> partition_translator::translate_until_stopped() {
         auto clear_finish_request = ss::defer(
           [this] { _finish_translation_requested = false; });
 
-        auto offsets = co_await fetch_translation_offsets(rcn);
+        retry_chain_node fetch_offsets_rcn{_as, 1min, 100ms};
+        auto offsets = co_await fetch_translation_offsets(fetch_offsets_rcn);
         // this test of the finish translation request flag works here because
         // we are executing in a polling loop.
         auto finish_now = _finish_translation_requested
@@ -451,8 +458,30 @@ ss::future<> partition_translator::translate_until_stopped() {
             finish_now = translate_f.get();
         }
         if (finish_now || should_finish_inflight_translation()) {
+            // No global timeout for finishing. We are not blocking the
+            // scheduler here and if we can't make progress on this partition
+            // timing out/retrying can't help but wastes work.
+            retry_chain_node finish_rcn{
+              _as, ss::lowres_clock::time_point::max(), 100ms};
+
+            ssx::watchdog wd1min(1min, [ntp = _data_source->ntp()] {
+                vlog(
+                  datalake_log.debug,
+                  "Finishing inflight translation is taking more than 5min for "
+                  "{}",
+                  ntp);
+            });
+
+            ssx::watchdog wd5min(5min, [ntp = _data_source->ntp()] {
+                vlog(
+                  datalake_log.debug,
+                  "Finishing inflight translation is taking more than 5min "
+                  "for {}",
+                  ntp);
+            });
+
             auto success = co_await finish_inflight_translation(
-              offsets->coordinator_lto, rcn);
+              offsets->coordinator_lto, finish_rcn);
             if (!success) {
                 continue;
             }

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -74,17 +74,13 @@ partition_translator::partition_translator(
   std::unique_ptr<data_source> data_source,
   std::unique_ptr<translation_context> translation_ctx,
   std::unique_ptr<translation_lag_tracker> lag_tracker,
-  jitter_t jitter,
-  std::chrono::milliseconds retry_max_timeout,
-  std::chrono::milliseconds retry_initial_backoff)
+  jitter_t jitter)
   : _sg(sg)
   , _coordinator(std::move(coordinator))
   , _data_source(std::move(data_source))
   , _translation_ctx(std::move(translation_ctx))
   , _lag_tracking(std::move(lag_tracker))
   , _jitter{std::move(jitter)}
-  , _retry_max_timeout(retry_max_timeout)
-  , _retry_initial_backoff(retry_initial_backoff)
   , _term(_data_source->term())
   , _logger(
       datalake_log, fmt::format("{}-term-{}", _data_source->ntp(), _term)) {}

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -74,9 +74,7 @@ public:
       std::unique_ptr<data_source>,
       std::unique_ptr<translation_context>,
       std::unique_ptr<translation_lag_tracker>,
-      jitter_t jitter,
-      std::chrono::milliseconds retry_max_timeout,
-      std::chrono::milliseconds retry_initial_backoff);
+      jitter_t jitter);
 
     const scheduling::translator_id& id() const final;
 
@@ -189,8 +187,6 @@ private:
     std::unique_ptr<translation_lag_tracker> _lag_tracking;
     // TODO: consider baking backoff into the scheduler on translation failure.
     jitter_t _jitter;
-    std::chrono::milliseconds _retry_max_timeout;
-    std::chrono::milliseconds _retry_initial_backoff;
     model::term_id _term;
     prefix_logger _logger;
     bool _initialized = false;

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -420,9 +420,7 @@ protected:
             std::make_unique<fake_translation_ctx>(ctx),
             std::make_unique<fake_lag_tracker>(ctx),
             simple_time_jitter<ss::lowres_clock, std::chrono::milliseconds>{
-              retry_max_timeout, retry_initial_backoff},
-            retry_max_timeout,
-            retry_initial_backoff));
+              retry_max_timeout, retry_initial_backoff}));
     }
 
     fake_test_ctx& make_test_context() {

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -13,10 +13,14 @@
 #include "datalake/logger.h"
 #include "datalake/record_multiplexer.h"
 #include "iceberg/values_bytes.h"
+#include "utils/retry_chain_node.h"
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/seastar.hh>
 namespace datalake {
+
+using namespace std::chrono_literals;
+
 namespace {
 
 translation_task::errc map_error_code(cloud_data_io::errc errc) {
@@ -63,8 +67,17 @@ ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
       file.table_location / remote_path_prefix / file.partition_key_path
       / file.local_file.path().filename()};
 
+    // (Approximate because I'm ignoring backoff) ~5 retries at 1
+    // MiB/s with 10s overhead for acquiring/waiting/connecting a connection
+    // from the client pool. Very conservative.
+    const auto expected_upload_duration
+      = 5 * (10s + file.local_file.size_bytes / 1_MiB * 1s);
+
+    auto upload_rcn = retry_chain_node(
+      expected_upload_duration, 100ms, &parent_rcn);
+
     auto result = co_await _cloud_io.upload_data_file(
-      file.local_file, file_remote_path, parent_rcn, lazy_as);
+      file.local_file, file_remote_path, upload_rcn, lazy_as);
     if (result.has_error()) {
         vlog(
           datalake_log.warn,

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -629,7 +629,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                              "number": n,
                              "timestamp_us": int(t + n),
                          },
-                         wait_time_s=300)
+                         wait_time_s=900)
 
             describe_partitioning = self.describe_partitioning(dl, topic_name)
             expected_partitioning = [


### PR DESCRIPTION
Follow up work is needed to limit maximum concurrent partitions doing upload to limit memory usage?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
