### PR TITLE
tests: add ducktape retry configuration

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -1,0 +1,19 @@
+# This configuration contains common yaml anchors between
+# the ducktape-pr-retry.yml and the ducktape-merge-retry.yml
+# configs
+#
+# See https://redpandadata.atlassian.net/wiki/x/CAAIRg
+
+zero-drift: &zero-drift
+  zero-drift:
+    mode:
+      dynamic_reliability:
+        compare_with_branch: dev
+        time_window: 2w
+        allowed_drift: 0 # upstream_reliability - current_ci_reliability <= allowed_drift
+        fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)
+retry-all-except-nodecrash: &retry-all-except-nodecrash
+  include: # match stacktrace of failure
+    - .*
+  exclude:
+    - (\n|.)*NodeCrash # excludes NodeCrash errors from retries

--- a/tests/ducktape-merge-retry.yml
+++ b/tests/ducktape-merge-retry.yml
@@ -1,0 +1,16 @@
+# This configuration is parsed by pandatriage on merge builds in order to:
+# 1. decide which tests should be retried based on the stacktrace of
+#    failures
+# 2. consider a test passed or failed based on the pass_criteria
+#    configuration
+#
+# See https://redpandadata.atlassian.net/wiki/x/CAAIRg
+
+pass_criteria:
+  <<: *zero-drift
+retry:
+  default:
+    repeat: 20
+    retry_on:
+      *retry-all-except-nodecrash
+    pass_criteria: zero-drift

--- a/tests/ducktape-pr-retry.yml
+++ b/tests/ducktape-pr-retry.yml
@@ -1,0 +1,16 @@
+# This configuration is parsed by pandatriage on PR builds in order to:
+# 1. decide which tests should be retried based on the stacktrace of
+#    failures
+# 2. consider a test passed or failed based on the pass_criteria
+#    configuration
+#
+# See https://redpandadata.atlassian.net/wiki/x/CAAIRg
+
+pass_criteria:
+  <<: *zero-drift
+retry:
+  default:
+    repeat: 20
+    retry_on:
+      *retry-all-except-nodecrash
+    pass_criteria: zero-drift


### PR DESCRIPTION
Adding retry configuration for ducktape tests, for PR and merge builds. Currently, the same configuration is applied for PR and merge builds, but can be segregated.

This configuration is parsed by pandatriage in order to:

1. decide which tests should be retried based on the stacktrace of failures
2. consider a test passed or failed based on the pass_criteria configuration

### configuration

`pass_criteria`: 1 or more pass criteria definitions by name. Currently, only `dynamic_reliability` mode can be defined as mode and accepts the args `compare_with_branch`, `time_window`, `allowed_drift`, `fallback_reliability`. This mode can be referenced by name in the `retry` configuration in order to consider a test `PASS` or `FAIL`. It will compare the reliability between <the current CI run (original \+ retried results) > and <upstream reliability of original failure signature on the `compare_with_branch` branch for a specific time window)

`retry`:
* `repeat`: a static number that will be passed to ducktape cli `--repeat` arg.
* `default`: The default configuration of failed tests. Compares the summary (stackrtace) with the `include` and `exclude` regex lists in order to retry or not.

Eventually, we'll move to a parser that can parse other modes (e.g.`fixed_reliability`) for pass criteria, and `overrides` of the `default` retry; e.g. test `foo` is quite flaky so it should be configured with a fixed reliability percentage, and 20 times.

The parser will be defined in the vtools repo once this and all backports are merged, since the parser depends on having the configurations in the redpanda repo. for ref the vtools WIP PR is https://github.com/redpanda-data/vtools/pull/3536

jira: [DEVPROD-2780]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

* none


[DEVPROD-2780]: https://redpandadata.atlassian.net/browse/DEVPROD-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ