### PR TITLE
storage: Disable TS for `__consumer_offsets`

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -634,6 +634,7 @@ redpanda_cc_gtest(
         "//src/v/cluster",
         "//src/v/cluster/cloud_metadata/tests:manual_mixin",
         "//src/v/kafka/data:partition_proxy",
+        "//src/v/kafka/protocol:find_coordinator",
         "//src/v/kafka/server/tests:kafka_test_utils",
         "//src/v/model",
         "//src/v/random:generators",

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -15,8 +15,10 @@
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/ntp_archiver_service.h"
 #include "cluster/cloud_metadata/tests/manual_mixin.h"
+#include "cluster/controller_api.h"
 #include "cluster/health_monitor_frontend.h"
 #include "kafka/data/replicated_partition.h"
+#include "kafka/protocol/find_coordinator.h"
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
@@ -1264,6 +1266,34 @@ TEST_P(EndToEndFixture, TestMixedTimequery) {
           true,
           model::offset{i});
     }
+}
+
+TEST_P(EndToEndFixture, TestConsumerOffsetsNoTieredStorage) {
+    model::ntp ntp(
+      model::kafka_consumer_offsets_nt.ns,
+      model::kafka_consumer_offsets_nt.tp,
+      model::partition_id{0});
+
+    auto client = make_kafka_client().get();
+    auto client_stop_guard = ss::defer([&client] { client.stop().get(); });
+
+    client.connect().get();
+    kafka::find_coordinator_request req(kafka::group_instance_id("foo"));
+    req.data.key_type = kafka::coordinator_type::group;
+    client.dispatch(std::move(req), kafka::api_version(1)).get();
+
+    ASSERT_EQ(
+      cluster::errc::success,
+      app.controller->get_api()
+        .local()
+        .wait_for_topic(
+          model::kafka_consumer_offsets_nt, model::timeout_clock::now() + 30s)
+        .get());
+
+    auto partition = app.partition_manager.local().get(ntp);
+    ASSERT_FALSE(partition->archiver().has_value());
+    ASSERT_EQ(nullptr, partition->archival_meta_stm().get());
+    ASSERT_FALSE(partition->cloud_data_available());
 }
 
 INSTANTIATE_TEST_SUITE_P(WithOverride, EndToEndFixture, ::testing::Bool());

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -27,6 +27,7 @@
 #include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
 #include "model/record_utils.h"
@@ -1687,6 +1688,7 @@ archival_metadata_stm_factory::archival_metadata_stm_factory(
 bool archival_metadata_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
     return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
+           && ntp_cfg.ntp().tp.topic != model::kafka_consumer_offsets_topic
            && ntp_cfg.ntp().ns == model::kafka_namespace;
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -803,7 +803,16 @@ bool partition::should_construct_archiver() {
     return config::shard_local_cfg().cloud_storage_enabled()
            && config::shard_local_cfg().cloud_storage_disable_archiver_manager()
            && _cloud_storage_api.local_is_initialized()
+           // The archiver can only be created for partitions that belong to
+           // user topics. This includes everything inside the kafka namespace
+           // except for the kafka consumer offsets topic. The consumer offsets
+           // topic is backed up separately by the cluster/cluster_metadata
+           // subsystem. The archival_metadata_stm can't be created for the
+           // consumer offsets topic partitions. The schema registry topic is
+           // not exempt from this. It should be possible to create an archiver
+           // for it.
            && _raft->ntp().ns == model::kafka_namespace
+           && _raft->ntp().tp.topic != model::kafka_consumer_offsets_topic
            && (ntp_config.is_archival_enabled() || ntp_config.is_read_replica_mode_enabled());
 }
 


### PR DESCRIPTION
This PR prevents Tiered Storage from being enabled for `__consumer_offsets` if TS is enabled by default.
It also disables TS for existing topics by altering the output of the `is_archival_enabled` and `is_tiered_storage_enabled` method of the `ntp_config`. This has similar effect to disabling this properties manually for the `__consumer_offsets` topic. The archival STM is no longer created for the CO topic. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Tiered storage and Iceberg can no longer be enabled for the `__consumer_offsets` topic.