### PR TITLE
[v25.1.x] rptest: fix property name typo

### DIFF
--- a/tests/rptest/services/catalog_service.py
+++ b/tests/rptest/services/catalog_service.py
@@ -120,7 +120,7 @@ class CatalogService(abc.ABC, Service):
             conf["adlfs.account-key"] = self.credentials.account_key
             # Modern pyiceberg https://github.com/apache/iceberg-python/issues/866
             conf["adls.account-name"] = self.credentials.account_name
-            conf["alds.account-key"] = self.credentials.account_key
+            conf["adls.account-key"] = self.credentials.account_key
         else:
             raise ValueError(
                 f"Unsupported credential type: {type(self.credentials)}")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25700
