### PR TITLE
[v25.1.x] rpk: print how leaders and replicas are distributed across brokers

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/partitions/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/partitions/BUILD
@@ -14,6 +14,7 @@ go_library(
         "toggle.go",
         "transfer_leadership.go",
         "unsafe_recover.go",
+        "util.go",
     ],
     importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/partitions",
     visibility = ["//visibility:public"],

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -30,6 +30,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type response struct {
+	LeaderDistributions  []LeaderDistribution       `json:"leader_distribution" yaml:"leader_distribution"`
+	ReplicaDistributions []ReplicaDistribution      `json:"replica_distribution" yaml:"replica_distribution"`
+	Partitions           []rpadmin.ClusterPartition `json:"partitions" yaml:"partitions"`
+}
+
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
 		all             bool
@@ -86,7 +92,7 @@ List all in json format.
 `,
 		Run: func(cmd *cobra.Command, topics []string) {
 			f := p.Formatter
-			if h, ok := f.Help([]rpadmin.ClusterPartition{}); ok {
+			if h, ok := f.Help(response{}); ok {
 				out.Exit(h)
 			}
 			if len(topics) == 0 && !all {
@@ -172,40 +178,62 @@ List all in json format.
 }
 
 func printClusterPartitions(f config.OutFormatter, clusterPartitions []rpadmin.ClusterPartition) {
+	leaderDist := buildLeaderPerBroker(clusterPartitions)
+	replicaDist := buildReplicaPerBroker(clusterPartitions)
+	types.Sort(leaderDist)
+	types.Sort(replicaDist)
 	types.Sort(clusterPartitions)
-	if isText, _, formatted, err := f.Format(clusterPartitions); !isText {
+	resp := buildResponse(clusterPartitions, leaderDist, replicaDist)
+	if isText, _, formatted, err := f.Format(resp); !isText {
 		out.MaybeDie(err, "unable to print partitions in the required format %q: %v", f.Kind, err)
 		fmt.Println(formatted)
 		return
 	}
-	tw := out.NewTable("NAMESPACE", "TOPIC", "PARTITION", "LEADER-ID", "REPLICA-CORE", "DISABLED")
-	defer tw.Flush()
-	for _, p := range clusterPartitions {
-		var leader, disabled string
-		var replicas []string
-		if p.LeaderID == nil {
-			leader = "-"
-		} else {
-			leader = strconv.Itoa(*p.LeaderID)
-		}
-		if p.Disabled == nil {
-			disabled = "-"
-		} else {
-			disabled = strconv.FormatBool(*p.Disabled)
-		}
 
-		for _, r := range p.Replicas {
-			replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
+	const (
+		secLeaderDist        = "Leader distribution"
+		secReplicaDist       = "Replica distribution"
+		secClusterPartitions = "List of partitions"
+	)
+	sections := out.NewSections(
+		out.ConditionalSectionHeaders(map[string]bool{
+			secLeaderDist:        true,
+			secReplicaDist:       true,
+			secClusterPartitions: true,
+		})...,
+	)
+	sections.Add(secLeaderDist, func() { printLeaderDistribution(leaderDist) })
+	sections.Add(secReplicaDist, func() { printReplicaDistribution(replicaDist) })
+	sections.Add(secClusterPartitions, func() {
+		tw := out.NewTable("NAMESPACE", "TOPIC", "PARTITION", "LEADER-ID", "REPLICA-CORE", "DISABLED")
+		defer tw.Flush()
+		for _, p := range clusterPartitions {
+			var leader, disabled string
+			var replicas []string
+			if p.LeaderID == nil {
+				leader = "-"
+			} else {
+				leader = strconv.Itoa(*p.LeaderID)
+			}
+			if p.Disabled == nil {
+				disabled = "-"
+			} else {
+				disabled = strconv.FormatBool(*p.Disabled)
+			}
+
+			for _, r := range p.Replicas {
+				replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
+			}
+			tw.PrintStructFields(struct {
+				Namespace string
+				Topic     string
+				Partition int
+				LeaderID  string
+				Replicas  []string
+				Disabled  string
+			}{p.Ns, p.Topic, p.PartitionID, leader, replicas, disabled})
 		}
-		tw.PrintStructFields(struct {
-			Namespace string
-			Topic     string
-			Partition int
-			LeaderID  string
-			Replicas  []string
-			Disabled  string
-		}{p.Ns, p.Topic, p.PartitionID, leader, replicas, disabled})
-	}
+	})
 }
 
 // nsTopic splits a topic string consisting of <namespace>/<topicName> and
@@ -283,4 +311,12 @@ func replicaOnBroker(replicas rpadmin.Replicas, nodeIDs []int) bool {
 		}
 	}
 	return foundCount == len(nodeIDs)
+}
+
+func buildResponse(clusterPartitions []rpadmin.ClusterPartition, leaderDist []LeaderDistribution, replicaDist []ReplicaDistribution) response {
+	return response{
+		LeaderDistributions:  leaderDist,
+		ReplicaDistributions: replicaDist,
+		Partitions:           clusterPartitions,
+	}
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/status.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/twmb/types"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -31,7 +32,8 @@ If continuous partition balancing is enabled, redpanda will continuously
 reassign partitions from both unavailable nodes and from nodes using more disk
 space than the configured limit.
 
-This command can be used to monitor the partition balancer status.
+Use this command to monitor the partition balancer status and
+the partition distribution across brokers in the cluster.
 
 FIELDS
 
@@ -89,25 +91,48 @@ investigation. A few areas to investigate:
 			status, err := cl.GetPartitionStatus(cmd.Context())
 			out.MaybeDie(err, "unable to request balancer status: %v", err)
 
-			printBalancerStatus(status)
+			var clusterPartitions []rpadmin.ClusterPartition
+			clusterPartitions, err = cl.AllClusterPartitions(cmd.Context(), true, false)
+			if err != nil {
+				fmt.Printf("unable to query all partitions in the cluster: %v", err)
+			}
+
+			printBalancerStatus(status, clusterPartitions)
 		},
 	}
 
 	return cmd
 }
 
-func printBalancerStatus(pbs rpadmin.PartitionBalancerStatus) {
-	tw := out.NewTable()
-	defer tw.Flush()
-	tw.Print("Status:", pbs.Status)
-	tw.Print("Seconds Since Last Tick:", pbs.SecondsSinceLastTick)
-	tw.Print("Current Reassignment Count:", pbs.CurrentReassignmentsCount)
-	if pbs.PartitionsPendingForceRecovery != nil && pbs.PartitionsPendingRecoveryList != nil {
-		tw.Print(fmt.Sprintf("Partitions Pending Recovery (%v):", *pbs.PartitionsPendingForceRecovery), pbs.PartitionsPendingRecoveryList)
-	}
-	v := pbs.Violations
-	if len(v.OverDiskLimitNodes) > 0 || len(v.UnavailableNodes) > 0 {
-		tw.Print("Unavailable Nodes:", v.UnavailableNodes)
-		tw.Print("Over Disk Limit Nodes:", v.OverDiskLimitNodes)
-	}
+func printBalancerStatus(pbs rpadmin.PartitionBalancerStatus, clusterPartitions []rpadmin.ClusterPartition) {
+	const (
+		secBalancerStatus = "Balancer status"
+		secReplicaDist    = "Replica distribution"
+	)
+	sections := out.NewSections(
+		out.ConditionalSectionHeaders(map[string]bool{
+			secBalancerStatus: true,
+			secReplicaDist:    true,
+		})...,
+	)
+	sections.Add(secBalancerStatus, func() {
+		tw := out.NewTable()
+		defer tw.Flush()
+		tw.Print("Status:", pbs.Status)
+		tw.Print("Seconds Since Last Tick:", pbs.SecondsSinceLastTick)
+		tw.Print("Current Reassignment Count:", pbs.CurrentReassignmentsCount)
+		if pbs.PartitionsPendingForceRecovery != nil && pbs.PartitionsPendingRecoveryList != nil {
+			tw.Print(fmt.Sprintf("Partitions Pending Recovery (%v):", *pbs.PartitionsPendingForceRecovery), pbs.PartitionsPendingRecoveryList)
+		}
+		v := pbs.Violations
+		if len(v.OverDiskLimitNodes) > 0 || len(v.UnavailableNodes) > 0 {
+			tw.Print("Unavailable Nodes:", v.UnavailableNodes)
+			tw.Print("Over Disk Limit Nodes:", v.OverDiskLimitNodes)
+		}
+	})
+	sections.Add(secReplicaDist, func() {
+		replicaDist := buildReplicaPerBroker(clusterPartitions)
+		types.Sort(replicaDist)
+		printReplicaDistribution(replicaDist)
+	})
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/util.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/util.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package partitions
+
+import (
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+)
+
+// LeaderDistribution represents the number of partition leaders assigned to a broker.
+type LeaderDistribution struct {
+	NodeID int `json:"node_id" yaml:"node_id"`
+	Count  int `json:"count" yaml:"count"`
+}
+
+// ReplicaDistribution represents the number of partitions assigned to a broker.
+type ReplicaDistribution struct {
+	NodeID int `json:"node_id" yaml:"node_id"`
+	Count  int `json:"count" yaml:"count"`
+}
+
+func buildLeaderPerBroker(clusterPartitions []rpadmin.ClusterPartition) []LeaderDistribution {
+	brokerLeaders := make(map[int]int)
+	for _, p := range clusterPartitions {
+		brokerLeaders[*p.LeaderID]++
+	}
+	var distribution []LeaderDistribution
+	for brokerID, leaderCount := range brokerLeaders {
+		distribution = append(distribution, LeaderDistribution{
+			NodeID: brokerID,
+			Count:  leaderCount,
+		})
+	}
+	return distribution
+}
+
+func printLeaderDistribution(leaderDist []LeaderDistribution) {
+	tw := out.NewTable("BROKER", "LEADER-COUNT")
+	defer tw.Flush()
+	for _, p := range leaderDist {
+		tw.PrintStructFields(struct {
+			NodeID int
+			Count  int
+		}{p.NodeID, p.Count})
+	}
+}
+
+func buildReplicaPerBroker(clusterPartitions []rpadmin.ClusterPartition) []ReplicaDistribution {
+	brokerReplicas := make(map[int]int)
+	for _, p := range clusterPartitions {
+		for _, r := range p.Replicas {
+			brokerReplicas[r.NodeID]++
+		}
+	}
+	var distribution []ReplicaDistribution
+	for brokerID, replicaCount := range brokerReplicas {
+		distribution = append(distribution, ReplicaDistribution{
+			NodeID: brokerID,
+			Count:  replicaCount,
+		})
+	}
+	return distribution
+}
+
+func printReplicaDistribution(replicaDist []ReplicaDistribution) {
+	tw := out.NewTable("BROKER", "PARTITION-COUNT")
+	defer tw.Flush()
+	for _, p := range replicaDist {
+		tw.PrintStructFields(struct {
+			NodeID int
+			Count  int
+		}{p.NodeID, p.Count})
+	}
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25197
