### PR TITLE
rpk: expand debug bundle commands

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -83,6 +83,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveResourceUsageData(ps, bp.y),
 		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
+		saveSoftwareInterrupts(ps),
 		saveUname(ctx, ps),
 	}
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -76,6 +76,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveInterrupts(ps),
 		saveKafkaMetadata(ctx, ps, bp.cl),
 		saveKernelSymbols(ps),
+		saveLsblk(ctx, ps),
 		saveMdstat(ps),
 		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -157,6 +157,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveStartupLog(ps, bp.y),
 		saveSlabInfo(ps),
 		saveSocketData(ctx, ps),
+		saveSoftwareInterrupts(ps),
 		saveSysctl(ctx, ps),
 		saveSyslog(ps),
 		saveTopOutput(ctx, ps),
@@ -561,6 +562,17 @@ func saveInterrupts(ps *stepParams) step {
 			return err
 		}
 		return writeFileToZip(ps, "proc/interrupts", bs)
+	}
+}
+
+// Saves the contents of '/proc/softirqs/'.
+func saveSoftwareInterrupts(ps *stepParams) step {
+	return func() error {
+		bs, err := afero.ReadFile(ps.fs, "/proc/softirqs")
+		if err != nil {
+			return err
+		}
+		return writeFileToZip(ps, "proc/softirqs", bs)
 	}
 }
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -147,6 +147,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveKernelSymbols(ps),
 		saveLogs(ctx, ps, bp.logsSince, bp.logsUntil, bp.logsLimitBytes),
 		saveLspci(ctx, ps),
+		saveLsblk(ctx, ps),
 		saveMdstat(ps),
 		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),
@@ -812,6 +813,18 @@ func saveLspci(ctx context.Context, ps *stepParams) step {
 			ps,
 			filepath.Join(linuxUtilsRoot, "lspci.txt"),
 			"lspci",
+		)
+	}
+}
+
+// Saves the output of `lsblk --all`.
+func saveLsblk(ctx context.Context, ps *stepParams) step {
+	return func() error {
+		return writeCommandOutputToZip(
+			ctx,
+			ps,
+			filepath.Join(linuxUtilsRoot, "lsblk.txt"),
+			"lsblk", "--all",
 		)
 	}
 }

--- a/src/go/rpk/pkg/cli/generate/license.go
+++ b/src/go/rpk/pkg/cli/generate/license.go
@@ -164,7 +164,7 @@ func (l *licenseRequest) prompt() error {
 		return fmt.Errorf("unable to get the firt name: %v", err)
 	}
 	l.name = name
-	lastname, err := out.Prompt("Last name:")
+	lastname, err := out.Prompt("Last Name:")
 	if err != nil {
 		return fmt.Errorf("unable to get the last name: %v", err)
 	}


### PR DESCRIPTION
Add the content of `/proc/softirqs/` and the output of `lsblk --all` to rpk debug bundle.

Fixes UX-100 and UX-101 plus a small consistency issue in our prompt for `rpk generate license`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* rpk: add the content of `/proc/softirqs/` and the output of `lsblk --all` to rpk debug bundle.
