### PR TITLE
[v25.1.x] cluster/tests: rename log_eviction_stm_test

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -611,10 +611,10 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "eviction_stm_test",
+    name = "log_eviction_stm_test",
     timeout = "short",
     srcs = [
-        "eviction_stm_test.cc",
+        "log_eviction_stm_test.cc",
     ],
     deps = [
         "//src/v/cluster",
@@ -622,7 +622,6 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/raft",
         "//src/v/raft/tests:raft_fixture",
-        "//src/v/storage",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:to_string",
         "@googletest//:gtest",

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ set(srcs
     tm_stm_tests.cc
     data_migration_table_test.cc
     manual_log_deletion_test.cc
-    eviction_stm_test.cc
+    log_eviction_stm_test.cc
     )
 
 foreach(cluster_test_src ${srcs})

--- a/src/v/cluster/tests/log_eviction_stm_test.cc
+++ b/src/v/cluster/tests/log_eviction_stm_test.cc
@@ -9,7 +9,6 @@
 
 #include "cluster/log_eviction_stm.h"
 #include "raft/tests/raft_fixture.h"
-#include "storage/disk_log_impl.h"
 #include "test_utils/async.h"
 
 ss::logger logger("eviction_stm_test");


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25724
