### PR TITLE
utils/rcn: enable warn unused

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2377,10 +2377,6 @@ ntp_archiver::maybe_truncate_manifest() {
           "archival metadata cleanup, some segments will be removed from the "
           "manifest, start offset before cleanup: {}",
           manifest().get_start_offset());
-        retry_chain_node rc_node(
-          _conf->manifest_upload_timeout(),
-          _conf->upload_loop_initial_backoff(),
-          &rtc);
         auto error = co_await _parent.archival_meta_stm()->truncate(
           adjusted_start_offset,
           ss::lowres_clock::now() + _conf->manifest_upload_timeout(),

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -175,7 +175,6 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
         amv->stop().get();
     });
 
-    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get();
 
     auto non_compacted_result = res.non_compacted_upload_result;
@@ -308,7 +307,6 @@ FIXTURE_TEST(test_upload_after_failure, archiver_fixture) {
         amv->stop().get();
     });
 
-    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get();
 
     auto&& [non_compacted_result, compacted_result] = res;
@@ -403,7 +401,6 @@ FIXTURE_TEST(
         amv->stop().get();
     });
 
-    retry_chain_node fib(never_abort);
     auto res = archiver
                  .upload_next_candidates(
                    archival_stm_fence{.emit_rw_fence_cmd = false})
@@ -490,7 +487,6 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
         amv->stop().get();
     });
 
-    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
@@ -614,7 +610,6 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
     });
 
     // Wait for uploads to complete
-    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get();
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 4);
     BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
@@ -1196,8 +1191,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
 
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
-    retry_chain_node fib(never_abort);
-
     auto res = upload_next_with_retries(archiver).get();
 
     auto non_compacted_result = res.non_compacted_upload_result;
@@ -1423,7 +1416,6 @@ static void test_partial_upload_impl(
       *part,
       amv);
 
-    retry_chain_node fib(never_abort);
     test.listen();
     auto res = test.upload_next_with_retries(archiver, lso).get();
 
@@ -1915,7 +1907,6 @@ FIXTURE_TEST(test_upload_with_gap_blocked, archiver_fixture) {
         manifest_view->stop().get();
     });
 
-    retry_chain_node fib(never_abort);
     auto res = upload_next_with_retries(archiver).get();
 
     for (auto [url, req] : get_targets()) {

--- a/src/v/cluster/archival/tests/upload_housekeeping_service_test.cc
+++ b/src/v/cluster/archival/tests/upload_housekeeping_service_test.cc
@@ -131,7 +131,6 @@ void wait_for_job_execution(
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_stop) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10s);
     mock_job job2(10s);
@@ -152,7 +151,6 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_stop) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_pause) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10ms);
     mock_job job2(10ms);
@@ -179,7 +177,6 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_pause) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_drain) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10ms);
     mock_job job2(10ms);
@@ -210,7 +207,6 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_drain) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_interrupt) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10s);
     mock_job job2(10ms);
@@ -229,7 +225,6 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_interrupt) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_no_jobs) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     {
         mock_job job1(10s);
@@ -254,7 +249,6 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_no_jobs) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_job_throws) {
-    retry_chain_node rtc(abort_never);
     archival::housekeeping_workflow wf(mock_quota);
     {
         mock_job job1; // This job will throw

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -198,7 +198,7 @@ struct retry_permit {
 /// It can also receive its own timeout value and backoff interval. The
 /// timeout value have to be smaller that the one of the parent node.
 template<class Clock = ss::lowres_clock>
-class basic_retry_chain_node {
+class [[gnu::warn_unused]] basic_retry_chain_node {
 public:
     using clock = Clock;
     using duration = typename clock::duration;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
