### PR TITLE
[CORE-9110] cluster: enable shard_placement_table persistence if the feature is active

### DIFF
--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -391,6 +391,18 @@ using ntp2target_t
   = chunked_hash_map<model::ntp, std::optional<shard_placement_target>>;
 
 ss::future<> shard_balancer::do_assign_ntps(mutex::units& lock) {
+    if (
+      _features.is_active(features::feature::node_local_core_assignment)
+      && !_shard_placement.is_persistence_enabled()) {
+        vlog(
+          clusterlog.warn,
+          "node_local_core_assignment feature got activated after node "
+          "startup, but shard placement persistence was not properly enabled, "
+          "enabling it now. This can happen if a node is joining with the same "
+          "id after its disk was erased.");
+        co_await _shard_placement.enable_persistence();
+    }
+
     ntp2target_t new_targets;
     auto to_assign = std::exchange(_to_assign, {});
     co_await ssx::async_for_each(

--- a/tests/rptest/tests/admin_uuid_operations_test.py
+++ b/tests/rptest/tests/admin_uuid_operations_test.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
 from rptest.util import expect_exception
 from ducktape.cluster.cluster import ClusterNode
@@ -188,6 +189,9 @@ class AdminUUIDOperationsTest(RedpandaTest):
     @parametrize(mode=TestMode.NO_OVERRIDE)
     @parametrize(mode=TestMode.CLI_OVERRIDE)
     def test_force_uuid_override(self, mode):
+        # create a topic so that the cluster is not completely empty
+        RpkTool(self.redpanda).create_topic("foo", 10, 3)
+
         to_stop = self.redpanda.nodes[0]
         initial_to_stop_id = self.redpanda.node_id(to_stop)
 
@@ -311,6 +315,9 @@ class AdminUUIDOperationsTest(RedpandaTest):
     @parametrize(mode=TestMode.CFG_OVERRIDE)
     @parametrize(mode=TestMode.CLI_OVERRIDE)
     def test_force_uuid_override_multinode(self, mode):
+        # create a topic so that the cluster is not completely empty
+        RpkTool(self.redpanda).create_topic("foo", 10, 3)
+
         to_stop = self.redpanda.nodes[1:]
         initial_to_stop_ids = [self.redpanda.node_id(n) for n in to_stop]
 


### PR DESCRIPTION
It is possible that the node_local_core_assignment feature flag gets activated on a node after the startup, but the prepare phase (and the associated migration) is skipped. This can happen if the node re-joins with the same id after its disk was erased and node UUID overriden.

Enable persistence in this case as well, thereby bringing local kvstore state in sync with the global feature table state.

Fixes https://redpandadata.atlassian.net/browse/CORE-9110

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Fix an assert crash that happens after a node rejoins the cluster with the same node ID after its disk was erased.
