### PR TITLE
bench-wrapper: ensure wrapper exits with right rc

### DIFF
--- a/tools/bench-wrapper.sh
+++ b/tools/bench-wrapper.sh
@@ -49,6 +49,7 @@ if [[ $rc -ne 0 ]]; then
   else
     echo "$msg"
   fi
+  exit $rc
 else
   echo "[bench-wrapper] benchmark completed successfully"
 fi


### PR DESCRIPTION
- Updated `tools/bench-wrapper.sh` to handle exit codes properly.
- This change ensures that the script propagates the correct exit status.

## Backports Required



- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
