### PR TITLE
[DNM] sr: Relax reference lookup

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -563,7 +563,7 @@ ss::future<collected_schema> collect_schema(
     for (const auto& ref : schema.def().refs()) {
         if (!collected.contains(ref.name)) {
             auto ss = co_await store.get_subject_schema(
-              ref.sub, ref.version, include_deleted::no);
+              ref.sub, ref.version, include_deleted::yes);
             collected = co_await collect_schema(
               store, std::move(collected), ref.name, std::move(ss.schema));
         }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -439,7 +439,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
             continue;
         }
         auto dep = co_await store.get_subject_schema(
-          ref.sub, ref.version, include_deleted::no);
+          ref.sub, ref.version, include_deleted::yes);
         co_await build_file_with_refs(
           dp,
           store,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -488,6 +488,8 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
           return s.get_schema_definition(id).value();
       });
 
+    auto s_def = def.share();
+
     try {
         auto canonical = co_await make_canonical_schema(
           {sub, std::move(def)}, norm);
@@ -499,12 +501,24 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
           .deleted = v_id.deleted};
     } catch (const exception& e) {
         vlog(
-          plog.warn,
+          plog.info,
           "Failed to parse stored schema, subject {}, version {}: {}",
           sub,
           v_id.id,
           e.what());
-        throw;
+        // Hack around creating a canonical_schema from an unparsed and invalid
+        // one
+        auto [raw_def, type, refs] = std::move(s_def).destructure();
+        canonical_schema temp{
+          sub,
+          {canonical_schema_definition::raw_string{std::move(raw_def)()},
+           type,
+           std::move(refs)}};
+        co_return subject_schema{
+          .schema = std::move(temp),
+          .version = v_id.version,
+          .id = v_id.id,
+          .deleted = v_id.deleted};
     }
 }
 


### PR DESCRIPTION
New schemas may now use soft-deleted subjects as references.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none