### PR TITLE
iceberg: fix protobuf timestamps

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -294,6 +294,7 @@ redpanda_cc_library(
         "//src/v/iceberg:values",
         "//src/v/serde/protobuf",
         "//src/v/ssx:future_util",
+        "@abseil-cpp//absl/time",
         "@fmt",
         "@protobuf",
         "@seastar",

--- a/src/v/datalake/schema_protobuf.cc
+++ b/src/v/datalake/schema_protobuf.cc
@@ -15,6 +15,7 @@
 #include "iceberg/datatypes.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/util/defer.hh>
 
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
@@ -59,7 +60,9 @@ struct_outcome struct_from_protobuf(
           msg.DebugString(),
           max_recursion_depth));
     }
+
     stack.push_back(&msg);
+    auto pop_stack = ss::defer([&stack] { stack.pop_back(); });
     iceberg::struct_type struct_t;
     struct_t.fields.reserve(msg.field_count());
     for (int i = 0; i < msg.field_count(); ++i) {
@@ -146,15 +149,12 @@ field_outcome from_protobuf(
           fd.type_name()));
     case pb::FieldDescriptor::TYPE_MESSAGE: {
         auto msg_t = fd.message_type();
-
         // special case for handling google.protobuf.Timestamp
         if (
           msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_TIMESTAMP) {
             return success(fd, iceberg::timestamp_type{});
         }
-
         auto st_result = struct_from_protobuf(*msg_t, stack);
-        stack.pop_back();
         if (st_result.has_error()) {
             return st_result.error();
         }

--- a/src/v/datalake/tests/BUILD
+++ b/src/v/datalake/tests/BUILD
@@ -9,6 +9,7 @@ proto_library(
 proto_library(
     name = "complex_proto",
     srcs = ["testdata/complex.proto"],
+    deps = ["@protobuf//:timestamp_proto"],
 )
 
 proto_library(

--- a/src/v/datalake/tests/datalake_protobuf_tests.cc
+++ b/src/v/datalake/tests/datalake_protobuf_tests.cc
@@ -178,6 +178,15 @@ TEST_CORO(SchemaProtobuf, TestMessageWithOneOfField) {
         IsField(4, "oneof_bool", boolean_type{})));
 }
 
+TEST_CORO(SchemaProtobuf, TestMessageWithTimestamp) {
+    auto d = StructWithTimestamp::GetDescriptor();
+    auto result = datalake::type_to_iceberg(*d);
+    ASSERT_FALSE_CORO(result.has_error());
+    auto field = std::move(result.value());
+    EXPECT_THAT(
+      field.fields, ElementsAre(IsField(1, "timestamp", timestamp_type{})));
+}
+
 TEST_CORO(SchemaProtobuf, TestProtoTestMessages) {
     auto d = protobuf_test_messages::editions::TestAllTypesEdition2023::
       GetDescriptor();
@@ -553,6 +562,22 @@ TEST(values_protobuf, TestUInt64Fallback) {
             OptionalIcebergPrimitive<long_value>(-123),
             OptionalIcebergPrimitive<string_value>("123")));
     }
+}
+
+TEST(values_protobuf, TestTimestamp) {
+    StructWithTimestamp ts;
+    ts.mutable_timestamp()->set_seconds(1743540027);
+    ts.mutable_timestamp()->set_nanos(1635902);
+    auto result = serialize_and_convert(ts).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_THAT(
+      struct_v->fields,
+      ElementsAre(OptionalIcebergPrimitive<timestamp_value>(1743540027001635)));
 }
 
 TEST_CORO(values_protobuf, TestNotSupportedMessageType) {

--- a/src/v/datalake/tests/testdata/complex.proto
+++ b/src/v/datalake/tests/testdata/complex.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 enum State {
     ACTIVE = 0;
     DISABLED = 1;
@@ -53,4 +55,8 @@ message StructWithOneOf {
         bytes oneof_bytes = 3;
         bool oneof_bool = 4;
     }
+}
+
+message StructWithTimestamp {
+    google.protobuf.Timestamp timestamp = 1;
 }

--- a/src/v/datalake/values_protobuf.cc
+++ b/src/v/datalake/values_protobuf.cc
@@ -20,6 +20,7 @@
 #include <seastar/util/log.hh>
 #include <seastar/util/variant_utils.hh>
 
+#include <absl/time/time.h>
 #include <fmt/core.h>
 
 namespace datalake {
@@ -209,6 +210,25 @@ ss::future<optional_value_outcome> convert_map(
     co_return ret;
 }
 
+ss::future<optional_value_outcome>
+convert_timestamp(std::unique_ptr<parsed::message> message) {
+    if (message == nullptr) {
+        co_return std::nullopt;
+    }
+    constexpr int seconds_tag = 1;
+    constexpr int nanos_tag = 2;
+    auto it = message->fields.find(seconds_tag);
+    absl::Time ts = absl::UnixEpoch();
+    if (it != message->fields.end()) {
+        ts += absl::Seconds(std::get<int64_t>(std::move(it->second)));
+    }
+    it = message->fields.find(nanos_tag);
+    if (it != message->fields.end()) {
+        ts += absl::Nanoseconds(std::get<int32_t>(std::move(it->second)));
+    }
+    co_return value_outcome{iceberg::timestamp_value{absl::ToUnixMicros(ts)}};
+}
+
 ss::future<optional_value_outcome> message_field_to_value(
   std::optional<parsed::message::field> field,
   const pb::FieldDescriptor& field_descriptor,
@@ -291,7 +311,11 @@ ss::future<optional_value_outcome> single_field_to_value(
             msg_field = std::get<std::unique_ptr<parsed::message>>(
               std::move(field.value()));
         }
-
+        if (
+          field_descriptor.message_type()->well_known_type()
+          == pb::Descriptor::WELLKNOWNTYPE_TIMESTAMP) {
+            co_return co_await convert_timestamp(std::move(msg_field));
+        }
         co_return co_await message_to_value(
           std::move(msg_field), *field_descriptor.message_type(), stack);
     }

--- a/src/v/datalake/values_protobuf.cc
+++ b/src/v/datalake/values_protobuf.cc
@@ -16,6 +16,7 @@
 #include "iceberg/values.h"
 #include "ssx/future-util.h"
 
+#include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -324,7 +325,9 @@ ss::future<optional_value_outcome> message_to_value(
           "Reached maximum recursion depth. Descriptor: {}",
           descriptor.DebugString()));
     }
+
     stack.push_back(&descriptor);
+    auto pop_stack = ss::defer([&stack] { stack.pop_back(); });
     auto ret = std::make_unique<iceberg::struct_value>();
     ret->fields.reserve(descriptor.field_count());
     /**
@@ -347,7 +350,6 @@ ss::future<optional_value_outcome> message_to_value(
         }
         ret->fields.push_back(std::move(result.value()));
     }
-    stack.pop_back();
     co_return ret;
 }
 } // namespace


### PR DESCRIPTION
- **datalake: use defer**
- **datalake/protobuf: fix conversion into well known timestamps**

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
