### PR TITLE
Allow rpbenches to opt out of running in shm, opt out wasm

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -355,7 +355,7 @@ def redpanda_cc_bench(
         tags = [],
         target_compatible_with = [],
         redirect_stderr = False,
-        exec_in_shm = True):
+        exec_in_shm = False):
     """
     Create a seastar benchmark target
 

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -354,7 +354,8 @@ def redpanda_cc_bench(
         data = [],
         tags = [],
         target_compatible_with = [],
-        redirect_stderr = False):
+        redirect_stderr = False,
+        exec_in_shm = True):
     """
     Create a seastar benchmark target
 
@@ -375,6 +376,10 @@ def redpanda_cc_bench(
       target_compatible_with: constraints for the test target
       redirect_stderr: if True, redirects stdout (seastar logging, mostly) to a file
                        so that it does not overwhelm the result output
+      exec_in_shm: if True, the benchmark will execute in a subdir in /dev/shm which leads
+                   to very fast IO, but the inability to resolve paths relative to the bazel
+                   workspace root, so False is useful for benchmarks that need to access their
+                   runfiles
     """
 
     # We require this naming convention as we do things like extract
@@ -432,6 +437,7 @@ def redpanda_cc_bench(
     args = ["$(rootpath :{})".format(binary_name)] + args
 
     env = env | {
+        "MB_EXEC_IN_SHM": "1" if exec_in_shm else "0",
         "MB_REDIRECT_STDERR_DEFAULT": "1" if redirect_stderr else "0",
     }
 

--- a/src/v/wasm/tests/BUILD
+++ b/src/v/wasm/tests/BUILD
@@ -273,6 +273,7 @@ redpanda_cc_bench(
     env = {
         "IDENTITY_WASM_BINARY": "$(rootpath //src/transform-sdk/go/transform/internal/testdata/identity)",
     },
+    exec_in_shm = False,
     memory = "512MiB",
     deps = [
         ":logger",

--- a/tools/bench-wrapper.sh
+++ b/tools/bench-wrapper.sh
@@ -6,26 +6,37 @@ set -euo pipefail
 
 basename=$(basename "$1")
 stderr=$(mktemp --tmpdir "$basename.stderr.XXXXXXXX")
-rundir=${MB_RUNDIR:-/dev/shm/vectorized_io}
 exe_path=$(realpath "$1")
+exec_in_shm=${MB_EXEC_IN_SHM:-1}
+if [[ $exec_in_shm == 1 ]]; then
+  rundir=${MB_RUNDIR:-/dev/shm/vectorized_io}
+else
+  rundir=${MB_RUNDIR:-.}
+fi
 # whether to redirect stderr (to avoid overwhelming the result output with
 # seastar logging: use MB_REDIRECT_STDERR=1 in your env
 # while calling bazel to override: bazel itself passes MB_REDIRECT_STDERR_DEFAULT
 # based on how the benchmark is configured
 redirect_stderr=${MB_REDIRECT_STDERR:-${MB_REDIRECT_STDERR_DEFAULT:-0}}
+verbose=${MB_VERBOSE:-0}
 
 # drop the relative exe path from the args
 shift
 
 echo "[bench-wrapper] running benchmark : $basename"
+echo "[bench-wrapper] verbsose=$verbose, exec_in_shm=$exec_in_shm, redirect_stderr=$redirect_stderr"
 if [[ $redirect_stderr == 1 ]]; then
   echo "[bench-wrapper] redirecting stderr: $stderr"
-else
-  echo "[bench-wrapper] not redirecting stderr"
 fi
 echo "[bench-wrapper] stderr saved at   : $stderr"
 echo "[bench-wrapper] rundir            : $rundir"
 echo "[bench-wrapper] command           : ${exe_path} $*"
+
+if [[ $verbose == 1 ]]; then
+  echo "[bench-wrapper] env begin:"
+  env
+  echo "[bench-wrapper] env end"
+fi
 
 mkdir -p "$rundir"
 cd "$rundir"


### PR DESCRIPTION
This pull request allows opting out of the recent change to execute benchmarks in /dev/shm, for benchmarks where this doesn't work. This would be few benchmarks since all cmake benchmarks did this, but there could be bazel-only benchmarks. The wasm benchmark is failing after this change since it expects to find its runfiles.

The changes include modifications to the `redpanda_cc_bench` function in the `bazel/test.bzl` file, updates to the `BUILD` file for wasm tests, and enhancements to the `bench-wrapper.sh` script to support this new feature.

Key changes include:

### New Feature: Opt out of executing benchmarks in shm

* [`bazel/test.bzl`](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L357-R358): Added the `exec_in_shm` parameter to the `redpanda_cc_bench` function, which allows benchmarks to be executed in a subdirectory of `/dev/shm` for faster I/O. Updated the environment variable `MB_EXEC_IN_SHM` based on this parameter. [[1]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L357-R358) [[2]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7R379-R382) [[3]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7R440)
* [`src/v/wasm/tests/BUILD`](diffhunk://#diff-7903d3fc67bb680736ba6a0670d75063a34f92ed70fad336aa5cf03c83e8fc93R276): Set the `exec_in_shm` parameter to `False` for the `redpanda_cc_bench` function in the wasm tests.
* [`tools/bench-wrapper.sh`](diffhunk://#diff-7628d20e1aa85b55147a1c843dea7cb51bb4a1a554030f1cea17d3ff5fb54efbL9-R40): Modified the script to check the `MB_EXEC_IN_SHM` environment variable and set the `rundir` accordingly. Added verbose logging to display environment variables when `MB_VERBOSE` is set.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
