### PR TITLE
README: stop mentioning v23.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ For amd64:
 
 ```
 curl -LO \
-  https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/raw/names/redpanda-amd64/versions/23.3.6/redpanda-24.2.7-amd64.tar.gz
+  https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/raw/names/redpanda-amd64/versions/25.1.1/redpanda-25.1.1-amd64.tar.gz
 ```
 
 For arm64:
 
 ```
 curl -LO \
-  https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/raw/names/redpanda-arm64/versions/23.3.6/redpanda-24.2.7-arm64.tar.gz
+  https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/raw/names/redpanda-arm64/versions/25.1.1/redpanda-25.1.1-arm64.tar.gz
 ```
 
-Replace `24.2.7` with the version you want to download. See [Release Notes](https://github.com/redpanda-data/redpanda/releases).
+Replace `25.1.1` with the version you want to download. See [Release Notes](https://github.com/redpanda-data/redpanda/releases).
 
 ## Build Manually
 
@@ -131,10 +131,10 @@ sudo yum install redpanda
 
 ### RC releases on Docker
 
-Example with `v23.1.1-rc1`:
+Example with `v25.1.1-rc1`:
 
 ```bash
-docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v23.1.1-rc1
+docker pull docker.redpanda.com/redpandadata/redpanda-unstable:v25.1.1-rc1
 ```
 
 # Community


### PR DESCRIPTION
Updates broken links and references to EOL versions of Redpanda software.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
 