### PR TITLE
CORE-8496 k/server: improve full disk produce error response

### DIFF
--- a/src/v/kafka/protocol/produce.h
+++ b/src/v/kafka/protocol/produce.h
@@ -67,7 +67,7 @@ struct produce_request final {
     produce_response make_error_response(
       error_code error,
       const std::optional<ss::sstring>& error_msg = std::nullopt) const;
-    produce_response make_full_disk_response() const;
+    produce_response make_full_disk_response(api_version) const;
 
     /// True if the request contains a batch with a transactional id.
     bool has_transactional = false;

--- a/src/v/kafka/protocol/produce.h
+++ b/src/v/kafka/protocol/produce.h
@@ -64,7 +64,9 @@ struct produce_request final {
     /**
      * Build a generic error response for a given request.
      */
-    produce_response make_error_response(error_code error) const;
+    produce_response make_error_response(
+      error_code error,
+      const std::optional<ss::sstring>& error_msg = std::nullopt) const;
     produce_response make_full_disk_response() const;
 
     /// True if the request contains a batch with a transactional id.

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -620,8 +620,14 @@ produce_response produce_request::make_error_response(
     return response;
 }
 
-produce_response produce_request::make_full_disk_response() const {
-    auto resp = make_error_response(error_code::broker_not_available);
+produce_response
+produce_request::make_full_disk_response(api_version version) const {
+    // Version 4 is the same as version 3, but the requester must be prepared to
+    // handle a KAFKA_STORAGE_ERROR.
+    auto errc = version >= api_version(4) ? error_code::kafka_storage_error
+                                          : error_code::broker_not_available;
+    auto resp = make_error_response(
+      errc, "no disk space; bytes free less than configurable threshold");
     // TODO set a field in response to signal to quota manager to throttle the
     // client
     return resp;
@@ -667,7 +673,7 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
           ctx.connection()->client_port());
 
         return process_result_stages::single_stage(
-          ctx.respond(request.make_full_disk_response()));
+          ctx.respond(request.make_full_disk_response(ctx.header().version)));
     }
 
     // Account for special internal topic bytes for usage

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -41,8 +41,9 @@ static constexpr auto despam_interval = std::chrono::minutes(5);
 void fill_response_with_errors(
   produce_request::topic_cit topics_begin,
   produce_request::topic_cit topics_end,
+  produce_response& response,
   error_code error,
-  produce_response& response) {
+  const std::optional<ss::sstring>& error_msg = std::nullopt) {
     size_t cnt = std::distance(topics_begin, topics_end);
     response.data.responses.reserve(response.data.responses.size() + cnt);
     for (const auto& topic : std::views::counted(topics_begin, cnt)) {
@@ -53,7 +54,8 @@ void fill_response_with_errors(
         for (const auto& partition : topic.partitions) {
             t.partitions.push_back(produce_response::partition{
               .partition_index = partition.partition_index,
-              .error_code = error});
+              .error_code = error,
+              .error_message = error_msg});
         }
     }
 }
@@ -610,10 +612,11 @@ std::vector<topic_produce_stages> produce_topics(produce_ctx& octx) {
 }
 } // namespace
 
-produce_response produce_request::make_error_response(error_code error) const {
+produce_response produce_request::make_error_response(
+  error_code error, const std::optional<ss::sstring>& error_msg) const {
     produce_response response;
     fill_response_with_errors(
-      data.topics.cbegin(), data.topics.cend(), error, response);
+      data.topics.cbegin(), data.topics.cend(), response, error, error_msg);
     return response;
 }
 
@@ -763,8 +766,8 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     fill_response_with_errors(
       unauthorized_it,
       request.data.topics.cend(),
-      error_code::topic_authorization_failed,
-      resp);
+      resp,
+      error_code::topic_authorization_failed);
     request.data.topics.erase_to_end(unauthorized_it);
 
     // Make sure to not write into migrated-from topics in their critical stages
@@ -778,8 +781,8 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     fill_response_with_errors(
       migrated_it,
       request.data.topics.cend(),
-      error_code::invalid_topic_exception,
-      resp);
+      resp,
+      error_code::invalid_topic_exception);
     request.data.topics.erase_to_end(migrated_it);
     ss::promise<> dispatched_promise;
     auto dispatched_f = dispatched_promise.get_future();

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -166,17 +166,7 @@ class JavaCompressionTest(EndToEndTest):
             expected_num_segments, compression_type=compression_type.value)
         self.wait_for_compacted_segments(expected_num_segments - 1)
 
-        if compression_type == TopicSpec.CompressionTypes.SNAPPY:
-            # Refer to the Github issue in the function comment above re: the issue with
-            # `snappy` compression for `redpanda` versions pre 25.1 and `kafka-python`
-            # versions pre-fix in https://github.com/dpkp/kafka-python/pull/2483. We should see
-            # consume fail here due to the little-endian encoding of version fields in
-            # the `snappy` header. If the version of `kafka-python` used in ducktape is bumped
-            # to include the above fix, this `expect_exception()` can be removed.
-            with expect_exception(Exception, lambda e: True):
-                self.consume()
-        else:
-            self.consume()
+        self.consume()
 
         # Install the latest version of `redpanda` and restart nodes
         self.redpanda._installer.install(self.redpanda.nodes,

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -15,7 +15,7 @@ from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from kafka import KafkaProducer
-from kafka.errors import BrokerNotAvailableError, NotLeaderForPartitionError
+from kafka.errors import KafkaStorageError, NotLeaderForPartitionError
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -97,7 +97,7 @@ class WriteRejectTest(RedpandaTest):
                     i = i + 1
                     f = producer.send(topic, msg)
                     f.get(30)
-            except BrokerNotAvailableError as e1:
+            except KafkaStorageError as e1:
                 was_blocked = True
                 if expect_blocked:
                     self.logger.info(f"Write rejected as expected: {e1}")

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'ducktape@git+https://github.com/redpanda-data/ducktape.git@a87a474ed802e46a9e3af879240ac41eeebbc905',
         'prometheus-client==0.9.0',
-        'kafka-python==2.0.2',
+        'kafka-python==2.0.6',
         'crc32c==2.2',
         'confluent-kafka==2.6.1',
         'zstandard==0.15.2',


### PR DESCRIPTION
This improves the client-side observability of the scenario when produce
requests are getting rejected due to brokers running out of disk space.

We change the error code to kafka_storage_error conditional on a
sufficiently up to date produce api version, and add a custom error
message to the response.

Note that some older clients that do not know about kafka_storage_error
would handle it as an unknown_error. While kafka_storage_error and
broker_not_available are retriable, unknown_server_error is not. A
retriable error is preferred for easier recovery once disk health
recovers. Hence, we condition the return on supporting at least api
version 4.

The kafka-client version is bumped to get support for the
KafkaStorageError.

Fixes https://redpandadata.atlassian.net/browse/CORE-8496

Relates to https://github.com/redpanda-data/redpanda/issues/24492

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Improvements
* Improve produce error response when produce requests are rejected due to full disk.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
