### PR TITLE
datalake: strict enforcement of scratch space usage

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4125,6 +4125,16 @@ configuration::configuration()
       "Size, in bytes, of the amount of scratch space datalake should use.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5_GiB)
+  , datalake_scratch_space_soft_limit_size_percent(
+      *this,
+      "datalake_scratch_space_soft_limit_size_percent",
+      "Size of the scratch space datalake soft limit expressed as a percentage "
+      "of the datalake_scratch_space_size_bytes configuration value.",
+      {.needs_restart = needs_restart::no,
+       .example = "80.0",
+       .visibility = visibility::user},
+      80.0,
+      {.min = 0.0, .max = 100.0})
   , datalake_disk_usage_overage_coeff(
       *this,
       "datalake_disk_usage_overage_coeff",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4108,17 +4108,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
   , datalake_disk_space_monitor_interval(
-      *this,
-      "datalake_disk_space_monitor_interval",
-      "The amount of time between invocations of the datalake disk space usage "
-      "monitor which examines disk usage and dispatches requests to "
-      "translators to reduce their usage if it is above the configured "
-      "threshold.",
-      {.needs_restart = needs_restart::no,
-       .example = "3600000",
-       .visibility = visibility::tunable},
-      30s,
-      {.min = 2s})
+      *this, "datalake_disk_space_monitor_interval")
   , datalake_scratch_space_size_bytes(
       *this,
       "datalake_scratch_space_size_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4145,6 +4145,17 @@ configuration::configuration()
        .example = "1.8",
        .visibility = visibility::tunable},
       2.0)
+  , datalake_scheduler_disk_reservation_block_size(
+      *this,
+      "datalake_scheduler_disk_reservation_block_size",
+      "The size, in bytes, of the block of disk reservation that the datalake "
+      "manager will assign to each datalake scheduler when it runs out of "
+      "local reservation.",
+      {.needs_restart = needs_restart::no,
+       .example = "10000000",
+       .visibility = visibility::tunable},
+      50_MiB,
+      {.min = 1_MiB})
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -763,6 +763,8 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds>
       datalake_disk_space_monitor_interval;
     property<size_t> datalake_scratch_space_size_bytes;
+    bounded_property<double, numeric_bounds>
+      datalake_scratch_space_soft_limit_size_percent;
     property<double> datalake_disk_usage_overage_coeff;
 
     configuration();

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -760,8 +760,7 @@ struct configuration final : public config_store {
       datalake_scheduler_time_slice_ms;
     bounded_property<size_t> datalake_translator_flush_bytes;
     property<bool> datalake_disk_space_monitor_enable;
-    bounded_property<std::chrono::milliseconds>
-      datalake_disk_space_monitor_interval;
+    deprecated_property datalake_disk_space_monitor_interval;
     property<size_t> datalake_scratch_space_size_bytes;
     bounded_property<double, numeric_bounds>
       datalake_scratch_space_soft_limit_size_percent;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -766,6 +766,7 @@ struct configuration final : public config_store {
     bounded_property<double, numeric_bounds>
       datalake_scratch_space_soft_limit_size_percent;
     property<double> datalake_disk_usage_overage_coeff;
+    bounded_property<size_t> datalake_scheduler_disk_reservation_block_size;
 
     configuration();
 

--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -30,6 +30,8 @@ std::ostream& operator<<(std::ostream& os, const writer_error& ev) {
         return os << "Time limit exceeded";
     case writer_error::shutting_down:
         return os << "Shutting down";
+    case writer_error::out_of_disk:
+        return os << "Disk exhausted";
     case writer_error::unknown_error:
         return os << "Unknown error";
     }
@@ -48,6 +50,8 @@ writer_error map_to_writer_error(reservation_error reservation_err) {
         return writer_error::oom_error;
     case time_quota_exceeded:
         return writer_error::time_limit_exceeded;
+    case out_of_disk:
+        return writer_error::out_of_disk;
     case unknown:
         return writer_error::unknown_error;
     }
@@ -58,6 +62,7 @@ bool is_recoverable_error(datalake::writer_error err) {
     case datalake::writer_error::ok:
     case datalake::writer_error::oom_error:
     case datalake::writer_error::time_limit_exceeded:
+    case datalake::writer_error::out_of_disk:
         return true;
     case datalake::writer_error::parquet_conversion_error:
     case datalake::writer_error::file_io_error:

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -65,6 +65,55 @@ enum reservation_error {
 };
 
 writer_error map_to_writer_error(reservation_error);
+
+/**
+ * Interface to track disk used by parquet writers.
+ *
+ * disk space tracking considers the combined total of buffered and already
+ * flushed data. this is because in the current implementation when a translator
+ * uploads and removes data from disk it also flushes all of its bufferred data.
+ * if those two actions are decoupled, then this accounting could be updated to
+ * provide more flexibility in controlling resource usage.
+ */
+class writer_disk_tracker {
+public:
+    writer_disk_tracker() = default;
+    writer_disk_tracker(const writer_disk_tracker&) = delete;
+    writer_disk_tracker(writer_disk_tracker&&) = default;
+    writer_disk_tracker& operator=(const writer_disk_tracker&) = delete;
+    writer_disk_tracker& operator=(writer_disk_tracker&&) = delete;
+
+    virtual ~writer_disk_tracker() = default;
+
+    /**
+     * Reserves passed input bytes.
+     */
+    virtual ss::future<reservation_error>
+    reserve_bytes(size_t bytes, ss::abort_source&) noexcept = 0;
+
+    /**
+     * Frees up passed input bytes.
+     *
+     * The amount of data on disk isn't being reduced here, but disk accounting
+     * is the total of buffered and flushed, and the buffered component may
+     * shrink (e.g. due to compression).
+     */
+    virtual ss::future<> free_bytes(size_t bytes, ss::abort_source&) = 0;
+
+    /**
+     * Releases all the reservations. After this caller, the reserved bytes
+     * tracked is 0. May not be called concurrently with other methods.
+     */
+    virtual void release() = 0;
+
+    /**
+     * Release unused reservation units. Invoke this if units are not expected
+     * be used in the near term. See reservation_tracker::reserve_disk for
+     * additional information.
+     */
+    virtual void release_unused() = 0;
+};
+
 /**
  * Interface to track memory used by the parquet writers. The reservations are
  * held until the tracker object is alive or release is explicitly called.
@@ -95,6 +144,16 @@ public:
      * tracked is 0. May not be called concurrently with other methods.
      */
     virtual void release() = 0;
+
+    /*
+     * Return a reference to the disk resource tracker.
+     *
+     * TODO: instead of plumbing additional resource trackers around in
+     * parallel to the writer_mem_tracker, the writer_mem_tracker should be
+     * renamed to resource_tracker and expose the writer_mem_tracker like we are
+     * doing here for the disk resource.
+     */
+    virtual writer_disk_tracker& disk() = 0;
 };
 
 /**

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -29,6 +29,7 @@ enum class writer_error {
     oom_error,
     time_limit_exceeded,
     shutting_down,
+    out_of_disk,
     unknown_error,
 };
 std::ostream& operator<<(std::ostream&, const writer_error&);
@@ -59,7 +60,8 @@ enum reservation_error {
     shutting_down = 1,
     out_of_memory = 2,
     time_quota_exceeded = 3,
-    unknown = 4,
+    out_of_disk = 4,
+    unknown = 5,
 };
 
 writer_error map_to_writer_error(reservation_error);

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -142,7 +142,15 @@ datalake_manager::datalake_manager(
             ex);
       })
   , _disk_usage_interval(
-      config::shard_local_cfg().datalake_disk_space_monitor_interval.bind()) {}
+      config::shard_local_cfg().datalake_disk_space_monitor_interval.bind())
+  , _core0_disk_bytes_reservable{0, "datalake::core0_disk_bytes_reservable"}
+  , _disk_space_manager_enable(
+      config::shard_local_cfg().datalake_disk_space_monitor_enable.bind())
+  , _scratch_space_size_bytes(
+      config::shard_local_cfg().datalake_scratch_space_size_bytes.bind())
+  , _scratch_space_soft_limit_size_percent(
+      config::shard_local_cfg()
+        .datalake_scratch_space_soft_limit_size_percent.bind()) {}
 datalake_manager::~datalake_manager() = default;
 
 size_t datalake_manager::total_translation_backlog() const {
@@ -266,6 +274,15 @@ ss::future<> datalake_manager::start() {
      */
     const ss::shard_id disk_space_monitor_core = 0;
     if (ss::this_shard_id() == disk_space_monitor_core) {
+        // setup config bindings to trigger reconfiguration
+        _disk_space_manager_enable.watch([this] { update_disk_limits(); });
+        _scratch_space_size_bytes.watch([this] { update_disk_limits(); });
+        _scratch_space_soft_limit_size_percent.watch(
+          [this] { update_disk_limits(); });
+
+        // initialize
+        update_disk_limits();
+
         ssx::spawn_with_gate(_gate, [this] { return disk_space_monitor(); });
     }
 
@@ -648,6 +665,60 @@ size_t datalake_manager::partitions_with_translation_blocked() const {
     // TODO: Return blocked if partition wasn't translated for a long time f.e.
     // moret
     return 0;
+}
+
+void datalake_manager::update_disk_limits() {
+    // the requests
+    auto new_total_size = _scratch_space_size_bytes();
+    if (!_disk_space_manager_enable()) {
+        // when we disable the manager we want to effectively stop enforcing
+        // limits. so make the total allowable size massive, but not so big that
+        // we need to worry about any kind of integer overflow.
+        new_total_size = 50_TiB;
+    }
+
+    const auto new_soft_percent = _scratch_space_soft_limit_size_percent();
+
+    // current settings
+    const auto prev_total = _disk_bytes_reservable_total;
+    const auto prev_soft_limit = _disk_bytes_reservable_soft_limit;
+    const auto prev_available = _core0_disk_bytes_reservable.available_units();
+
+    _disk_bytes_reservable_soft_limit = static_cast<size_t>(
+      static_cast<double>(new_total_size) * (new_soft_percent / 100.0));
+
+    if (new_total_size > _disk_bytes_reservable_total) {
+        auto units = new_total_size - _disk_bytes_reservable_total;
+        _disk_bytes_reservable_total = new_total_size;
+        _core0_disk_bytes_reservable.signal(units);
+
+    } else if (new_total_size < _disk_bytes_reservable_total) {
+        auto units = _disk_bytes_reservable_total - new_total_size;
+        _disk_bytes_reservable_total = new_total_size;
+        _core0_disk_bytes_reservable.consume(units);
+    }
+
+    /*
+     * when shrinking the size of the scratch space the semaphore tracking
+     * available units on core 0 may become negative because all the units are
+     * currently handed out to other cores.
+     */
+    auto format_reservable = [](auto v) {
+        if (v >= 0) {
+            return fmt::format("{}", human::bytes(v));
+        }
+        return fmt::format("{} ({})", human::bytes(0), v);
+    };
+
+    vlog(
+      datalake_log.info,
+      "Setting scratch space total {} soft {} available {} prev ({}, {}, {})",
+      human::bytes(_disk_bytes_reservable_total),
+      human::bytes(_disk_bytes_reservable_soft_limit),
+      format_reservable(_core0_disk_bytes_reservable.available_units()),
+      human::bytes(prev_total),
+      human::bytes(prev_soft_limit),
+      format_reservable(prev_available));
 }
 
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -84,6 +84,16 @@ make_record_translator(const model::iceberg_mode& mode) {
 }
 } // namespace
 
+class core_0_disk_manager : public translation::scheduling::disk_manager {
+public:
+    static constexpr ss::shard_id manager_shard = 0;
+
+    /*
+     * A temporary implementation that grants all requests.
+     */
+    ss::future<size_t> reserve() override { co_return 1_MiB; }
+};
+
 datalake_manager::datalake_manager(
   model::node_id self,
   ss::sharded<raft::group_manager>* group_mgr,
@@ -125,6 +135,7 @@ datalake_manager::datalake_manager(
   , _iceberg_invalid_record_action(
       config::shard_local_cfg().iceberg_invalid_record_action.bind())
   , _writer_scratch_space(config::node().datalake_staging_path())
+  , _disk_manager(std::make_unique<core_0_disk_manager>())
   , _scheduler(
       memory_limit,
       config::shard_local_cfg().datalake_scheduler_block_size_bytes(),
@@ -132,7 +143,8 @@ datalake_manager::datalake_manager(
         config::shard_local_cfg()
           .datalake_scheduler_max_concurrent_translations.bind(),
         std::chrono::duration_cast<translation::scheduling::clock::duration>(
-          config::shard_local_cfg().datalake_scheduler_time_slice_ms())))
+          config::shard_local_cfg().datalake_scheduler_time_slice_ms())),
+      *_disk_manager)
   , _queue(
       sg,
       [](const std::exception_ptr& ex) {
@@ -272,8 +284,7 @@ ss::future<> datalake_manager::start() {
     /*
      * Start the global disk space usage monitor loop
      */
-    const ss::shard_id disk_space_monitor_core = 0;
-    if (ss::this_shard_id() == disk_space_monitor_core) {
+    if (ss::this_shard_id() == core_0_disk_manager::manager_shard) {
         // setup config bindings to trigger reconfiguration
         _disk_space_manager_enable.watch([this] { update_disk_limits(); });
         _scratch_space_size_bytes.watch([this] { update_disk_limits(); });

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -386,6 +386,34 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
     using index_type = absl::btree_multimap<size_t, translator_info>;
 
     /*
+     * it may be the case that there is plenty of free space, but each scheduler
+     * is holding on to unused units. so the first step is to go harvest excess
+     * units and then take additional action if we are really out of space.
+     */
+    auto excess_units = co_await container().map_reduce0(
+      [](datalake_manager& mgr) {
+          return mgr._scheduler.release_unused_disk_units();
+      },
+      size_t{0},
+      [](size_t acc, size_t units) { return acc + units; });
+
+    // if schedulers miss their disk units, they'll come say hi
+    if (excess_units > 0) {
+        _core0_disk_bytes_reservable.signal(excess_units);
+    }
+
+    vlog(
+      datalake_log.debug,
+      "Collected {} unused disk reservation units, remaining {}",
+      human::bytes(excess_units),
+      human::bytes(_core0_disk_bytes_reservable.current()));
+
+    // low disk problem solved?
+    if (!disk_space_soft_limit_exceeded()) {
+        co_return;
+    }
+
+    /*
      * Collect disk usage from all translators managed by the scheduler, and
      * combine these usages from across all cores to create a global set of
      * translators ordered by their disk usage.

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -84,14 +84,62 @@ make_record_translator(const model::iceberg_mode& mode) {
 }
 } // namespace
 
+/*
+ * high-level design of space management
+ *
+ * Core 0 manages the total space reservation on the system. It is modeled as a
+ * semaphore that records the unreserved space (aka free space), and is
+ * initialized to the total allowable scratch space size. Each scheduler
+ * also has a disk reservation which is initialized to 0.
+ *
+ * When a translator writes data to disk is attempts to acquire disk reservation
+ * from its core-local scheduler. When the core-local scheduler does not have
+ * any reservation available then it tries to acquire a block of reservation
+ * from the core 0 manager.
+ *
+ * If core 0 has sufficient units to hand out to a scheduler, then the request
+ * is granted immediately. Otherwise, no units are granted and the scheduler
+ * will go into a polling loop until units become available.
+ *
+ * When core 0 unused space dips below the soft limit (e.g. 80% of the total)
+ * then it initiates a process to bring utilization down below the soft limit
+ * and free up space.
+ *
+ * It is a two step process. First, core 0 requests all cores to release their
+ * unused disk reservation to core 0. If this brings down the usage below soft
+ * limit then the process completes. Otherwise, core 0 requests that translators
+ * with large reservations finish immedinately and release their units. The
+ * process continues until usage falls below the soft limit.
+ */
 class core_0_disk_manager : public translation::scheduling::disk_manager {
 public:
     static constexpr ss::shard_id manager_shard = 0;
 
     /*
-     * A temporary implementation that grants all requests.
+     * ideally we could initialize with container() in the datalake manager
+     * constructor. however, seastar doesn't set the underlying container()
+     * pointer until after service instance is constructed. so we need to patch
+     * the proxy pointer, and a convenient place is datalake_manager::start.
      */
-    ss::future<size_t> reserve() override { co_return 1_MiB; }
+    void set_manager_reference(ss::sharded<datalake_manager>& manager) {
+        vassert(_manager == nullptr, "manager reference set twice");
+        _manager = &manager;
+    }
+
+    ss::future<size_t> reserve() override {
+        if (_manager) {
+            const auto from = ss::this_shard_id();
+            return _manager->invoke_on(
+              manager_shard, [from](datalake_manager& manager) {
+                  return manager.reserve_disk(from);
+              });
+        }
+        vlog(datalake_log.debug, "Dropping disk reservation request");
+        return ss::make_ready_future<size_t>(0);
+    }
+
+private:
+    ss::sharded<datalake_manager>* _manager{nullptr};
 };
 
 datalake_manager::datalake_manager(
@@ -183,6 +231,7 @@ datalake_manager::get_or_create_probe(const model::ntp& ntp) {
 }
 
 ss::future<> datalake_manager::start() {
+    _disk_manager->set_manager_reference(container());
     _catalog = co_await _catalog_factory->create_catalog();
     _schema_mgr = std::make_unique<catalog_schema_manager>(*_catalog);
     // partition managed notification, this is particularly
@@ -359,19 +408,20 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
           return acc;
       });
 
-    const size_t target_size
-      = config::shard_local_cfg().datalake_scratch_space_size_bytes();
-
     const auto total_bytes = std::reduce(
       usage.begin(),
       usage.end(),
       size_t(0),
       [](const auto acc, const auto& elem) { return acc + elem.first; });
 
-    // the amount of disk usage over the target
-    const auto real_target_excess = total_bytes < target_size
-                                      ? 0
-                                      : total_bytes - target_size;
+    // check again after scheduling point
+    if (!disk_space_soft_limit_exceeded()) {
+        co_return;
+    }
+
+    // amount to free to get back to the soft limit
+    const auto soft_limit_excess = disk_space_soft_limit()
+                                   - _core0_disk_bytes_reservable.current();
 
     /*
      * do nothing if we are over the limit, but only by a "small" amount, which
@@ -380,13 +430,14 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
      * to avoid thrashing (see resource_mgm/storage.cc).
      */
     const size_t min_size_threshold = 64_MiB;
-    if (real_target_excess <= min_size_threshold) {
+    if (soft_limit_excess <= min_size_threshold) {
         vlog(
           datalake_log.trace,
-          "Disk monitor total {} target {} excess",
+          "Disk monitor total {} available {} soft limit {} excess {}",
           human::bytes(total_bytes),
-          human::bytes(target_size),
-          human::bytes(real_target_excess));
+          human::bytes(_core0_disk_bytes_reservable.current()),
+          human::bytes(disk_space_soft_limit()),
+          human::bytes(soft_limit_excess));
         co_return;
     }
 
@@ -394,7 +445,7 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
       = config::shard_local_cfg().datalake_disk_usage_overage_coeff();
 
     const auto adjusted_target_excess = static_cast<size_t>(
-      real_target_excess * coeff);
+      soft_limit_excess * coeff);
 
     /*
      * Generate a schedule of translators that should be finished immediately so
@@ -421,14 +472,14 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
     }
 
     vlog(
-      datalake_log.info,
-      "Requesting {} translators to reclaim {}. Current total {} target {}/{} "
-      "excess {}",
+      datalake_log.debug,
+      "Requesting {} translators to reclaim {}. Current total {} soft limit {} "
+      "excess {} adjusted {}",
       num_translators,
       human::bytes(schedule_total_bytes),
       human::bytes(total_bytes),
-      human::bytes(target_size),
-      human::bytes(real_target_excess),
+      human::bytes(disk_space_soft_limit()),
+      human::bytes(soft_limit_excess),
       human::bytes(adjusted_target_excess));
 
     /*
@@ -443,6 +494,48 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
                 mgr._scheduler.request_immediate_finish(std::move(translators));
             });
       });
+}
+
+size_t datalake_manager::disk_space_soft_limit() {
+    return _disk_bytes_reservable_soft_limit;
+}
+
+bool datalake_manager::disk_space_soft_limit_exceeded() {
+    // we use the available_units semaphore interface which is adjusted to
+    // reflect any deficits (cores owe us units), and might be negative.
+    const auto used = static_cast<ssize_t>(_disk_bytes_reservable_total)
+                      - _core0_disk_bytes_reservable.available_units();
+    return used > static_cast<ssize_t>(disk_space_soft_limit());
+}
+
+ss::future<size_t> datalake_manager::reserve_disk(ss::shard_id shard) {
+    /*
+     * figure out how many units we'll return to the caller. if after consuming
+     * these units we've exceeded the configured soft limit then kick the disk
+     * space monitor which will attempt to bring usage back down below the soft
+     * limit.
+     */
+    const auto units = std::min(
+      _core0_disk_bytes_reservable.current(),
+      config::shard_local_cfg()
+        .datalake_scheduler_disk_reservation_block_size());
+    if (units > 0) {
+        _core0_disk_bytes_reservable.consume(units);
+    }
+
+    if (disk_space_soft_limit_exceeded()) {
+        _disk_space_monitor_sem.signal();
+    }
+
+    vlog(
+      datalake_log.debug,
+      "Allocated {} disk reservation for shard {} from global pool. Total "
+      "available {}",
+      human::bytes(units),
+      shard,
+      human::bytes(_core0_disk_bytes_reservable.current()));
+
+    co_return units;
 }
 
 ss::future<>

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -378,14 +378,16 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
     size_t schedule_total_bytes = 0;
     absl::flat_hash_map<
       ss::shard_id,
-      chunked_vector<std::pair<translator_id, size_t>>>
+      chunked_vector<translation::scheduling::scheduler::finish_request>>
       schedule;
     for (auto& it : std::ranges::reverse_view(usage)) {
         if (schedule_total_bytes >= adjusted_target_excess) {
             break;
         }
-        schedule[it.second.first].push_back(
-          std::make_pair(it.second.second, it.first));
+        schedule[it.second.first].emplace_back(
+          it.second.second,
+          it.first,
+          translation::scheduling::translator::stop_reason::out_of_disk);
         schedule_total_bytes += it.first;
         num_translators++;
     }

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -201,8 +201,6 @@ datalake_manager::datalake_manager(
             "unexpected error in managing translator: {}",
             ex);
       })
-  , _disk_usage_interval(
-      config::shard_local_cfg().datalake_disk_space_monitor_interval.bind())
   , _core0_disk_bytes_reservable{0, "datalake::core0_disk_bytes_reservable"}
   , _disk_space_manager_enable(
       config::shard_local_cfg().datalake_disk_space_monitor_enable.bind())
@@ -345,29 +343,15 @@ ss::future<> datalake_manager::start() {
 
         ssx::spawn_with_gate(_gate, [this] { return disk_space_monitor(); });
     }
-
-    _disk_usage_interval.watch([this] { _disk_space_monitor_sem.signal(); });
 }
 
 ss::future<> datalake_manager::disk_space_monitor() {
     while (!_gate.is_closed()) {
-        const auto interval = _disk_usage_interval();
-        try {
-            co_await _disk_space_monitor_sem.wait(
-              interval, std::max(_disk_space_monitor_sem.current(), size_t(1)));
-        } catch (const ss::semaphore_timed_out& ex) {
-            std::ignore = ex;
-            // drop through to perform work
-        }
-
-        if (_disk_usage_interval() != interval) {
-            // configuration change
-            continue;
-        }
-
-        if (!config::shard_local_cfg().datalake_disk_space_monitor_enable()) {
-            continue;
-        }
+        co_await _disk_space_monitor_cv.wait([this] {
+            return config::shard_local_cfg()
+                     .datalake_disk_space_monitor_enable()
+                   && disk_space_soft_limit_exceeded();
+        });
 
         try {
             co_await check_and_manage_disk_space();
@@ -377,6 +361,12 @@ ss::future<> datalake_manager::disk_space_monitor() {
               "Recoverable error checking datalake disk space: {}",
               std::current_exception());
         }
+
+        /*
+         * even when we the system is driven to high disk space utilization
+         * frequently, we don't want to go too hard with the reclaim loop.
+         */
+        co_await ss::sleep_abortable(1s, _as->local());
     }
 }
 
@@ -552,7 +542,7 @@ ss::future<size_t> datalake_manager::reserve_disk(ss::shard_id shard) {
     }
 
     if (disk_space_soft_limit_exceeded()) {
-        _disk_space_monitor_sem.signal();
+        _disk_space_monitor_cv.signal();
     }
 
     vlog(
@@ -618,7 +608,7 @@ datalake_manager::prepare_staging_directory(std::filesystem::path path) {
 
 ss::future<> datalake_manager::shutdown() {
     vlog(datalake_log.debug, "Stopping datalake manager...");
-    _disk_space_monitor_sem.broken();
+    _disk_space_monitor_cv.broken();
     auto f = _gate.close();
     co_await _queue.shutdown();
     if (_backlog_controller) {
@@ -829,6 +819,11 @@ void datalake_manager::update_disk_limits() {
         _disk_bytes_reservable_total = new_total_size;
         _core0_disk_bytes_reservable.consume(units);
     }
+
+    /*
+     * let the monitor see if anything needs to be done based on the changes
+     */
+    _disk_space_monitor_cv.signal();
 
     /*
      * when shrinking the size of the scratch space the semaphore tracking

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -481,9 +481,11 @@ ss::future<> datalake_manager::check_and_manage_disk_space() {
         if (schedule_total_bytes >= adjusted_target_excess) {
             break;
         }
+        // it.first is the data usage by the translator. if the scheduling
+        // policy can make use of it, then it coudl be passed in here to avoid
+        // recalulation of the same value.
         schedule[it.second.first].emplace_back(
           it.second.second,
-          it.first,
           translation::scheduling::translator::stop_reason::out_of_disk);
         schedule_total_bytes += it.first;
         num_translators++;

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -138,6 +138,12 @@ private:
      */
     ss::future<> check_and_manage_disk_space();
 
+    /*
+     * A helper that can be called when disk limit configuration values change
+     * which will recompute the active configuration.
+     */
+    void update_disk_limits();
+
 private:
     model::node_id _self;
     ss::sharded<raft::group_manager>* _group_mgr;
@@ -171,6 +177,35 @@ private:
     ssx::work_queue _queue;
     ssx::semaphore _disk_space_monitor_sem{0, "datalake::disk_space_monitor"};
     config::binding<std::chrono::milliseconds> _disk_usage_interval;
+    /*
+     * _disk_bytes_reservable_total
+     *
+     * - this is the total amount of disk space that can be reserved. it is
+     * a fixed value set when configuration changes. it's basically the upper
+     * limit on the total size of the scratch space used on the system. it
+     * is only accessed by core 0.
+     *
+     * _core0_disk_bytes_reservable
+     *
+     * - this is a semaphore that represents a subset of the reservable
+     * total which is currently available for reserving. when the system
+     * starts this semaphore has units equal to the reservable total. as
+     * translators on other cores reserve disk space, they subtract off
+     * units from this semaphore, making those units unreservable. the
+     * semaphore is only used on core 0.
+     *
+     * schedulers consume units from the semaphore by contacting the datalake
+     * manager on core 0. currently cores do not return units willingly.
+     * instead, when the data lake manager is low on reservable space, it (1)
+     * requests translators to free space by finishing and then (2) steals
+     * unreserved units from each core to be handed back out on demand.
+     */
+    size_t _disk_bytes_reservable_total{0};
+    size_t _disk_bytes_reservable_soft_limit{0};
+    ssx::semaphore _core0_disk_bytes_reservable;
+    config::binding<bool> _disk_space_manager_enable;
+    config::binding<size_t> _scratch_space_size_bytes;
+    config::binding<double> _scratch_space_soft_limit_size_percent;
 };
 
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -141,6 +141,21 @@ private:
     ss::future<> check_and_manage_disk_space();
 
     /*
+     * Returns the disk soft limit, which is the threshold above which disk
+     * utilization will trigger asynchronous requests to translators to finish
+     * their translations and release on disk resources.
+     */
+    size_t disk_space_soft_limit();
+
+    /*
+     * Returns true if the disk space soft limit were breached.
+     */
+    bool disk_space_soft_limit_exceeded();
+
+    friend class core_0_disk_manager;
+    ss::future<size_t> reserve_disk(ss::shard_id);
+
+    /*
      * A helper that can be called when disk limit configuration values change
      * which will recompute the active configuration.
      */

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -46,6 +46,8 @@ class registry;
 
 namespace datalake {
 
+class core_0_disk_manager;
+
 /*
  * Per shard instance responsible for launching and synchronizing all datalake
  * related tasks like file format translation, frontend etc.
@@ -173,6 +175,7 @@ private:
     config::binding<model::iceberg_invalid_record_action>
       _iceberg_invalid_record_action;
     std::filesystem::path _writer_scratch_space;
+    std::unique_ptr<core_0_disk_manager> _disk_manager;
     translation::scheduling::scheduler _scheduler;
     ssx::work_queue _queue;
     ssx::semaphore _disk_space_monitor_sem{0, "datalake::disk_space_monitor"};

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -193,8 +193,7 @@ private:
     std::unique_ptr<core_0_disk_manager> _disk_manager;
     translation::scheduling::scheduler _scheduler;
     ssx::work_queue _queue;
-    ssx::semaphore _disk_space_monitor_sem{0, "datalake::disk_space_monitor"};
-    config::binding<std::chrono::milliseconds> _disk_usage_interval;
+    ss::condition_variable _disk_space_monitor_cv;
     /*
      * _disk_bytes_reservable_total
      *

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -26,6 +26,27 @@ ss::future<writer_error> serde_parquet_writer::add_data_struct(
             _buffered_bytes = stats.buffered_size;
             _flushed_bytes = stats.flushed_size;
         });
+
+        /*
+         * handle disk reservation. see writer_disk_tracker for more info.
+         */
+        const auto total_bytes = _buffered_bytes + _flushed_bytes;
+        const auto new_total_bytes = stats.buffered_size + stats.flushed_size;
+        if (new_total_bytes > total_bytes) {
+            auto& disk = _mem_tracker.disk();
+            auto result = co_await disk.reserve_bytes(
+              new_total_bytes - total_bytes, as);
+            if (result != reservation_error::ok) {
+                co_return map_to_writer_error(result);
+            }
+        } else if (new_total_bytes < total_bytes) {
+            auto& disk = _mem_tracker.disk();
+            co_await disk.free_bytes(total_bytes - new_total_bytes, as);
+        }
+
+        /*
+         * handle memory reservation
+         */
         auto new_buffered_bytes = stats.buffered_size;
         if (new_buffered_bytes > _buffered_bytes) {
             auto reservation_result = co_await _mem_tracker.reserve_bytes(

--- a/src/v/datalake/tests/test_data_writer.h
+++ b/src/v/datalake/tests/test_data_writer.h
@@ -31,6 +31,24 @@ public:
         return ss::make_ready_future<>();
     }
     void release() override {}
+    writer_disk_tracker& disk() override { return _disk; }
+
+private:
+    class noop_disk_tracker : public writer_disk_tracker {
+    public:
+        ss::future<reservation_error>
+        reserve_bytes(size_t, ss::abort_source&) noexcept override {
+            return ss::make_ready_future<reservation_error>(
+              reservation_error::ok);
+        }
+        ss::future<> free_bytes(size_t, ss::abort_source&) override {
+            return ss::make_ready_future<>();
+        }
+        void release() override {}
+        void release_unused() override {}
+    };
+
+    noop_disk_tracker _disk;
 };
 
 class test_data_writer : public parquet_file_writer {

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -53,6 +53,7 @@ redpanda_cc_library(
         "//src/v/random:generators",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
+        "//src/v/utils:human",
         "//src/v/utils:to_string",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/datalake/translation/BUILD
+++ b/src/v/datalake/translation/BUILD
@@ -117,6 +117,7 @@ redpanda_cc_library(
         "//src/v/kafka/data:partition_proxy",
         "//src/v/kafka/utils:txn_reader",
         "//src/v/model",
+        "//src/v/utils:human",
         "//src/v/utils:retry_chain_node",
         "@seastar",
     ],

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -45,6 +45,8 @@ map_error_code(datalake::translation_task::errc errc) {
         return translation_errc::time_limit_exceeded;
     case datalake::translation_task::errc::shutting_down:
         return translation_errc::shutting_down;
+    case datalake::translation_task::errc::out_of_disk:
+        return translation_errc::out_of_disk;
     }
 }
 } // namespace
@@ -97,6 +99,8 @@ ss::future<reservation_error> translator_mem_tracker::reserve_bytes(
         co_return reservation_error::shutting_down;
     } catch (const translator_time_quota_exceeded_error&) {
         co_return reservation_error::time_quota_exceeded;
+    } catch (const translator_out_of_disk_error&) {
+        co_return reservation_error::out_of_disk;
     } catch (...) {
         co_return reservation_error::unknown;
     }
@@ -401,6 +405,8 @@ std::ostream& operator<<(std::ostream& o, translation_errc ec) {
         return o << "translation_errc::time_limit_exceeded";
     case shutting_down:
         return o << "translation_errc::shutting_down";
+    case out_of_disk:
+        return o << "translation_errc::out_of_disk";
     }
 }
 

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -23,6 +23,7 @@
 #include "datalake/translation_task.h"
 #include "kafka/data/partition_proxy.h"
 #include "kafka/utils/txn_reader.h"
+#include "utils/human.h"
 
 #include <seastar/util/defer.hh>
 
@@ -71,6 +72,16 @@ ss::future<cluster::errc> wait_stm_translated(
 } // namespace
 
 ss::future<reservation_error>
+noop_disk_tracker::reserve_bytes(size_t, ss::abort_source&) noexcept {
+    return ss::make_ready_future<reservation_error>(reservation_error::ok);
+}
+ss::future<> noop_disk_tracker::free_bytes(size_t, ss::abort_source&) {
+    return ss::make_ready_future<>();
+}
+void noop_disk_tracker::release() {}
+void noop_disk_tracker::release_unused() {}
+
+ss::future<reservation_error>
 noop_mem_tracker::reserve_bytes(size_t, ss::abort_source&) noexcept {
     return ss::make_ready_future<reservation_error>(reservation_error::ok);
 }
@@ -78,6 +89,7 @@ ss::future<> noop_mem_tracker::free_bytes(size_t, ss::abort_source&) {
     return ss::make_ready_future<>();
 }
 void noop_mem_tracker::release() {}
+writer_disk_tracker& noop_mem_tracker::disk() { return _disk; }
 
 ss::future<reservation_error> translator_mem_tracker::reserve_bytes(
   size_t bytes, ss::abort_source& as) noexcept {
@@ -122,6 +134,57 @@ size_t translator_mem_tracker::current_usage() const { return _current_usage; }
 
 size_t translator_mem_tracker::total_reserved() const {
     return _reservations.count();
+}
+
+writer_disk_tracker& translator_mem_tracker::disk() { return _disk; }
+
+ss::future<reservation_error> translator_disk_tracker::reserve_bytes(
+  size_t bytes, ss::abort_source& as) noexcept {
+    _current_usage += bytes;
+    try {
+        while (_current_usage > _reservations.count()) {
+            auto reservation = co_await _reservations_tracker.reserve_disk(
+              bytes, as);
+            if (_reservations.count()) {
+                _reservations.adopt(std::move(reservation));
+            } else {
+                _reservations = std::move(reservation);
+            }
+        }
+    } catch (const translator_out_of_memory_error&) {
+        co_return reservation_error::out_of_memory;
+    } catch (const translator_shutdown_error&) {
+        co_return reservation_error::shutting_down;
+    } catch (const translator_time_quota_exceeded_error&) {
+        co_return reservation_error::time_quota_exceeded;
+    } catch (const translator_out_of_disk_error&) {
+        co_return reservation_error::out_of_disk;
+    } catch (...) {
+        co_return reservation_error::unknown;
+    }
+    co_return reservation_error::ok;
+}
+ss::future<>
+translator_disk_tracker::free_bytes(size_t bytes, ss::abort_source&) {
+    // we don't update the reservation here as the next time we call
+    // reserve_bytes we'll have already reserved an excess amount
+    _current_usage -= std::min(_current_usage, bytes);
+    return ss::now();
+}
+void translator_disk_tracker::release() {
+    _current_usage = 0;
+    _reservations.return_all();
+}
+void translator_disk_tracker::release_unused() {
+    if (_reservations.count() > _current_usage) {
+        const auto units = _reservations.count() - _current_usage;
+        _reservations.return_units(units);
+        vlog(
+          datalake_log.debug,
+          "Releasing {} excess disk reservation. Current reserved {}",
+          human::bytes(units),
+          human::bytes(_reservations.count()));
+    }
 }
 
 // Creates or alters the table by delegating to the coordinator.
@@ -544,7 +607,12 @@ public:
                   }
                   return ss::now();
               })
-              .finally([this]() { _mem_tracker.release(); });
+              .finally([this]() {
+                  _mem_tracker.release();
+                  // the translator finished a round of translation and may be
+                  // taken out of the running state, so give back unused units.
+                  _mem_tracker.disk().release_unused();
+              });
         }
         return ss::now();
     }
@@ -553,7 +621,11 @@ public:
     finish(retry_chain_node& rcn, ss::abort_source& as) final {
         // This is strictly not needed as flush() is always called after
         // every scheduler iteration but we do it just to be extra cautious.
-        auto cleanup = ss::defer([this] { _mem_tracker.release(); });
+        auto cleanup = ss::defer([this] {
+            _mem_tracker.release();
+            // staging data will be deleted via finish()
+            _mem_tracker.disk().release();
+        });
         if (!_in_progress_translation) {
             co_return translation_errc::no_data;
         }
@@ -573,6 +645,8 @@ public:
     }
 
     ss::future<> discard() final {
+        // staging data will be deleted via discard()
+        auto cleanup = ss::defer([this] { _mem_tracker.disk().release(); });
         if (!_in_progress_translation) {
             co_return;
         }

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -45,6 +45,12 @@ public:
       : std::runtime_error("translator_time_quota_exceeded") {}
 };
 
+class translator_out_of_disk_error final : public std::runtime_error {
+public:
+    explicit translator_out_of_disk_error()
+      : std::runtime_error("translator_out_of_disk") {}
+};
+
 class noop_mem_tracker : public writer_mem_tracker {
 public:
     ss::future<reservation_error>
@@ -183,6 +189,7 @@ enum translation_errc {
     oom_error,
     time_limit_exceeded,
     shutting_down,
+    out_of_disk,
 };
 
 std::ostream& operator<<(std::ostream&, translation_errc);

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -51,12 +51,45 @@ public:
       : std::runtime_error("translator_out_of_disk") {}
 };
 
+class noop_disk_tracker : public writer_disk_tracker {
+    ss::future<reservation_error>
+    reserve_bytes(size_t, ss::abort_source&) noexcept override;
+    ss::future<> free_bytes(size_t, ss::abort_source&) override;
+    void release() override;
+    void release_unused() override;
+};
+
 class noop_mem_tracker : public writer_mem_tracker {
 public:
     ss::future<reservation_error>
     reserve_bytes(size_t, ss::abort_source&) noexcept override;
     ss::future<> free_bytes(size_t, ss::abort_source&) override;
     void release() override;
+    writer_disk_tracker& disk() override;
+
+private:
+    noop_disk_tracker _disk;
+};
+
+/**
+ * Tracks disk usage across all writers in a single translator.
+ */
+class translator_disk_tracker : public writer_disk_tracker {
+public:
+    explicit translator_disk_tracker(
+      scheduling::reservations_tracker& scheduling_reservations)
+      : _reservations_tracker(scheduling_reservations) {}
+
+    ss::future<reservation_error>
+    reserve_bytes(size_t, ss::abort_source&) noexcept override;
+    ss::future<> free_bytes(size_t, ss::abort_source&) override;
+    void release() override;
+    void release_unused() override;
+
+private:
+    size_t _current_usage{0};
+    scheduling::reservations_tracker& _reservations_tracker;
+    ssx::semaphore_units _reservations;
 };
 
 /**
@@ -66,12 +99,14 @@ class translator_mem_tracker : public writer_mem_tracker {
 public:
     explicit translator_mem_tracker(
       scheduling::reservations_tracker& scheduling_reservations)
-      : _reservations_tracker(scheduling_reservations) {}
+      : _reservations_tracker(scheduling_reservations)
+      , _disk(scheduling_reservations) {}
 
     ss::future<reservation_error>
     reserve_bytes(size_t, ss::abort_source&) noexcept override;
     ss::future<> free_bytes(size_t, ss::abort_source&) override;
     void release() override;
+    writer_disk_tracker& disk() override;
 
     size_t current_usage() const;
     size_t total_reserved() const;
@@ -80,6 +115,7 @@ private:
     size_t _current_usage{0};
     scheduling::reservations_tracker& _reservations_tracker;
     ssx::semaphore_units _reservations;
+    translator_disk_tracker _disk;
 };
 
 class coordinator_api {

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -571,15 +571,17 @@ void partition_translator::start_translation(
     _ready_to_translate.broadcast();
 }
 
-void partition_translator::stop_translation() {
+void partition_translator::stop_translation(translator::stop_reason reason) {
     if (_gate.is_closed() || !_inflight_translation_state) {
         return;
     }
 
-    // Currently only preempted on exceeding memory budget, if the policy
-    // changes to preempt on other errors, should be updated accordingly.
-    _inflight_translation_state->as.request_abort_ex(
-      translator_out_of_memory_error{});
+    switch (reason) {
+    case stop_reason::oom:
+        _inflight_translation_state->as.request_abort_ex(
+          translator_out_of_memory_error{});
+        break;
+    }
 }
 
 void partition_translator::set_finish_translation() {

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -299,6 +299,9 @@ partition_translator::run_one_translation_iteration(
         vlog(
           _logger.debug,
           "Translation attempt exceeded scheduler time limit quota");
+    } catch (const translator_out_of_disk_error&) {
+        // Finishing will free up scratch space on disk
+        result = finish_immediately::yes;
     } catch (...) {
         // unknown exception or shutdown exception.
         unexpected_ex = std::current_exception();
@@ -580,6 +583,10 @@ void partition_translator::stop_translation(translator::stop_reason reason) {
     case stop_reason::oom:
         _inflight_translation_state->as.request_abort_ex(
           translator_out_of_memory_error{});
+        break;
+    case stop_reason::out_of_disk:
+        _inflight_translation_state->as.request_abort_ex(
+          translator_out_of_disk_error{});
         break;
     }
 }

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -90,7 +90,7 @@ public:
 
     void start_translation(scheduling::clock::duration time_slice) final;
 
-    void stop_translation() final;
+    void stop_translation(stop_reason) final;
 
     void reconcile_properties() noexcept final;
 

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -215,13 +215,13 @@ void translator_executable::mark_idle() {
     _stop_in_progress = false;
 }
 
-void translator_executable::mark_stopping() {
+void translator_executable::mark_stopping(translator::stop_reason reason) {
     vassert(
       !_waiting_hook.is_linked() && _running_hook.is_linked()
         && !_stop_in_progress,
       "Invalid request to stop translation: {}",
       *this);
-    _translator->stop_translation();
+    _translator->stop_translation(reason);
     _stop_in_progress = true;
 }
 
@@ -245,11 +245,12 @@ void executor::start_translation(
     running.push_back(state);
 }
 
-void executor::stop_translation(translator_executable& state) {
+void executor::stop_translation(
+  translator_executable& state, translator::stop_reason reason) {
     auto holder = gate.hold();
     vlog(datalake_log.debug, "stopping translator: {}", state);
     try {
-        state.mark_stopping();
+        state.mark_stopping(reason);
     } catch (...) {
         vlog(
           datalake_log.warn,

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -11,6 +11,7 @@
 #include "datalake/logger.h"
 #include "datalake/translation/scheduling_policies.h"
 #include "ssx/future-util.h"
+#include "utils/human.h"
 #include "utils/to_string.h"
 
 namespace datalake::translation::scheduling {
@@ -28,6 +29,7 @@ public:
       , _available_memory{_total_memory, "dl/translation/memory"}
       , _reservation_block_size(block_size)
       , _notifier(notifier)
+      , _shard_available_disk{0, "dl/translation/disk"}
       , _disk_manager(disk_manager) {
         auto blocks = _total_memory / block_size;
         vassert(
@@ -76,6 +78,142 @@ public:
         return _total_memory - _available_memory.available_units();
     }
 
+    /*
+     * disk reservation overages are handled by requesting units from the global
+     * disk manager, and then waiting for sufficient disk resources to become
+     * available.
+     */
+    ss::future<reservation>
+    reserve_disk(size_t, ss::abort_source& as) override {
+        const auto init_backoff = 100ms;
+        const auto max_backoff = 1000ms;
+
+        /*
+         * Having some block reservation acquired by each translator is nice
+         * because even though the hot path for tiny, frequent allocations would
+         * usually return an immediately ready future in this method, we'd still
+         * be subject to seastar scheduler preemptions and these allocations are
+         * made in the translation loop.
+         *
+         * However, it is much less clear what a good value is for the size of a
+         * memory block reservation that a schedulers gives to a translator.
+         * Currently we use the same size as the memory reservation (on the
+         * order of single digit MBs). There are a few reasons for this. First,
+         * even modestly sized reservations will reduce small allocations
+         * round-trips to coroutine invocations and thus reduce preemption
+         * checks for the translation loop.
+         *
+         * But the primary reasons for re-using the memory block size is
+         * that (1) such reservations are unavailable to other translators so
+         * choosing a smaller size allows more fine grained control and (2)
+         * using a larger size is unlikely to provide any real value since disk
+         * will generally be found in more abundance than memory, and both disk
+         * and memory are decremented in lock step by the serde parquet reader.
+         */
+        const auto block_size = _reservation_block_size;
+
+        auto backoff = init_backoff;
+        while (true) {
+            /*
+             * first we attempt to acquire disk reservation from what is
+             * available local on this shard. when a translator on this core
+             * finishes it will return its units to this pool. we use up all of
+             * the available units, so check that get_units returns a positive
+             * value because when requesting 0 units it will be granted but the
+             * system won't make progress.
+             */
+            auto opt_units = ss::try_get_units(
+              _shard_available_disk,
+              std::min(block_size, _shard_available_disk.current()));
+            if (opt_units.has_value() && opt_units.value().count() > 0) {
+                if (datalake_log.is_enabled(ss::log_level::trace)) {
+                    vlog(
+                      datalake_log.trace,
+                      "Allocated {} disk reservation from shard-local pool. "
+                      "Total "
+                      "available {}",
+                      human::bytes(opt_units.value().count()),
+                      human::bytes(_shard_available_disk.current()));
+                }
+                co_return std::move(opt_units.value());
+            }
+
+            /*
+             * if we are unable to acquire units locally, then pop on over
+             * to core-0 and ask the disk manager if there are available
+             * units that we can have. deposit any units locally and try
+             * again. note that below we add a very short, intentional delay
+             * to prevent accidentally spinning. we avoid immediately taking the
+             * units and returning to avoid the possibility that the translators
+             * on a core continually take units from each other rather than
+             * giving the system an opportunity to redistribute the units. this
+             * concern, however, is speculative.
+             *
+             * unlike the smaller block reserved for a translators, here we
+             * will get back a much larger reservations, say 50mb or 100mb,
+             * which helps reduce x-core communication. The size of the block of
+             * memory reserved by a scheduler from the datalake manager is
+             * governed by datalake_disk_reservation_block_size.
+             */
+            auto units = co_await _disk_manager.reserve();
+            if (units > 0) {
+                _shard_available_disk.signal(units);
+                if (datalake_log.is_enabled(ss::log_level::debug)) {
+                    vlog(
+                      datalake_log.debug,
+                      "Received {} disk reservation from global pool. Total "
+                      "available {}",
+                      human::bytes(units),
+                      human::bytes(_shard_available_disk.current()));
+                }
+            }
+
+            /*
+             * for the case in which we are unable to get enough units to
+             * continue we go into a polling loop where we again check
+             * locally and then check with the disk manager. the reason that
+             * this works is that the contract with the disk manager is such
+             * that if it cannot satisfy a request for additional units that
+             * it will actively work towards acquiring more units. this is
+             * done by requesting translators to finish. the released disk
+             * reservations which will first be available to the finishing
+             * translator's core, and then to the global pool.
+             */
+            backoff = std::min(backoff, max_backoff);
+            try {
+                co_await ss::sleep_abortable(backoff, as);
+            } catch (...) {
+                as.check();
+                std::rethrow_exception(std::current_exception());
+            }
+            backoff *= 2;
+
+            /*
+             * waiting until max backoff limits noise from normal retries, and
+             * limiting the logging rate itself helps when multiple translators
+             * are in this same retry loop.
+             */
+            if (backoff >= max_backoff) {
+                static constexpr auto freq = 5s;
+                thread_local static ss::logger::rate_limit rate(freq);
+                vloglr(
+                  datalake_log,
+                  ss::log_level::info,
+                  rate,
+                  "Waiting on shard-local disk reservation. Total available {}",
+                  human::bytes(_shard_available_disk.current()));
+            }
+        }
+    }
+
+    size_t release_unused_disk_units() override {
+        const auto units = _shard_available_disk.current();
+        if (units > 0) {
+            _shard_available_disk.consume(units);
+        }
+        return units;
+    }
+
 private:
     const size_t _total_memory;
     // note: the semaphore should be alive until all the reserved units are
@@ -83,7 +221,8 @@ private:
     ssx::semaphore _available_memory;
     const size_t _reservation_block_size;
     scheduling_notifications& _notifier;
-    [[maybe_unused]] disk_manager& _disk_manager;
+    ssx::semaphore _shard_available_disk;
+    disk_manager& _disk_manager;
 };
 
 std::ostream& operator<<(std::ostream& os, const translation_status& status) {
@@ -412,6 +551,10 @@ ss::future<> scheduler::remove_translator(const translator_id& id) {
 
 size_t scheduler::running_translators() const {
     return _executor.running.size();
+}
+
+size_t scheduler::release_unused_disk_units() {
+    return _mem_tracker->release_unused_disk_units();
 }
 
 void scheduler::request_immediate_finish(

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -410,7 +410,7 @@ size_t scheduler::running_translators() const {
 }
 
 void scheduler::request_immediate_finish(
-  chunked_vector<std::pair<translator_id, size_t>> translators) {
+  chunked_vector<finish_request> translators) {
     _executor.translators_for_immediate_finish.clear();
     // `i` captures both priority (lowest is highest), and serves as a unique
     // identifer. see `on_resource_exhaustion` for how this property is used.
@@ -418,7 +418,9 @@ void scheduler::request_immediate_finish(
         // the flush size of the translator is thrown away here, but preserved
         // at the scheduler API level for future use by the scheduler.
         _executor.translators_for_immediate_finish.emplace(
-          i, std::move(translators[i].first));
+          i,
+          executor::finish_request(
+            std::move(translators[i].id), translators[i].reason));
     }
     // there is no mechanism for backing out a request to finish, so there isn't
     // any additional work that can be done if the requests are cleared.

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -563,8 +563,6 @@ void scheduler::request_immediate_finish(
     // `i` captures both priority (lowest is highest), and serves as a unique
     // identifer. see `on_resource_exhaustion` for how this property is used.
     for (size_t i = 0; i < translators.size(); ++i) {
-        // the flush size of the translator is thrown away here, but preserved
-        // at the scheduler API level for future use by the scheduler.
         _executor.translators_for_immediate_finish.emplace(
           i,
           executor::finish_request(

--- a/src/v/datalake/translation/scheduling.cc
+++ b/src/v/datalake/translation/scheduling.cc
@@ -22,11 +22,13 @@ public:
     explicit default_reservations_tracker(
       size_t total_memory,
       size_t block_size,
-      scheduling_notifications& notifier)
+      scheduling_notifications& notifier,
+      disk_manager& disk_manager)
       : _total_memory((total_memory / block_size) * block_size)
       , _available_memory{_total_memory, "dl/translation/memory"}
       , _reservation_block_size(block_size)
-      , _notifier(notifier) {
+      , _notifier(notifier)
+      , _disk_manager(disk_manager) {
         auto blocks = _total_memory / block_size;
         vassert(
           blocks > 0,
@@ -81,6 +83,7 @@ private:
     ssx::semaphore _available_memory;
     const size_t _reservation_block_size;
     scheduling_notifications& _notifier;
+    [[maybe_unused]] disk_manager& _disk_manager;
 };
 
 std::ostream& operator<<(std::ostream& os, const translation_status& status) {
@@ -263,10 +266,12 @@ void executor::stop_translation(
 scheduler::scheduler(
   size_t total_memory,
   size_t memory_block_size,
-  std::unique_ptr<scheduling_policy> policy)
+  std::unique_ptr<scheduling_policy> policy,
+  disk_manager& disk_monitor)
   : _scheduling_policy(std::move(policy))
+  , _disk_monitor(disk_monitor)
   , _mem_tracker(reservations_tracker::make_default(
-      total_memory, memory_block_size, *this)) {
+      total_memory, memory_block_size, *this, _disk_monitor)) {
     ssx::repeat_until_gate_closed_or_aborted(
       _executor.gate, _executor.as, [this] {
           return main().handle_exception([](const std::exception_ptr& e) {
@@ -462,9 +467,10 @@ std::unique_ptr<scheduling_policy> scheduling_policy::make_default(
 std::unique_ptr<reservations_tracker> reservations_tracker::make_default(
   size_t total_memory,
   size_t memory_block_size,
-  scheduling_notifications& notifier) {
+  scheduling_notifications& notifier,
+  disk_manager& disk_manager) {
     return std::make_unique<default_reservations_tracker>(
-      total_memory, memory_block_size, notifier);
+      total_memory, memory_block_size, notifier, disk_manager);
 }
 
 } // namespace datalake::translation::scheduling

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -183,7 +183,11 @@ public:
      * resources should be released and the translator should invoke \ref
      * scheduling_notifications::notify_done when done.
      */
-    virtual void stop_translation() = 0;
+    enum class stop_reason {
+        oom,
+    };
+
+    virtual void stop_translation(stop_reason) = 0;
 
     /**
      * Request that the translator finish and upload its data. This is distinct
@@ -251,7 +255,7 @@ public:
     void mark_waiting();
     void mark_running();
     void mark_idle();
-    void mark_stopping();
+    void mark_stopping(translator::stop_reason);
 
     // hook into the waiting queue
     intrusive_list_hook _waiting_hook;
@@ -310,7 +314,7 @@ using translators = chunked_hash_map<translator_id, translator_executable>;
  */
 struct executor {
     void start_translation(translator_executable&, clock::duration time_slice);
-    void stop_translation(translator_executable&);
+    void stop_translation(translator_executable&, translator::stop_reason);
     translators translators{};
     intrusive_list<translator_executable, &translator_executable::_running_hook>
       running;

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -82,8 +82,7 @@ using reservation = ssx::semaphore_units;
 
 /**
  * Tracks the resources needed by translators. Translators work with a
- * reservation tracker to reserve resources needed for translation. Currently
- * tracks memory but can be extended to other resources like disk usage.
+ * reservation tracker to reserve resources needed for translation.
  *
  * note: All reservations must be destroyed before destroying the tracker.
  */
@@ -104,6 +103,20 @@ public:
     virtual bool memory_exhausted() const = 0;
 
     virtual size_t allocated_memory() const = 0;
+
+    /**
+     * Returns a reservation of disk space. The reservation may be any size,
+     * with the passed-in size being a hint. If more units are reserved than are
+     * needed, then release the unused units if they will not be used in the
+     * near term (e.g. a translator leaving the running state).
+     *
+     * Returning the unused units is important because disk space reservations
+     * are held across all translator states, including the idle state. Because
+     * of this persistence, even small amounts of unused reservation can add up
+     * to large reservations across hundreds or thousands of translators.
+     */
+    virtual ss::future<reservation> reserve_disk(size_t, ss::abort_source&) = 0;
+    virtual size_t release_unused_disk_units() = 0;
 
     static std::unique_ptr<reservations_tracker> make_default(
       size_t total_memory,
@@ -454,6 +467,13 @@ public:
           , reason(reason) {}
     };
     void request_immediate_finish(chunked_vector<finish_request>);
+
+    /*
+     * Consume and return unused disk reservation units. This interface is used
+     * by the global disk manager to harvest units from cores in order to
+     * redistribute them.
+     */
+    size_t release_unused_disk_units();
 
 private:
     ss::future<> main();

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -59,6 +59,25 @@ public:
     virtual void notify_memory_exhausted() = 0;
 };
 
+/*
+ * Interface for scheduler to interact with the global disk manager.
+ */
+class disk_manager {
+public:
+    disk_manager() = default;
+    disk_manager(const disk_manager&) = delete;
+    disk_manager& operator=(const disk_manager&) = delete;
+    disk_manager(disk_manager&& other) noexcept;
+    disk_manager& operator=(disk_manager&&) noexcept;
+    virtual ~disk_manager() = default;
+
+    /*
+     * Request additional disk reservation from the global pool. This method
+     * will return zero units if the request cannot be satisfied immediately.
+     */
+    virtual ss::future<size_t> reserve() = 0;
+};
+
 using reservation = ssx::semaphore_units;
 
 /**
@@ -87,7 +106,10 @@ public:
     virtual size_t allocated_memory() const = 0;
 
     static std::unique_ptr<reservations_tracker> make_default(
-      size_t total_memory, size_t memory_block_size, scheduling_notifications&);
+      size_t total_memory,
+      size_t memory_block_size,
+      scheduling_notifications&,
+      disk_manager&);
 };
 
 /**
@@ -378,7 +400,8 @@ public:
     explicit scheduler(
       size_t total_memory,
       size_t memory_block_size,
-      std::unique_ptr<scheduling_policy>);
+      std::unique_ptr<scheduling_policy>,
+      disk_manager&);
     scheduler(const scheduler&) = delete;
     scheduler& operator=(const scheduler&) = delete;
     scheduler(scheduler&&) = delete;
@@ -437,6 +460,7 @@ private:
     bool requires_scheduling_actions() const;
     ss::condition_variable _state_changed_cvar;
     std::unique_ptr<scheduling_policy> _scheduling_policy;
+    disk_manager& _disk_monitor;
     std::unique_ptr<reservations_tracker> _mem_tracker;
     executor _executor;
 };

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -327,7 +327,15 @@ struct executor {
      * finished with lowest value being highest priority.
      */
     using finish_priority = size_t;
-    absl::btree_map<finish_priority, translator_id>
+    struct finish_request {
+        translator_id id;
+        translator::stop_reason reason;
+
+        finish_request(translator_id id, translator::stop_reason reason)
+          : id(std::move(id))
+          , reason(reason) {}
+    };
+    absl::btree_map<finish_priority, finish_request>
       translators_for_immediate_finish;
 
     ss::gate gate;
@@ -411,8 +419,18 @@ public:
      * the total size of the translator which can be used to avoid requerying
      * for the same information from the translator status API.
      */
-    void request_immediate_finish(
-      chunked_vector<std::pair<translator_id, size_t>>);
+    struct finish_request {
+        translator_id id;
+        size_t size;
+        translator::stop_reason reason;
+
+        finish_request(
+          translator_id id, size_t size, translator::stop_reason reason)
+          : id(std::move(id))
+          , size(size)
+          , reason(reason) {}
+    };
+    void request_immediate_finish(chunked_vector<finish_request>);
 
 private:
     ss::future<> main();

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -185,6 +185,7 @@ public:
      */
     enum class stop_reason {
         oom,
+        out_of_disk,
     };
 
     virtual void stop_translation(stop_reason) = 0;

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -457,13 +457,10 @@ public:
      */
     struct finish_request {
         translator_id id;
-        size_t size;
         translator::stop_reason reason;
 
-        finish_request(
-          translator_id id, size_t size, translator::stop_reason reason)
+        finish_request(translator_id id, translator::stop_reason reason)
           : id(std::move(id))
-          , size(size)
           , reason(reason) {}
     };
     void request_immediate_finish(chunked_vector<finish_request>);

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -61,7 +61,8 @@ ss::future<> simple_fcfs_scheduling_policy::on_resource_exhaustion(
     while (mem_tracker.memory_exhausted() && !executor.as.abort_requested()) {
         // pick the earliest scheduled translator and force a flush.
         if (!executor.running.empty()) {
-            executor.stop_translation(*executor.running.begin());
+            executor.stop_translation(
+              *executor.running.begin(), translator::stop_reason::oom);
         }
         co_await ss::sleep_abortable(5s, executor.as);
     }
@@ -389,7 +390,8 @@ ss::future<> fair_scheduling_policy::on_resource_exhaustion(
       datalake_log.debug,
       "[{}] stopping translator due to memory exhaustion",
       *executor.running.begin());
-    executor.stop_translation(*executor.running.begin());
+    executor.stop_translation(
+      *executor.running.begin(), translator::stop_reason::oom);
 
     while (mem_tracker.memory_exhausted() && !executor.as.abort_requested()
            && executor.running.size() == num_running) {
@@ -488,7 +490,7 @@ ss::future<> fair_scheduling_policy::finish_translator(
      */
     switch (choice.status) {
     case finish_choice_info::status::running:
-        executor.stop_translation(executable);
+        executor.stop_translation(executable, translator::stop_reason::oom);
         break;
 
     case finish_choice_info::status::waiting:
@@ -497,7 +499,7 @@ ss::future<> fair_scheduling_policy::finish_translator(
         // out-of-memory exception which has "immediate finish"
         // semantics rather than adding completely new states.
         executor.start_translation(executable, _translation_time_quota);
-        executor.stop_translation(executable);
+        executor.stop_translation(executable, translator::stop_reason::oom);
         break;
 
     case finish_choice_info::status::idle:

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -490,7 +490,8 @@ ss::future<> fair_scheduling_policy::finish_translator(
      */
     switch (choice.status) {
     case finish_choice_info::status::running:
-        executor.stop_translation(executable, translator::stop_reason::oom);
+        executor.stop_translation(
+          executable, translator::stop_reason::out_of_disk);
         break;
 
     case finish_choice_info::status::waiting:
@@ -499,7 +500,8 @@ ss::future<> fair_scheduling_policy::finish_translator(
         // out-of-memory exception which has "immediate finish"
         // semantics rather than adding completely new states.
         executor.start_translation(executable, _translation_time_quota);
-        executor.stop_translation(executable, translator::stop_reason::oom);
+        executor.stop_translation(
+          executable, translator::stop_reason::out_of_disk);
         break;
 
     case finish_choice_info::status::idle:

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -432,17 +432,17 @@ fair_scheduling_policy::choose_translator_to_finish(executor& executor) {
     for (auto it = translators_to_finish.begin();
          it != translators_to_finish.end();) {
         // map translator_id -> translator_executable
-        auto eit = executor.translators.find(it->second);
+        auto eit = executor.translators.find(it->second.id);
         if (eit == executor.translators.end()) {
             it = translators_to_finish.erase(it);
             continue;
         }
 
         // potential return value for choice
-        const auto curr_info = finish_choice_info{
-          .id = eit->first,
-          .status = finish_choice_info::translator_status(eit->second),
-        };
+        const auto curr_info = finish_choice_info(
+          eit->first,
+          finish_choice_info::translator_status(eit->second),
+          it->second.reason);
 
         // first choice is a running translator
         if (curr_info.status == finish_choice_info::status::running) {
@@ -490,8 +490,7 @@ ss::future<> fair_scheduling_policy::finish_translator(
      */
     switch (choice.status) {
     case finish_choice_info::status::running:
-        executor.stop_translation(
-          executable, translator::stop_reason::out_of_disk);
+        executor.stop_translation(executable, choice.reason);
         break;
 
     case finish_choice_info::status::waiting:
@@ -500,8 +499,7 @@ ss::future<> fair_scheduling_policy::finish_translator(
         // out-of-memory exception which has "immediate finish"
         // semantics rather than adding completely new states.
         executor.start_translation(executable, _translation_time_quota);
-        executor.stop_translation(
-          executable, translator::stop_reason::out_of_disk);
+        executor.stop_translation(executable, choice.reason);
         break;
 
     case finish_choice_info::status::idle:

--- a/src/v/datalake/translation/scheduling_policies.h
+++ b/src/v/datalake/translation/scheduling_policies.h
@@ -151,6 +151,13 @@ private:
 
         translator_id id;
         status status;
+        translator::stop_reason reason;
+
+        finish_choice_info(
+          translator_id id, enum status status, translator::stop_reason reason)
+          : id(std::move(id))
+          , status(status)
+          , reason(reason) {}
     };
 
     /*

--- a/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
+++ b/src/v/datalake/translation/tests/fair_scheduling_policy_tests.cc
@@ -54,7 +54,10 @@ public:
 
     ss::lw_shared_ptr<scheduler> make_scheduler() override {
         return ss::make_lw_shared<scheduler>(
-          total_memory(), memory_block_size(), make_scheduling_policy());
+          total_memory(),
+          memory_block_size(),
+          make_scheduling_policy(),
+          _disk_manager);
     }
 
     std::unique_ptr<scheduling_policy> make_scheduling_policy() override {

--- a/src/v/datalake/translation/tests/scheduler_fixture.cc
+++ b/src/v/datalake/translation/tests/scheduler_fixture.cc
@@ -239,7 +239,7 @@ translation_status mock_translator::status() const {
     return status;
 }
 
-void mock_translator::stop_translation() {
+void mock_translator::stop_translation(translator::stop_reason) {
     auto holder = _gate.hold();
     vassert(_started, "Translator should be started first");
     if (!_translation_state) {
@@ -271,11 +271,11 @@ void exceptional_translator::start_translation(clock::duration translate_for) {
     return mock_translator::start_translation(translate_for);
 }
 
-void exceptional_translator::stop_translation() {
+void exceptional_translator::stop_translation(translator::stop_reason reason) {
     if (tests::random_bool()) {
         throw ss::gate_closed_exception();
     }
-    return mock_translator::stop_translation();
+    return mock_translator::stop_translation(reason);
 }
 
 std::unique_ptr<translator>

--- a/src/v/datalake/translation/tests/scheduler_fixture.h
+++ b/src/v/datalake/translation/tests/scheduler_fixture.h
@@ -38,7 +38,7 @@ public:
     ss::future<> close() noexcept override;
     translation_status status() const override;
     void start_translation(clock::duration translate_for) override;
-    void stop_translation() override;
+    void stop_translation(stop_reason) override;
     void reconcile_properties() noexcept override {}
     std::chrono::milliseconds current_lag_ms() const override {
         return std::chrono::milliseconds{0};
@@ -125,7 +125,7 @@ public:
     ss::future<>
     init(scheduling_notifications&, reservations_tracker&) override;
     void start_translation(clock::duration deadline) override;
-    void stop_translation() override;
+    void stop_translation(stop_reason) override;
 };
 
 class scheduler_fixture : public seastar_test {

--- a/src/v/datalake/translation/tests/scheduler_fixture.h
+++ b/src/v/datalake/translation/tests/scheduler_fixture.h
@@ -128,11 +128,17 @@ public:
     void stop_translation(stop_reason) override;
 };
 
+class noop_disk_manager : public disk_manager {
+public:
+    // the default noop disk manager implements an infinite disk
+    ss::future<size_t> reserve() override { co_return 1_MiB; }
+};
+
 class scheduler_fixture : public seastar_test {
 public:
     virtual ss::lw_shared_ptr<scheduler> make_scheduler() {
         return ss::make_lw_shared<scheduler>(
-          total_memory, block_size, make_scheduling_policy());
+          total_memory, block_size, make_scheduling_policy(), _disk_manager);
     }
 
     virtual std::unique_ptr<scheduling_policy> make_scheduling_policy() {
@@ -200,6 +206,8 @@ protected:
 
     int _partition_counter{0};
     ss::lw_shared_ptr<scheduler> _scheduler;
+
+    noop_disk_manager _disk_manager;
 };
 
 } // namespace datalake::translation::scheduling

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -52,6 +52,8 @@ translation_task::errc map_error_code(writer_error errc) {
         return translation_task::errc::time_limit_exceeded;
     case writer_error::shutting_down:
         return translation_task::errc::shutting_down;
+    case writer_error::out_of_disk:
+        return translation_task::errc::out_of_disk;
     case writer_error::unknown_error:
         return translation_task::errc::file_io_error;
     }
@@ -401,6 +403,8 @@ std::ostream& operator<<(std::ostream& o, translation_task::errc ec) {
         return o << "time limit exceeded";
     case translation_task::errc::shutting_down:
         return o << "shutting down";
+    case translation_task::errc::out_of_disk:
+        return o << "disk exhausted";
     }
 }
 } // namespace datalake

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -48,6 +48,7 @@ public:
         oom_error,
         time_limit_exceeded,
         shutting_down,
+        out_of_disk,
     };
 
     using custom_partitioning_enabled

--- a/tests/rptest/tests/datalake/disk_budget_test.py
+++ b/tests/rptest/tests/datalake/disk_budget_test.py
@@ -7,6 +7,7 @@
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
 import time
+import threading
 from rptest.services.catalog_service import CatalogType
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
@@ -44,7 +45,8 @@ class DatalakeDiskUsageTest(RedpandaTest):
         # this limit it force finishes. this makes it difficult to accumulate
         # data on disk. so bump up the shard memory limit to make that a bit
         # easier.
-        resource_setting = ResourceSettings(num_cpus=1, memory_mb=4096)
+        resource_setting = ResourceSettings(num_cpus=2, memory_mb=8192)
+        self.target_lag_sec = 5 * 60
         super(DatalakeDiskUsageTest, self).__init__(
             test_ctx,
             num_brokers=1,
@@ -59,7 +61,7 @@ class DatalakeDiskUsageTest(RedpandaTest):
                 # is set low to avoid hitting the per-core memory limit.
                 "datalake_scheduler_time_slice_ms": 3000,
                 "datalake_translator_flush_bytes": 100 * 2**30,
-                "iceberg_target_lag_ms": 10 * 60 * 1000,
+                "iceberg_target_lag_ms": self.target_lag_sec * 1000,
                 "datalake_scratch_space_size_bytes": 100 * 2**30,
             },
             *args,
@@ -98,7 +100,7 @@ class DatalakeDiskUsageTest(RedpandaTest):
             producer.start()
             producer.wait()
             producer.free()
-            time.sleep(10)
+            time.sleep(5)
             current_size = self.datalake_staging_usage()
             self.logger.info(f"Staging data usage {current_size}")
             assert (
@@ -106,9 +108,13 @@ class DatalakeDiskUsageTest(RedpandaTest):
                 start_time) < timeout_sec, f"{current_size} < {target_size}"
         return current_size
 
+    def translation_lag(self):
+        metric_name = "vectorized_cluster_partition_iceberg_offsets_pending_translation"
+        return self.redpanda.metric_sum(metric_name, expect_metric=True)
+
     @cluster(num_nodes=2)
     @skip_debug_mode
-    @matrix(num_partitions=[10],
+    @matrix(num_partitions=[10, 40],
             concurrent_translations=[4],
             cloud_storage_type=supported_storage_types())
     def test_idle_finish(self, num_partitions, concurrent_translations,
@@ -145,3 +151,57 @@ class DatalakeDiskUsageTest(RedpandaTest):
         wait_until(lambda: self.datalake_staging_usage() <= new_target_size,
                    timeout_sec=60,
                    backoff_sec=2)
+
+        # start a thread that tracks the max observed usage
+        self.max_usage_observed = 0
+        self.stopped = threading.Event()
+
+        def usage_monitor():
+            while not self.stopped.is_set():
+                usage = self.datalake_staging_usage()
+                lag = self.translation_lag()
+                self.max_usage_observed = max(self.max_usage_observed, usage)
+                self.logger.info(
+                    f"Max usage observed {self.max_usage_observed} lag {lag} current usage {usage}"
+                )
+                time.sleep(1)
+
+        usage_monitor_thread = threading.Thread(target=usage_monitor,
+                                                daemon=True)
+        usage_monitor_thread.start()
+
+        try:
+            # now let's go ham with the producing
+            lag_start = self.translation_lag()
+            producer = RpkProducer(
+                self.test_ctx,
+                self.redpanda,
+                self.topic_name,
+                2**14,  # 16kb message size
+                2**18,  # 4gb total data written
+                acks=-1)
+            producer.start()
+
+            # make sure stuff looks like it is happening!
+            wait_until(lambda: self.translation_lag() > lag_start,
+                       timeout_sec=60,
+                       backoff_sec=5)
+
+            producer.wait()
+            producer.free()
+
+            # after we finish producing, wait for translation to finish. since
+            # we had to set the lag time high to increase data that lands on
+            # disk, we also need to wait a long time for lag to go to zero.
+            # currently it doens't look like we can dynamically change that.
+            wait_until(lambda: self.translation_lag() == 0,
+                       timeout_sec=self.target_lag_sec * 2,
+                       backoff_sec=10,
+                       err_msg=f"lag={self.translation_lag()}")
+
+            self.logger.info("Finished waiting on translation to complete")
+
+            assert self.max_usage_observed > 0 and self.max_usage_observed <= new_target_size, f"{self.max_usage_observed} > {new_target_size}"
+        finally:
+            self.stopped.set()
+            usage_monitor_thread.join()


### PR DESCRIPTION
Add struct limits on datalake scratch space. The important configuration options are:

```
property<size_t> datalake_scratch_space_size_bytes;
property<size_t> datalake_scratch_space_soft_limit_size_percent;
```

The first is a hard limit on space usage. When this limit is reached, translators stop making progress. When the soft limit is reach, translators are not stopped, but in the background the datalake manager tries to bring space usage back down below the soft limit.

At a high level the datalake manager on core 0 maintains a global pool of memory, initialized to configured limits. Each scheduler also maintains a pool of memory, initialized to zero. When a parquet file writer uses disk space, it acquires a disk reservation from its local scheduler. If the scheduler cannot satisfy the request, it requests a block reservation from core 0 manager.

When the a reservation is handed out by core 0 and the soft limit is breached, core 0 reaps unused disk reservations from all cores. If this brings usage back below the soft limit, then it stops. Otherwise, it requests the largest translators in the system to finish immediately which will cause them to release their units.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
