### PR TITLE
[Core 9769] pandaproxy/sr: implement a 2 pass topic load

### DIFF
--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -114,6 +114,7 @@ ss::future<> seq_writer::read_sync() {
 
     auto max_offset = offsets.data.topics[0].partitions[0].offset;
     co_await wait_for(max_offset - model::offset{1});
+    co_await _store.process_marked_schemas();
 }
 
 ss::future<> seq_writer::check_mutable(const std::optional<subject>& sub) {
@@ -179,6 +180,7 @@ ss::future<bool> seq_writer::produce_and_apply(
     if (success) {
         vlog(plog.debug, "seq_writer: Successful write at {}", res.base_offset);
         co_await consume_to_store(_store, *this)(std::move(batch));
+        co_await _store.process_marked_schemas();
     } else {
         vlog(
           plog.debug,

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -597,6 +597,11 @@ ss::future<> service::fetch_internal_topic() {
       model::offset{0},
       max_offset)
       .consume(consume_to_store{_store, writer()}, model::no_timeout);
+
+    // If a schema failed to be compiled, it will be marked. We attempt to
+    // reprocess them once now that the whole topic has been read,  in case they
+    // have a reference to a schema declared later in the topic.
+    co_await _store.process_marked_schemas();
 }
 
 service::service(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -13,6 +13,7 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "container/fragmented_vector.h"
 #include "hashing/jump_consistent_hash.h"
 #include "hashing/xx.h"
 #include "pandaproxy/logger.h"
@@ -29,6 +30,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 
 #include <absl/algorithm/container.h>
@@ -253,17 +255,51 @@ ss::future<bool> sharded_store::upsert(
   schema_id id,
   schema_version version,
   is_deleted deleted) {
-    try {
-        schema = co_await make_canonical_schema(
-          schema.share(), normalize::no, false);
-    } catch (...) {
-        // do nothing. In case make_canonical_schema fails, continue with the
-        // schema as-is in the topic
+    auto canonical_fut = co_await ss::coroutine::as_future(
+      make_canonical_schema(schema.share(), normalize::no, false));
+    bool processing_failed = canonical_fut.failed();
+    if (processing_failed) {
+        canonical_fut.ignore_ready_future();
+    } else {
+        schema = canonical_fut.get();
     }
+
     auto [sub, def] = std::move(schema).destructure();
-    co_await upsert_schema(id, std::move(def));
+    // mark schemas that failed to be processed here. They will be given
+    // one more chance once we have loaded all the topic to the store.
+    co_await upsert_schema(id, std::move(def), processing_failed);
     co_return co_await upsert_subject(
       marker, std::move(sub), version, id, deleted);
+}
+
+ss::future<> sharded_store::process_marked_schemas() {
+    return _store.invoke_on_all([this](store& store) {
+        return ss::do_with(
+          store.extract_marked_schemas(), [this, &store](auto& marked) {
+              return ss::do_for_each(marked, [this, &store](auto id) {
+                  auto schema = store.get_schema_definition(id);
+                  if (schema.has_failure()) {
+                      // schema not found, ignore
+                      return ss::now();
+                  }
+                  return make_canonical_schema(
+                           {{}, std::move(schema).assume_value()},
+                           normalize::no,
+                           false)
+                    .then([id, &store](auto canonical) {
+                        // Update the stored form of this schema to its
+                        // canonical form
+                        store.upsert_schema(
+                          id, std::move(canonical).def(), false);
+                    })
+                    .handle_exception([](const std::exception_ptr&) {
+                        // processing attempt failed on marked schema. This is
+                        // not an issue of forward references. Ignore error and
+                        // keep schema in the store as-is
+                    });
+              });
+          });
+    });
 }
 
 ss::future<bool> sharded_store::has_schema(schema_id id) {
@@ -658,12 +694,14 @@ sharded_store::clear_compatibility(seq_marker marker, subject sub) {
       });
 }
 
-ss::future<bool>
-sharded_store::upsert_schema(schema_id id, schema_definition def) {
+ss::future<bool> sharded_store::upsert_schema(
+  schema_id id, schema_definition def, bool mark_schema) {
     co_await maybe_update_max_schema_id(id);
     co_return co_await _store.invoke_on(
-      shard_for(id), _smp_opts, [id, def{std::move(def)}](store& s) mutable {
-          return s.upsert_schema(id, std::move(def));
+      shard_for(id),
+      _smp_opts,
+      [id, mark_schema, def{std::move(def)}](store& s) mutable {
+          return s.upsert_schema(id, std::move(def), mark_schema);
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -62,6 +62,11 @@ public:
       schema_version version,
       is_deleted deleted);
 
+    // This function will try to compile all marked schemas.
+    // It should be called every time new schemas are loaded from
+    // the topic into the store.
+    ss::future<> process_marked_schemas();
+
     ss::future<bool> has_schema(schema_id id);
     ss::future<stored_schema> has_schema(
       subject_schema schema, include_deleted inc_del = include_deleted::no);
@@ -201,7 +206,8 @@ private:
     ss::future<compatibility_result> do_is_compatible(
       schema_version version, subject_schema new_schema, verbose is_verbose);
 
-    ss::future<bool> upsert_schema(schema_id id, schema_definition def);
+    ss::future<bool>
+    upsert_schema(schema_id id, schema_definition def, bool mark_schema);
     ss::future<> delete_schema(schema_id id);
 
     struct insert_subject_result {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -28,6 +28,7 @@
 
 #include <optional>
 #include <ranges>
+#include <utility>
 
 namespace pandaproxy::schema_registry {
 
@@ -640,12 +641,20 @@ public:
         return {id, inserted};
     }
 
-    bool upsert_schema(schema_id id, schema_definition def) {
+    bool upsert_schema(schema_id id, schema_definition def, bool mark_schema) {
+        if (mark_schema) {
+            _marked_schemas.push_back(id);
+        }
         return _schemas.insert_or_assign(id, schema_entry(std::move(def)))
           .second;
     }
 
     void delete_schema(schema_id id) { _schemas.erase(id); }
+
+    // This function returns and unmarkes all marked schemas.
+    chunked_vector<schema_id> extract_marked_schemas() {
+        return std::exchange(_marked_schemas, {});
+    }
 
     struct insert_subject_result {
         schema_version version;
@@ -903,6 +912,7 @@ private:
 
     schema_map _schemas;
     subject_map _subjects;
+    chunked_vector<schema_id> _marked_schemas;
     compatibility_level _compatibility{compatibility_level::backward};
     mode _mode{mode::read_write};
     is_mutable _mutable;

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -78,7 +78,7 @@ bool upsert(
   pps::schema_id id,
   pps::schema_version version,
   pps::is_deleted deleted) {
-    store.upsert_schema(id, std::move(def));
+    store.upsert_schema(id, std::move(def), false);
     return store.upsert_subject(
       pps::seq_marker{}, std::move(sub), version, id, deleted);
 }

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -427,10 +427,8 @@ import_schemas = {
         }],
         "schema":
         schema_c_proto_def,
-        #schema c will be invalid during startup in the test it is used.
-        #that's why the 'sanitized' form is not the actual sanitized form but the input form.
         "sanitized":
-        schema_c_proto_def,
+        schema_c_proto_sanitized_def,
     },
     "schema_d": {
         "subject":
@@ -2621,6 +2619,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         valid_entries = [
             (1, "schema_a"),
+            (2, "schema_c"),
             (3, "schema_b"),
             (5, "schema_f_v1"),
             (6, "schema_f_v3"),
@@ -2636,13 +2635,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             (12, "schema_i"),
             (13, "schema_j"),
             (14, "schema_k"),
-        ]
-        #These are schemas whose references are loaded after them during startup
-        forward_references_entries = [
-            (2, "schema_c"),
-        ]
-        forward_references_entries_new_ids = [
-            (15, "schema_c"),
         ]
 
         #Test /schemas/ids/{id}
@@ -2664,7 +2656,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #All schemas should be retrievable by id.
-        for id, _ in valid_entries + forward_references_entries + invalid_entries:
+        for id, _ in valid_entries + invalid_entries:
             test_schemas_ids_id(id, expected_successful=True)
 
         #Test /schemas/ids/{id}/versions
@@ -2679,7 +2671,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #Versions should be retrievable for all ids.
-        for id, _ in valid_entries + forward_references_entries + invalid_entries:
+        for id, _ in valid_entries + invalid_entries:
             test_schemas_ids_id_versions(id, expected_successful=True)
 
         #Test /schemas/ids/{id}/subjects
@@ -2694,7 +2686,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #Subjects should be retrievable for all ids.
-        for id, _ in valid_entries + forward_references_entries + invalid_entries:
+        for id, _ in valid_entries + invalid_entries:
             test_schemas_ids_id_subjects(id, expected_successful=True)
 
         #Test /subjects
@@ -2745,12 +2737,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         for _, s in invalid_entries:
             test_subjects_subject(s, expected_code=422)
 
-        #At this point, all references from these schemas are satisfied. So the input
-        #schema is valid. However, the stored schema could not be processed during startup
-        #so its stored form has not been canonicallized and the request fails
-        for _, s in forward_references_entries:
-            test_subjects_subject(s, expected_code=404)
-
         #Test /subjects/{subject}/versions/{version}
         def test_subjects_subject_versions_version(entry, expected_successful):
             lookup_schema = import_schemas[entry]
@@ -2772,7 +2758,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #All schemas should be retrievable through subject/version.
-        for _, s in valid_entries + forward_references_entries + invalid_entries:
+        for _, s in valid_entries + invalid_entries:
             test_subjects_subject_versions_version(s, expected_successful=True)
 
         #Test /subjects/{subject}/versions/{version}/schema
@@ -2799,7 +2785,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #All schemas should be retrievable through subject/version.
-        for _, s in valid_entries + forward_references_entries + invalid_entries:
+        for _, s in valid_entries + invalid_entries:
             test_subjects_subject_versions_version_schema(
                 s, expected_successful=True)
 
@@ -2863,13 +2849,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                            expected_id=id,
                                            expected_successful=True)
 
-        #forward_references will fail the lookup, as they didn't get canonicallized.
-        #Each will create a new entry.
-        for id, s in forward_references_entries_new_ids:
-            test_subjects_subject_versions(s,
-                                           expected_id=id,
-                                           expected_successful=True)
-
         #These schemas should fail, as the *input* schema has an unsatisfied dependencies
         for id, s in invalid_entries:
             test_subjects_subject_versions(s,
@@ -2899,7 +2878,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         #startup and it was not in canonical form. Thus it cannot be found and a
         #new version is created.
         test_subjects_subject_versions("schema_d",
-                                       expected_id=17,
+                                       expected_id=16,
                                        expected_successful=True)
         #After pushing, schema_d is not stored by its canonical form
         import_schemas["schema_d"]["sanitized"] = schema_d_proto_sanitized_def
@@ -2915,7 +2894,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Fix problematic schemas by adding missing dependency for g_v2 and deleting g_v4.
         test_subjects_subject_versions("schema_f_v2",
-                                       expected_id=18,
+                                       expected_id=17,
                                        expected_successful=True)
 
         result_raw = self._delete_subject_version("schema_g", version=4)
@@ -2923,12 +2902,12 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                             "DELETE subjects/schema_g/versions/4")
 
         test_subjects_subject_versions("schema_g_v5",
-                                       expected_id=19,
+                                       expected_id=18,
                                        expected_successful=True)
 
         #Fix problematic dependency chain by adding base schema.
         test_subjects_subject_versions("schema_h",
-                                       expected_id=20,
+                                       expected_id=19,
                                        expected_successful=True)
         test_schemas_ids_id(12, expected_successful=True)
         test_schemas_ids_id(13, expected_successful=True)


### PR DESCRIPTION
Implements: [CORE-9769](https://redpandadata.atlassian.net/browse/CORE-9769)

We are adding a 2-way pass, where schemas that fail to be processed when being loaded into the store are given a second chance once the whole topic has been loaded into the store. This allows support of schemas whose references are defined in a higher offset in the topic.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none



[CORE-9769]: https://redpandadata.atlassian.net/browse/CORE-9769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ