### PR TITLE
Checking cluster health and spec details

### DIFF
--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -34,15 +34,15 @@ class CloudBroker():
 
         spec = pod.get('spec', {})
         if not spec or 'nodeName' not in spec:
-            health_overview = self.get_health_overview()
             self.logger.error(
-                f"Pod spec is missing or does not contain 'nodeName'. Pod details: {pod}"
+                f"Pod spec is missing or does not contain 'nodeName'. Pod details: {pod}, Spec details: {spec}"
             )
+            health_overview = self.get_health_overview()
             self.logger.error(
                 f"Before processing pods, ensure that the Redpanda cluster is healthy. Health overview is: {health_overview}"
             )
             raise KeyError(
-                "Missing 'nodeName' in pod['spec']. Health overview: {health_overview}"
+                f"Missing 'nodeName' in pod['spec']. Health overview: {health_overview}"
             )
 
         # Backward compatibility

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -32,6 +32,19 @@ class CloudBroker():
         self._meta = pod['metadata']
         self.name = self._meta['name']
 
+        spec = pod.get('spec', {})
+        if not spec or 'nodeName' not in spec:
+            health_overview = self.get_health_overview()
+            self.logger.error(
+                f"Pod spec is missing or does not contain 'nodeName'. Pod details: {pod}"
+            )
+            self.logger.error(
+                f"Before processing pods, ensure that the Redpanda cluster is healthy. Health overview is: {health_overview}"
+            )
+            raise KeyError(
+                "Missing 'nodeName' in pod['spec']. Health overview: {health_overview}"
+            )
+
         # Backward compatibility
         # Various classes will use this to hash and compare nodes
         try:


### PR DESCRIPTION
This PR improves error handling with pos spec. In some cases, when Redpanda cluster is not up and running, spec would not have nodeName and test(s) would fail. We should check for cluster health and show a better error message.

This is related to group failures in DEVPROD-2560, panda triage would re-open this item every time when cluster is not running and nodeMane is not available in the spec.

## Backports Required

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
