### PR TITLE
benchmarks: run benchmarks in shared memory

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -353,7 +353,8 @@ def redpanda_cc_bench(
         duration = None,
         data = [],
         tags = [],
-        target_compatible_with = []):
+        target_compatible_with = [],
+        redirect_stderr = False):
     """
     Create a seastar benchmark target
 
@@ -372,6 +373,8 @@ def redpanda_cc_bench(
       tags: custom tags for the test
       timeout: the timeout for smoke testing the benchmark
       target_compatible_with: constraints for the test target
+      redirect_stderr: if True, redirects stdout (seastar logging, mostly) to a file
+                       so that it does not overwhelm the result output
     """
     args = [
         "--blocked-reactor-notify-ms 2000000",
@@ -403,14 +406,15 @@ def redpanda_cc_bench(
 
     tags = tags + ["bench"]
 
+    binary_name = name + "_binary"
+
     native.cc_binary(
-        name = name,
+        name = binary_name,
         srcs = srcs,
         defines = defines,
         deps = deps,
         testonly = True,
         copts = redpanda_copts(),
-        args = args + binary_args,
         features = [
             "layering_check",
         ],
@@ -418,6 +422,28 @@ def redpanda_cc_bench(
         env = env,
         data = data,
     )
+
+    args = ["$(rootpath :{})".format(binary_name)] + args
+
+    env = env | {
+        "MB_REDIRECT_STDERR_DEFAULT": "1" if redirect_stderr else "0",
+    }
+
+    # to run a benchmark in the right way, we need to wrap it in bench-wrapper.sh,
+    # which can cd to the right location and make other adjustments
+    native.sh_binary(
+        name = name,
+        srcs = ["//tools:bench_wrapper"],
+        args = args,
+        data = data + [
+            ":" + binary_name,
+        ],
+        env = env,
+        testonly = True,
+    )
+
+    # we write a wrapper to test the benchmark, which tries to
+    # run it as quickly as possible in order to smoke test it
     write_file(
         name = name + "_test_script",
         out = name + "_test_wrapper.sh",
@@ -433,11 +459,9 @@ def redpanda_cc_bench(
         tags = resource_tags + tags,
         srcs = [name + "_test_script"],
         env = env | test_env,
-        args = [
-            "$(rootpath :{})".format(name),
-        ] + args,
+        args = args,
         data = [
-            ":" + name,
+            ":" + binary_name,
         ] + data + test_data,
         target_compatible_with = target_compatible_with,
     )

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -862,6 +862,7 @@ redpanda_cc_bench(
     ],
     duration = 1,
     memory = "4GiB",
+    redirect_stderr = True,
     runs = 1,
     tags = ["exclusive"],
     deps = [

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -75,3 +75,9 @@ alias(
     name = "format_clang",
     actual = ":clang_format",
 )
+
+filegroup(
+    name = "bench_wrapper",
+    srcs = ["bench-wrapper.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/bench-wrapper.sh
+++ b/tools/bench-wrapper.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# A wrapper which execs benchmarks after some prep.
+
+set -euo pipefail
+
+basename=$(basename "$1")
+stderr=$(mktemp --tmpdir "$basename.stderr.XXXXXXXX")
+rundir=${MB_RUNDIR:-/dev/shm/vectorized_io}
+exe_path=$(realpath "$1")
+# whether to redirect stderr (to avoid overwhelming the result output with
+# seastar logging: use MB_REDIRECT_STDERR=1 in your env
+# while calling bazel to override: bazel itself passes MB_REDIRECT_STDERR_DEFAULT
+# based on how the benchmark is configured
+redirect_stderr=${MB_REDIRECT_STDERR:-${MB_REDIRECT_STDERR_DEFAULT:-0}}
+
+# drop the relative exe path from the args
+shift
+
+echo "[bench-wrapper] running benchmark : $basename"
+if [[ $redirect_stderr == 1 ]]; then
+  echo "[bench-wrapper] redirecting stderr: $stderr"
+else
+  echo "[bench-wrapper] not redirecting stderr"
+fi
+echo "[bench-wrapper] stderr saved at   : $stderr"
+echo "[bench-wrapper] rundir            : $rundir"
+echo "[bench-wrapper] command           : ${exe_path} $*"
+
+mkdir -p "$rundir"
+cd "$rundir"
+
+rc=0
+if [[ $redirect_stderr == 1 ]]; then
+  $exe_path "$@" 2>$stderr || rc=$?
+else
+  $exe_path "$@" || rc=$?
+fi
+
+if [[ $rc -ne 0 ]]; then
+  msg="[bench-wrapper] ERROR: benchmark failed (rc=$rc)"
+  if [[ $redirect_stderr == 1 ]]; then
+    echo "$msg first and last 40 lines of stderr below"
+    echo "=== First 40 lines of stderr ==="
+    head -n 40 "$stderr"
+    echo "=== Last 40 lines of stderr ==="
+    tail -n 40 "$stderr"
+    echo "$msg, full stderr at $stderr"
+  else
+    echo "$msg"
+  fi
+else
+  echo "[bench-wrapper] benchmark completed successfully"
+fi


### PR DESCRIPTION
Introduce bench-wrapper.sh, which is a wrapper script for a microbenchmark. The main thing it does now is runs the benchmark in shared memory. This is important because the benchmark may do IO and doing it to shm is low-variance and fast. The old ctest way did it this way and this resulted in spurious CDP detection when we moved to bazel.

To run the benchmark int the wrapper, append `.run` to the benchmark target, like:

```
bazel run //src/v/kafka/server/tests:kafka_produce_partition_rpbench.run
```

Fixes CORE-9760.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
