### PR TITLE
rptest: ensure there are query engines available

### DIFF
--- a/tests/rptest/perf/openmessaging_perf_test.py
+++ b/tests/rptest/perf/openmessaging_perf_test.py
@@ -71,6 +71,6 @@ class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
                                            topology="ensemble")
 
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark_time_min = benchmark.benchmark_time_mins() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()

--- a/tests/rptest/perf/small_batches_test.py
+++ b/tests/rptest/perf/small_batches_test.py
@@ -59,6 +59,6 @@ class SmallBatchesTest(RedpandaTest):
                                            topology="ensemble")
 
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark_time_min = benchmark.benchmark_time_mins() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()

--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -73,7 +73,7 @@ class TSReadOpenmessagingTest(RedpandaTest):
                                            driver=driver_idx,
                                            workload=(workload, validator))
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time_mins(
         ) + TSReadOpenmessagingTest.BENCHMARK_WAIT_TIME_MIN
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -83,7 +83,7 @@ class TSWriteOpenmessagingTest(RedpandaTest):
                                            driver=driver,
                                            workload=(workload, validator))
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time_mins(
         ) + TSWriteOpenmessagingTest.BENCHMARK_WAIT_TIME_MIN
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -188,7 +188,7 @@ def omb_runner(context: TestContext, redpanda: RedpandaServiceCloud,
     # On nodes with lower perf start takes longer than 60 sec
     bench.start(timeout_sec=120)
     try:
-        benchmark_time_min = bench.benchmark_time() + 1
+        benchmark_time_min = bench.benchmark_time_mins() + 1
         bench.wait(timeout_sec=benchmark_time_min * 60)
         yield bench
     except:
@@ -1756,7 +1756,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         consumer.stop()
         consumer.free()
 
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark_time_min = benchmark.benchmark_time_mins() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -93,7 +93,7 @@ class OMBValidationTest(RedpandaCloudTest):
             self.logger.info(
                 f"Starting benchmark attempt {try_count}/{max_retries}.")
             benchmark.start()
-            benchmark_time_min = benchmark.benchmark_time() + 5
+            benchmark_time_min = benchmark.benchmark_time_mins() + 5
             benchmark.wait(timeout_sec=benchmark_time_min * 60)
 
             res = benchmark.check_succeed(raise_exceptions=False)
@@ -471,15 +471,15 @@ class OMBValidationTest(RedpandaCloudTest):
 
         # run the OMB portion of the benchmark and ensure it succeeded
         benchmark.start()
-        omb_seconds = benchmark.benchmark_time() * 60
+        omb_seconds = benchmark.benchmark_time_mins() * 60
         benchmark.wait(timeout_sec=omb_seconds + 300)
 
         assert_no_rejected()
 
         body_runtime = time() - time_before_body
 
-        assert body_runtime >= benchmark.benchmark_time(), \
-            f"unexpectedly short runtime: {body_runtime} vs {benchmark.benchmark_time()}"
+        assert body_runtime >= benchmark.benchmark_time_mins(), \
+            f"unexpectedly short runtime: {body_runtime} vs {benchmark.benchmark_time_mins()}"
 
         assert time() - time_before_swarm < swarm_runtime, (
             f"test ran too long and so swarm will have stopped: "
@@ -650,7 +650,7 @@ class OMBValidationTest(RedpandaCloudTest):
                                            num_workers=self.CLUSTER_NODES - 1,
                                            topology="ensemble")
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark_time_min = benchmark.benchmark_time_mins() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
 
         # check if omb gave errors, but don't process metrics

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -716,7 +716,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             node=bench_node,
             worker_nodes=worker_nodes)
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        benchmark_time_min = benchmark.benchmark_time_mins() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 

--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -97,7 +97,7 @@ class ShardPlacementScaleTest(RedpandaTest):
         return [t for t in rpk.list_topics() if t.startswith('test-topic-')]
 
     def finish_omb(self):
-        benchmark_time_min = self._benchmark.benchmark_time() + 2
+        benchmark_time_min = self._benchmark.benchmark_time_mins() + 2
         self._benchmark.wait(timeout_sec=benchmark_time_min * 60)
         self._benchmark.check_succeed()
 

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -604,7 +604,7 @@ class OpenMessagingBenchmark(Service):
         assert isinstance(v, int), f"value {v} for {key} was not an int"
         return v
 
-    def benchmark_time(self) -> int:
+    def benchmark_time_mins(self) -> int:
         """An estimate of the runtime of the test in minutes. This simply sums the warmup and test runtime so
         is always an underestimate (unless the run fails early), so you should add a few minutes of
         buffer to the returned value to set timeouts."""

--- a/tests/rptest/tests/datalake/datalake_omb_test.py
+++ b/tests/rptest/tests/datalake/datalake_omb_test.py
@@ -152,6 +152,6 @@ class DatalakeOMBTest(RedpandaTest):
             # Ensure 10% of messages were succesfully translated as a basic correctness test.
             dl.wait_for_translation(
                 topic_name,
-                msg_count=(0.1 * benchmark.benchmark_time()) *
+                msg_count=(0.1 * benchmark.benchmark_time() * 60) *
                 (producer_rate_bytes_s // payload_size),
                 op=operator.gt)

--- a/tests/rptest/tests/datalake/datalake_omb_test.py
+++ b/tests/rptest/tests/datalake/datalake_omb_test.py
@@ -145,13 +145,13 @@ class DatalakeOMBTest(RedpandaTest):
                                                topology="ensemble",
                                                local_payload_dir=payloads)
             benchmark.start()
-            benchmark_time_min = benchmark.benchmark_time() + 5
+            benchmark_time_min = benchmark.benchmark_time_mins() + 5
             benchmark.wait(timeout_sec=benchmark_time_min * 60)
             benchmark.check_succeed()
 
             # Ensure 10% of messages were succesfully translated as a basic correctness test.
             dl.wait_for_translation(
                 topic_name,
-                msg_count=(0.1 * benchmark.benchmark_time() * 60) *
+                msg_count=(0.1 * benchmark.benchmark_time_mins() * 60) *
                 (producer_rate_bytes_s // payload_size),
                 op=operator.gt)

--- a/tests/rptest/tests/datalake/datalake_omb_test.py
+++ b/tests/rptest/tests/datalake/datalake_omb_test.py
@@ -11,6 +11,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark, LocalPayloadDirectory
 from rptest.services.openmessaging_benchmark_configs import \
@@ -66,7 +67,7 @@ class DatalakeOMBTest(RedpandaTest):
 
         return msg
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=8)
     @matrix(cloud_storage_type=supported_storage_types())
     def basic_workload_linear_20_test(self, cloud_storage_type):
         topic_name = "atestingtopic"
@@ -79,7 +80,7 @@ class DatalakeOMBTest(RedpandaTest):
 
         with DatalakeServices(self._ctx,
                               redpanda=self.redpanda,
-                              include_query_engines=[],
+                              include_query_engines=[QueryEngineType.SPARK],
                               catalog_type=filesystem_catalog_type()) as dl:
             dl.create_iceberg_enabled_topic(
                 name=topic_name,

--- a/tests/rptest/tests/datalake/datalake_omb_test.py
+++ b/tests/rptest/tests/datalake/datalake_omb_test.py
@@ -24,6 +24,7 @@ from ducktape.mark import matrix
 
 import rptest.tests.datalake.schemas.linear_pb2 as linear_pb2
 
+import operator
 import string
 import random
 
@@ -151,4 +152,5 @@ class DatalakeOMBTest(RedpandaTest):
             dl.wait_for_translation(
                 topic_name,
                 msg_count=(0.1 * benchmark.benchmark_time()) *
-                (producer_rate_bytes_s // payload_size))
+                (producer_rate_bytes_s // payload_size),
+                op=operator.gt)

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -273,7 +273,8 @@ class DatalakeServices():
                     (e.engine_name(), e.count_table("redpanda", table_name)),
                     self.query_engines))
             self.redpanda.logger.debug(
-                f"Current counts for {table_name}: {counts}")
+                f"Current counts for {table_name}: {counts}, want {op=} {msg_count}"
+            )
             return all([op(c, msg_count) for _, c in counts.items()])
 
         wait_until(

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -231,6 +231,10 @@ class DatalakeServices():
         self.wait_for_iceberg_table("redpanda", topic, timeout, backoff_sec)
 
         def translation_done():
+            assert len(
+                self.query_engines
+            ) > 0, "At least one query engine is required to check translation status"
+
             offsets = dict(
                 map(
                     lambda e: (e.engine_name(
@@ -267,6 +271,10 @@ class DatalakeServices():
                                     backoff_sec)
 
         def translation_done():
+            assert len(
+                self.query_engines
+            ) > 0, "At least one query engine is required to check translation status"
+
             counts = dict(
                 map(
                     lambda e:

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -48,7 +48,7 @@ class OpenBenchmarkSelfTest(RedpandaTest):
         benchmark = OpenMessagingBenchmark(self.test_context, self.redpanda,
                                            driver, workload)
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time(
+        benchmark_time_min = benchmark.benchmark_time_mins(
         ) + self.BENCHMARK_WAIT_TIME_MIN
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         # docker runs have high variance in perf numbers, check only in dedicate node


### PR DESCRIPTION
I don't believe this should fail any existing test. Found while developing a new test and it was passing while miss-configured.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
