### PR TITLE
rptest: add UpdateRequirement\$Assert to allowed list

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -129,6 +129,11 @@ DEFAULT_LOG_ALLOW_LIST = [
     # which is not present in typical CI runs, which results in the following
     # error message from the debug bundle service
     re.compile(r"Current specified RPK location"),
+
+    # Tests that use Iceberg REST catalogs may log error messages coming from
+    # the catalog that have "Assert" in them. These are typically benign and
+    # just indicate a race in committing to Iceberg.
+    re.compile(r"UpdateRequirement.*Assert"),
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test

--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -37,7 +37,6 @@ from rptest.utils.rpcn_utils import counter_stream_config
 OOM_ALLOW_LIST = [
     # partitioning_writer.cc:65 - Failed to create new writer: Memory exhausted
     re.compile("Failed to create new writer: Memory exhausted"),
-    "UpdateRequirement\\$Assert",
 ]
 
 
@@ -319,9 +318,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
                 "translation_parquet_rows_added"] == msg_count
             assert metric2value_sum["translation_parquet_bytes_added"] > 0
 
-    @cluster(num_nodes=6, log_allow_list=[
-        "UpdateRequirement\\$Assert",
-    ])
+    @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
     def test_spec_evolution(self, cloud_storage_type, catalog_type):
@@ -492,9 +489,7 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             ]
             assert describe_partitioning == expected_partitioning
 
-    @cluster(num_nodes=7, log_allow_list=[
-        "UpdateRequirement\\$Assert",
-    ])
+    @cluster(num_nodes=7)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
     def test_spec_evolution_rpcn(self, cloud_storage_type, catalog_type):

--- a/tests/rptest/tests/datalake/many_topics_test.py
+++ b/tests/rptest/tests/datalake/many_topics_test.py
@@ -97,9 +97,7 @@ class DatalakeManyTopicsTest(RedpandaTest):
 
         self._execute_in_parallel(topics, produce_batch)
 
-    @cluster(num_nodes=8, log_allow_list=[
-        "UpdateRequirement\\$Assert",
-    ])
+    @cluster(num_nodes=8)
     @matrix(cloud_storage_type=supported_storage_types())
     def test_basic(self, cloud_storage_type):
         with DatalakeServices(self.test_context,


### PR DESCRIPTION
This is misconstrued by Redpanda as an error and it's totally normal, especially in tests that drive load.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
