### PR TITLE
host-metrics: Don't use RedpandaCloudMixin

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -17,5 +17,4 @@ cloud:
     - redpanda_cloud_tests/rolling_restart_test.py
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest
     - redpanda_cloud_tests/cloud_self_test.py
-    - tests/host_metrics_test.py
     - tests/services_self_test.py::SimpleSelfTest.test_cloud

--- a/tests/rptest/tests/host_metrics_test.py
+++ b/tests/rptest/tests/host_metrics_test.py
@@ -8,12 +8,12 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
-from rptest.tests.redpanda_test import RedpandaMixedTest
+from rptest.tests.redpanda_test import RedpandaTest
 
 
-class HostMetricsTest(RedpandaMixedTest):
+class HostMetricsTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, min_brokers=1, **kwargs)
+        super().__init__(*args, num_brokers=1, **kwargs)
 
     @cluster(num_nodes=1)
     def test_basic_hoststats(self):


### PR DESCRIPTION
Test is broken in the cloud which seems like a bug in RedpandaCloudMixin
(see CORE-9761).

However, I realized we can't use the cloud test yet because cloud isn't
on a version yet that has this enabled by default. Hence we need to wait
at least another release.

This partially reverts commit https://github.com/redpanda-data/redpanda/commit/1018b9f9ded2af79d34a7704d2d03d291bbc15f6.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
