### PR TITLE
`config`: reduce `min_cleanable_dirty_ratio` default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1018,9 +1018,9 @@ configuration::configuration()
       "The topic property `min.cleanable.dirty.ratio` overrides the value of "
       "`min_cleanable_dirty_ratio` at the topic level.",
       {.needs_restart = needs_restart::no,
-       .example = "0.5",
+       .example = "0.2",
        .visibility = visibility::user},
-      0.5,
+      0.2,
       {.min = 0.0, .max = 1.0})
   , log_disable_housekeeping_for_tests(
       *this,

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -316,7 +316,7 @@ class DescribeTopicsTest(RedpandaTest):
             "min.cleanable.dirty.ratio":
             ConfigProperty(
                 config_type="DOUBLE",
-                value="0.5",
+                value="0.2",
                 doc_string=
                 "The minimum ratio between the number of bytes in \"dirty\" segments and "
                 "the total number of bytes in closed segments that must be reached "


### PR DESCRIPTION
The previous default of `0.5` was chosen to be in line with the default value of `min.cleanable.dirty.ratio` in Kafka.

However, to be more conservative about the change in `redpanda` behavior from unconditionally compacting every log every `log_compaction_interval_ms` to _perhaps_ compacting _some_ logs every `log_compaction_interval_ms`, a lower default value of `0.2` will be at least a little bit closer to the current status quo, and a less dramatic change for users.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
