### PR TITLE
base: Introduce opt<T>

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -19,6 +19,7 @@ redpanda_cc_library(
         "vassert-register.h",
         "vformat.h",
         "vlog.h",
+        "opt.h",
     ],
     include_prefix = "base",
     visibility = ["//visibility:public"],

--- a/src/v/base/opt.h
+++ b/src/v/base/opt.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <optional>
+
+template<typename T>
+class opt final : private std::optional<T> {
+public:
+    explicit opt(std::optional<T>&& o)
+      : std::optional<T>(std::move(o)) {}
+
+    using value_type = T;
+
+    using std::optional<T>::optional;
+    using std::optional<T>::operator=;
+    using std::optional<T>::value;
+    using std::optional<T>::has_value;
+    using std::optional<T>::value_or;
+    // NOTE: that's not gonna work
+    // using std::optional<T>::swap;
+    using std::optional<T>::reset;
+    using std::optional<T>::emplace;
+
+    // TODO: monadic ops (c++23)
+
+    friend auto operator<=>(const opt<T>&, const opt<T>&) = default;
+
+    // TODO: comparison to std::nullopt_t
+
+    opt& operator=(std::nullopt_t) noexcept {
+        reset();
+        return *this;
+    }
+};
+
+template<typename T>
+constexpr opt<std::decay_t<T>> make_opt(T&& v) {
+    return opt<std::decay_t<T>>(std::forward<T>(v));
+}
+
+template<typename T, typename... Args>
+constexpr opt<T> make_opt(Args&&... args) {
+    return opt<T>{std::in_place, std::forward<Args>(args)...};
+}
+
+// TODO(oren): initializer list version

--- a/src/v/base/tests/BUILD
+++ b/src/v/base/tests/BUILD
@@ -37,3 +37,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "opt_test",
+    timeout = "short",
+    srcs = ["opt_test.cc"],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:gtest",
+        "//src/v/random:generators",
+         "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/base/tests/opt_test.cc
+++ b/src/v/base/tests/opt_test.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/opt.h"
+#include "base/seastarx.h"
+#include "base/type_traits.h"
+#include "base/vassert.h"
+#include "random/generators.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <optional>
+
+TEST(opt, WorksWithPrimitiveTypes) {
+    opt<int> a;
+    ASSERT_FALSE(a.has_value());
+    a = std::nullopt;
+    ASSERT_FALSE(a.has_value());
+    a.emplace(1);
+    ASSERT_TRUE(a.has_value());
+    ASSERT_EQ(a.value(), 1);
+    a.reset();
+    ASSERT_FALSE(a.has_value());
+    ASSERT_THROW(a.value(), std::bad_optional_access);
+    ASSERT_EQ(a.value_or(42), 42);
+    a = make_opt<int>(64);
+    ASSERT_EQ(a.value(), 64);
+
+    opt<int> b{23};
+    a = b;
+    ASSERT_EQ(a, b);
+    ASSERT_LE(a, b);
+    ASSERT_GE(a, b);
+    b.emplace(42);
+    ASSERT_NE(a, b);
+    ASSERT_LT(a, b);
+    ASSERT_GT(b, a);
+
+    opt<int> c{std::make_optional<int>(99)};
+    ASSERT_EQ(c.value(), 99);
+
+    // below does not compile, as intended
+    // ASSERT_TRUE(b);
+    // ASSERT_EQ(*b, 42);
+    // b = std::nullopt;
+    // ASSERT_FALSE(b);
+    // struct foo {
+    //     int a;
+    // };
+    // auto some_foo = make_opt<foo>(23);
+    // ASSERT_EQ(some_foo->a, 23);
+
+    auto d = std::exchange(b, std::nullopt);
+    ASSERT_EQ(d.value(), 42);
+}
+
+struct constructor_stats {
+    friend auto operator<=>(const constructor_stats&, const constructor_stats&)
+      = default;
+    int copy_count{};
+    int move_count{};
+    int default_count{};
+    int value_count{};
+    int destructor_count{};
+    int copy_assign_count{};
+    int move_assign_count{};
+};
+
+std::ostream& operator<<(std::ostream& os, const constructor_stats& s) {
+    fmt::print(
+      os,
+      "cp: {}, mv: {}, dflt: {}, val: {}, dest: {}, cp_a: {}, mv_a: {}",
+      s.copy_count,
+      s.move_count,
+      s.default_count,
+      s.value_count,
+      s.destructor_count,
+      s.copy_assign_count,
+      s.move_assign_count);
+    return os;
+}
+
+template<typename tag>
+struct nontrivial {
+    nontrivial() { ++stats.default_count; }
+    explicit nontrivial(size_t n) {
+        ++stats.value_count;
+        v.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            v.push_back(random_generators::gen_alphanum_string(128));
+        }
+    }
+    ~nontrivial() { ++stats.destructor_count; }
+    nontrivial(const nontrivial& other)
+      : v(other.v.begin(), other.v.end()) {
+        ++stats.copy_count;
+    }
+    nontrivial(nontrivial&& other) noexcept
+      : v(std::move(other.v)) {
+        ++stats.move_count;
+    }
+    nontrivial& operator=(const nontrivial& other) {
+        ++stats.copy_assign_count;
+        if (this == &other) {
+            return *this;
+        }
+        v = other.v;
+        return *this;
+    }
+    nontrivial& operator=(nontrivial&& other) noexcept {
+        ++stats.move_assign_count;
+        v = std::move(other.v);
+        return *this;
+    }
+
+    std::vector<ss::sstring> v{};
+
+    static constructor_stats stats;
+};
+
+template<typename T>
+constructor_stats nontrivial<T>::stats{};
+
+using s1 = nontrivial<struct s1_tag>;
+using s2 = nontrivial<struct s2_tag>;
+using s3 = nontrivial<struct s3_tag>;
+
+template<typename T>
+requires reflection::is_std_optional<T> || reflection::is_opt<T>
+T run_optional_test(T oval) {
+    vassert(oval.has_value(), "Pass a value please");
+    // copy
+    T copy{oval};
+    // destroy original
+    oval.reset();
+    // move
+    T moved{std::move(copy).value()};
+    // destroy copy
+    copy = std::nullopt;
+    return std::move(moved).value();
+}
+
+template<typename Container>
+constructor_stats run_container_of_optional_test(int n = 100) {
+    Container c;
+    for (int i = 0; i < n; ++i) {
+        c.emplace_back(10);
+    }
+
+    Container copy_c;
+    copy_c.reserve(c.size());
+    std::ranges::copy(c, std::back_inserter(copy_c));
+    return Container::value_type::value_type::stats;
+}
+
+TEST(opt, WorksWithNontrivialTypes) {
+    {
+        auto stdopt = run_optional_test(std::make_optional<s1>(10));
+        stdopt = run_optional_test(
+          std::make_optional<s1>(std::move(stdopt).value()));
+        stdopt = run_optional_test(std::make_optional<s1>(stdopt.value()));
+        ASSERT_TRUE(stdopt.has_value());
+    }
+
+    {
+        auto rpdopt = run_optional_test(make_opt<s2>(10));
+        rpdopt = run_optional_test(make_opt<s2>(std::move(rpdopt).value()));
+        rpdopt = run_optional_test(make_opt<s2>(rpdopt.value()));
+        ASSERT_TRUE(rpdopt.has_value());
+    }
+
+    {
+        auto rpdopt = run_optional_test(opt<s3>{std::make_optional<s3>(10)});
+        rpdopt = run_optional_test(
+          std::make_optional<s3>(std::move(rpdopt).value()));
+        rpdopt = run_optional_test(std::make_optional<s3>(rpdopt.value()));
+        ASSERT_TRUE(rpdopt.has_value());
+    }
+
+    ASSERT_EQ(s1::stats, s2::stats) << s1::stats << " - " << s2::stats;
+    ASSERT_GT(s3::stats, s1::stats) << s3::stats;
+    ASSERT_EQ(s3::stats.move_count, s2::stats.move_count + 1);
+    ASSERT_EQ(s3::stats.destructor_count, s2::stats.destructor_count + 1);
+}
+
+TEST(opt, WorksWithContainersOfNontrivialTypes) {
+    auto stdopt
+      = run_container_of_optional_test<std::vector<std::optional<s1>>>();
+    auto rpdopt = run_container_of_optional_test<std::vector<opt<s2>>>();
+
+    ASSERT_EQ(stdopt, rpdopt);
+}

--- a/src/v/base/type_traits.h
+++ b/src/v/base/type_traits.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "base/opt.h"
+
 #include <optional>
 #include <type_traits>
 
@@ -77,4 +79,6 @@ namespace reflection {
 template<typename T>
 concept is_std_optional = ::detail::is_specialization_of_v<T, std::optional>;
 
-}
+template<typename T>
+concept is_opt = ::detail::is_specialization_of_v<T, opt>;
+} // namespace reflection


### PR DESCRIPTION
Inherits most functionality from std::optional, with the exception of:

- Pointer style access
- optional::swap (incidental, but not feasible I think)
- Direct comparison to the ::value_type or nullopt_t

Includes some tests aiming to confirm no funny business with respect to copying, moving and so on.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
