### PR TITLE
bazel: enforce _rpbench naming scheme

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -373,6 +373,12 @@ def redpanda_cc_bench(
       timeout: the timeout for smoke testing the benchmark
       target_compatible_with: constraints for the test target
     """
+
+    # We require this naming convention as we do things like extract
+    # the list of all benchmarks using a name-based query.
+    if not name.endswith("_rpbench"):
+        fail("benchmark names must end with _rpbench")
+
     args = [
         "--blocked-reactor-notify-ms 2000000",
         "--abort-on-seastar-bad-alloc",

--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -292,7 +292,7 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_bench(
-    name = "tx_range_manifest_bench",
+    name = "tx_range_manifest_rpbench",
     srcs = ["tx_range_manifest_bench.cc"],
     deps = [
         "//src/v/base",

--- a/src/v/cloud_topics/core/tests/BUILD
+++ b/src/v/cloud_topics/core/tests/BUILD
@@ -83,7 +83,7 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_bench(
-    name = "pipeline_bench",
+    name = "pipeline_rpbench",
     timeout = "short",
     srcs = [
         "pipeline_bench.cc",


### PR DESCRIPTION
We require that benchmark target names end with _rpbench: this naming convention is needed when we do things like extract the list of all benchmarks using a name-based query.

Enforce it in the bazel build and update two benchmarks which didn't follow this rule

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
