### PR TITLE
Core 9736/sr allow sd refs

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -563,7 +563,7 @@ ss::future<collected_schema> collect_schema(
     for (const auto& ref : schema.def().refs()) {
         if (!collected.contains(ref.name)) {
             auto ss = co_await store.get_subject_schema(
-              ref.sub, ref.version, include_deleted::no);
+              ref.sub, ref.version, include_deleted::yes);
             collected = co_await collect_schema(
               store, std::move(collected), ref.name, std::move(ss.schema));
         }

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -232,13 +232,15 @@ std::string_view as_string_view(const json::Value& v) {
 
 ss::future<> check_references(sharded_store& store, canonical_schema schema) {
     for (const auto& ref : schema.def().refs()) {
-        co_await store.is_subject_version_deleted(ref.sub, ref.version)
-          .handle_exception([](auto) { return is_deleted::yes; })
-          .then([&](is_deleted d) {
-              if (d) {
+        co_await store.get_id(ref.sub, ref.version)
+          .handle_exception_type([&](const exception& e) -> schema_id {
+              if (
+                e.code() == error_code::subject_not_found
+                || e.code() == error_code::schema_id_not_found) {
                   throw as_exception(
                     no_reference_found_for(schema, ref.sub, ref.version));
               }
+              throw;
           });
     }
 }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -438,7 +438,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
             continue;
         }
         auto dep = co_await store.get_subject_schema(
-          ref.sub, ref.version, include_deleted::no);
+          ref.sub, ref.version, include_deleted::yes);
         co_await build_file_with_refs(
           dp,
           store,

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -629,6 +629,11 @@ soft_deleted_schemas = {
         "schema": schema_proto_def,
         "type": "PROTOBUF",
     },
+    "json": {
+        "subject": "schema_json",
+        "schema": json_number_schema_def,
+        "type": "JSON",
+    }
 }
 dependent_schemas = {
     "proto": {
@@ -644,7 +649,22 @@ dependent_schemas = {
         "type":
         "PROTOBUF",
         "id":
-        2,
+        3,
+    },
+    "json": {
+        "subject":
+        "schema_json_dependee_schema",
+        "schema":
+        json_number_schema_def,
+        "references": [{
+            "name": "schema_json.json",
+            "subject": "schema_json",
+            "version": 1
+        }],
+        "type":
+        "JSON",
+        "id":
+        4,
     },
 }
 
@@ -3381,7 +3401,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Test setup. Insert and soft-delete schemas to be referencedby
 
-        for name in ["proto"]:
+        for name in ["proto", "json"]:
             schema = soft_deleted_schemas[name]
             result_raw = self._post_subjects_subject_versions(
                 subject=schema["subject"],
@@ -3400,7 +3420,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                     f"Request content: {result_raw.content}"
 
         #Register schemas that reference the soft-deleted schemas
-        for name in ["proto"]:
+        for name in ["proto", "json"]:
             schema = dependent_schemas[name]
             result_raw = self._post_subjects_subject_versions(
                 subject=schema["subject"],

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -608,6 +608,46 @@ import_schemas = {
     },
 }
 
+schema_proto_def = """
+syntax = "proto3";
+
+message ProtoType {
+  float f =  1;
+}"""
+
+schema_proto_dependee_def = """
+syntax = "proto3";
+
+import "schema_proto.proto";
+message Dependee {
+  ProtoType p =  1;
+}"""
+
+soft_deleted_schemas = {
+    "proto": {
+        "subject": "schema_proto",
+        "schema": schema_proto_def,
+        "type": "PROTOBUF",
+    },
+}
+dependent_schemas = {
+    "proto": {
+        "subject":
+        "schema_proto_dependee_schema",
+        "schema":
+        schema_proto_dependee_def,
+        "references": [{
+            "name": "schema_proto.proto",
+            "subject": "schema_proto",
+            "version": 1
+        }],
+        "type":
+        "PROTOBUF",
+        "id":
+        2,
+    },
+}
+
 log_config = LoggingConfig('info',
                            logger_levels={
                                'security': 'trace',
@@ -3331,6 +3371,51 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_subjects_subject(sanitized, expected_version=1, norm=True)
         test_subjects_subject(normalized, expected_version=1)
         test_subjects_subject(normalized, expected_version=1, norm=True)
+
+    @cluster(num_nodes=3)
+    def test_soft_deleted_references(self):
+        """
+        Soft-deleted references should be valid references and
+        schemas that reference a soft-deleted ref should be accepted
+        """
+
+        #Test setup. Insert and soft-delete schemas to be referencedby
+
+        for name in ["proto"]:
+            schema = soft_deleted_schemas[name]
+            result_raw = self._post_subjects_subject_versions(
+                subject=schema["subject"],
+                data=json.dumps({
+                    "schema": schema["schema"],
+                    "schemaType": schema["type"]
+                }))
+            assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                    f"Request content: {result_raw.content}"
+
+            result_raw = self._delete_subject_version(
+                subject=schema["subject"], version=1)
+            assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                    f"Request content: {result_raw.content}"
+
+        #Register schemas that reference the soft-deleted schemas
+        for name in ["proto"]:
+            schema = dependent_schemas[name]
+            result_raw = self._post_subjects_subject_versions(
+                subject=schema["subject"],
+                data=json.dumps({
+                    "schema": schema["schema"],
+                    "schemaType": schema["type"],
+                    "references": schema["references"],
+                }))
+            assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code}. "\
+                    f"Request content: {result_raw.content}"
+            result_id = result_raw.json()["id"]
+            assert result_id == schema["id"], \
+                    f"Expected id {schema['id']} but got {result_id}. "\
+                    f"Request content: {result_raw.content}"
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -615,12 +615,36 @@ message ProtoType {
   float f =  1;
 }"""
 
+schema_avro_def = """
+{
+    "type": "record",
+    "name": "myrecord",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "string"
+        }
+    ]
+}"""
+
 schema_proto_dependee_def = """
 syntax = "proto3";
 
 import "schema_proto.proto";
 message Dependee {
   ProtoType p =  1;
+}"""
+
+schema_avro_dependee_def = """
+{
+    "type": "record",
+    "name": "myotherrecord",
+    "fields": [
+        {
+            "name": "f2",
+            "type": "string"
+        }
+    ]
 }"""
 
 soft_deleted_schemas = {
@@ -633,6 +657,11 @@ soft_deleted_schemas = {
         "subject": "schema_json",
         "schema": json_number_schema_def,
         "type": "JSON",
+    },
+    "avro": {
+        "subject": "schema_avro",
+        "schema": schema_avro_def,
+        "type": "AVRO",
     }
 }
 dependent_schemas = {
@@ -649,7 +678,7 @@ dependent_schemas = {
         "type":
         "PROTOBUF",
         "id":
-        3,
+        4,
     },
     "json": {
         "subject":
@@ -664,7 +693,22 @@ dependent_schemas = {
         "type":
         "JSON",
         "id":
-        4,
+        5,
+    },
+    "avro": {
+        "subject":
+        "schema_avro_dependee_schema",
+        "schema":
+        schema_avro_dependee_def,
+        "references": [{
+            "name": "schema_avro.avro",
+            "subject": "schema_avro",
+            "version": 1
+        }],
+        "type":
+        "AVRO",
+        "id":
+        6,
     },
 }
 
@@ -3401,7 +3445,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Test setup. Insert and soft-delete schemas to be referencedby
 
-        for name in ["proto", "json"]:
+        for name in ["proto", "json", "avro"]:
             schema = soft_deleted_schemas[name]
             result_raw = self._post_subjects_subject_versions(
                 subject=schema["subject"],
@@ -3411,16 +3455,16 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 }))
             assert result_raw.status_code == requests.codes.ok, \
                     f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
-                    f"Request content: {result_raw.content}"
+                    f"Request content: {result_raw.content}. Processing {name}."
 
             result_raw = self._delete_subject_version(
                 subject=schema["subject"], version=1)
             assert result_raw.status_code == requests.codes.ok, \
                     f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
-                    f"Request content: {result_raw.content}"
+                    f"Request content: {result_raw.content}. Processing {name}."
 
         #Register schemas that reference the soft-deleted schemas
-        for name in ["proto", "json"]:
+        for name in ["proto", "json", "avro"]:
             schema = dependent_schemas[name]
             result_raw = self._post_subjects_subject_versions(
                 subject=schema["subject"],
@@ -3431,11 +3475,11 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 }))
             assert result_raw.status_code == requests.codes.ok, \
                     f"Expected {requests.codes.ok} but got {result_raw.status_code}. "\
-                    f"Request content: {result_raw.content}"
+                    f"Request content: {result_raw.content}. Processing {name}."
             result_id = result_raw.json()["id"]
             assert result_id == schema["id"], \
                     f"Expected id {schema['id']} but got {result_id}. "\
-                    f"Request content: {result_raw.content}"
+                    f"Request content: {result_raw.content}. Processing {name}."
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
Implements: [CORE-9736](https://redpandadata.atlassian.net/browse/CORE-9736)

Relax reference lookup for avro, proto and json to allow for references to be soft deleted.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-9736]: https://redpandadata.atlassian.net/browse/CORE-9736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ