### PR TITLE
pandaproxy/sr: Fix logging where id was printed instead of version

### DIFF
--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -503,7 +503,7 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
           plog.warn,
           "Failed to parse stored schema, subject {}, version {}: {}",
           sub,
-          v_id.id,
+          v_id.version,
           e.what());
         throw;
     }


### PR DESCRIPTION
Fix a logging issue where the schema id was printed instead of the subject version.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
