### PR TITLE
datalake: allow for translation from tiered storage

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -946,7 +946,8 @@ ss::future<
   result<async_manifest_view::archive_start_offset_advance, error_outcome>>
 async_manifest_view::compute_retention(
   std::optional<size_t> size_limit,
-  std::optional<std::chrono::milliseconds> time_limit) noexcept {
+  std::optional<std::chrono::milliseconds> time_limit,
+  std::optional<kafka::offset> pinned_offset) noexcept {
     archive_start_offset_advance time_result;
     archive_start_offset_advance size_result;
     if (time_limit.has_value()) {
@@ -995,7 +996,8 @@ async_manifest_view::compute_retention(
           "Start kafka offset override {} exceeds computed retention {}",
           _stm_manifest.get_start_kafka_offset_override(),
           result.offset);
-        auto r = co_await offset_based_retention();
+        auto r = co_await find_highest_le(
+          _stm_manifest.get_start_kafka_offset_override());
         if (r.has_error()) {
             co_return r;
         }
@@ -1005,15 +1007,32 @@ async_manifest_view::compute_retention(
           "Found offset {} to advance start offset to",
           result.offset);
     }
+    if (pinned_offset && result.offset - result.delta > *pinned_offset) {
+        vlog(
+          _ctxlog.debug,
+          "Computed retention Kafka offset {} is above the pinned offset {}",
+          result.offset - result.delta,
+          *pinned_offset);
+        auto r = co_await find_highest_le(*pinned_offset);
+        if (r.has_error()) {
+            co_return r;
+        }
+        result = r.value();
+        vlog(
+          _ctxlog.debug,
+          "Found Kafka offset {} to pin the start offset to {}",
+          result.offset - result.delta,
+          *pinned_offset);
+    }
     co_return result;
 }
 
 ss::future<
   result<async_manifest_view::archive_start_offset_advance, error_outcome>>
-async_manifest_view::offset_based_retention() noexcept {
+async_manifest_view::find_highest_le(kafka::offset o) noexcept {
     archive_start_offset_advance result;
     try {
-        auto boundary = _stm_manifest.get_start_kafka_offset_override();
+        auto boundary = o;
         auto res = co_await get_cursor(
           boundary, std::nullopt, cursor_base_t::archive_clean_offset);
         if (res.has_failure()) {

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -158,7 +158,8 @@ public:
     ss::future<result<archive_start_offset_advance, error_outcome>>
     compute_retention(
       std::optional<size_t> size_limit,
-      std::optional<std::chrono::milliseconds> time_limit) noexcept;
+      std::optional<std::chrono::milliseconds> time_limit,
+      std::optional<kafka::offset> pinned_offset = std::nullopt) noexcept;
 
     const remote_path_provider& path_provider() const {
         return _remote_path_provider;
@@ -171,8 +172,10 @@ private:
     ss::future<result<archive_start_offset_advance, error_outcome>>
     size_based_retention(size_t size_limit) noexcept;
 
+    // Returns a point that corresponds to the beginning of the highest
+    // manifest less than or containing the given offset.
     ss::future<result<archive_start_offset_advance, error_outcome>>
-    offset_based_retention() noexcept;
+      find_highest_le(kafka::offset) noexcept;
 
     // Perform a term upper bound search within the spillover manifest list.
     // Returns the index of the first spillover manifest that contains a segment

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2501,6 +2501,52 @@ partition_manifest::timequery(model::timestamp t) const {
     return *_segments.at_index(target_ix);
 }
 
+size_t partition_manifest::estimate_size_between(
+  kafka::offset begin, kafka::offset end) const {
+    if (begin > end) {
+        return 0;
+    }
+    auto stm_start_offset = get_start_kafka_offset();
+    auto stm_next_offset = get_next_kafka_offset();
+    if (!stm_start_offset.has_value() || !stm_next_offset.has_value()) {
+        // The manifest is empty, implying the cloud log is empty.
+        return 0;
+    }
+    size_t spillover_sz = 0;
+    if (begin < *stm_start_offset) {
+        // 'begin' falls below the STM manifest, meaning the range includes
+        // part of the spillover region: aggregate them.
+        for (const auto& m : _spillover_manifests) {
+            if (
+              m.base_kafka_offset() <= end && m.last_kafka_offset() >= begin) {
+                spillover_sz += m.size_bytes;
+            }
+        }
+    }
+    if (end < *stm_start_offset) {
+        // 'end' falls below the STM manifest, mening the entire range was in
+        // the spillover region and we can just return what we have.
+        return spillover_sz;
+    }
+    // At this point we know there is overlap between the input range and the
+    // the STM manifest.
+
+    size_t stm_sz = 0;
+    auto stm_end_offset = kafka::prev_offset(*stm_next_offset);
+    if (begin <= *stm_start_offset && end >= stm_end_offset) {
+        // The range covers the entire STM manifest -- no need to iterate.
+        stm_sz = stm_region_size_bytes();
+    } else {
+        for (const auto& s : _segments) {
+            if (
+              s.base_kafka_offset() <= end && s.last_kafka_offset() >= begin) {
+                stm_sz += s.size_bytes;
+            }
+        }
+    }
+    return stm_sz + spillover_sz;
+}
+
 // this class is a serde-enabled version of partition_manifest. it's needed
 // because segment_meta_cstore is not copyable, and moving it would empty out
 // partition_manifest

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -251,6 +251,10 @@ public:
     /// Find the earliest segment that has max timestamp >= t
     std::optional<segment_meta> timequery(model::timestamp t) const;
 
+    /// Returns an estimate for the size of data between the given Kafka
+    /// offsets inclusive. This is a best-effort method that may overestimate.
+    size_t estimate_size_between(kafka::offset begin, kafka::offset end) const;
+
     remote_segment_path generate_segment_path(
       const segment_meta&, const remote_path_provider&) const;
     remote_segment_path generate_segment_path(

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -716,16 +716,15 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     }
 
     // Check the case when retention overshoots
-    // auto rr1 = view.compute_retention(total_size * 2,
-    // std::nullopt).get(); BOOST_REQUIRE(rr1.has_value());
-    // BOOST_REQUIRE_EQUAL(rr1.value().offset, model::offset{});
-    // BOOST_REQUIRE_EQUAL(rr1.value().delta, model::offset_delta{});
+    auto rr1 = view.compute_retention(total_size * 2, std::nullopt).get();
+    BOOST_REQUIRE(rr1.has_value());
+    BOOST_REQUIRE_EQUAL(rr1.value().offset, model::offset{});
+    BOOST_REQUIRE_EQUAL(rr1.value().delta, model::offset_delta{});
 
     auto rr2 = view.compute_retention(std::nullopt, storage_duration * 2).get();
     BOOST_REQUIRE(rr2.has_value());
     BOOST_REQUIRE_EQUAL(rr2.value().offset, model::offset{});
     BOOST_REQUIRE_EQUAL(rr2.value().delta, model::offset_delta{});
-    return;
 
     auto rr3
       = view.compute_retention(total_size * 2, storage_duration * 2).get();
@@ -806,10 +805,78 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
       prefix_delta);
 
     auto rr6 = view.compute_retention(total_size, storage_duration).get();
-
     BOOST_REQUIRE(rr6.has_value());
     BOOST_REQUIRE_EQUAL(rr6.value().offset, prefix_base_offset);
     BOOST_REQUIRE_EQUAL(rr6.value().delta, prefix_delta);
+
+    // Check that an offset pinned above the normal retention point will not
+    // change the retention point.
+    auto prefix_kafka_offset = prefix_base_offset - prefix_delta;
+    auto rr7 = view
+                 .compute_retention(
+                   total_size,
+                   storage_duration,
+                   prefix_kafka_offset + kafka::offset{100000})
+                 .get();
+    BOOST_REQUIRE(rr7.has_value());
+    BOOST_CHECK_EQUAL(rr7.value().offset, prefix_base_offset);
+    BOOST_CHECK_EQUAL(rr7.value().delta, prefix_delta);
+
+    // Check that an offset pinned below the normal retention point will cause
+    // retention to return a lower value.
+    auto rr8 = view
+                 .compute_retention(
+                   total_size,
+                   storage_duration,
+                   kafka::prev_offset(prefix_kafka_offset))
+                 .get();
+    BOOST_REQUIRE(rr8.has_value());
+    BOOST_CHECK_LT(rr8.value().offset, prefix_base_offset);
+    BOOST_CHECK_EQUAL(rr8.value().delta, prefix_delta);
+}
+
+FIXTURE_TEST(
+  test_async_manifest_view_retention_with_pin, async_manifest_view_fixture) {
+    std::vector<segment_meta> segments;
+    collect_segments_to(segments);
+    for (int i = 0; i < 10; i++) {
+        generate_manifest_section(100);
+    }
+    listen();
+
+    // Sanity check that aggressive size limits results in removing the entire
+    // spillover region.
+    auto res = view.compute_retention(0, storage_duration).get();
+    BOOST_REQUIRE(res.has_value());
+    auto& stm_manifest = view.stm_manifest();
+    BOOST_CHECK_EQUAL(res.value().offset, stm_manifest.get_start_offset());
+    BOOST_CHECK_EQUAL(
+      res.value().delta,
+      stm_manifest.first_addressable_segment()->delta_offset);
+
+    // Any pin within a given spillover manifest should pin the whole manifest.
+    auto first_manifest = view.stm_manifest().get_spillover_map().begin();
+    for (auto o :
+         {first_manifest->base_kafka_offset(),
+          first_manifest->last_kafka_offset()}) {
+        auto pinned_res = view.compute_retention(0, storage_duration, o).get();
+        BOOST_REQUIRE(pinned_res.has_value());
+        BOOST_CHECK_EQUAL(pinned_res.value().offset, model::offset{0});
+        BOOST_CHECK_EQUAL(pinned_res.value().delta, model::offset_delta{0});
+    }
+    // A pin past a manifest should allow the manifest to be removed.
+    auto second_manifest = std::next(
+      view.stm_manifest().get_spillover_map().begin());
+    for (auto o :
+         {second_manifest->base_kafka_offset(),
+          second_manifest->last_kafka_offset()}) {
+        auto pinned_res = view.compute_retention(0, storage_duration, o).get();
+        BOOST_REQUIRE(pinned_res.has_value());
+        BOOST_CHECK_EQUAL(
+          pinned_res.value().offset, second_manifest->base_offset);
+        BOOST_CHECK_EQUAL(
+          pinned_res.value().delta, second_manifest->delta_offset);
+    }
 }
 
 FIXTURE_TEST(test_async_manifest_view_after_gc, async_manifest_view_fixture) {

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -9,8 +9,6 @@
  */
 
 #include "cloud_io/tests/s3_imposter.h"
-#include "cloud_storage/remote.h"
-#include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/tests/manual_fixture.h"
 #include "cloud_storage/tests/produce_utils.h"
 #include "cloud_storage/tests/read_replica_e2e_fixture.h"
@@ -18,7 +16,7 @@
 #include "cluster/archival/ntp_archiver_service.h"
 #include "cluster/cloud_metadata/tests/manual_mixin.h"
 #include "cluster/health_monitor_frontend.h"
-#include "config/configuration.h"
+#include "kafka/data/replicated_partition.h"
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
@@ -104,6 +102,87 @@ TEST_F(ManualFixture, TestSpilloverRetentionCompactedTopic) {
     ASSERT_EQ(
       archiver.manifest().full_log_start_offset().value_or(model::offset{})(),
       0);
+}
+
+TEST_F(ManualFixture, TestSizeEstimationWithCloud) {
+    test_local_cfg.get("log_compaction_interval_ms")
+      .set_value(std::chrono::duration_cast<std::chrono::milliseconds>(1s));
+    test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+      .set_value(true);
+    test_local_cfg.get("cloud_storage_spillover_manifest_max_segments")
+      .set_value(std::make_optional<size_t>(5));
+    test_local_cfg.get("cloud_storage_spillover_manifest_size")
+      .set_value(std::optional<size_t>{});
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+    wait_for_leader(ntp).get();
+
+    const auto records_per_seg = 5;
+    const auto num_segs = 100;
+    auto partition = app.partition_manager.local().get(ntp);
+    auto& archiver = partition->archiver().value().get();
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(records_per_seg)
+                           .additional_local_segments(10)
+                           .produce()
+                           .get();
+    ASSERT_GE(total_records, 550);
+    ASSERT_TRUE(archiver.sync_for_tests().get());
+    archiver.apply_spillover().get();
+
+    // Aggressively GC, relying on max collectible to preserve local segments
+    // not yet in tiered storage.
+    auto log = partition->log();
+    auto& manifest = partition->archival_meta_stm()->manifest();
+    log->set_cloud_gc_offset(model::next_offset(manifest.get_last_offset()));
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        vlog(e2e_test_log.info, "Log has {} segments", log->segment_count());
+        return log->segment_count() == 11;
+    });
+
+    kafka::replicated_partition kafka_partition(partition);
+    auto lso_res = kafka_partition.last_stable_offset();
+    ASSERT_FALSE(lso_res.has_error());
+    auto last_offset = kafka::prev_offset(model::offset_cast(lso_res.value()));
+    auto local_start = model::offset_cast(kafka_partition.local_start_offset());
+
+    auto total_estimated_sz = kafka_partition.estimate_size_between(
+      kafka::offset(0), last_offset);
+    auto cloud_estimated_sz = kafka_partition.estimate_size_between(
+      kafka::offset(0), kafka::prev_offset(local_start));
+    auto local_estimated_sz = kafka_partition.estimate_size_between(
+      local_start, last_offset);
+
+    vlog(
+      e2e_test_log.info,
+      "Local log start: {}, last offset: {}",
+      local_start,
+      last_offset);
+    EXPECT_EQ(local_estimated_sz, partition->size_bytes());
+    EXPECT_EQ(cloud_estimated_sz, partition->cloud_log_size());
+    EXPECT_EQ(total_estimated_sz, local_estimated_sz + cloud_estimated_sz);
+
+    for (int64_t i = 0; i < 13; i++) {
+        kafka::offset cut(i * total_records / 13);
+        auto left_estimated_sz = kafka_partition.estimate_size_between(
+          kafka::offset(0), kafka::prev_offset(cut));
+        auto right_estimated_sz = kafka_partition.estimate_size_between(
+          cut, last_offset);
+        EXPECT_LE(left_estimated_sz, total_estimated_sz);
+        EXPECT_LE(right_estimated_sz, total_estimated_sz);
+
+        // NOTE: error of 4000 chosen emperically.
+        // TODO: we expect some error given the estimate is based on the
+        // segment index, but it seems a little high, figure out why that is.
+        EXPECT_NEAR(
+          total_estimated_sz, left_estimated_sz + right_estimated_sz, 4000);
+    }
 }
 
 class EndToEndFixture

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -136,7 +136,7 @@ TEST_F(ManualFixture, TestSizeEstimationWithCloud) {
     ASSERT_TRUE(archiver.sync_for_tests().get());
     archiver.apply_spillover().get();
 
-    // Aggressively GC, relying on max collectible to preserve local segments
+    // Aggressively GC, relying on max removable to preserve local segments
     // not yet in tiered storage.
     auto log = partition->log();
     auto& manifest = partition->archival_meta_stm()->manifest();
@@ -232,12 +232,12 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     ASSERT_EQ(2, log->segments().size());
     ASSERT_EQ(1, archiver.manifest().size());
 
-    // Compact the local log to GC to the collectible offset.
+    // Compact the local log to GC to the removable offset.
     ss::abort_source as;
     storage::housekeeping_config housekeeping_conf(
       model::timestamp::min(),
       1,
-      log->stm_manager()->max_collectible_offset(),
+      log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);
@@ -661,7 +661,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
     storage::housekeeping_config housekeeping_conf(
       model::timestamp::min(),
       1, // max_bytes_in_log
-      log->stm_manager()->max_collectible_offset(),
+      log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);
@@ -958,7 +958,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     storage::housekeeping_config housekeeping_conf(
       model::timestamp::max(),
       0,
-      log->stm_manager()->max_collectible_offset(),
+      log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2381,6 +2381,166 @@ SEASTAR_THREAD_TEST_CASE(test_archive_offsets_serialization) {
     BOOST_REQUIRE_EQUAL(restored.get_archive_clean_offset(), model::offset(50));
 }
 
+namespace {
+segment_meta make_segment(
+  std::pair<int64_t, int64_t> kafka_bounds, size_t size, int64_t delta = 10) {
+    auto model_start = kafka_bounds.first + delta;
+    auto model_last = kafka_bounds.second + delta;
+    return {
+      .is_compacted = false,
+      .size_bytes = size,
+      .base_offset = model::offset(model_start),
+      .committed_offset = model::offset(model_last),
+      .base_timestamp = model::timestamp{1689985196373},
+      .max_timestamp = model::timestamp{1689985643129},
+      .delta_offset = model::offset_delta(delta),
+      .ntp_revision = model::initial_revision_id(1234),
+      .archiver_term = model::term_id(16),
+      .segment_term = model::term_id(1),
+      .delta_offset_end = model::offset_delta(delta),
+      .sname_format = segment_name_format::v3,
+      .metadata_size_hint = 0};
+}
+} // namespace
+
+SEASTAR_THREAD_TEST_CASE(test_estimate_size) {
+    partition_manifest m;
+    m.add(make_segment({10, 99}, 1234));
+    m.add(make_segment({100, 199}, 1000));
+    BOOST_CHECK_EQUAL(kafka::offset{200}, m.get_next_kafka_offset());
+
+    // Check values before the start.
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{0}));
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{9}));
+
+    // Overlapping with just the first segment.
+    BOOST_CHECK_EQUAL(
+      1234, m.estimate_size_between(kafka::offset{0}, kafka::offset{10}));
+    BOOST_CHECK_EQUAL(
+      1234, m.estimate_size_between(kafka::offset{10}, kafka::offset{99}));
+    BOOST_CHECK_EQUAL(
+      1234, m.estimate_size_between(kafka::offset{99}, kafka::offset{99}));
+
+    // Overlapping with both segments.
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{99}, kafka::offset{100}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{0}, kafka::offset{100}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{0}, kafka::offset{200}));
+
+    // Overlapping with just the second segment.
+    BOOST_CHECK_EQUAL(
+      1000, m.estimate_size_between(kafka::offset{100}, kafka::offset{100}));
+    BOOST_CHECK_EQUAL(
+      1000, m.estimate_size_between(kafka::offset{100}, kafka::offset{199}));
+    BOOST_CHECK_EQUAL(
+      1000, m.estimate_size_between(kafka::offset{199}, kafka::offset{199}));
+    BOOST_CHECK_EQUAL(
+      1000, m.estimate_size_between(kafka::offset{100}, kafka::offset{200}));
+
+    // Check values past the end.
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{200}, kafka::offset{200}));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_estimate_size_spillover) {
+    partition_manifest m;
+    m.add(make_segment({10, 99}, 1234));
+    m.add(make_segment({100, 199}, 1000));
+    m.add(make_segment({200, 299}, 2000));
+    m.add(make_segment({300, 399}, 500));
+    m.set_archive_start_offset(model::offset{20}, model::offset_delta{10});
+    m.spillover(make_segment({10, 199}, 2234));
+    m.spillover(make_segment({200, 299}, 2000));
+
+    BOOST_CHECK_EQUAL(kafka::offset{10}, m.full_log_start_kafka_offset());
+    BOOST_CHECK_EQUAL(kafka::offset{400}, m.get_next_kafka_offset());
+    BOOST_CHECK_EQUAL(500, m.stm_region_size_bytes());
+    BOOST_CHECK_EQUAL(4234, m.archive_size_bytes());
+
+    // At this point, the archival layout looks like this:
+    //   size bytes    [2234B  ][2000B   ][500B ]
+    //   kafka offsets [10, 199][200, 299][300, 399]
+    //   region        [archive          ][stm     ]
+
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{0}));
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{9}));
+
+    // Overlapping with just the first segment.
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{0}, kafka::offset{10}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{10}, kafka::offset{99}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{99}, kafka::offset{99}));
+
+    // Overlapping with both segments.
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{99}, kafka::offset{100}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{0}, kafka::offset{100}));
+
+    // Overlapping with just the second segment.
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{100}, kafka::offset{100}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{100}, kafka::offset{199}));
+    BOOST_CHECK_EQUAL(
+      2234, m.estimate_size_between(kafka::offset{199}, kafka::offset{199}));
+
+    // Overlap with the second spillover manifest too.
+    BOOST_CHECK_EQUAL(
+      4234, m.estimate_size_between(kafka::offset{0}, kafka::offset{200}));
+    BOOST_CHECK_EQUAL(
+      4234, m.estimate_size_between(kafka::offset{100}, kafka::offset{200}));
+
+    // Overlap with just the second spillover manifest.
+    BOOST_CHECK_EQUAL(
+      2000, m.estimate_size_between(kafka::offset{299}, kafka::offset{299}));
+
+    // Overlap the spillover manifest and STM manifest.
+    BOOST_CHECK_EQUAL(
+      2500, m.estimate_size_between(kafka::offset{299}, kafka::offset{300}));
+
+    // Now just the STM manifest.
+    BOOST_CHECK_EQUAL(
+      500, m.estimate_size_between(kafka::offset{300}, kafka::offset{300}));
+
+    // And now the whole cloud log.
+    BOOST_CHECK_EQUAL(
+      4734, m.estimate_size_between(kafka::offset{0}, kafka::offset{300}));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_estimate_size_empty) {
+    partition_manifest m;
+    BOOST_CHECK(!m.get_next_kafka_offset().has_value());
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{0}));
+
+    m.add(make_segment({10, 99}, 1234));
+    BOOST_CHECK_EQUAL(kafka::offset{100}, m.get_next_kafka_offset());
+
+    // Sanity check that we get non-zero for a valid range...
+    BOOST_CHECK_EQUAL(
+      1234, m.estimate_size_between(kafka::offset{90}, kafka::offset{90}));
+    // ...but zero when the range is empty.
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{90}, kafka::offset{89}));
+
+    // Now truncate such that the whole manifest is empty.
+    m.truncate(model::next_offset(m.last_segment()->committed_offset));
+    BOOST_CHECK(!m.get_next_kafka_offset().has_value());
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{0}, kafka::offset{0}));
+    BOOST_CHECK_EQUAL(
+      0, m.estimate_size_between(kafka::offset{100}, kafka::offset{100}));
+}
+
 SEASTAR_THREAD_TEST_CASE(test_partition_manifest_outofbound_trigger) {
     BOOST_TEST_INFO(
       fmt::format("random_seed: [{}]", random_generators::internal::gen));

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1309,7 +1309,7 @@ archival_metadata_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
       0, snapshot_offset, std::move(snap_data));
 }
 
-model::offset archival_metadata_stm::max_collectible_offset() {
+model::offset archival_metadata_stm::max_removable_local_log_offset() {
     // From Redpanda 22.3 up, the ntp_config's impression of whether
     // archival is enabled is authoritative.
     bool collect_all = !_raft->log_config().is_archival_enabled();

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -277,7 +277,7 @@ public:
 
     model::offset get_last_clean_at() const { return _last_clean_at; };
 
-    model::offset max_collectible_offset() override;
+    model::offset max_removable_local_log_offset() override;
 
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 

--- a/src/v/cluster/archival/archiver_manager.cc
+++ b/src/v/cluster/archival/archiver_manager.cc
@@ -409,8 +409,8 @@ public:
             // is true for the `ssx::spawn_with_gate` call. The danger of not
             // running the archiver is that the broker may run out of disk
             // space. Because the data is not uploaded to the cloud storage the
-            // max_collectible_offset can't be propagated forward. Because of
-            // that the local data can't be evicted.
+            // max_removable_local_log_offset can't be propagated forward.
+            // Because of that the local data can't be evicted.
             vlog(
               fsm._ctxlog.error,
               "ALERT! ntp_archiver failed to start {}",

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2508,8 +2508,10 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     std::optional<std::chrono::milliseconds> retention_ms
       = ntp_conf.retention_duration();
 
+    auto pinned_offset
+      = _parent.raft()->log()->stm_manager()->lowest_pinned_data_offset();
     auto res = co_await _manifest_view->compute_retention(
-      retention_bytes, retention_ms);
+      retention_bytes, retention_ms, pinned_offset);
 
     if (res.has_error()) {
         if (res.error() == cloud_storage::error_outcome::shutting_down) {
@@ -3057,8 +3059,10 @@ ss::future<> ntp_archiver::apply_retention() {
         co_return;
     }
 
+    auto pinned_offset
+      = _parent.raft()->log()->stm_manager()->lowest_pinned_data_offset();
     auto retention_calculator = retention_calculator::factory(
-      manifest(), _parent.get_ntp_config());
+      manifest(), _parent.get_ntp_config(), pinned_offset);
     if (!retention_calculator) {
         co_return;
     }

--- a/src/v/cluster/archival/retention_calculator.cc
+++ b/src/v/cluster/archival/retention_calculator.cc
@@ -77,7 +77,8 @@ private:
 
 std::optional<retention_calculator> retention_calculator::factory(
   const cloud_storage::partition_manifest& manifest,
-  const storage::ntp_config& ntp_config) {
+  const storage::ntp_config& ntp_config,
+  std::optional<kafka::offset> pinned_offset) {
     if (!ntp_config.is_collectable()) {
         vlog(
           archival_log.trace, "{} Partition not collectible", ntp_config.ntp());
@@ -90,11 +91,12 @@ std::optional<retention_calculator> retention_calculator::factory(
     vlog(
       archival_log.debug,
       "{} Creating retention calculator, ntp_config: {}, archive start offset: "
-      "{}, start offset: {}",
+      "{}, start offset: {}, pinned kafka offset: {}",
       ntp_config.ntp(),
       ntp_config,
       arch_so,
-      last_so);
+      last_so,
+      pinned_offset);
 
     if (arch_so != model::offset{} && arch_so != last_so) {
         // Retention should be applied to the archive area of the log first
@@ -175,19 +177,33 @@ std::optional<retention_calculator> retention_calculator::factory(
         return std::nullopt;
     }
 
-    return retention_calculator{manifest, std::move(strats)};
+    return retention_calculator{manifest, std::move(strats), pinned_offset};
 }
 
 retention_calculator::retention_calculator(
   const cloud_storage::partition_manifest& manifest,
-  std::vector<std::unique_ptr<retention_strategy>> strategies)
+  std::vector<std::unique_ptr<retention_strategy>> strategies,
+  std::optional<kafka::offset> pinned_offset)
   : _manifest(manifest)
-  , _strategies(std::move(strategies)) {}
+  , _strategies(std::move(strategies))
+  , _pinned_offset(pinned_offset) {}
 
 std::optional<model::offset> retention_calculator::next_start_offset() {
     auto it = _manifest.first_addressable_segment();
     for (; it != _manifest.end(); ++it) {
         const auto& entry = *it;
+        if (_pinned_offset && entry.last_kafka_offset() >= *_pinned_offset) {
+            // The pin is blocking us from removing this segment and beyond.
+            vlog(
+              archival_log.debug,
+              "{} retention is blocked on segment [{}, {}] by pin at Kafka "
+              "offset {}",
+              _manifest.get_ntp(),
+              entry.base_kafka_offset(),
+              entry.last_kafka_offset(),
+              *_pinned_offset);
+            break;
+        }
         const auto all_done = std::all_of(
           _strategies.begin(), _strategies.end(), [&](auto& strat) {
               return strat->done(entry);
@@ -195,6 +211,9 @@ std::optional<model::offset> retention_calculator::next_start_offset() {
         if (all_done) {
             break;
         }
+    }
+    if (it == _manifest.first_addressable_segment()) {
+        return std::nullopt;
     }
 
     // We made it to the end of our strategies and our policies are still not

--- a/src/v/cluster/archival/retention_calculator.h
+++ b/src/v/cluster/archival/retention_calculator.h
@@ -35,7 +35,9 @@ public:
 class retention_calculator {
 public:
     static std::optional<retention_calculator> factory(
-      const cloud_storage::partition_manifest&, const storage::ntp_config&);
+      const cloud_storage::partition_manifest&,
+      const storage::ntp_config&,
+      std::optional<kafka::offset> pinned_offset = std::nullopt);
 
     std::optional<model::offset> next_start_offset();
 
@@ -44,10 +46,12 @@ public:
 private:
     retention_calculator(
       const cloud_storage::partition_manifest&,
-      std::vector<std::unique_ptr<retention_strategy>>);
+      std::vector<std::unique_ptr<retention_strategy>>,
+      std::optional<kafka::offset> pinned_offset);
 
     const cloud_storage::partition_manifest& _manifest;
     std::vector<std::unique_ptr<retention_strategy>> _strategies;
+    std::optional<kafka::offset> _pinned_offset;
 };
 
 } // namespace archival

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -239,7 +239,7 @@ struct reupload_fixture : public archiver_fixture {
     }
 
     ss::lw_shared_ptr<storage::segment> run_disk_log_housekeeping(
-      model::offset max_collectible = model::offset::max()) {
+      model::offset max_removable = model::offset::max()) {
         auto& seg_set = disk_log_impl()->segments();
         scoped_config cfg;
         // Make sure that the compaction always runs
@@ -251,7 +251,7 @@ struct reupload_fixture : public archiver_fixture {
           ->housekeeping(storage::housekeeping_config{
             model::timestamp::max(),
             std::nullopt,
-            max_collectible,
+            max_removable,
             std::nullopt,
             ss::default_priority_class(),
             abort_source})
@@ -554,7 +554,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     // compacted and one non-compacted segments are uploaded.
     //
     // NOTE: we can only compact up to what's been uploaded, since that
-    // determines the max collectible offset.
+    // determines the max removable offset.
     reset_http_call_state();
     auto seg = run_disk_log_housekeeping(
       manifest.first_addressable_segment()->committed_offset);

--- a/src/v/cluster/archival/tests/retention_strategy_test.cc
+++ b/src/v/cluster/archival/tests/retention_strategy_test.cc
@@ -9,8 +9,6 @@
  */
 
 #include "cluster/archival/retention_calculator.h"
-#include "cluster/archival/tests/service_fixture.h"
-#include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/archival.h"
 #include "test_utils/tmp_dir.h"
 
@@ -28,20 +26,12 @@ struct size_based_retention_test_spec {
     tristate<size_t> retention_bytes;
     tristate<std::chrono::milliseconds> retention_duration;
     tristate<kafka::offset> desired_start_offset;
+    std::optional<kafka::offset> pinned_offset;
     std::optional<model::offset> next_start_offset;
 };
 
 const auto delta_10_min = model::timestamp{
   model::timestamp::now().value() - std::chrono::milliseconds{10min}.count()};
-
-namespace {
-segment_spec make_segment_spec_with_uninitialized_start_offset() {
-    auto ret = segment_spec(0, 9, 1024);
-    ret.start_offset = model::offset{};
-    return ret;
-}
-
-} // namespace
 
 const std::vector<size_based_retention_test_spec> retention_tests{
   // retention disabled
@@ -187,6 +177,49 @@ const std::vector<size_based_retention_test_spec> retention_tests{
     .desired_start_offset = tristate<kafka::offset>{},
     .next_start_offset = model::offset{30}},
 
+  // Mixed retention but with a pin at the start of the log.
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .desired_start_offset = tristate<kafka::offset>{},
+    .pinned_offset = kafka::offset{0},
+    .next_start_offset = std::nullopt},
+
+  // Mixed retention but with an offset pin that is actually a no-op (normal
+  // retention polciy results in the same offset).
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .desired_start_offset = tristate<kafka::offset>{},
+    .pinned_offset = kafka::offset{30},
+    .next_start_offset = model::offset{30}},
+
+  // Mixed retention with an offset pin that pins exactly at the start of the
+  // previous segment.
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .desired_start_offset = tristate<kafka::offset>{},
+    .pinned_offset = kafka::offset{20},
+    .next_start_offset = model::offset{20}},
+
+  // Mixed retention with an offset pin that pins exactly at the end of the
+  // previous segment, pinning the entire previous segment.
+  size_based_retention_test_spec{
+    .remote_segments
+    = {{0, 9, 1024, delta_10_min}, {10, 19, 1024, delta_10_min}, {20, 29, 1024}, {30, 39, 1024}},
+    .retention_bytes = tristate<size_t>{1024 * 2 - 42},
+    .retention_duration = tristate<std::chrono::milliseconds>{5min},
+    .desired_start_offset = tristate<kafka::offset>{},
+    .pinned_offset = kafka::offset{29},
+    .next_start_offset = model::offset{20}},
+
   // mixed retention with offset-based retention, no-op
   size_based_retention_test_spec{
     .remote_segments
@@ -205,15 +238,6 @@ const std::vector<size_based_retention_test_spec> retention_tests{
     .retention_duration = tristate<std::chrono::milliseconds>{5min},
     .desired_start_offset = tristate<kafka::offset>{kafka::offset(42)},
     .next_start_offset = model::offset{40}},
-
-  // Remote segment with uninitalized start offset and all sorts of retention
-  // enabled.
-  size_based_retention_test_spec{
-    .remote_segments = {make_segment_spec_with_uninitialized_start_offset()},
-    .retention_bytes = tristate<size_t>{1024},
-    .retention_duration = tristate<std::chrono::milliseconds>{100ms},
-    .desired_start_offset = tristate<kafka::offset>{},
-    .next_start_offset = std::nullopt},
 };
 
 SEASTAR_THREAD_TEST_CASE(test_retention_strategies) {
@@ -224,16 +248,17 @@ SEASTAR_THREAD_TEST_CASE(test_retention_strategies) {
         // clang-format off
         const auto& [remote_segments, retention_bytes,
                      retention_duration, desired_start_offset,
-                     next_start_offset] = test;
+                     pinned_offset, next_start_offset] = test;
         // clang-format on
 
         vlog(
           test_log.info,
           "Running test case: segments={}, retention_bytes={}, "
-          "retention_duration={}, next_start_offset={}",
+          "retention_duration={}, pinned_offset={}, next_start_offset={}",
           remote_segments,
           retention_bytes,
           retention_duration,
+          pinned_offset,
           next_start_offset);
 
         ntp_config config{{"test_ns", "test_topic", 0}, {data_path}};
@@ -248,7 +273,8 @@ SEASTAR_THREAD_TEST_CASE(test_retention_strategies) {
               m.advance_start_kafka_offset(desired_start_offset.value()));
         }
 
-        auto retention_calculator = retention_calculator::factory(m, config);
+        auto retention_calculator = retention_calculator::factory(
+          m, config, pinned_offset);
         if (next_start_offset.has_value()) {
             BOOST_REQUIRE(retention_calculator.has_value());
             auto next_so = retention_calculator->next_start_offset();

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -381,7 +381,8 @@ std::vector<partition_stm_state> get_partition_stm_state(consensus_ptr ptr) {
         partition_stm_state state;
         state.name = stm->name();
         state.last_applied_offset = stm->last_applied();
-        state.max_collectible_offset = stm->max_collectible_offset();
+        state.max_removable_local_log_offset
+          = stm->max_removable_local_log_offset();
         result.push_back(std::move(state));
     }
     return result;

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -576,7 +576,8 @@ controller_backend::calculate_learner_initial_offset(
         return std::nullopt;
     }
 
-    const auto max_collectible_offset = p->max_collectible_offset();
+    const auto max_removable_local_log_offset
+      = p->max_removable_local_log_offset();
     /**
      * Last offset uploaded to the cloud is target learner retention upper
      * bound. We can not start retention recover from the point which is not yet
@@ -585,15 +586,15 @@ controller_backend::calculate_learner_initial_offset(
     vlog(
       clusterlog.info,
       "[{}] calculated retention offset: {}, last uploaded to cloud: {}, "
-      "manifest clean offset: {}, max_collectible_offset: {}",
+      "manifest clean offset: {}, max_removable_local_log_offset: {}",
       p->ntp(),
       *retention_offset,
       p->archival_meta_stm()->manifest().get_last_offset(),
       p->archival_meta_stm()->get_last_clean_at(),
-      max_collectible_offset);
+      max_removable_local_log_offset);
 
     return model::next_offset(
-      std::min(max_collectible_offset, *retention_offset));
+      std::min(max_removable_local_log_offset, *retention_offset));
 }
 
 void controller_backend::process_delta(const topic_table::ntp_delta& d) {

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -71,7 +71,7 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
                 co_await _has_pending_truncation.wait();
             } else {
                 // Previous iter didn't get everything (e.g. because max
-                // collectible offset prevented use from truncating). Be sure
+                // removable offset prevented use from truncating). Be sure
                 // to try again soon even if no other notifications come in.
                 co_await _has_pending_truncation.wait(retry_backoff_time);
             }
@@ -172,10 +172,10 @@ log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
     co_await _raft->refresh_commit_index();
     co_await _raft->log()->stm_manager()->ensure_snapshot_exists(
       truncation_point);
-    const auto max_collectible_offset
-      = _raft->log()->stm_manager()->max_collectible_offset();
-    if (truncation_point > max_collectible_offset) {
-        truncation_point = max_collectible_offset;
+    const auto max_removable_local_log_offset
+      = _raft->log()->stm_manager()->max_removable_local_log_offset();
+    if (truncation_point > max_removable_local_log_offset) {
+        truncation_point = max_removable_local_log_offset;
         if (truncation_point <= _raft->last_snapshot_index()) {
             /// Cannot truncate, have already reached maximum allowable
             co_return;
@@ -183,7 +183,7 @@ log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
         vlog(
           _log.trace,
           "Can only evict up to offset: {}, asked to evict to: {} ",
-          max_collectible_offset,
+          max_removable_local_log_offset,
           truncation_point);
     }
     if (truncation_point <= _raft->last_snapshot_index()) {

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -33,8 +33,8 @@ class consensus;
  *
  * The process goes like this: storage layer will send a "deletion notification"
  * - a request to evict log up to a certain offset. log_eviction_stm will then
- * adjust that offset with _stm_manager->max_collectible_offset(), write the
- * raft snapshot and notify the storage layer that log eviction can safely
+ * adjust that offset with _stm_manager->max_removable_local_log_offset(), write
+ * the raft snapshot and notify the storage layer that log eviction can safely
  * proceed up to the adjusted offset.
  *
  * This class also initiates and responds to delete-records events. Call

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1429,16 +1429,16 @@ partition::do_unsafe_reset_remote_partition_manifest_from_cloud(bool force) {
           "No matching manifest for {} rev {}", ntp(), initial_rev));
     }
 
-    const auto max_collectible
-      = _raft->log()->stm_manager()->max_collectible_offset();
-    if (new_manifest.get_last_offset() < max_collectible) {
+    const auto max_removable
+      = _raft->log()->stm_manager()->max_removable_local_log_offset();
+    if (new_manifest.get_last_offset() < max_removable) {
         auto msg = ssx::sformat(
           "Applying the cloud manifest would cause data loss since the last "
-          "offset in the downloaded manifest is below the max_collectible "
+          "offset in the downloaded manifest is below the max_removable "
           "offset "
           "{} < {}",
           new_manifest.get_last_offset(),
-          max_collectible);
+          max_removable);
 
         if (!force) {
             throw std::runtime_error(msg);
@@ -1579,8 +1579,8 @@ partition::archival_meta_stm() const {
     return _archival_meta_stm;
 }
 
-model::offset partition::max_collectible_offset() {
-    return _raft->log()->stm_manager()->max_collectible_offset();
+model::offset partition::max_removable_local_log_offset() {
+    return _raft->log()->stm_manager()->max_removable_local_log_offset();
 }
 
 std::optional<model::offset> partition::kafka_start_offset_override() const {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -178,7 +178,7 @@ public:
      * learners as claimed by the state machines implemented on top of this
      * partition.
      */
-    model::offset max_collectible_offset();
+    model::offset max_removable_local_log_offset();
 
     ss::future<std::error_code> update_replica_set(
       std::vector<raft::broker_revision> brokers,
@@ -350,7 +350,7 @@ public:
     // from an iobuf containing the JSON representation of the manifest.
     //
     // Warning: in order to call this safely, one must stop the archiver
-    // manually whilst ensuring that the max collectible offset reported
+    // manually whilst ensuring that the max removable offset reported
     // by the archival metadata STM remains stable. Prefer its sibling
     // which resets from the cloud state.
     //

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -166,11 +166,11 @@ public:
      *
      * Callers should be wary to either ensure that the stm is synced before
      * calling, or ensure that the producer_id doesn't need to reflect batches
-     * later than the max_collectible_offset.
+     * later than the max_removable_local_log_offset.
      */
     model::producer_id highest_producer_id() const;
 
-    model::offset max_collectible_offset() override {
+    model::offset max_removable_local_log_offset() override {
         const auto lso = last_stable_offset();
         if (lso < model::offset{0}) {
             return model::offset{};

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -106,7 +106,7 @@ public:
                     model::timestamp(
                       model::timestamp::now().value() - ret_duration.count()),
                     std::nullopt,
-                    log->stm_manager()->max_collectible_offset(),
+                    log->stm_manager()->max_removable_local_log_offset(),
                     std::nullopt,
                     ss::default_priority_class(),
                     dummy_as,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1241,7 +1241,7 @@ enum class reconfiguration_policy {
      * With target initial retention partition move policy controller backend
      * will calculate the learner start offset based on the configured learner
      * initial retention configuration (either a global cluster property or
-     * topic override ) and partition max collectible offset. Max collectible
+     * topic override ) and partition max removable offset. Max removable
      * offset is advanced after all the previous offsets were successfully
      * uploaded to the cloud.
      */
@@ -2804,10 +2804,11 @@ struct partition_stm_state
 
     ss::sstring name;
     model::offset last_applied_offset;
-    model::offset max_collectible_offset;
+    model::offset max_removable_local_log_offset;
 
     auto serde_fields() {
-        return std::tie(name, last_applied_offset, max_collectible_offset);
+        return std::tie(
+          name, last_applied_offset, max_removable_local_log_offset);
     }
 };
 

--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -140,7 +140,7 @@ ss::future<> coordinator_stm::do_apply(const model::record_batch& b) {
     rearm_snapshot_timer();
 }
 
-model::offset coordinator_stm::max_collectible_offset() { return {}; }
+model::offset coordinator_stm::max_removable_local_log_offset() { return {}; }
 
 ss::future<raft::local_snapshot_applied> coordinator_stm::apply_local_snapshot(
   raft::stm_snapshot_header, iobuf&& snapshot_buf) {

--- a/src/v/datalake/coordinator/state_machine.h
+++ b/src/v/datalake/coordinator/state_machine.h
@@ -55,7 +55,7 @@ protected:
 
     ss::future<> do_apply(const model::record_batch&) override;
 
-    model::offset max_collectible_offset() override;
+    model::offset max_removable_local_log_offset() override;
 
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -315,6 +315,10 @@ public:
     }
 
     kafka::offset min_offset_for_translation() const final {
+        auto highest_translated = _stm->cached_highest_translated_offset();
+        if (highest_translated != kafka::offset::min()) {
+            return kafka::next_offset(highest_translated);
+        }
         return calculate_min_offset_for_translation(
           _partition->is_read_replica_mode_enabled(), *_partition_proxy);
     }
@@ -772,59 +776,25 @@ public:
     }
 
     std::optional<size_t> translation_backlog() const final {
+        auto lso_res = _partition_proxy->last_stable_offset();
+        if (lso_res.has_error()) {
+            return std::nullopt;
+        }
+        auto max_translatable = kafka::prev_offset(
+          model::offset_cast(lso_res.value()));
         auto checkpointed_lto = _stm->cached_highest_translated_offset();
-
-        const auto final_lto
-          = _inflight_translation_lto
-              ? std::max(checkpointed_lto, *_inflight_translation_lto)
-              : checkpointed_lto;
-
-        auto min_offset_for_translation = calculate_min_offset_for_translation(
-          _partition->is_read_replica_mode_enabled(), *_partition_proxy);
-
-        if (final_lto <= min_offset_for_translation) {
-            return _partition->size_bytes();
+        auto next_to_translate
+          = checkpointed_lto == kafka::offset::min()
+              ? calculate_min_offset_for_translation(
+                  _partition->is_read_replica_mode_enabled(), *_partition_proxy)
+              : kafka::next_offset(checkpointed_lto);
+        if (_inflight_translation_lto) {
+            next_to_translate = std::max(
+              kafka::next_offset(*_inflight_translation_lto),
+              next_to_translate);
         }
-
-        const auto log_lto = highest_log_offset_below_next(
-          _partition->log(), final_lto);
-
-        const auto max_translatable_offset = model::prev_offset(
-          _partition->last_stable_offset());
-
-        if (log_lto == max_translatable_offset) {
-            return 0;
-        }
-        /**
-         * It is possible that the last stable offset is not yet established or
-         * simply smaller than the highest translated offset. f.e. during the
-         * partition movement. In such cases, we cannot calculate the backlog.
-         */
-        if (log_lto > max_translatable_offset) {
-            return std::nullopt;
-        }
-
-        auto size_after_translated = _partition->log()->size_bytes_after_offset(
-          log_lto);
-
-        auto size_after_max_translatable
-          = _partition->log()->size_bytes_after_offset(max_translatable_offset);
-
-        if (size_after_translated < size_after_max_translatable) {
-            vlog(
-              datalake_log.error,
-              "Expected partition {} size after translated offset({}) {} to be "
-              "greater than or equal to the size of log after max translatable "
-              "offset({}): {}",
-              _partition->ntp().path(),
-              log_lto,
-              size_after_translated,
-              max_translatable_offset,
-              size_after_max_translatable);
-            return std::nullopt;
-        }
-
-        return size_after_translated - size_after_max_translatable;
+        return _partition_proxy->estimate_size_between(
+          next_to_translate, max_translatable);
     }
 
     std::optional<model::timestamp> get_translated_offset_timestamp_estimate(

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -173,7 +173,7 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
                                : _data_source->min_offset_for_translation();
 
     // Replicate an initialized last translated offset to unblock the max
-    // collectible offset while pinning this Kafka offset from
+    // removable offset while pinning this Kafka offset from
     // application-facing retention or compaction.
     //
     // NOTE: kafka::prev_offset(0) is kafka::offset::min() (uninitialized).
@@ -359,7 +359,7 @@ ss::future<bool> partition_translator::finish_inflight_translation(
     if (expected_begin != translation_result.start_offset) {
         // This is possible if there is a gap in offsets range, eg from
         // compaction. Normally that shouldn't be the case, as translation
-        // enforces max_collectible_offset which prevents compaction or
+        // enforces max_removable_local_log_offset which prevents compaction or
         // other forms of retention from kicking in before translation
         // actually happens. However there could be a sequence of enabling /
         // disabling iceberg configuration on the topic that can temporarily

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -168,9 +168,19 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
     // least until 'wait_for_data' returns and we re-enter the loop.
     _data_source->update_commit_lag(last_committed_offset);
 
-    // LTO stands for last translated offset
-    const auto checkpointed_lto = result.last_added_offset.value_or(
-      kafka::prev_offset(_data_source->min_offset_for_translation()));
+    auto next_start_offset = result.last_added_offset
+                               ? kafka::next_offset(*result.last_added_offset)
+                               : _data_source->min_offset_for_translation();
+
+    // Replicate an initialized last translated offset to unblock the max
+    // collectible offset while pinning this Kafka offset from
+    // application-facing retention or compaction.
+    //
+    // NOTE: kafka::prev_offset(0) is kafka::offset::min() (uninitialized).
+    // in this case we want -1 to differentiate from uninitialized.
+    auto checkpointed_lto = next_start_offset == kafka::offset{0}
+                              ? kafka::offset{-1}
+                              : kafka::prev_offset(next_start_offset);
     /**
      * We do not replicate the timestamp of the highest translated offset
      * here as this information is not present in coordinator. This is fine

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -170,7 +170,7 @@ ss::future<std::error_code> translation_stm::reset_highest_translated_offset(
     co_return error;
 }
 
-model::offset translation_stm::max_collectible_offset() {
+model::offset translation_stm::max_removable_local_log_offset() {
     if (!_raft->log_config().iceberg_enabled()) {
         return model::offset::max();
     }

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -174,13 +174,30 @@ model::offset translation_stm::max_collectible_offset() {
     if (!_raft->log_config().iceberg_enabled()) {
         return model::offset::max();
     }
-    // if offset is not initialized, do not attempt translation.
+    // If offset is not initialized (we've never translated anything), avoid
+    // removing data. This means that when we haven't yet translated anything,
+    // local data is pinned until we start translating. Since the first
+    // translation starts at the beginning of the local log, this helps ensure:
+    // - on a new partition, we translate from 0 without reading from cloud
+    // - on a recovery topic partition, we don't backfill historical data
     if (_highest_translated_offset == kafka::offset{}) {
-        return model::offset{};
+        return model::offset::min();
     }
+    // If we have translated data before, no need to pin local data because
+    // translators don't need to read local data.
+    return model::offset::max();
+}
 
-    return highest_log_offset_below_next(
-      _raft->log(), _highest_translated_offset);
+std::optional<kafka::offset>
+translation_stm::lowest_pinned_data_offset() const {
+    if (!_raft->log_config().iceberg_enabled()) {
+        return std::nullopt;
+    }
+    // If we haven't translated anything yet, aggressively pin data.
+    if (_highest_translated_offset == kafka::offset{}) {
+        return kafka::offset{0};
+    }
+    return kafka::next_offset(_highest_translated_offset);
 }
 
 ss::future<raft::local_snapshot_applied> translation_stm::apply_local_snapshot(

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -29,7 +29,7 @@ public:
     ss::future<> stop() override;
 
     ss::future<> do_apply(const model::record_batch&) override;
-    model::offset max_collectible_offset() override;
+    model::offset max_removable_local_log_offset() override;
     std::optional<kafka::offset> lowest_pinned_data_offset() const override;
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -30,6 +30,7 @@ public:
 
     ss::future<> do_apply(const model::record_batch&) override;
     model::offset max_collectible_offset() override;
+    std::optional<kafka::offset> lowest_pinned_data_offset() const override;
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;
 
@@ -103,6 +104,9 @@ private:
 
     void update_highest_translated_offset(kafka::offset new_offset);
 
+    // The offset one below the starting point of the next translation.
+    // When this is kafka::offset::min() (the default), this indicates that it
+    // is not initialized.
     kafka::offset _highest_translated_offset{};
 
     // approximate system time at which _highest_translated_offset became

--- a/src/v/datalake/translation/tests/state_machine_test.cc
+++ b/src/v/datalake/translation/tests/state_machine_test.cc
@@ -47,11 +47,11 @@ struct translator_stm_fixture : stm_raft_fixture<stm> {
         }
     }
 
-    ss::future<std::vector<model::offset>> max_collectible_offsets() {
+    ss::future<std::vector<model::offset>> max_removable_local_log_offsets() {
         std::vector<model::offset> result;
         result.reserve(node_stms.size());
         co_await for_each_stm([&result](stm_ptr stm) {
-            result.push_back(stm->max_collectible_offset());
+            result.push_back(stm->max_removable_local_log_offset());
         });
         co_return result;
     }
@@ -89,13 +89,13 @@ struct translator_stm_fixture : stm_raft_fixture<stm> {
           update, ts, stm->raft()->term(), 5s, as);
     }
 
-    ss::future<> check_max_collectible_offset(model::offset expected) {
+    ss::future<> check_max_removable_local_log_offset(model::offset expected) {
         RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this, expected]() {
-            return max_collectible_offsets().then(
+            return max_removable_local_log_offsets().then(
               [this, expected](std::vector<model::offset> result) {
                   vlog(
                     logger().info,
-                    "max collectible offsets: {}, expected: {}",
+                    "max removable offsets: {}, expected: {}",
                     result,
                     expected);
                   auto equal = std::all_of(
@@ -140,9 +140,9 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
     co_await wait_for_leader(5s);
     scoped_config config;
     config.get("iceberg_enabled").set_value(true);
-    // since iceberg is not enabled, ensure max_collectible offset
+    // since iceberg is not enabled, ensure max_removable offset
     // is max()
-    co_await check_max_collectible_offset(model::offset::max());
+    co_await check_max_removable_local_log_offset(model::offset::max());
     co_await check_highest_translated_offset(std::nullopt);
     co_await check_highest_translated_timestamp(std::nullopt);
 
@@ -156,21 +156,21 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
             .then([](std::error_code ec) { return !bool(ec); });
       });
 
-    // iceberg is still disabled, max_collectible offset shouldn't change.
-    co_await check_max_collectible_offset(model::offset::max());
+    // iceberg is still disabled, max_removable offset shouldn't change.
+    co_await check_max_removable_local_log_offset(model::offset::max());
     co_await check_highest_translated_offset(std::nullopt);
     co_await check_highest_translated_timestamp(std::nullopt);
 
     // enable iceberg.
     co_await enable_iceberg();
 
-    co_await check_max_collectible_offset(model::offset::max());
+    co_await check_max_removable_local_log_offset(model::offset::max());
     co_await check_highest_translated_offset(new_translated_offset);
     co_await check_highest_translated_timestamp(new_catchup_timestamp);
 
     co_await disable_iceberg();
 
-    co_await check_max_collectible_offset(model::offset::max());
+    co_await check_max_removable_local_log_offset(model::offset::max());
     co_await check_highest_translated_offset(std::nullopt);
     co_await check_highest_translated_timestamp(std::nullopt);
 
@@ -182,7 +182,7 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
     co_await restart_nodes();
 
     co_await enable_iceberg();
-    co_await check_max_collectible_offset(model::offset::max());
+    co_await check_max_removable_local_log_offset(model::offset::max());
     co_await check_highest_translated_offset(new_translated_offset);
     co_await check_highest_translated_timestamp(new_catchup_timestamp);
 }

--- a/src/v/datalake/translation/tests/state_machine_test.cc
+++ b/src/v/datalake/translation/tests/state_machine_test.cc
@@ -164,14 +164,7 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
     // enable iceberg.
     co_await enable_iceberg();
 
-    model::offset max_collectible_offset{};
-    {
-        auto log = std::get<0>(node_stms.begin()->second)->raft()->log();
-        max_collectible_offset
-          = datalake::translation::highest_log_offset_below_next(
-            log, new_translated_offset);
-    }
-    co_await check_max_collectible_offset(max_collectible_offset);
+    co_await check_max_collectible_offset(model::offset::max());
     co_await check_highest_translated_offset(new_translated_offset);
     co_await check_highest_translated_timestamp(new_catchup_timestamp);
 
@@ -189,7 +182,7 @@ TEST_F_CORO(translator_stm_fixture, state_machine_ops) {
     co_await restart_nodes();
 
     co_await enable_iceberg();
-    co_await check_max_collectible_offset(max_collectible_offset);
+    co_await check_max_collectible_offset(model::offset::max());
     co_await check_highest_translated_offset(new_translated_offset);
     co_await check_highest_translated_timestamp(new_catchup_timestamp);
 }

--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -89,6 +89,8 @@ public:
           = 0;
 
         virtual result<partition_info> get_partition_info() const = 0;
+        virtual size_t estimate_size_between(kafka::offset, kafka::offset) const
+          = 0;
         virtual cluster::partition_probe& probe() = 0;
         virtual ~impl() noexcept = default;
     };
@@ -163,6 +165,10 @@ public:
 
     result<partition_info> get_partition_info() const {
         return _impl->get_partition_info();
+    }
+
+    size_t estimate_size_between(kafka::offset begin, kafka::offset end) const {
+        return _impl->estimate_size_between(begin, end);
     }
 
     ss::future<result<model::offset>>

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -254,7 +254,8 @@ replicated_partition::aborted_transactions_remote(
  * Based on the lower offset of an incoming request, decide whether it should
  * be sent to cloud storage (return true), or local raft storage (return false)
  */
-bool replicated_partition::may_read_from_cloud(kafka::offset start_offset) {
+bool replicated_partition::may_read_from_cloud(
+  kafka::offset start_offset) const {
     return _partition->is_remote_fetch_enabled()
            && _partition->cloud_data_available()
            && (start_offset < model::offset_cast(_translator->from_log_offset(_partition->raft_start_offset())));
@@ -663,6 +664,58 @@ result<partition_info> replicated_partition::get_partition_info() const {
     });
 
     return {std::move(ret)};
+}
+
+size_t replicated_partition::estimate_size_between(
+  kafka::offset begin, kafka::offset end) const {
+    if (begin > end) {
+        return 0;
+    }
+    if (
+      _partition->is_read_replica_mode_enabled()
+      && _partition->cloud_data_available()) {
+        auto& m = _partition->archival_meta_stm()->manifest();
+        return m.estimate_size_between(begin, end);
+    }
+    auto ot = _partition->log()->get_offset_translator_state();
+    auto local_log_start = _partition->raft_start_offset();
+    auto local_kafka_start = model::offset_cast(
+      ot->from_log_offset(local_log_start));
+    auto local_kafka_end = kafka::prev_offset(
+      model::offset_cast(ot->from_log_offset(_partition->high_watermark())));
+
+    size_t cloud_sz = 0;
+    if (may_read_from_cloud(begin)) {
+        // There is some data that falls below the local log and should be
+        // served from the cloud.
+
+        // Clamp the target end point to just below the local log so we don't
+        // double account for data that is both in the local log and in cloud.
+        auto cloud_clamped_kafka_end = std::min(
+          end, kafka::prev_offset(local_kafka_start));
+        auto& m = _partition->archival_meta_stm()->manifest();
+        cloud_sz = m.estimate_size_between(begin, cloud_clamped_kafka_end);
+    }
+    size_t local_sz = 0;
+    if (end >= local_kafka_start) {
+        // There is some data that will be served from the local log.
+
+        // Clamp the target offsets with what is actually available in the log.
+        auto local_clamped_kafka_begin = std::max(begin, local_kafka_start);
+        auto local_clamped_kafka_end = std::min(end, local_kafka_end);
+        auto local_clamped_begin = ot->to_log_offset(
+          kafka::offset_cast(local_clamped_kafka_begin));
+        auto local_clamped_end = model::prev_offset(ot->to_log_offset(
+          kafka::offset_cast(kafka::next_offset(local_clamped_kafka_end))));
+
+        auto log = _partition->log();
+        auto local_sz_from_begin = log->size_bytes_after_offset(
+          model::prev_offset(local_clamped_begin));
+        auto local_sz_after_end = log->size_bytes_after_offset(
+          local_clamped_end);
+        local_sz = local_sz_from_begin - local_sz_after_end;
+    }
+    return cloud_sz + local_sz;
 }
 
 } // namespace kafka

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -103,6 +103,8 @@ public:
 
     result<partition_info> get_partition_info() const final;
 
+    size_t estimate_size_between(kafka::offset, kafka::offset) const final;
+
 private:
     // Returns the Kafka offset corresponding to the lowest offset in the
     // log, including local and cloud storage. Doesn't take into account any
@@ -125,7 +127,7 @@ private:
       cloud_storage::offset_range offsets,
       ss::lw_shared_ptr<const storage::offset_translator_state> ot_state);
 
-    bool may_read_from_cloud(kafka::offset);
+    bool may_read_from_cloud(kafka::offset) const;
 
     ss::lw_shared_ptr<cluster::partition> _partition;
     ss::lw_shared_ptr<const storage::offset_translator_state> _translator;

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -106,7 +106,7 @@ ss::future<> group_tx_tracker_stm::do_apply(const model::record_batch& b) {
           features::feature::group_tx_fence_dedicated_batch_type))) {
         // This is only relevant for upgrades from 24.1.x to 24.2.x where a
         // mixed mode cluster has this feature disabled until the upgrade is
-        // done. Holding off stm updates ensures that max_collectible offset
+        // done. Holding off stm updates ensures that max_removable offset
         // does not progress for the duration of the upgrade, which is ok since
         // group compaction was not considering any control batches in 24.1.x,
         // so nothing was being compacted.
@@ -116,7 +116,7 @@ ss::future<> group_tx_tracker_stm::do_apply(const model::record_batch& b) {
     co_await parse(b.copy());
 }
 
-model::offset group_tx_tracker_stm::max_collectible_offset() {
+model::offset group_tx_tracker_stm::max_removable_local_log_offset() {
     auto result = last_applied_offset();
     for (const auto& [_, group_state] : _all_txs) {
         if (!group_state.begin_offsets.empty()) {
@@ -352,13 +352,13 @@ bool group_tx_tracker_stm::producer_tx_state::expired_deprecated_fence_tx()
     // transaction.
     // After this buggy compaction, these uncleaned tx_fence batches are
     // accounted as open transactions when computing
-    // max_collectible_offset thus blocking further compaction after
+    // max_removable_local_log_offset thus blocking further compaction after
     // upgrade to 24.2.x.
     if (fence_type != model::record_batch_type::tx_fence) {
         return false;
     }
     // note: this is a heuristic to ignore any transactions that have long been
-    // expired and we do not want them to block max collectible offset.
+    // expired and we do not want them to block max removable offset.
     // clamp the timeout, incase timeout is unset
     auto max_timeout
       = std::chrono::duration_cast<model::timeout_clock::duration>(

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -95,7 +95,7 @@ public:
 
     ss::future<> do_apply(const model::record_batch&) override;
 
-    model::offset max_collectible_offset() override;
+    model::offset max_removable_local_log_offset() override;
 
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -352,7 +352,7 @@ ss::future<> run_workload(
               ->housekeeping(storage::housekeeping_config{
                 model::timestamp::max(),
                 std::nullopt,
-                log->stm_manager()->max_collectible_offset(),
+                log->stm_manager()->max_removable_local_log_offset(),
                 std::nullopt,
                 ss::default_priority_class(),
                 dummy_as,
@@ -435,20 +435,20 @@ TEST_P_CORO(group_basic_workload_fixture, test_group_tx_stm_tracking) {
     co_await wait_until_stm_apply();
     // no transactions in flight
     ASSERT_EQ_CORO(
-      stm->max_collectible_offset(), log->offsets().committed_offset);
-    auto before = stm->max_collectible_offset();
+      stm->max_removable_local_log_offset(), log->offsets().committed_offset);
+    auto before = stm->max_removable_local_log_offset();
     // begin transaction.
     co_await execute_op(1);
-    ASSERT_EQ_CORO(stm->max_collectible_offset(), before);
+    ASSERT_EQ_CORO(stm->max_removable_local_log_offset(), before);
     // tx offset commit
     co_await execute_op(2);
-    ASSERT_EQ_CORO(stm->max_collectible_offset(), before);
+    ASSERT_EQ_CORO(stm->max_removable_local_log_offset(), before);
     // end transaction
     co_await execute_op(3);
-    // ensure max collectible offset moved.
-    ASSERT_GT_CORO(stm->max_collectible_offset(), before);
+    // ensure max removable offset moved.
+    ASSERT_GT_CORO(stm->max_removable_local_log_offset(), before);
     ASSERT_EQ_CORO(
-      stm->max_collectible_offset(), log->offsets().committed_offset);
+      stm->max_removable_local_log_offset(), log->offsets().committed_offset);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -367,7 +367,7 @@ ss::future<> persisted_stm_base<BaseT, T>::ensure_local_snapshot_exists(
 }
 
 template<typename BaseT, supported_stm_snapshot T>
-model::offset persisted_stm_base<BaseT, T>::max_collectible_offset() {
+model::offset persisted_stm_base<BaseT, T>::max_removable_local_log_offset() {
     return model::offset::max();
 }
 

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -208,7 +208,7 @@ public:
       std::optional<std::reference_wrapper<ss::abort_source>>
       = std::nullopt) const noexcept;
 
-    model::offset max_collectible_offset() override;
+    model::offset max_removable_local_log_offset() override;
     std::optional<kafka::offset> lowest_pinned_data_offset() const override {
         return std::nullopt;
     }

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -209,6 +209,9 @@ public:
       = std::nullopt) const noexcept;
 
     model::offset max_collectible_offset() override;
+    std::optional<kafka::offset> lowest_pinned_data_offset() const override {
+        return std::nullopt;
+    }
     ss::future<fragmented_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1137,9 +1137,9 @@
                     "type": "long",
                     "description": "Last applied offset"
                 },
-                "max_collectible_offset": {
+                "max_removable_local_log_offset": {
                     "type": "long",
-                    "description": "Max collectible offset"
+                    "description": "Max removable offset"
                 }
             }
         },

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -105,7 +105,8 @@ void fill_raft_state(
         ss::httpd::debug_json::stm_state state;
         state.name = stm.name;
         state.last_applied_offset = stm.last_applied_offset;
-        state.max_collectible_offset = stm.max_collectible_offset;
+        state.max_removable_local_log_offset
+          = stm.max_removable_local_log_offset;
         raft_state.stms.push(std::move(state));
     }
     if (src.recovery_state) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -463,7 +463,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
               config().ntp(),
               s.reader().filename(),
               s.offsets().get_stable_offset(),
-              cfg.max_collectible_offset);
+              cfg.max_removable_local_log_offset);
             return true;
         } else {
             vlog(
@@ -473,7 +473,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
               config().ntp(),
               s.reader().filename(),
               s.offsets().get_stable_offset(),
-              cfg.max_collectible_offset);
+              cfg.max_removable_local_log_offset);
             return false;
         }
     };
@@ -3524,13 +3524,13 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
      *
      * Because this effort is split between the log, raft, and eviction_stm we
      * end up having to duplicate some of the logic here, such as handling the
-     * max collectible offset from stm. A future refactoring may consider moving
+     * max removable offset from stm. A future refactoring may consider moving
      * more of the retention controls into a higher level location.
      */
-    const auto max_collectible = stm_manager()->max_collectible_offset();
+    const auto max_removable = stm_manager()->max_removable_local_log_offset();
     const auto retention_offset = [&]() -> std::optional<model::offset> {
         if (max_offset.has_value()) {
-            return std::min(max_offset.value(), max_collectible);
+            return std::min(max_offset.value(), max_removable);
         }
         return std::nullopt;
     }();
@@ -3551,7 +3551,7 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
             retention_segments.push_back(seg);
         } else if (
           is_cloud_retention_active()
-          && seg->offsets().get_dirty_offset() <= max_collectible) {
+          && seg->offsets().get_dirty_offset() <= max_removable) {
             available_segments.push_back(seg);
         } else {
             remaining_segments.push_back(seg);
@@ -3568,7 +3568,7 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
         if (
           !config().is_read_replica_mode_enabled()
           && is_cloud_retention_active() && seg != _segs.back()
-          && seg->offsets().get_dirty_offset() <= max_collectible
+          && seg->offsets().get_dirty_offset() <= max_removable
           && local_retention_offset.has_value()
           && seg->offsets().get_dirty_offset()
                <= local_retention_offset.value()) {
@@ -3875,16 +3875,16 @@ disk_log_impl::cloud_gc_eligible_segments() {
 
     /*
      * how much are we allowed to collect? sub-systems (e.g. transactions)
-     * may signal restrictions through the max collectible offset. for cloud
-     * topics max collectible will include a reflection of how much data has
+     * may signal restrictions through the max removable offset. for cloud
+     * topics max removable will include a reflection of how much data has
      * been uploaded into the cloud.
      */
-    const auto max_collectible = stm_manager()->max_collectible_offset();
+    const auto max_removable = stm_manager()->max_removable_local_log_offset();
 
     // collect eligible segments
     fragmented_vector<segment_set::type> segments;
     for (auto remaining = _segs.size() - keep_segs; auto& seg : _segs) {
-        if (seg->offsets().get_committed_offset() <= max_collectible) {
+        if (seg->offsets().get_committed_offset() <= max_removable) {
             segments.push_back(seg);
         }
         if (--remaining <= 0) {
@@ -3931,7 +3931,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
 
     /*
      * there is currently a bug with read replicas that makes the max
-     * collectible offset unreliable. the read replica topics still have a
+     * removable offset unreliable. the read replica topics still have a
      * retention setting, but we are going to exempt them from forced reclaim
      * until this bug is fixed to avoid any complications.
      *
@@ -3975,7 +3975,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
      * for a cloud-backed topic the max collecible offset is the threshold below
      * which data has been uploaded and can safely be removed from local disk.
      */
-    const auto max_collectible = stm_manager()->max_collectible_offset();
+    const auto max_removable = stm_manager()->max_removable_local_log_offset();
 
     /*
      * lightweight segment set copy for safe iteration
@@ -3997,13 +3997,13 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
     vlog(
       stlog.debug,
       "Categorizing {} {} segments for {} with local retention {} low "
-      "space {} max collectible {}",
+      "space {} max removable {}",
       segments.size(),
       (hinted ? "hinted" : "non-hinted"),
       config().ntp(),
       local_retention_offset,
       low_space_offset,
-      max_collectible);
+      max_removable);
 
     /*
      * categorize each segment.
@@ -4024,13 +4024,13 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
              * a potential:
              *
              *   1. rolling the active segment will bound progress towards
-             *   making its current full size reclaimable as max collectible
+             *   making its current full size reclaimable as max removable
              *   increases to cover the entire segment.
              *
-             *   2. finally, we don't report it if max collectible hasn't even
+             *   2. finally, we don't report it if max removable hasn't even
              *   made it to the active segment yet.
              */
-            if (seg->offsets().get_base_offset() <= max_collectible) {
+            if (seg->offsets().get_base_offset() <= max_removable) {
                 res.force_roll = seg_size;
                 vlog(
                   stlog.trace,
@@ -4050,13 +4050,13 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
          * if the current segment is not fully collectible, then subsequent
          * segments will not be either, and don't require consideration.
          */
-        if (point.offset > max_collectible) {
+        if (point.offset > max_removable) {
             vlog(
               stlog.trace,
-              "Stopping collection at offset {}:{} above max collectible {}",
+              "Stopping collection at offset {}:{} above max removable {}",
               point.offset,
               human::bytes(point.size),
-              max_collectible);
+              max_removable);
             break;
         }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -308,8 +308,8 @@ private:
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_adjacent_compaction_range(const compaction_config& cfg);
 
-    // Requests compaction of adjacent segments per the max_collectible_offset
-    // in the compaction_config.
+    // Requests compaction of adjacent segments per the
+    // max_removable_local_log_offset in the compaction_config.
     //
     // Returns std::nullopt if an adjacent pair could not be found for adjacent
     // compaction, or a compaction_result. This result should also have its

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -397,7 +397,8 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
 
         // Until we better implement bailing out of compaction, the best thing
         // we can do for observability is add a watchdog here.
-        ssx::watchdog wd5m(5min, [ntp = current_log.handle->config().ntp()] {
+        auto ntp = current_log.handle->config().ntp();
+        ssx::watchdog wd5m(5min, [ntp] {
             vlog(
               gclog.warn, "{}: Housekeeping process exceeding 5 minutes", ntp);
         });
@@ -405,10 +406,44 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         // NOTE: housekeeping holds _compaction_housekeeping_gate, that prevents
         // the removal of the parent object. this makes awaiting housekeeping
         // safe against removal of segments from _logs_list
+        auto& log = current_log.handle;
+        auto pinned_kafka_offset
+          = current_log.handle->stm_manager()->lowest_pinned_data_offset();
+        std::optional<model::offset> max_unpinned_offset;
+        if (pinned_kafka_offset) {
+            auto local_log_start = log->offsets().start_offset;
+            auto kafka_local_start = model::offset_cast(
+              log->from_log_offset(local_log_start));
+            if (*pinned_kafka_offset >= kafka_local_start) {
+                // Translate the pinned Kafka offset.
+                max_unpinned_offset = model::prev_offset(
+                  log->to_log_offset(kafka::offset_cast(*pinned_kafka_offset)));
+            } else {
+                // The pin falls below the log start, in which case the entire
+                // local log is pinned.
+                max_unpinned_offset = model::prev_offset(
+                  log->offsets().start_offset);
+            }
+        }
+        model::offset max_compactible_offset
+          = current_log.handle->stm_manager()->max_collectible_offset();
+        if (
+          max_unpinned_offset
+          && *max_unpinned_offset < max_compactible_offset) {
+            vlog(
+              gclog.debug,
+              "{}: Compaction is pinned by offset: pinned Kafka offset: {}, "
+              "log offsets max unpinned {} < max collectible {}",
+              ntp,
+              *pinned_kafka_offset,
+              *max_unpinned_offset,
+              max_compactible_offset);
+            max_compactible_offset = *max_unpinned_offset;
+        }
         co_await current_log.handle->housekeeping(housekeeping_config(
           collection_threshold,
           _config.retention_bytes(),
-          current_log.handle->stm_manager()->max_collectible_offset(),
+          max_compactible_offset,
           current_log.handle->config().tombstone_retention_ms(),
           _config.compaction_priority,
           _abort_source,

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -426,14 +426,14 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
             }
         }
         model::offset max_compactible_offset
-          = current_log.handle->stm_manager()->max_collectible_offset();
+          = current_log.handle->stm_manager()->max_removable_local_log_offset();
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {
             vlog(
               gclog.debug,
               "{}: Compaction is pinned by offset: pinned Kafka offset: {}, "
-              "log offsets max unpinned {} < max collectible {}",
+              "log offsets max unpinned {} < max removable {}",
               ntp,
               *pinned_kafka_offset,
               *max_unpinned_offset,

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -217,7 +217,7 @@ public:
     bool has_appender() const;
     compacted_index_writer& compaction_index();
     const compacted_index_writer& compaction_index() const;
-    // We currently use `max_collectible_offset` to control both
+    // We currently use `max_removable_local_log_offset` to control both
     // deletion/eviction, and compaction.
     bool has_compactible_offsets(const compaction_config& cfg) const;
 
@@ -439,7 +439,7 @@ inline bool
 segment::has_compactible_offsets(const compaction_config& cfg) const {
     // since we don't support partially-compacted segments, a segment must
     // end before the max compactible offset to be eligible for compaction.
-    return _tracker.get_stable_offset() <= cfg.max_collectible_offset;
+    return _tracker.get_stable_offset() <= cfg.max_removable_local_log_offset;
 }
 
 inline void segment::mark_as_compacted_segment() {

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -76,7 +76,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     storage::housekeeping_config conf(
       model::timestamp::min(),
       std::nullopt,
-      first_log->stm_manager()->max_collectible_offset(),
+      first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);
@@ -125,7 +125,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     storage::housekeeping_config conf2(
       model::timestamp::min(),
       std::nullopt,
-      new_log->stm_manager()->max_collectible_offset(),
+      new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);
@@ -198,7 +198,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     storage::housekeeping_config conf(
       model::timestamp::min(),
       std::nullopt,
-      first_log->stm_manager()->max_collectible_offset(),
+      first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);
@@ -227,7 +227,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     storage::housekeeping_config conf2(
       model::timestamp::min(),
       std::nullopt,
-      new_log->stm_manager()->max_collectible_offset(),
+      new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       ss::default_priority_class(),
       as);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1843,14 +1843,14 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     // Check if it honors max_compactible offset by resetting it to the base
     // offset of first segment. Nothing should be compacted.
     const auto first_segment_offsets = log->segments().front()->offsets();
-    c_cfg.compact.max_collectible_offset
+    c_cfg.compact.max_removable_local_log_offset
       = first_segment_offsets.get_base_offset();
     log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 3);
 
-    // Now compact without restricting collectible offset. The segment count
+    // Now compact without restricting removable offset. The segment count
     // will be reduced again.
-    c_cfg.compact.max_collectible_offset = model::offset::max();
+    c_cfg.compact.max_removable_local_log_offset = model::offset::max();
     log->housekeeping(c_cfg).get();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 2);
 
@@ -4054,7 +4054,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
     BOOST_REQUIRE_EQUAL(log.segment_count(), 2);
 
     // Grab the new start offset from the notification and
-    // update the collectible offset and start offsets.
+    // update the removable offset and start offsets.
     auto evict_at_offset = eviction_future.get();
     BOOST_REQUIRE_EQUAL(*new_start_offset, model::next_offset(evict_at_offset));
     BOOST_REQUIRE(b.update_start_offset(*new_start_offset).get());

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -31,6 +31,17 @@ model::offset stm_manager::max_collectible_offset() {
     return result;
 }
 
+std::optional<kafka::offset> stm_manager::lowest_pinned_data_offset() const {
+    std::optional<kafka::offset> result;
+    for (const auto& stm : _stms) {
+        auto pinned = stm->lowest_pinned_data_offset();
+        if (pinned) {
+            result = std::min(*pinned, result.value_or(kafka::offset::max()));
+        }
+    }
+    return result;
+}
+
 std::ostream& operator<<(std::ostream& o, const disk& d) {
     fmt::print(
       o,

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -21,12 +21,16 @@
 
 namespace storage {
 
-model::offset stm_manager::max_collectible_offset() {
+model::offset stm_manager::max_removable_local_log_offset() {
     model::offset result = model::offset::max();
     for (const auto& stm : _stms) {
-        auto mco = stm->max_collectible_offset();
+        auto mco = stm->max_removable_local_log_offset();
         result = std::min(result, mco);
-        vlog(stlog.trace, "max_collectible_offset[{}] = {}", stm->name(), mco);
+        vlog(
+          stlog.trace,
+          "max_removable_local_log_offset[{}] = {}",
+          stm->name(),
+          mco);
     }
     return result;
 }
@@ -217,10 +221,10 @@ std::ostream& operator<<(std::ostream& os, const gc_config& cfg) {
 std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
-      "{{max_collectible_offset:{}, "
+      "{{max_removable_local_log_offset:{}, "
       "should_sanitize:{}, "
       "tombstone_retention_ms:{}}}",
-      c.max_collectible_offset,
+      c.max_removable_local_log_offset,
       c.sanitizer_config,
       c.tombstone_retention_ms);
     return o;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -95,9 +95,27 @@ public:
     virtual ss::future<> ensure_local_snapshot_exists(model::offset) = 0;
     // hints stm_manager that now it's a good time to make a snapshot
     virtual void write_local_snapshot_in_background() = 0;
-    // lets the stm control snapshotting and log eviction by limiting
-    // log eviction attempts to offsets not greater than this.
+
+    // Lets the STM control snapshotting and local data removal by limiting
+    // local log eviction and compaction attempts to offsets not greater than
+    // this.
+    //
+    // For example, this can be used to ensure local data is not removed before
+    // first uploading it to tiered storage.
     virtual model::offset max_collectible_offset() = 0;
+
+    // Lets the STM limit application-facing removal or compaction of data by
+    // limiting GC or compaction attempts to offsets exclusively below this
+    // offset. For data that is in both tiered storage and local storage, the
+    // pin will not prevent removal of the local data because applications will
+    // still see the data from tiered storage.
+    //
+    // For example, this can be used to ensure data is written to Iceberg
+    // before being removed from the Kafka-application-facing log.
+    //
+    // May refer to a Kafka offset that does not exist, i.e. it may be up to or
+    // equal to the high watermark.
+    virtual std::optional<kafka::offset> lowest_pinned_data_offset() const = 0;
 
     virtual model::offset last_applied() const = 0;
 
@@ -169,6 +187,7 @@ public:
     }
 
     model::offset max_collectible_offset();
+    std::optional<kafka::offset> lowest_pinned_data_offset() const;
 
     ss::future<fragmented_vector<model::tx_range>>
     aborted_tx_ranges(model::offset to, model::offset from) {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -102,7 +102,7 @@ public:
     //
     // For example, this can be used to ensure local data is not removed before
     // first uploading it to tiered storage.
-    virtual model::offset max_collectible_offset() = 0;
+    virtual model::offset max_removable_local_log_offset() = 0;
 
     // Lets the STM limit application-facing removal or compaction of data by
     // limiting GC or compaction attempts to offsets exclusively below this
@@ -186,7 +186,7 @@ public:
         }
     }
 
-    model::offset max_collectible_offset();
+    model::offset max_removable_local_log_offset();
     std::optional<kafka::offset> lowest_pinned_data_offset() const;
 
     ss::future<fragmented_vector<model::tx_range>>
@@ -496,7 +496,7 @@ struct compaction_config {
       std::optional<size_t> max_keys = std::nullopt,
       hash_key_offset_map* key_map = nullptr,
       scoped_file_tracker::set_t* to_clean = nullptr)
-      : max_collectible_offset(max_collect_offset)
+      : max_removable_local_log_offset(max_collect_offset)
       , tombstone_retention_ms(tombstone_ret_ms)
       , iopc(p)
       , sanitizer_config(std::move(san_cfg))
@@ -507,7 +507,7 @@ struct compaction_config {
 
     // Cannot delete or compact past this offset (i.e. for unresolved txn
     // records): that is, only offsets <= this may be compacted.
-    model::offset max_collectible_offset;
+    model::offset max_removable_local_log_offset;
 
     // The retention time for tombstones. Tombstone removal occurs only for
     // "clean" compacted segments past the tombstone deletion horizon timestamp,

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -651,6 +651,10 @@ private:
         cluster::partition_probe& probe() override {
             throw std::runtime_error("unimplemented");
         }
+        size_t
+        estimate_size_between(kafka::offset, kafka::offset) const override {
+            throw std::runtime_error("unimplemented");
+        }
 
     private:
         model::offset latest_offset() {

--- a/tests/rptest/services/apache_iceberg_catalog.py
+++ b/tests/rptest/services/apache_iceberg_catalog.py
@@ -106,6 +106,10 @@ class IcebergRESTCatalog(CatalogService):
         assert self._catalog_url, "URL not available because service is not started"
         return self._catalog_url
 
+    @property
+    def iceberg_rest_port(self) -> int:
+        return 8181
+
     def set_filesystem_wrapper_mode(self, mode: bool):
         self.filesystem_wrapper_mode = mode
         self.compute_warehouse_path()
@@ -231,7 +235,7 @@ class IcebergRESTCatalog(CatalogService):
             f"Starting Iceberg REST catalog service on {node.name} with command {cmd}"
         )
         node.account.ssh(cmd, allow_fail=False)
-        self._catalog_url = f"http://{node.account.hostname}:8181"
+        self._catalog_url = f"http://{node.account.hostname}:{self.iceberg_rest_port}"
         self.wait(timeout_sec=30)
 
     def wait_node(self, node, timeout_sec=None):

--- a/tests/rptest/services/catalog_service.py
+++ b/tests/rptest/services/catalog_service.py
@@ -65,6 +65,11 @@ class CatalogService(abc.ABC, Service):
         ...
 
     @property
+    @abc.abstractmethod
+    def iceberg_rest_port(self) -> int:
+        ...
+
+    @property
     def vendor_api_url(self) -> str:
         """
         Some services (e.g. Nessie) may expose a vendor-specific API endpoint

--- a/tests/rptest/services/nessie_catalog.py
+++ b/tests/rptest/services/nessie_catalog.py
@@ -71,6 +71,10 @@ class NessieCatalog(CatalogService):
         return self._catalog_url
 
     @property
+    def iceberg_rest_port(self) -> int:
+        return self.NESSIE_PORT
+
+    @property
     def vendor_api_url(self) -> str:
         assert self._vendor_api_url, "URL not available because service is not started"
         return self._vendor_api_url

--- a/tests/rptest/tests/datalake/blocked_catalog_test.py
+++ b/tests/rptest/tests/datalake/blocked_catalog_test.py
@@ -1,0 +1,304 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+import time
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.catalog_service import CatalogType
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings
+from rptest.services.redpanda_connect import RedpandaConnectService
+from rptest.services.spark_service import SparkService
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.util import firewall_blocked
+from rptest.utils.rpcn_utils import counter_stream_config
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DatalakeBlockedCatalogTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(DatalakeBlockedCatalogTest, self).__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx, fast_uploads=True),
+            extra_rp_conf={
+                # Write to Iceberg quickly.
+                "iceberg_enabled": True,
+                "iceberg_catalog_commit_interval_ms": 1000,
+                "iceberg_target_lag_ms": 1000,
+
+                # Trim local storage aggressively.
+                "retention_local_target_capacity_bytes": 1024,
+                "retention_local_trim_interval": 1000,
+                "log_segment_ms": 1000,
+                "log_segment_ms_min": 1000,
+
+                # Aggressively GC in tiered storage.
+                "cloud_storage_housekeeping_interval_ms": 1000,
+            },
+            *args,
+            **kwargs)
+        self.rpcn = RedpandaConnectService(self.test_context, self.redpanda)
+        self.topic_name: str = "tapioca"
+        self.stream_name: str = "tapioca_stream"
+
+    def setUp(self):
+        # NOTE: defer cluster startup to DatalakeServices.
+        self.rpcn.start()
+
+    def make_rpcn_config(self):
+        return counter_stream_config(
+            self.redpanda,
+            self.topic_name,
+            "",  # subject
+            cnt=0,  # indefinite count
+            interval_ms=10)
+
+    def local_storage_trimmed(self) -> bool:
+        """
+        Returns true if the local log has been prefix truncated.
+        """
+        admin = Admin(self.redpanda)
+        status = admin.get_partition_cloud_storage_status(self.topic_name, 0)
+        return status["local_log_start_offset"] > 0
+
+    def cloud_log_trimmed(self) -> bool:
+        """
+        Returns true if the cloud log has been prefix truncated.
+        """
+        _, lso = self.get_hwm_lso()
+        return lso > 0
+
+    def has_spilled_over(self) -> bool:
+        """
+        Returns true if the cloud log spilled over.
+        """
+        admin = Admin(self.redpanda)
+        status = admin.get_partition_cloud_storage_status(self.topic_name, 0)
+        return status["archive_size_bytes"] > 0
+
+    def iceberg_writes_quiesced(self, spark: SparkService) -> bool:
+        """
+        Returns true if the Iceberg table is no longer being written to.
+        """
+        initial_o = spark.max_translated_offset("redpanda", self.topic_name, 0)
+        time.sleep(5)
+        final_o = spark.max_translated_offset("redpanda", self.topic_name, 0)
+        return initial_o == final_o
+
+    def log_start_quiesced(self) -> bool:
+        """
+        Returns true if the log start offset is not changing.
+        """
+        _, initial_log_start = self.get_hwm_lso()
+        time.sleep(5)
+        _, final_log_start = self.get_hwm_lso()
+        return initial_log_start == final_log_start
+
+    def get_hwm_lso(self) -> tuple[int, int]:
+        """
+        Returns the partitions high watermark and start offset.
+        """
+        rpk = RpkTool(self.redpanda)
+        hwm_lsos = [(p.high_watermark, p.start_offset)
+                    for p in rpk.describe_topic(self.topic_name)]
+        assert len(hwm_lsos) == 1, f"Expected one partition: {hwm_lsos}"
+        return hwm_lsos[0]
+
+    def check_offsets(self, spark: SparkService, hwm):
+        """
+        Asserts that the Iceberg table has all of the offsets expected up to
+        and including HWM - 1.
+        NOTE: this can be used instead of DatalakeVerifier (which expects the
+        topic to match the table) when low retention is set for a topic.
+        """
+        TARGET_STEP_SIZE = 500
+        num_steps = hwm // TARGET_STEP_SIZE
+        ranges = [(i * hwm // num_steps, (i + 1) * hwm // num_steps)
+                  for i in range(num_steps)]
+        for start, end_excl in ranges:
+            actual = [
+                r[0] for r in spark.run_query_fetch_all(
+                    f"select redpanda.offset from redpanda.{self.topic_name} where redpanda.offset >= {start} and redpanda.offset < {end_excl} order by redpanda.offset"
+                )
+            ]
+            expected = list(range(start, end_excl))
+            assert actual == expected, f"Expected: {expected}, got: {actual}"
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_trim_local_before_first_translation(self, cloud_storage_type):
+        """
+        Test that blocks the catalog before the first translation and ensures
+        that once unblocked, translation proceeds from the start of the log
+        that resides in tiered storage.
+        """
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=CatalogType.REST_JDBC) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name)
+            spark = dl.spark()
+
+            with firewall_blocked(self.redpanda.nodes,
+                                  dl.catalog_service.iceberg_rest_port):
+                self.rpcn.start_stream(self.stream_name,
+                                       self.make_rpcn_config())
+
+                # Give some time for Redpanda to attempt some translation, but
+                # ultimately not create the table because of the firewall.
+                time.sleep(5)
+                assert not dl.table_exists(self.topic_name)
+
+                # Because we've set such an aggressive local target capacity,
+                # we should trim local data, despite not translating anything.
+                wait_until(self.local_storage_trimmed,
+                           timeout_sec=30,
+                           backoff_sec=1)
+                assert not dl.table_exists(self.topic_name)
+
+            dl.wait_for_translation_until_offset(self.topic_name, 100)
+            self.rpcn.stop_stream(self.stream_name, should_finish=None)
+
+            # Check that we have data, and that our log starts from 0.
+            hwm, lso = self.get_hwm_lso()
+            assert lso == 0, f"Expected {lso} = 0"
+            assert hwm > 0, f"Expected {hwm} > 0"
+            dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
+            DatalakeVerifier.oneshot(self.redpanda, self.topic_name, spark)
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_trim_local_after_first_translation(self, cloud_storage_type):
+        """
+        Test that blocks the catalog after the first translation and ensures
+        that once unblocked, translation proceeds from the start of the log
+        that resides in tiered storage.
+        """
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=CatalogType.REST_JDBC) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name)
+            self.rpcn.start_stream(self.stream_name, self.make_rpcn_config())
+            dl.wait_for_translation_until_offset(self.topic_name, 100)
+            wait_until(self.local_storage_trimmed,
+                       timeout_sec=30,
+                       backoff_sec=1)
+
+            spark = dl.spark()
+            with firewall_blocked(self.redpanda.nodes,
+                                  dl.catalog_service.iceberg_rest_port):
+                wait_until(lambda: self.iceberg_writes_quiesced(spark),
+                           timeout_sec=30,
+                           backoff_sec=1)
+
+            self.rpcn.stop_stream(self.stream_name, should_finish=None)
+
+            hwm, lso = self.get_hwm_lso()
+            assert lso == 0, f"Expected {lso} = 0"
+            assert hwm > 0, f"Expected {hwm} > 0"
+            dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
+
+            # Finally, verify correctness.
+            DatalakeVerifier.oneshot(self.redpanda, self.topic_name, spark)
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            with_spillover=[True, False])
+    def test_block_cloud_retention_before_translation(self, cloud_storage_type,
+                                                      with_spillover):
+        """
+        Test that blocks the catalog before the first translation and ensures
+        that cloud retention is blocked while local space management can make
+        progress.
+        """
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=CatalogType.REST_JDBC) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            config=dict({"retention.ms": 1}))
+            spark = dl.spark()
+            rpk = RpkTool(self.redpanda)
+            if with_spillover:
+                rpk.cluster_config_set("cloud_storage_spillover_manifest_size",
+                                       "null")
+                rpk.cluster_config_set(
+                    "cloud_storage_spillover_manifest_max_segments", "1")
+
+            with firewall_blocked(self.redpanda.nodes,
+                                  dl.catalog_service.iceberg_rest_port):
+                self.rpcn.start_stream(self.stream_name,
+                                       self.make_rpcn_config())
+                time.sleep(5)
+                assert not dl.table_exists(self.topic_name)
+                wait_until(self.local_storage_trimmed,
+                           timeout_sec=30,
+                           backoff_sec=1)
+                if with_spillover:
+                    wait_until(self.has_spilled_over,
+                               timeout_sec=30,
+                               backoff_sec=1)
+                assert not dl.table_exists(self.topic_name)
+
+                # Despite our retention settings being so low, we shouldn't
+                # trim anything because we haven't translated anything.
+                _, lso = self.get_hwm_lso()
+                assert lso == 0, f"Expected {lso} = 0"
+
+            dl.wait_for_translation_until_offset(self.topic_name, 100)
+            self.rpcn.stop_stream(self.stream_name, should_finish=None)
+
+            # Now that we've translated, tiered storage is free to remove
+            # historical data.
+            wait_until(self.cloud_log_trimmed, timeout_sec=10, backoff_sec=1)
+            hwm, _ = self.get_hwm_lso()
+            dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
+            self.check_offsets(spark, hwm)
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_block_cloud_retention_after_translation(self, cloud_storage_type):
+        """
+        Test that blocks the catalog after the first translation and ensures
+        that cloud retention is blocked while local space management can make
+        progress.
+        """
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=CatalogType.REST_JDBC) as dl:
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            config=dict({"retention.ms": 1}))
+            self.rpcn.start_stream(self.stream_name, self.make_rpcn_config())
+            dl.wait_for_translation_until_offset(self.topic_name, 100)
+            wait_until(self.local_storage_trimmed,
+                       timeout_sec=30,
+                       backoff_sec=1)
+
+            spark = dl.spark()
+            with firewall_blocked(self.redpanda.nodes,
+                                  dl.catalog_service.iceberg_rest_port):
+                wait_until(lambda: self.iceberg_writes_quiesced(spark),
+                           timeout_sec=30,
+                           backoff_sec=1)
+                wait_until(self.log_start_quiesced,
+                           timeout_sec=30,
+                           backoff_sec=1)
+
+            self.rpcn.stop_stream(self.stream_name, should_finish=None)
+
+            hwm, _ = self.get_hwm_lso()
+            dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
+            self.check_offsets(spark, hwm)

--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -615,7 +615,8 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
     @parametrize(cloud_storage_enabled=False)
     def test_delete_records_with_transactions(self, cloud_storage_enabled):
         """
-        Tests that the log_eviction_stm is respecting the max_collectible_offset
+        Tests that the log_eviction_stm is respecting the
+        max_removable_local_log_offset
         """
         self._start(cloud_storage_enabled)
 

--- a/tests/rptest/transactions/consumer_offsets_test.py
+++ b/tests/rptest/transactions/consumer_offsets_test.py
@@ -71,8 +71,9 @@ class VerifyConsumerOffsetsThruUpgrades(RedpandaTest):
                 for replica in state["replicas"]:
                     for stm in replica["raft_state"]["stms"]:
                         if stm["name"] == "group_tx_tracker_stm.snapshot":
-                            collectible.append(stm["last_applied_offset"] ==
-                                               stm["max_collectible_offset"])
+                            collectible.append(
+                                stm["last_applied_offset"] ==
+                                stm["max_removable_local_log_offset"])
                 return len(collectible) == 3 and all(collectible)
             except Exception as e:
                 self.redpanda.logger.debug(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
The high level problem is that without this change, when the Iceberg catalog is down, translation will be blocked and the translation STM's max collectible offset will block local data from being reclaimed by space management. This PR decouples the translation STM's max collectible offset from translation progress by introducing a new concept to the partition, `kafka::offset lowest_pinned_offset()`. Data including and above this offset will not be eligible for compaction or tiered storage retention, and translation progress will move this pinned offset rather than the max collectible offset.

In introducing this concept, the max collectible offset for the translation STM is now only blocked if we have never replicated a highest translated offset. The first replication done by translators is updated to replicate the local start offset - 1 (which may be -1, and is differentiated from `kafka::offset::min()`), ensuring that we retain the semantics of starting translation from local data when translation is first enabled.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Iceberg topics will no longer prevent space management from reclaiming local disk space when data is not translated. Instead, the data to translate will come from tiered storage.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
